### PR TITLE
DNM: Draft: Allow active migrations to adopt shorter timing

### DIFF
--- a/lib/src/features/migration/screens/ironwood_migration_flow/schedule.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/schedule.dart
@@ -83,14 +83,23 @@ class IronwoodMigrationPreparationScheduleScreen extends ConsumerWidget {
   }
 }
 
-class IronwoodMigrationScheduleScreen extends ConsumerWidget {
+class IronwoodMigrationScheduleScreen extends ConsumerStatefulWidget {
   const IronwoodMigrationScheduleScreen({this.previewStatus, super.key});
 
   final rust_sync.MigrationStatus? previewStatus;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final preview = previewStatus;
+  ConsumerState<IronwoodMigrationScheduleScreen> createState() =>
+      _IronwoodMigrationScheduleScreenState();
+}
+
+class _IronwoodMigrationScheduleScreenState
+    extends ConsumerState<IronwoodMigrationScheduleScreen> {
+  bool _retiming = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final preview = widget.previewStatus;
     if (preview != null) {
       return _frame(context, preview, ref.watch(syncProvider).asData?.value);
     }
@@ -126,10 +135,15 @@ class IronwoodMigrationScheduleScreen extends ConsumerWidget {
                     context,
                     cachedStatus,
                     ref.watch(syncProvider).asData?.value,
+                    request: request,
                   );
           },
-          data: (status) =>
-              _frame(context, status, ref.watch(syncProvider).asData?.value),
+          data: (status) => _frame(
+            context,
+            status,
+            ref.watch(syncProvider).asData?.value,
+            request: request,
+          ),
         );
   }
 
