### PR TITLE
Avoid redundant transaction downloads during recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,7 +394,7 @@ The entire sync loop runs in Rust (`rust/src/wallet/sync_engine.rs`). A single c
 2. Download subtree roots (sapling + orchard, incremental with start_index optimization)
 3. Download compact blocks into memory (in-memory `MemoryBlockSource`, no file I/O)
 4. `scan_cached_blocks` from memory (100 blocks per batch)
-5. Enhancement: fetch full tx data (`GetStatus`, `Enhancement`, `TransactionsInvolvingAddress`). While scan ranges remain, status-only (`GetStatus`) requests with durable evidence of prior compact-block mining are deferred and resolved locally once scanning restores their mined heights; normal pending transactions continue through status lookup and resubmission.
+5. Enhancement: fetch full tx data (`GetStatus`, `Enhancement`, `TransactionsInvolvingAddress`). A status-only (`GetStatus`) request with durable evidence of prior compact-block mining is deferred only while a pending scan range could still restore it. Compact scanning then resolves it locally; normal pending transactions continue through status lookup and resubmission.
 6. Progress streamed to Dart via FRB `StreamSink` per batch
 
 Single DB connection reused across entire sync (opened once, passed to all operations).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,7 +394,7 @@ The entire sync loop runs in Rust (`rust/src/wallet/sync_engine.rs`). A single c
 2. Download subtree roots (sapling + orchard, incremental with start_index optimization)
 3. Download compact blocks into memory (in-memory `MemoryBlockSource`, no file I/O)
 4. `scan_cached_blocks` from memory (100 blocks per batch)
