### PR TITLE
Timed rebroadcast for accepted-but-unstored migration txs

### DIFF
--- a/release_notes/v0.0.42.md
+++ b/release_notes/v0.0.42.md
@@ -11,3 +11,7 @@ This release fixes stuck Ironwood migration transfer scheduling.
   fails, the part is marked submitted (`broadcasted`) instead of left
   `scheduled`, so later parts are not head-of-line blocked while storage is
   retried.
+- Accepted migration transfers that are still missing from local storage are
+  rebroadcast after a short block quiet period if they remain unconfirmed,
+  so recovery does not wait for full ZIP 318 expiry when a mempool eviction
+  may have dropped the transaction.

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -133,6 +133,11 @@ pub(crate) struct PendingMigrationTxMetadata {
     pub tx_kind: String,
     pub funding_account_uuid: String,
     pub selected_note: PreparedOrchardNoteRef,
+    /// Last chain tip at which timed blind rebroadcast was attempted for an
+    /// accepted-but-unstored part. Prevents same-tip advance spam while tip is
+    /// stuck on a quiet boundary. Absent in older rows (serde default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_resubmit_tip: Option<u32>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -3917,7 +3922,8 @@ pub(crate) fn migration_broadcast_resubmit_on_quiet_boundary(
 
 /// Accepted (`broadcasted`) pending rows still missing local wallet identity
 /// that are due for a height-windowed blind rebroadcast. Never selected as due
-/// broadcasts — recovery only.
+/// broadcasts — recovery only. Skips parts already attempted at `chain_tip_height`
+/// so repeated advances at a stuck quiet-boundary tip do not re-SendTransaction.
 pub(crate) fn broadcasted_pending_txs_due_for_resubmit(
     db_path: &str,
     run_id: &str,
@@ -3930,7 +3936,7 @@ pub(crate) fn broadcasted_pending_txs_due_for_resubmit(
     ensure_schema(&conn)?;
     let mut stmt = conn
         .prepare_cached(&format!(
-            "SELECT txid_hex, encrypted_raw_tx, scheduled_height
+            "SELECT txid_hex, encrypted_raw_tx, scheduled_height, metadata_json
              FROM {PENDING_TXS_TABLE}
              WHERE run_id = ?1 AND status = 'broadcasted'
              ORDER BY scheduled_height ASC, txid_hex ASC"
@@ -3942,18 +3948,24 @@ pub(crate) fn broadcasted_pending_txs_due_for_resubmit(
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, u32>(2)?,
+                row.get::<_, String>(3)?,
             ))
         })
         .map_err(|e| format!("Query broadcasted migration resubmit txs: {e}"))?;
 
     let mut due = Vec::new();
     for row in rows {
-        let (txid_hex, encrypted_raw_tx, scheduled_height) =
+        let (txid_hex, encrypted_raw_tx, scheduled_height, metadata_json) =
             row.map_err(|e| format!("Read broadcasted migration resubmit tx: {e}"))?;
         if local_denomination_chain_identity(&conn, &txid_hex)?.is_some() {
             continue;
         }
         if !migration_broadcast_resubmit_on_quiet_boundary(chain_tip_height, scheduled_height) {
+            continue;
+        }
+        let metadata = serde_json::from_str::<PendingMigrationTxMetadata>(&metadata_json)
+            .map_err(|e| format!("Decode migration resubmit metadata: {e}"))?;
+        if metadata.last_resubmit_tip == Some(chain_tip_height) {
             continue;
         }
         let raw_tx = secret_payload::decrypt_payload(
@@ -3967,6 +3979,49 @@ pub(crate) fn broadcasted_pending_txs_due_for_resubmit(
         });
     }
     Ok(due)
+}
+
+/// Record that timed blind rebroadcast was attempted at `tip` for this pending
+/// row (success or failure). Subsequent advances at the same tip skip rebroadcast.
+pub(crate) fn mark_pending_timed_resubmit_attempted(
+    db_path: &str,
+    run_id: &str,
+    txid_hex: &str,
+    tip: u32,
+) -> Result<(), String> {
+    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    ensure_schema(&conn)?;
+    let metadata_json: String = conn
+        .query_row(
+            &format!(
+                "SELECT metadata_json FROM {PENDING_TXS_TABLE}
+                 WHERE run_id = ?1 AND txid_hex = ?2"
+            ),
+            params![run_id, txid_hex],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("Read migration timed-resubmit metadata: {e}"))?;
+    let mut metadata = serde_json::from_str::<PendingMigrationTxMetadata>(&metadata_json)
+        .map_err(|e| format!("Decode migration timed-resubmit metadata: {e}"))?;
+    metadata.last_resubmit_tip = Some(tip);
+    let updated = serde_json::to_string(&metadata)
+        .map_err(|e| format!("Encode migration timed-resubmit metadata: {e}"))?;
+    let changed = conn
+        .execute(
+            &format!(
+                "UPDATE {PENDING_TXS_TABLE}
+                 SET metadata_json = ?1
+                 WHERE run_id = ?2 AND txid_hex = ?3"
+            ),
+            params![updated, run_id, txid_hex],
+        )
+        .map_err(|e| format!("Mark migration timed-resubmit attempt: {e}"))?;
+    if changed == 0 {
+        return Err(format!(
+            "Migration timed-resubmit metadata update missed pending tx {txid_hex}"
+        ));
+    }
+    Ok(())
 }
 
 fn update_run_after_pending_broadcast(

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -3899,6 +3899,76 @@ pub(crate) fn broadcasted_pending_txs_missing_local_identity(
     Ok(missing)
 }
 
+/// True when `tip` is on a quiet/backoff boundary for blind rebroadcast of an
+/// accepted-but-unstored migration part scheduled at `scheduled_height`.
+pub(crate) fn migration_broadcast_resubmit_on_quiet_boundary(
+    tip: u32,
+    scheduled_height: u32,
+) -> bool {
+    let Some(min_tip) = scheduled_height.checked_add(MIGRATION_BROADCAST_RESUBMIT_QUIET_BLOCKS)
+    else {
+        return false;
+    };
+    if tip < min_tip {
+        return false;
+    }
+    tip.saturating_sub(scheduled_height) % MIGRATION_BROADCAST_RESUBMIT_QUIET_BLOCKS == 0
+}
+
+/// Accepted (`broadcasted`) pending rows still missing local wallet identity
+/// that are due for a height-windowed blind rebroadcast. Never selected as due
+/// broadcasts — recovery only.
+pub(crate) fn broadcasted_pending_txs_due_for_resubmit(
+    db_path: &str,
+    run_id: &str,
+    chain_tip_height: u32,
+    password: &[u8],
+    salt_base64: &str,
+) -> Result<Vec<DuePendingMigrationTx>, String> {
+    let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration pending salt")?;
+    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    ensure_schema(&conn)?;
+    let mut stmt = conn
+        .prepare_cached(&format!(
+            "SELECT txid_hex, encrypted_raw_tx, scheduled_height
+             FROM {PENDING_TXS_TABLE}
+             WHERE run_id = ?1 AND status = 'broadcasted'
+             ORDER BY scheduled_height ASC, txid_hex ASC"
+        ))
+        .map_err(|e| format!("Prepare broadcasted migration resubmit query: {e}"))?;
+    let rows = stmt
+        .query_map(params![run_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, u32>(2)?,
+            ))
+        })
+        .map_err(|e| format!("Query broadcasted migration resubmit txs: {e}"))?;
+
+    let mut due = Vec::new();
+    for row in rows {
+        let (txid_hex, encrypted_raw_tx, scheduled_height) =
+            row.map_err(|e| format!("Read broadcasted migration resubmit tx: {e}"))?;
+        if local_denomination_chain_identity(&conn, &txid_hex)?.is_some() {
+            continue;
+        }
+        if !migration_broadcast_resubmit_on_quiet_boundary(chain_tip_height, scheduled_height) {
+            continue;
+        }
+        let raw_tx = secret_payload::decrypt_payload(
+            encrypted_raw_tx.as_bytes(),
+            password,
+            salt.as_slice(),
+        )?;
+        due.push(DuePendingMigrationTx {
+            txid_hex,
+            raw_tx: raw_tx.to_vec(),
+        });
+    }
+    Ok(due)
+}
+
 fn update_run_after_pending_broadcast(
     tx: &rusqlite::Transaction<'_>,
     run_id: &str,

--- a/rust/src/wallet/sync/migration/policy.rs
+++ b/rust/src/wallet/sync/migration/policy.rs
@@ -5,6 +5,11 @@ pub(crate) const ZIP318_ANCHOR_BUCKET_MODULUS: u32 = 144;
 pub(crate) const REGTEST_ANCHOR_BUCKET_MODULUS: u32 = 1;
 pub(crate) const ZIP318_ANCHOR_AGE_CAP: u32 = 4;
 pub(crate) const ZIP318_EXPIRY_MODULUS: u32 = 34_560;
+/// Quiet/backoff window for blind rebroadcast of accepted-but-unstored
+/// migration parts (`broadcasted`, missing local identity). Attempts land on
+/// `scheduled_height + n * QUIET` so recovery does not wait for full ZIP 318
+/// expiry and does not probe lightwalletd with GetTransaction.
+pub(crate) const MIGRATION_BROADCAST_RESUBMIT_QUIET_BLOCKS: u32 = 32;
 // Keep the original value readable for runs created before the shorter policy.
 pub(crate) const ZIP318_TRANSFER_MEAN_DELAY_BLOCKS: u32 = 144;
 pub(crate) const ZIP318_TRANSFER_MAX_DELAY_BLOCKS: u32 = 576;

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -137,6 +137,7 @@ fn create_outbox_test_run(
                     tx_kind: "migration".to_string(),
                     funding_account_uuid: "account-1".to_string(),
                     selected_note,
+                    last_resubmit_tip: None,
                 },
             }
         })
