### PR TITLE
Recover stalled Ironwood migrations

### DIFF
--- a/lib/src/features/migration/models/ironwood_migration_presentation.dart
+++ b/lib/src/features/migration/models/ironwood_migration_presentation.dart
@@ -18,6 +18,20 @@ bool migrationHasDueScheduledBroadcast(
   );
 }
 
+bool migrationHasDueRecoverableBroadcast(
+  rust_sync.MigrationStatus status, {
+  required int currentHeight,
+}) {
+  if (currentHeight <= 0) return false;
+  return status.scheduledBroadcasts.any((broadcast) {
+    final broadcastStatus = broadcast.status.toLowerCase();
+    return (broadcastStatus == 'scheduled' ||
+            broadcastStatus == 'needs_resign') &&
+        broadcast.scheduledHeight > 0 &&
+        broadcast.scheduledHeight <= currentHeight;
+  });
+}
+
 bool migrationHasDueProofBatch(
   rust_sync.MigrationStatus status, {
   required int currentHeight,

--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -71,7 +71,7 @@ class DesktopOpenMigrationFallbackGate {
     _openOverdueScheduleByTxid.clear();
     for (final status in statuses) {
       for (final broadcast in status.scheduledBroadcasts) {
-        if (broadcast.status.toLowerCase() == 'scheduled' &&
+        if (_isRecoverableBroadcastStatus(broadcast.status) &&
             broadcast.scheduledHeight > 0 &&
             broadcast.scheduledHeight <= entryHeight) {
           _openOverdueScheduleByTxid[broadcast.txidHex] =
@@ -120,7 +120,7 @@ class DesktopOpenMigrationFallbackGate {
         .toSet();
     final acceptedOpenOverdueTx = before.scheduledBroadcasts.any(
       (broadcast) =>
-          broadcast.status.toLowerCase() == 'scheduled' &&
+          _isRecoverableBroadcastStatus(broadcast.status) &&
           _openOverdueScheduleByTxid[broadcast.txidHex] ==
               broadcast.scheduledHeight &&
           resultTxids.contains(broadcast.txidHex.toLowerCase()),
@@ -139,7 +139,7 @@ class DesktopOpenMigrationFallbackGate {
   bool isOpenOverdue(rust_sync.MigrationStatus status) {
     return status.scheduledBroadcasts.any(
       (broadcast) =>
-          broadcast.status.toLowerCase() == 'scheduled' &&
+          _isRecoverableBroadcastStatus(broadcast.status) &&
           _openOverdueScheduleByTxid[broadcast.txidHex] ==
               broadcast.scheduledHeight,
     );
@@ -148,9 +148,55 @@ class DesktopOpenMigrationFallbackGate {
   bool _hasScheduledTransfer(rust_sync.MigrationStatus status) {
     return status.scheduledBroadcasts.any(
       (broadcast) =>
-          broadcast.status.toLowerCase() == 'scheduled' &&
+          _isRecoverableBroadcastStatus(broadcast.status) &&
           broadcast.scheduledHeight > 0,
     );
+  }
+
+  bool _isRecoverableBroadcastStatus(String status) {
+    final normalized = status.toLowerCase();
+    return normalized == 'scheduled' || normalized == 'needs_resign';
+  }
+}
+
+/// Serializes passive reconciliation with account advances while coalescing
+/// duplicate reconciliation requests for the same account.
+class MigrationReconciliationOperationGate {
+  final Map<String, Future<void>> _operations = {};
+
+  Future<void>? operationFor(String accountUuid) => _operations[accountUuid];
+
+  Future<void> waitFor(String accountUuid) async {
+    final operation = _operations[accountUuid];
+    if (operation != null) await operation;
+  }
+
+  Future<void> run(
+    String accountUuid, {
+    required Future<void>? Function() activeAdvance,
+    required Future<void> Function() reconcile,
+  }) {
+    final existing = _operations[accountUuid];
+    if (existing != null) return existing;
+
+    final operation = () async {
+      final advance = activeAdvance();
+      if (advance != null) {
+        try {
+          await advance;
+        } catch (_) {
+          // A failed or ambiguous broadcast is exactly when txid
+          // reconciliation is most useful, so continue after it unwinds.
+        }
+      }
+      await reconcile();
+    }();
+    _operations[accountUuid] = operation;
+    return operation.whenComplete(() {
+      if (identical(_operations[accountUuid], operation)) {
+        _operations.remove(accountUuid);
+      }
+    });
   }
 }
 
@@ -208,10 +254,13 @@ class IronwoodMigrationCoordinator
   bool _hasObservedInitialAccountList = false;
   Future<void>? _backgroundPreparationRecovery;
   final Map<String, DateTime> _lastAdvanceAt = {};
+  final Map<String, DateTime> _lastReconciliationAt = {};
+  final Map<String, String> _lastReconciliationProgressKeys = {};
   final Map<String, ({String progressKey, DateTime retryAt})>
   _outboxRecoveryWindows = {};
   final Map<String, String> _lastAdvanceProgressKeys = {};
   final Map<String, Future<void>> _advanceOperations = {};
+  final _reconciliationGate = MigrationReconciliationOperationGate();
 
   @override
   IronwoodMigrationCoordinatorState build() {
@@ -443,7 +492,7 @@ class IronwoodMigrationCoordinator
     // Its route provider may already have a current status while this
     // coordinator has not completed its first polling pass. Preserve that
     // observed proof state for the explicit user action.
-    final statusForAdvance = status ?? state.statuses[accountUuid];
+    var statusForAdvance = status ?? state.statuses[accountUuid];
     if (statusForAdvance != null &&
         _isChildProofBatchAdvance(statusForAdvance)) {
       grantChildProofBatchPermit(accountUuid);
@@ -460,6 +509,15 @@ class IronwoodMigrationCoordinator
         }
       }
       final service = ref.read(ironwoodMigrationServiceProvider);
+      if (kAppFormFactor == AppFormFactor.desktop &&
+          statusForAdvance != null &&
+          _hasDueRecoverableBroadcast(statusForAdvance)) {
+        await _reconcileDesktopMigration(accountUuid);
+        statusForAdvance = await service.status(
+          network: ref.read(rpcEndpointFailoverProvider).current.networkName,
+          accountUuid: accountUuid,
+        );
+      }
       if (statusForAdvance != null &&
           service.supportsBackgroundMigrationRetry &&
           _manualRetryNeedsOutboxRecovery(statusForAdvance)) {
@@ -642,6 +700,23 @@ class IronwoodMigrationCoordinator
         nextStatuses[account.uuid] = status;
         nextErrors.remove(account.uuid);
 
+        if (_shouldReconcileDesktopMigration(
+          status,
+          accountUuid: account.uuid,
+        )) {
+          await _reconcileDesktopMigration(account.uuid);
+          _lastReconciliationAt[account.uuid] = DateTime.now();
+          _lastReconciliationProgressKeys[account.uuid] =
+              _reconciliationProgressKey(status);
+          if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
+          status = await service.status(
+            network: endpoint.networkName,
+            accountUuid: account.uuid,
+          );
+          if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
+          nextStatuses[account.uuid] = status;
+        }
+
         if (_shouldRecoverDueNativeOutbox(
           status,
           usesNativeOutbox: service.supportsBackgroundMigrationRetry,
@@ -736,12 +811,16 @@ class IronwoodMigrationCoordinator
         state.foregroundProgressPermits.isNotEmpty ||
         state.childProofBatchPermits.isNotEmpty ||
         _lastAdvanceAt.isNotEmpty ||
+        _lastReconciliationAt.isNotEmpty ||
+        _lastReconciliationProgressKeys.isNotEmpty ||
         _outboxRecoveryWindows.isNotEmpty ||
         _lastAdvanceProgressKeys.isNotEmpty;
     if (!hadWalletState) return;
 
     _hasObservedInitialAccountList = false;
     _lastAdvanceAt.clear();
+    _lastReconciliationAt.clear();
+    _lastReconciliationProgressKeys.clear();
     _outboxRecoveryWindows.clear();
     _lastAdvanceProgressKeys.clear();
     _desktopOpenFallbackGate.leaveForeground();
@@ -811,6 +890,56 @@ class IronwoodMigrationCoordinator
       return true;
     }
     return !DateTime.now().isBefore(window.retryAt);
+  }
+
+  bool _shouldReconcileDesktopMigration(
+    rust_sync.MigrationStatus status, {
+    required String accountUuid,
+  }) {
+    if (kAppFormFactor != AppFormFactor.desktop ||
+        !_hasDueRecoverableBroadcast(status)) {
+      _lastReconciliationAt.remove(accountUuid);
+      _lastReconciliationProgressKeys.remove(accountUuid);
+      return false;
+    }
+    final progressKey = _reconciliationProgressKey(status);
+    if (_lastReconciliationProgressKeys[accountUuid] != progressKey) {
+      return true;
+    }
+    final lastAttempt = _lastReconciliationAt[accountUuid];
+    return lastAttempt == null ||
+        DateTime.now().difference(lastAttempt) >= _migrationAdvanceInterval;
+  }
+
+  Future<void> _reconcileDesktopMigration(String accountUuid) {
+    return _reconciliationGate.run(
+      accountUuid,
+      activeAdvance: () => _advanceOperations[accountUuid],
+      reconcile: () => ref
+          .read(ironwoodMigrationServiceProvider)
+          .reconcileSoftwarePrivateMigrationTransactions(
+            accountUuid: accountUuid,
+          ),
+    );
+  }
+
+  String _reconciliationProgressKey(rust_sync.MigrationStatus status) {
+    final scheduled =
+        status.scheduledBroadcasts
+            .where((broadcast) {
+              final broadcastStatus = broadcast.status.toLowerCase();
+              return broadcastStatus == 'scheduled' ||
+                  broadcastStatus == 'needs_resign';
+            })
+            .map(
+              (broadcast) =>
+                  '${broadcast.txidHex.toLowerCase()}:'
+                  '${broadcast.status.toLowerCase()}:'
+                  '${broadcast.scheduledHeight}',
+            )
+            .toList()
+          ..sort();
+    return '${status.activeRunId}:${status.phase}:${scheduled.join(',')}';
   }
 
   /// Whether an explicit retry must go through native outbox recovery instead of
@@ -975,6 +1104,13 @@ class IronwoodMigrationCoordinator
     );
   }
 
+  bool _hasDueRecoverableBroadcast(rust_sync.MigrationStatus status) {
+    return migrationHasDueRecoverableBroadcast(
+      status,
+      currentHeight: _observedBroadcastHeight(),
+    );
+  }
+
   bool _canPrepareNextProof(rust_sync.MigrationStatus status) {
     final nextActionHeight = status.nextActionHeight;
     if (status.signedChildPcztCount <= 0 ||
@@ -1007,9 +1143,22 @@ class IronwoodMigrationCoordinator
   Future<void> _advance(
     String accountUuid, {
     rust_sync.MigrationStatus? status,
-  }) {
+  }) async {
     final existing = _advanceOperations[accountUuid];
-    if (existing != null) return existing;
+    if (existing != null) {
+      await existing;
+      return;
+    }
+    if (_reconciliationGate.operationFor(accountUuid) != null) {
+      await _reconciliationGate.waitFor(accountUuid);
+      // Another caller may have started an advance while this operation was
+      // waiting for reconciliation to release the Rust account guard.
+      final advanceAfterReconciliation = _advanceOperations[accountUuid];
+      if (advanceAfterReconciliation != null) {
+        await advanceAfterReconciliation;
+        return;
+      }
+    }
     final reservesOpenOverdueAllowance =
         kAppFormFactor == AppFormFactor.desktop &&
         status != null &&
@@ -1021,7 +1170,7 @@ class IronwoodMigrationCoordinator
       // `_shouldAdvance`. Keep the ZIP 318 on-open allowance centralized at
       // this last coordinator boundary so no UI or polling entry point can
       // submit a second overdue transfer in the same foreground epoch.
-      return Future.value();
+      return;
     }
     final operation = () async {
       try {
@@ -1045,7 +1194,7 @@ class IronwoodMigrationCoordinator
       }
     }();
     _advanceOperations[accountUuid] = operation;
-    return operation.whenComplete(() {
+    await operation.whenComplete(() {
       if (identical(_advanceOperations[accountUuid], operation)) {
         _advanceOperations.remove(accountUuid);
       }

--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -200,6 +200,51 @@ class MigrationReconciliationOperationGate {
   }
 }
 
+/// Throttles repeated automatic reconciliation attempts for unchanged
+/// migration progress, including attempts that fail.
+class MigrationReconciliationAttemptThrottle {
+  MigrationReconciliationAttemptThrottle({
+    this.interval = _migrationAdvanceInterval,
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
+
+  final Duration interval;
+  final DateTime Function() _now;
+  final Map<String, DateTime> _lastAttemptAt = {};
+  final Map<String, String> _lastProgressKeys = {};
+
+  bool get hasState =>
+      _lastAttemptAt.isNotEmpty || _lastProgressKeys.isNotEmpty;
+
+  bool shouldAttempt(String accountUuid, String progressKey) {
+    if (_lastProgressKeys[accountUuid] != progressKey) return true;
+    final lastAttempt = _lastAttemptAt[accountUuid];
+    return lastAttempt == null || _now().difference(lastAttempt) >= interval;
+  }
+
+  Future<T> run<T>(
+    String accountUuid,
+    String progressKey,
+    Future<T> Function() operation,
+  ) {
+    // Record before invoking the operation so transient failures are throttled
+    // just like successful no-op reconciliation attempts.
+    _lastAttemptAt[accountUuid] = _now();
+    _lastProgressKeys[accountUuid] = progressKey;
+    return operation();
+  }
+
+  void clearAccount(String accountUuid) {
+    _lastAttemptAt.remove(accountUuid);
+    _lastProgressKeys.remove(accountUuid);
+  }
+
+  void clear() {
+    _lastAttemptAt.clear();
+    _lastProgressKeys.clear();
+  }
+}
+
 class IronwoodMigrationCoordinatorState {
   const IronwoodMigrationCoordinatorState({
     this.statuses = const {},
@@ -254,13 +299,12 @@ class IronwoodMigrationCoordinator
   bool _hasObservedInitialAccountList = false;
   Future<void>? _backgroundPreparationRecovery;
   final Map<String, DateTime> _lastAdvanceAt = {};
-  final Map<String, DateTime> _lastReconciliationAt = {};
-  final Map<String, String> _lastReconciliationProgressKeys = {};
   final Map<String, ({String progressKey, DateTime retryAt})>
   _outboxRecoveryWindows = {};
   final Map<String, String> _lastAdvanceProgressKeys = {};
   final Map<String, Future<void>> _advanceOperations = {};
   final _reconciliationGate = MigrationReconciliationOperationGate();
+  final _reconciliationThrottle = MigrationReconciliationAttemptThrottle();
 
   @override
   IronwoodMigrationCoordinatorState build() {
@@ -704,10 +748,11 @@ class IronwoodMigrationCoordinator
           status,
           accountUuid: account.uuid,
         )) {
-          await _reconcileDesktopMigration(account.uuid);
-          _lastReconciliationAt[account.uuid] = DateTime.now();
-          _lastReconciliationProgressKeys[account.uuid] =
-              _reconciliationProgressKey(status);
+          await _reconciliationThrottle.run(
+            account.uuid,
+            _reconciliationProgressKey(status),
+            () => _reconcileDesktopMigration(account.uuid),
+          );
           if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
           status = await service.status(
             network: endpoint.networkName,
@@ -811,16 +856,14 @@ class IronwoodMigrationCoordinator
         state.foregroundProgressPermits.isNotEmpty ||
         state.childProofBatchPermits.isNotEmpty ||
         _lastAdvanceAt.isNotEmpty ||
-        _lastReconciliationAt.isNotEmpty ||
-        _lastReconciliationProgressKeys.isNotEmpty ||
+        _reconciliationThrottle.hasState ||
         _outboxRecoveryWindows.isNotEmpty ||
         _lastAdvanceProgressKeys.isNotEmpty;
     if (!hadWalletState) return;
 
     _hasObservedInitialAccountList = false;
     _lastAdvanceAt.clear();
-    _lastReconciliationAt.clear();
-    _lastReconciliationProgressKeys.clear();
+    _reconciliationThrottle.clear();
     _outboxRecoveryWindows.clear();
     _lastAdvanceProgressKeys.clear();
     _desktopOpenFallbackGate.leaveForeground();
@@ -898,17 +941,11 @@ class IronwoodMigrationCoordinator
   }) {
     if (kAppFormFactor != AppFormFactor.desktop ||
         !_hasDueRecoverableBroadcast(status)) {
-      _lastReconciliationAt.remove(accountUuid);
-      _lastReconciliationProgressKeys.remove(accountUuid);
+      _reconciliationThrottle.clearAccount(accountUuid);
       return false;
     }
     final progressKey = _reconciliationProgressKey(status);
-    if (_lastReconciliationProgressKeys[accountUuid] != progressKey) {
-      return true;
-    }
-    final lastAttempt = _lastReconciliationAt[accountUuid];
-    return lastAttempt == null ||
-        DateTime.now().difference(lastAttempt) >= _migrationAdvanceInterval;
+    return _reconciliationThrottle.shouldAttempt(accountUuid, progressKey);
   }
 
   Future<void> _reconcileDesktopMigration(String accountUuid) {

--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -245,6 +245,42 @@ class MigrationReconciliationAttemptThrottle {
   }
 }
 
+bool migrationBalanceMayHaveChanged(
+  rust_sync.MigrationStatus? previous,
+  rust_sync.MigrationStatus current,
+) {
+  // The first observation is normally paired with bootstrap/re-entry sync, so
+  // do not add an extra balance fetch merely because the coordinator mounted.
+  // Callers that perform reconciliation should compare its non-null before and
+  // after statuses separately so first-pass recovery is still detected.
+  if (previous == null) return false;
+
+  if (previous.pendingTxCount != current.pendingTxCount ||
+      previous.broadcastedTxCount != current.broadcastedTxCount ||
+      previous.confirmedTxCount != current.confirmedTxCount ||
+      previous.denominationConfirmationCount !=
+          current.denominationConfirmationCount ||
+      previous.denominationSplitCompletedCount !=
+          current.denominationSplitCompletedCount) {
+    return true;
+  }
+
+  final previousParts = {
+    for (final part in previous.parts) part.partIndex: part,
+  };
+  if (previousParts.length != current.parts.length) return true;
+  for (final part in current.parts) {
+    final before = previousParts[part.partIndex];
+    if (before == null ||
+        before.state != part.state ||
+        before.txidHex != part.txidHex ||
+        before.confirmationCount != part.confirmationCount) {
+      return true;
+    }
+  }
+  return false;
+}
+
 class IronwoodMigrationCoordinatorState {
   const IronwoodMigrationCoordinatorState({
     this.statuses = const {},
@@ -748,6 +784,7 @@ class IronwoodMigrationCoordinator
           status,
           accountUuid: account.uuid,
         )) {
+          final statusBeforeReconciliation = status;
           await _reconciliationThrottle.run(
             account.uuid,
             _reconciliationProgressKey(status),
@@ -760,6 +797,13 @@ class IronwoodMigrationCoordinator
           );
           if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
           nextStatuses[account.uuid] = status;
+          if (account.uuid == accountState.activeAccountUuid &&
+              migrationBalanceMayHaveChanged(
+                statusBeforeReconciliation,
+                status,
+              )) {
+            activeBalanceMayHaveChanged = true;
+          }
         }
 
         if (_shouldRecoverDueNativeOutbox(
@@ -815,7 +859,7 @@ class IronwoodMigrationCoordinator
           nextStatuses[account.uuid] = status;
         }
         if (account.uuid == accountState.activeAccountUuid &&
-            _migrationBalanceMayHaveChanged(previousStatus, status)) {
+            migrationBalanceMayHaveChanged(previousStatus, status)) {
           activeBalanceMayHaveChanged = true;
         }
       } catch (error) {
@@ -872,42 +916,6 @@ class IronwoodMigrationCoordinator
     }
     state = const IronwoodMigrationCoordinatorState();
     _invalidateMigrationProviders(null);
-  }
-
-  bool _migrationBalanceMayHaveChanged(
-    rust_sync.MigrationStatus? previous,
-    rust_sync.MigrationStatus current,
-  ) {
-    // The first observation is normally paired with bootstrap/re-entry sync,
-    // so do not add an extra balance fetch merely because the coordinator was
-    // mounted. Subsequent child transaction transitions need a fresh snapshot
-    // for the home balance card.
-    if (previous == null) return false;
-
-    if (previous.pendingTxCount != current.pendingTxCount ||
-        previous.broadcastedTxCount != current.broadcastedTxCount ||
-        previous.confirmedTxCount != current.confirmedTxCount ||
-        previous.denominationConfirmationCount !=
-            current.denominationConfirmationCount ||
-        previous.denominationSplitCompletedCount !=
-            current.denominationSplitCompletedCount) {
-      return true;
-    }
-
-    final previousParts = {
-      for (final part in previous.parts) part.partIndex: part,
-    };
-    if (previousParts.length != current.parts.length) return true;
-    for (final part in current.parts) {
-      final before = previousParts[part.partIndex];
-      if (before == null ||
-          before.state != part.state ||
-          before.txidHex != part.txidHex ||
-          before.confirmationCount != part.confirmationCount) {
-        return true;
-      }
-    }
-    return false;
   }
 
   bool _shouldRecoverDueNativeOutbox(

--- a/lib/src/features/migration/screens/ironwood_migration_flow/private_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/private_status.dart
@@ -344,13 +344,13 @@ enum _StatusAction { none, needsInput, retry, backHome }
 extension _StatusActionLabels on _StatusAction {
   String get label => switch (this) {
     _StatusAction.needsInput => 'Sign with Keystone',
-    _StatusAction.retry => 'Retry migration',
+    _StatusAction.retry => 'Recover migration',
     _StatusAction.backHome => 'Back home',
     _StatusAction.none => '',
   };
 
   String get busyLabel => switch (this) {
-    _StatusAction.retry => 'Retrying...',
+    _StatusAction.retry => 'Recovering...',
     _ => 'Continuing...',
   };
 }
@@ -437,9 +437,9 @@ _StatusPresentation _statusPresentation(rust_sync.MigrationStatus status) {
           'Vizor hit a recoverable migration error before completing the '
           'Ironwood transition.',
       footer:
-          'No funds are lost. Retry migration after checking that Vizor is '
-          'synced and online.',
-      buttonLabel: 'Retry migration',
+          'No funds are lost. Vizor will check the saved transaction before '
+          'submitting anything again.',
+      buttonLabel: 'Recover migration',
     ),
     _ => const _StatusPresentation(
       title: 'Migration Status',

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -607,6 +607,7 @@ class IronwoodMigrationService {
     IronwoodMigrationUnbroadcastRetirer? retireUnbroadcastMigration,
     IronwoodMigrationMacosSoftwareStarter? startMacosSoftwareMigration,
     IronwoodMigrationDueBroadcaster? broadcastDueMigration,
+    IronwoodMigrationDueBroadcaster? reconcileMigrationTransactions,
     IronwoodMigrationOutboxPreparer? prepareMigrationOutbox,
     IronwoodMigrationOutboxExporter? exportMigrationOutbox,
     IronwoodMigrationOutboxReceiptReconciler? reconcileMigrationOutboxReceipt,
@@ -694,6 +695,9 @@ class IronwoodMigrationService {
        broadcastDueMigration =
            broadcastDueMigration ??
            rust_sync.broadcastOneDueOrchardMigrationTransaction,
+       reconcileMigrationTransactions =
+           reconcileMigrationTransactions ??
+           rust_sync.reconcileOrchardMigrationTransactions,
        prepareMigrationOutbox =
            prepareMigrationOutbox ?? rust_sync.prepareOrchardMigrationOutbox,
        exportMigrationOutbox =
@@ -787,6 +791,7 @@ class IronwoodMigrationService {
   final IronwoodMigrationUnbroadcastRetirer retireUnbroadcastMigration;
   final IronwoodMigrationMacosSoftwareStarter startMacosSoftwareMigration;
   final IronwoodMigrationDueBroadcaster broadcastDueMigration;
+  final IronwoodMigrationDueBroadcaster reconcileMigrationTransactions;
   final IronwoodMigrationOutboxPreparer prepareMigrationOutbox;
   final IronwoodMigrationOutboxExporter exportMigrationOutbox;
   final IronwoodMigrationOutboxReceiptReconciler
@@ -1382,6 +1387,35 @@ class IronwoodMigrationService {
           mnemonicBytes.fillRange(0, mnemonicBytes.length, 0);
         }
       },
+    );
+  }
+
+  /// Repairs local tracking for an already-submitted desktop migration
+  /// transaction without broadcasting a new transaction.
+  Future<rust_sync.IronwoodMigrationResult>
+  reconcileSoftwarePrivateMigrationTransactions({
+    required String accountUuid,
+  }) async {
+    final dbPath = await getWalletDbPath();
+    final endpoint = getEndpoint();
+    final context = _MigrationCredentialContext(
+      dbPath: dbPath,
+      network: endpoint.networkName,
+      accountUuid: accountUuid,
+      lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+    );
+    return _runCredentialOperation(
+      context: context,
+      mayCreateRun: false,
+      prepareOutboxAfterOperation: false,
+      operation: (credential) => reconcileMigrationTransactions(
+        dbPath: dbPath,
+        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        network: endpoint.networkName,
+        accountUuid: accountUuid,
+        password: credential.password,
+        saltBase64: credential.saltBase64,
+      ),
     );
   }
 

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -515,6 +515,28 @@ Future<IronwoodMigrationResult> broadcastOneDueOrchardMigrationTransaction({
       saltBase64: saltBase64,
     );
 
+/// Reconciles a due migration transaction without submitting anything new.
+///
+/// If the saved txid is already present in the local wallet, lightwalletd
+/// mempool, or chain, this restores local tracking and reschedules the
+/// remaining overdue transfers. A not-found response leaves the transaction
+/// scheduled for the normal privacy-gated broadcast path.
+Future<IronwoodMigrationResult> reconcileOrchardMigrationTransactions({
+  required String dbPath,
+  required String lightwalletdUrl,
+  required String network,
+  required String accountUuid,
+  required String password,
+  required String saltBase64,
+}) => RustLib.instance.api.crateApiSyncReconcileOrchardMigrationTransactions(
+  dbPath: dbPath,
+  lightwalletdUrl: lightwalletdUrl,
+  network: network,
+  accountUuid: accountUuid,
+  password: password,
+  saltBase64: saltBase64,
+);
+
 /// Prepares denomination PCZTs with expiry heights derived from their planned
 /// broadcast heights.
 Future<KeystoneMigrationSigningRequest>

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1229719647;
+  int get rustContentHash => -824455040;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -885,6 +885,16 @@ abstract class RustLibApi extends BaseApi {
     String? responseMessage,
     required List<MigrationOutboxScheduleUpdate> scheduleUpdates,
     Uint8List? acceptedRawTransaction,
+  });
+
+  Future<IronwoodMigrationResult>
+  crateApiSyncReconcileOrchardMigrationTransactions({
+    required String dbPath,
+    required String lightwalletdUrl,
+    required String network,
+    required String accountUuid,
+    required String password,
+    required String saltBase64,
   });
 
   Future<void> crateApiVotingRecordShareDelegation({
@@ -6251,6 +6261,65 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<IronwoodMigrationResult>
+  crateApiSyncReconcileOrchardMigrationTransactions({
+    required String dbPath,
+    required String lightwalletdUrl,
+    required String network,
+    required String accountUuid,
+    required String password,
+    required String saltBase64,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
+          sse_encode_String(password, serializer);
+          sse_encode_String(saltBase64, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 120,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_ironwood_migration_result,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncReconcileOrchardMigrationTransactionsConstMeta,
+        argValues: [
+          dbPath,
+          lightwalletdUrl,
+          network,
+          accountUuid,
+          password,
+          saltBase64,
+        ],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiSyncReconcileOrchardMigrationTransactionsConstMeta =>
+      const TaskConstMeta(
+        debugName: "reconcile_orchard_migration_transactions",
+        argNames: [
+          "dbPath",
+          "lightwalletdUrl",
+          "network",
+          "accountUuid",
+          "password",
+          "saltBase64",
+        ],
+      );
+
+  @override
   Future<void> crateApiVotingRecordShareDelegation({
     required String dbPath,
     required String accountUuid,
@@ -6276,7 +6345,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 121,
             port: port_,
           );
         },
@@ -6335,7 +6404,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 122,
             port: port_,
           );
         },
@@ -6382,7 +6451,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 123,
             port: port_,
           );
         },
@@ -6427,7 +6496,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 124,
             port: port_,
           );
         },
@@ -6457,7 +6526,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 125,
           )!;
         },
         codec: SseCodec(
@@ -6490,7 +6559,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6527,7 +6596,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6562,7 +6631,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6604,7 +6673,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6639,7 +6708,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6680,7 +6749,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6729,7 +6798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6767,7 +6836,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6822,7 +6891,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 134,
             port: port_,
           );
         },
@@ -6892,7 +6961,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 135,
             port: port_,
           );
         },
@@ -6939,7 +7008,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 136,
           )!;
         },
         codec: SseCodec(
@@ -6974,7 +7043,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 137,
             port: port_,
           );
         },
@@ -7007,7 +7076,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 138,
             port: port_,
           );
         },
@@ -7047,7 +7116,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7088,7 +7157,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7142,7 +7211,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7192,7 +7261,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 141,
+              funcId: 142,
               port: port_,
             );
           },
@@ -7233,7 +7302,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 142,
+              funcId: 143,
               port: port_,
             );
           },
@@ -7265,7 +7334,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 144,
           )!;
         },
         codec: SseCodec(
@@ -7306,7 +7375,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7357,7 +7426,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
             port: port_,
           );
         },
@@ -7396,7 +7465,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7439,7 +7508,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
             port: port_,
           );
         },