-5. Enhancement: fetch full tx data (`GetStatus`, `Enhancement`, `TransactionsInvolvingAddress`). Status-only (`GetStatus`) requests are deferred while the scan frontier sits far below the chain tip (recovery rescan / deep catch-up) and are resolved locally once scanning restores mined heights; pending backfill below a tip-current frontier (e.g. an imported account's history) does not defer them.
+5. Enhancement: fetch full tx data (`GetStatus`, `Enhancement`, `TransactionsInvolvingAddress`). While scan ranges remain, status-only (`GetStatus`) requests with durable evidence of prior compact-block mining are deferred and resolved locally once scanning restores their mined heights; normal pending transactions continue through status lookup and resubmission.
 6. Progress streamed to Dart via FRB `StreamSink` per batch
 
 Single DB connection reused across entire sync (opened once, passed to all operations).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,7 +394,7 @@ The entire sync loop runs in Rust (`rust/src/wallet/sync_engine.rs`). A single c
 2. Download subtree roots (sapling + orchard, incremental with start_index optimization)
 3. Download compact blocks into memory (in-memory `MemoryBlockSource`, no file I/O)
 4. `scan_cached_blocks` from memory (100 blocks per batch)
-5. Enhancement: fetch full tx data (`GetStatus`, `Enhancement`, `TransactionsInvolvingAddress`)
+5. Enhancement: fetch full tx data (`GetStatus`, `Enhancement`, `TransactionsInvolvingAddress`). Status-only (`GetStatus`) requests are deferred while the scan frontier sits far below the chain tip (recovery rescan / deep catch-up) and are resolved locally once scanning restores mined heights; pending backfill below a tip-current frontier (e.g. an imported account's history) does not defer them.
 6. Progress streamed to Dart via FRB `StreamSink` per batch
 
 Single DB connection reused across entire sync (opened once, passed to all operations).

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -99,8 +99,9 @@ pub use transactions::{
 };
 #[allow(unused_imports)] // ditto
 pub(crate) use transactions::{
-    get_export_birthday_anchor, get_oldest_mined_transaction_anchor, ExportBirthdayAnchor,
-    TransactionDetail, TransactionDetailOutput, TransactionInfo, TxDataRequest, WalletBalance,
+    get_export_birthday_anchor, get_oldest_mined_transaction_anchor,
+    get_unmined_txids_with_mined_output_evidence, ExportBirthdayAnchor, TransactionDetail,
+    TransactionDetailOutput, TransactionInfo, TxDataRequest, WalletBalance,
     WalletBalanceAvailability,
 };
 

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -5402,6 +5402,9 @@ pub(crate) struct ResubmitStats {
 /// The caller owns the gRPC client. In the sync loop the same
 /// client that downloaded the compact blocks is threaded straight
 /// through, so auto-resubmit reuses the same connection.
+/// `excluded_txids` are filtered before their raw bytes are loaded.
+/// Recovery uses this to avoid rebroadcasting transactions that
+/// compact scanning can restore as mined.
 ///
 /// Logging uses `log::info!` for the "broadcasting N txs" entry
 /// and `log::warn!` for per-tx failures / retries so an operator
@@ -5411,6 +5414,7 @@ pub(crate) async fn resubmit_pending_transactions<ShouldExit>(
     db_path: &str,
     client: &mut zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient<tonic::transport::Channel>,
     current_height: u32,
+    excluded_txids: &HashSet<Vec<u8>>,
     should_exit: ShouldExit,
 ) -> ResubmitStats
 where
@@ -5421,7 +5425,11 @@ where
         return ResubmitStats::default();
     }
 
-    let candidates = match super::transactions::get_resubmittable_txs(db_path, current_height) {
+    let candidates = match super::transactions::get_resubmittable_txs_excluding(
+        db_path,
+        current_height,
+        excluded_txids,
+    ) {
         Ok(c) => c,
         Err(e) => {
             log::warn!(

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -265,6 +265,46 @@ pub fn get_transaction_data_requests(
         .collect())
 }
 
+/// Returns unmined transactions that the wallet previously discovered in a
+/// compact block. A shielded note only receives a commitment-tree position
+/// when it is scanned as mined; truncation retains that position even after it
+/// clears the transaction's mined height.
+pub(crate) fn get_unmined_txids_with_mined_output_evidence(
+    db_path: &str,
+) -> Result<HashSet<Vec<u8>>, String> {
+    let conn = open_readonly_conn(db_path)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT DISTINCT t.txid
+             FROM transactions t
+             WHERE t.mined_height IS NULL
+               AND (
+                 EXISTS (
+                   SELECT 1 FROM sapling_received_notes n
+                   WHERE n.transaction_id = t.id_tx
+                     AND n.commitment_tree_position IS NOT NULL
+                 )
+                 OR EXISTS (
+                   SELECT 1 FROM orchard_received_notes n
+                   WHERE n.transaction_id = t.id_tx
+                     AND n.commitment_tree_position IS NOT NULL
+                 )
+                 OR EXISTS (
+                   SELECT 1 FROM ironwood_received_notes n
+                   WHERE n.transaction_id = t.id_tx
+                     AND n.commitment_tree_position IS NOT NULL
+                 )
+               )",
+        )
+        .map_err(|e| format!("SQL error: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, Vec<u8>>(0))
+        .map_err(|e| format!("Query error: {e}"))?;
+
+    rows.collect::<Result<HashSet<_>, _>>()
+        .map_err(|e| format!("Row error: {e}"))
+}
+
 pub fn decrypt_and_store_transaction(
     db_path: &str,
     network: WalletNetwork,
@@ -1670,6 +1710,62 @@ pub(crate) fn get_resubmittable_txs(
         .map_err(|e| format!("Row error: {e}"))
 }
 
+/// Returns resubmittable transactions after filtering `excluded_txids` before
+/// loading raw transaction bytes.
+pub(crate) fn get_resubmittable_txs_excluding(
+    db_path: &str,
+    current_height: u32,
+    excluded_txids: &HashSet<Vec<u8>>,
+) -> Result<Vec<ResubmittableTx>, String> {
+    if excluded_txids.is_empty() {
+        return get_resubmittable_txs(db_path, current_height);
+    }
+
+    let conn = open_readonly_conn(db_path)?;
+    let candidate_metadata = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT DISTINCT txid, expiry_height \
+                 FROM v_transactions \
+                 WHERE mined_height IS NULL \
+                   AND (expiry_height = 0 OR expiry_height > ?1) \
+                   AND account_balance_delta < 0 \
+                   AND raw IS NOT NULL",
+            )
+            .map_err(|e| format!("SQL error: {e}"))?;
+        let rows = stmt
+            .query_map([current_height], |row| {
+                let txid_bytes: Vec<u8> = row.get(0)?;
+                let expiry_height = row
+                    .get::<_, Option<i64>>(1)?
+                    .map(|h| h.max(0) as u32)
+                    .unwrap_or(0);
+                Ok((txid_bytes, expiry_height))
+            })
+            .map_err(|e| format!("Query error: {e}"))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Row error: {e}"))?
+    };
+
+    let mut raw_stmt = conn
+        .prepare("SELECT raw FROM transactions WHERE txid = ?1 AND raw IS NOT NULL")
+        .map_err(|e| format!("SQL error: {e}"))?;
+    candidate_metadata
+        .into_iter()
+        .filter(|(txid_bytes, _)| !excluded_txids.contains(txid_bytes))
+        .map(|(txid_bytes, expiry_height)| {
+            let raw_tx = raw_stmt
+                .query_row([&txid_bytes], |row| row.get::<_, Vec<u8>>(0))
+                .map_err(|e| format!("Raw transaction query error: {e}"))?;
+            Ok(ResubmittableTx {
+                txid_bytes,
+                raw_tx,
+                expiry_height,
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     //! SQL-predicate regression tests for `get_resubmittable_txs`.
@@ -1722,12 +1818,42 @@ mod tests {
         let file = NamedTempFile::new().unwrap();
         let conn = rusqlite::Connection::open(file.path()).unwrap();
         conn.execute_batch(
-            "CREATE TABLE v_transactions (
+            "CREATE TABLE transactions (
+                 txid BLOB PRIMARY KEY,
+                 raw BLOB
+             );
+             CREATE TABLE v_transactions (
                  txid BLOB NOT NULL,
                  raw BLOB,
                  mined_height INTEGER,
                  expiry_height INTEGER,
                  account_balance_delta INTEGER NOT NULL
+             );",
+        )
+        .unwrap();
+        file
+    }
+
+    fn mined_output_evidence_db() -> NamedTempFile {
+        let file = NamedTempFile::new().unwrap();
+        let conn = rusqlite::Connection::open(file.path()).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE transactions (
+                 id_tx INTEGER PRIMARY KEY,
+                 txid BLOB NOT NULL,
+                 mined_height INTEGER
+             );
+             CREATE TABLE sapling_received_notes (
+                 transaction_id INTEGER NOT NULL,
+                 commitment_tree_position INTEGER
+             );
+             CREATE TABLE orchard_received_notes (
+                 transaction_id INTEGER NOT NULL,
+                 commitment_tree_position INTEGER
+             );
+             CREATE TABLE ironwood_received_notes (
+                 transaction_id INTEGER NOT NULL,
+                 commitment_tree_position INTEGER
              );",
         )
         .unwrap();
@@ -1745,6 +1871,12 @@ mod tests {
     ) {
         let conn = rusqlite::Connection::open(db.path()).unwrap();
         conn.execute(
+            "INSERT INTO transactions (txid, raw) VALUES (?1, ?2)
+             ON CONFLICT(txid) DO UPDATE SET raw = excluded.raw",
+            rusqlite::params![txid, raw],
+        )
+        .unwrap();
+        conn.execute(
             "INSERT INTO v_transactions (txid, raw, mined_height, expiry_height, account_balance_delta)
              VALUES (?1, ?2, ?3, ?4, ?5)",
             rusqlite::params![txid, raw, mined_height, expiry_height, account_balance_delta],
@@ -1754,6 +1886,48 @@ mod tests {
 
     fn fake_txid(byte: u8) -> [u8; 32] {
         [byte; 32]
+    }
+
+    #[test]
+    fn mined_output_evidence_requires_an_unmined_tx_with_a_positioned_note() {
+        let db = mined_output_evidence_db();
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        for (id, mined_height) in [
+            (1, None),
+            (2, None),
+            (3, None),
+            (4, None),
+            (5, Some(1_000_000)),
+            (6, None),
+        ] {
+            conn.execute(
+                "INSERT INTO transactions (id_tx, txid, mined_height)
+                 VALUES (?1, ?2, ?3)",
+                rusqlite::params![id, fake_txid(id as u8), mined_height],
+            )
+            .unwrap();
+        }
+        conn.execute(
+            "INSERT INTO sapling_received_notes VALUES (1, 10), (4, NULL), (5, 20)",
+            [],
+        )
+        .unwrap();
+        conn.execute("INSERT INTO orchard_received_notes VALUES (2, 30)", [])
+            .unwrap();
+        conn.execute("INSERT INTO ironwood_received_notes VALUES (3, 40)", [])
+            .unwrap();
+        drop(conn);
+
+        let got =
+            get_unmined_txids_with_mined_output_evidence(db.path().to_str().unwrap()).unwrap();
+        assert_eq!(
+            got,
+            HashSet::from([
+                fake_txid(1).to_vec(),
+                fake_txid(2).to_vec(),
+                fake_txid(3).to_vec(),
+            ])
+        );
     }
 
     fn tx_base_for_history() -> TxBase {
@@ -4517,6 +4691,47 @@ mod tests {
         assert_eq!(got[0].txid_bytes, txid.to_vec());
         assert_eq!(got[0].raw_tx, raw);
         assert_eq!(got[0].expiry_height, 1_000_100);
+    }
+
+    #[test]
+    fn resubmit_excludes_only_deferred_txids() {
+        let db = fresh_db();
+        let deferred_txid = fake_txid(0x15);
+        let pending_txid = fake_txid(0x16);
+        let raw = fake_raw();
+        insert_row(
+            &db,
+            &deferred_txid,
+            Some(&raw),
+            None,
+            Some(1_000_100),
+            -5_000,
+        );
+        insert_row(
+            &db,
+            &pending_txid,
+            Some(&raw),
+            None,
+            Some(1_000_100),
+            -5_000,
+        );
+        // The metadata query's stand-in view still reports raw bytes, but the
+        // backing lookup cannot return them. Exclusion must happen before the
+        // raw transaction query.
+        rusqlite::Connection::open(db.path())
+            .unwrap()
+            .execute(
+                "UPDATE transactions SET raw = NULL WHERE txid = ?1",
+                [&deferred_txid],
+            )
+            .unwrap();
+
+        let excluded = HashSet::from([deferred_txid.to_vec()]);
+        let got =
+            get_resubmittable_txs_excluding(db.path().to_str().unwrap(), 1_000_000, &excluded)
+                .unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].txid_bytes, pending_txid);
     }
 
     #[test]

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -16,7 +16,10 @@
 //! chain-tip update, scan range management) and the shared
 //! PROPOSAL_STORE used by both the software and PCZT send paths.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Range,
+};
 
 use rusqlite::OptionalExtension;
 use transparent::address::TransparentAddress;
@@ -266,16 +269,22 @@ pub fn get_transaction_data_requests(
 }
 
 /// Returns unmined transactions that the wallet previously discovered in a
-/// compact block. A shielded note only receives a commitment-tree position
-/// when it is scanned as mined; truncation retains that position even after it
-/// clears the transaction's mined height.
+/// compact block and that a pending scan range could still restore as mined.
+/// A shielded note only receives a commitment-tree position when it is scanned
+/// as mined; truncation retains that position even after it clears the
+/// transaction's mined height.
 pub(crate) fn get_unmined_txids_with_mined_output_evidence(
     db_path: &str,
+    pending_ranges: &[Range<BlockHeight>],
 ) -> Result<HashSet<Vec<u8>>, String> {
+    if pending_ranges.is_empty() {
+        return Ok(HashSet::new());
+    }
+
     let conn = open_readonly_conn(db_path)?;
     let mut stmt = conn
         .prepare(
-            "SELECT DISTINCT t.txid
+            "SELECT DISTINCT t.txid, t.min_observed_height, t.expiry_height
              FROM transactions t
              WHERE t.mined_height IS NULL
                AND (
@@ -298,11 +307,32 @@ pub(crate) fn get_unmined_txids_with_mined_output_evidence(
         )
         .map_err(|e| format!("SQL error: {e}"))?;
     let rows = stmt
-        .query_map([], |row| row.get::<_, Vec<u8>>(0))
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, Vec<u8>>(0)?,
+                row.get::<_, u32>(1)?,
+                row.get::<_, Option<u32>>(2)?,
+            ))
+        })
         .map_err(|e| format!("Query error: {e}"))?;
 
-    rows.collect::<Result<HashSet<_>, _>>()
-        .map_err(|e| format!("Row error: {e}"))
+    rows.filter_map(|row| match row {
+        Ok((txid, min_observed_height, expiry_height))
+            if pending_ranges.iter().any(|range| {
+                let range_start = u32::from(range.start);
+                let range_end = u32::from(range.end);
+                let known_expiry = expiry_height.filter(|height| *height > 0);
+                range_end > min_observed_height
+                    && known_expiry.is_none_or(|height| range_start < height)
+            }) =>
+        {
+            Some(Ok(txid))
+        }
+        Ok(_) => None,
+        Err(error) => Some(Err(error)),
+    })
+    .collect::<Result<HashSet<_>, _>>()
+    .map_err(|e| format!("Row error: {e}"))
 }
 
 pub fn decrypt_and_store_transaction(
@@ -1841,7 +1871,9 @@ mod tests {
             "CREATE TABLE transactions (
                  id_tx INTEGER PRIMARY KEY,
                  txid BLOB NOT NULL,
-                 mined_height INTEGER
+                 mined_height INTEGER,
+                 min_observed_height INTEGER NOT NULL,
+                 expiry_height INTEGER
              );
              CREATE TABLE sapling_received_notes (
                  transaction_id INTEGER NOT NULL,
@@ -1901,8 +1933,9 @@ mod tests {
             (6, None),
         ] {
             conn.execute(
-                "INSERT INTO transactions (id_tx, txid, mined_height)
-                 VALUES (?1, ?2, ?3)",
+                "INSERT INTO transactions
+                    (id_tx, txid, mined_height, min_observed_height, expiry_height)
+                 VALUES (?1, ?2, ?3, 900, 1_100)",
                 rusqlite::params![id, fake_txid(id as u8), mined_height],
             )
             .unwrap();
@@ -1918,8 +1951,12 @@ mod tests {
             .unwrap();
         drop(conn);
 
-        let got =
-            get_unmined_txids_with_mined_output_evidence(db.path().to_str().unwrap()).unwrap();
+        let pending_ranges = [BlockHeight::from_u32(900)..BlockHeight::from_u32(1_100)];
+        let got = get_unmined_txids_with_mined_output_evidence(
+            db.path().to_str().unwrap(),
+            &pending_ranges,
+        )
+        .unwrap();
         assert_eq!(
             got,
             HashSet::from([
@@ -1927,6 +1964,58 @@ mod tests {
                 fake_txid(2).to_vec(),
                 fake_txid(3).to_vec(),
             ])
+        );
+    }
+
+    #[test]
+    fn mined_output_evidence_stops_deferring_after_restoring_ranges_pass() {
+        let db = mined_output_evidence_db();
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        for (id, expiry_height) in [(1, 600), (2, 0)] {
+            conn.execute(
+                "INSERT INTO transactions
+                    (id_tx, txid, mined_height, min_observed_height, expiry_height)
+                 VALUES (?1, ?2, NULL, 500, ?3)",
+                rusqlite::params![id, fake_txid(id as u8), expiry_height],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO orchard_received_notes VALUES (?1, ?2)",
+                rusqlite::params![id, id * 10],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        let recovery_and_older = [
+            BlockHeight::from_u32(500)..BlockHeight::from_u32(600),
+            BlockHeight::from_u32(100)..BlockHeight::from_u32(400),
+        ];
+        assert_eq!(
+            get_unmined_txids_with_mined_output_evidence(
+                db.path().to_str().unwrap(),
+                &recovery_and_older,
+            )
+            .unwrap(),
+            HashSet::from([fake_txid(1).to_vec(), fake_txid(2).to_vec()])
+        );
+
+        let older_only = [BlockHeight::from_u32(100)..BlockHeight::from_u32(400)];
+        assert!(get_unmined_txids_with_mined_output_evidence(
+            db.path().to_str().unwrap(),
+            &older_only,
+        )
+        .unwrap()
+        .is_empty());
+
+        let after_expiry = [BlockHeight::from_u32(600)..BlockHeight::from_u32(700)];
+        assert_eq!(
+            get_unmined_txids_with_mined_output_evidence(
+                db.path().to_str().unwrap(),
+                &after_expiry,
+            )
+            .unwrap(),
+            HashSet::from([fake_txid(2).to_vec()])
         );
     }
 

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -253,6 +253,10 @@ pub(super) async fn run_enhancement(
     Ok(())
 }
 
+/// Whether servicing `request` can make progress right now: full-data
+/// enhancements always can, status-only requests only when
+/// `query_unmined_statuses` permits them, and address-scoped requests only
+/// when they carry a bounded block range.
 fn request_is_actionable(request: &TransactionDataRequest, query_unmined_statuses: bool) -> bool {
     match request {
         TransactionDataRequest::Enhancement(_) => true,
@@ -263,6 +267,11 @@ fn request_is_actionable(request: &TransactionDataRequest, query_unmined_statuse
     }
 }
 
+/// Resolves a `GetStatus` request locally when the wallet DB already records
+/// a mined height for `txid` (restored by compact scanning), re-asserting
+/// `TransactionStatus::Mined` — which also dequeues the request — without
+/// downloading the transaction. Returns `Ok(false)` when the height is
+/// unknown and the caller must query lightwalletd.
 fn resolve_status_from_scanned_height(
     db: &mut WalletDatabase,
     txid: TxId,
@@ -469,6 +478,10 @@ fn transaction_status_from_raw_height(raw_height: u64) -> Result<TransactionStat
 mod tests {
     use super::*;
 
+    /// Builds a real migrated wallet DB containing one transaction with a
+    /// known mined height plus an explicit status-type retrieval-queue entry
+    /// for it, mirroring the post-recovery state `resolve_status_from_scanned_height`
+    /// services.
     fn status_recovery_test_db(
         txid: TxId,
         mined_height: BlockHeight,

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -14,7 +14,7 @@
 //!     backfill its activity).
 //!
 //! Librustzcash signals these gaps by populating
-//! `db.transaction_data_requests()`. This module drains the queue
+//! `db.transaction_data_requests()`. This module services the queue
 //! against lightwalletd via three gRPC calls (`GetTransaction`,
 //! `TransactionsInvolvingAddress`) and writes the results back into
 //! `db` using `decrypt_and_store_transaction` and
@@ -34,7 +34,7 @@ use zcash_client_backend::{
     },
     proto::service::compact_tx_streamer_client::CompactTxStreamerClient,
 };
-use zcash_primitives::transaction::Transaction;
+use zcash_primitives::transaction::{Transaction, TxId};
 use zcash_protocol::consensus::{BlockHeight, BranchId};
 use zcash_protocol::value::{BalanceError, Zatoshis};
 
@@ -43,8 +43,9 @@ use crate::wallet::network::WalletNetwork;
 
 use super::{lwd, SyncError, WalletDatabase};
 
-/// Drains `db.transaction_data_requests()` against lightwalletd until
-/// the queue is empty or no request is actionable. Returns
+/// Services `db.transaction_data_requests()` against lightwalletd until
+/// the queue is empty or no request is actionable. Status-only requests
+/// remain queued while `query_unmined_statuses` is false. Returns
 /// `SyncError::Db` if `db.transaction_data_requests()` itself fails.
 /// Per-request failures are split by semantics: an explicit
 /// "txid not recognized" response is recorded via
@@ -56,6 +57,7 @@ pub(super) async fn run_enhancement(
     db: &mut WalletDatabase,
     db_path: &str,
     network: WalletNetwork,
+    query_unmined_statuses: bool,
 ) -> Result<(), SyncError> {
     let mut failed_txids: HashSet<String> = HashSet::new();
 
@@ -71,23 +73,31 @@ pub(super) async fn run_enhancement(
         // requests without an `end` height, which we can't service
         // without synthesizing a range), break rather than looping
         // forever on the same inert queue.
-        let actionable = requests.iter().any(|r| match r {
-            TransactionDataRequest::Enhancement(_) | TransactionDataRequest::GetStatus(_) => true,
-            TransactionDataRequest::TransactionsInvolvingAddress(req) => {
-                req.block_range_end().is_some()
-            }
-        });
+        let actionable = requests
+            .iter()
+            .any(|request| request_is_actionable(request, query_unmined_statuses));
         if !actionable {
             break;
         }
 
         for req in &requests {
             match req {
+                TransactionDataRequest::GetStatus(_) if !query_unmined_statuses => continue,
                 TransactionDataRequest::GetStatus(txid)
                 | TransactionDataRequest::Enhancement(txid) => {
                     let txid_str = format!("{txid}");
                     if failed_txids.contains(&txid_str) {
                         continue;
+                    }
+
+                    if matches!(req, TransactionDataRequest::GetStatus(_)) {
+                        match resolve_status_from_scanned_height(db, *txid) {
+                            Ok(true) => continue,
+                            Ok(false) => {}
+                            Err(e) => log::error!(
+                                "sync: could not resolve transaction status locally: {e}"
+                            ),
+                        }
                     }
 
                     match lwd::get_transaction(client, txid.as_ref().to_vec()).await {
@@ -241,6 +251,37 @@ pub(super) async fn run_enhancement(
         }
     }
     Ok(())
+}
+
+fn request_is_actionable(request: &TransactionDataRequest, query_unmined_statuses: bool) -> bool {
+    match request {
+        TransactionDataRequest::Enhancement(_) => true,
+        TransactionDataRequest::GetStatus(_) => query_unmined_statuses,
+        TransactionDataRequest::TransactionsInvolvingAddress(req) => {
+            req.block_range_end().is_some()
+        }
+    }
+}
+
+fn resolve_status_from_scanned_height(
+    db: &mut WalletDatabase,
+    txid: TxId,
+) -> Result<bool, SyncError> {
+    let Some(mined_height) = db
+        .get_tx_height(txid)
+        .map_err(|e| SyncError::db(format!("get transaction height: {e}")))?
+    else {
+        return Ok(false);
+    };
+
+    with_wallet_db_write_lock(
+        "sync_engine.enhance.set_known_mined_transaction_status",
+        || {
+            db.set_transaction_status(txid, TransactionStatus::Mined(mined_height))
+                .map_err(|e| SyncError::db(format!("set known mined transaction status: {e}")))
+        },
+    )?;
+    Ok(true)
 }
 
 async fn fill_missing_transparent_fee(
@@ -428,6 +469,47 @@ fn transaction_status_from_raw_height(raw_height: u64) -> Result<TransactionStat
 mod tests {
     use super::*;
 
+    fn status_recovery_test_db(
+        txid: TxId,
+        mined_height: BlockHeight,
+    ) -> (tempfile::NamedTempFile, WalletDatabase) {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let db_path = file.path().to_str().unwrap();
+        let mut db = crate::wallet::db::open_wallet_db_with_timeout(
+            db_path,
+            WalletNetwork::Regtest,
+            SYNC_DB_BUSY_TIMEOUT,
+        )
+        .unwrap();
+        zcash_client_sqlite::wallet::init::init_wallet_db(&mut db, None).unwrap();
+        db.update_chain_tip(mined_height + 10).unwrap();
+        drop(db);
+
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.execute(
+            "INSERT INTO transactions
+                (txid, mined_height, raw, min_observed_height)
+             VALUES (?1, ?2, X'00', ?2)",
+            rusqlite::params![txid.as_ref(), u32::from(mined_height)],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO tx_retrieval_queue (txid, query_type)
+             VALUES (?1, 0)",
+            rusqlite::params![txid.as_ref()],
+        )
+        .unwrap();
+        drop(conn);
+
+        let db = crate::wallet::db::open_wallet_db_with_timeout(
+            db_path,
+            WalletNetwork::Regtest,
+            SYNC_DB_BUSY_TIMEOUT,
+        )
+        .unwrap();
+        (file, db)
+    }
+
     fn transparent_fee_test_tx() -> Transaction {
         let tx_bytes = hex::decode(
             "0400008085202f8901aee37187e843da597683c26c01457f5fd3b1a038996ef74dc8d60d483aaf395a000000006b483045022100874c70db77ea9e93f75cc83a9e141e17c8eb97588e29fe4e307631fdde4f162a02203493df62d648cd86a1189eaf9bcafc652bc14c5df02519d9e45e25b32aaffb5b012102106a2dcaaac2ae3b24358a03f4264e05db420c5b090399bc23885fa02fef7716ffffffff02764e1900000000001976a914fb451987556f7a19b726966ee6cff917e0bb3bfb88ac560ca400000000001976a9141634f5ff0b8f6603a17570436d6c12a91f4b1fed88ac00000000000000000000000000000000000000",
@@ -501,6 +583,40 @@ mod tests {
                 GetTransactionErrorAction::RetryAsNetwork,
             );
         }
+    }
+
+    #[test]
+    fn deferred_status_requests_do_not_block_full_data_enhancement() {
+        assert!(!request_is_actionable(
+            &TransactionDataRequest::GetStatus(TxId::from_bytes([1; 32])),
+            false,
+        ));
+        assert!(request_is_actionable(
+            &TransactionDataRequest::GetStatus(TxId::from_bytes([1; 32])),
+            true,
+        ));
+        assert!(request_is_actionable(
+            &TransactionDataRequest::Enhancement(TxId::from_bytes([2; 32])),
+            false,
+        ));
+    }
+
+    #[test]
+    fn scanned_height_resolves_status_without_transaction_download() {
+        let txid = TxId::from_bytes([3; 32]);
+        let mined_height = BlockHeight::from_u32(500);
+        let (_file, mut db) = status_recovery_test_db(txid, mined_height);
+
+        assert!(db
+            .transaction_data_requests()
+            .unwrap()
+            .contains(&TransactionDataRequest::GetStatus(txid)));
+        assert!(resolve_status_from_scanned_height(&mut db, txid).unwrap());
+        assert!(!db
+            .transaction_data_requests()
+            .unwrap()
+            .contains(&TransactionDataRequest::GetStatus(txid)));
+        assert_eq!(db.get_tx_height(txid).unwrap(), Some(mined_height));
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -45,7 +45,7 @@ use super::{lwd, SyncError, WalletDatabase};
 
 /// Services `db.transaction_data_requests()` against lightwalletd until
 /// the queue is empty or no request is actionable. Status-only requests
-/// remain queued while `query_unmined_statuses` is false. Returns
+/// in `deferred_status_txids` remain queued for compact scanning. Returns
 /// `SyncError::Db` if `db.transaction_data_requests()` itself fails.
 /// Per-request failures are split by semantics: an explicit
 /// "txid not recognized" response is recorded via
@@ -57,7 +57,7 @@ pub(super) async fn run_enhancement(
     db: &mut WalletDatabase,
     db_path: &str,
     network: WalletNetwork,
-    query_unmined_statuses: bool,
+    deferred_status_txids: &HashSet<Vec<u8>>,
 ) -> Result<(), SyncError> {
     let mut failed_txids: HashSet<String> = HashSet::new();
 
@@ -75,14 +75,18 @@ pub(super) async fn run_enhancement(
         // forever on the same inert queue.
         let actionable = requests
             .iter()
-            .any(|request| request_is_actionable(request, query_unmined_statuses));
+            .any(|request| request_is_actionable(request, deferred_status_txids));
         if !actionable {
             break;
         }
 
         for req in &requests {
             match req {
-                TransactionDataRequest::GetStatus(_) if !query_unmined_statuses => continue,
+                TransactionDataRequest::GetStatus(txid)
+                    if deferred_status_txids.contains(txid.as_ref().as_slice()) =>
+                {
+                    continue
+                }
                 TransactionDataRequest::GetStatus(txid)
                 | TransactionDataRequest::Enhancement(txid) => {
                     let txid_str = format!("{txid}");
@@ -254,13 +258,18 @@ pub(super) async fn run_enhancement(
 }
 
 /// Whether servicing `request` can make progress right now: full-data
-/// enhancements always can, status-only requests only when
-/// `query_unmined_statuses` permits them, and address-scoped requests only
-/// when they carry a bounded block range.
-fn request_is_actionable(request: &TransactionDataRequest, query_unmined_statuses: bool) -> bool {
+/// enhancements always can, status-only requests unless their transaction is
+/// deferred for compact scanning, and address-scoped requests only when they
+/// carry a bounded block range.
+fn request_is_actionable(
+    request: &TransactionDataRequest,
+    deferred_status_txids: &HashSet<Vec<u8>>,
+) -> bool {
     match request {
         TransactionDataRequest::Enhancement(_) => true,
-        TransactionDataRequest::GetStatus(_) => query_unmined_statuses,
+        TransactionDataRequest::GetStatus(txid) => {
+            !deferred_status_txids.contains(txid.as_ref().as_slice())
+        }
         TransactionDataRequest::TransactionsInvolvingAddress(req) => {
             req.block_range_end().is_some()
         }
@@ -600,17 +609,18 @@ mod tests {
 
     #[test]
     fn deferred_status_requests_do_not_block_full_data_enhancement() {
+        let deferred = HashSet::from([vec![1; 32]]);
         assert!(!request_is_actionable(
             &TransactionDataRequest::GetStatus(TxId::from_bytes([1; 32])),
-            false,
+            &deferred,
         ));
         assert!(request_is_actionable(
-            &TransactionDataRequest::GetStatus(TxId::from_bytes([1; 32])),
-            true,
+            &TransactionDataRequest::GetStatus(TxId::from_bytes([2; 32])),
+            &deferred,
         ));
         assert!(request_is_actionable(
-            &TransactionDataRequest::Enhancement(TxId::from_bytes([2; 32])),
-            false,
+            &TransactionDataRequest::Enhancement(TxId::from_bytes([1; 32])),
+            &deferred,
         ));
     }
 

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -95,11 +95,43 @@ pub(super) async fn run_enhancement(
                     }
 
                     if matches!(req, TransactionDataRequest::GetStatus(_)) {
-                        match resolve_status_from_scanned_height(db, *txid) {
-                            Ok(true) => continue,
-                            Ok(false) => {}
+                        match scanned_mined_height(db, *txid) {
+                            Ok(Some(mined_height)) => {
+                                let can_resolve_locally = match db.get_transaction(*txid) {
+                                    Ok(Some(tx)) => {
+                                        if let Err(e) =
+                                            fill_missing_transparent_fee(client, db_path, &tx).await
+                                        {
+                                            log::warn!(
+                                                "sync: transparent fee enhancement failed for {txid_str}: {e}"
+                                            );
+                                        }
+                                        true
+                                    }
+                                    Ok(None) => true,
+                                    Err(e) => {
+                                        log::error!(
+                                            "sync: could not read stored transaction for local status resolution: {e}"
+                                        );
+                                        false
+                                    }
+                                };
+                                if can_resolve_locally {
+                                    match resolve_status_from_scanned_height(
+                                        db,
+                                        *txid,
+                                        mined_height,
+                                    ) {
+                                        Ok(()) => continue,
+                                        Err(e) => log::error!(
+                                            "sync: could not resolve transaction status locally: {e}"
+                                        ),
+                                    }
+                                }
+                            }
+                            Ok(None) => {}
                             Err(e) => log::error!(
-                                "sync: could not resolve transaction status locally: {e}"
+                                "sync: could not read locally restored transaction status: {e}"
                             ),
                         }
                     }
@@ -276,30 +308,25 @@ fn request_is_actionable(
     }
 }
 
-/// Resolves a `GetStatus` request locally when the wallet DB already records
-/// a mined height for `txid` (restored by compact scanning), re-asserting
-/// `TransactionStatus::Mined` — which also dequeues the request — without
-/// downloading the transaction. Returns `Ok(false)` when the height is
-/// unknown and the caller must query lightwalletd.
+fn scanned_mined_height(db: &WalletDatabase, txid: TxId) -> Result<Option<BlockHeight>, SyncError> {
+    db.get_tx_height(txid)
+        .map_err(|e| SyncError::db(format!("get transaction height: {e}")))
+}
+
+/// Re-asserts a compact-scan-restored mined status after any missing fee has
+/// been backfilled, which also dequeues the `GetStatus` request.
 fn resolve_status_from_scanned_height(
     db: &mut WalletDatabase,
     txid: TxId,
-) -> Result<bool, SyncError> {
-    let Some(mined_height) = db
-        .get_tx_height(txid)
-        .map_err(|e| SyncError::db(format!("get transaction height: {e}")))?
-    else {
-        return Ok(false);
-    };
-
+    mined_height: BlockHeight,
+) -> Result<(), SyncError> {
     with_wallet_db_write_lock(
         "sync_engine.enhance.set_known_mined_transaction_status",
         || {
             db.set_transaction_status(txid, TransactionStatus::Mined(mined_height))
                 .map_err(|e| SyncError::db(format!("set known mined transaction status: {e}")))
         },
-    )?;
-    Ok(true)
+    )
 }
 
 async fn fill_missing_transparent_fee(
@@ -492,9 +519,11 @@ mod tests {
     /// for it, mirroring the post-recovery state `resolve_status_from_scanned_height`
     /// services.
     fn status_recovery_test_db(
-        txid: TxId,
         mined_height: BlockHeight,
-    ) -> (tempfile::NamedTempFile, WalletDatabase) {
+        fee: Option<i64>,
+    ) -> (tempfile::NamedTempFile, WalletDatabase, Transaction) {
+        let (tx, raw) = transparent_fee_test_tx_and_bytes();
+        let txid = tx.txid();
         let file = tempfile::NamedTempFile::new().unwrap();
         let db_path = file.path().to_str().unwrap();
         let mut db = crate::wallet::db::open_wallet_db_with_timeout(
@@ -510,9 +539,25 @@ mod tests {
         let conn = rusqlite::Connection::open(db_path).unwrap();
         conn.execute(
             "INSERT INTO transactions
-                (txid, mined_height, raw, min_observed_height)
-             VALUES (?1, ?2, X'00', ?2)",
-            rusqlite::params![txid.as_ref(), u32::from(mined_height)],
+                (txid, mined_height, raw, fee, min_observed_height)
+             VALUES (?1, ?2, ?3, ?4, ?2)",
+            rusqlite::params![txid.as_ref(), u32::from(mined_height), raw, fee],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO accounts
+                (uuid, account_kind, uivk, birthday_height, has_spend_key)
+             VALUES (randomblob(16), 1, 'test-uivk', 1, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sapling_received_notes
+                (transaction_id, output_index, account_id, diversifier, value,
+                 rcm, is_change, commitment_tree_position, recipient_key_scope)
+             SELECT id_tx, 0, 1, X'00', 1, X'00', 1, 1, 1
+             FROM transactions WHERE txid = ?1",
+            rusqlite::params![txid.as_ref()],
         )
         .unwrap();
         conn.execute(
@@ -529,15 +574,20 @@ mod tests {
             SYNC_DB_BUSY_TIMEOUT,
         )
         .unwrap();
-        (file, db)
+        (file, db, tx)
     }
 
-    fn transparent_fee_test_tx() -> Transaction {
+    fn transparent_fee_test_tx_and_bytes() -> (Transaction, Vec<u8>) {
         let tx_bytes = hex::decode(
             "0400008085202f8901aee37187e843da597683c26c01457f5fd3b1a038996ef74dc8d60d483aaf395a000000006b483045022100874c70db77ea9e93f75cc83a9e141e17c8eb97588e29fe4e307631fdde4f162a02203493df62d648cd86a1189eaf9bcafc652bc14c5df02519d9e45e25b32aaffb5b012102106a2dcaaac2ae3b24358a03f4264e05db420c5b090399bc23885fa02fef7716ffffffff02764e1900000000001976a914fb451987556f7a19b726966ee6cff917e0bb3bfb88ac560ca400000000001976a9141634f5ff0b8f6603a17570436d6c12a91f4b1fed88ac00000000000000000000000000000000000000",
         )
         .unwrap();
-        Transaction::read(&tx_bytes[..], BranchId::Sapling).unwrap()
+        let tx = Transaction::read(&tx_bytes[..], BranchId::Sapling).unwrap();
+        (tx, tx_bytes)
+    }
+
+    fn transparent_fee_test_tx() -> Transaction {
+        transparent_fee_test_tx_and_bytes().0
     }
 
     fn transparent_fee_test_db(
@@ -626,20 +676,41 @@ mod tests {
 
     #[test]
     fn scanned_height_resolves_status_without_transaction_download() {
-        let txid = TxId::from_bytes([3; 32]);
         let mined_height = BlockHeight::from_u32(500);
-        let (_file, mut db) = status_recovery_test_db(txid, mined_height);
+        let (_file, mut db, tx) = status_recovery_test_db(mined_height, Some(0));
+        let txid = tx.txid();
 
         assert!(db
             .transaction_data_requests()
             .unwrap()
             .contains(&TransactionDataRequest::GetStatus(txid)));
-        assert!(resolve_status_from_scanned_height(&mut db, txid).unwrap());
+        assert_eq!(scanned_mined_height(&db, txid).unwrap(), Some(mined_height));
+        resolve_status_from_scanned_height(&mut db, txid, mined_height).unwrap();
         assert!(!db
             .transaction_data_requests()
             .unwrap()
             .contains(&TransactionDataRequest::GetStatus(txid)));
         assert_eq!(db.get_tx_height(txid).unwrap(), Some(mined_height));
+    }
+
+    #[test]
+    fn scanned_status_loads_missing_fee_input_before_dequeue() {
+        let mined_height = BlockHeight::from_u32(500);
+        let (file, mut db, tx) = status_recovery_test_db(mined_height, None);
+        let txid = tx.txid();
+
+        assert_eq!(db.get_transaction(txid).unwrap().unwrap().txid(), txid);
+        assert!(should_fill_missing_transparent_fee(file.path().to_str().unwrap(), &tx).unwrap());
+        assert!(db
+            .transaction_data_requests()
+            .unwrap()
+            .contains(&TransactionDataRequest::GetStatus(txid)));
+
+        resolve_status_from_scanned_height(&mut db, txid, mined_height).unwrap();
+        assert!(!db
+            .transaction_data_requests()
+            .unwrap()
+            .contains(&TransactionDataRequest::GetStatus(txid)));
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -243,6 +243,29 @@ fn should_query_unmined_statuses(
         .is_some_and(|max_scanned| max_scanned + MINED_STATUS_TIP_MARGIN >= chain_tip_height)
 }
 
+/// Reads the live inputs for [`should_query_unmined_statuses`] (pending scan
+/// ranges, max scanned block) from `db` and evaluates it against
+/// `chain_tip_height`.
+fn compute_query_unmined_statuses(
+    db: &WalletDatabase,
+    chain_tip_height: u64,
+) -> Result<bool, SyncError> {
+    let has_pending_scan_ranges = db
+        .suggest_scan_ranges()
+        .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?
+        .iter()
+        .any(is_pending_scan_range);
+    let max_scanned_height = db
+        .block_max_scanned()
+        .map_err(|e| SyncError::db(format!("block_max_scanned: {e}")))?
+        .map(|meta| u32::from(meta.block_height()) as u64);
+    Ok(should_query_unmined_statuses(
+        has_pending_scan_ranges,
+        max_scanned_height,
+        chain_tip_height,
+    ))
+}
+
 fn pending_scan_blocks(ranges: &[ScanRange]) -> u64 {
     ranges
         .iter()
@@ -1445,12 +1468,24 @@ async fn run_sync_impl(
     // slow connection, which is long enough for the user to hit
     // stop. Skip the whole pass in that case instead of sending
     // one more round of broadcasts after the UI asked us to quit.
+    //
+    // Recovery gate: a restart mid-recovery would re-select formerly
+    // mined transactions that truncation marked unmined, so this pass
+    // waits behind the same scan-frontier check as the post-batch
+    // resubmit (see `should_query_unmined_statuses`). Once the frontier
+    // catches back up, the post-batch pass covers resubmission for the
+    // rest of this run.
     if !allow_resubmit {
         log::info!("[{}] sync: startup resubmit disabled", elapsed());
     } else if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode
     {
         log::info!(
             "[{}] sync: cancel/mode observed before startup resubmit, skipping",
+            elapsed(),
+        );
+    } else if !compute_query_unmined_statuses(&db, tip.height)? {
+        log::info!(
+            "[{}] sync: startup resubmit deferred, scan frontier below tip",
             elapsed(),
         );
     } else {
@@ -2079,22 +2114,7 @@ async fn run_sync_impl(
         // querying lightwalletd for the statuses that remain unknown; backfill
         // below a tip-current scan frontier does not defer status work (see
         // `should_query_unmined_statuses`).
-        let query_unmined_statuses = {
-            let has_pending_scan_ranges = db
-                .suggest_scan_ranges()
-                .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?
-                .iter()
-                .any(is_pending_scan_range);
-            let max_scanned_height = db
-                .block_max_scanned()
-                .map_err(|e| SyncError::db(format!("block_max_scanned: {e}")))?
-                .map(|meta| u32::from(meta.block_height()) as u64);
-            should_query_unmined_statuses(
-                has_pending_scan_ranges,
-                max_scanned_height,
-                current_tip_height,
-            )
-        };
+        let query_unmined_statuses = compute_query_unmined_statuses(&db, current_tip_height)?;
 
         // Enhancement
         run_enhancement(

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 
@@ -213,57 +213,16 @@ fn is_pending_scan_range(range: &ScanRange) -> bool {
     range.priority() != ScanPriority::Ignored && range.priority() != ScanPriority::Scanned
 }
 
-/// Blocks below the chain tip within which the max scanned height must sit
-/// for the wallet's mined-height view to count as current. Mirrors
-/// zcash_client_sqlite's (non-public) `PRUNING_DEPTH` stable-region depth,
-/// the same boundary its `update_chain_tip` uses to distinguish a
-/// steady-state wallet from one performing a deep rescan.
-const MINED_STATUS_TIP_MARGIN: u64 = 100;
-
-/// Whether the wallet's local mined-height view is current enough to act on
-/// unmined-transaction statuses (servicing `GetStatus` data requests and
-/// selecting transactions for resubmission).
-///
-/// True when the scan queue is drained, or when the max scanned block sits
-/// within [`MINED_STATUS_TIP_MARGIN`] of the chain tip: pending work in that
-/// state is backfill below the scan frontier (an imported account's history,
-/// repair rescans), which cannot restore the mined height of a tip-recent
-/// transaction. A recovery truncation deletes block rows above the rewind
-/// point, pulling the max scanned height far below the tip until the rescan
-/// completes, so recovery keeps status lookups deferred.
-fn should_query_unmined_statuses(
-    has_pending_scan_ranges: bool,
-    max_scanned_height: Option<u64>,
-    chain_tip_height: u64,
-) -> bool {
-    if !has_pending_scan_ranges {
-        return true;
+fn deferred_status_txids(
+    db_path: &str,
+    ranges: &[ScanRange],
+) -> Result<HashSet<Vec<u8>>, SyncError> {
+    if ranges.iter().any(is_pending_scan_range) {
+        crate::wallet::sync::get_unmined_txids_with_mined_output_evidence(db_path)
+            .map_err(SyncError::db)
+    } else {
+        Ok(HashSet::new())
     }
-    max_scanned_height
-        .is_some_and(|max_scanned| max_scanned + MINED_STATUS_TIP_MARGIN >= chain_tip_height)
-}
-
-/// Reads the live inputs for [`should_query_unmined_statuses`] (pending scan
-/// ranges, max scanned block) from `db` and evaluates it against
-/// `chain_tip_height`.
-fn compute_query_unmined_statuses(
-    db: &WalletDatabase,
-    chain_tip_height: u64,
-) -> Result<bool, SyncError> {
-    let has_pending_scan_ranges = db
-        .suggest_scan_ranges()
-        .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?
-        .iter()
-        .any(is_pending_scan_range);
-    let max_scanned_height = db
-        .block_max_scanned()
-        .map_err(|e| SyncError::db(format!("block_max_scanned: {e}")))?
-        .map(|meta| u32::from(meta.block_height()) as u64);
-    Ok(should_query_unmined_statuses(
-        has_pending_scan_ranges,
-        max_scanned_height,
-        chain_tip_height,
-    ))
 }
 
 fn pending_scan_blocks(ranges: &[ScanRange]) -> u64 {
@@ -1455,8 +1414,8 @@ async fn run_sync_impl(
 
     refresh_utxos(&mut client, db_data_path, &mut db, network, tip_height).await?;
 
-    // 2.5. Resubmit any unmined, unexpired wallet txs now that we
-    // know the current tip. Matches the first of the three
+    // 2.5. Resubmit eligible unmined wallet txs now that we know the
+    // current tip. Matches the first of the three
     // resubmit call sites in zcash-android-wallet-sdk's
     // `processNewBlocks` (line 551). Best-effort: failures are
     // logged inside the helper and must not abort the sync.
@@ -1468,13 +1427,6 @@ async fn run_sync_impl(
     // slow connection, which is long enough for the user to hit
     // stop. Skip the whole pass in that case instead of sending
     // one more round of broadcasts after the UI asked us to quit.
-    //
-    // Recovery gate: a restart mid-recovery would re-select formerly
-    // mined transactions that truncation marked unmined, so this pass
-    // waits behind the same scan-frontier check as the post-batch
-    // resubmit (see `should_query_unmined_statuses`). Once the frontier
-    // catches back up, the post-batch pass covers resubmission for the
-    // rest of this run.
     if !allow_resubmit {
         log::info!("[{}] sync: startup resubmit disabled", elapsed());
     } else if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode
@@ -1483,16 +1435,16 @@ async fn run_sync_impl(
             "[{}] sync: cancel/mode observed before startup resubmit, skipping",
             elapsed(),
         );
-    } else if !compute_query_unmined_statuses(&db, tip.height)? {
-        log::info!(
-            "[{}] sync: startup resubmit deferred, scan frontier below tip",
-            elapsed(),
-        );
     } else {
+        let startup_ranges = db
+            .suggest_scan_ranges()
+            .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?;
+        let startup_deferred_status_txids = deferred_status_txids(db_data_path, &startup_ranges)?;
         let _ = crate::wallet::sync::resubmit_pending_transactions(
             db_data_path,
             &mut client,
             tip.height as u32,
+            &startup_deferred_status_txids,
             || {
                 cancel.load(Ordering::Relaxed)
                     || desired_mode.load(Ordering::SeqCst) != running_mode
@@ -2109,12 +2061,14 @@ async fn run_sync_impl(
             return Ok(());
         }
 
-        // A recovery can temporarily mark many locally stored transactions as
-        // unmined. Let compact scanning restore their mined heights before
-        // querying lightwalletd for the statuses that remain unknown; backfill
-        // below a tip-current scan frontier does not defer status work (see
-        // `should_query_unmined_statuses`).
-        let query_unmined_statuses = compute_query_unmined_statuses(&db, current_tip_height)?;
+        // Truncation can temporarily clear a transaction's mined height while
+        // retaining note positions that prove compact scanning found it mined.
+        // Let scanning restore those statuses without blocking normal pending
+        // transaction lookups.
+        let post_scan_ranges = db
+            .suggest_scan_ranges()
+            .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?;
+        let deferred_status_txids = deferred_status_txids(db_data_path, &post_scan_ranges)?;
 
         // Enhancement
         run_enhancement(
@@ -2122,7 +2076,7 @@ async fn run_sync_impl(
             &mut db,
             db_data_path,
             network,
-            query_unmined_statuses,
+            &deferred_status_txids,
         )
         .await?;
 
@@ -2202,14 +2156,12 @@ async fn run_sync_impl(
                         }
                     }
                 }
-                // Status lookups are deferred while recovery scanning remains.
-                // Wait until mined status is reliable before selecting
-                // transactions for resubmission.
-                if allow_resubmit && query_unmined_statuses {
+                if allow_resubmit {
                     let _ = crate::wallet::sync::resubmit_pending_transactions(
                         db_data_path,
                         &mut client,
                         fresh_tip_height,
+                        &deferred_status_txids,
                         || {
                             cancel.load(Ordering::Relaxed)
                                 || desired_mode.load(Ordering::SeqCst) != running_mode
@@ -2569,48 +2521,6 @@ mod tests {
             ),
             None,
         );
-    }
-
-    #[test]
-    fn unmined_statuses_query_when_scan_queue_is_drained() {
-        assert!(should_query_unmined_statuses(false, None, 1_000_000));
-        assert!(should_query_unmined_statuses(
-            false,
-            Some(500_000),
-            1_000_000
-        ));
-    }
-
-    #[test]
-    fn unmined_statuses_defer_while_scan_frontier_is_far_below_tip() {
-        // Recovery: truncation pulled the max scanned height far below the tip.
-        assert!(!should_query_unmined_statuses(
-            true,
-            Some(777_800),
-            1_000_000
-        ));
-        // Fresh restore: nothing scanned yet.
-        assert!(!should_query_unmined_statuses(true, None, 1_000_000));
-    }
-
-    #[test]
-    fn unmined_statuses_query_during_backfill_with_tip_current_frontier() {
-        // Imported-account backfill: historic ranges pending, frontier at tip.
-        assert!(should_query_unmined_statuses(
-            true,
-            Some(1_000_000),
-            1_000_000
-        ));
-        assert!(should_query_unmined_statuses(
-            true,
-            Some(1_000_000 - MINED_STATUS_TIP_MARGIN),
-            1_000_000
-        ));
-        assert!(!should_query_unmined_statuses(
-            true,
-            Some(1_000_000 - MINED_STATUS_TIP_MARGIN - 1),
-            1_000_000
-        ));
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -2044,8 +2044,24 @@ async fn run_sync_impl(
             return Ok(());
         }
 
+        // A recovery can temporarily mark many locally stored transactions as
+        // unmined. Let compact scanning restore their mined heights before
+        // querying lightwalletd for the statuses that remain unknown.
+        let query_unmined_statuses = !db
+            .suggest_scan_ranges()
+            .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?
+            .iter()
+            .any(is_pending_scan_range);
+
         // Enhancement
-        run_enhancement(&mut client, &mut db, db_data_path, network).await?;
+        run_enhancement(
+            &mut client,
+            &mut db,
+            db_data_path,
+            network,
+            query_unmined_statuses,
+        )
+        .await?;
 
         // Post-batch auto-resubmit. Matches zcash-android-wallet-sdk's
         // lines 593/701 call sites (end of verify batch / end of
@@ -2123,7 +2139,10 @@ async fn run_sync_impl(
                         }
                     }
                 }
-                if allow_resubmit {
+                // Status lookups are deferred while recovery scanning remains.
+                // Wait until mined status is reliable before selecting
+                // transactions for resubmission.
+                if allow_resubmit && query_unmined_statuses {
                     let _ = crate::wallet::sync::resubmit_pending_transactions(
                         db_data_path,
                         &mut client,

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -217,12 +217,13 @@ fn deferred_status_txids(
     db_path: &str,
     ranges: &[ScanRange],
 ) -> Result<HashSet<Vec<u8>>, SyncError> {
-    if ranges.iter().any(is_pending_scan_range) {
-        crate::wallet::sync::get_unmined_txids_with_mined_output_evidence(db_path)
-            .map_err(SyncError::db)
-    } else {
-        Ok(HashSet::new())
-    }
+    let pending_ranges = ranges
+        .iter()
+        .filter(|range| is_pending_scan_range(range))
+        .map(|range| range.block_range().clone())
+        .collect::<Vec<_>>();
+    crate::wallet::sync::get_unmined_txids_with_mined_output_evidence(db_path, &pending_ranges)
+        .map_err(SyncError::db)
 }
 
 fn pending_scan_blocks(ranges: &[ScanRange]) -> u64 {

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -213,6 +213,36 @@ fn is_pending_scan_range(range: &ScanRange) -> bool {
     range.priority() != ScanPriority::Ignored && range.priority() != ScanPriority::Scanned
 }
 
+/// Blocks below the chain tip within which the max scanned height must sit
+/// for the wallet's mined-height view to count as current. Mirrors
+/// zcash_client_sqlite's (non-public) `PRUNING_DEPTH` stable-region depth,
+/// the same boundary its `update_chain_tip` uses to distinguish a
+/// steady-state wallet from one performing a deep rescan.
+const MINED_STATUS_TIP_MARGIN: u64 = 100;
+
+/// Whether the wallet's local mined-height view is current enough to act on
+/// unmined-transaction statuses (servicing `GetStatus` data requests and
+/// selecting transactions for resubmission).
+///
+/// True when the scan queue is drained, or when the max scanned block sits
+/// within [`MINED_STATUS_TIP_MARGIN`] of the chain tip: pending work in that
+/// state is backfill below the scan frontier (an imported account's history,
+/// repair rescans), which cannot restore the mined height of a tip-recent
+/// transaction. A recovery truncation deletes block rows above the rewind
+/// point, pulling the max scanned height far below the tip until the rescan
+/// completes, so recovery keeps status lookups deferred.
+fn should_query_unmined_statuses(
+    has_pending_scan_ranges: bool,
+    max_scanned_height: Option<u64>,
+    chain_tip_height: u64,
+) -> bool {
+    if !has_pending_scan_ranges {
+        return true;
+    }
+    max_scanned_height
+        .is_some_and(|max_scanned| max_scanned + MINED_STATUS_TIP_MARGIN >= chain_tip_height)
+}
+
 fn pending_scan_blocks(ranges: &[ScanRange]) -> u64 {
     ranges
         .iter()
@@ -2046,12 +2076,25 @@ async fn run_sync_impl(
 
         // A recovery can temporarily mark many locally stored transactions as
         // unmined. Let compact scanning restore their mined heights before
-        // querying lightwalletd for the statuses that remain unknown.
-        let query_unmined_statuses = !db
-            .suggest_scan_ranges()
-            .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?
-            .iter()
-            .any(is_pending_scan_range);
+        // querying lightwalletd for the statuses that remain unknown; backfill
+        // below a tip-current scan frontier does not defer status work (see
+        // `should_query_unmined_statuses`).
+        let query_unmined_statuses = {
+            let has_pending_scan_ranges = db
+                .suggest_scan_ranges()
+                .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?
+                .iter()
+                .any(is_pending_scan_range);
+            let max_scanned_height = db
+                .block_max_scanned()
+                .map_err(|e| SyncError::db(format!("block_max_scanned: {e}")))?
+                .map(|meta| u32::from(meta.block_height()) as u64);
+            should_query_unmined_statuses(
+                has_pending_scan_ranges,
+                max_scanned_height,
+                current_tip_height,
+            )
+        };
 
         // Enhancement
         run_enhancement(
@@ -2506,6 +2549,48 @@ mod tests {
             ),
             None,
         );
+    }
+
+    #[test]
+    fn unmined_statuses_query_when_scan_queue_is_drained() {
+        assert!(should_query_unmined_statuses(false, None, 1_000_000));
+        assert!(should_query_unmined_statuses(
+            false,
+            Some(500_000),
+            1_000_000
+        ));
+    }
+
+    #[test]
+    fn unmined_statuses_defer_while_scan_frontier_is_far_below_tip() {
+        // Recovery: truncation pulled the max scanned height far below the tip.
+        assert!(!should_query_unmined_statuses(
+            true,
+            Some(777_800),
+            1_000_000
+        ));
+        // Fresh restore: nothing scanned yet.
+        assert!(!should_query_unmined_statuses(true, None, 1_000_000));
+    }
+
+    #[test]
+    fn unmined_statuses_query_during_backfill_with_tip_current_frontier() {
+        // Imported-account backfill: historic ranges pending, frontier at tip.
+        assert!(should_query_unmined_statuses(
+            true,
+            Some(1_000_000),
+            1_000_000
+        ));
+        assert!(should_query_unmined_statuses(
+            true,
+            Some(1_000_000 - MINED_STATUS_TIP_MARGIN),
+            1_000_000
+        ));
+        assert!(!should_query_unmined_statuses(
+            true,
+            Some(1_000_000 - MINED_STATUS_TIP_MARGIN - 1),
+            1_000_000
+        ));
     }
 
     #[test]


### PR DESCRIPTION
A recovery rewind can temporarily clear `mined_height` for transactions above the rewind point while retained shielded note positions still prove that compact scanning previously found them. Vizor used to treat every resulting `GetStatus` request as a reason to download and decrypt the full transaction from lightwalletd after every batch. Because every account shares one database and sync queue, recovering one account made old transaction history from the other accounts pay this cost too.

The reproduced wallet carried legacy state from the earlier `zcash_client_backend 0.24.0-rc.1` and `zcash_client_sqlite 0.22.0-rc.1` line. A fresh rc4 account import does not itself recreate that deep unmining, but current Vizor still needs to recover existing databases efficiently.

This change defers status and rebroadcast only when an unmined transaction has retained Sapling, Orchard, or Ironwood commitment positions and a pending scan range could still contain it. Compact scanning restores mined heights and clears those requests locally; once the relevant range passes, normal status lookup and rebroadcast resume. Genuine pending transactions without prior-mining evidence continue normal status checks, missing full transaction data is enhanced immediately, and local resolution preserves transparent fee backfill.

In the same cloned three-account wallet replay, sync fell from 819.5s to 232.6s, `GetTransaction` calls from 1,123 to 41, and downloaded transaction data from 57.77 MB to 0.45 MB. The refined discriminator matched 1,122 of the 1,123 legacy-unmined rows and excluded all 1,078 affected rebroadcast candidates before loading their raw bytes.