@@ -399,6 +400,7 @@ fn legacy_signed_schedule_backfill_preserves_identity_for_pending_recovery() {
         tx_kind: "migration".to_string(),
         funding_account_uuid: "account-1".to_string(),
         selected_note: selected_note.clone(),
+        last_resubmit_tip: None,
     })
     .unwrap();
     conn.execute(
@@ -1061,6 +1063,7 @@ fn pending_insert_rejects_expiry_from_a_different_schedule_bucket() {
                 tx_kind: "migration".to_string(),
                 funding_account_uuid: "account-1".to_string(),
                 selected_note,
+                last_resubmit_tip: None,
             },
         }],
         TEST_PASSWORD,
@@ -1369,6 +1372,7 @@ fn incremental_child_promotion_uses_immutable_signed_schedule_origin() {
                 tx_kind: "migration".to_string(),
                 funding_account_uuid: "account-1".to_string(),
                 selected_note,
+                last_resubmit_tip: None,
             },
         }],
         TEST_PASSWORD,
@@ -1883,6 +1887,7 @@ fn persisting_presigned_children_keeps_ready_phase_and_proof_height() {
                 tx_kind: "migration".to_string(),
                 funding_account_uuid: "account-1".to_string(),
                 selected_note,
+                last_resubmit_tip: None,
             },
         }],
         TEST_PASSWORD,
@@ -3140,6 +3145,7 @@ fn approved_schedule_controls_storage_and_overdue_catch_up() {
                     tx_kind: "migration".to_string(),
                     funding_account_uuid: "account-1".to_string(),
                     selected_note,
+                    last_resubmit_tip: None,
                 },
             }
         })
@@ -3237,6 +3243,7 @@ fn regtest_fast_policy_survives_pending_transaction_materialization() {
                 tx_kind: "migration".to_string(),
                 funding_account_uuid: "account-1".to_string(),
                 selected_note,
+                last_resubmit_tip: None,
             },
         }],
         TEST_PASSWORD,
@@ -3315,6 +3322,7 @@ fn approved_schedule_part_index_disambiguates_equal_values() {
                     tx_kind: "migration".to_string(),
                     funding_account_uuid: "account-1".to_string(),
                     selected_note,
+                    last_resubmit_tip: None,
                 },
             }
         })
@@ -3531,6 +3539,7 @@ fn approved_schedule_keeps_unpromoted_anchor_retention_candidates() {
                 tx_kind: "migration".to_string(),
                 funding_account_uuid: "account-1".to_string(),
                 selected_note,
+                last_resubmit_tip: None,
             },
         }
     };
@@ -3782,6 +3791,7 @@ fn legacy_equal_value_schedule_maps_incremental_parts_by_rank() {
                 note_version: 2,
                 nullifier_hex: None,
             },
+            last_resubmit_tip: None,
         },
     };
 
@@ -3817,6 +3827,7 @@ fn expired_pending_transaction_is_resigned_without_changing_its_denomination() {
         tx_kind: "migration".to_string(),
         funding_account_uuid: "account-1".to_string(),
         selected_note: selected_note.clone(),
+        last_resubmit_tip: None,
     };
     conn.execute(
         &format!(
@@ -3927,6 +3938,7 @@ fn expired_pending_transaction_is_resigned_without_changing_its_denomination() {
                 tx_kind: "migration".to_string(),
                 funding_account_uuid: "account-1".to_string(),
                 selected_note: selected_note.clone(),
+                last_resubmit_tip: None,
             },
         }],
         TEST_PASSWORD,
@@ -4018,6 +4030,7 @@ fn expired_pending_transaction_is_resigned_without_changing_its_denomination() {
                     tx_kind: "migration".to_string(),
                     funding_account_uuid: "account-1".to_string(),
                     selected_note: selected_note.clone(),
+                    last_resubmit_tip: None,
                 },
             },
         }],
@@ -4077,6 +4090,7 @@ fn expired_pending_transaction_is_resigned_without_changing_its_denomination() {
                 tx_kind: "migration".to_string(),
                 funding_account_uuid: "account-1".to_string(),
                 selected_note: selected_note.clone(),
+                last_resubmit_tip: None,
             },
         }],
         TEST_PASSWORD,