@@ -139,7 +153,12 @@ class IronwoodMigrationScheduleScreen extends ConsumerWidget {
     SyncState? syncState, {
     bool statusUnavailable = false,
     VoidCallback? onRetry,
+    IronwoodMigrationStatusRequest? request,
   }) {
+    final canRetime =
+        request != null &&
+        status != null &&
+        canShortenIronwoodMigrationTiming(status);
     return _IronwoodMigrationFrame(
       toolbar: AppPaneToolbar(
         leading: AppBackLink(
@@ -156,8 +175,58 @@ class IronwoodMigrationScheduleScreen extends ConsumerWidget {
           : _MigrationScheduleContent(
               status: status,
               currentHeight: _currentMigrationHeight(syncState),
+              retiming: _retiming,
+              onShortenTiming: canRetime
+                  ? () => _confirmShorterTiming(request, status)
+                  : null,
             ),
     );
+  }
+
+  Future<void> _confirmShorterTiming(
+    IronwoodMigrationStatusRequest request,
+    rust_sync.MigrationStatus status,
+  ) async {
+    if (_retiming || status.activeRunId == null) return;
+    final appTheme = AppTheme.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AppTheme(
+        data: appTheme,
+        child: const IronwoodMigrationRetimeDialog(),
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    setState(() => _retiming = true);
+    try {
+      final result = await ref
+          .read(ironwoodMigrationServiceProvider)
+          .shortenActiveMigrationTiming(
+            network: request.network,
+            accountUuid: request.accountUuid,
+            expectedRunId: status.activeRunId!,
+          );
+      if (!mounted) return;
+      ref.invalidate(ironwoodMigrationStatusProvider(request));
+      showAppToast(
+        context,
+        result.needsSignatureCount == 0
+            ? 'Migration timing updated.'
+            : 'Timing updated. ${result.needsSignatureCount} transfer(s) '
+                  'need a fresh signature.',
+      );
+    } catch (error) {
+      if (mounted) {
+        showAppToast(
+          context,
+          "Couldn't update migration timing. $error",
+          iconName: AppIcons.warning,
+          tone: AppToastTone.destructive,
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _retiming = false);
+    }
   }
 }
 
@@ -682,10 +751,14 @@ class _MigrationScheduleContent extends StatelessWidget {
   const _MigrationScheduleContent({
     required this.status,
     required this.currentHeight,
+    required this.retiming,
+    this.onShortenTiming,
   });
 
   final rust_sync.MigrationStatus status;
   final int currentHeight;
+  final bool retiming;
+  final VoidCallback? onShortenTiming;
 
   @override
   Widget build(BuildContext context) {
@@ -743,6 +816,26 @@ class _MigrationScheduleContent extends StatelessWidget {
               ],
             ),
           ),
+          if (onShortenTiming != null) ...[
+            const SizedBox(height: 10),
+            Center(
+              child: AppButton(
+                key: const ValueKey('ironwood_migration_use_shorter_timing'),
+                variant: AppButtonVariant.ghost,
+                size: AppButtonSize.medium,
+                onPressed: retiming ? null : onShortenTiming,
+                leading: retiming
+                    ? const AppIcon(
+                        AppIcons.loader,
+                        semanticLabel: 'Updating migration timing',
+                      )
+                    : null,
+                child: Text(
+                  retiming ? 'Updating timing...' : 'Use shorter timing',
+                ),
+              ),
+            ),
+          ],
           const SizedBox(height: 20),
           Expanded(
             child: Padding(

--- a/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
@@ -52,6 +52,7 @@ import '../providers/ironwood_migration_announcement_provider.dart';
 import '../providers/ironwood_migration_coordinator_provider.dart';
 import '../providers/ironwood_migration_privacy_lock_provider.dart';
 import '../services/ironwood_migration_service.dart';
+import '../widgets/ironwood_migration_retime_dialog.dart';
 import '../widgets/ironwood_migration_shimmer_text.dart';
 import '../widgets/mobile/mobile_ironwood_keystone_signing_view.dart';
 

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
@@ -22,6 +22,7 @@ import '../../../../core/theme/primitives.dart';
 import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/app_profile_picture.dart';
+import '../../../../core/widgets/app_toast.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/sync_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
@@ -31,6 +32,7 @@ import '../../models/mobile_ironwood_migration_status_entry.dart';
 import '../../providers/ironwood_migration_announcement_provider.dart';
 import '../../providers/ironwood_migration_coordinator_provider.dart';
 import '../../services/ironwood_migration_service.dart';
+import '../../widgets/ironwood_migration_retime_dialog.dart';
 import '../../widgets/mobile/mobile_ironwood_migration_attention.dart';
 import '../ironwood_migration_flow_screen.dart';
 

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -1075,6 +1075,8 @@ class _MigrationProgressPreview extends StatelessWidget {
     this.actionBatchLabel,
     this.actionBatchValue,
     this.onAction,
+    this.secondaryActionLabel,
+    this.onSecondaryAction,
     this.actionRunning = false,
     this.onBack,
     this.onPreparationCompleteDone,
@@ -1100,6 +1102,8 @@ class _MigrationProgressPreview extends StatelessWidget {
   final String? actionBatchLabel;
   final String? actionBatchValue;
   final VoidCallback? onAction;
+  final String? secondaryActionLabel;
+  final VoidCallback? onSecondaryAction;
   final bool actionRunning;
   final VoidCallback? onBack;
   final VoidCallback? onPreparationCompleteDone;
@@ -1176,6 +1180,19 @@ class _MigrationProgressPreview extends StatelessWidget {
                   statusValueOverride: statusValueOverride,
                 ),
                 const Spacer(),
+                if (secondaryActionLabel != null) ...[
+                  AppButton(
+                    key: const ValueKey(
+                      'mobile_ironwood_migration_use_shorter_timing',
+                    ),
+                    expand: true,
+                    constrainContent: true,
+                    variant: AppButtonVariant.ghost,
+                    onPressed: onSecondaryAction,
+                    child: Text(secondaryActionLabel!),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                ],
                 if (state == _MigrationProgressState.needsInput)
                   _MigrationNeedsInputCard(
                     message: actionMessage,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -619,6 +619,10 @@ class _MobileMigrationRedesignedStatusState
         widget.status.parts.any(
           (part) => part.state == rust_sync.MigrationPartState.needsInput,
         );
+    final canShortenTiming =
+        accountUuid != null &&
+        state != _MigrationProgressState.needsInput &&
+        canShortenIronwoodMigrationTiming(widget.status);
     return _MigrationProgressPreview(
       state: state,
       showPreparationCompleteModal: _showPreparationComplete,
@@ -661,6 +665,14 @@ class _MobileMigrationRedesignedStatusState
       onAction: accountUuid == null || _actionRunning
           ? null
           : () => unawaited(_performRequiredAction(accountUuid)),
+      secondaryActionLabel: canShortenTiming
+          ? _actionRunning
+                ? 'Updating timing...'
+                : 'Use shorter timing'
+          : null,
+      onSecondaryAction: !canShortenTiming || _actionRunning
+          ? null
+          : () => unawaited(_confirmShorterTiming(accountUuid)),
     );
   }
 
@@ -817,6 +829,52 @@ class _MobileMigrationRedesignedStatusState
       await ref
           .read(ironwoodMigrationCoordinatorProvider.notifier)
           .recover(accountUuid);
+    } finally {
+      if (mounted) setState(() => _actionRunning = false);
+    }
+  }
+
+  Future<void> _confirmShorterTiming(String accountUuid) async {
+    if (_actionRunning || widget.status.activeRunId == null) return;
+    final request = ref.read(ironwoodMigrationInputsProvider).statusRequest;
+    if (request == null || request.accountUuid != accountUuid) return;
+    final appTheme = AppTheme.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AppTheme(
+        data: appTheme,
+        child: const IronwoodMigrationRetimeDialog(),
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    setState(() => _actionRunning = true);
+    try {
+      final result = await ref
+          .read(ironwoodMigrationServiceProvider)
+          .shortenActiveMigrationTiming(
+            network: request.network,
+            accountUuid: accountUuid,
+            expectedRunId: widget.status.activeRunId!,
+          );
+      if (!mounted) return;
+      ref.invalidate(ironwoodMigrationStatusProvider(request));
+      ref.invalidate(ironwoodMigrationRouteCtaProvider);
+      showAppToast(
+        context,
+        result.needsSignatureCount == 0
+            ? 'Migration timing updated.'
+            : 'Timing updated. ${result.needsSignatureCount} transfer(s) '
+                  'need a fresh signature.',
+      );
+    } catch (error) {
+      if (mounted) {
+        showAppToast(
+          context,
+          "Couldn't update migration timing. $error",
+          iconName: AppIcons.warning,
+          tone: AppToastTone.destructive,
+        );
+      }
     } finally {
       if (mounted) setState(() => _actionRunning = false);
     }

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -225,6 +225,15 @@ typedef IronwoodMigrationUnbroadcastRetirer =
       required String accountUuid,
       required String expectedRunId,
     });
+typedef IronwoodMigrationRetimer =
+    Future<rust_sync.MigrationRetimeResult> Function({
+      required String dbPath,
+      required String network,
+      required String accountUuid,
+      required String expectedRunId,
+    });
+typedef IronwoodMigrationWorkQuiescer = Future<void> Function();
+typedef IronwoodMigrationWorkResumer = Future<void> Function();
 typedef IronwoodMigrationMacosSoftwareStarter =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
@@ -605,6 +614,9 @@ class IronwoodMigrationService {
     IronwoodMigrationImmediatePlanGetter? getImmediatePlan,
     IronwoodMigrationImmediateStarter? startImmediateMigration,
     IronwoodMigrationUnbroadcastRetirer? retireUnbroadcastMigration,
+    IronwoodMigrationRetimer? retimeActiveMigration,
+    IronwoodMigrationWorkQuiescer? quiesceMigrationWork,
+    IronwoodMigrationWorkResumer? resumeMigrationWork,
     IronwoodMigrationMacosSoftwareStarter? startMacosSoftwareMigration,
     IronwoodMigrationDueBroadcaster? broadcastDueMigration,
     IronwoodMigrationOutboxPreparer? prepareMigrationOutbox,
@@ -689,6 +701,14 @@ class IronwoodMigrationService {
        retireUnbroadcastMigration =
            retireUnbroadcastMigration ??
            rust_sync.retireUnbroadcastOrchardMigration,
+       retimeActiveMigration =
+           retimeActiveMigration ?? rust_sync.retimeActiveOrchardMigration,
+       quiesceMigrationWork =
+           quiesceMigrationWork ??
+           IronwoodMigrationBackgroundLifecycle.instance.quiesce,
+       resumeMigrationWork =
+           resumeMigrationWork ??
+           IronwoodMigrationBackgroundLifecycle.instance.resumeAfterMutation,
        startMacosSoftwareMigration =
            startMacosSoftwareMigration ?? _defaultStartMacosSoftwareMigration,
        broadcastDueMigration =
@@ -785,6 +805,9 @@ class IronwoodMigrationService {
   final IronwoodMigrationSoftwareStarter startSoftwareMigration;
   final IronwoodMigrationImmediateStarter startImmediateMigration;
   final IronwoodMigrationUnbroadcastRetirer retireUnbroadcastMigration;
+  final IronwoodMigrationRetimer retimeActiveMigration;
+  final IronwoodMigrationWorkQuiescer quiesceMigrationWork;
+  final IronwoodMigrationWorkResumer resumeMigrationWork;
   final IronwoodMigrationMacosSoftwareStarter startMacosSoftwareMigration;
   final IronwoodMigrationDueBroadcaster broadcastDueMigration;
   final IronwoodMigrationOutboxPreparer prepareMigrationOutbox;
@@ -941,6 +964,158 @@ class IronwoodMigrationService {
             status: status,
           );
           return status;
+        });
+      },
+    );
+  }
+
+  /// Pauses native migration delivery and redraws only this run's unsubmitted
+  /// transfers under the shorter timing policy. Any accepted receipt is
+  /// reconciled before mutation, and an outbox batch with an uncertain
+  /// submission prevents the change.
+  Future<rust_sync.MigrationRetimeResult> shortenActiveMigrationTiming({
+    required String network,
+    required String accountUuid,
+    required String expectedRunId,
+  }) {
+    return operationRegistry.run(
+      network: network,
+      accountUuid: accountUuid,
+      operation: () async {
+        final dbPath = await getWalletDbPath();
+        final endpoint = getEndpoint();
+        final context = _MigrationCredentialContext(
+          dbPath: dbPath,
+          network: network,
+          accountUuid: accountUuid,
+          lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        );
+        return _serializeCredentialState(context, () async {
+          var quiesceAttempted = false;
+          try {
+            quiesceAttempted = true;
+            await quiesceMigrationWork();
+
+            var status = await _getStatusForContext(context);
+            _validateMigrationRetimeStatus(status, expectedRunId);
+            _MigrationCredential? credential;
+            var hadScheduledOutbox = false;
+            var outboxCleared = false;
+
+            if (_usesNativeMigrationOutbox) {
+              final reconciliation = await _reconcileMigrationOutboxReceipts(
+                context: context,
+              );
+              if (reconciliation.unreconciledCount > 0) {
+                throw StateError(
+                  'A submitted migration transfer could not be reconciled. '
+                  'Try again after Vizor refreshes its migration status.',
+                );
+              }
+              status = await _getStatusForContext(context);
+              _validateMigrationRetimeStatus(status, expectedRunId);
+              hadScheduledOutbox = _scheduledBroadcastTxids(status).isNotEmpty;
+              if (hadScheduledOutbox) {
+                final manifest = await backgroundCredentialStore.read(
+                  network: context.network,
+                  accountUuid: context.accountUuid,
+                );
+                if (manifest == null) {
+                  throw StateError(
+                    '$_credentialRecoveryRequiredError The current schedule '
+                    'must remain available until timing is updated.',
+                  );
+                }
+                final resolvedManifest = await _resolveManifestContext(
+                  manifest,
+                  context,
+                );
+                await backgroundCredentialStore.bindExpectedRunId(
+                  network: context.network,
+                  accountUuid: context.accountUuid,
+                  expectedRunId: expectedRunId,
+                );
+                credential = _MigrationCredential(
+                  password: resolvedManifest.credentialHex,
+                  saltBase64: resolvedManifest.saltBase64,
+                );
+                try {
+                  await discardMigrationOutboxBatch(
+                    batchId: _migrationOutboxBatchId(context, expectedRunId),
+                  );
+                  outboxCleared = true;
+                  _scheduledBackgroundMigrations.remove(
+                    _credentialKey(context),
+                  );
+                } catch (error) {
+                  throw StateError(
+                    'A migration transfer is still being submitted. Wait for '
+                    'its status to settle before changing the timing. $error',
+                  );
+                }
+              }
+            }
+
+            rust_sync.MigrationRetimeResult result;
+            try {
+              result = await retimeActiveMigration(
+                dbPath: context.dbPath,
+                network: context.network,
+                accountUuid: context.accountUuid,
+                expectedRunId: expectedRunId,
+              );
+            } catch (error) {
+              if (hadScheduledOutbox && outboxCleared && credential != null) {
+                try {
+                  await _stagePersistedMigrationOutbox(
+                    context: context,
+                    credential: credential,
+                    expectedRunId: expectedRunId,
+                    statusForStaleBatchDiscard: status,
+                  );
+                } catch (restoreError) {
+                  debugPrint(
+                    'Failed to restore the migration outbox after timing '
+                    'update failed: $restoreError',
+                  );
+                }
+              }
+              rethrow;
+            }
+
+            final updatedStatus = await _getStatusForContext(context);
+            final scheduledTxids = _scheduledBroadcastTxids(updatedStatus);
+            if (_usesNativeMigrationOutbox && scheduledTxids.isNotEmpty) {
+              final currentCredential = credential;
+              if (currentCredential == null) {
+                throw StateError(
+                  '$_credentialRecoveryRequiredError The shortened schedule '
+                  'could not be restored to background delivery.',
+                );
+              }
+              await _stagePersistedMigrationOutbox(
+                context: context,
+                credential: currentCredential,
+                expectedRunId: expectedRunId,
+                requiredTxids: scheduledTxids,
+                statusForStaleBatchDiscard: updatedStatus,
+              );
+            } else if (_usesNativeMigrationOutbox) {
+              _scheduledBackgroundMigrations.remove(_credentialKey(context));
+            }
+            return result;
+          } finally {
+            if (quiesceAttempted) {
+              try {
+                await resumeMigrationWork();
+              } catch (error) {
+                debugPrint(
+                  'Failed to resume Ironwood migration after timing update: '
+                  '$error',
+                );
+              }
+            }
+          }
         });
       },
     );
@@ -2674,6 +2849,23 @@ final ironwoodMigrationServiceProvider = Provider<IronwoodMigrationService>((
     },
   );
 });
+
+void _validateMigrationRetimeStatus(
+  rust_sync.MigrationStatus status,
+  String expectedRunId,
+) {
+  if (status.activeRunId != expectedRunId) {
+    throw StateError(
+      'The active Ironwood migration changed before timing could be updated.',
+    );
+  }
+  if (status.scheduleMeanDelayBlocks != 144 &&
+      status.scheduleMeanDelayBlocks != 72) {
+    throw StateError(
+      'This migration does not use timing that can be shortened.',
+    );
+  }
+}
 
 RpcEndpointConfig _missingEndpoint() {
   throw StateError('Ironwood migration endpoint getter is not configured.');

--- a/lib/src/features/migration/widgets/ironwood_migration_retime_dialog.dart
+++ b/lib/src/features/migration/widgets/ironwood_migration_retime_dialog.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart' show Dialog;
+import 'package:flutter/widgets.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../rust/api/sync.dart' as rust_sync;
+
+/// Whether an active migration still uses the legacy three-hour spacing that
+/// the user can replace with the shorter policy.
+bool canShortenIronwoodMigrationTiming(rust_sync.MigrationStatus status) =>
+    status.activeRunId != null && status.scheduleMeanDelayBlocks == 144;
+
+/// Confirmation shown before Vizor pauses delivery and redraws the remaining
+/// migration transfer times.
+class IronwoodMigrationRetimeDialog extends StatelessWidget {
+  const IronwoodMigrationRetimeDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Dialog(
+      backgroundColor: colors.background.ground,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Use shorter timing?',
+                  style: AppTypography.bodyLarge.copyWith(
+                    color: colors.text.accent,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  'Vizor will pause automatic migration and redraw the '
+                  'remaining transfer times with a 90-minute mean and '
+                  '12-hour maximum. Transfers already submitted stay '
+                  'unchanged. A transfer that moves into a new expiry window '
+                  'will need a fresh signature.',
+                  style: AppTypography.bodyMedium.copyWith(
+                    color: colors.text.secondary,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.md),
+                AppButton(
+                  key: const ValueKey(
+                    'ironwood_migration_confirm_shorter_timing',
+                  ),
+                  expand: true,
+                  constrainContent: true,
+                  onPressed: () => Navigator.of(context).pop(true),
+                  child: const Text('Use shorter timing'),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                AppButton(
+                  expand: true,
+                  constrainContent: true,
+                  variant: AppButtonVariant.ghost,
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: const Text('Keep current timing'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -413,6 +413,24 @@ Future<MigrationStatus> getOrchardMigrationStatus({
   accountUuid: accountUuid,
 );
 
+/// Changes one expected active migration from the legacy three-hour transfer
+/// spacing to the 90-minute policy.
+///
+/// The wallet must be fully synced. The operation is atomic, leaves submitted
+/// transactions untouched, and returns an idempotent unchanged result if the
+/// same run was already updated by an earlier call.
+Future<MigrationRetimeResult> retimeActiveOrchardMigration({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+  required String expectedRunId,
+}) => RustLib.instance.api.crateApiSyncRetimeActiveOrchardMigration(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  expectedRunId: expectedRunId,
+);
+
 Future<OrchardMigrationPrivatePlan?> getOrchardMigrationPrivatePlan({
   required String dbPath,
   required String network,
@@ -1581,6 +1599,48 @@ class MigrationPreparationTransactionStatus {
           minedHeight == other.minedHeight &&
           confirmationCount == other.confirmationCount &&
           confirmationTarget == other.confirmationTarget;
+}
+
+/// Outcome of changing an active legacy migration to the shorter timing
+/// policy. Transactions already submitted to the network are never changed.
+class MigrationRetimeResult {
+  final String runId;
+
+  /// False when a retry observes that the requested run already uses the
+  /// shorter policy.
+  final bool changed;
+
+  /// Signed transactions that kept their original expiry and were assigned
+  /// a new broadcast height.
+  final int rescheduledTxCount;
+
+  /// Remaining transactions whose committed expiry or unsigned schedule
+  /// requires a fresh signature.
+  final int needsSignatureCount;
+
+  const MigrationRetimeResult({
+    required this.runId,
+    required this.changed,
+    required this.rescheduledTxCount,
+    required this.needsSignatureCount,
+  });
+
+  @override
+  int get hashCode =>
+      runId.hashCode ^
+      changed.hashCode ^
+      rescheduledTxCount.hashCode ^
+      needsSignatureCount.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MigrationRetimeResult &&
+          runtimeType == other.runtimeType &&
+          runId == other.runId &&
+          changed == other.changed &&
+          rescheduledTxCount == other.rescheduledTxCount &&
+          needsSignatureCount == other.needsSignatureCount;
 }
 
 class MigrationScheduledBroadcast {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1229719647;
+  int get rustContentHash => 1950772100;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -947,6 +947,13 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiSyncRetainProposalLockUntilExpiry({
     required BigInt proposalId,
     required String sendFlowId,
+  });
+
+  Future<MigrationRetimeResult> crateApiSyncRetimeActiveOrchardMigration({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String expectedRunId,
   });
 
   Future<void> crateApiSyncRetireUnbroadcastOrchardMigration({
@@ -6661,6 +6668,45 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<MigrationRetimeResult> crateApiSyncRetimeActiveOrchardMigration({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String expectedRunId,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
+          sse_encode_String(expectedRunId, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 130,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_migration_retime_result,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncRetimeActiveOrchardMigrationConstMeta,
+        argValues: [dbPath, network, accountUuid, expectedRunId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncRetimeActiveOrchardMigrationConstMeta =>
+      const TaskConstMeta(
+        debugName: "retime_active_orchard_migration",
+        argNames: ["dbPath", "network", "accountUuid", "expectedRunId"],
+      );
+
+  @override
   Future<void> crateApiSyncRetireUnbroadcastOrchardMigration({
     required String dbPath,
     required String lightwalletdUrl,
@@ -6680,7 +6726,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6729,7 +6775,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6767,7 +6813,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6822,7 +6868,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 134,
             port: port_,
           );
         },
@@ -6892,7 +6938,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 135,
             port: port_,
           );
         },
@@ -6939,7 +6985,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 136,
           )!;
         },
         codec: SseCodec(
@@ -6974,7 +7020,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 137,
             port: port_,
           );
         },
@@ -7007,7 +7053,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 138,
             port: port_,
           );
         },
@@ -7047,7 +7093,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7088,7 +7134,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7142,7 +7188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7192,7 +7238,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 141,
+              funcId: 142,
               port: port_,
             );
           },
@@ -7233,7 +7279,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 142,
+              funcId: 143,
               port: port_,
             );
           },
@@ -7265,7 +7311,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 144,
           )!;
         },
         codec: SseCodec(
@@ -7306,7 +7352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7357,7 +7403,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
             port: port_,
           );
         },
@@ -7396,7 +7442,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7439,7 +7485,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
             port: port_,
           );
         },
@@ -7489,7 +7535,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7521,7 +7567,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7549,7 +7595,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
           )!;
         },
         codec: SseCodec(
@@ -7581,7 +7627,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7618,7 +7664,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7649,7 +7695,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 154,
           )!;
         },
         codec: SseCodec(
@@ -7680,7 +7726,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
             port: port_,
           );
         },
@@ -8951,6 +8997,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       minedHeight: dco_decode_opt_box_autoadd_u_32(arr[10]),
       confirmationCount: dco_decode_u_32(arr[11]),
       confirmationTarget: dco_decode_u_32(arr[12]),
+    );
+  }
+
+  @protected
+  MigrationRetimeResult dco_decode_migration_retime_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return MigrationRetimeResult(
+      runId: dco_decode_String(arr[0]),
+      changed: dco_decode_bool(arr[1]),
+      rescheduledTxCount: dco_decode_u_32(arr[2]),
+      needsSignatureCount: dco_decode_u_32(arr[3]),
     );
   }
 
