### PR TITLE
Prevent startup sync from hanging on stalled UTXO streams

### DIFF
--- a/integration_test/regtest_sync_startup_stall_recovery_test.dart
+++ b/integration_test/regtest_sync_startup_stall_recovery_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import 'support/desktop_regtest_flow.dart';
+import 'support/regtest_lightwalletd_proxy.dart';
+
+const _fallbackToast =
+    'Selected endpoint is unstable. Switched to fallback endpoint.';
+const _networkFailure =
+    "Network connection lost. We'll keep trying automatically.";
+const _endpointFailure =
+    'Cannot reach the configured Zcash endpoint. Check your endpoint settings.';
+const _genericFailure = 'Sync failed. Retry sync to continue.';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  testWidgets(
+    'recovers from a stalled startup UTXO stream instead of staying at zero percent',
+    (tester) async {
+      await cleanupDesktopRegtestWallet();
+      final proxy = RegtestLightwalletdProxy(log: e2eLog);
+      await proxy.start();
+      // Keep later scanning minimal while retaining a persisted completed tip.
+      proxy.setSlowHeight(1);
+      proxy.serveEmptyGenesisTreeState();
+      addTearDown(() async {
+        proxy.releaseStalledAddressUtxosStream();
+        try {
+          await cleanupDesktopRegtestWallet();
+        } finally {
+          await proxy.stop();
+        }
+      });
+
+      final storage = AppSecureStore.instance;
+      await storage.writePlain(kRpcEndpointUrlKey, proxy.url);
+      await storage.writePlain(
+        kRpcEndpointPresetKey,
+        kCustomRpcEndpointPresetId,
+      );
+
+      e2eLog('pumping app with a custom endpoint proxy');
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+
+      await tapAppButton(
+        tester,
+        const ValueKey('welcome_import_wallet_button'),
+      );
+      await enterAppText(
+        tester,
+        const ValueKey('import_mnemonic_first_word_field'),
+        desktopRegtestMnemonic,
+      );
+      await tapAppButton(tester, const ValueKey('import_secret_submit_button'));
+      await tapAppButton(tester, const ValueKey('import_birthday_skip_button'));
+      await tapAppButton(
+        tester,
+        const ValueKey('unknown_birthday_confirm_button'),
+      );
+      await enterAppText(
+        tester,
+        const ValueKey('set_password_password_field'),
+        desktopRegtestPassword,
+      );
+      await enterAppText(
+        tester,
+        const ValueKey('set_password_confirm_field'),
+        desktopRegtestPassword,
+      );
+      proxy.stallNextAddressUtxosStreamAfterHeaders();
+      await tapAppButton(tester, const ValueKey('set_password_submit_button'));
+
+      await pumpUntil(
+        tester,
+        () => proxy.addressUtxosStreamCallCount >= 1,
+        description: 'stalled transparent UTXO stream request',
+        timeout: const Duration(seconds: 60),
+      );
+      expect(rust_sync.isSyncRunning(), isTrue);
+      expect(find.text('0% Syncing...'), findsOneWidget);
+      e2eLog('reproduced the pre-progress sync wait');
+
+      await pumpUntil(
+        tester,
+        () =>
+            proxy.addressUtxosStreamCallCount >= 2 &&
+            !rust_sync.isSyncRunning() &&
+            textForKey(tester, const ValueKey('sidebar_sync_text')) == 'Synced',
+        description: 'completed sync after the stalled UTXO stream timeout',
+        timeout: const Duration(seconds: 75),
+      );
+
+      expect(proxy.addressUtxosStreamCallCount, greaterThanOrEqualTo(2));
+      expect(rust_sync.isSyncRunning(), isFalse);
+      final persistedStatus = await rust_sync.getSyncStatus(
+        dbPath: await getWalletDbPath(),
+        network: 'regtest',
+      );
+      expect(persistedStatus.isComplete, isTrue);
+      expect(textForKey(tester, const ValueKey('sidebar_sync_text')), 'Synced');
+      expect(find.text(_networkFailure), findsNothing);
+      expect(find.text(_endpointFailure), findsNothing);
+      expect(find.text(_genericFailure), findsNothing);
+      expect(find.text(_fallbackToast), findsNothing);
+      e2eLog('stalled UTXO stream recovered on the healthy retry');
+    },
+    timeout: const Timeout(Duration(minutes: 3)),
+  );
+}