@@ -4154,6 +4168,7 @@ fn pending_policy_checks_detect_fee_drift_and_only_mined_input_spends() {
         tx_kind: "migration".to_string(),
         funding_account_uuid: "account-1".to_string(),
         selected_note: selected_note.clone(),
+        last_resubmit_tip: None,
     })
     .unwrap();
     conn.execute(

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -3972,6 +3972,7 @@ fn rebuild_expired_software_migration_parts(
             tx_kind: "migration".to_string(),
             funding_account_uuid: account_uuid.to_string(),
             selected_note: recovery.selected_note.clone(),
+            last_resubmit_tip: None,
         };
 
         replacements.push(super::migration::PendingMigrationTxReplacement {
@@ -4160,6 +4161,7 @@ fn finalize_presigned_migration_children(
                 tx_kind: child.metadata.tx_kind,
                 funding_account_uuid: child.metadata.funding_account_uuid,
                 selected_note: current_note.clone(),
+                last_resubmit_tip: None,
             },
         };
         let next_finalized_count = finalized_count
@@ -4791,7 +4793,14 @@ async fn broadcast_due_scheduled_migration_txs(
 
     // Blind rebroadcast of accepted-but-unstored parts on quiet-height
     // boundaries. Never counts toward accepted_txids / one-open gate.
-    rebroadcast_timed_broadcasted_migration_txs(&mut client, &resubmit).await;
+    rebroadcast_timed_broadcasted_migration_txs(
+        &mut client,
+        db_path,
+        run_id,
+        chain_tip_height,
+        &resubmit,
+    )
+    .await;
 
     if due.is_empty() {
         let status = super::migration::run_phase(db_path, run_id)?;
@@ -5238,8 +5247,12 @@ fn retry_store_broadcasted_migration_txs_missing_local(
 /// Blind-rebroadcast accepted-but-unstored migration parts on quiet-height
 /// boundaries. Returns txids for which `broadcast` returned Ok (including
 /// soft-accept). Does not change pending status or report acceptance for the
-/// one-open gate.
+/// one-open gate. Records `last_resubmit_tip` after each attempt so the same
+/// tip is not retried on later advances.
 fn rebroadcast_timed_broadcasted_migration_txs_with<F>(
+    db_path: &str,
+    run_id: &str,
+    tip: u32,
     candidates: &[super::migration::DuePendingMigrationTx],
     mut broadcast: F,
 ) -> Vec<String>
@@ -5248,7 +5261,19 @@ where
 {
     let mut succeeded = Vec::new();
     for pending in candidates {
-        match broadcast(&pending.txid_hex, &pending.raw_tx) {
+        let outcome = broadcast(&pending.txid_hex, &pending.raw_tx);
+        if let Err(error) = super::migration::mark_pending_timed_resubmit_attempted(
+            db_path,
+            run_id,
+            &pending.txid_hex,
+            tip,
+        ) {
+            log::warn!(
+                "migration: failed to record timed rebroadcast tip for {}: {error}",
+                pending.txid_hex
+            );
+        }
+        match outcome {
             Ok(()) => {
                 log::info!(
                     "migration: timed rebroadcast accepted for previously submitted tx {}",
@@ -5271,10 +5296,25 @@ async fn rebroadcast_timed_broadcasted_migration_txs(
     client: &mut zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient<
         tonic::transport::Channel,
     >,
+    db_path: &str,
+    run_id: &str,
+    tip: u32,
     candidates: &[super::migration::DuePendingMigrationTx],
 ) {
     for pending in candidates {
-        match broadcast_raw_transaction(client, &pending.raw_tx).await {
+        let outcome = broadcast_raw_transaction(client, &pending.raw_tx).await;
+        if let Err(error) = super::migration::mark_pending_timed_resubmit_attempted(
+            db_path,
+            run_id,
+            &pending.txid_hex,
+            tip,
+        ) {
+            log::warn!(
+                "migration: failed to record timed rebroadcast tip for {}: {error}",
+                pending.txid_hex
+            );
+        }
+        match outcome {
             Ok(()) => {
                 log::info!(
                     "migration: timed rebroadcast accepted for previously submitted tx {}",

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -4614,45 +4614,77 @@ async fn broadcast_pending_denomination_stages(
     }))
 }
 
-async fn broadcast_due_scheduled_migration_txs(
+enum PreparedDueScheduledAdvance {
+    Finished(MigrationBroadcastAdvance),
+    Ready {
+        totals_before: super::migration::PendingMigrationTotals,
+        resubmit: Vec<super::migration::DuePendingMigrationTx>,
+        due: Vec<super::migration::DuePendingMigrationTx>,
+    },
+}
+
+fn scheduled_migration_waiting_advance(
     db_path: &str,
-    lightwalletd_url: &str,
+    run_id: &str,
+    totals_before: super::migration::PendingMigrationTotals,
+    fallback_total_count: u32,
+    fallback_migrated_zatoshi: u64,
+) -> Result<MigrationBroadcastAdvance, String> {
+    let status = super::migration::run_phase(db_path, run_id)?;
+    let message = if status == super::migration::PHASE_BROADCAST_SCHEDULED
+        && super::migration::next_scheduled_height(db_path, run_id)?.is_none()
+    {
+        "Migration is waiting to prepare the next transaction."
+    } else {
+        "Migration transactions are scheduled for delayed broadcast."
+    };
+    Ok(MigrationBroadcastAdvance::without_acceptance(
+        migration_result_from_pending_totals(
+            totals_before,
+            &status,
+            Some(message.to_string()),
+            fallback_total_count,
+            fallback_migrated_zatoshi,
+        ),
+    ))
+}
+
+fn prepare_due_scheduled_migration_advance(
+    db_path: &str,
     network: WalletNetwork,
     run_id: &str,
     pending_password: &[u8],
     pending_salt_base64: &str,
     fallback_total_count: u32,
     fallback_migrated_zatoshi: u64,
-    policy: MigrationBroadcastPolicy<'_>,
-) -> Result<MigrationBroadcastAdvance, String> {
+    policy: &MigrationBroadcastPolicy<'_>,
+    chain_tip_height: u32,
+) -> Result<PreparedDueScheduledAdvance, String> {
     let totals_before = super::migration::pending_totals_for_run(db_path, run_id)?;
     if totals_before.total_count == 0 {
-        return Ok(MigrationBroadcastAdvance::without_acceptance(
-            migration_result_from_pending_totals(
+        return Ok(PreparedDueScheduledAdvance::Finished(
+            MigrationBroadcastAdvance::without_acceptance(migration_result_from_pending_totals(
                 totals_before,
                 super::migration::PHASE_READY_TO_MIGRATE,
                 Some("No signed migration transactions are scheduled yet.".to_string()),
                 fallback_total_count,
                 fallback_migrated_zatoshi,
-            ),
+            )),
         ));
     }
 
-    let chain_tip_height =
-        u32::try_from(super::get_sync_progress(db_path, network)?.chain_tip_height)
-            .map_err(|_| "Migration chain tip exceeds u32".to_string())?;
     if let Some(message) =
         pending_migration_policy_rebuild_message(db_path, network, run_id, chain_tip_height)?
     {
         super::migration::retire_run_for_rebuild(db_path, network, run_id, &message)?;
-        return Ok(MigrationBroadcastAdvance::without_acceptance(
-            migration_result_from_pending_totals(
+        return Ok(PreparedDueScheduledAdvance::Finished(
+            MigrationBroadcastAdvance::without_acceptance(migration_result_from_pending_totals(
                 totals_before,
                 super::migration::PHASE_FAILED_TERMINAL,
                 Some(message),
                 fallback_total_count,
                 fallback_migrated_zatoshi,
-            ),
+            )),
         ));
     }
 
@@ -4663,14 +4695,14 @@ async fn broadcast_due_scheduled_migration_txs(
             "{expired_count} migration transaction(s) expired before confirmation. Re-sign the affected denomination(s) with fresh anchors and expiry heights."
         );
         super::migration::mark_expired_pending_parts_for_resign(db_path, run_id, chain_tip_height)?;
-        return Ok(MigrationBroadcastAdvance::without_acceptance(
-            migration_result_from_pending_totals(
+        return Ok(PreparedDueScheduledAdvance::Finished(
+            MigrationBroadcastAdvance::without_acceptance(migration_result_from_pending_totals(
                 totals_before,
                 super::migration::PHASE_READY_TO_MIGRATE,
                 Some(message),
                 fallback_total_count,
                 fallback_migrated_zatoshi,
-            ),
+            )),
         ));
     }
     let noncanonical_due_count =
@@ -4681,8 +4713,8 @@ async fn broadcast_due_scheduled_migration_txs(
         )?;
     if noncanonical_due_count > 0 {
         let totals = super::migration::pending_totals_for_run(db_path, run_id)?;
-        return Ok(MigrationBroadcastAdvance::without_acceptance(
-            migration_result_from_pending_totals(
+        return Ok(PreparedDueScheduledAdvance::Finished(
+            MigrationBroadcastAdvance::without_acceptance(migration_result_from_pending_totals(
                 totals,
                 super::migration::PHASE_READY_TO_MIGRATE,
                 Some(format!(
@@ -4690,7 +4722,7 @@ async fn broadcast_due_scheduled_migration_txs(
                 )),
                 fallback_total_count,
                 fallback_migrated_zatoshi,
-            ),
+            )),
         ));
     }
     // Retry local store for already-accepted parts before selecting the next due
@@ -4717,58 +4749,115 @@ async fn broadcast_due_scheduled_migration_txs(
         pending_salt_base64,
     )?;
     if resubmit.is_empty() && due.is_empty() {
-        let status = super::migration::run_phase(db_path, run_id)?;
-        let message = if status == super::migration::PHASE_BROADCAST_SCHEDULED
-            && super::migration::next_scheduled_height(db_path, run_id)?.is_none()
-        {
-            "Migration is waiting to prepare the next transaction."
-        } else {
-            "Migration transactions are scheduled for delayed broadcast."
-        };
-        return Ok(MigrationBroadcastAdvance::without_acceptance(
-            migration_result_from_pending_totals(
+        return Ok(PreparedDueScheduledAdvance::Finished(
+            scheduled_migration_waiting_advance(
+                db_path,
+                run_id,
                 totals_before,
-                &status,
-                Some(message.to_string()),
                 fallback_total_count,
                 fallback_migrated_zatoshi,
-            ),
+            )?,
         ));
     }
     if policy.is_cancelled() {
-        return Ok(MigrationBroadcastAdvance::without_acceptance(
-            migration_result_from_pending_totals(
+        return Ok(PreparedDueScheduledAdvance::Finished(
+            MigrationBroadcastAdvance::without_acceptance(migration_result_from_pending_totals(
                 totals_before,
                 super::migration::PHASE_BROADCAST_SCHEDULED,
                 Some("Background migration stopped before the next broadcast.".to_string()),
                 fallback_total_count,
                 fallback_migrated_zatoshi,
-            ),
+            )),
         ));
     }
+    Ok(PreparedDueScheduledAdvance::Ready {
+        totals_before,
+        resubmit,
+        due,
+    })
+}
+
+async fn broadcast_due_scheduled_migration_txs(
+    db_path: &str,
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+    run_id: &str,
+    pending_password: &[u8],
+    pending_salt_base64: &str,
+    fallback_total_count: u32,
+    fallback_migrated_zatoshi: u64,
+    policy: MigrationBroadcastPolicy<'_>,
+) -> Result<MigrationBroadcastAdvance, String> {
+    let chain_tip_height =
+        u32::try_from(super::get_sync_progress(db_path, network)?.chain_tip_height)
+            .map_err(|_| "Migration chain tip exceeds u32".to_string())?;
+    broadcast_due_scheduled_migration_txs_at_tip(
+        db_path,
+        lightwalletd_url,
+        network,
+        run_id,
+        pending_password,
+        pending_salt_base64,
+        fallback_total_count,
+        fallback_migrated_zatoshi,
+        policy,
+        chain_tip_height,
+    )
+    .await
+}
+
+async fn broadcast_due_scheduled_migration_txs_at_tip(
+    db_path: &str,
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+    run_id: &str,
+    pending_password: &[u8],
+    pending_salt_base64: &str,
+    fallback_total_count: u32,
+    fallback_migrated_zatoshi: u64,
+    policy: MigrationBroadcastPolicy<'_>,
+    chain_tip_height: u32,
+) -> Result<MigrationBroadcastAdvance, String> {
+    let prepared = prepare_due_scheduled_migration_advance(
+        db_path,
+        network,
+        run_id,
+        pending_password,
+        pending_salt_base64,
+        fallback_total_count,
+        fallback_migrated_zatoshi,
+        &policy,
+        chain_tip_height,
+    )?;
+    let (totals_before, resubmit, due) = match prepared {
+        PreparedDueScheduledAdvance::Finished(advance) => return Ok(advance),
+        PreparedDueScheduledAdvance::Ready {
+            totals_before,
+            resubmit,
+            due,
+        } => (totals_before, resubmit, due),
+    };
+
+    // ONE_FOREGROUND shares one SendTransaction slot across recovery resubmit
+    // and new due broadcast so desktop on-open cannot submit multiple txs.
+    let (resubmit_batch, due_batch) = take_migration_submit_budget(policy, resubmit, due);
 
     let mut client = match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await {
         Ok(client) => client,
         Err(e) => {
-            if due.is_empty() {
+            if due_batch.is_empty() {
                 // Timed recovery rebroadcast is best-effort; do not fail the run
-                // when only recovery work was pending.
+                // when only recovery work would run this step.
                 log::warn!(
                     "migration: timed rebroadcast skipped; could not open lightwalletd: {e}"
                 );
-                let status = super::migration::run_phase(db_path, run_id)?;
-                return Ok(MigrationBroadcastAdvance::without_acceptance(
-                    migration_result_from_pending_totals(
-                        totals_before,
-                        &status,
-                        Some(
-                            "Migration transactions are scheduled for delayed broadcast."
-                                .to_string(),
-                        ),
-                        fallback_total_count,
-                        fallback_migrated_zatoshi,
-                    ),
-                ));
+                return scheduled_migration_waiting_advance(
+                    db_path,
+                    run_id,
+                    totals_before,
+                    fallback_total_count,
+                    fallback_migrated_zatoshi,
+                );
             }
             let message = format!("Migration broadcast could not start: {e}");
             super::migration::mark_run_phase(
@@ -4793,38 +4882,29 @@ async fn broadcast_due_scheduled_migration_txs(
 
     // Blind rebroadcast of accepted-but-unstored parts on quiet-height
     // boundaries. Never counts toward accepted_txids / one-open gate.
+    // Candidates skipped by the shared budget keep last_resubmit_tip unset.
     rebroadcast_timed_broadcasted_migration_txs(
         &mut client,
         db_path,
         run_id,
         chain_tip_height,
-        &resubmit,
+        &resubmit_batch,
     )
     .await;
 
-    if due.is_empty() {
-        let status = super::migration::run_phase(db_path, run_id)?;
-        let message = if status == super::migration::PHASE_BROADCAST_SCHEDULED
-            && super::migration::next_scheduled_height(db_path, run_id)?.is_none()
-        {
-            "Migration is waiting to prepare the next transaction."
-        } else {
-            "Migration transactions are scheduled for delayed broadcast."
-        };
-        return Ok(MigrationBroadcastAdvance::without_acceptance(
-            migration_result_from_pending_totals(
-                totals_before,
-                &status,
-                Some(message.to_string()),
-                fallback_total_count,
-                fallback_migrated_zatoshi,
-            ),
-        ));
+    if due_batch.is_empty() {
+        return scheduled_migration_waiting_advance(
+            db_path,
+            run_id,
+            totals_before,
+            fallback_total_count,
+            fallback_migrated_zatoshi,
+        );
     }
 
     super::migration::mark_run_phase(db_path, run_id, super::migration::PHASE_BROADCASTING, None)?;
     let mut accepted_txids = Vec::new();
-    for pending in due.into_iter().take(policy.limit(usize::MAX)) {
+    for pending in due_batch {
         if policy.is_cancelled() {
             super::migration::mark_run_phase(
                 db_path,
@@ -5242,6 +5322,24 @@ fn retry_store_broadcasted_migration_txs_missing_local(
         }
     }
     Ok(())
+}
+
+/// Split recovery resubmit and due broadcast candidates under the shared
+/// per-step `SendTransaction` budget (`ONE_FOREGROUND` → 1). Resubmit is
+/// preferred so accepted-but-unstored recovery runs before a new due submit.
+fn take_migration_submit_budget(
+    policy: MigrationBroadcastPolicy<'_>,
+    resubmit: Vec<super::migration::DuePendingMigrationTx>,
+    due: Vec<super::migration::DuePendingMigrationTx>,
+) -> (
+    Vec<super::migration::DuePendingMigrationTx>,
+    Vec<super::migration::DuePendingMigrationTx>,
+) {
+    let budget = policy.limit(resubmit.len().saturating_add(due.len()));
+    let resubmit_batch: Vec<_> = resubmit.into_iter().take(budget).collect();
+    let due_budget = budget.saturating_sub(resubmit_batch.len());
+    let due_batch: Vec<_> = due.into_iter().take(due_budget).collect();
+    (resubmit_batch, due_batch)
 }
 
 /// Blind-rebroadcast accepted-but-unstored migration parts on quiet-height

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -5262,31 +5262,8 @@ where
     let mut succeeded = Vec::new();
     for pending in candidates {
         let outcome = broadcast(&pending.txid_hex, &pending.raw_tx);
-        if let Err(error) = super::migration::mark_pending_timed_resubmit_attempted(
-            db_path,
-            run_id,
-            &pending.txid_hex,
-            tip,
-        ) {
-            log::warn!(
-                "migration: failed to record timed rebroadcast tip for {}: {error}",
-                pending.txid_hex
-            );
-        }
-        match outcome {
-            Ok(()) => {
-                log::info!(
-                    "migration: timed rebroadcast accepted for previously submitted tx {}",
-                    pending.txid_hex
-                );
-                succeeded.push(pending.txid_hex.clone());
-            }
-            Err(error) => {
-                log::warn!(
-                    "migration: timed rebroadcast failed for {}: {error}",
-                    pending.txid_hex
-                );
-            }
+        if finish_timed_rebroadcast_attempt(db_path, run_id, tip, &pending.txid_hex, outcome) {
+            succeeded.push(pending.txid_hex.clone());
         }
     }
     succeeded
@@ -5301,32 +5278,44 @@ async fn rebroadcast_timed_broadcasted_migration_txs(
     tip: u32,
     candidates: &[super::migration::DuePendingMigrationTx],
 ) {
+    // Thin async adapter over the same per-attempt policy as `_with` (record tip,
+    // log, classify Ok/Err). Keep awaiting outside the sync helper.
     for pending in candidates {
         let outcome = broadcast_raw_transaction(client, &pending.raw_tx).await;
-        if let Err(error) = super::migration::mark_pending_timed_resubmit_attempted(
+        let _ = finish_timed_rebroadcast_attempt(
             db_path,
             run_id,
-            &pending.txid_hex,
             tip,
-        ) {
-            log::warn!(
-                "migration: failed to record timed rebroadcast tip for {}: {error}",
-                pending.txid_hex
+            &pending.txid_hex,
+            outcome,
+        );
+    }
+}
+
+/// Shared post-broadcast policy for timed recovery: always record `tip`, then
+/// log success or failure. Returns whether lightwalletd accepted (incl. soft-accept).
+fn finish_timed_rebroadcast_attempt(
+    db_path: &str,
+    run_id: &str,
+    tip: u32,
+    txid_hex: &str,
+    outcome: Result<(), String>,
+) -> bool {
+    if let Err(error) =
+        super::migration::mark_pending_timed_resubmit_attempted(db_path, run_id, txid_hex, tip)
+    {
+        log::warn!("migration: failed to record timed rebroadcast tip for {txid_hex}: {error}");
+    }
+    match outcome {
+        Ok(()) => {
+            log::info!(
+                "migration: timed rebroadcast accepted for previously submitted tx {txid_hex}"
             );
+            true
         }
-        match outcome {
-            Ok(()) => {
-                log::info!(
-                    "migration: timed rebroadcast accepted for previously submitted tx {}",
-                    pending.txid_hex
-                );
-            }
-            Err(error) => {
-                log::warn!(
-                    "migration: timed rebroadcast failed for {}: {error}",
-                    pending.txid_hex
-                );
-            }
+        Err(error) => {
+            log::warn!("migration: timed rebroadcast failed for {txid_hex}: {error}");
+            false
         }
     }
 }

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -4700,6 +4700,13 @@ async fn broadcast_due_scheduled_migration_txs(
         pending_password,
         pending_salt_base64,
     )?;
+    let resubmit = super::migration::broadcasted_pending_txs_due_for_resubmit(
+        db_path,
+        run_id,
+        chain_tip_height,
+        pending_password,
+        pending_salt_base64,
+    )?;
     let due = super::migration::due_pending_txs(
         db_path,
         run_id,
@@ -4707,7 +4714,7 @@ async fn broadcast_due_scheduled_migration_txs(
         pending_password,
         pending_salt_base64,
     )?;
-    if due.is_empty() {
+    if resubmit.is_empty() && due.is_empty() {
         let status = super::migration::run_phase(db_path, run_id)?;
         let message = if status == super::migration::PHASE_BROADCAST_SCHEDULED
             && super::migration::next_scheduled_height(db_path, run_id)?.is_none()
@@ -4741,6 +4748,26 @@ async fn broadcast_due_scheduled_migration_txs(
     let mut client = match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await {
         Ok(client) => client,
         Err(e) => {
+            if due.is_empty() {
+                // Timed recovery rebroadcast is best-effort; do not fail the run
+                // when only recovery work was pending.
+                log::warn!(
+                    "migration: timed rebroadcast skipped; could not open lightwalletd: {e}"
+                );
+                let status = super::migration::run_phase(db_path, run_id)?;
+                return Ok(MigrationBroadcastAdvance::without_acceptance(
+                    migration_result_from_pending_totals(
+                        totals_before,
+                        &status,
+                        Some(
+                            "Migration transactions are scheduled for delayed broadcast."
+                                .to_string(),
+                        ),
+                        fallback_total_count,
+                        fallback_migrated_zatoshi,
+                    ),
+                ));
+            }
             let message = format!("Migration broadcast could not start: {e}");
             super::migration::mark_run_phase(
                 db_path,
@@ -4761,6 +4788,30 @@ async fn broadcast_due_scheduled_migration_txs(
             ));
         }
     };
+
+    // Blind rebroadcast of accepted-but-unstored parts on quiet-height
+    // boundaries. Never counts toward accepted_txids / one-open gate.
+    rebroadcast_timed_broadcasted_migration_txs(&mut client, &resubmit).await;
+
+    if due.is_empty() {
+        let status = super::migration::run_phase(db_path, run_id)?;
+        let message = if status == super::migration::PHASE_BROADCAST_SCHEDULED
+            && super::migration::next_scheduled_height(db_path, run_id)?.is_none()
+        {
+            "Migration is waiting to prepare the next transaction."
+        } else {
+            "Migration transactions are scheduled for delayed broadcast."
+        };
+        return Ok(MigrationBroadcastAdvance::without_acceptance(
+            migration_result_from_pending_totals(
+                totals_before,
+                &status,
+                Some(message.to_string()),
+                fallback_total_count,
+                fallback_migrated_zatoshi,
+            ),
+        ));
+    }
 
     super::migration::mark_run_phase(db_path, run_id, super::migration::PHASE_BROADCASTING, None)?;
     let mut accepted_txids = Vec::new();
@@ -5182,6 +5233,62 @@ fn retry_store_broadcasted_migration_txs_missing_local(
         }
     }
     Ok(())
+}
+
+/// Blind-rebroadcast accepted-but-unstored migration parts on quiet-height
+/// boundaries. Returns txids for which `broadcast` returned Ok (including
+/// soft-accept). Does not change pending status or report acceptance for the
+/// one-open gate.
+fn rebroadcast_timed_broadcasted_migration_txs_with<F>(
+    candidates: &[super::migration::DuePendingMigrationTx],
+    mut broadcast: F,
+) -> Vec<String>
+where
+    F: FnMut(&str, &[u8]) -> Result<(), String>,
+{
+    let mut succeeded = Vec::new();
+    for pending in candidates {
+        match broadcast(&pending.txid_hex, &pending.raw_tx) {
+            Ok(()) => {
+                log::info!(
+                    "migration: timed rebroadcast accepted for previously submitted tx {}",
+                    pending.txid_hex
+                );
+                succeeded.push(pending.txid_hex.clone());
+            }
+            Err(error) => {
+                log::warn!(
+                    "migration: timed rebroadcast failed for {}: {error}",
+                    pending.txid_hex
+                );
+            }
+        }
+    }
+    succeeded
+}
+
+async fn rebroadcast_timed_broadcasted_migration_txs(
+    client: &mut zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient<
+        tonic::transport::Channel,
+    >,
+    candidates: &[super::migration::DuePendingMigrationTx],
+) {
+    for pending in candidates {
+        match broadcast_raw_transaction(client, &pending.raw_tx).await {
+            Ok(()) => {
+                log::info!(
+                    "migration: timed rebroadcast accepted for previously submitted tx {}",
+                    pending.txid_hex
+                );
+            }
+            Err(error) => {
+                log::warn!(
+                    "migration: timed rebroadcast failed for {}: {error}",
+                    pending.txid_hex
+                );
+            }
+        }
+    }
 }
 
 fn migration_result_from_pending_totals(

--- a/rust/src/wallet/sync/send/ironwood_migration.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration.rs
@@ -568,6 +568,7 @@ pub(crate) async fn complete_orchard_migration_single_qr_pczt(
                         tx_kind: "migration".to_string(),
                         funding_account_uuid: account_uuid.to_string(),
                         selected_note,
+                        last_resubmit_tip: None,
                     },
                 })
             })
@@ -1194,6 +1195,7 @@ pub(crate) fn complete_orchard_migration_batch_pczt(
                             tx_kind: "migration".to_string(),
                             funding_account_uuid: account_uuid.to_string(),
                             selected_note: message.selected_note,
+                            last_resubmit_tip: None,
                         },
                     })
                 })
@@ -1258,6 +1260,7 @@ pub(crate) fn complete_orchard_migration_batch_pczt(
                     tx_kind: "migration".to_string(),
                     funding_account_uuid: account_uuid.to_string(),
                     selected_note: message.selected_note,
+                    last_resubmit_tip: None,
                 },
             });
         }

--- a/rust/src/wallet/sync/send/ironwood_migration/status_advance.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/status_advance.rs
@@ -409,6 +409,7 @@ fn prepare_software_migration_run(
                     tx_kind: "migration".to_string(),
                     funding_account_uuid: account_uuid.to_string(),
                     selected_note,
+                    last_resubmit_tip: None,
                 },
             })
         })

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -631,6 +631,7 @@ fn create_outbox_receipt_test_run(
                 tx_kind: "migration".to_string(),
                 funding_account_uuid: MIGRATION_TEST_ACCOUNT.to_string(),
                 selected_note,
+                last_resubmit_tip: None,
             },
         }],
         MIGRATION_TEST_PASSWORD,
@@ -1744,6 +1745,7 @@ fn scheduled_storage_failure_after_acceptance_marks_broadcasted() {
                 tx_kind: "migration".to_string(),
                 funding_account_uuid: MIGRATION_TEST_ACCOUNT.to_string(),
                 selected_note,
+                last_resubmit_tip: None,
             },
         }],
         MIGRATION_TEST_PASSWORD,
@@ -1914,6 +1916,7 @@ fn seed_broadcasted_unstored_migration_part(
                 tx_kind: "migration".to_string(),
                 funding_account_uuid: MIGRATION_TEST_ACCOUNT.to_string(),
                 selected_note,
+                last_resubmit_tip: None,
             },
         }],
         MIGRATION_TEST_PASSWORD,
@@ -1945,10 +1948,16 @@ fn timed_resubmit_skips_mid_quiet_window() {
     assert!(candidates.is_empty());
 
     let mut broadcasts = 0usize;
-    let succeeded = rebroadcast_timed_broadcasted_migration_txs_with(&candidates, |_, _| {
-        broadcasts += 1;
-        Ok(())
-    });
+    let succeeded = rebroadcast_timed_broadcasted_migration_txs_with(
+        &db_path,
+        &run_id,
+        mid,
+        &candidates,
+        |_, _| {
+            broadcasts += 1;
+            Ok(())
+        },
+    );
     assert!(succeeded.is_empty());
     assert_eq!(broadcasts, 0);
 }
@@ -2003,14 +2012,31 @@ fn timed_resubmit_on_quiet_boundary_soft_accepts_without_due_or_gate() {
     assert_eq!(candidates[0].raw_tx, vec![5, 6, 7, 8]);
 
     let mut broadcasted_raw = Vec::new();
-    let succeeded = rebroadcast_timed_broadcasted_migration_txs_with(&candidates, |txid, raw| {
-        assert_eq!(txid, pending_txid);
-        broadcasted_raw = raw.to_vec();
-        // Soft-accept path: broadcast helper returns Ok.
-        Ok(())
-    });
+    let succeeded = rebroadcast_timed_broadcasted_migration_txs_with(
+        &db_path,
+        &run_id,
+        tip,
+        &candidates,
+        |txid, raw| {
+            assert_eq!(txid, pending_txid);
+            broadcasted_raw = raw.to_vec();
+            // Soft-accept path: broadcast helper returns Ok.
+            Ok(())
+        },
+    );
     assert_eq!(succeeded, vec![pending_txid.to_string()]);
     assert_eq!(broadcasted_raw, vec![5, 6, 7, 8]);
+
+    // Same tip must not select the part again (advance spam while tip is stuck).
+    let again = migration::broadcasted_pending_txs_due_for_resubmit(
+        &db_path,
+        &run_id,
+        tip,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap();
+    assert!(again.is_empty());
 
     // HOL: broadcasted head must not win due selection.
     let due = migration::due_pending_txs(
@@ -2063,9 +2089,13 @@ fn timed_resubmit_hard_reject_leaves_broadcasted_and_skips_gate() {
         MIGRATION_TEST_SALT,
     )
     .unwrap();
-    let succeeded = rebroadcast_timed_broadcasted_migration_txs_with(&candidates, |_, _| {
-        Err("Broadcast rejected: txn-mempool-conflict".to_string())
-    });
+    let succeeded = rebroadcast_timed_broadcasted_migration_txs_with(
+        &db_path,
+        &run_id,
+        tip,
+        &candidates,
+        |_, _| Err("Broadcast rejected: txn-mempool-conflict".to_string()),
+    );
     assert!(succeeded.is_empty());
     assert_eq!(
         migration::pending_totals_for_run(&db_path, &run_id)
@@ -2076,6 +2106,30 @@ fn timed_resubmit_hard_reject_leaves_broadcasted_and_skips_gate() {
     assert_eq!(
         migration::scheduled_pending_count(&db_path, &run_id).unwrap(),
         0
+    );
+    // Hard reject still records the tip so same-tip advances do not hammer LWD.
+    assert!(migration::broadcasted_pending_txs_due_for_resubmit(
+        &db_path,
+        &run_id,
+        tip,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap()
+    .is_empty());
+    // Next quiet boundary remains eligible.
+    let next_tip = tip + migration::MIGRATION_BROADCAST_RESUBMIT_QUIET_BLOCKS;
+    assert_eq!(
+        migration::broadcasted_pending_txs_due_for_resubmit(
+            &db_path,
+            &run_id,
+            next_tip,
+            MIGRATION_TEST_PASSWORD,
+            MIGRATION_TEST_SALT,
+        )
+        .unwrap()
+        .len(),
+        1
     );
 }
 

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -1895,6 +1895,11 @@ fn seed_broadcasted_unstored_migration_part(
         MIGRATION_TEST_SALT,
     )
     .unwrap();
+    // Fee must match canonical ZIP-317 fee at the quiet tip used by prepare /
+    // broadcast_due_at_tip, or policy rebuild retires the run before resubmit.
+    let quiet_tip = scheduled_height + migration::MIGRATION_BROADCAST_RESUBMIT_QUIET_BLOCKS;
+    let fee_zatoshi =
+        canonical_migration_fee_zatoshi(WalletNetwork::Test, quiet_tip + 1).unwrap();
     // Match the stable #388 fixture: target_height == scheduled_height triggers
     // the legacy rewrite (target - 1 + block). With offset 1 that stays at
     // scheduled_height.
@@ -1910,7 +1915,7 @@ fn seed_broadcasted_unstored_migration_part(
             expiry_height: 69_120,
             scheduled_height,
             value_zatoshi: 100_000,
-            fee_zatoshi: 10_000,
+            fee_zatoshi,
             selected_note: selected_note.clone(),
             metadata: migration::PendingMigrationTxMetadata {
                 tx_kind: "migration".to_string(),
@@ -2124,6 +2129,196 @@ fn timed_resubmit_hard_reject_leaves_broadcasted_and_skips_gate() {
             &db_path,
             &run_id,
             next_tip,
+            MIGRATION_TEST_PASSWORD,
+            MIGRATION_TEST_SALT,
+        )
+        .unwrap()
+        .len(),
+        1
+    );
+}
+
+fn test_due_pending(txid_hex: &str, raw: u8) -> migration::DuePendingMigrationTx {
+    migration::DuePendingMigrationTx {
+        txid_hex: txid_hex.to_string(),
+        raw_tx: vec![raw],
+    }
+}
+
+#[test]
+fn one_foreground_submit_budget_prefers_resubmit_over_due() {
+    let resubmit = vec![
+        test_due_pending("resubmit-a", 1),
+        test_due_pending("resubmit-b", 2),
+    ];
+    let due = vec![test_due_pending("due-a", 3)];
+    let (resubmit_batch, due_batch) = take_migration_submit_budget(
+        MigrationBroadcastPolicy::ONE_FOREGROUND,
+        resubmit,
+        due,
+    );
+    assert_eq!(resubmit_batch.len(), 1);
+    assert_eq!(resubmit_batch[0].txid_hex, "resubmit-a");
+    assert!(
+        due_batch.is_empty(),
+        "shared budget of 1 must defer due when resubmit consumes the slot"
+    );
+}
+
+#[test]
+fn one_foreground_submit_budget_allows_due_when_no_resubmit() {
+    let (resubmit_batch, due_batch) = take_migration_submit_budget(
+        MigrationBroadcastPolicy::ONE_FOREGROUND,
+        Vec::new(),
+        vec![test_due_pending("due-a", 3), test_due_pending("due-b", 4)],
+    );
+    assert!(resubmit_batch.is_empty());
+    assert_eq!(due_batch.len(), 1);
+    assert_eq!(due_batch[0].txid_hex, "due-a");
+}
+
+#[test]
+fn foreground_submit_budget_allows_all_candidates() {
+    let resubmit = vec![
+        test_due_pending("resubmit-a", 1),
+        test_due_pending("resubmit-b", 2),
+    ];
+    let due = vec![test_due_pending("due-a", 3)];
+    let (resubmit_batch, due_batch) =
+        take_migration_submit_budget(MigrationBroadcastPolicy::FOREGROUND, resubmit, due);
+    assert_eq!(resubmit_batch.len(), 2);
+    assert_eq!(due_batch.len(), 1);
+}
+
+#[test]
+fn prepare_due_advance_resubmit_only_at_quiet_tip() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let pending_txid = "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f";
+    let scheduled = 100u32;
+    let run_id = seed_broadcasted_unstored_migration_part(&db_path, pending_txid, scheduled);
+    let tip = scheduled + migration::MIGRATION_BROADCAST_RESUBMIT_QUIET_BLOCKS;
+    let policy = MigrationBroadcastPolicy::FOREGROUND;
+
+    let prepared = prepare_due_scheduled_migration_advance(
+        &db_path,
+        WalletNetwork::Test,
+        &run_id,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+        1,
+        100_000,
+        &policy,
+        tip,
+    )
+    .unwrap();
+    let PreparedDueScheduledAdvance::Ready {
+        totals_before,
+        resubmit,
+        due,
+    } = prepared
+    else {
+        panic!("expected Ready with timed-resubmit candidates");
+    };
+    assert!(due.is_empty());
+    assert_eq!(resubmit.len(), 1);
+    assert_eq!(resubmit[0].txid_hex, pending_txid);
+    assert_eq!(totals_before.broadcasted_count, 1);
+
+    let succeeded = rebroadcast_timed_broadcasted_migration_txs_with(
+        &db_path,
+        &run_id,
+        tip,
+        &resubmit,
+        |_, _| Ok(()),
+    );
+    assert_eq!(succeeded, vec![pending_txid.to_string()]);
+
+    // Production resubmit-only success returns waiting advance with empty accepted_txids.
+    let advance =
+        scheduled_migration_waiting_advance(&db_path, &run_id, totals_before, 1, 100_000)
+            .unwrap();
+    assert!(advance.accepted_txids.is_empty());
+    let one_due = one_due_migration_result(advance);
+    assert!(one_due.txids.is_empty());
+
+    // Same tip is no longer selected after the attempt was recorded.
+    let prepared_again = prepare_due_scheduled_migration_advance(
+        &db_path,
+        WalletNetwork::Test,
+        &run_id,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+        1,
+        100_000,
+        &policy,
+        tip,
+    )
+    .unwrap();
+    assert!(matches!(
+        prepared_again,
+        PreparedDueScheduledAdvance::Finished(_)
+    ));
+}
+
+#[tokio::test]
+async fn broadcast_due_at_tip_resubmit_only_survives_lwd_open_failure() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let pending_txid = "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f";
+    let scheduled = 100u32;
+    let run_id = seed_broadcasted_unstored_migration_part(&db_path, pending_txid, scheduled);
+    let tip = scheduled + migration::MIGRATION_BROADCAST_RESUBMIT_QUIET_BLOCKS;
+    let policy = MigrationBroadcastPolicy::FOREGROUND;
+
+    // Prove we reach the LWD open path (Ready), not a rebuild Finished short-circuit.
+    assert!(matches!(
+        prepare_due_scheduled_migration_advance(
+            &db_path,
+            WalletNetwork::Test,
+            &run_id,
+            MIGRATION_TEST_PASSWORD,
+            MIGRATION_TEST_SALT,
+            1,
+            100_000,
+            &policy,
+            tip,
+        )
+        .unwrap(),
+        PreparedDueScheduledAdvance::Ready { .. }
+    ));
+
+    let advance = broadcast_due_scheduled_migration_txs_at_tip(
+        &db_path,
+        "http://127.0.0.1:1",
+        WalletNetwork::Test,
+        &run_id,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+        1,
+        100_000,
+        MigrationBroadcastPolicy::FOREGROUND,
+        tip,
+    )
+    .await
+    .unwrap();
+
+    assert!(advance.accepted_txids.is_empty());
+    assert_ne!(
+        advance.result.status,
+        migration::PHASE_FAILED_RECOVERABLE
+    );
+    let one_due = one_due_migration_result(advance);
+    assert!(one_due.txids.is_empty());
+
+    // Open failed before SendTransaction, so the quiet tip remains eligible.
+    assert_eq!(
+        migration::broadcasted_pending_txs_due_for_resubmit(
+            &db_path,
+            &run_id,
+            tip,
             MIGRATION_TEST_PASSWORD,
             MIGRATION_TEST_SALT,
         )

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -1868,6 +1868,14 @@ fn seed_broadcasted_unstored_migration_part(
     let selected_note_txid = "101112131415161718191a1b1c1d1e1f000102030405060708090a0b0c0d0e0f";
     let selected_note = migration_test_note(selected_note_txid);
     let plan = migration_test_plan();
+    // Deterministic schedule: empty schedule_json makes insert_pending_txs draw a
+    // random ZIP-318 offset that can exceed scheduled_height and fail with
+    // "Migration signed schedule starts below zero".
+    let approved_schedule = [migration::MigrationScheduleEntry {
+        part_index: Some(0),
+        value_zatoshi: 100_000,
+        block_offset: 1,
+    }];
     let run_id = migration::create_run_with_staged_denominations_and_signed_children(
         db_path,
         MIGRATION_TEST_ACCOUNT,
@@ -1879,12 +1887,15 @@ fn seed_broadcasted_unstored_migration_part(
             denomination_input_txid,
             selected_note_txid,
         )],
-        None,
+        Some(approved_schedule.as_slice()),
         migration::PreparationTimingPolicy::Immediate,
         MIGRATION_TEST_PASSWORD,
         MIGRATION_TEST_SALT,
     )
     .unwrap();
+    // Match the stable #388 fixture: target_height == scheduled_height triggers
+    // the legacy rewrite (target - 1 + block). With offset 1 that stays at
+    // scheduled_height.
     migration::insert_pending_txs(
         db_path,
         &run_id,
@@ -1892,12 +1903,9 @@ fn seed_broadcasted_unstored_migration_part(
             part_index: 0,
             txid_hex: pending_txid.to_string(),
             raw_tx: vec![5, 6, 7, 8],
-            // Keep target != scheduled so insert does not rewrite scheduled_height
-            // via the legacy target_height==scheduled_height compatibility path.
-            target_height: scheduled_height.saturating_sub(1).max(1),
+            target_height: scheduled_height,
             anchor_boundary_height: None,
-            expiry_height: migration::zip318_canonical_migration_expiry_height(scheduled_height)
-                .unwrap(),
+            expiry_height: 69_120,
             scheduled_height,
             value_zatoshi: 100_000,
             fee_zatoshi: 10_000,

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -1834,6 +1834,244 @@ fn scheduled_storage_failure_after_acceptance_marks_broadcasted() {
 }
 
 #[test]
+fn quiet_boundary_requires_scheduled_plus_n_quiet_blocks() {
+    let scheduled = 100u32;
+    let quiet = migration::MIGRATION_BROADCAST_RESUBMIT_QUIET_BLOCKS;
+    assert!(!migration::migration_broadcast_resubmit_on_quiet_boundary(
+        scheduled, scheduled
+    ));
+    assert!(!migration::migration_broadcast_resubmit_on_quiet_boundary(
+        scheduled + quiet - 1,
+        scheduled
+    ));
+    assert!(migration::migration_broadcast_resubmit_on_quiet_boundary(
+        scheduled + quiet,
+        scheduled
+    ));
+    assert!(!migration::migration_broadcast_resubmit_on_quiet_boundary(
+        scheduled + quiet + 1,
+        scheduled
+    ));
+    assert!(migration::migration_broadcast_resubmit_on_quiet_boundary(
+        scheduled + quiet * 2,
+        scheduled
+    ));
+}
+
+fn seed_broadcasted_unstored_migration_part(
+    db_path: &str,
+    pending_txid: &str,
+    scheduled_height: u32,
+) -> String {
+    let denomination_input_txid =
+        "303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f";
+    let selected_note_txid = "101112131415161718191a1b1c1d1e1f000102030405060708090a0b0c0d0e0f";
+    let selected_note = migration_test_note(selected_note_txid);
+    let plan = migration_test_plan();
+    let run_id = migration::create_run_with_staged_denominations_and_signed_children(
+        db_path,
+        MIGRATION_TEST_ACCOUNT,
+        WalletNetwork::Test,
+        &plan,
+        &[selected_note.clone()],
+        Vec::new(),
+        vec![migration_test_stage(
+            denomination_input_txid,
+            selected_note_txid,
+        )],
+        None,
+        migration::PreparationTimingPolicy::Immediate,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap();
+    migration::insert_pending_txs(
+        db_path,
+        &run_id,
+        vec![migration::PendingMigrationTxInsert {
+            part_index: 0,
+            txid_hex: pending_txid.to_string(),
+            raw_tx: vec![5, 6, 7, 8],
+            // Keep target != scheduled so insert does not rewrite scheduled_height
+            // via the legacy target_height==scheduled_height compatibility path.
+            target_height: scheduled_height.saturating_sub(1).max(1),
+            anchor_boundary_height: None,
+            expiry_height: migration::zip318_canonical_migration_expiry_height(scheduled_height)
+                .unwrap(),
+            scheduled_height,
+            value_zatoshi: 100_000,
+            fee_zatoshi: 10_000,
+            selected_note: selected_note.clone(),
+            metadata: migration::PendingMigrationTxMetadata {
+                tx_kind: "migration".to_string(),
+                funding_account_uuid: MIGRATION_TEST_ACCOUNT.to_string(),
+                selected_note,
+            },
+        }],
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap();
+    migration::mark_pending_broadcasted(db_path, &run_id, pending_txid).unwrap();
+    run_id
+}
+
+#[test]
+fn timed_resubmit_skips_mid_quiet_window() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let pending_txid = "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f";
+    let scheduled = 100u32;
+    let run_id = seed_broadcasted_unstored_migration_part(&db_path, pending_txid, scheduled);
+
+    let mid = scheduled + migration::MIGRATION_BROADCAST_RESUBMIT_QUIET_BLOCKS - 1;
+    let candidates = migration::broadcasted_pending_txs_due_for_resubmit(
+        &db_path,
+        &run_id,
+        mid,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap();
+    assert!(candidates.is_empty());
+
+    let mut broadcasts = 0usize;
+    let succeeded = rebroadcast_timed_broadcasted_migration_txs_with(&candidates, |_, _| {
+        broadcasts += 1;
+        Ok(())
+    });
+    assert!(succeeded.is_empty());
+    assert_eq!(broadcasts, 0);
+}
+
+#[test]
+fn timed_resubmit_on_quiet_boundary_soft_accepts_without_due_or_gate() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let pending_txid = "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f";
+    let scheduled = 100u32;
+    let run_id = seed_broadcasted_unstored_migration_part(&db_path, pending_txid, scheduled);
+
+    let tip = scheduled + migration::MIGRATION_BROADCAST_RESUBMIT_QUIET_BLOCKS;
+    assert!(
+        migration::migration_broadcast_resubmit_on_quiet_boundary(tip, scheduled),
+        "tip {tip} should be on quiet boundary for scheduled {scheduled}"
+    );
+    assert_eq!(
+        migration::pending_totals_for_run(&db_path, &run_id)
+            .unwrap()
+            .broadcasted_count,
+        1
+    );
+    let missing = migration::broadcasted_pending_txs_missing_local_identity(
+        &db_path,
+        &run_id,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap();
+    assert_eq!(
+        missing.len(),
+        1,
+        "expected missing-local broadcasted part before timed resubmit"
+    );
+    let candidates = migration::broadcasted_pending_txs_due_for_resubmit(
+        &db_path,
+        &run_id,
+        tip,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap();
+    assert_eq!(
+        candidates.len(),
+        1,
+        "missing={:?} tip={tip} scheduled={scheduled}",
+        missing.iter().map(|c| c.txid_hex.clone()).collect::<Vec<_>>()
+    );
+    assert_eq!(candidates[0].txid_hex, pending_txid);
+    assert_eq!(candidates[0].raw_tx, vec![5, 6, 7, 8]);
+
+    let mut broadcasted_raw = Vec::new();
+    let succeeded = rebroadcast_timed_broadcasted_migration_txs_with(&candidates, |txid, raw| {
+        assert_eq!(txid, pending_txid);
+        broadcasted_raw = raw.to_vec();
+        // Soft-accept path: broadcast helper returns Ok.
+        Ok(())
+    });
+    assert_eq!(succeeded, vec![pending_txid.to_string()]);
+    assert_eq!(broadcasted_raw, vec![5, 6, 7, 8]);
+
+    // HOL: broadcasted head must not win due selection.
+    let due = migration::due_pending_txs(
+        &db_path,
+        &run_id,
+        tip,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap();
+    assert!(due.is_empty());
+    assert_eq!(
+        migration::scheduled_pending_count(&db_path, &run_id).unwrap(),
+        0
+    );
+
+    let one_due = one_due_migration_result(MigrationBroadcastAdvance::without_acceptance(
+        migration_result_from_pending_totals(
+            migration::pending_totals_for_run(&db_path, &run_id).unwrap(),
+            migration::PHASE_WAITING_MIGRATION_CONFIRMATIONS,
+            None,
+            1,
+            100_000,
+        ),
+    ));
+    assert!(one_due.txids.is_empty());
+    assert_eq!(
+        migration::pending_totals_for_run(&db_path, &run_id)
+            .unwrap()
+            .broadcasted_count,
+        1
+    );
+}
+
+#[test]
+fn timed_resubmit_hard_reject_leaves_broadcasted_and_skips_gate() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let pending_txid = "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f";
+    let scheduled = 100u32;
+    let run_id = seed_broadcasted_unstored_migration_part(&db_path, pending_txid, scheduled);
+
+    let tip = scheduled + migration::MIGRATION_BROADCAST_RESUBMIT_QUIET_BLOCKS;
+    let candidates = migration::broadcasted_pending_txs_due_for_resubmit(
+        &db_path,
+        &run_id,
+        tip,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap();
+    let succeeded = rebroadcast_timed_broadcasted_migration_txs_with(&candidates, |_, _| {
+        Err("Broadcast rejected: txn-mempool-conflict".to_string())
+    });
+    assert!(succeeded.is_empty());
+    assert_eq!(
+        migration::pending_totals_for_run(&db_path, &run_id)
+            .unwrap()
+            .broadcasted_count,
+        1
+    );
+    assert_eq!(
+        migration::scheduled_pending_count(&db_path, &run_id).unwrap(),
+        0
+    );
+}
+
+#[test]
 fn migration_child_bundle_shape_and_fee_are_two_plus_one() {
     let orchard_actions = orchard::builder::BundleType::DEFAULT
         .num_actions(


### PR DESCRIPTION
## Summary
- Builds on [#388](https://github.com/chainapsis/vizor-wallet/pull/388): after accept + local store failure leaves a part `broadcasted`, recover from possible mempool eviction without waiting for ZIP 318 expiry (~30–60 days).
- On quiet-height boundaries (`scheduled_height + n×32`), blind-`SendTransaction` the encrypted pending raw for `broadcasted` parts still missing local wallet identity. Soft-accept if still in mempool.
- No `GetTransaction` probes (avoids an LWD interest oracle). No SQL schema changes — eligibility is derived from `(tip, scheduled_height)`.
- Recovery never re-enters due selection and never adds to `accepted_txids`, so HOL and the one-open gate stay intact.

## Why
#388 correctly stops HOL by leaving bare `scheduled` after network accept + store fail. The residual is weaker recovery if lightwalletd drops the tx before mine/store: only local store is retried until full ZIP expiry → resign. This PR closes that gap with rate-limited blind rebroadcast.

## Test plan
- [x] `cargo test --lib -- quiet_boundary_requires_scheduled_plus_n_quiet_blocks timed_resubmit_skips_mid_quiet_window timed_resubmit_on_quiet_boundary_soft_accepts_without_due_or_gate timed_resubmit_hard_reject_leaves_broadcasted_and_skips_gate`
- [ ] Merge after #388 (base is `fix/migration-accepted-unstored`)