### PR TITLE
Rebroadcast accepted-but-unstored migration txs during store retry

### DIFF
--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -225,6 +225,15 @@ pub(crate) struct DuePendingMigrationTx {
     pub raw_tx: Vec<u8>,
 }
 
+/// A network-accepted (`broadcasted`) pending row the local wallet DB has no
+/// mined identity for yet. `scheduled_height` lets recovery pace rebroadcasts
+/// without persisting per-attempt state.
+pub(crate) struct BroadcastedPendingMigrationTx {
+    pub txid_hex: String,
+    pub raw_tx: Vec<u8>,
+    pub scheduled_height: u32,
+}
+
 #[derive(Debug)]
 pub(crate) struct MigrationOutboxItem {
     pub item_id: String,
@@ -4520,13 +4529,13 @@ pub(crate) fn broadcasted_pending_txs_missing_local_identity(
     run_id: &str,
     password: &[u8],
     salt_base64: &str,
-) -> Result<Vec<DuePendingMigrationTx>, String> {
+) -> Result<Vec<BroadcastedPendingMigrationTx>, String> {
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration pending salt")?;
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
     let mut stmt = conn
         .prepare_cached(&format!(
-            "SELECT txid_hex, encrypted_raw_tx
+            "SELECT txid_hex, encrypted_raw_tx, scheduled_height
              FROM {PENDING_TXS_TABLE}
              WHERE run_id = ?1 AND status = 'broadcasted'
              ORDER BY scheduled_height ASC, txid_hex ASC"
@@ -4534,13 +4543,17 @@ pub(crate) fn broadcasted_pending_txs_missing_local_identity(
         .map_err(|e| format!("Prepare broadcasted migration store-retry query: {e}"))?;
     let rows = stmt
         .query_map(params![run_id], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, u32>(2)?,
+            ))
         })
         .map_err(|e| format!("Query broadcasted migration store-retry txs: {e}"))?;
 
     let mut missing = Vec::new();
     for row in rows {
-        let (txid_hex, encrypted_raw_tx) =
+        let (txid_hex, encrypted_raw_tx, scheduled_height) =
             row.map_err(|e| format!("Read broadcasted migration store-retry tx: {e}"))?;
         // Skip once local wallet storage has the raw bytes. Mined identity is
         // not required — store-retry is about persist, not confirmation.
@@ -4552,9 +4565,10 @@ pub(crate) fn broadcasted_pending_txs_missing_local_identity(
             password,
             salt.as_slice(),
         )?;
-        missing.push(DuePendingMigrationTx {
+        missing.push(BroadcastedPendingMigrationTx {
             txid_hex,
             raw_tx: raw_tx.to_vec(),
+            scheduled_height,
         });
     }
     Ok(missing)

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -101,6 +101,24 @@ pub use transactions::{
     get_transaction_detail, get_transaction_history, get_wallet_balance,
     parse_address_request_kind, set_transaction_status, AddressRequestKind,
 };
+
+/// Integration-test hook: hex txids the sync loop's auto-resubmit would
+/// rebroadcast at `current_height`. Lets the Ironwood regtest E2E pin the
+/// eviction-recovery handoff: migration rebroadcast stops once the local
+/// store succeeds, so a stored-but-unmined part must satisfy the
+/// `get_resubmittable_txs` predicate (a self-transfer nets to `-fee`).
+#[doc(hidden)]
+pub fn resubmittable_txids_for_test(
+    db_path: &str,
+    current_height: u32,
+) -> Result<Vec<String>, String> {
+    Ok(
+        transactions::get_resubmittable_txs(db_path, current_height)?
+            .into_iter()
+            .map(|tx| hex::encode(&tx.txid_bytes))
+            .collect(),
+    )
+}
 #[allow(unused_imports)] // ditto
 pub(crate) use transactions::{
     get_export_birthday_anchor, get_oldest_mined_transaction_anchor,

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -684,26 +684,33 @@ fn pending_migration_policy_rebuild_message(
     Ok(None)
 }
 
-/// Persist accepted-but-unstored migration txs, reconcile confirmations, then
-/// evaluate fee/input policy rebuild. Store must run before retirement so a
-/// lightwalletd-accepted tx is recorded locally before the run goes terminal
-/// and note locks are released. If store retry still leaves gaps, return Err so
-/// callers cannot fall through to rebuild/expiry.
-fn retry_store_then_pending_migration_policy_rebuild_message(
+/// Persist accepted-but-unstored migration txs (and rebroadcast any that stay
+/// missing), reconcile confirmations, then evaluate fee/input policy rebuild.
+/// Store must run before retirement so a lightwalletd-accepted tx is recorded
+/// locally before the run goes terminal and note locks are released. If store
+/// retry still leaves gaps, return Err so callers cannot fall through to
+/// rebuild/expiry — rebroadcast already ran for that recovery window.
+async fn retry_store_then_pending_migration_policy_rebuild_message(
     db_path: &str,
+    lightwalletd_url: &str,
     network: WalletNetwork,
     run_id: &str,
     chain_tip_height: u32,
     pending_password: &[u8],
     pending_salt_base64: &str,
+    policy: MigrationBroadcastPolicy<'_>,
 ) -> Result<Option<String>, String> {
-    let _stored = retry_store_broadcasted_migration_txs_missing_local(
+    retry_store_broadcasted_migration_txs_missing_local(
         db_path,
+        lightwalletd_url,
         network,
         run_id,
+        chain_tip_height,
         pending_password,
         pending_salt_base64,
-    )?;
+        policy,
+    )
+    .await?;
     super::migration::reconcile_run_pending_confirmations(db_path, run_id)?;
     let still_missing = super::migration::broadcasted_pending_txs_missing_local_identity(
         db_path,
@@ -1429,12 +1436,15 @@ pub(crate) async fn migrate_orchard_to_ironwood(
                     if let Some(message) =
                         retry_store_then_pending_migration_policy_rebuild_message(
                             db_path,
+                            lightwalletd_url,
                             network,
                             &run.run_id,
                             chain_tip_height,
                             pending_password.as_slice(),
                             pending_salt_base64,
-                        )?
+                            MigrationBroadcastPolicy::FOREGROUND,
+                        )
+                        .await?
                     {
                         drop(seed);
                         super::migration::retire_run_for_rebuild(
@@ -2216,12 +2226,16 @@ async fn prepare_orchard_migration_outbox(
             .map_err(|_| "Migration chain tip exceeds u32".to_string())?;
     if let Some(message) = retry_store_then_pending_migration_policy_rebuild_message(
         db_path,
+        lightwalletd_url,
         network,
         &run.run_id,
         chain_tip_height,
         pending_password,
         pending_salt_base64,
-    )? {
+        MigrationBroadcastPolicy::FOREGROUND,
+    )
+    .await?
+    {
         super::migration::retire_run_for_rebuild(db_path, network, &run.run_id, &message)?;
         let totals = super::migration::pending_totals_for_run(db_path, &run.run_id)?;
         return Ok(migration_result_from_pending_totals(
@@ -4948,18 +4962,23 @@ async fn broadcast_due_scheduled_migration_txs(
         u32::try_from(super::get_sync_progress(db_path, network)?.chain_tip_height)
             .map_err(|_| "Migration chain tip exceeds u32".to_string())?;
     // Store accepted-but-unstored rows before fee-policy retirement and before
-    // expiry handling. Policy rebuild would otherwise go terminal and release
-    // locks without recording network-accepted state; expiry flips
-    // `broadcasted` → `needs_resign` and would drop rows out of store-retry.
-    // Unresolved store gaps return Err so callers cannot fall through.
+    // expiry handling (and rebroadcast any that stay missing). Policy rebuild
+    // would otherwise go terminal and release locks without recording
+    // network-accepted state; expiry flips `broadcasted` → `needs_resign` and
+    // would drop rows out of store-retry. Unresolved store gaps return Err so
+    // callers cannot fall through — rebroadcast already ran for that window.
     if let Some(message) = retry_store_then_pending_migration_policy_rebuild_message(
         db_path,
+        lightwalletd_url,
         network,
         run_id,
         chain_tip_height,
         pending_password,
         pending_salt_base64,
-    )? {
+        policy,
+    )
+    .await?
+    {
         super::migration::retire_run_for_rebuild(db_path, network, run_id, &message)?;
         return Ok(MigrationBroadcastAdvance::without_acceptance(
             migration_result_from_pending_totals(
@@ -5458,30 +5477,137 @@ where
     Ok(None)
 }
 
-/// Retry local wallet storage for network-accepted (`broadcasted`) rows that
-/// still lack `transactions.raw`. Returns how many rows were newly stored.
+/// Minimum tip advance between network rebroadcasts of the same
+/// accepted-but-unstored migration tx. An arbitrary pacing choice
+/// (~25 minutes), not a protocol constant: it only trades recovery
+/// latency against duplicate idempotent sends.
+const MIGRATION_REBROADCAST_MIN_TIP_DELTA: u32 = 20;
+
+/// `(run_id, txid)` -> chain tip at the last rebroadcast attempt made
+/// by this process. In-memory only: it just paces attempts within a
+/// session, while eligibility is anchored to the durable
+/// `scheduled_height`, so recovery survives restarts. Keyed by run as
+/// well as txid so per-run pruning cannot touch another run's entries.
+static MIGRATION_REBROADCAST_LAST_TIP: OnceLock<Mutex<HashMap<(String, String), u32>>> =
+    OnceLock::new();
+
+/// Whether an accepted-but-unstored tx is due for a network rebroadcast.
 ///
-/// On any successful store, clears the run's durable storage-retry
-/// `last_error` so `MigrationStatus.message` changes even though the row
-/// remains `broadcasted`. The coordinator uses that message diff to refresh
-/// home balances after an otherwise status-stable store. Remaining failures
-/// re-stamp `last_error` afterward.
-fn retry_store_broadcasted_migration_txs_missing_local(
+/// Gate 1: `tip >= scheduled_height + MIGRATION_REBROADCAST_MIN_TIP_DELTA`,
+/// read off the pending row so a restart cannot reset it. Gate 2: a full
+/// pacing window since this process last *attempted* the tx. A first
+/// sighting passes gate 2 immediately — seeding the map without sending
+/// would leave short-lived sessions unable to ever reach a send.
+fn migration_rebroadcast_due(
+    run_id: &str,
+    txid_hex: &str,
+    chain_tip_height: u32,
+    scheduled_height: u32,
+) -> bool {
+    if chain_tip_height < scheduled_height.saturating_add(MIGRATION_REBROADCAST_MIN_TIP_DELTA) {
+        return false;
+    }
+    let last_tips = MIGRATION_REBROADCAST_LAST_TIP
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("migration rebroadcast pacing lock poisoned");
+    match last_tips.get(&(run_id.to_string(), txid_hex.to_string())) {
+        Some(&last) => {
+            chain_tip_height >= last.saturating_add(MIGRATION_REBROADCAST_MIN_TIP_DELTA)
+        }
+        None => true,
+    }
+}
+
+/// Arm the session pacing window for `txid_hex`. Call only after
+/// `SendTransaction` actually ran (success or RPC error) — a failed
+/// channel open must not consume the slot and delay recovery by a
+/// full window once connectivity returns.
+fn record_migration_rebroadcast_attempt(run_id: &str, txid_hex: &str, chain_tip_height: u32) {
+    MIGRATION_REBROADCAST_LAST_TIP
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("migration rebroadcast pacing lock poisoned")
+        .insert(
+            (run_id.to_string(), txid_hex.to_string()),
+            chain_tip_height,
+        );
+}
+
+/// Drop this run's pacing entries for txs that left its recovery set,
+/// bounding the map. Scoped to `run_id`: pruning another run's entries
+/// would let two accounts' alternating advances reset each other's
+/// pacing and starve both rebroadcasts.
+fn prune_migration_rebroadcast_pacing(run_id: &str, live_txids: &HashSet<String>) {
+    if let Some(last_tips) = MIGRATION_REBROADCAST_LAST_TIP.get() {
+        last_tips
+            .lock()
+            .expect("migration rebroadcast pacing lock poisoned")
+            .retain(|(entry_run_id, txid), _| entry_run_id != run_id || live_txids.contains(txid));
+    }
+}
+
+/// Recovery pass for `broadcasted` parts that lightwalletd accepted
+/// but the wallet DB does not know about yet. Best-effort and
+/// phase-preserving, in two layers:
+///
+///   1. Retry the local store from the encrypted pending raw. Once it
+///      succeeds, the sync loop's auto-resubmit
+///      (`resubmit_pending_transactions`) owns mempool-eviction
+///      recovery for the tx. (iOS native preparation sync runs with
+///      resubmit disabled; there the handoff waits for a foreground
+///      sync.) On any successful store, clears the run's durable
+///      storage-retry `last_error` so `MigrationStatus.message`
+///      changes even though the row remains `broadcasted` — the
+///      coordinator uses that message diff to refresh home balances.
+///   2. While the store keeps failing, auto-resubmit cannot see the tx
+///      (`raw IS NULL`), so re-send the same signed bytes, paced by
+///      [`migration_rebroadcast_due`]. "Already in mempool/chain" is
+///      soft-accepted; other rejections are logged and ignored — the
+///      network accepted this tx once, never fail the run for a
+///      rebroadcast.
+///
+/// The gRPC channel opens lazily, so the common "store retry
+/// succeeded" path stays network-free. The cancel token is honored
+/// before the query and per row: this pass runs ahead of the caller's
+/// own cancel check, and the account-DB mutation fence relies on it to
+/// quiesce native migration work promptly. Skipping a pass costs
+/// nothing — the next advance repeats it.
+#[allow(clippy::too_many_arguments)]
+async fn retry_store_broadcasted_migration_txs_missing_local(
     db_path: &str,
+    lightwalletd_url: &str,
     network: WalletNetwork,
     run_id: &str,
+    chain_tip_height: u32,
     pending_password: &[u8],
     pending_salt_base64: &str,
-) -> Result<u32, String> {
+    policy: MigrationBroadcastPolicy<'_>,
+) -> Result<(), String> {
+    if policy.is_cancelled() {
+        log::info!("migration: cancel observed before store-retry pass, skipping");
+        return Ok(());
+    }
     let missing = super::migration::broadcasted_pending_txs_missing_local_identity(
         db_path,
         run_id,
         pending_password,
         pending_salt_base64,
     )?;
+    prune_migration_rebroadcast_pacing(
+        run_id,
+        &missing.iter().map(|p| p.txid_hex.clone()).collect(),
+    );
+    let mut client = None;
+    let mut channel_unavailable = false;
+    let mut rebroadcasts_attempted = 0usize;
     let mut stored = 0u32;
     let mut last_failure: Option<String> = None;
     for pending in missing {
+        if policy.is_cancelled() {
+            log::info!("migration: cancel observed mid store-retry pass, stopping");
+            break;
+        }
         match decrypt_and_store_migration_tx(db_path, network, &pending.raw_tx) {
             Ok(()) => {
                 stored = stored.saturating_add(1);
@@ -5489,6 +5615,7 @@ fn retry_store_broadcasted_migration_txs_missing_local(
                     "migration: recorded previously accepted tx {} after local store retry",
                     pending.txid_hex
                 );
+                continue;
             }
             Err(error) => {
                 let message = migration_storage_retry_message(
@@ -5500,6 +5627,54 @@ fn retry_store_broadcasted_migration_txs_missing_local(
                 last_failure = Some(message);
             }
         }
+        // Skips here only disable rebroadcast; store retries keep going.
+        // `policy.limit` caps rebroadcasts per pass without charging the
+        // one-open submission gate.
+        if channel_unavailable
+            || rebroadcasts_attempted >= policy.limit(usize::MAX)
+            || !migration_rebroadcast_due(
+                run_id,
+                &pending.txid_hex,
+                chain_tip_height,
+                pending.scheduled_height,
+            )
+        {
+            continue;
+        }
+        let client = match &mut client {
+            Some(client) => client,
+            None => match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await {
+                Ok(opened) => client.insert(opened),
+                Err(error) => {
+                    // Pacing slot not recorded: next pass may retry at once.
+                    log::warn!(
+                        "migration: rebroadcast channel open failed, will retry next pass: {error}"
+                    );
+                    channel_unavailable = true;
+                    continue;
+                }
+            },
+        };
+        let attempt = broadcast_raw_transaction(client, &pending.raw_tx).await;
+        // Either outcome is a real attempt: arm pacing and spend budget.
+        record_migration_rebroadcast_attempt(run_id, &pending.txid_hex, chain_tip_height);
+        rebroadcasts_attempted += 1;
+        match attempt {
+            Ok(()) => {
+                log::info!(
+                    "migration: rebroadcast accepted-but-unstored tx {} at tip {}",
+                    pending.txid_hex,
+                    chain_tip_height
+                );
+            }
+            Err(error) => {
+                log::warn!(
+                    "migration: rebroadcast of accepted-but-unstored tx {} failed \
+                     (already accepted once, leaving broadcasted): {error}",
+                    pending.txid_hex
+                );
+            }
+        }
     }
     if stored > 0 {
         let phase = super::migration::run_phase(db_path, run_id)?;
@@ -5509,7 +5684,7 @@ fn retry_store_broadcasted_migration_txs_missing_local(
         let phase = super::migration::run_phase(db_path, run_id)?;
         super::migration::mark_run_phase(db_path, run_id, &phase, Some(message))?;
     }
-    Ok(stored)
+    Ok(())
 }
 
 fn migration_result_from_pending_totals(

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -2643,3 +2643,300 @@ fn prefers_non_ephemeral_sources_over_ephemeral_sources() {
     assert_eq!(addresses, vec![taddr(2)]);
     assert_eq!(u64::from(total), 120_000);
 }
+
+#[test]
+fn migration_rebroadcast_waits_for_quiet_blocks_after_scheduled_height() {
+    // Distinct txid per test keeps this independent of other tests
+    // sharing the process-wide pacing map.
+    let run_id = "rebroadcast-scheduled-gate-test-run";
+    let txid = "rebroadcast-scheduled-gate-test-tx";
+    prune_migration_rebroadcast_pacing(run_id, &std::collections::HashSet::new());
+    let scheduled = 1_000;
+
+    // Inside the quiet window after the scheduled height the tx was
+    // submitted too recently to be treated as evicted.
+    assert!(!migration_rebroadcast_due(
+        run_id, txid, scheduled, scheduled
+    ));
+    assert!(!migration_rebroadcast_due(
+        run_id,
+        txid,
+        scheduled + MIGRATION_REBROADCAST_MIN_TIP_DELTA - 1,
+        scheduled
+    ));
+
+    // The window is measured from `scheduled_height`, not from the first
+    // sighting, so the first pass that observes a sufficiently old row
+    // sends immediately — including the first pass after a restart.
+    assert!(migration_rebroadcast_due(
+        run_id,
+        txid,
+        scheduled + MIGRATION_REBROADCAST_MIN_TIP_DELTA,
+        scheduled
+    ));
+}
+
+#[test]
+fn migration_rebroadcast_paces_attempts_within_a_session() {
+    let run_id = "rebroadcast-session-pacing-test-run";
+    let txid = "rebroadcast-session-pacing-test-tx";
+    prune_migration_rebroadcast_pacing(run_id, &std::collections::HashSet::new());
+    // Long overdue relative to its schedule: the durable gate is open on
+    // every call, so only the in-session pacing map limits attempts.
+    let scheduled = 1_000;
+    let first_tip = scheduled + 5_000;
+
+    assert!(migration_rebroadcast_due(
+        run_id, txid, first_tip, scheduled
+    ));
+    // The due check is read-only: until an attempt is recorded, a
+    // channel-open failure (which records nothing) must not burn the
+    // slot — the same tip stays due.
+    assert!(migration_rebroadcast_due(
+        run_id, txid, first_tip, scheduled
+    ));
+    record_migration_rebroadcast_attempt(run_id, txid, first_tip);
+    // Same tip, and mid-window: the advance loop runs far more often
+    // than once per quiet window, so these must not re-send.
+    assert!(!migration_rebroadcast_due(
+        run_id, txid, first_tip, scheduled
+    ));
+    assert!(!migration_rebroadcast_due(
+        run_id,
+        txid,
+        first_tip + MIGRATION_REBROADCAST_MIN_TIP_DELTA - 1,
+        scheduled
+    ));
+    // A full window of tip advance re-arms it.
+    assert!(migration_rebroadcast_due(
+        run_id,
+        txid,
+        first_tip + MIGRATION_REBROADCAST_MIN_TIP_DELTA,
+        scheduled
+    ));
+
+    // Pruning forgets the in-session pacing, but the durable gate still
+    // applies, so a forgotten txid cannot burst-send below its window.
+    prune_migration_rebroadcast_pacing(run_id, &std::collections::HashSet::new());
+    record_migration_rebroadcast_attempt(run_id, txid, first_tip);
+    prune_migration_rebroadcast_pacing(run_id, &std::collections::HashSet::new());
+    assert!(migration_rebroadcast_due(
+        run_id, txid, first_tip, scheduled
+    ));
+    assert!(!migration_rebroadcast_due(
+        run_id,
+        txid,
+        scheduled + 1,
+        scheduled
+    ));
+}
+
+#[test]
+fn migration_rebroadcast_pruning_is_scoped_to_the_pruning_run() {
+    // Two accounts can hold active migration runs in the same wallet DB,
+    // and their advance passes interleave. Run A's prune must not evict
+    // run B's pacing entry, or alternating passes would reset each
+    // other's pacing forever and starve both rebroadcasts.
+    let run_a = "rebroadcast-cross-run-prune-run-a";
+    let run_b = "rebroadcast-cross-run-prune-run-b";
+    let txid_a = "rebroadcast-cross-run-prune-tx-a";
+    let txid_b = "rebroadcast-cross-run-prune-tx-b";
+    prune_migration_rebroadcast_pacing(run_a, &std::collections::HashSet::new());
+    prune_migration_rebroadcast_pacing(run_b, &std::collections::HashSet::new());
+    let scheduled = 1_000;
+    let tip = scheduled + 5_000;
+
+    // B attempts, then A's pass prunes with a live set that does not
+    // contain B's txid (it never could — live sets are per-run).
+    assert!(migration_rebroadcast_due(run_b, txid_b, tip, scheduled));
+    record_migration_rebroadcast_attempt(run_b, txid_b, tip);
+    prune_migration_rebroadcast_pacing(run_a, &[txid_a.to_string()].into());
+
+    // B's pacing entry must have survived A's prune: mid-window calls
+    // stay suppressed instead of re-sending on every alternating pass.
+    assert!(!migration_rebroadcast_due(run_b, txid_b, tip, scheduled));
+
+    // B's own prune still forgets its entry once the tx leaves the
+    // recovery set.
+    prune_migration_rebroadcast_pacing(run_b, &std::collections::HashSet::new());
+    assert!(migration_rebroadcast_due(run_b, txid_b, tip, scheduled));
+}
+
+/// Build a run holding one `broadcasted` part whose local store never
+/// succeeded — the state
+/// `retry_store_broadcasted_migration_txs_missing_local` exists to
+/// recover from. Returns `(temp_dir, db_path, run_id)`; the caller must
+/// keep `temp_dir` alive.
+fn broadcasted_but_unstored_migration_run() -> (tempfile::TempDir, String, String) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let denomination_input_txid =
+        "303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f";
+    let selected_note_txid = "101112131415161718191a1b1c1d1e1f000102030405060708090a0b0c0d0e0f";
+    let pending_txid = "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f";
+    let selected_note = migration_test_note(selected_note_txid);
+    let plan = migration_test_plan();
+    let run_id = migration::create_run_with_staged_denominations_and_signed_children(
+        &db_path,
+        MIGRATION_TEST_ACCOUNT,
+        WalletNetwork::Test,
+        &plan,
+        std::slice::from_ref(&selected_note),
+        Vec::new(),
+        vec![migration_test_stage(
+            denomination_input_txid,
+            selected_note_txid,
+        )],
+        None,
+        migration::PreparationTimingPolicy::Immediate,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap();
+    migration::insert_pending_txs(
+        &db_path,
+        &run_id,
+        vec![migration::PendingMigrationTxInsert {
+            part_index: 0,
+            txid_hex: pending_txid.to_string(),
+            raw_tx: vec![5, 6, 7, 8],
+            target_height: 100,
+            anchor_boundary_height: None,
+            expiry_height: 69_120,
+            scheduled_height: MIGRATION_CANCEL_TEST_SCHEDULED_HEIGHT,
+            value_zatoshi: 100_000,
+            fee_zatoshi: 10_000,
+            selected_note: selected_note.clone(),
+            metadata: migration::PendingMigrationTxMetadata {
+                tx_kind: "migration".to_string(),
+                funding_account_uuid: MIGRATION_TEST_ACCOUNT.to_string(),
+                selected_note,
+            },
+        }],
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap();
+    // Accept on the network, fail the local store: leaves the row
+    // `broadcasted` with nothing in the wallet DB.
+    record_accepted_scheduled_migration_tx(
+        &db_path,
+        WalletNetwork::Test,
+        &run_id,
+        &migration::DuePendingMigrationTx {
+            txid_hex: pending_txid.to_string(),
+            raw_tx: vec![5, 6, 7, 8],
+        },
+        1,
+        100_000,
+        |_db_path, _network, _raw_tx| Err("db busy".to_string()),
+    )
+    .unwrap()
+    .unwrap();
+    (temp_dir, db_path, run_id)
+}
+
+const MIGRATION_CANCEL_TEST_SCHEDULED_HEIGHT: u32 = 100;
+const MIGRATION_CANCEL_TEST_SENTINEL: &str = "sentinel: recovery pass has not run";
+
+fn migration_run_last_error(db_path: &str) -> Option<String> {
+    migration::active_migration_run(db_path, MIGRATION_TEST_ACCOUNT, WalletNetwork::Test)
+        .unwrap()
+        .unwrap()
+        .last_error
+}
+
+/// Overwrite `last_error` with a sentinel so a later assertion can tell
+/// "the recovery pass did no work" from "the pass ran and re-reported the
+/// storage-retry message".
+fn arm_migration_recovery_sentinel(db_path: &str, run_id: &str) {
+    let phase = migration::run_phase(db_path, run_id).unwrap();
+    migration::mark_run_phase(
+        db_path,
+        run_id,
+        &phase,
+        Some(MIGRATION_CANCEL_TEST_SENTINEL),
+    )
+    .unwrap();
+    assert_eq!(
+        migration_run_last_error(db_path).as_deref(),
+        Some(MIGRATION_CANCEL_TEST_SENTINEL)
+    );
+}
+
+#[tokio::test]
+async fn store_retry_pass_skips_every_row_when_preparation_is_cancelled() {
+    // This pass runs ahead of the caller's own `policy.is_cancelled()`
+    // early return, so it must honor the token itself: the account-DB
+    // mutation fence and the lock path both quiesce native migration work
+    // through cancellation, and a pass that ignored it would still open a
+    // channel and broadcast after the operation was told to stop.
+    let (_temp_dir, db_path, run_id) = broadcasted_but_unstored_migration_run();
+    arm_migration_recovery_sentinel(&db_path, &run_id);
+
+    let cancel = std::sync::atomic::AtomicBool::new(true);
+    // A tip below `scheduled_height + MIGRATION_REBROADCAST_MIN_TIP_DELTA`
+    // keeps the rebroadcast gate shut, so this test can never reach the
+    // network even if the cancel check regresses — the store retry's
+    // `last_error` write is the observable.
+    retry_store_broadcasted_migration_txs_missing_local(
+        &db_path,
+        "http://127.0.0.1:1",
+        WalletNetwork::Test,
+        &run_id,
+        MIGRATION_CANCEL_TEST_SCHEDULED_HEIGHT,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+        MigrationBroadcastPolicy::background_preparation(&cancel),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        migration_run_last_error(&db_path).as_deref(),
+        Some(MIGRATION_CANCEL_TEST_SENTINEL),
+        "a cancelled pass must not retry the local store"
+    );
+}
+
+#[tokio::test]
+async fn store_retry_pass_runs_when_preparation_is_not_cancelled() {
+    // Companion to the cancelled case: proves the assertion above is
+    // detecting cancellation rather than a fixture that never does work.
+    let (_temp_dir, db_path, run_id) = broadcasted_but_unstored_migration_run();
+    arm_migration_recovery_sentinel(&db_path, &run_id);
+
+    let cancel = std::sync::atomic::AtomicBool::new(false);
+    retry_store_broadcasted_migration_txs_missing_local(
+        &db_path,
+        "http://127.0.0.1:1",
+        WalletNetwork::Test,
+        &run_id,
+        MIGRATION_CANCEL_TEST_SCHEDULED_HEIGHT,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+        MigrationBroadcastPolicy::background_preparation(&cancel),
+    )
+    .await
+    .unwrap();
+
+    // The fixture's raw bytes are not a decodable transaction, so the
+    // store retry fails and replaces the sentinel with the storage-retry
+    // message. The row stays `broadcasted` either way.
+    let last_error = migration_run_last_error(&db_path).unwrap();
+    assert_ne!(
+        last_error, MIGRATION_CANCEL_TEST_SENTINEL,
+        "an active pass must retry the local store"
+    );
+    assert!(
+        last_error.contains("accepted by lightwalletd"),
+        "unexpected recovery message: {last_error}"
+    );
+    assert_eq!(
+        migration::pending_totals_for_run(&db_path, &run_id)
+            .unwrap()
+            .broadcasted_count,
+        1
+    );
+}

--- a/rust/tests/ironwood_regtest_migration.rs
+++ b/rust/tests/ironwood_regtest_migration.rs
@@ -88,6 +88,32 @@ fn orchard_funds_migrate_after_controlled_nu6_3_activation() {
     );
     assert!(migration.broadcasted_count > 0);
 
+    // Pin the eviction-recovery handoff: right now at least one migration
+    // part is stored in the wallet DB and unmined — exactly the state in
+    // which mempool-eviction recovery relies on the sync loop's
+    // auto-resubmit seeing the tx. If a self-transfer's
+    // `account_balance_delta` ever fails to net negative (it should be
+    // `-fee`), this assertion catches the silent gap.
+    let tip = u32::try_from(latest_height()).expect("tip must fit u32");
+    let resubmittable = rust_lib_zcash_wallet::wallet::sync::resubmittable_txids_for_test(&db, tip)
+        .expect("query auto-resubmit candidates");
+    let run_txids: std::collections::HashSet<String> = migration
+        .txids
+        .split(',')
+        .filter(|txid| !txid.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect();
+    assert!(
+        // The wallet DB stores txids in raw byte order while migration
+        // results use display (byte-reversed) hex; accept either.
+        resubmittable.iter().any(|raw_hex| {
+            run_txids.contains(&raw_hex.to_ascii_lowercase())
+                || run_txids.contains(&reverse_txid_hex(raw_hex))
+        }),
+        "a stored-but-unmined migration part must match the auto-resubmit \
+         predicate; resubmittable={resubmittable:?}, run txids={run_txids:?}"
+    );
+
     mine_and_sync(&db, TRUSTED_CONFIRMATIONS);
     let status = sync_api::get_orchard_migration_status(
         db.clone(),
@@ -119,6 +145,21 @@ fn orchard_funds_migrate_after_controlled_nu6_3_activation() {
         migrated.orchard, 0,
         "the deterministic migration must consume all funded Orchard value"
     );
+}
+
+/// Convert txid hex between raw byte order and display order (the
+/// encoding is its own inverse: reverse the byte pairs).
+fn reverse_txid_hex(txid_hex: &str) -> String {
+    txid_hex
+        .as_bytes()
+        .chunks(2)
+        .rev()
+        .map(|pair| {
+            std::str::from_utf8(pair)
+                .expect("txid hex must be ASCII")
+                .to_ascii_lowercase()
+        })
+        .collect()
 }
 
 fn activation_height() -> u32 {


### PR DESCRIPTION
## Problem

[#404](https://github.com/chainapsis/vizor-wallet/pull/404) (via [#388](https://github.com/chainapsis/vizor-wallet/pull/388)) closes the head-of-line blocking window by marking an accepted-but-unstored part `broadcasted`, but it leaves an eviction gap: while the local store keeps failing, the tx exists nowhere the wallet can see it. The sync loop's auto-resubmit (`resubmit_pending_transactions`) only re-drives transactions stored in the wallet DB (`raw IS NOT NULL`), so if the mempool drops the tx in this window, nothing resubmits it until ZIP 318 expiry diverts the part to re-sign — a stall of 1–2 expiry windows (~30–60 days).

## Approach

Close the gap inside the store-retry pass #404 already runs on every advance (before fee-policy rebuild / expiry fall-through), instead of the separate quiet-boundary scheduling subsystem proposed in #393. Rows that stay unstored re-send the **same signed bytes** over a lazily opened channel — no `GetTransaction` probes, no schema changes, no new eligibility query, no due-selection or one-open-gate interaction.

The two recovery layers are mutually exclusive by construction:

1. **Store retry** (existing): once `decrypt_and_store_migration_tx` succeeds, the tx is in the wallet DB and auto-resubmit owns eviction recovery like any other outbound tx. The handoff assumption — a stored-but-unmined migration self-transfer matches the auto-resubmit predicate (`account_balance_delta` nets to `-fee`) — is now pinned by a regtest E2E assertion via a `#[doc(hidden)]` test hook.
2. **Direct rebroadcast** (new): only while the row is still invisible to layer 1.

## Base

Rebased onto [`roman/fix-migration-races`](https://github.com/chainapsis/vizor-wallet/pull/404) so this stacks on the combined #387+#388 HOL fixes. Rebroadcast runs inside #404's store-before-rebuild deferral pass: unresolved store gaps still return Err (no fall-through to rebuild/expiry), after any due rebroadcast attempts for that window.

## Mechanism

- **Durable gate**: rebroadcast only when `tip ≥ scheduled_height + 20`. Read straight off the pending row, so an app restart cannot reset it — a wallet opened in short sessions still recovers (seeding an in-memory map on first sighting would make recovery inert for sessions shorter than the pacing window).
- **Session pacing on real attempts**: at most one `SendTransaction` per tx per 20 blocks of tip advance, tracked in-memory keyed by `(run_id, txid)`. The pacing slot is armed only after a `SendTransaction` actually ran (success or RPC error) — a failed channel open does not burn the slot, so one transient connectivity failure cannot delay recovery by a full window after connectivity returns.
- **Run-scoped pruning**: pruning the pacing map is scoped to the pruning run, so two accounts' concurrent runs alternating advances cannot evict each other's entries and starve both recoveries.
- **Per-pass cap**: rebroadcast attempts are bounded by `policy.limit` (`ONE_FOREGROUND` → one per pass) but are **not** charged against the one-open submission gate — they are idempotent re-sends of already-accepted txs, not new submissions.
- **Log-only outcomes**: "already in mempool/chain" is soft-accepted inside `broadcast_raw_transaction`; hard rejections are logged and never change run phase, due selection, `accepted_txids`, or the one-open gate. The network accepted this tx once — a rebroadcast must never fail the run.
- **Cancel + offline safety**: the policy cancel token is checked before the candidate query and per row (this pass runs ahead of the caller's own cancel early-return, and the account-DB mutation fence relies on prompt quiesce). Channel-open failure disables only the rebroadcast layer for the pass — store retries continue for the remaining rows.
- The 20-block delta (~25 min) is a pacing choice, not a protocol constant; anything in roughly 4–32 blocks is safe and only trades recovery latency against duplicate idempotent sends.

Known limit: the iOS native preparation sync runs with resubmit disabled, so on that path the layer-1 handoff completes only once the app reaches a foreground sync; the rebroadcast layer covers the window meanwhile.