--- a/integration_test/support/regtest_lightwalletd_proxy.dart
+++ b/integration_test/support/regtest_lightwalletd_proxy.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:fixnum/fixnum.dart';
@@ -35,9 +36,14 @@ class RegtestLightwalletdProxy
   int? _slowHeight;
   int _sendTransactionFailuresRemaining = 0;
   int _failedSendTransactionCount = 0;
+  bool _stallNextAddressUtxosAfterHeaders = false;
+  Completer<void>? _addressUtxosStallRelease;
+  int _addressUtxosStreamCallCount = 0;
+  bool _serveEmptyGenesisTreeState = false;
 
   String get url => 'http://127.0.0.1:$listenPort';
   int get failedSendTransactionCount => _failedSendTransactionCount;
+  int get addressUtxosStreamCallCount => _addressUtxosStreamCallCount;
 
   Future<void> start() async {
     _server = grpc.Server.create(services: [this]);
@@ -49,6 +55,7 @@ class RegtestLightwalletdProxy
   }
 
   Future<void> stop() async {
+    releaseStalledAddressUtxosStream();
     await _server?.shutdown();
     await _channel.shutdown();
   }
@@ -76,6 +83,29 @@ class RegtestLightwalletdProxy
     }
     _sendTransactionFailuresRemaining = count;
     _log('primary proxy will fail next $count SendTransaction call(s)');
+  }
+
+  void stallNextAddressUtxosStreamAfterHeaders() {
+    _stallNextAddressUtxosAfterHeaders = true;
+    _addressUtxosStallRelease = Completer<void>();
+    _addressUtxosStreamCallCount = 0;
+    _log(
+      'primary proxy will stall the first GetAddressUtxosStream call '
+      'after response headers, then forward retries',
+    );
+  }
+
+  void releaseStalledAddressUtxosStream() {
+    _stallNextAddressUtxosAfterHeaders = false;
+    final release = _addressUtxosStallRelease;
+    if (release != null && !release.isCompleted) {
+      release.complete();
+    }
+  }
+
+  void serveEmptyGenesisTreeState() {
+    _serveEmptyGenesisTreeState = true;
+    _log('primary proxy will serve an empty genesis tree state');
   }
 
   void _throwIfDown() {
@@ -233,8 +263,17 @@ class RegtestLightwalletdProxy
   Future<service.TreeState> getTreeState(
     grpc.ServiceCall call,
     service.BlockID request,
-  ) {
+  ) async {
     _throwIfDown();
+    if (_serveEmptyGenesisTreeState &&
+        request.height == Int64.ZERO &&
+        request.hash.isEmpty) {
+      return service.TreeState(
+        network: 'regtest',
+        height: Int64.ZERO,
+        hash: List.filled(64, '0').join(),
+      );
+    }
     return _client.getTreeState(request);
   }
 
@@ -269,9 +308,21 @@ class RegtestLightwalletdProxy
   Stream<service.GetAddressUtxosReply> getAddressUtxosStream(
     grpc.ServiceCall call,
     service.GetAddressUtxosArg request,
-  ) {
+  ) async* {
     _throwIfDown();
-    return _client.getAddressUtxosStream(request);
+    _addressUtxosStreamCallCount += 1;
+    if (_stallNextAddressUtxosAfterHeaders) {
+      _stallNextAddressUtxosAfterHeaders = false;
+      call.sendHeaders();
+      _log(
+        'primary proxy stalled GetAddressUtxosStream after response headers',
+      );
+      await _addressUtxosStallRelease!.future;
+      throw grpc.GrpcError.unavailable(
+        'released stalled GetAddressUtxosStream',
+      );
+    }
+    yield* _client.getAddressUtxosStream(request);
   }
 
   @override

--- a/integration_test/sync_stream_error_test.dart
+++ b/integration_test/sync_stream_error_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  test(
+    'startFullSync forwards terminal Rust errors through its stream',
+    () async {
+      addTearDown(() {
+        rust_sync.setSyncMode(mode: 0);
+      });
+
+      final stream = rust_sync.startFullSync(
+        dbPath: 'unused',
+        lightwalletdUrl: 'http://127.0.0.1:1',
+        network: 'invalid-test-network',
+        mode: 1,
+      );
+
+      await expectLater(
+        stream,
+        emitsInOrder([
+          emitsError(
+            isA<Object>().having(
+              (error) => error.toString(),
+              'message',
+              contains('Unknown network: invalid-test-network'),
+            ),
+          ),
+          emitsDone,
+        ]),
+      );
+      expect(rust_sync.isSyncRunning(), isFalse);
+    },
+  );
+}

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -992,6 +992,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
                   }
                   if (gen != _syncGen || !_isSyncing) return;
                 }