@@ -7489,7 +7558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7521,7 +7590,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7549,7 +7618,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
           )!;
         },
         codec: SseCodec(
@@ -7581,7 +7650,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7618,7 +7687,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7649,7 +7718,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 154,
           )!;
         },
         codec: SseCodec(
@@ -7680,7 +7749,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
             port: port_,
           );
         },

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -1657,6 +1657,44 @@ pub fn broadcast_one_due_orchard_migration_transaction(
     })
 }
 
+/// Reconciles a due migration transaction without submitting anything new.
+///
+/// If the saved txid is already present in the local wallet, lightwalletd
+/// mempool, or chain, this restores local tracking and reschedules the
+/// remaining overdue transfers. A not-found response leaves the transaction
+/// scheduled for the normal privacy-gated broadcast path.
+pub fn reconcile_orchard_migration_transactions(
+    db_path: String,
+    lightwalletd_url: String,
+    network: String,
+    account_uuid: String,
+    password: String,
+    salt_base64: String,
+) -> Result<IronwoodMigrationResult, String> {
+    catch(|| {
+        let network = parse_network_and_migrate(&db_path, &network)?;
+        let password = Zeroizing::new(password.into_bytes());
+        let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
+        let r = rt.block_on(wallet_sync::reconcile_orchard_migration_transactions(
+            &db_path,
+            &lightwalletd_url,
+            network,
+            &account_uuid,
+            password,
+            &salt_base64,
+        ))?;
+        Ok(IronwoodMigrationResult {
+            txids: r.txids,
+            status: r.status,
+            broadcasted_count: r.broadcasted_count,
+            total_count: r.total_count,
+            message: r.message,
+            fee_zatoshi: r.fee_zatoshi,
+            migrated_zatoshi: r.migrated_zatoshi,
+        })
+    })
+}
+
 /// Prepares denomination PCZTs with expiry heights derived from their planned
 /// broadcast heights.
 pub fn prepare_orchard_migration_denominations_pczt(

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1229719647;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -824455040;
 
 // Section: executor
 
@@ -4789,6 +4789,51 @@ fn wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(
         },
     )
 }