@@ -11640,6 +11700,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       minedHeight: var_minedHeight,
       confirmationCount: var_confirmationCount,
       confirmationTarget: var_confirmationTarget,
+    );
+  }
+
+  @protected
+  MigrationRetimeResult sse_decode_migration_retime_result(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_runId = sse_decode_String(deserializer);
+    var var_changed = sse_decode_bool(deserializer);
+    var var_rescheduledTxCount = sse_decode_u_32(deserializer);
+    var var_needsSignatureCount = sse_decode_u_32(deserializer);
+    return MigrationRetimeResult(
+      runId: var_runId,
+      changed: var_changed,
+      rescheduledTxCount: var_rescheduledTxCount,
+      needsSignatureCount: var_needsSignatureCount,
     );
   }
 
@@ -14370,6 +14447,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_box_autoadd_u_32(self.minedHeight, serializer);
     sse_encode_u_32(self.confirmationCount, serializer);
     sse_encode_u_32(self.confirmationTarget, serializer);
+  }
+
+  @protected
+  void sse_encode_migration_retime_result(
+    MigrationRetimeResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.runId, serializer);
+    sse_encode_bool(self.changed, serializer);
+    sse_encode_u_32(self.rescheduledTxCount, serializer);
+    sse_encode_u_32(self.needsSignatureCount, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -478,6 +478,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_migration_preparation_transaction_status(dynamic raw);
 
   @protected
+  MigrationRetimeResult dco_decode_migration_retime_result(dynamic raw);
+
+  @protected
   MigrationScheduledBroadcast dco_decode_migration_scheduled_broadcast(
     dynamic raw,
   );
@@ -1304,6 +1307,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   MigrationPreparationTransactionStatus
   sse_decode_migration_preparation_transaction_status(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  MigrationRetimeResult sse_decode_migration_retime_result(
     SseDeserializer deserializer,
   );
 
@@ -2319,6 +2327,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_migration_preparation_transaction_status(
     MigrationPreparationTransactionStatus self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_migration_retime_result(
+    MigrationRetimeResult self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -480,6 +480,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_migration_preparation_transaction_status(dynamic raw);
 
   @protected
+  MigrationRetimeResult dco_decode_migration_retime_result(dynamic raw);
+
+  @protected
   MigrationScheduledBroadcast dco_decode_migration_scheduled_broadcast(
     dynamic raw,
   );
@@ -1306,6 +1309,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   MigrationPreparationTransactionStatus
   sse_decode_migration_preparation_transaction_status(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  MigrationRetimeResult sse_decode_migration_retime_result(
     SseDeserializer deserializer,
   );
 
@@ -2321,6 +2329,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_migration_preparation_transaction_status(
     MigrationPreparationTransactionStatus self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_migration_retime_result(
+    MigrationRetimeResult self,
     SseSerializer serializer,
   );
 

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -712,6 +712,21 @@ pub struct MigrationScheduledTransfer {
     pub block_offset: u32,
 }
 
+/// Outcome of changing an active legacy migration to the shorter timing
+/// policy. Transactions already submitted to the network are never changed.
+pub struct MigrationRetimeResult {
+    pub run_id: String,
+    /// False when a retry observes that the requested run already uses the
+    /// shorter policy.
+    pub changed: bool,
+    /// Signed transactions that kept their original expiry and were assigned
+    /// a new broadcast height.
+    pub rescheduled_tx_count: u32,
+    /// Remaining transactions whose committed expiry or unsigned schedule
+    /// requires a fresh signature.
+    pub needs_signature_count: u32,
+}
+
 pub struct MigrationOutboxItem {
     /// Stable Swift outbox item identifier. This is the finalized txid.
     pub item_id: String,
@@ -1423,6 +1438,35 @@ pub fn get_orchard_migration_status(
                     confirmation_target: part.confirmation_target,
                 })
                 .collect(),
+        })
+    })
+}
+
+/// Changes one expected active migration from the legacy three-hour transfer
+/// spacing to the 90-minute policy.
+///
+/// The wallet must be fully synced. The operation is atomic, leaves submitted
+/// transactions untouched, and returns an idempotent unchanged result if the
+/// same run was already updated by an earlier call.
+pub fn retime_active_orchard_migration(
+    db_path: String,
+    network: String,
+    account_uuid: String,
+    expected_run_id: String,
+) -> Result<MigrationRetimeResult, String> {
+    catch(|| {
+        let network = parse_network_and_migrate(&db_path, &network)?;
+        wallet_sync::retime_active_orchard_migration(
+            &db_path,
+            network,
+            &account_uuid,
+            &expected_run_id,
+        )
+        .map(|result| MigrationRetimeResult {
+            run_id: result.run_id,
+            changed: result.changed,
+            rescheduled_tx_count: result.rescheduled_tx_count,
+            needs_signature_count: result.needs_signature_count,
         })
     })
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1229719647;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1950772100;
 
 // Section: executor
 
@@ -5182,6 +5182,47 @@ fn wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(
         },
     )
 }