+                ++_progressEventVersion;
                 _isSyncing = false;
                 _stopDisplayProgressTimer();
                 log(
@@ -1007,6 +1008,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
             onError: (e) {
               if (!ref.mounted || gen != _syncGen) return;
               log('Sync: stream error: $e');
+              ++_progressEventVersion;
               _isSyncing = false;
               _stopDisplayProgressTimer();
               // Sync died mid-stream: tear the mempool observer down
@@ -1027,6 +1029,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         .catchError((e, st) {
           if (gen != _syncGen) return;
           log('SyncNotifier: ERROR: $e\n$st');
+          ++_progressEventVersion;
           _isSyncing = false;
           _stopDisplayProgressTimer();
           // Sync setup threw before the stream was ever attached.
@@ -1176,6 +1179,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   }
 
   void _recordSyncFailure(Object error) {
+    ++_progressEventVersion;
     final failure = classifySyncFailure(error);
     final prev = state.value;
     final accountUuid = _getActiveAccountUuid();
@@ -1875,7 +1879,15 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         balanceReadIsCurrent;
     final useFetchedRecentTxs =
         useFetchedAccountData && didFetchRecentTxs && balanceReadIsCurrent;
-    if (progressEventVersion != _progressEventVersion) {
+    // A stream error can be recorded while this handler awaits DB reads. Its
+    // stopped failure state must win over this older progress event.
+    final currentState = state.value;
+    final failureRecordedWhileAwaiting =
+        currentState?.failure != null &&
+        (!identical(currentState?.failure, prev?.failure) ||
+            currentState?.lastSyncFailedAt != prev?.lastSyncFailedAt);
+    if (progressEventVersion != _progressEventVersion ||
+        failureRecordedWhileAwaiting) {
       _mergeFetchedAccountDataIntoLatestState(
         accountUuid: accountUuid,
         balance: useFetchedBalance ? fetchedBalance : null,
@@ -1885,7 +1897,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         shieldTransparentAmount: shieldTransparentAmount,
       );
       log(
-        'SyncNotifier: discarded out-of-order progress metadata'
+        'SyncNotifier: discarded stale progress metadata'
         '${useFetchedBalance || useFetchedRecentTxs ? ', kept account data' : ''}',
       );
       return;
@@ -1893,7 +1905,10 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     if (useFetchedBalance) {
       ++_authoritativeBalanceVersion;
     }
-    final stateScopedPrev = _previousScopedState(state.value, stateAccountUuid);
+    final stateScopedPrev = _previousScopedState(
+      currentState,
+      stateAccountUuid,
+    );
     final hasBalanceData =
         useFetchedBalance || (stateScopedPrev?.hasBalanceData ?? false);
     final hasRecentTransactionsData =

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -112,7 +112,10 @@ pub fn start_full_sync(
             })
             .is_err()
         {
-            log::warn!("sync: StreamSink closed, progress not delivered");
+            log::warn!(
+                "[{}] sync: StreamSink closed, progress not delivered",
+                sync_engine::elapsed(),
+            );
         }
     });
 
@@ -120,7 +123,10 @@ pub fn start_full_sync(
     // detached. Forward terminal errors through the stream it actually reads.
     if let Err(error) = result {
         if sink.add_error(error.clone()).is_err() {
-            log::warn!("sync: StreamSink closed before error delivery: {error}");
+            log::warn!(
+                "[{}] sync: StreamSink closed before error delivery: {error}",
+                sync_engine::elapsed(),
+            );
         }
     }
 

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -97,7 +97,7 @@ pub fn start_full_sync(
     mode: u8,
     sink: StreamSink<ApiSyncProgressEvent>,
 ) -> Result<(), String> {
-    run_full_sync_internal(db_path, lightwalletd_url, network, mode, |progress| {
+    let result = run_full_sync_internal(db_path, lightwalletd_url, network, mode, |progress| {
         if sink
             .add(ApiSyncProgressEvent {
                 scanned_height: progress.scanned_height,
@@ -114,7 +114,17 @@ pub fn start_full_sync(
         {
             log::warn!("sync: StreamSink closed, progress not delivered");
         }
-    })
+    });
+
+    // Generated Dart exposes the sink stream, while the FRB task future is
+    // detached. Forward terminal errors through the stream it actually reads.
+    if let Err(error) = result {
+        if sink.add_error(error.clone()).is_err() {
+            log::warn!("sync: StreamSink closed before error delivery: {error}");
+        }
+    }
+
+    Ok(())
 }
 
 /// Blocking sync entrypoint that uses the same API-layer network parsing,

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -98,6 +98,20 @@ where
     }
 }
 
+type AddressUtxoStream = tonic::Streaming<service::GetAddressUtxosReply>;
+
+async fn await_address_utxo_stream<F>(
+    timeout: Duration,
+    future: F,
+) -> Result<AddressUtxoStream, SyncError>
+where
+    F: Future<Output = Result<Response<AddressUtxoStream>, Status>>,
+{
+    await_tonic_stream("get_address_utxos_stream", timeout, future)
+        .await
+        .map_err(|e| status_to_network_error("get_address_utxos_stream", e))
+}
+
 // Server-streaming calls intentionally use plain `Request::new` at
 // their call sites. A `grpc-timeout` header would bound the whole
 // stream lifetime; here we only bound stream start and per-message idle
@@ -261,20 +275,48 @@ pub(crate) async fn get_taddress_txids(
     .map_err(|e| status_to_network_error("get_taddress_txids", e))
 }
 
+/// Open a transparent UTXO stream with a bounded wait for response headers.
+pub(super) async fn get_address_utxos_stream(
+    client: &mut CompactTxStreamerClient<Channel>,
+    addresses: Vec<String>,
+    start_height: BlockHeight,
+) -> Result<AddressUtxoStream, SyncError> {
+    await_address_utxo_stream(
+        LIGHTWALLETD_STREAM_START_TIMEOUT,
+        client.get_address_utxos_stream(Request::new(service::GetAddressUtxosArg {
+            addresses,
+            start_height: u32::from(start_height) as u64,
+            max_entries: 0,
+        })),
+    )
+    .await
+}
+
+async fn await_stream_message<T, F>(
+    label: &str,
+    timeout: Duration,
+    future: F,
+) -> Result<Option<T>, SyncError>
+where
+    F: Future<Output = Result<Option<T>, Status>>,
+{
+    match tokio::time::timeout(timeout, future).await {
+        Ok(Ok(message)) => Ok(message),
+        Ok(Err(status)) => Err(status_to_network_error(label, status)),
+        Err(_) => Err(SyncError::net(format!(
+            "{label}: timed out after {}s waiting for next message",
+            timeout.as_secs()
+        ))),
+    }
+}
+
 /// Read the next server-streaming message with a bounded idle wait.
 /// `Ok(None)` remains the server's normal EOF signal.
 pub(crate) async fn next_stream_message<T>(
     stream: &mut tonic::Streaming<T>,
     label: &str,
 ) -> Result<Option<T>, SyncError> {
-    match tokio::time::timeout(LIGHTWALLETD_STREAM_IDLE_TIMEOUT, stream.message()).await {
-        Ok(Ok(message)) => Ok(message),
-        Ok(Err(status)) => Err(status_to_network_error(label, status)),
-        Err(_) => Err(SyncError::net(format!(
-            "{label}: timed out after {}s waiting for next message",
-            LIGHTWALLETD_STREAM_IDLE_TIMEOUT.as_secs()
-        ))),
-    }
+    await_stream_message(label, LIGHTWALLETD_STREAM_IDLE_TIMEOUT, stream.message()).await
 }
 
 /// Pulls the latest shielded subtree roots from lightwalletd
@@ -529,6 +571,47 @@ pub(super) async fn download_blocks(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn stalled_address_utxo_stream_start_is_bounded() {
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            await_address_utxo_stream(
+                Duration::from_millis(5),
+                std::future::pending::<Result<Response<AddressUtxoStream>, Status>>(),
+            ),
+        )
+        .await
+        .expect("test guard: address UTXO stream start hung");
+
+        assert!(matches!(
+            result,
+            Err(SyncError::Network(message))
+                if message.contains("get_address_utxos_stream")
+                    && message.contains("timed out")
+        ));
+    }
+
+    #[tokio::test]
+    async fn stalled_stream_message_is_bounded() {
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            await_stream_message::<service::GetAddressUtxosReply, _>(
+                "get_address_utxos_stream",
+                Duration::from_millis(5),
+                std::future::pending(),
+            ),
+        )
+        .await
+        .expect("test guard: address UTXO stream message hung");
+
+        assert!(matches!(
+            result,
+            Err(SyncError::Network(message))
+                if message.contains("get_address_utxos_stream")
+                    && message.contains("timed out")
+        ));
+    }
 
     #[test]
     fn explicit_ironwood_pool_requests_follow_nu6_3_activation() {

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -119,7 +119,7 @@ const ANCHOR_ROOT_REPAIR_REWIND_DISTANCES: [u32; 3] = [100, 1000, 10_000];
 /// Sync-scoped elapsed time reference. Set at sync start.
 static SYNC_START: std::sync::Mutex<Option<std::time::Instant>> = std::sync::Mutex::new(None);
 
-fn elapsed() -> String {
+pub(crate) fn elapsed() -> String {
     SYNC_START
         .lock()
         .ok()

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -6,14 +6,11 @@ use nonempty::NonEmpty;
 use rusqlite::{params, OptionalExtension};
 use shardtree::error::{InsertionError, QueryError, ShardTreeError};
 use tonic::transport::Channel;
-use zcash_client_backend::{
-    data_api::{
-        chain::{self, error::Error as ChainError, scan_cached_blocks},
-        scanning::{ScanPriority, ScanRange},
-        wallet::ConfirmationsPolicy,
-        WalletCommitmentTrees, WalletRead, WalletWrite,
-    },
-    proto::service,
+use zcash_client_backend::data_api::{
+    chain::{self, error::Error as ChainError, scan_cached_blocks},
+    scanning::{ScanPriority, ScanRange},
+    wallet::ConfirmationsPolicy,
+    WalletCommitmentTrees, WalletRead, WalletWrite,
 };
 use zcash_client_sqlite::{error::SqliteClientError, AccountUuid};
 use zcash_primitives::block::BlockHash;
@@ -54,7 +51,7 @@ pub(crate) mod mempool;
 use enhance::run_enhancement;
 pub(crate) use error::SyncError;
 use error::{RecoveryStrategy, MAX_REWINDS_PER_RUN};
-use lwd::{download_blocks, download_subtree_roots, get_tree_state};
+use lwd::{download_blocks, download_subtree_roots, get_address_utxos_stream, get_tree_state};
 pub(crate) use lwd::{
     get_latest_block, get_taddress_txids, get_transaction, next_stream_message, open_lwd_channel,
     send_transaction, send_transaction_with_status,
@@ -980,11 +977,15 @@ async fn refresh_utxos(
     db: &mut WalletDatabase,
     network: WalletNetwork,
     tip_height: BlockHeight,
+    should_exit: &impl Fn() -> bool,
 ) -> Result<(), SyncError> {
     for account_id in db
         .get_account_ids()
         .map_err(|e| SyncError::db(format!("get_account_ids: {e}")))?
     {
+        if should_exit() {
+            return Ok(());
+        }
         let account_uuid = account_id.expose_uuid().to_string();
         let safety_start_height = db
             .utxo_query_height(account_id)
@@ -1042,6 +1043,9 @@ async fn refresh_utxos(
         };
 
         for (batch_index, batch) in external_batches.into_iter().enumerate() {
+            if should_exit() {
+                return Ok(());
+            }
             let start_height = block_height_from_u64(
                 batch.start_height,
                 "transparent receive UTXO batch start height",
@@ -1058,8 +1062,12 @@ async fn refresh_utxos(
                 start_height,
                 &label,
                 || mark_transparent_receive_cache_dirty(db_data_path, &account_uuid),
+                should_exit,
             )
             .await?;
+            if should_exit() {
+                return Ok(());
+            }
             if let Err(e) = transparent_receive_cache::mark_utxo_refresh_batch_complete(
                 db_data_path,
                 network,
@@ -1097,6 +1105,7 @@ async fn refresh_utxos(
                 safety_start_height,
                 "transparent non-external UTXOs",
                 || mark_transparent_receive_cache_dirty(db_data_path, &account_uuid),
+                should_exit,
             )
             .await?;
         }
@@ -1142,8 +1151,9 @@ async fn refresh_transparent_addresses(
     start_height: BlockHeight,
     label: &str,
     mut mark_cache_dirty: impl FnMut(),
+    should_exit: &impl Fn() -> bool,
 ) -> Result<bool, SyncError> {
-    if addresses.is_empty() {
+    if addresses.is_empty() || should_exit() {
         return Ok(false);
     }
 
@@ -1155,22 +1165,36 @@ async fn refresh_transparent_addresses(
         addresses.len(),
     );
 
-    let mut stream = client
-        .get_address_utxos_stream(service::GetAddressUtxosArg {
-            addresses,
-            start_height: u32::from(start_height) as u64,
-            max_entries: 0,
-        })
-        .await
-        .map_err(|e| SyncError::net(format!("get_address_utxos_stream: {e}")))?
-        .into_inner();
+    let mut stream = tokio::select! {
+        biased;
+        _ = watch_for_exit(should_exit) => {
+            log::info!(
+                "[{}] sync: exiting during {} transparent UTXO stream start",
+                elapsed(),
+                label,
+            );
+            return Ok(false);
+        }
+        result = get_address_utxos_stream(client, addresses, start_height) => result?,
+    };
 
     let mut received_any = false;
-    while let Some(reply) = stream
-        .message()
-        .await
-        .map_err(|e| SyncError::net(format!("get_address_utxos_stream message: {e}")))?
-    {
+    loop {
+        let reply = tokio::select! {
+            biased;
+            _ = watch_for_exit(should_exit) => {
+                log::info!(
+                    "[{}] sync: exiting during {} transparent UTXO refresh",
+                    elapsed(),
+                    label,
+                );
+                return Ok(received_any);
+            }
+            result = next_stream_message(&mut stream, "get_address_utxos_stream") => result?,
+        };
+        let Some(reply) = reply else {
+            break;
+        };
         let txid: [u8; 32] = reply
             .txid
             .try_into()
@@ -1211,6 +1235,12 @@ async fn refresh_transparent_addresses(
     }
 
     Ok(received_any)
+}
+
+async fn watch_for_exit(should_exit: &impl Fn() -> bool) {
+    while !should_exit() {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
 }
 
 // ==================== Main sync ====================
@@ -1388,10 +1418,6 @@ async fn run_sync_impl(
     crate::wallet::sync::recover_orphaned_send_locks(db_data_path, network)
         .map_err(SyncError::db)?;
 
-    // Match the cancellation granularity we already use for
-    // `run_enhancement`: let this stage run to completion once it has
-    // started, but don't enter it (or continue past it) after a
-    // cancel/mode change has already been observed.
     if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode {
         log::info!(
             "[{}] sync: cancel/mode observed before transparent UTXO refresh, skipping",
@@ -1400,7 +1426,25 @@ async fn run_sync_impl(
         return Ok(());
     }
 
-    refresh_utxos(&mut client, db_data_path, &mut db, network, tip_height).await?;
+    let should_exit =
+        || cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode;
+    refresh_utxos(
+        &mut client,
+        db_data_path,
+        &mut db,
+        network,
+        tip_height,
+        &should_exit,
+    )
+    .await?;
+
+    if should_exit() {
+        log::info!(
+            "[{}] sync: cancel/mode observed after transparent UTXO refresh",
+            elapsed(),
+        );
+        return Ok(());
+    }
 
     // 2.5. Resubmit any unmined, unexpired wallet txs now that we
     // know the current tip. Matches the first of the three

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -27,34 +27,37 @@ require_cmd python3
 cd "$ROOT_DIR"
 
 # Keep this ordered from the narrowest smoke test to broader user flows.
-run_test "1/10 import funded wallet and sync balances" \
+run_test "1/11 import funded wallet and sync balances" \
   "scripts/e2e/flutter-macos-regtest-import-sync.sh"
 
-run_test "2/10 fallback from unavailable endpoint and sync balances" \
+run_test "2/11 fallback from unavailable endpoint and sync balances" \
   "scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh"
 
-run_test "3/10 keep custom endpoint failures private" \
+run_test "3/11 keep custom endpoint failures private" \
   "scripts/e2e/flutter-macos-regtest-custom-endpoint-no-fallback.sh"
 
-run_test "4/10 fallback from slow-height primary and recover" \
+run_test "4/11 recover from a stalled startup stream" \
+  "scripts/e2e/flutter-macos-regtest-sync-startup-stall-recovery.sh"
+
+run_test "5/11 fallback from slow-height primary and recover" \
   "scripts/e2e/flutter-macos-regtest-slow-height-fallback.sh"
 
-run_test "5/10 create wallet and shield transparent funds" \
+run_test "6/11 create wallet and shield transparent funds" \
   "scripts/e2e/flutter-macos-regtest-shield-transparent.sh"
 
-run_test "6/10 retry shield transparent broadcast failure" \
+run_test "7/11 retry shield transparent broadcast failure" \
   "scripts/e2e/flutter-macos-regtest-shield-transparent-retry.sh"
 
-run_test "7/10 import two accounts and send shielded funds" \
+run_test "8/11 import two accounts and send shielded funds" \
   "scripts/e2e/flutter-macos-regtest-multi-account-send.sh"
 
-run_test "8/10 show mempool receives in activity history" \
+run_test "9/11 show mempool receives in activity history" \
   "scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh"
 
-run_test "9/10 show mempool receives while sync is running" \
+run_test "10/11 show mempool receives while sync is running" \
   "scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh"
 
-run_test "10/10 expire unmined mempool receives" \
+run_test "11/11 expire unmined mempool receives" \
   "scripts/e2e/flutter-macos-regtest-mempool-expiry.sh"
 
 echo

--- a/scripts/e2e/flutter-macos-regtest-sync-startup-stall-recovery.sh
+++ b/scripts/e2e/flutter-macos-regtest-sync-startup-stall-recovery.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd fvm
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+echo "running Flutter macOS startup stall recovery integration test"
+fvm flutter test \
+  integration_test/regtest_sync_startup_stall_recovery_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
+  --dart-define=VIZOR_E2E_HIDDEN_WINDOW="${VIZOR_E2E_HIDDEN_WINDOW:-true}"

--- a/test/providers/sync_provider_test.dart
+++ b/test/providers/sync_provider_test.dart
@@ -3,6 +3,9 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/formatting/sync_status_label.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_failure.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
 void main() {
@@ -99,6 +102,61 @@ void main() {
 
     await expectLater(handling, completes);
   });
+
+  test('in-flight progress cannot replace a newer sync failure', () async {
+    final resolverStarted = Completer<void>();
+    final dbPath = Completer<String>();
+    late _LifecycleTestSyncNotifier notifier;
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+        accountProvider.overrideWith(_ExistingAccountNotifier.new),
+        syncProvider.overrideWith(
+          () => notifier = _LifecycleTestSyncNotifier(() async {
+            resolverStarted.complete();
+            return dbPath.future;
+          }),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.listen(syncProvider, (_, _) {});
+    await container.read(syncProvider.future);
+
+    final handling = notifier.handleSyncProgressForTesting(
+      const SyncProgressEvent(
+        scannedHeight: 10,
+        chainTipHeight: 100,
+        percentage: 0,
+        displayTargetPercentage: 0,
+        displayTargetBlocks: 0,
+        isSyncing: true,
+        isComplete: false,
+        hasNewTx: false,
+      ),
+    );
+    await resolverStarted.future;
+
+    final failure = classifySyncFailure(StateError('sync failed'));
+    notifier.replaceState(
+      SyncState(
+        accountUuid: _accountUuid,
+        failure: failure,
+        error: failure.rawMessage,
+        lastSyncFailedAt: DateTime.utc(2026, 7, 29),
+      ),
+    );
+    dbPath.complete('wallet.db');
+    await handling;
+
+    final current = container.read(syncProvider).requireValue;
+    expect(
+      SyncStatusLabel.from(current).label,
+      'Syncing failed. Unknown error...',
+    );
+    expect(current.failure, same(failure));
+    expect(current.isSyncing, isFalse);
+  });
 }
 
 class _LifecycleTestSyncNotifier extends SyncNotifier {
@@ -107,4 +165,18 @@ class _LifecycleTestSyncNotifier extends SyncNotifier {
 
   @override
   Future<SyncState> build() async => SyncState();
+
+  void replaceState(SyncState next) {
+    state = AsyncData(next);
+  }
+}
+
+const _accountUuid = 'account-1';
+
+class _ExistingAccountNotifier extends AccountNotifier {
+  @override
+  AccountState build() => const AccountState(
+    accounts: [AccountInfo(uuid: _accountUuid, name: 'Account 1', order: 0)],
+    activeAccountUuid: _accountUuid,
+  );
 }


### PR DESCRIPTION
Startup sync queries transparent UTXOs before emitting its first progress event, but this server-streaming call did not apply the existing response-header and per-message timeout policy. If lightwalletd opened the call and then stopped responding, Rust could remain active indefinitely while the sidebar stayed at 0%.

This bounds the UTXO stream waits, makes them responsive to cancellation and sync-mode changes, forwards terminal Rust failures through the FRB stream Dart actually consumes, and prevents late progress handling from replacing a newer terminal state. The regtest proxy now reproduces a first-call stall and verifies that the existing retry path reaches persisted sync completion. This addresses one concrete startup-stall class; it does not assume every reported 0% case has the same cause.

Validated with the focused 58-test Rust sync-engine suite, sync-provider widget tests, the native Rust-to-Dart stream-error test, the native macOS stalled-startup recovery E2E, targeted Flutter analysis, formatting, and shell checks.