+fn wire__crate__api__sync__reconcile_orchard_migration_transactions_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "reconcile_orchard_migration_transactions",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_password = <String>::sse_decode(&mut deserializer);
+            let api_salt_base64 = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::sync::reconcile_orchard_migration_transactions(
+                        api_db_path,
+                        api_lightwalletd_url,
+                        api_network,
+                        api_account_uuid,
+                        api_password,
+                        api_salt_base64,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__voting__record_share_delegation_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -9435,36 +9480,37 @@ fn pde_ffi_dispatcher_primary_impl(
 117 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
 118 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
 119 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-145 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__sync__reconcile_orchard_migration_transactions_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+146 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+148 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -9490,11 +9536,11 @@ fn pde_ffi_dispatcher_sync_impl(
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
         105 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        124 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        135 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        143 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        150 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        153 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        125 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        136 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        144 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        151 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        154 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/wallet/db.rs
+++ b/rust/src/wallet/db.rs
@@ -1,5 +1,6 @@
 use std::{
-    sync::{Mutex, OnceLock},
+    cell::Cell,
+    sync::{Mutex, MutexGuard, OnceLock},
     time::{Duration, Instant},
 };
 
@@ -144,10 +145,59 @@ fn configure_wallet_connection(
     Ok(())
 }
 
-pub(crate) fn with_wallet_db_write_lock<T>(
+thread_local! {
+    static WALLET_DB_WRITE_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+struct WalletDbWriteDepthGuard;
+
+impl WalletDbWriteDepthGuard {
+    fn enter() -> Self {
+        WALLET_DB_WRITE_DEPTH.with(|depth| {
+            depth.set(
+                depth
+                    .get()
+                    .checked_add(1)
+                    .expect("wallet DB write lock nesting overflow"),
+            );
+        });
+        Self
+    }
+}
+
+impl Drop for WalletDbWriteDepthGuard {
+    fn drop(&mut self) {
+        WALLET_DB_WRITE_DEPTH.with(|depth| {
+            depth.set(
+                depth
+                    .get()
+                    .checked_sub(1)
+                    .expect("wallet DB write lock nesting underflow"),
+            );
+        });
+    }
+}
+
+struct WalletDbWriteGuard {
+    _guard: MutexGuard<'static, ()>,
     operation: &'static str,
-    write: impl FnOnce() -> T,
-) -> T {
+    hold_start: Instant,
+}
+
+impl Drop for WalletDbWriteGuard {
+    fn drop(&mut self) {
+        let held = self.hold_start.elapsed();
+        if held >= Duration::from_secs(1) {
+            log::info!(
+                "wallet DB write lock held {:.3}s by {}",
+                held.as_secs_f64(),
+                self.operation
+            );
+        }
+    }
+}
+
+fn acquire_wallet_db_write_lock(operation: &'static str) -> WalletDbWriteGuard {
     // Serializes wallet-DB writes across FRB foreground calls, C-FFI
     // background sync calls, and Rust sync tasks inside this process. This
     // does not coordinate with a separate OS process that opens the same DB.
@@ -171,18 +221,26 @@ pub(crate) fn with_wallet_db_write_lock<T>(
         );
     }
 
-    let hold_start = Instant::now();
-    let result = write();
-    let held = hold_start.elapsed();
-    if held >= Duration::from_secs(1) {
-        log::info!(
-            "wallet DB write lock held {:.3}s by {operation}",
-            held.as_secs_f64()
-        );
+    WalletDbWriteGuard {
+        _guard: guard,
+        operation,
+        hold_start: Instant::now(),
+    }
+}
+
+pub(crate) fn with_wallet_db_write_lock<T>(
+    operation: &'static str,
+    write: impl FnOnce() -> T,
+) -> T {
+    let is_nested = WALLET_DB_WRITE_DEPTH.with(|depth| depth.get() > 0);
+    if is_nested {
+        let _depth = WalletDbWriteDepthGuard::enter();
+        return write();
     }
 
-    drop(guard);
-    result
+    let _guard = acquire_wallet_db_write_lock(operation);
+    let _depth = WalletDbWriteDepthGuard::enter();
+    write()
 }
 
 pub(crate) fn open_readonly_conn_with_timeout(
@@ -238,6 +296,31 @@ mod tests {
         });
 
         assert!(called);
+    }
+
+    #[test]
+    fn wallet_db_write_lock_allows_same_thread_nesting() {
+        let (outer_acquired_tx, outer_acquired_rx) = std::sync::mpsc::channel();
+        let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+
+        let nested = std::thread::spawn(move || {
+            with_wallet_db_write_lock("test.outer", || {
+                outer_acquired_tx.send(()).unwrap();
+                with_wallet_db_write_lock("test.inner", || {
+                    completed_tx.send(()).unwrap();
+                });
+            });
+        });
+
+        // Other parallel tests legitimately hold the process-wide lock. Start
+        // the deadlock timeout only after this test owns the outer lock.
+        outer_acquired_rx
+            .recv_timeout(Duration::from_secs(30))
+            .expect("outer wallet DB write lock was not acquired");
+        completed_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("nested wallet DB write lock deadlocked");
+        nested.join().unwrap();
     }
 
     #[test]

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -218,6 +218,7 @@ pub(crate) struct SignedChildProofCandidate {
 pub(crate) struct DuePendingMigrationTx {
     pub txid_hex: String,
     pub raw_tx: Vec<u8>,
+    pub status: String,
 }
 
 #[derive(Debug)]
@@ -1307,19 +1308,21 @@ pub(crate) fn mark_run_phase(
     phase: &str,
     message: Option<&str>,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
-    ensure_schema(&conn)?;
-    let now = now_ms()?;
-    conn.execute(
-        &format!(
-            "UPDATE {RUNS_TABLE}
-             SET phase = ?1, updated_at_ms = ?2, last_error = ?3
-             WHERE run_id = ?4"
-        ),
-        params![phase, now, message, run_id],
-    )
-    .map_err(|e| format!("Update migration run phase: {e}"))?;
-    Ok(())
+    with_wallet_db_write_lock("migration.mark_run_phase", || {
+        let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+        ensure_schema(&conn)?;
+        let now = now_ms()?;
+        conn.execute(
+            &format!(
+                "UPDATE {RUNS_TABLE}
+                 SET phase = ?1, updated_at_ms = ?2, last_error = ?3
+                 WHERE run_id = ?4"
+            ),
+            params![phase, now, message, run_id],
+        )
+        .map_err(|e| format!("Update migration run phase: {e}"))?;
+        Ok(())
+    })
 }
 
 pub(crate) fn run_phase(db_path: &str, run_id: &str) -> Result<String, String> {
@@ -3098,9 +3101,60 @@ pub(crate) fn due_pending_txs(
         due.push(DuePendingMigrationTx {
             txid_hex,
             raw_tx: raw_tx.to_vec(),
+            status: "scheduled".to_string(),
         });
     }
     Ok(due)
+}
+
+/// Returns the oldest due transaction that may need accepted-state recovery.
+///
+/// Unlike [`due_pending_txs`], this intentionally accepts `needs_resign` rows
+/// and does not require the saved schedule to remain canonical. Recovery by
+/// txid must happen before replacing an expired transaction: the original
+/// bytes may already be in the mempool or chain.
+pub(crate) fn recoverable_due_pending_tx(
+    db_path: &str,
+    run_id: &str,
+    chain_tip_height: u32,
+    password: &[u8],
+    salt_base64: &str,
+) -> Result<Option<DuePendingMigrationTx>, String> {
+    let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration pending salt")?;
+    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    ensure_schema(&conn)?;
+    let row = conn
+        .query_row(
+            &format!(
+                "SELECT txid_hex, encrypted_raw_tx, status
+                 FROM {PENDING_TXS_TABLE}
+                 WHERE run_id = ?1
+                   AND status IN ('scheduled', 'needs_resign')
+                   AND scheduled_height <= ?2
+                 ORDER BY scheduled_height ASC, txid_hex ASC
+                 LIMIT 1"
+            ),
+            params![run_id, chain_tip_height],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|e| format!("Read recoverable migration transaction: {e}"))?;
+    let Some((txid_hex, encrypted_raw_tx, status)) = row else {
+        return Ok(None);
+    };
+    let raw_tx =
+        secret_payload::decrypt_payload(encrypted_raw_tx.as_bytes(), password, salt.as_slice())?;
+    Ok(Some(DuePendingMigrationTx {
+        txid_hex,
+        raw_tx: raw_tx.to_vec(),
+        status,
+    }))
 }
 
 pub(crate) fn mark_due_parts_with_noncanonical_broadcast_height_for_resign(
@@ -3632,6 +3686,30 @@ pub(crate) fn reschedule_overdue_pending_txs(
     reschedule_overdue_pending_txs_with_options(db_path, run_id, network, chain_tip_height, 0, None)
 }
 
+/// Reschedules every other overdue transfer in the run before an accepted
+/// transaction is durably marked broadcasted.
+///
+/// Keeping the accepted row excluded and still recoverable until the
+/// reschedule commits makes the multi-step recovery resumable: if either this
+/// update or the later broadcast-state update fails, the saved txid remains
+/// eligible for another reconciliation pass.
+pub(crate) fn reschedule_overdue_pending_txs_after_accepted(
+    db_path: &str,
+    run_id: &str,
+    network: WalletNetwork,
+    chain_tip_height: u32,
+    accepted_txid: &str,
+) -> Result<(), String> {
+    reschedule_overdue_pending_txs_with_options(
+        db_path,
+        run_id,
+        network,
+        chain_tip_height,
+        0,
+        Some(accepted_txid),
+    )
+}
+
 fn reschedule_overdue_pending_txs_with_options(
     db_path: &str,
     run_id: &str,
@@ -3809,24 +3887,26 @@ pub(crate) fn mark_pending_broadcasted(
     run_id: &str,
     txid_hex: &str,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
-    ensure_schema(&conn)?;
-    let now = now_ms()?;
-    let tx = conn
-        .unchecked_transaction()
-        .map_err(|e| format!("Begin pending migration broadcast update: {e}"))?;
-    tx.execute(
-        &format!(
-            "UPDATE {PENDING_TXS_TABLE}
-             SET status = 'broadcasted'
-             WHERE run_id = ?1 AND txid_hex = ?2"
-        ),
-        params![run_id, txid_hex],
-    )
-    .map_err(|e| format!("Mark pending migration tx broadcasted: {e}"))?;
-    update_run_after_pending_broadcast(&tx, run_id, now)?;
-    tx.commit()
-        .map_err(|e| format!("Commit pending migration broadcast update: {e}"))
+    with_wallet_db_write_lock("migration.mark_pending_broadcasted", || {
+        let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+        ensure_schema(&conn)?;
+        let now = now_ms()?;
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| format!("Begin pending migration broadcast update: {e}"))?;
+        tx.execute(
+            &format!(
+                "UPDATE {PENDING_TXS_TABLE}
+                 SET status = 'broadcasted'
+                 WHERE run_id = ?1 AND txid_hex = ?2"
+            ),
+            params![run_id, txid_hex],
+        )
+        .map_err(|e| format!("Mark pending migration tx broadcasted: {e}"))?;
+        update_run_after_pending_broadcast(&tx, run_id, now)?;
+        tx.commit()
+            .map_err(|e| format!("Commit pending migration broadcast update: {e}"))
+    })
 }
 
 fn update_run_after_pending_broadcast(

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -1280,6 +1280,65 @@ fn on_open_storage_recovery_keeps_accepted_tx_and_redraws_every_other_run() {
 }
 
 #[test]
+fn run_recovery_keeps_accepted_tx_recoverable_until_peer_reschedule_finishes() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    let txids = create_outbox_test_run(&db_path, "run-1", &[100, 200], &[Some(90), Some(90)]);
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    conn.execute(
+        &format!(
+            "UPDATE {PENDING_TXS_TABLE}
+             SET scheduled_height = 503, schedule_start_height = 502
+             WHERE run_id = 'run-1'"
+        ),
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    reschedule_overdue_pending_txs_after_accepted(
+        &db_path,
+        "run-1",
+        WalletNetwork::Regtest,
+        503,
+        &txids[0],
+    )
+    .unwrap();
+
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let accepted_state: (String, u32) = conn
+        .query_row(
+            &format!(
+                "SELECT status, scheduled_height FROM {PENDING_TXS_TABLE}
+                 WHERE run_id = 'run-1' AND txid_hex = ?1"
+            ),
+            params![txids[0]],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(accepted_state, ("scheduled".to_string(), 503));
+    drop(conn);
+
+    mark_pending_broadcasted(&db_path, "run-1", &txids[0]).unwrap();
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let accepted_status: String = conn
+        .query_row(
+            &format!(
+                "SELECT status FROM {PENDING_TXS_TABLE}
+                 WHERE run_id = 'run-1' AND txid_hex = ?1"
+            ),
+            params![txids[0]],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(accepted_status, "broadcasted");
+}
+
+#[test]
 fn overdue_broadcast_crossing_expiry_bucket_requires_resigning_before_send() {
     let temp_dir = tempfile::tempdir().unwrap();
     let db_path = temp_dir
@@ -1311,6 +1370,12 @@ fn overdue_broadcast_crossing_expiry_bucket_requires_resigning_before_send() {
             .unwrap()
             .is_empty()
     );
+    let recoverable =
+        recoverable_due_pending_tx(&db_path, "run-1", 34_560, TEST_PASSWORD, TEST_SALT_BASE64)
+            .unwrap()
+            .expect("needs-resign transaction remains recoverable by its original txid");
+    assert_eq!(recoverable.raw_tx.first(), Some(&0));
+    assert_eq!(recoverable.status, "needs_resign");
 }
 
 #[test]

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -69,7 +69,7 @@ pub(crate) use send::{
 pub use send::{
     broadcast_due_orchard_migration_transactions, broadcast_one_due_orchard_migration_transaction,
     estimate_fee, execute_proposal, execute_proposal_with_seed_loader, propose_send,
-    ExecuteProposalResult, IronwoodMigrationResult,
+    reconcile_orchard_migration_transactions, ExecuteProposalResult, IronwoodMigrationResult,
 };
 pub(crate) use send::{
     create_shield_transparent_pczt, get_shield_transparent_status, shield_transparent_balance,

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -339,6 +339,27 @@ fn one_due_migration_result(advance: MigrationBroadcastAdvance) -> IronwoodMigra
     result
 }
 
+fn recovered_migration_advance(
+    result: IronwoodMigrationResult,
+    recovered_txid: String,
+    recovered_was_current_submission: bool,
+) -> MigrationBroadcastAdvance {
+    MigrationBroadcastAdvance {
+        result,
+        accepted_txids: recovered_was_current_submission
+            .then_some(recovered_txid)
+            .into_iter()
+            .collect(),
+    }
+}
+
+fn should_rebroadcast_missing_migration_tx(
+    pending_status: &str,
+    rebroadcast_needs_resign_if_missing: bool,
+) -> bool {
+    rebroadcast_needs_resign_if_missing && pending_status == "needs_resign"
+}
+
 fn accepted_migration_processing_failure_result(
     totals_before: &super::migration::PendingMigrationTotals,
     accepted_txids: Vec<String>,
@@ -2239,6 +2260,56 @@ pub async fn broadcast_one_due_orchard_migration_transaction(
     Ok(one_due_migration_result(advance))
 }
 
+pub async fn reconcile_orchard_migration_transactions(
+    db_path: &str,
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    pending_password: zeroize::Zeroizing<Vec<u8>>,
+    pending_salt_base64: &str,
+) -> Result<IronwoodMigrationResult, String> {
+    let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
+    let Some(run) = super::migration::active_migration_run(db_path, account_uuid, network)? else {
+        return Ok(IronwoodMigrationResult {
+            txids: String::new(),
+            status: super::migration::PHASE_COMPLETE.to_string(),
+            broadcasted_count: 0,
+            total_count: 0,
+            message: None,
+            fee_zatoshi: 0,
+            migrated_zatoshi: 0,
+        });
+    };
+    let chain_tip_height =
+        u32::try_from(super::get_sync_progress(db_path, network)?.chain_tip_height)
+            .map_err(|_| "Migration chain tip exceeds u32".to_string())?;
+    let totals = super::migration::pending_totals_for_run(db_path, &run.run_id)?;
+    let reconciled = reconcile_due_scheduled_migration_tx(
+        db_path,
+        lightwalletd_url,
+        network,
+        &run.run_id,
+        chain_tip_height,
+        pending_password.as_slice(),
+        pending_salt_base64,
+        run.target_values_zatoshi.len() as u32,
+        run.target_values_zatoshi.iter().sum(),
+        true,
+        false,
+        false,
+    )
+    .await?;
+    Ok(reconciled.map(|advance| advance.result).unwrap_or_else(|| {
+        migration_result_from_pending_totals(
+            totals,
+            &run.phase,
+            Some("No submitted migration transaction needs local recovery.".to_string()),
+            run.target_values_zatoshi.len() as u32,
+            run.target_values_zatoshi.iter().sum(),
+        )
+    }))
+}
+
 async fn broadcast_due_orchard_migration_transactions_inner(
     db_path: &str,
     lightwalletd_url: &str,
@@ -2275,6 +2346,24 @@ async fn broadcast_due_orchard_migration_transactions_inner(
     let chain_tip_height =
         u32::try_from(super::get_sync_progress(db_path, network)?.chain_tip_height)
             .map_err(|_| "Migration chain tip exceeds u32".to_string())?;
+    if let Some(recovered) = reconcile_due_scheduled_migration_tx(
+        db_path,
+        lightwalletd_url,
+        network,
+        &run.run_id,
+        chain_tip_height,
+        pending_password.as_slice(),
+        pending_salt_base64,
+        run.target_values_zatoshi.len() as u32,
+        run.target_values_zatoshi.iter().sum(),
+        policy.reschedule_wallet_overdue,
+        true,
+        false,
+    )
+    .await?
+    {
+        return Ok(recovered);
+    }
     if super::migration::due_scheduled_pending_count(db_path, &run.run_id, chain_tip_height)? > 0 {
         return broadcast_due_scheduled_migration_txs(
             db_path,
@@ -4769,6 +4858,28 @@ async fn broadcast_due_scheduled_migration_txs(
                 pending.txid_hex,
                 e,
             );
+            // A transport failure can happen after lightwalletd accepted the
+            // bytes but before its response reached Vizor. Resolve that
+            // ambiguity by txid before changing the run to a failed or rebuild
+            // state.
+            if let Some(recovered) = reconcile_due_scheduled_migration_tx(
+                db_path,
+                lightwalletd_url,
+                network,
+                run_id,
+                chain_tip_height,
+                pending_password,
+                pending_salt_base64,
+                fallback_total_count,
+                fallback_migrated_zatoshi,
+                policy.reschedule_wallet_overdue,
+                false,
+                true,
+            )
+            .await?
+            {
+                return Ok(recovered);
+            }
             let message = format!(
                 "Migration broadcast failed for {}. Error: {e}",
                 pending.txid_hex
@@ -4921,6 +5032,245 @@ async fn broadcast_due_scheduled_migration_txs(
         ),
         accepted_txids,
     })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn reconcile_due_scheduled_migration_tx(
+    db_path: &str,
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+    run_id: &str,
+    chain_tip_height: u32,
+    pending_password: &[u8],
+    pending_salt_base64: &str,
+    fallback_total_count: u32,
+    fallback_migrated_zatoshi: u64,
+    reschedule_wallet_overdue: bool,
+    rebroadcast_needs_resign_if_missing: bool,
+    recovered_was_current_submission: bool,
+) -> Result<Option<MigrationBroadcastAdvance>, String> {
+    // Recovery must run before expiry and re-sign checks. A transaction can
+    // already be in the mempool or chain even though a crash left its durable
+    // migration row in `scheduled` or `needs_resign`.
+    let Some(pending) = super::migration::recoverable_due_pending_tx(
+        db_path,
+        run_id,
+        chain_tip_height,
+        pending_password,
+        pending_salt_base64,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    let local_chain_identity = {
+        let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+        super::migration::local_denomination_chain_identity(&conn, &pending.txid_hex)?
+    };
+
+    let (accepted_raw, mined_height, source, accepted_by_current_submission) = if let Some(
+        chain_identity,
+    ) =
+        local_chain_identity
+    {
+        (
+            None,
+            Some(u64::from(chain_identity.mined_height)),
+            "the local chain",
+            recovered_was_current_submission,
+        )
+    } else {
+        let mut client = match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await
+        {
+            Ok(client) => client,
+            Err(error) => {
+                let totals = super::migration::pending_totals_for_run(db_path, run_id)?;
+                return Ok(Some(MigrationBroadcastAdvance::without_acceptance(
+                    migration_result_from_pending_totals(
+                        totals,
+                        super::migration::PHASE_BROADCAST_SCHEDULED,
+                        Some(format!(
+                            "Vizor could not check whether migration transaction {} was already submitted: {error}",
+                            pending.txid_hex
+                        )),
+                        fallback_total_count,
+                        fallback_migrated_zatoshi,
+                    ),
+                )));
+            }
+        };
+        let txid = parse_txid_hex(&pending.txid_hex)?;
+        match crate::wallet::sync_engine::get_transaction(&mut client, txid.as_ref().to_vec()).await
+        {
+            Ok(remote) => {
+                use zcash_primitives::transaction::Transaction;
+                use zcash_protocol::consensus::BranchId;
+
+                let transaction = Transaction::read(&remote.data[..], BranchId::Sapling)
+                    .map_err(|e| format!("Read recovered migration transaction: {e}"))?;
+                if !transaction
+                    .txid()
+                    .to_string()
+                    .eq_ignore_ascii_case(&pending.txid_hex)
+                {
+                    return Err(format!(
+                        "Recovered migration transaction ID mismatch for {}",
+                        pending.txid_hex
+                    ));
+                }
+                let mined_height = if remote.height == 0 {
+                    None
+                } else {
+                    Some(remote.height)
+                };
+                (
+                    Some(remote.data),
+                    mined_height,
+                    "lightwalletd",
+                    recovered_was_current_submission,
+                )
+            }
+            Err(status)
+                if status.code() == Code::NotFound
+                    && should_rebroadcast_missing_migration_tx(
+                        &pending.status,
+                        rebroadcast_needs_resign_if_missing,
+                    ) =>
+            {
+                match broadcast_raw_transaction(&mut client, &pending.raw_tx).await {
+                    Ok(()) => (
+                        Some(pending.raw_tx.clone()),
+                        None,
+                        "a saved-transaction rebroadcast",
+                        true,
+                    ),
+                    Err(error) if migration_broadcast_failure_requires_rebuild(&error) => {
+                        // A definitive node rejection is the first point at
+                        // which it is safe to replace this expired-schedule
+                        // transaction with a freshly signed one.
+                        return Ok(None);
+                    }
+                    Err(error) => {
+                        let totals = super::migration::pending_totals_for_run(db_path, run_id)?;
+                        return Ok(Some(MigrationBroadcastAdvance::without_acceptance(
+                            migration_result_from_pending_totals(
+                                totals,
+                                super::migration::PHASE_BROADCAST_SCHEDULED,
+                                Some(format!(
+                                    "Vizor could not re-submit saved migration transaction {} yet: {error}",
+                                    pending.txid_hex
+                                )),
+                                fallback_total_count,
+                                fallback_migrated_zatoshi,
+                            ),
+                        )));
+                    }
+                }
+            }
+            Err(status) if status.code() == Code::NotFound => return Ok(None),
+            Err(status) => {
+                let totals = super::migration::pending_totals_for_run(db_path, run_id)?;
+                return Ok(Some(MigrationBroadcastAdvance::without_acceptance(
+                    migration_result_from_pending_totals(
+                        totals,
+                        super::migration::PHASE_BROADCAST_SCHEDULED,
+                        Some(format!(
+                            "Vizor could not verify migration transaction {} yet: {status}",
+                            pending.txid_hex
+                        )),
+                        fallback_total_count,
+                        fallback_migrated_zatoshi,
+                    ),
+                )));
+            }
+        }
+    };
+
+    let totals_before = super::migration::pending_totals_for_run(db_path, run_id)?;
+    let bookkeeping_result =
+        with_wallet_db_write_lock("send.migration.recover_scheduled_transaction", || {
+            if let Some(raw_tx) = accepted_raw.as_deref() {
+                super::transactions::decrypt_and_store_transaction(
+                    db_path,
+                    network,
+                    raw_tx,
+                    mined_height,
+                )?;
+            }
+            if reschedule_wallet_overdue {
+                super::migration::reschedule_wallet_overdue_pending_txs_after_accepted(
+                    db_path,
+                    network,
+                    chain_tip_height,
+                    run_id,
+                    &pending.txid_hex,
+                )
+            } else {
+                super::migration::reschedule_overdue_pending_txs_after_accepted(
+                    db_path,
+                    run_id,
+                    network,
+                    chain_tip_height,
+                    &pending.txid_hex,
+                )
+            }?;
+            // Commit the accepted state last. If any earlier bookkeeping
+            // fails, the row remains scheduled/needs_resign and the next
+            // reconciliation pass can safely resume by the same txid.
+            super::migration::mark_pending_broadcasted(db_path, run_id, &pending.txid_hex)
+        });
+    if let Err(error) = bookkeeping_result {
+        if accepted_by_current_submission {
+            return Ok(Some(accepted_migration_processing_failure_result(
+                &totals_before,
+                vec![pending.txid_hex],
+                error,
+                fallback_total_count,
+                fallback_migrated_zatoshi,
+            )));
+        }
+        return Err(error);
+    }
+
+    let post_recovery_state = (|| {
+        Ok::<_, String>((
+            super::migration::pending_totals_for_run(db_path, run_id)?,
+            super::migration::run_phase(db_path, run_id)?,
+        ))
+    })();
+    let (totals, status) = match post_recovery_state {
+        Ok(state) => state,
+        Err(error) if accepted_by_current_submission => {
+            return Ok(Some(accepted_migration_processing_failure_result(
+                &totals_before,
+                vec![pending.txid_hex],
+                error,
+                fallback_total_count,
+                fallback_migrated_zatoshi,
+            )));
+        }
+        Err(error) => return Err(error),
+    };
+    log::info!(
+        "migration: recovered scheduled transaction {} from {}",
+        pending.txid_hex,
+        source
+    );
+    let result = migration_result_from_pending_totals(
+        totals,
+        &status,
+        Some(format!(
+            "Recovered migration transaction {} from {}. Remaining transfers were rescheduled.",
+            pending.txid_hex, source
+        )),
+        fallback_total_count,
+        fallback_migrated_zatoshi,
+    );
+    Ok(Some(recovered_migration_advance(
+        result,
+        pending.txid_hex,
+        accepted_by_current_submission,
+    )))
 }
 
 fn migration_broadcast_failure_requires_rebuild(error: &str) -> bool {

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -360,6 +360,12 @@ fn should_rebroadcast_missing_migration_tx(
     rebroadcast_needs_resign_if_missing && pending_status == "needs_resign"
 }
 
+fn migration_recovery_mined_height(raw_height: u64) -> Result<Option<u64>, String> {
+    crate::wallet::sync_engine::mined_height_from_raw_height(raw_height)
+        .map(|height| height.map(|height| u64::from(u32::from(height))))
+        .map_err(|e| format!("Read recovered migration transaction height: {e}"))
+}
+
 fn accepted_migration_processing_failure_result(
     totals_before: &super::migration::PendingMigrationTotals,
     accepted_txids: Vec<String>,
@@ -5118,11 +5124,7 @@ async fn reconcile_due_scheduled_migration_tx(
                         pending.txid_hex
                     ));
                 }
-                let mined_height = if remote.height == 0 {
-                    None
-                } else {
-                    Some(remote.height)
-                };
+                let mined_height = migration_recovery_mined_height(remote.height)?;
                 (
                     Some(remote.data),
                     mined_height,

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -501,6 +501,17 @@ fn only_normal_advance_rebroadcasts_a_missing_needs_resign_transaction() {
 }
 
 #[test]
+fn migration_recovery_height_preserves_lightwalletd_sentinels() {
+    assert_eq!(migration_recovery_mined_height(0).unwrap(), None);
+    assert_eq!(migration_recovery_mined_height(u64::MAX).unwrap(), None);
+    assert_eq!(
+        migration_recovery_mined_height(1_234_567).unwrap(),
+        Some(1_234_567),
+    );
+    assert!(migration_recovery_mined_height(u32::MAX as u64 + 1).is_err());
+}
+
+#[test]
 fn one_due_result_preserves_acceptance_when_local_bookkeeping_fails() {
     let totals_before = migration::PendingMigrationTotals {
         txids: vec!["older-pending".to_string()],

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -461,6 +461,46 @@ fn one_due_result_does_not_report_aggregate_txids_when_nothing_was_accepted() {
 }
 
 #[test]
+fn post_broadcast_recovery_reports_the_current_submission_as_accepted() {
+    let migration_result = || IronwoodMigrationResult {
+        txids: "aggregate-a".to_string(),
+        status: migration::PHASE_WAITING_MIGRATION_CONFIRMATIONS.to_string(),
+        broadcasted_count: 1,
+        total_count: 2,
+        message: None,
+        fee_zatoshi: 10_000,
+        migrated_zatoshi: 100_000,
+    };
+
+    let current_submission = one_due_migration_result(recovered_migration_advance(
+        migration_result(),
+        "accepted-after-timeout".to_string(),
+        true,
+    ));
+    let previous_submission = one_due_migration_result(recovered_migration_advance(
+        migration_result(),
+        "accepted-before-this-call".to_string(),
+        false,
+    ));
+
+    assert_eq!(current_submission.txids, "accepted-after-timeout");
+    assert!(previous_submission.txids.is_empty());
+}
+
+#[test]
+fn only_normal_advance_rebroadcasts_a_missing_needs_resign_transaction() {
+    assert!(should_rebroadcast_missing_migration_tx(
+        "needs_resign",
+        true
+    ));
+    assert!(!should_rebroadcast_missing_migration_tx(
+        "needs_resign",
+        false
+    ));
+    assert!(!should_rebroadcast_missing_migration_tx("scheduled", true));
+}
+
+#[test]
 fn one_due_result_preserves_acceptance_when_local_bookkeeping_fails() {
     let totals_before = migration::PendingMigrationTotals {
         txids: vec!["older-pending".to_string()],
@@ -1753,6 +1793,7 @@ fn scheduled_storage_failure_after_acceptance_leaves_tx_scheduled() {
     let pending = migration::DuePendingMigrationTx {
         txid_hex: pending_txid.to_string(),
         raw_tx: vec![5, 6, 7, 8],
+        status: "scheduled".to_string(),
     };
 
     let result = record_accepted_scheduled_migration_tx(

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -35,13 +35,13 @@ use zcash_client_backend::{
     proto::service::compact_tx_streamer_client::CompactTxStreamerClient,
 };
 use zcash_primitives::transaction::Transaction;
-use zcash_protocol::consensus::{BlockHeight, BranchId};
+use zcash_protocol::consensus::BranchId;
 use zcash_protocol::value::{BalanceError, Zatoshis};
 
 use crate::wallet::db::{with_wallet_db_write_lock, SYNC_DB_BUSY_TIMEOUT};
 use crate::wallet::network::WalletNetwork;
 
-use super::{lwd, SyncError, WalletDatabase};
+use super::{lwd, mined_height_from_raw_height, SyncError, WalletDatabase};
 
 /// Drains `db.transaction_data_requests()` against lightwalletd until
 /// the queue is empty or no request is actionable. Returns
@@ -404,16 +404,6 @@ fn classify_get_transaction_error(status: &Status) -> GetTransactionErrorAction 
     match status.code() {
         Code::NotFound => GetTransactionErrorAction::MarkTxidNotRecognized,
         _ => GetTransactionErrorAction::RetryAsNetwork,
-    }
-}
-
-fn mined_height_from_raw_height(raw_height: u64) -> Result<Option<BlockHeight>, SyncError> {
-    match raw_height {
-        0 | u64::MAX => Ok(None),
-        h if h <= u32::MAX as u64 => Ok(Some(BlockHeight::from_u32(h as u32))),
-        h => Err(SyncError::parse(format!(
-            "raw transaction height out of range: {h}"
-        ))),
     }
 }
 

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -60,6 +60,18 @@ pub(crate) use lwd::{
     send_transaction, send_transaction_with_status,
 };
 
+pub(crate) fn mined_height_from_raw_height(
+    raw_height: u64,
+) -> Result<Option<BlockHeight>, SyncError> {
+    match raw_height {
+        0 | u64::MAX => Ok(None),
+        h if h <= u32::MAX as u64 => Ok(Some(BlockHeight::from_u32(h as u32))),
+        h => Err(SyncError::parse(format!(
+            "raw transaction height out of range: {h}"
+        ))),
+    }
+}
+
 /// Progress event sent to caller (Dart or Swift).
 #[derive(Clone, Debug)]
 pub struct SyncProgressEvent {

--- a/test/features/migration/desktop_open_migration_fallback_gate_test.dart
+++ b/test/features/migration/desktop_open_migration_fallback_gate_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
     as frb;
 import 'package:flutter_test/flutter_test.dart';
@@ -5,6 +7,67 @@ import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 void main() {
+  test('coalesces reconciliation and waits for an account advance', () async {
+    final gate = MigrationReconciliationOperationGate();
+    final releaseAdvance = Completer<void>();
+    final reconciliationStarted = Completer<void>();
+    var reconciliationCount = 0;
+
+    Future<void> reconcile() async {
+      reconciliationCount++;
+      reconciliationStarted.complete();
+    }
+
+    final first = gate.run(
+      'account-1',
+      activeAdvance: () => releaseAdvance.future,
+      reconcile: reconcile,
+    );
+    final duplicate = gate.run(
+      'account-1',
+      activeAdvance: () => null,
+      reconcile: reconcile,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(reconciliationCount, 0);
+
+    releaseAdvance.complete();
+    await reconciliationStarted.future;
+    await Future.wait([first, duplicate]);
+
+    expect(reconciliationCount, 1);
+    expect(gate.operationFor('account-1'), isNull);
+  });
+
+  test('account advance can wait for reconciliation to finish', () async {
+    final gate = MigrationReconciliationOperationGate();
+    final reconciliationStarted = Completer<void>();
+    final releaseReconciliation = Completer<void>();
+    var advanceStarted = false;
+
+    final reconciliation = gate.run(
+      'account-1',
+      activeAdvance: () => null,
+      reconcile: () async {
+        reconciliationStarted.complete();
+        await releaseReconciliation.future;
+      },
+    );
+    await reconciliationStarted.future;
+
+    final advance = () async {
+      await gate.waitFor('account-1');
+      advanceStarted = true;
+    }();
+    await Future<void>.delayed(Duration.zero);
+    expect(advanceStarted, isFalse);
+
+    releaseReconciliation.complete();
+    await Future.wait([reconciliation, advance]);
+
+    expect(advanceStarted, isTrue);
+  });
+
   test('fails closed before an authoritative desktop-open height', () {
     final gate = DesktopOpenMigrationFallbackGate();
 
@@ -211,6 +274,29 @@ void main() {
     expect(gate.tryAcquireForAdvance(laterRetry), isFalse);
   });
 
+  test('commits a reservation after rebroadcasting a needs-resign tx', () {
+    final gate = DesktopOpenMigrationFallbackGate()
+      ..observeForegroundEntryHeight(1_000);
+    final recovered = _statusWithScheduledHeight(
+      999,
+      scheduledTxid: 'recovered',
+      broadcastStatus: 'needs_resign',
+    );
+    final laterRetry = _statusWithScheduledHeight(
+      998,
+      scheduledTxid: 'later-retry',
+    );
+    gate.captureOpenStatuses([recovered, laterRetry]);
+
+    expect(gate.tryAcquireForAdvance(recovered), isTrue);
+    gate.completeAdvance(
+      recovered,
+      _result(broadcastedCount: 1, txids: 'recovered'),
+    );
+
+    expect(gate.tryAcquireForAdvance(laterRetry), isFalse);
+  });
+
   test('denomination broadcast does not commit the fallback reservation', () {
     final gate = DesktopOpenMigrationFallbackGate()
       ..observeForegroundEntryHeight(1_000);
@@ -251,6 +337,7 @@ rust_sync.IronwoodMigrationResult _result({
 rust_sync.MigrationStatus _statusWithScheduledHeight(
   int scheduledHeight, {
   String scheduledTxid = 'scheduled-tx',
+  String broadcastStatus = 'scheduled',
   int broadcastedTxCount = 0,
   int confirmedTxCount = 0,
 }) {
@@ -279,7 +366,7 @@ rust_sync.MigrationStatus _statusWithScheduledHeight(
         valueZatoshi: BigInt.from(100000000),
         scheduledAtMs: 0,
         scheduledHeight: scheduledHeight,
-        status: 'scheduled',
+        status: broadcastStatus,
       ),
     ],
     parts: const [],

--- a/test/features/migration/desktop_open_migration_fallback_gate_test.dart
+++ b/test/features/migration/desktop_open_migration_fallback_gate_test.dart
@@ -7,6 +7,20 @@ import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 void main() {
+  test('detects a balance change from first-pass reconciliation', () {
+    final before = _statusWithScheduledHeight(1_000);
+    final after = _statusWithScheduledHeight(
+      1_000,
+      broadcastStatus: 'broadcasted',
+      broadcastedTxCount: 1,
+    );
+
+    // The coordinator has no previous cached status on its first pass, but it
+    // can still compare the statuses immediately before and after recovery.
+    expect(migrationBalanceMayHaveChanged(null, after), isFalse);
+    expect(migrationBalanceMayHaveChanged(before, after), isTrue);
+  });
+
   test('throttles a failed reconciliation attempt', () async {
     var now = DateTime(2026, 7, 30);
     final throttle = MigrationReconciliationAttemptThrottle(

--- a/test/features/migration/desktop_open_migration_fallback_gate_test.dart
+++ b/test/features/migration/desktop_open_migration_fallback_gate_test.dart
@@ -7,6 +7,30 @@ import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 void main() {
+  test('throttles a failed reconciliation attempt', () async {
+    var now = DateTime(2026, 7, 30);
+    final throttle = MigrationReconciliationAttemptThrottle(
+      interval: const Duration(seconds: 30),
+      now: () => now,
+    );
+
+    expect(throttle.shouldAttempt('account-1', 'progress-1'), isTrue);
+    await expectLater(
+      throttle.run<void>(
+        'account-1',
+        'progress-1',
+        () async => throw StateError('lightwalletd unavailable'),
+      ),
+      throwsStateError,
+    );
+
+    expect(throttle.shouldAttempt('account-1', 'progress-1'), isFalse);
+    expect(throttle.shouldAttempt('account-1', 'progress-2'), isTrue);
+
+    now = now.add(const Duration(seconds: 30));
+    expect(throttle.shouldAttempt('account-1', 'progress-1'), isTrue);
+  });
+
   test('coalesces reconciliation and waits for an account advance', () async {
     final gate = MigrationReconciliationOperationGate();
     final releaseAdvance = Completer<void>();

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -1712,7 +1712,7 @@ void main() {
           activeRunId: 'run-1',
         ),
         title: 'Migration Needs Attention',
-        buttonLabel: 'Retry migration',
+        buttonLabel: 'Recover migration',
         buttonEnabled: true,
       ),
       _StatusUiCase(
@@ -3335,7 +3335,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(continueCount, 0);
-    await tester.tap(find.widgetWithText(AppButton, 'Retry migration'));
+    await tester.tap(find.widgetWithText(AppButton, 'Recover migration'));
     await tester.pumpAndSettle();
 
     expect(continueCount, 1);

--- a/test/features/migration/ironwood_migration_presentation_test.dart
+++ b/test/features/migration/ironwood_migration_presentation_test.dart
@@ -359,6 +359,28 @@ void main() {
       isTrue,
     );
   });
+
+  test('keeps an expired signed transaction eligible for txid recovery', () {
+    final status = _status(
+      phase: 'ready_to_migrate',
+      broadcasts: [
+        _broadcast('needs_resign', DateTime(2026), scheduledHeight: 1_000),
+      ],
+    );
+
+    expect(
+      migrationHasDueRecoverableBroadcast(status, currentHeight: 999),
+      isFalse,
+    );
+    expect(
+      migrationHasDueRecoverableBroadcast(status, currentHeight: 1_000),
+      isTrue,
+    );
+    expect(
+      migrationHasDueScheduledBroadcast(status, currentHeight: 1_000),
+      isFalse,
+    );
+  });
 }
 
 rust_sync.MigrationScheduledBroadcast _broadcast(

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -2204,6 +2204,60 @@ void main() {
     expect(seenSalts[1], seenSalts[0]);
   });
 
+  test('desktop reconciliation checks saved txid without broadcasting', () async {
+    var reconciliationCalls = 0;
+    var broadcastCalls = 0;
+    final service = IronwoodMigrationService(
+      getWalletDbPath: () async => '/tmp/wallet.db',
+      getStatus:
+          ({required dbPath, required network, required accountUuid}) async =>
+              _migrationStatus(),
+      getPrivatePlan:
+          ({required dbPath, required network, required accountUuid}) async =>
+              null,
+      secureStore: AppSecureStore.testing(
+        storage: const FlutterSecureStorage(),
+      ),
+      getEndpoint: _testEndpoint,
+      getSessionPassword: () => 'test-password',
+      reconcileMigrationTransactions:
+          ({
+            required dbPath,
+            required lightwalletdUrl,
+            required network,
+            required accountUuid,
+            required password,
+            required saltBase64,
+          }) async {
+            reconciliationCalls++;
+            expect(dbPath, '/tmp/wallet.db');
+            expect(network, 'test');
+            expect(accountUuid, 'account-1');
+            expect(password, 'test-password');
+            return _migrationResult();
+          },
+      broadcastDueMigration:
+          ({
+            required dbPath,
+            required lightwalletdUrl,
+            required network,
+            required accountUuid,
+            required password,
+            required saltBase64,
+          }) async {
+            broadcastCalls++;
+            return _migrationResult();
+          },
+    );
+
+    await service.reconcileSoftwarePrivateMigrationTransactions(
+      accountUuid: 'account-1',
+    );
+
+    expect(reconciliationCalls, 1);
+    expect(broadcastCalls, 0);
+  });
+
   test('software continuation re-enters the macOS signing path', () async {
     List<rust_sync.MigrationScheduledTransfer>? seenSchedule;
     String? seenSalt;


### PR DESCRIPTION
## Summary

- add a desktop recovery path that checks a saved migration txid against the local chain and lightwalletd before submitting anything new
- restore locally missing accepted transactions and atomically transition migration bookkeeping
- safely rebroadcast the exact saved raw transaction when a `needs_resign` transaction is absent, treating duplicate responses as success
- reschedule only the remaining transfers after recovery
- serialize automatic reconciliation, manual recovery, and migration advances per account
- expose the recovery flow in the migration UI and regenerate Flutter Rust Bridge bindings

## Root cause

A transaction could be accepted by lightwalletd while Vizor restarted or failed before persisting the accepted state. The durable migration row then remained `scheduled` or `needs_resign`, leaving the UI at `Due now` and risking an unsafe replacement transaction if the wallet simply rebuilt or rescheduled it.

## Impact

Vizor now recovers an already-submitted migration transaction by txid, preserves the original transaction bytes when a retry is necessary, and only creates a fresh schedule after the previous transaction is definitively absent or rejected.

## Validation

- `cargo test -q --lib` — 479 passed, 1 ignored
- relevant Flutter migration tests — 190 passed
- targeted mobile automatic/manual retry race test passed
- `fvm flutter analyze` on changed migration Dart files
- `git diff --check`