+fn wire__crate__api__sync__retime_active_orchard_migration_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "retime_active_orchard_migration",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_expected_run_id = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::sync::retime_active_orchard_migration(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                        api_expected_run_id,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -8046,6 +8087,22 @@ impl SseDecode for crate::api::sync::MigrationPreparationTransactionStatus {
     }
 }
 
+impl SseDecode for crate::api::sync::MigrationRetimeResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_runId = <String>::sse_decode(deserializer);
+        let mut var_changed = <bool>::sse_decode(deserializer);
+        let mut var_rescheduledTxCount = <u32>::sse_decode(deserializer);
+        let mut var_needsSignatureCount = <u32>::sse_decode(deserializer);
+        return crate::api::sync::MigrationRetimeResult {
+            run_id: var_runId,
+            changed: var_changed,
+            rescheduled_tx_count: var_rescheduledTxCount,
+            needs_signature_count: var_needsSignatureCount,
+        };
+    }
+}
+
 impl SseDecode for crate::api::sync::MigrationScheduledBroadcast {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -9444,27 +9501,28 @@ fn pde_ffi_dispatcher_primary_impl(
 127 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
 128 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
 129 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-145 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__sync__retime_active_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+146 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+148 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -9491,10 +9549,10 @@ fn pde_ffi_dispatcher_sync_impl(
         }
         105 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
         124 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        135 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        143 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        150 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        153 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        136 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        144 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        151 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        154 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -10671,6 +10729,29 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::MigrationPreparationTra
     for crate::api::sync::MigrationPreparationTransactionStatus
 {
     fn into_into_dart(self) -> crate::api::sync::MigrationPreparationTransactionStatus {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sync::MigrationRetimeResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.run_id.into_into_dart().into_dart(),
+            self.changed.into_into_dart().into_dart(),
+            self.rescheduled_tx_count.into_into_dart().into_dart(),
+            self.needs_signature_count.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sync::MigrationRetimeResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::MigrationRetimeResult>
+    for crate::api::sync::MigrationRetimeResult
+{
+    fn into_into_dart(self) -> crate::api::sync::MigrationRetimeResult {
         self
     }
 }
@@ -13162,6 +13243,16 @@ impl SseEncode for crate::api::sync::MigrationPreparationTransactionStatus {
         <Option<u32>>::sse_encode(self.mined_height, serializer);
         <u32>::sse_encode(self.confirmation_count, serializer);
         <u32>::sse_encode(self.confirmation_target, serializer);
+    }
+}
+
+impl SseEncode for crate::api::sync::MigrationRetimeResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.run_id, serializer);
+        <bool>::sse_encode(self.changed, serializer);
+        <u32>::sse_encode(self.rescheduled_tx_count, serializer);
+        <u32>::sse_encode(self.needs_signature_count, serializer);
     }
 }
 

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -618,6 +618,14 @@ pub(crate) struct ActiveRun {
     pub last_error: Option<String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MigrationRetimeResult {
+    pub run_id: String,
+    pub changed: bool,
+    pub rescheduled_tx_count: u32,
+    pub needs_signature_count: u32,
+}
+
 fn timing_policy_for_run_with_conn(
     conn: &rusqlite::Connection,
     run_id: &str,
@@ -697,6 +705,285 @@ fn adopt_timing_policy_for_active_run(
     )
     .map_err(|e| format!("Adopt fast Testnet migration timing: {e}"))?;
     Ok(())
+}
+
+pub(crate) fn retime_active_migration_with_rng<R: RngCore + CryptoRng + ?Sized>(
+    db_path: &str,
+    account_uuid: &str,
+    network: WalletNetwork,
+    expected_run_id: &str,
+    schedule_origin_height: u32,
+    rng: &mut R,
+) -> Result<MigrationRetimeResult, String> {
+    if !matches!(network, WalletNetwork::Main | WalletNetwork::Test) {
+        return Err(
+            "Shorter migration timing is only available on Mainnet and Testnet".to_string(),
+        );
+    }
+
+    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    ensure_schema(&conn)?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| format!("Begin migration timing update: {e}"))?;
+    let run = active_run(&tx, account_uuid, network)?
+        .ok_or("There is no active Ironwood migration for this account")?;
+    if run.run_id != expected_run_id {
+        return Err(
+            "The active Ironwood migration changed before timing could be updated".to_string(),
+        );
+    }
+
+    let current_policy = timing_policy_for_run_with_conn(&tx, &run.run_id, network)?;
+    if current_policy == MigrationTimingPolicy::Standard90Minutes {
+        tx.commit()
+            .map_err(|e| format!("Close unchanged migration timing update: {e}"))?;
+        return Ok(MigrationRetimeResult {
+            run_id: run.run_id,
+            changed: false,
+            rescheduled_tx_count: 0,
+            needs_signature_count: 0,
+        });
+    }
+    if current_policy != MigrationTimingPolicy::Standard {
+        return Err("This migration does not use the legacy timing policy".to_string());
+    }
+
+    let old_schedule_json = tx
+        .query_row(
+            &format!("SELECT schedule_json FROM {RUNS_TABLE} WHERE run_id = ?1"),
+            params![run.run_id],
+            |row| row.get::<_, String>(0),
+        )
+        .map_err(|e| format!("Read migration schedule before timing update: {e}"))?;
+    let old_schedule =
+        serde_json::from_str::<Vec<MigrationScheduleEntry>>(&old_schedule_json).unwrap_or_default();
+    let old_order = old_schedule
+        .iter()
+        .enumerate()
+        .filter_map(|(order, entry)| entry.part_index.map(|part_index| (part_index, order)))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut immutable_stmt = tx
+        .prepare_cached(&format!(
+            "SELECT part_index FROM {PENDING_TXS_TABLE}
+             WHERE run_id = ?1 AND status IN ('broadcasted', 'confirmed')"
+        ))
+        .map_err(|e| format!("Prepare immutable migration part query: {e}"))?;
+    let immutable_parts = immutable_stmt
+        .query_map(params![run.run_id], |row| row.get::<_, Option<u32>>(0))
+        .map_err(|e| format!("Query immutable migration parts: {e}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Read immutable migration parts: {e}"))?
+        .into_iter()
+        .map(|part_index| {
+            part_index.ok_or_else(|| {
+                "A submitted migration transaction is missing its part index".to_string()
+            })
+        })
+        .collect::<Result<BTreeSet<_>, _>>()?;
+    drop(immutable_stmt);
+
+    let mut immutable_entries = immutable_parts
+        .iter()
+        .map(|part_index| {
+            let value_zatoshi = run
+                .target_values_zatoshi
+                .get(*part_index as usize)
+                .copied()
+                .ok_or("A submitted migration part is outside the approved target list")?;
+            Ok((
+                old_order.get(part_index).copied().unwrap_or(usize::MAX),
+                MigrationScheduleEntry {
+                    part_index: Some(*part_index),
+                    value_zatoshi,
+                    block_offset: 0,
+                },
+            ))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    immutable_entries.sort_by_key(|(order, entry)| (*order, entry.part_index));
+
+    let remaining_parts = run
+        .target_values_zatoshi
+        .iter()
+        .copied()
+        .enumerate()
+        .filter_map(|(part_index, value_zatoshi)| {
+            let part_index = u32::try_from(part_index).ok()?;
+            (!immutable_parts.contains(&part_index)).then_some((part_index, value_zatoshi))
+        });
+    let mut schedule = immutable_entries
+        .into_iter()
+        .map(|(_, entry)| entry)
+        .collect::<Vec<_>>();
+    schedule.extend(planned_transfer_schedule_for_parts_with_policy(
+        remaining_parts,
+        network,
+        MigrationTimingPolicy::Standard90Minutes,
+        rng,
+    ));
+    validate_schedule_with_policy(
+        &schedule,
+        &run.target_values_zatoshi,
+        network,
+        MigrationTimingPolicy::Standard90Minutes,
+    )?;
+    let schedule_json = serde_json::to_string(&schedule)
+        .map_err(|e| format!("Encode shortened migration schedule: {e}"))?;
+    let offsets_by_part = schedule
+        .iter()
+        .filter_map(|entry| {
+            entry
+                .part_index
+                .map(|part_index| (part_index, entry.block_offset))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    let mut pending_stmt = tx
+        .prepare_cached(&format!(
+            "SELECT txid_hex, part_index, expiry_height, status
+             FROM {PENDING_TXS_TABLE}
+             WHERE run_id = ?1 AND status IN ('scheduled', 'needs_resign')"
+        ))
+        .map_err(|e| format!("Prepare migration transactions for timing update: {e}"))?;
+    let pending = pending_stmt
+        .query_map(params![run.run_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<u32>>(1)?,
+                row.get::<_, u32>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .map_err(|e| format!("Query migration transactions for timing update: {e}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Read migration transactions for timing update: {e}"))?;
+    drop(pending_stmt);
+
+    let now = now_ms()?;
+    let mut rescheduled_tx_count = 0u32;
+    for (txid_hex, part_index, expiry_height, status) in pending {
+        let part_index = part_index
+            .ok_or_else(|| format!("Migration transaction {txid_hex} is missing its part index"))?;
+        let block_offset = offsets_by_part
+            .get(&part_index)
+            .copied()
+            .ok_or("The shortened migration schedule is missing a pending part")?;
+        let scheduled_height = schedule_origin_height
+            .checked_add(block_offset)
+            .ok_or("Shortened migration scheduled height overflow")?;
+        let scheduled_at_ms = now
+            .checked_add(i64::from(block_offset).saturating_mul(1000))
+            .ok_or("Shortened migration scheduled time overflow")?;
+        let remains_valid = status == "scheduled"
+            && zip318_canonical_migration_expiry_height(scheduled_height)? == expiry_height;
+        if remains_valid {
+            tx.execute(
+                &format!(
+                    "UPDATE {PENDING_TXS_TABLE}
+                     SET scheduled_height = ?1, schedule_start_height = ?2,
+                         scheduled_at_ms = ?3
+                     WHERE run_id = ?4 AND txid_hex = ?5 AND status = 'scheduled'"
+                ),
+                params![
+                    scheduled_height,
+                    schedule_origin_height,
+                    scheduled_at_ms,
+                    run.run_id,
+                    txid_hex,
+                ],
+            )
+            .map_err(|e| format!("Apply shortened migration transaction timing: {e}"))?;
+            rescheduled_tx_count = rescheduled_tx_count
+                .checked_add(1)
+                .ok_or("Shortened migration transaction count overflow")?;
+        } else {
+            tx.execute(
+                &format!(
+                    "UPDATE {PENDING_TXS_TABLE}
+                     SET status = 'needs_resign', scheduled_height = ?1,
+                         schedule_start_height = ?2, scheduled_at_ms = ?3
+                     WHERE run_id = ?4 AND txid_hex = ?5
+                       AND status IN ('scheduled', 'needs_resign')"
+                ),
+                params![
+                    scheduled_height,
+                    schedule_origin_height,
+                    scheduled_at_ms,
+                    run.run_id,
+                    txid_hex,
+                ],
+            )
+            .map_err(|e| format!("Require a fresh migration signature after timing update: {e}"))?;
+        }
+    }
+
+    let invalidated_signed_children = tx
+        .execute(
+            &format!(
+                "DELETE FROM {SIGNED_CHILD_PCZTS_TABLE}
+                 WHERE run_id = ?1
+                   AND child_index NOT IN (
+                       SELECT part_index FROM {PENDING_TXS_TABLE}
+                       WHERE run_id = ?1 AND part_index IS NOT NULL
+                   )"
+            ),
+            params![run.run_id],
+        )
+        .map_err(|e| format!("Invalidate unsigned-schedule migration signatures: {e}"))?;
+    let pending_needs_signature = count_pending_with_status(&tx, &run.run_id, "needs_resign")?;
+    let invalidated_signed_children = u32::try_from(invalidated_signed_children)
+        .map_err(|_| "Invalidated migration signature count overflow".to_string())?;
+    let needs_signature_count = pending_needs_signature
+        .checked_add(invalidated_signed_children)
+        .ok_or("Migration signature count overflow")?;
+    let phase = if needs_signature_count > 0 {
+        PHASE_READY_TO_MIGRATE
+    } else {
+        run.phase.as_str()
+    };
+    let message = (needs_signature_count > 0).then(|| {
+        format!(
+            "Migration timing was shortened. {needs_signature_count} remaining transaction(s) need fresh signatures."
+        )
+    });
+    let updated = tx
+        .execute(
+            &format!(
+                "UPDATE {RUNS_TABLE}
+                 SET timing_policy = ?1, schedule_json = ?2,
+                     signed_schedule_origin_height = ?3, phase = ?4,
+                     proof_retry_height = CASE WHEN ?5 > 0 THEN NULL ELSE proof_retry_height END,
+                     updated_at_ms = ?6, last_error = ?7
+                 WHERE run_id = ?8 AND account_uuid = ?9 AND network = ?10
+                   AND timing_policy = 'standard'"
+            ),
+            params![
+                MigrationTimingPolicy::Standard90Minutes.as_str(),
+                schedule_json,
+                schedule_origin_height,
+                phase,
+                needs_signature_count,
+                now,
+                message,
+                run.run_id,
+                account_uuid,
+                network_name(network),
+            ],
+        )
+        .map_err(|e| format!("Save shortened migration timing: {e}"))?;
+    if updated != 1 {
+        return Err("The active migration changed while timing was being updated".to_string());
+    }
+    tx.commit()
+        .map_err(|e| format!("Commit shortened migration timing: {e}"))?;
+    Ok(MigrationRetimeResult {
+        run_id: run.run_id,
+        changed: true,
+        rescheduled_tx_count,
+        needs_signature_count,
+    })
 }
 
 pub(crate) fn active_migration_run(

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -2761,6 +2761,267 @@ fn ninety_minute_schedule_samples_the_truncated_distribution() {
 }
 
 #[test]
+fn active_migration_retime_preserves_submitted_parts_and_invalidates_expiry_changes() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let values = [100, 200, 300, 400];
+    let schedule_origin = 1_000;
+    let mut expected_rng = StdRng::seed_from_u64(0x90_318);
+    let expected_remaining = planned_transfer_schedule_for_parts_with_policy(
+        [(1, 200), (2, 300), (3, 400)],
+        WalletNetwork::Main,
+        MigrationTimingPolicy::Standard90Minutes,
+        &mut expected_rng,
+    );
+    let expected_heights = expected_remaining
+        .iter()
+        .map(|entry| {
+            (
+                entry.part_index.unwrap(),
+                schedule_origin + entry.block_offset,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let reusable_expiry = zip318_canonical_migration_expiry_height(expected_heights[&1]).unwrap();
+    let crossing_expiry = zip318_canonical_migration_expiry_height(expected_heights[&2]).unwrap()
+        + ZIP318_EXPIRY_MODULUS;
+
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    ensure_schema(&conn).unwrap();
+    let old_schedule = values
+        .iter()
+        .enumerate()
+        .map(|(part_index, value_zatoshi)| MigrationScheduleEntry {
+            part_index: Some(part_index as u32),
+            value_zatoshi: *value_zatoshi,
+            block_offset: (part_index as u32 + 1) * ZIP318_TRANSFER_MEAN_DELAY_BLOCKS,
+        })
+        .collect::<Vec<_>>();
+    conn.execute(
+        &format!(
+            "INSERT INTO {RUNS_TABLE}
+             (run_id, account_uuid, network, db_fingerprint, phase,
+              created_at_ms, updated_at_ms, target_values_json, schedule_json,
+              timing_policy, signed_schedule_origin_height)
+             VALUES ('run-1', 'account-1', 'main', ?1, ?2, 1, 1, ?3, ?4,
+                     'standard', 10)"
+        ),
+        params![
+            db_path,
+            PHASE_BROADCAST_SCHEDULED,
+            serde_json::to_string(&values).unwrap(),
+            serde_json::to_string(&old_schedule).unwrap(),
+        ],
+    )
+    .unwrap();
+    for (part_index, status, scheduled_height, schedule_start_height, expiry_height) in [
+        (0, "confirmed", 50, 20, 69_120),
+        (1, "scheduled", 200, 10, reusable_expiry),
+        (
+            2,
+            "scheduled",
+            ZIP318_EXPIRY_MODULUS + 10,
+            10,
+            crossing_expiry,
+        ),
+    ] {
+        conn.execute(
+            &format!(
+                "INSERT INTO {PENDING_TXS_TABLE}
+                 (run_id, txid_hex, part_index, encrypted_raw_tx, target_height,
+                  expiry_height, value_zatoshi, fee_zatoshi, selected_note_txid,
+                  selected_note_output_index, selected_note_value, scheduled_at_ms,
+                  schedule_start_height, scheduled_height, original_scheduled_height,
+                  status, metadata_json)
+                 VALUES ('run-1', ?1, ?2, 'ciphertext', 11, ?3, ?4, 1, ?5,
+                         0, ?4, 1, ?6, ?7, ?7, ?8, '{{}}')"
+            ),
+            params![
+                format!("{part_index:064x}"),
+                part_index,
+                expiry_height,
+                values[part_index as usize],
+                format!("{:064x}", part_index + 100),
+                schedule_start_height,
+                scheduled_height,
+                status,
+            ],
+        )
+        .unwrap();
+    }
+    for child_index in [2u32, 3] {
+        conn.execute(
+            &format!(
+                "INSERT INTO {SIGNED_CHILD_PCZTS_TABLE}
+                 (run_id, message_id, child_index, encrypted_base_pczt,
+                  encrypted_compact_sigs, target_height, expiry_height,
+                  scheduled_height, value_zatoshi, fee_zatoshi,
+                  selected_note_json, metadata_json)
+                 VALUES ('run-1', ?1, ?2, 'base', 'sigs', 11, 69120, 12,
+                         ?3, 1, '{{}}', '{{}}')"
+            ),
+            params![
+                format!("migration-{}", child_index + 1),
+                child_index,
+                values[child_index as usize],
+            ],
+        )
+        .unwrap();
+    }
+    drop(conn);
+
+    let mut rng = StdRng::seed_from_u64(0x90_318);
+    let result = retime_active_migration_with_rng(
+        &db_path,
+        "account-1",
+        WalletNetwork::Main,
+        "run-1",
+        schedule_origin,
+        &mut rng,
+    )
+    .unwrap();
+    assert_eq!(
+        result,
+        MigrationRetimeResult {
+            run_id: "run-1".to_string(),
+            changed: true,
+            rescheduled_tx_count: 1,
+            needs_signature_count: 2,
+        }
+    );
+
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let run_state = conn
+        .query_row(
+            &format!(
+                "SELECT timing_policy, phase, signed_schedule_origin_height, schedule_json
+                 FROM {RUNS_TABLE} WHERE run_id = 'run-1'"
+            ),
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, u32>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(run_state.0, "standard_90m");
+    assert_eq!(run_state.1, PHASE_READY_TO_MIGRATE);
+    assert_eq!(run_state.2, schedule_origin);
+    let shortened_schedule: Vec<MigrationScheduleEntry> =
+        serde_json::from_str(&run_state.3).unwrap();
+    validate_schedule_with_policy(
+        &shortened_schedule,
+        &values,
+        WalletNetwork::Main,
+        MigrationTimingPolicy::Standard90Minutes,
+    )
+    .unwrap();
+    assert_eq!(shortened_schedule[0].part_index, Some(0));
+    assert_eq!(shortened_schedule[0].block_offset, 0);
+
+    let pending = [0u32, 1, 2].map(|part_index| {
+        conn.query_row(
+            &format!(
+                "SELECT status, scheduled_height, schedule_start_height
+                     FROM {PENDING_TXS_TABLE}
+                     WHERE run_id = 'run-1' AND part_index = ?1"
+            ),
+            params![part_index],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, u32>(1)?,
+                    row.get::<_, u32>(2)?,
+                ))
+            },
+        )
+        .unwrap()
+    });
+    assert_eq!(pending[0], ("confirmed".to_string(), 50, 20));
+    assert_eq!(
+        pending[1],
+        (
+            "scheduled".to_string(),
+            expected_heights[&1],
+            schedule_origin,
+        )
+    );
+    assert_eq!(
+        pending[2],
+        (
+            "needs_resign".to_string(),
+            expected_heights[&2],
+            schedule_origin,
+        )
+    );
+    let remaining_signed_children: Vec<u32> = conn
+        .prepare(&format!(
+            "SELECT child_index FROM {SIGNED_CHILD_PCZTS_TABLE}
+             WHERE run_id = 'run-1' ORDER BY child_index"
+        ))
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(remaining_signed_children, vec![2]);
+    drop(conn);
+
+    let mut retry_rng = StdRng::seed_from_u64(0xdead_beef);
+    let retry = retime_active_migration_with_rng(
+        &db_path,
+        "account-1",
+        WalletNetwork::Main,
+        "run-1",
+        schedule_origin + 10,
+        &mut retry_rng,
+    )
+    .unwrap();
+    assert!(!retry.changed);
+}
+
+#[test]
+fn active_migration_retime_rejects_a_stale_run_without_mutating_policy() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    ensure_schema(&conn).unwrap();
+    conn.execute(
+        &format!(
+            "INSERT INTO {RUNS_TABLE}
+             (run_id, account_uuid, network, db_fingerprint, phase,
+              created_at_ms, updated_at_ms, target_values_json, schedule_json)
+             VALUES ('run-current', 'account-1', 'main', ?1, ?2, 1, 1,
+                     '[100]', '[{{\"part_index\":0,\"value_zatoshi\":100,\"block_offset\":144}}]')"
+        ),
+        params![db_path, PHASE_READY_TO_MIGRATE],
+    )
+    .unwrap();
+    drop(conn);
+
+    let error = retime_active_migration_with_rng(
+        &db_path,
+        "account-1",
+        WalletNetwork::Main,
+        "run-stale",
+        1_000,
+        &mut StdRng::seed_from_u64(1),
+    )
+    .unwrap_err();
+    assert!(error.contains("changed before timing could be updated"));
+    assert_eq!(
+        timing_policy_for_run(&db_path, "run-current", WalletNetwork::Main).unwrap(),
+        MigrationTimingPolicy::Standard,
+    );
+}
+
+#[test]
 fn fast_testnet_uses_accelerated_schedule_and_anchor_timing() {
     assert_eq!(
         schedule_parameters_with_policy(WalletNetwork::Regtest, MigrationTimingPolicy::FastTestnet,),

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -63,8 +63,9 @@ pub(crate) use send::{
     orchard_migration_proof_readiness, orchard_migration_proof_readiness_at_scanned_height,
     prepare_orchard_migration_batch_pczt, prepare_orchard_migration_denominations_pczt,
     prepare_orchard_migration_immediate_pczt, prepare_orchard_migration_single_qr_pczt,
-    retain_prepared_note_anchor_checkpoints_after_scan, retire_unbroadcast_orchard_migration,
-    KeystoneSignedMigrationMessage, OrchardMigrationImmediatePlan,
+    retain_prepared_note_anchor_checkpoints_after_scan, retime_active_orchard_migration,
+    retire_unbroadcast_orchard_migration, KeystoneSignedMigrationMessage,
+    OrchardMigrationImmediatePlan,
 };
 pub use send::{
     broadcast_due_orchard_migration_transactions, broadcast_one_due_orchard_migration_transaction,

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -2807,6 +2807,36 @@ struct ActiveIronwoodMigration {
     key: String,
 }
 
+pub(crate) fn retime_active_orchard_migration(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    expected_run_id: &str,
+) -> Result<super::migration::MigrationRetimeResult, String> {
+    let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
+    let progress = super::get_sync_progress(db_path, network)?;
+    let scanned_height = u32::try_from(progress.scanned_height)
+        .map_err(|_| "Migration scanned height exceeds u32".to_string())?;
+    let chain_tip_height = u32::try_from(progress.chain_tip_height)
+        .map_err(|_| "Migration chain tip exceeds u32".to_string())?;
+    if scanned_height < chain_tip_height {
+        return Err("Sync the wallet before shortening migration timing".to_string());
+    }
+    if scanned_height == 0 {
+        return Err("Wallet must sync before shortening migration timing".to_string());
+    }
+    with_wallet_db_write_lock("send.migration.retime_active", || {
+        super::migration::retime_active_migration_with_rng(
+            db_path,
+            account_uuid,
+            network,
+            expected_run_id,
+            scanned_height,
+            &mut OsRng,
+        )
+    })
+}
+
 impl ActiveIronwoodMigration {
     fn acquire(db_path: &str, account_uuid: &str) -> Result<Self, String> {
         let key = format!("{db_path}:{account_uuid}");

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -3076,6 +3076,100 @@ void main() {
     expect(find.text('Migration schedule unavailable'), findsNothing);
   });
 
+  testWidgets('migration schedule confirms and applies shorter timing', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1440, 900);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    var shortened = false;
+    var retimeCalls = 0;
+    Future<rust_sync.MigrationStatus> getStatus({
+      required String dbPath,
+      required String network,
+      required String accountUuid,
+    }) async => _migrationStatus(
+      phase: kIronwoodMigrationBroadcastScheduledPhase,
+      activeRunId: 'run-1',
+      scheduleMeanDelayBlocks: shortened ? 72 : 144,
+      targetValuesZatoshi: const [10_000_000],
+      totalCount: 1,
+      parts: [
+        _migrationPart(0, 10_000_000, rust_sync.MigrationPartState.scheduled),
+      ],
+    );
+    final service = IronwoodMigrationService(
+      getWalletDbPath: () async => '/tmp/wallet.db',
+      getStatus: getStatus,
+      getPrivatePlan:
+          ({required dbPath, required network, required accountUuid}) async =>
+              null,
+      secureStore: AppSecureStore.testing(
+        storage: const FlutterSecureStorage(),
+      ),
+      getEndpoint: () => defaultRpcEndpointConfig('main'),
+      isIOS: () => false,
+      isAndroid: () => false,
+      quiesceMigrationWork: () async {},
+      resumeMigrationWork: () async {},
+      retimeActiveMigration:
+          ({
+            required dbPath,
+            required network,
+            required accountUuid,
+            required expectedRunId,
+          }) async {
+            retimeCalls++;
+            shortened = true;
+            return const rust_sync.MigrationRetimeResult(
+              runId: 'run-1',
+              changed: true,
+              rescheduledTxCount: 1,
+              needsSignatureCount: 0,
+            );
+          },
+    );
+    final initialStatus = await getStatus(
+      dbPath: '/tmp/wallet.db',
+      network: 'main',
+      accountUuid: 'account-1',
+    );
+    await tester.pumpWidget(
+      _migrationEntryHarness(
+        ctaState: IronwoodHomeMigrationCtaState.resume(
+          network: 'main',
+          accountUuid: 'account-1',
+          status: initialStatus,
+        ),
+        initialLocation: '/migration/private/schedule',
+        statusGetter: getStatus,
+        migrationService: service,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey('ironwood_migration_use_shorter_timing')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Use shorter timing?'), findsOneWidget);
+    expect(retimeCalls, 0);
+
+    await tester.tap(
+      find.byKey(const ValueKey('ironwood_migration_confirm_shorter_timing')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(retimeCalls, 1);
+    expect(find.text('Migration timing updated.'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('ironwood_migration_use_shorter_timing')),
+      findsNothing,
+    );
+  });
+
   testWidgets(
     'migration schedule uses the authoritative anchor-aware completion height',
     (tester) async {
@@ -4653,6 +4747,7 @@ rust_sync.MigrationStatus _migrationStatus({
   List<int>? nextProofWindowPartIndices,
   int? estimatedCompletionHeight,
   int? preparationMeanDelayBlocks,
+  int scheduleMeanDelayBlocks = 144,
   bool? proofReady,
   List<int>? currentSigningPartIndices,
   List<rust_sync.MigrationScheduledBroadcast> scheduledBroadcasts = const [],
@@ -4678,7 +4773,7 @@ rust_sync.MigrationStatus _migrationStatus({
     pendingSplitStageCount: pendingSplitStageCount,
     canAbandon: false,
     signingBatchLimit: 35,
-    scheduleMeanDelayBlocks: 144,
+    scheduleMeanDelayBlocks: scheduleMeanDelayBlocks,
     scheduleMaxDelayBlocks: 576,
     nextActionHeight: nextActionHeight,
     nextProofWindowHeight: nextProofWindowHeight,

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -4580,6 +4580,153 @@ void main() {
       ]);
     },
   );
+
+  test(
+    'shorter timing pauses delivery, redraws, and stages the replacement batch',
+    () async {
+      final events = <String>[];
+      var shortened = false;
+      final service = await _retimeService(
+        events: events,
+        getStatus:
+            ({required dbPath, required network, required accountUuid}) async =>
+                _migrationStatus(
+                  phase: 'broadcast_scheduled',
+                  activeRunId: 'run-1',
+                  scheduleMeanDelayBlocks: shortened ? 72 : 144,
+                  parts: [_migrationPart(txidHex: 'tx-1')],
+                  scheduledBroadcasts: [_scheduledBroadcast(txidHex: 'tx-1')],
+                ),
+        onRetime: () => shortened = true,
+      );
+
+      final result = await service.shortenActiveMigrationTiming(
+        network: 'test',
+        accountUuid: 'account-1',
+        expectedRunId: 'run-1',
+      );
+
+      expect(result.changed, isTrue);
+      expect(result.rescheduledTxCount, 1);
+      expect(events, [
+        'quiesce',
+        'receipts',
+        'discard',
+        'retime',
+        'export',
+        'stage',
+        'arm',
+        'resume',
+      ]);
+    },
+  );
+
+  test(
+    'shorter timing refuses an unreconciled accepted receipt before mutation',
+    () async {
+      final events = <String>[];
+      final service = await _retimeService(
+        events: events,
+        getStatus:
+            ({required dbPath, required network, required accountUuid}) async =>
+                _migrationStatus(
+                  phase: 'broadcast_scheduled',
+                  activeRunId: 'run-1',
+                  parts: [_migrationPart(txidHex: 'tx-1')],
+                  scheduledBroadcasts: [_scheduledBroadcast(txidHex: 'tx-1')],
+                ),
+        receipts: const [
+          {'network': 'test', 'accountUuid': 'account-1'},
+        ],
+      );
+
+      await expectLater(
+        service.shortenActiveMigrationTiming(
+          network: 'test',
+          accountUuid: 'account-1',
+          expectedRunId: 'run-1',
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('could not be reconciled'),
+          ),
+        ),
+      );
+      expect(events, ['quiesce', 'receipts', 'resume']);
+    },
+  );
+
+  test(
+    'shorter timing refuses a native batch with uncertain delivery state',
+    () async {
+      final events = <String>[];
+      final service = await _retimeService(
+        events: events,
+        getStatus:
+            ({required dbPath, required network, required accountUuid}) async =>
+                _migrationStatus(
+                  phase: 'broadcast_scheduled',
+                  activeRunId: 'run-1',
+                  parts: [_migrationPart(txidHex: 'tx-1')],
+                  scheduledBroadcasts: [_scheduledBroadcast(txidHex: 'tx-1')],
+                ),
+        discardError: PlatformException(code: 'outbox_item_submitting'),
+      );
+
+      await expectLater(
+        service.shortenActiveMigrationTiming(
+          network: 'test',
+          accountUuid: 'account-1',
+          expectedRunId: 'run-1',
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('still being submitted'),
+          ),
+        ),
+      );
+      expect(events, ['quiesce', 'receipts', 'discard', 'resume']);
+    },
+  );
+
+  test('failed shorter timing mutation restores the original outbox', () async {
+    final events = <String>[];
+    final service = await _retimeService(
+      events: events,
+      getStatus:
+          ({required dbPath, required network, required accountUuid}) async =>
+              _migrationStatus(
+                phase: 'broadcast_scheduled',
+                activeRunId: 'run-1',
+                parts: [_migrationPart(txidHex: 'tx-1')],
+                scheduledBroadcasts: [_scheduledBroadcast(txidHex: 'tx-1')],
+              ),
+      retimeError: StateError('database busy'),
+    );
+
+    await expectLater(
+      service.shortenActiveMigrationTiming(
+        network: 'test',
+        accountUuid: 'account-1',
+        expectedRunId: 'run-1',
+      ),
+      throwsA(isA<StateError>()),
+    );
+    expect(events, [
+      'quiesce',
+      'receipts',
+      'discard',
+      'retime',
+      'export',
+      'stage',
+      'arm',
+      'resume',
+    ]);
+  });
 }
 
 rust_sync.MigrationStatus _migrationStatus({
@@ -4588,6 +4735,7 @@ rust_sync.MigrationStatus _migrationStatus({
   int broadcastedTxCount = 0,
   bool? proofReady,
   int? nextActionHeight,
+  int scheduleMeanDelayBlocks = 144,
   List<rust_sync.MigrationPartStatus> parts = const [],
   List<rust_sync.MigrationScheduledBroadcast> scheduledBroadcasts = const [],
 }) {
@@ -4608,7 +4756,7 @@ rust_sync.MigrationStatus _migrationStatus({
     pendingSplitStageCount: 0,
     canAbandon: false,
     signingBatchLimit: 35,
-    scheduleMeanDelayBlocks: 144,
+    scheduleMeanDelayBlocks: scheduleMeanDelayBlocks,
     scheduleMaxDelayBlocks: 576,
     nextActionHeight: nextActionHeight,
     proofReady: proofReady,
@@ -4647,6 +4795,78 @@ RpcEndpointConfig _testEndpoint() => const RpcEndpointConfig(
   networkName: 'test',
   lightwalletdUrl: 'https://lwd.example:443',
 );
+
+Future<IronwoodMigrationService> _retimeService({
+  required List<String> events,
+  required IronwoodMigrationStatusGetter getStatus,
+  List<Map<Object?, Object?>> receipts = const [],
+  Object? discardError,
+  Object? retimeError,
+  void Function()? onRetime,
+}) async {
+  final store = await _boundBackgroundCredentialStore();
+  return IronwoodMigrationService(
+    getWalletDbPath: () async => '/tmp/wallet.db',
+    getStatus: getStatus,
+    getPrivatePlan:
+        ({required dbPath, required network, required accountUuid}) async =>
+            null,
+    secureStore: AppSecureStore.testing(storage: const FlutterSecureStorage()),
+    backgroundCredentialStore: store,
+    getEndpoint: _testEndpoint,
+    isMobile: () => true,
+    isIOS: () => true,
+    isAndroid: () => false,
+    quiesceMigrationWork: () async => events.add('quiesce'),
+    resumeMigrationWork: () async => events.add('resume'),
+    listMigrationOutboxReceipts: () async {
+      events.add('receipts');
+      return receipts;
+    },
+    discardMigrationOutboxBatch: ({required batchId}) async {
+      events.add('discard');
+      if (discardError != null) throw discardError;
+      return true;
+    },
+    retimeActiveMigration:
+        ({
+          required dbPath,
+          required network,
+          required accountUuid,
+          required expectedRunId,
+        }) async {
+          events.add('retime');
+          if (retimeError != null) throw retimeError;
+          onRetime?.call();
+          return const rust_sync.MigrationRetimeResult(
+            runId: 'run-1',
+            changed: true,
+            rescheduledTxCount: 1,
+            needsSignatureCount: 0,
+          );
+        },
+    exportMigrationOutbox:
+        ({
+          required dbPath,
+          required network,
+          required accountUuid,
+          required password,
+          required saltBase64,
+        }) async {
+          events.add('export');
+          return _outboxBatch(txids: ['tx-1']);
+        },
+    stageMigrationOutboxBatch: (payload) async {
+      events.add('stage');
+      return {'tx-1': 'digest-1'};
+    },
+    armMigrationOutboxBatch:
+        ({required batchId, required expectedDigests}) async {
+          events.add('arm');
+          return true;
+        },
+  );
+}
 
 IronwoodMigrationService _notificationAuthorizationService({
   required bool isIOS,

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -425,6 +425,7 @@ rust_sync.MigrationStatus _status({
   int pendingTxCount = 2,
   int signedChildPcztCount = 0,
   int pendingSplitStageCount = 2,
+  int scheduleMeanDelayBlocks = 144,
   String? message,
   List<rust_sync.MigrationScheduledBroadcast>? scheduledBroadcasts,
 }) {
@@ -445,7 +446,7 @@ rust_sync.MigrationStatus _status({
     pendingSplitStageCount: pendingSplitStageCount,
     canAbandon: false,
     signingBatchLimit: 12,
-    scheduleMeanDelayBlocks: 144,
+    scheduleMeanDelayBlocks: scheduleMeanDelayBlocks,
     scheduleMaxDelayBlocks: 576,
     nextActionHeight: nextActionHeight,
     proofReady: proofReady,
@@ -860,6 +861,7 @@ IronwoodMigrationService _migrationService({
     List<rust_sync.MigrationScheduledTransfer> approvedSchedule,
   )?
   onCreatePrivateDraft,
+  IronwoodMigrationRetimer? onRetime,
 }) {
   return IronwoodMigrationService(
     getWalletDbPath: () async => '/tmp/wallet.db',
@@ -883,6 +885,9 @@ IronwoodMigrationService _migrationService({
     // iOS outbox credential contract. Credential behavior has dedicated
     // service tests.
     isMobile: () => false,
+    quiesceMigrationWork: () async {},
+    resumeMigrationWork: () async {},
+    retimeActiveMigration: onRetime,
     supportsBackgroundMigration: () => true,
     getNotificationAuthorizationStatus:
         getNotificationAuthorizationStatus ??
@@ -2626,6 +2631,72 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(continueCount, greaterThanOrEqualTo(1));
+  });
+
+  testWidgets('mobile migration status applies shorter timing', (tester) async {
+    _useMobileViewport(tester);
+
+    var shortened = false;
+    var retimeCalls = 0;
+    rust_sync.MigrationStatus currentStatus() => _status(
+      phase: kIronwoodMigrationBroadcastScheduledPhase,
+      scheduleMeanDelayBlocks: shortened ? 72 : 144,
+      pendingTxCount: 1,
+    );
+    final service = _migrationService(
+      onGetStatus: () async => currentStatus(),
+      onRetime:
+          ({
+            required dbPath,
+            required network,
+            required accountUuid,
+            required expectedRunId,
+          }) async {
+            retimeCalls++;
+            shortened = true;
+            return const rust_sync.MigrationRetimeResult(
+              runId: 'run-1',
+              changed: true,
+              rescheduledTxCount: 1,
+              needsSignatureCount: 0,
+            );
+          },
+    );
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: service,
+        status: currentStatus(),
+        statusLoader: () async => currentStatus(),
+        ctaBuilder: () => IronwoodHomeMigrationCtaState.resume(
+          network: 'main',
+          accountUuid: 'account-1',
+          status: currentStatus(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final action = find.byKey(
+      const ValueKey('mobile_ironwood_migration_use_shorter_timing'),
+    );
+    await tester.ensureVisible(action);
+    await tester.pumpAndSettle();
+    expect(action, findsOneWidget);
+
+    await tester.tap(action);
+    await tester.pumpAndSettle();
+    expect(find.text('Use shorter timing?'), findsOneWidget);
+    expect(retimeCalls, 0);
+
+    await tester.tap(
+      find.byKey(const ValueKey('ironwood_migration_confirm_shorter_timing')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(retimeCalls, 1);
+    expect(find.text('Migration timing updated.'), findsOneWidget);
+    expect(action, findsNothing);
   });
 
   testWidgets('keeps migration status actions reachable on compact screens', (


### PR DESCRIPTION
Adds an opt-in “Use shorter timing” action on desktop and mobile for legacy active migrations, backed by an atomic Rust retiming API. The change redraws only unsubmitted work under the 90-minute policy while leaving submitted transactions untouched.

Before mutation, iOS background delivery is paused, accepted receipts are reconciled, and uncertain submissions fail closed. Existing signed transactions are reused only when their canonical ZIP 318 expiry remains valid; otherwise Vizor requests a fresh signature. This PR is stacked on the shorter migration timing branch.