### PR TITLE
Polish desktop Ironwood migration flow

### DIFF
--- a/assets/illustrations/ironwood_migration_done_ribbon.svg
+++ b/assets/illustrations/ironwood_migration_done_ribbon.svg
@@ -1,0 +1,3 @@
+<svg preserveAspectRatio="none" overflow="visible" width="230.312" height="169.943" viewBox="0 0 230.312 169.943" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M27.781 44.6063C133.904 6.60606 196.67 54.7582 196.67 54.7582C149.39 46.5176 49.8225 69.214 16.1882 90.7711C64.0902 77.5385 171.058 74.5552 217.614 96.3048C129.49 88.3652 70.7696 117.348 43.7529 151.245" stroke="#007F49" stroke-width="60" stroke-linejoin="bevel"/>
+</svg>

--- a/lib/src/features/migration/screens/ironwood_migration_flow/immediate_review.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/immediate_review.dart
@@ -281,7 +281,11 @@ class _IronwoodMigrationImmediateReviewContentState
 }
 
 class _ImmediateReviewRow extends StatelessWidget {
-  const _ImmediateReviewRow({required this.label, required this.value});
+  const _ImmediateReviewRow({
+    required this.label,
+    required this.value,
+    super.key,
+  });
 
   final String label;
   final String value;

--- a/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
@@ -632,6 +632,7 @@ class _MigrationReviewContent extends StatelessWidget {
             top: 58,
             width: 396,
             child: const _MigrationStageHeader(
+              key: ValueKey('ironwood_migration_stage_header'),
               stage: _MigrationStage.preparation,
             ),
           ),
@@ -673,34 +674,59 @@ class _MigrationReviewContent extends StatelessWidget {
             top: 386,
             width: 396,
             child: _ImmediateReviewRow(
+              key: const ValueKey('ironwood_migration_review_completion_row'),
               label: 'Migration complete in',
               value: completionEstimate,
             ),
           ),
           Positioned(
-            left: 44,
+            left: 12,
             top: 442,
-            width: 332,
+            width: 396,
             child: Row(
+              key: const ValueKey('ironwood_migration_keep_running_content'),
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(12),
-                  child: Image.asset(
-                    _ironwoodMigrationExpectationRunningAsset,
-                    width: 32,
-                    height: 32,
-                    fit: BoxFit.cover,
+                DecoratedBox(
+                  key: const ValueKey(
+                    'ironwood_migration_keep_running_icon_tile',
+                  ),
+                  decoration: BoxDecoration(
+                    color: _migrationCarouselCrimson,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: SizedBox.square(
+                      dimension: 48,
+                      child: Image.asset(
+                        _ironwoodMigrationExpectationRunningAsset,
+                        fit: BoxFit.cover,
+                      ),
+                    ),
                   ),
                 ),
-                const SizedBox(width: 12),
+                const SizedBox(width: 16),
                 Expanded(
-                  child: Text(
-                    'Keep Vizor running. Preparation continues while the app '
-                    'is minimized, then migration starts automatically.',
-                    style: AppTypography.bodyMedium.copyWith(
-                      color: colors.text.secondary,
-                    ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Keep Vizor running',
+                        style: AppTypography.bodyMedium.copyWith(
+                          color: colors.text.accent,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'Preparation continues while the app is minimized, '
+                        'then migration starts automatically.',
+                        style: AppTypography.bodyMedium.copyWith(
+                          color: colors.text.secondary,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ],

--- a/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
@@ -617,19 +617,21 @@ class _MigrationReviewContent extends StatelessWidget {
       child: Stack(
         children: [
           Positioned(
-            top: 12,
+            top: 16,
             left: 12,
             width: 396,
             child: Text(
+              key: const ValueKey('ironwood_migration_review_title'),
               'Ironwood Migration',
-              style: AppTypography.bodyLarge.copyWith(
+              textAlign: TextAlign.center,
+              style: AppTypography.headlineSmall.copyWith(
                 color: colors.text.accent,
               ),
             ),
           ),
           Positioned(
             left: 12,
-            top: 58,
+            top: 54,
             width: 396,
             child: const _MigrationStageHeader(
               key: ValueKey('ironwood_migration_stage_header'),
@@ -775,6 +777,8 @@ class _MigrationStartRingPainter extends CustomPainter {
 
   final Color color;
 
+  double get outerDiameter => _migrationStatusRingOuterDiameter;
+
   static const _weights = [0.14, 0.08, 0.09, 0.12, 0.08, 0.15, 0.1, 0.12, 0.12];
   static const _visibleGap = 0.055;
 
@@ -782,12 +786,17 @@ class _MigrationStartRingPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
       ..color = color
-      ..strokeWidth = 12
+      ..strokeWidth = _migrationStatusRingMaxStrokeWidth
       ..strokeCap = StrokeCap.round
       ..style = PaintingStyle.stroke;
-    final rect = Rect.fromCircle(
+    final availableOuterDiameter = math.min(
+      outerDiameter,
+      math.min(size.width, size.height),
+    );
+    final rect = Rect.fromCenter(
       center: size.center(Offset.zero),
-      radius: math.min(size.width, size.height) / 2 - paint.strokeWidth,
+      width: availableOuterDiameter - paint.strokeWidth,
+      height: availableOuterDiameter - paint.strokeWidth,
     );
     const fullSweep = math.pi * 2;
     final radius = rect.width / 2;

--- a/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
@@ -152,11 +152,11 @@ class _IronwoodMigrationPrivateReviewContentState
         ? ref.watch(ironwoodMigrationPrivatePlanProvider)
         : AsyncValue<rust_sync.OrchardMigrationPrivatePlan?>.data(previewPlan);
     final plan = planAsync.asData?.value;
-    if (planAsync.isLoading) return const _MigrationAnalyzingContent();
     return FutureBuilder<void>(
       future: _minimumAnalyzingDelay,
       builder: (context, snapshot) {
-        if (snapshot.connectionState != ConnectionState.done) {
+        if (planAsync.isLoading ||
+            snapshot.connectionState != ConnectionState.done) {
           return const _MigrationAnalyzingContent();
         }
         if (planAsync.hasError || plan == null) {
@@ -425,7 +425,6 @@ class _MigrationAnalyzingDonut extends StatelessWidget {
         builder: (context, child) => Semantics(
           label: 'Preparing private migration plan',
           value: '${(progress.value * 100).round()}%',
-          liveRegion: true,
           child: CustomPaint(
             painter: _MigrationAnalyzingDonutPainter(
               progress: progress.value,

--- a/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
@@ -19,6 +19,7 @@ class _IronwoodMigrationPrivateReviewContent extends ConsumerStatefulWidget {
 class _IronwoodMigrationPrivateReviewContentState
     extends ConsumerState<_IronwoodMigrationPrivateReviewContent> {
   bool _isStarting = false;
+  bool _hasCompletedAnalyzingTransition = false;
   String? _startError;
   late final Future<void> _minimumAnalyzingDelay;
 
@@ -171,6 +172,18 @@ class _IronwoodMigrationPrivateReviewContentState
           );
         }
 
+        if (!_hasCompletedAnalyzingTransition) {
+          return _MigrationAnalyzingContent(
+            isReady: true,
+            onCompleted: () {
+              if (!mounted) return;
+              setState(() {
+                _hasCompletedAnalyzingTransition = true;
+              });
+            },
+          );
+        }
+
         return _MigrationReviewContent(
           plan: plan,
           isStarting: _isStarting,
@@ -183,7 +196,10 @@ class _IronwoodMigrationPrivateReviewContentState
 }
 
 class _MigrationAnalyzingContent extends StatefulWidget {
-  const _MigrationAnalyzingContent();
+  const _MigrationAnalyzingContent({this.isReady = false, this.onCompleted});
+
+  final bool isReady;
+  final VoidCallback? onCompleted;
 
   @override
   State<_MigrationAnalyzingContent> createState() =>
@@ -191,21 +207,35 @@ class _MigrationAnalyzingContent extends StatefulWidget {
 }
 
 class _MigrationAnalyzingContentState extends State<_MigrationAnalyzingContent>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   static const _messages = [
     'Analyzing your balance...',
     'Finding private batches...',
     'Preparing your migration plan...',
   ];
-  static const _switchDuration = Duration(milliseconds: 320);
+  static const _switchDuration = Duration(milliseconds: 240);
 
   late final AnimationController _shimmer = AnimationController(
     vsync: this,
     duration: _MigrationAnalyzingMotion.period,
   );
+  late final AnimationController _donutController = AnimationController(
+    vsync: this,
+    duration: _MigrationAnalyzingMotion.preparationPeriod,
+  );
+  late final Animation<double> _donutProgress = _MigrationAnalyzingMotion
+      .donutProgress
+      .animate(_donutController);
+  late final AnimationController _completionController = AnimationController(
+    vsync: this,
+    duration: _MigrationAnalyzingMotion.completionPeriod,
+  )..addStatusListener(_handleCompletionStatus);
+  Animation<double> _completionProgress = const AlwaysStoppedAnimation(0);
   Timer? _reducedMotionMessageTimer;
   var _messageIndex = 0;
   var _advancedMessageThisCycle = false;
+  var _completionStarted = false;
+  var _completionDispatched = false;
 
   bool get _shouldAnimate =>
       !(MediaQuery.maybeOf(context)?.disableAnimations ?? false);
@@ -220,6 +250,13 @@ class _MigrationAnalyzingContentState extends State<_MigrationAnalyzingContent>
   void didChangeDependencies() {
     super.didChangeDependencies();
     _syncAnimation();
+    if (widget.isReady) _beginCompletion();
+  }
+
+  @override
+  void didUpdateWidget(covariant _MigrationAnalyzingContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!oldWidget.isReady && widget.isReady) _beginCompletion();
   }
 
   void _syncAnimation() {
@@ -227,15 +264,52 @@ class _MigrationAnalyzingContentState extends State<_MigrationAnalyzingContent>
       _reducedMotionMessageTimer?.cancel();
       _reducedMotionMessageTimer = null;
       if (!_shimmer.isAnimating) _shimmer.repeat();
+      if (_donutController.status == AnimationStatus.dismissed) {
+        _donutController.forward();
+      }
     } else {
       _shimmer
         ..stop()
         ..value = 0;
+      _donutController
+        ..stop()
+        ..value = 0;
+      if (widget.isReady) {
+        _completionController.value = 1;
+      }
       _reducedMotionMessageTimer ??= Timer.periodic(
         _MigrationAnalyzingMotion.period,
         (_) => _advanceMessage(),
       );
     }
+  }
+
+  void _beginCompletion() {
+    if (_completionStarted) return;
+    _completionStarted = true;
+
+    final startProgress = _shouldAnimate
+        ? _donutProgress.value
+        : _MigrationAnalyzingMotion.reducedMotionProgress;
+    _donutController.stop();
+    _completionProgress = Tween<double>(begin: startProgress, end: 1).animate(
+      CurvedAnimation(parent: _completionController, curve: Curves.easeInOut),
+    );
+
+    if (_shouldAnimate) {
+      _completionController.forward(from: 0);
+    } else {
+      _completionController.value = 1;
+    }
+    setState(() {});
+  }
+
+  void _handleCompletionStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed || _completionDispatched) return;
+    _completionDispatched = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) widget.onCompleted?.call();
+    });
   }
 
   void _handleShimmerTick() {
@@ -264,6 +338,10 @@ class _MigrationAnalyzingContentState extends State<_MigrationAnalyzingContent>
     _reducedMotionMessageTimer?.cancel();
     _shimmer.removeListener(_handleShimmerTick);
     _shimmer.dispose();
+    _donutController.dispose();
+    _completionController
+      ..removeStatusListener(_handleCompletionStatus)
+      ..dispose();
     super.dispose();
   }
 
@@ -275,39 +353,52 @@ class _MigrationAnalyzingContentState extends State<_MigrationAnalyzingContent>
       key: const ValueKey('ironwood_migration_analyzing_screen'),
       width: 420,
       height: 656,
-      child: Column(
+      child: Stack(
         children: [
-          const SizedBox(height: 178),
-          const IronwoodMigrationAnalyzingProgressBar(),
-          const SizedBox(height: 72),
-          AnimatedBuilder(
-            animation: _shimmer,
-            builder: (context, _) {
-              return AnimatedSwitcher(
-                duration: _shouldAnimate ? _switchDuration : Duration.zero,
-                switchInCurve: Curves.easeOutCubic,
-                switchOutCurve: Curves.easeInCubic,
-                transitionBuilder: (child, animation) =>
-                    FadeTransition(opacity: animation, child: child),
-                child: _MigrationAnalyzingShimmerText(
-                  key: ValueKey(title),
-                  label: title,
-                  baseColor: colors.text.muted,
-                  highlightColor: colors.text.accent,
-                  progress: _shimmer.value,
-                ),
-              );
-            },
+          Positioned(
+            left: _migrationPlanDonutLeft,
+            top: _migrationPlanDonutTop,
+            width: _migrationPlanDonutSize,
+            height: _migrationPlanDonutSize,
+            child: _MigrationAnalyzingDonut(
+              progress: _completionStarted
+                  ? _completionProgress
+                  : _shouldAnimate
+                  ? _donutProgress
+                  : const AlwaysStoppedAnimation(
+                      _MigrationAnalyzingMotion.reducedMotionProgress,
+                    ),
+              child: AnimatedBuilder(
+                animation: _shimmer,
+                builder: (context, _) {
+                  return AnimatedSwitcher(
+                    duration: _shouldAnimate ? _switchDuration : Duration.zero,
+                    switchInCurve: Curves.easeOutCubic,
+                    switchOutCurve: Curves.easeOutCubic,
+                    transitionBuilder: (child, animation) =>
+                        FadeTransition(opacity: animation, child: child),
+                    child: _MigrationAnalyzingShimmerText(
+                      key: ValueKey(title),
+                      label: title,
+                      baseColor: colors.text.muted,
+                      highlightColor: colors.text.accent,
+                      progress: _shimmer.value,
+                    ),
+                  );
+                },
+              ),
+            ),
           ),
-          const SizedBox(height: 16),
-          SizedBox(
-            width: 298,
+          Positioned(
+            left: 60,
+            top: 424,
+            width: 300,
             child: Text(
-              'Vizor is working hard to find a perfect balance of safety, '
-              'privacy, and speed for your migration',
+              'Vizor is working hard to find a perfect balance\n'
+              'of safety, privacy, and speed for your migration',
               textAlign: TextAlign.center,
-              style: AppTypography.bodyMediumStrong.copyWith(
-                color: colors.text.primary,
+              style: AppTypography.bodyMedium.copyWith(
+                color: colors.text.accent,
               ),
             ),
           ),
@@ -317,11 +408,134 @@ class _MigrationAnalyzingContentState extends State<_MigrationAnalyzingContent>
   }
 }
 
+class _MigrationAnalyzingDonut extends StatelessWidget {
+  const _MigrationAnalyzingDonut({required this.progress, required this.child});
+
+  final Animation<double> progress;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return SizedBox.square(
+      key: const ValueKey('ironwood_migration_analyzing_donut'),
+      dimension: _migrationPlanDonutSize,
+      child: AnimatedBuilder(
+        animation: progress,
+        builder: (context, child) => Semantics(
+          label: 'Preparing private migration plan',
+          value: '${(progress.value * 100).round()}%',
+          liveRegion: true,
+          child: CustomPaint(
+            painter: _MigrationAnalyzingDonutPainter(
+              progress: progress.value,
+              trackColor: colors.text.accent.withValues(alpha: 0.15),
+              progressColor: colors.text.accent,
+            ),
+            child: child,
+          ),
+        ),
+        child: Center(
+          child: SizedBox(width: 200, child: Center(child: child)),
+        ),
+      ),
+    );
+  }
+}
+
+class _MigrationAnalyzingDonutPainter extends CustomPainter {
+  const _MigrationAnalyzingDonutPainter({
+    required this.progress,
+    required this.trackColor,
+    required this.progressColor,
+  });
+
+  final double progress;
+  final Color trackColor;
+  final Color progressColor;
+
+  static const _strokeWidth = 12.8;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = math.min(size.width, size.height) / 2 - _strokeWidth / 2;
+    final rect = Rect.fromCircle(center: center, radius: radius);
+    final trackPaint = Paint()
+      ..color = trackColor
+      ..strokeWidth = _strokeWidth
+      ..style = PaintingStyle.stroke;
+    canvas.drawCircle(center, radius, trackPaint);
+
+    if (progress <= 0) return;
+    final progressPaint = Paint()
+      ..color = progressColor
+      ..strokeWidth = _strokeWidth
+      ..strokeCap = StrokeCap.round
+      ..style = PaintingStyle.stroke;
+    canvas.drawArc(
+      rect,
+      -math.pi / 2,
+      math.pi * 2 * progress.clamp(0.0, 1.0),
+      false,
+      progressPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _MigrationAnalyzingDonutPainter oldDelegate) =>
+      oldDelegate.progress != progress ||
+      oldDelegate.trackColor != trackColor ||
+      oldDelegate.progressColor != progressColor;
+}
+
 abstract final class _MigrationAnalyzingMotion {
   static const period = Duration(seconds: 2);
+  static const preparationPeriod = Duration(milliseconds: 9500);
+  static const completionPeriod = Duration(milliseconds: 850);
+  static const reducedMotionProgress = 0.28;
   static const messageAdvanceProgress = 0.96;
   static const cycleResetProgress = 0.2;
   static const _bandHalf = 0.18;
+
+  static final donutProgress = TweenSequence<double>([
+    _hold(0, 350),
+    _ramp(0, 0.15, 1000),
+    _hold(0.15, 250),
+    _ramp(0.15, 0.40, 950),
+    _hold(0.40, 150),
+    _ramp(0.40, 0.47, 550),
+    _hold(0.47, 750),
+    _ramp(0.47, 0.63, 1050),
+    _hold(0.63, 300),
+    _ramp(0.63, 0.71, 500),
+    _hold(0.71, 850),
+    _ramp(0.71, 0.86, 900),
+    _hold(0.86, 400),
+    _ramp(0.86, 0.97, 950),
+    _hold(0.97, 550),
+  ]);
+
+  static TweenSequenceItem<double> _ramp(
+    double begin,
+    double end,
+    double milliseconds,
+  ) {
+    return TweenSequenceItem(
+      tween: Tween<double>(
+        begin: begin,
+        end: end,
+      ).chain(CurveTween(curve: Curves.easeInOut)),
+      weight: milliseconds,
+    );
+  }
+
+  static TweenSequenceItem<double> _hold(double value, double milliseconds) {
+    return TweenSequenceItem(
+      tween: ConstantTween<double>(value),
+      weight: milliseconds,
+    );
+  }
 }
 
 class _MigrationAnalyzingShimmerText extends StatelessWidget {
@@ -366,13 +580,18 @@ class _MigrationAnalyzingShimmerText extends StatelessWidget {
       child: Text(
         label,
         textAlign: TextAlign.center,
-        style: AppTypography.headlineSmall.copyWith(
+        style: AppTypography.labelLarge.copyWith(
           color: const Color(0xFFFFFFFF),
+          fontWeight: FontWeight.w600,
         ),
       ),
     );
   }
 }
+
+const _migrationPlanDonutLeft = 82.0;
+const _migrationPlanDonutTop = 108.0;
+const _migrationPlanDonutSize = 256.0;
 
 class _MigrationReviewContent extends StatelessWidget {
   const _MigrationReviewContent({
@@ -417,11 +636,12 @@ class _MigrationReviewContent extends StatelessWidget {
             ),
           ),
           Positioned(
-            left: 82,
-            top: 108,
-            width: 256,
-            height: 256,
+            left: _migrationPlanDonutLeft,
+            top: _migrationPlanDonutTop,
+            width: _migrationPlanDonutSize,
+            height: _migrationPlanDonutSize,
             child: CustomPaint(
+              key: const ValueKey('ironwood_migration_review_donut'),
               painter: _MigrationStartRingPainter(
                 color: colors.text.muted.withValues(alpha: 0.32),
               ),
@@ -536,12 +756,12 @@ class _MigrationStartRingPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
       ..color = color
-      ..strokeWidth = 12
+      ..strokeWidth = 12.8
       ..strokeCap = StrokeCap.round
       ..style = PaintingStyle.stroke;
     final rect = Rect.fromCircle(
       center: size.center(Offset.zero),
-      radius: math.min(size.width, size.height) / 2 - paint.strokeWidth,
+      radius: math.min(size.width, size.height) / 2 - paint.strokeWidth / 2,
     );
     const fullSweep = math.pi * 2;
     final radius = rect.width / 2;

--- a/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
@@ -756,12 +756,12 @@ class _MigrationStartRingPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
       ..color = color
-      ..strokeWidth = 12.8
+      ..strokeWidth = 12
       ..strokeCap = StrokeCap.round
       ..style = PaintingStyle.stroke;
     final rect = Rect.fromCircle(
       center: size.center(Offset.zero),
-      radius: math.min(size.width, size.height) / 2 - paint.strokeWidth / 2,
+      radius: math.min(size.width, size.height) / 2 - paint.strokeWidth,
     );
     const fullSweep = math.pi * 2;
     final radius = rect.width / 2;

--- a/lib/src/features/migration/screens/ironwood_migration_flow/schedule.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/schedule.dart
@@ -748,48 +748,71 @@ class _MigrationPreparationScheduleContent extends StatelessWidget {
     final remainingBlocks = math.max(0, finalProjectedHeight - currentHeight);
 
     return SizedBox(
+      key: const ValueKey('ironwood_migration_preparation_schedule_content'),
       width: 420,
       height: 656,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const SizedBox(height: 34),
-          Text(
-            'Preparation Schedule',
-            textAlign: TextAlign.center,
-            style: AppTypography.headlineSmall.copyWith(
-              color: colors.text.accent,
+          const SizedBox(height: 16),
+          SizedBox(
+            height: 44,
+            child: Center(
+              child: Text(
+                key: const ValueKey(
+                  'ironwood_migration_preparation_schedule_title',
+                ),
+                'Preparation Schedule',
+                textAlign: TextAlign.center,
+                style: AppTypography.headlineSmall.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
             ),
           ),
-          const SizedBox(height: 35),
+          const SizedBox(height: 12),
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 28),
-            child: Column(
-              children: [
-                _MigrationSummaryMetric(
-                  label: 'Current round',
-                  value: rounds.isEmpty
-                      ? 'Preparing'
-                      : '$currentRound of ${rounds.length}',
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: SizedBox(
+              key: const ValueKey(
+                'ironwood_migration_preparation_schedule_summary',
+              ),
+              height: 104,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 12,
                 ),
-                const SizedBox(height: 16),
-                _MigrationSummaryMetric(
-                  label: 'Ready to migrate',
-                  value: !hasCompletionProjection
-                      ? 'Calculating'
-                      : '#${formatGroupedInteger(finalProjectedHeight)}'
-                            '${remainingBlocks > 0 ? ' · ${_formatPreparationDuration(remainingBlocks)}' : ''}',
-                  valueIcon: hasCompletionProjection ? AppIcons.block : null,
-                  secondary: true,
+                child: Column(
+                  children: [
+                    _MigrationSummaryMetric(
+                      label: 'Current round',
+                      value: rounds.isEmpty
+                          ? 'Preparing'
+                          : '$currentRound of ${rounds.length}',
+                    ),
+                    const SizedBox(height: 16),
+                    _MigrationSummaryMetric(
+                      label: 'Ready to migrate',
+                      value: !hasCompletionProjection
+                          ? 'Calculating'
+                          : '#${formatGroupedInteger(finalProjectedHeight)}'
+                                '${remainingBlocks > 0 ? ' · ${_formatPreparationDuration(remainingBlocks)}' : ''}',
+                      valueIcon: hasCompletionProjection
+                          ? AppIcons.block
+                          : null,
+                      secondary: true,
+                    ),
+                    const SizedBox(height: 16),
+                    _MigrationSummaryMetric(
+                      label: 'Current block',
+                      value: formatGroupedInteger(currentHeight),
+                      valueIcon: AppIcons.block,
+                      secondary: true,
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 16),
-                _MigrationSummaryMetric(
-                  label: 'Current block',
-                  value: formatGroupedInteger(currentHeight),
-                  valueIcon: AppIcons.block,
-                  secondary: true,
-                ),
-              ],
+              ),
             ),
           ),
           if (onManage != null) ...[
@@ -797,7 +820,7 @@ class _MigrationPreparationScheduleContent extends StatelessWidget {
             _MigrationManageButton(onPressed: onManage!),
             const SizedBox(height: 8),
           ] else
-            const SizedBox(height: 20),
+            const SizedBox(height: 12),
           Expanded(
             child: transactions.isEmpty
                 ? Center(
@@ -809,22 +832,18 @@ class _MigrationPreparationScheduleContent extends StatelessWidget {
                     ),
                   )
                 : Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 28),
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
                     child: ListView.builder(
                       key: const ValueKey(
                         'ironwood_migration_preparation_schedule_list',
                       ),
-                      padding: const EdgeInsets.only(top: 4, bottom: 12),
+                      padding: EdgeInsets.zero,
                       itemCount: rounds.length,
-                      itemBuilder: (context, index) => Padding(
-                        padding: EdgeInsets.only(
-                          bottom: index == rounds.length - 1 ? 0 : 20,
-                        ),
-                        child: _MigrationPreparationRoundSection(
-                          round: rounds[index],
-                          currentHeight: currentHeight,
-                        ),
-                      ),
+                      itemBuilder: (context, index) =>
+                          _MigrationPreparationRoundSection(
+                            round: rounds[index],
+                            currentHeight: currentHeight,
+                          ),
                     ),
                   ),
           ),
@@ -892,16 +911,16 @@ class _MigrationPreparationRoundSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final projectedHeight = round.transactions.fold<int>(
-      0,
-      (height, item) => math.max(height, item.transaction.projectedHeight),
-    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Row(
-          children: [
-            Expanded(
+        const SizedBox(height: 12),
+        SizedBox(
+          height: 24,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Align(
+              alignment: Alignment.centerLeft,
               child: Text(
                 'Split round ${round.number}',
                 style: AppTypography.labelLarge.copyWith(
@@ -910,16 +929,9 @@ class _MigrationPreparationRoundSection extends StatelessWidget {
                 ),
               ),
             ),
-            if (projectedHeight > currentHeight)
-              Text(
-                'Expected by #${formatGroupedInteger(projectedHeight)}',
-                style: AppTypography.bodySmall.copyWith(
-                  color: colors.text.secondary,
-                ),
-              ),
-          ],
+          ),
         ),
-        const SizedBox(height: 10),
+        const SizedBox(height: 8),
         for (var index = 0; index < round.transactions.length; index++) ...[
           _MigrationPreparationStageCard(
             key: ValueKey(
@@ -930,8 +942,9 @@ class _MigrationPreparationRoundSection extends StatelessWidget {
             currentHeight: currentHeight,
           ),
           if (index != round.transactions.length - 1)
-            const SizedBox(height: 10),
+            const SizedBox(height: 20),
         ],
+        const SizedBox(height: 12),
       ],
     );
   }
@@ -958,7 +971,10 @@ class _MigrationPreparationStageCard extends StatelessWidget {
       child: Column(
         children: [
           SizedBox(
-            height: 50,
+            key: ValueKey(
+              'ironwood_migration_preparation_schedule_surface_${transaction.stageIndex}',
+            ),
+            height: 56,
             child: DecoratedBox(
               decoration: BoxDecoration(
                 color: colors.background.ground,
@@ -991,11 +1007,22 @@ class _MigrationPreparationStageCard extends StatelessWidget {
           ),
           if (transaction.outputs.isNotEmpty)
             Padding(
-              padding: const EdgeInsets.fromLTRB(16, 6, 12, 0),
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
               child: Column(
                 children: [
-                  for (final output in transaction.outputs)
-                    _MigrationPreparationOutputRow(output: output),
+                  for (
+                    var outputIndex = 0;
+                    outputIndex < transaction.outputs.length;
+                    outputIndex++
+                  ) ...[
+                    if (outputIndex > 0) const SizedBox(height: 8),
+                    _MigrationPreparationOutputRow(
+                      key: ValueKey(
+                        'ironwood_migration_preparation_output_${transaction.stageIndex}_$outputIndex',
+                      ),
+                      output: transaction.outputs[outputIndex],
+                    ),
+                  ],
                 ],
               ),
             ),
@@ -1006,7 +1033,7 @@ class _MigrationPreparationStageCard extends StatelessWidget {
 }
 
 class _MigrationPreparationOutputRow extends StatelessWidget {
-  const _MigrationPreparationOutputRow({required this.output});
+  const _MigrationPreparationOutputRow({required this.output, super.key});
 
   final rust_sync.MigrationPreparationOutputStatus output;
 
@@ -1021,7 +1048,7 @@ class _MigrationPreparationOutputRow extends StatelessWidget {
         'Used in round ${output.nextRound ?? 1}',
     };
     return SizedBox(
-      height: 26,
+      height: 24,
       child: Row(
         children: [
           Text(
@@ -1045,7 +1072,7 @@ class _MigrationPreparationOutputRow extends StatelessWidget {
           Text(
             destination,
             textAlign: TextAlign.right,
-            style: AppTypography.bodySmall.copyWith(
+            style: AppTypography.labelMedium.copyWith(
               color: colors.text.secondary,
             ),
           ),
@@ -1103,17 +1130,6 @@ class _MigrationPreparationScheduleStatus extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (active)
-          IronwoodMigrationShimmerText(
-            text: label,
-            style: style,
-            baseColor: colors.text.secondary,
-            highlightColor: colors.text.accent,
-            textAlign: TextAlign.right,
-          )
-        else
-          Text(label, textAlign: TextAlign.right, style: style),
-        const SizedBox(width: 4),
         AppIcon(
           completed
               ? AppIcons.checkCircle
@@ -1131,6 +1147,17 @@ class _MigrationPreparationScheduleStatus extends StatelessWidget {
               ? colors.icon.accent
               : colors.icon.regular,
         ),
+        const SizedBox(width: 4),
+        if (active)
+          IronwoodMigrationShimmerText(
+            text: label,
+            style: style,
+            baseColor: colors.text.secondary,
+            highlightColor: colors.text.accent,
+            textAlign: TextAlign.right,
+          )
+        else
+          Text(label, textAlign: TextAlign.right, style: style),
       ],
     );
   }
@@ -1261,23 +1288,26 @@ class _MigrationScheduleContent extends StatelessWidget {
     final leftToMigrate = total - completed;
 
     return SizedBox(
+      key: const ValueKey('ironwood_migration_schedule_content'),
       width: 420,
       height: 656,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const SizedBox(height: 18),
+          const SizedBox(height: 16),
           Text(
+            key: const ValueKey('ironwood_migration_schedule_title'),
             'Migration Schedule',
             textAlign: TextAlign.center,
             style: AppTypography.headlineSmall.copyWith(
               color: colors.text.accent,
             ),
           ),
-          const SizedBox(height: 35),
+          const SizedBox(height: 36),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 28),
             child: Column(
+              key: const ValueKey('ironwood_migration_schedule_summary'),
               children: [
                 _MigrationSummaryMetric(
                   label: 'Left to migrate',
@@ -1310,13 +1340,13 @@ class _MigrationScheduleContent extends StatelessWidget {
             _MigrationManageButton(onPressed: onManage!),
             const SizedBox(height: 8),
           ] else
-            const SizedBox(height: 20),
+            const SizedBox(height: 28),
           Expanded(
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 12),
               child: ListView.separated(
                 key: const ValueKey('ironwood_migration_schedule_list'),
-                padding: const EdgeInsets.only(top: 8, bottom: 8),
+                padding: const EdgeInsets.only(top: 16, bottom: 8),
                 itemCount: parts.length,
                 separatorBuilder: (_, _) => const SizedBox(height: 8),
                 itemBuilder: (context, index) {
@@ -1369,9 +1399,12 @@ class _MigrationScheduleRow extends StatelessWidget {
       child: SizedBox(
         height: 56,
         child: DecoratedBox(
+          key: ValueKey(
+            'ironwood_migration_schedule_surface_${part.partIndex}',
+          ),
           decoration: BoxDecoration(
             color: colors.background.ground,
-            borderRadius: BorderRadius.circular(AppRadii.large),
+            borderRadius: BorderRadius.circular(AppRadii.medium),
           ),
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -1478,8 +1511,11 @@ class _MigrationSchedulePartStatus extends StatelessWidget {
         : colors.icon.regular;
 
     return Row(
+      key: ValueKey('ironwood_migration_schedule_status_${part.partIndex}'),
       mainAxisSize: MainAxisSize.min,
       children: [
+        AppIcon(icon, size: 16, color: iconColor),
+        const SizedBox(width: 4),
         if (active)
           IronwoodMigrationShimmerText(
             text: label,
@@ -1490,8 +1526,6 @@ class _MigrationSchedulePartStatus extends StatelessWidget {
           )
         else
           Text(label, textAlign: TextAlign.right, style: textStyle),
-        const SizedBox(width: 4),
-        AppIcon(icon, size: 16, color: iconColor),
       ],
     );
   }

--- a/lib/src/features/migration/screens/ironwood_migration_flow/schedule.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/schedule.dart
@@ -773,17 +773,18 @@ class _MigrationPreparationScheduleContent extends StatelessWidget {
           const SizedBox(height: 12),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12),
-            child: SizedBox(
+            child: ConstrainedBox(
               key: const ValueKey(
                 'ironwood_migration_preparation_schedule_summary',
               ),
-              height: 104,
+              constraints: const BoxConstraints(minHeight: 104),
               child: Padding(
                 padding: const EdgeInsets.symmetric(
                   horizontal: 16,
                   vertical: 12,
                 ),
                 child: Column(
+                  mainAxisSize: MainAxisSize.min,
                   children: [
                     _MigrationSummaryMetric(
                       label: 'Current round',

--- a/lib/src/features/migration/screens/ironwood_migration_flow/shared_widgets.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/shared_widgets.dart
@@ -529,7 +529,7 @@ String _formatMigrationBlockDurationEstimate(int blocks) {
 enum _MigrationStage { preparation, migration, finish }
 
 class _MigrationStageHeader extends StatelessWidget {
-  const _MigrationStageHeader({required this.stage});
+  const _MigrationStageHeader({required this.stage, super.key});
 
   final _MigrationStage stage;
 

--- a/lib/src/features/migration/screens/ironwood_migration_flow/shared_widgets.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/shared_widgets.dart
@@ -1100,55 +1100,13 @@ class _OptionIcon extends StatelessWidget {
     final color = selected
         ? context.colors.text.accent
         : context.colors.icon.disabled;
-    return SizedBox(
-      width: 16,
-      height: 16,
-      child: CustomPaint(
-        painter: _OptionIconPainter(mode: mode, color: color),
-      ),
+    return AppIcon(
+      mode == _MigrationMode.private
+          ? AppIcons.shieldKeyhole
+          : AppIcons.migrationFast,
+      size: 20,
+      color: color,
     );
-  }
-}
-
-class _OptionIconPainter extends CustomPainter {
-  const _OptionIconPainter({required this.mode, required this.color});
-
-  final _MigrationMode mode;
-  final Color color;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = color
-      ..strokeWidth = 1.7
-      ..style = PaintingStyle.stroke
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
-    if (mode == _MigrationMode.private) {
-      final path = Path()
-        ..moveTo(8, 1.5)
-        ..lineTo(14, 4)
-        ..lineTo(13, 10)
-        ..quadraticBezierTo(11, 14, 8, 15)
-        ..quadraticBezierTo(5, 14, 3, 10)
-        ..lineTo(2, 4)
-        ..close();
-      canvas.drawPath(path, paint);
-      canvas.drawLine(const Offset(8, 6), const Offset(8, 10), paint);
-      canvas.drawLine(const Offset(6, 8), const Offset(10, 8), paint);
-    } else {
-      canvas.drawLine(const Offset(3, 5), const Offset(11, 5), paint);
-      canvas.drawLine(const Offset(8, 2), const Offset(12, 5), paint);
-      canvas.drawLine(const Offset(8, 8), const Offset(12, 5), paint);
-      canvas.drawLine(const Offset(5, 11), const Offset(13, 11), paint);
-      canvas.drawLine(const Offset(8, 8), const Offset(5, 11), paint);
-      canvas.drawLine(const Offset(8, 14), const Offset(5, 11), paint);
-    }
-  }
-
-  @override
-  bool shouldRepaint(covariant _OptionIconPainter oldDelegate) {
-    return oldDelegate.mode != mode || oldDelegate.color != color;
   }
 }
 

--- a/lib/src/features/migration/screens/ironwood_migration_flow/shell_intro_options.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/shell_intro_options.dart
@@ -462,32 +462,57 @@ class _IronwoodMigrationHowItWorksContentState
                                       horizontal: _pageInset,
                                     ),
                                     child: Semantics(
-                                      container: index == _page,
+                                      container: true,
+                                      button: index != _page,
+                                      selected: index == _page,
                                       label: index == _page
                                           ? 'Migration step ${index + 1} of '
                                                 '${_steps.length}. '
                                                 '${step.title}. ${step.body}'
-                                          : null,
+                                          : 'Show migration step '
+                                                '${index + 1} of '
+                                                '${_steps.length}',
+                                      onTap: index == _page
+                                          ? null
+                                          : () => _animateToPage(index),
                                       child: ExcludeSemantics(
-                                        child: MouseRegion(
-                                          cursor: index == _page
-                                              ? MouseCursor.defer
-                                              : SystemMouseCursors.click,
-                                          child: GestureDetector(
-                                            behavior: HitTestBehavior.opaque,
-                                            onTap: index == _page
-                                                ? null
-                                                : () => _animateToPage(index),
-                                            child:
-                                                _IronwoodMigrationHowStepCard(
-                                                  key: ValueKey(
-                                                    'ironwood_migration_how_'
-                                                    'card_$index',
+                                        child: _IronwoodMigrationCarouselAction(
+                                          actionKey: ValueKey(
+                                            'ironwood_migration_how_'
+                                            'card_action_$index',
+                                          ),
+                                          onActivate: index == _page
+                                              ? null
+                                              : () => _animateToPage(index),
+                                          borderRadius: BorderRadius.circular(
+                                            AppRadii.large,
+                                          ),
+                                          child: MouseRegion(
+                                            key: ValueKey(
+                                              'ironwood_migration_how_'
+                                              'card_cursor_$index',
+                                            ),
+                                            cursor: _pointerDown
+                                                ? MouseCursor.defer
+                                                : index == _page
+                                                ? MouseCursor.defer
+                                                : SystemMouseCursors.click,
+                                            child: GestureDetector(
+                                              behavior: HitTestBehavior.opaque,
+                                              onTap: index == _page
+                                                  ? null
+                                                  : () => _animateToPage(index),
+                                              child:
+                                                  _IronwoodMigrationHowStepCard(
+                                                    key: ValueKey(
+                                                      'ironwood_migration_how_'
+                                                      'card_$index',
+                                                    ),
+                                                    index: index,
+                                                    title: step.title,
+                                                    body: step.body,
                                                   ),
-                                                  index: index,
-                                                  title: step.title,
-                                                  body: step.body,
-                                                ),
+                                            ),
                                           ),
                                         ),
                                       ),
@@ -507,9 +532,9 @@ class _IronwoodMigrationHowItWorksContentState
           ),
           Positioned(
             left: 306,
-            top: 494,
+            top: 482,
             width: 88,
-            height: 8,
+            height: 32,
             child: Row(
               children: [
                 for (var index = 0; index < _steps.length; index++) ...[
@@ -518,23 +543,44 @@ class _IronwoodMigrationHowItWorksContentState
                     selected: index == _page,
                     label:
                         'Show migration step ${index + 1} of ${_steps.length}',
-                    child: MouseRegion(
-                      cursor: SystemMouseCursors.click,
-                      child: GestureDetector(
-                        behavior: HitTestBehavior.opaque,
-                        onTap: () => _animateToPage(index),
-                        child: AnimatedContainer(
-                          key: ValueKey(
-                            'ironwood_migration_how_indicator_$index',
-                          ),
-                          duration: const Duration(milliseconds: 220),
-                          width: index == _page ? 40 : 20,
-                          height: 8,
-                          decoration: BoxDecoration(
-                            color: index == _page
-                                ? colors.background.inverse
-                                : colors.background.overlay,
-                            borderRadius: BorderRadius.circular(AppRadii.full),
+                    onTap: () => _animateToPage(index),
+                    child: _IronwoodMigrationCarouselAction(
+                      actionKey: ValueKey(
+                        'ironwood_migration_how_indicator_action_$index',
+                      ),
+                      onActivate: () => _animateToPage(index),
+                      borderRadius: BorderRadius.circular(AppRadii.full),
+                      child: MouseRegion(
+                        cursor: SystemMouseCursors.click,
+                        child: GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onTap: () => _animateToPage(index),
+                          child: AnimatedContainer(
+                            key: ValueKey(
+                              'ironwood_migration_how_'
+                              'indicator_hit_target_$index',
+                            ),
+                            duration: const Duration(milliseconds: 220),
+                            width: index == _page ? 40 : 20,
+                            height: 32,
+                            child: Center(
+                              child: AnimatedContainer(
+                                key: ValueKey(
+                                  'ironwood_migration_how_indicator_$index',
+                                ),
+                                duration: const Duration(milliseconds: 220),
+                                width: index == _page ? 40 : 20,
+                                height: 8,
+                                decoration: BoxDecoration(
+                                  color: index == _page
+                                      ? colors.background.inverse
+                                      : colors.background.overlay,
+                                  borderRadius: BorderRadius.circular(
+                                    AppRadii.full,
+                                  ),
+                                ),
+                              ),
+                            ),
                           ),
                         ),
                       ),
@@ -566,6 +612,65 @@ class _IronwoodMigrationHowItWorksContentState
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _IronwoodMigrationCarouselAction extends StatelessWidget {
+  const _IronwoodMigrationCarouselAction({
+    required this.actionKey,
+    required this.onActivate,
+    required this.borderRadius,
+    required this.child,
+  });
+
+  final Key actionKey;
+  final VoidCallback? onActivate;
+  final BorderRadius borderRadius;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      canRequestFocus: onActivate != null,
+      onKeyEvent: (_, event) {
+        if (onActivate == null || event is! KeyDownEvent) {
+          return KeyEventResult.ignored;
+        }
+        final key = event.logicalKey;
+        if (key != LogicalKeyboardKey.enter &&
+            key != LogicalKeyboardKey.numpadEnter &&
+            key != LogicalKeyboardKey.space) {
+          return KeyEventResult.ignored;
+        }
+        onActivate!();
+        return KeyEventResult.handled;
+      },
+      child: Builder(
+        builder: (context) {
+          final focused = Focus.of(context).hasFocus;
+          return Stack(
+            clipBehavior: Clip.none,
+            children: [
+              KeyedSubtree(key: actionKey, child: child),
+              if (focused)
+                Positioned.fill(
+                  child: IgnorePointer(
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                          color: context.colors.state.focusRing,
+                          width: 2,
+                        ),
+                        borderRadius: borderRadius,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/src/features/migration/screens/ironwood_migration_flow/shell_intro_options.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/shell_intro_options.dart
@@ -857,29 +857,57 @@ class _MigrationExpectationIllustration extends StatelessWidget {
       2 => const Color(0xFF00A460),
       _ => const Color(0xFFB90A4A),
     };
+    final viewportTop = switch (index) {
+      1 || 2 => -6.0,
+      _ => 0.0,
+    };
+    final viewportHeight = index == 3 ? 48.0 : 54.0;
     final imageRect = switch (index) {
       0 => const Rect.fromLTWH(-27.12, -8.70, 102.39, 68.70),
-      1 => const Rect.fromLTWH(-9.75, -11.43, 69.19, 69.13),
-      2 => const Rect.fromLTWH(-18.11, -12.50, 84, 84),
+      1 => const Rect.fromLTWH(-9.75, -5.43, 69.19, 69.13),
+      2 => const Rect.fromLTWH(-18.11, -6.50, 84, 84),
       _ => const Rect.fromLTWH(0, 0, 48, 48),
     };
-
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(AppRadii.small),
-      child: ColoredBox(
-        color: background,
-        child: SizedBox.square(
-          dimension: 48,
-          child: Stack(
-            clipBehavior: Clip.hardEdge,
-            children: [
-              Positioned.fromRect(
-                rect: imageRect,
-                child: Image.asset(asset, fit: BoxFit.fill),
-              ),
-            ],
-          ),
+    final image = Stack(
+      children: [
+        Positioned.fromRect(
+          rect: imageRect,
+          child: Image.asset(asset, fit: BoxFit.fill),
         ),
+      ],
+    );
+    final clippedImage = index == 0
+        ? ClipRect(child: image)
+        : ClipRRect(
+            borderRadius: BorderRadius.circular(AppRadii.small),
+            child: image,
+          );
+
+    return SizedBox.square(
+      key: ValueKey('ironwood_migration_expectation_tile_$index'),
+      dimension: 48,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned.fill(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: background,
+                borderRadius: BorderRadius.circular(AppRadii.small),
+              ),
+            ),
+          ),
+          Positioned(
+            left: 0,
+            top: viewportTop,
+            width: 48,
+            height: viewportHeight,
+            child: SizedBox(
+              key: ValueKey('ironwood_migration_expectation_viewport_$index'),
+              child: clippedImage,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/features/migration/screens/ironwood_migration_flow/shell_intro_options.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/shell_intro_options.dart
@@ -298,6 +298,15 @@ class _IronwoodMigrationHowItWorksContent extends StatefulWidget {
 
 class _IronwoodMigrationHowItWorksContentState
     extends State<_IronwoodMigrationHowItWorksContent> {
+  static const _carouselWidth = 700.0;
+  static const _carouselHeight = 320.0;
+  static const _cardWidth = 396.0;
+  static const _cardHeight = 280.0;
+  static const _pageExtent = 412.0;
+  static const _pageInset = (_pageExtent - _cardWidth) / 2;
+  static const _viewportFraction = _pageExtent / _carouselWidth;
+  static const _inactiveOpacity = 0.3;
+
   static const _steps = [
     (
       title: 'Orchard (legacy shielded) balance is frozen',
@@ -308,24 +317,25 @@ class _IronwoodMigrationHowItWorksContentState
     (
       title: 'Pre-migration preparations',
       body:
-          'Vizor splits your total balance into smaller, common-sized notes '
-          'before migrating.',
+          'Vizor splits your total balance into many smaller notes '
+          '(e.g. 0.1 ZEC / 1 ZEC / 5 ZEC) before migrating.',
     ),
     (
       title: 'Delayed and randomized migrations',
       body:
-          'Vizor sends parts at staggered intervals across multiple batches '
-          'to reduce traceability.',
+          'Vizor slowly sends parts at staggered intervals across multiple '
+          'batches to reduce traceability.',
     ),
   ];
 
   late final PageController _pageController;
   var _page = 0;
+  var _pointerDown = false;
 
   @override
   void initState() {
     super.initState();
-    _pageController = PageController();
+    _pageController = PageController(viewportFraction: _viewportFraction);
   }
 
   @override
@@ -336,13 +346,33 @@ class _IronwoodMigrationHowItWorksContentState
 
   void _next() {
     if (_page < _steps.length - 1) {
-      _pageController.nextPage(
-        duration: const Duration(milliseconds: 360),
-        curve: Curves.easeOutCubic,
-      );
+      _animateToPage(_page + 1);
       return;
     }
     context.go('/migration/what-to-expect');
+  }
+
+  void _animateToPage(int page) {
+    if (page == _page || !_pageController.hasClients) return;
+    _pageController.animateToPage(
+      page,
+      duration: const Duration(milliseconds: 360),
+      curve: Curves.easeOutCubic,
+    );
+  }
+
+  void _setPointerDown(bool pointerDown) {
+    if (_pointerDown == pointerDown) return;
+    setState(() => _pointerDown = pointerDown);
+  }
+
+  double _opacityFor(int index) {
+    final position = _pageController.hasClients
+        ? _pageController.page ?? _page.toDouble()
+        : _page.toDouble();
+    return (1 - (position - index).abs() * (1 - _inactiveOpacity))
+        .clamp(_inactiveOpacity, 1)
+        .toDouble();
   }
 
   @override
@@ -350,13 +380,13 @@ class _IronwoodMigrationHowItWorksContentState
     final colors = context.colors;
 
     return SizedBox(
-      width: 420,
+      width: _carouselWidth,
       height: 656,
       child: Stack(
         children: [
           Positioned(
-            left: 12,
-            top: 45,
+            left: 152,
+            top: 78,
             width: 396,
             child: Text(
               'How the Migration Works',
@@ -367,107 +397,147 @@ class _IronwoodMigrationHowItWorksContentState
             ),
           ),
           Positioned(
-            left: 12,
-            top: 142,
-            width: 396,
-            height: 280,
-            child: PageView.builder(
-              controller: _pageController,
-              itemCount: _steps.length,
-              onPageChanged: (value) => setState(() => _page = value),
-              itemBuilder: (context, index) {
-                final step = _steps[index];
-                return DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: colors.background.ground,
-                    borderRadius: BorderRadius.circular(24),
-                  ),
-                  child: Column(
-                    children: [
-                      SizedBox(
-                        height: 160,
-                        child: Stack(
-                          children: [
-                            Positioned(
-                              left: 16,
-                              top: 24,
-                              child: Text(
-                                'Step ${index + 1}',
-                                style: AppTypography.labelLarge.copyWith(
-                                  color: colors.text.secondary,
-                                ),
-                              ),
-                            ),
-                            Positioned(
-                              right: 0,
-                              top: 0,
-                              width: 190,
-                              height: 160,
-                              child: ClipRRect(
-                                borderRadius: BorderRadius.circular(16),
-                                child: Image.asset(
-                                  _ironwoodMigrationHowStepAssets[index],
-                                  fit: BoxFit.cover,
-                                  alignment: Alignment.center,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
+            left: 0,
+            top: 144,
+            width: _carouselWidth,
+            height: _carouselHeight,
+            child: MouseRegion(
+              key: const ValueKey(
+                'ironwood_migration_how_carousel_drag_region',
+              ),
+              cursor: _pointerDown
+                  ? SystemMouseCursors.grabbing
+                  : SystemMouseCursors.grab,
+              child: Listener(
+                onPointerDown: (_) => _setPointerDown(true),
+                onPointerUp: (_) => _setPointerDown(false),
+                onPointerCancel: (_) => _setPointerDown(false),
+                child: ShaderMask(
+                  blendMode: BlendMode.dstIn,
+                  shaderCallback: (bounds) => const LinearGradient(
+                    colors: [
+                      Color(0x00FFFFFF),
+                      Color(0xFFFFFFFF),
+                      Color(0xFFFFFFFF),
+                      Color(0x00FFFFFF),
+                    ],
+                    stops: [0, 0.15, 0.85, 1],
+                  ).createShader(bounds),
+                  child: Align(
+                    child: SizedBox(
+                      key: const ValueKey(
+                        'ironwood_migration_how_carousel_viewport',
                       ),
-                      Expanded(
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 16),
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  step.title,
-                                  style: AppTypography.labelLarge.copyWith(
-                                    color: colors.text.accent,
+                      width: _carouselWidth,
+                      height: _carouselHeight,
+                      child: Align(
+                        child: SizedBox(
+                          height: _cardHeight,
+                          child: ScrollConfiguration(
+                            behavior:
+                                const _IronwoodMigrationCarouselScrollBehavior(),
+                            child: PageView.builder(
+                              key: const ValueKey(
+                                'ironwood_migration_how_page_view',
+                              ),
+                              controller: _pageController,
+                              itemCount: _steps.length,
+                              physics: const PageScrollPhysics(),
+                              onPageChanged: (value) =>
+                                  setState(() => _page = value),
+                              itemBuilder: (context, index) {
+                                final step = _steps[index];
+                                return AnimatedBuilder(
+                                  animation: _pageController,
+                                  builder: (context, child) => Opacity(
+                                    key: ValueKey(
+                                      'ironwood_migration_how_'
+                                      'card_opacity_$index',
+                                    ),
+                                    opacity: _opacityFor(index),
+                                    child: child,
                                   ),
-                                ),
-                                const SizedBox(height: 8),
-                                SizedBox(
-                                  width: 330,
-                                  child: Text(
-                                    step.body,
-                                    style: AppTypography.bodyMedium.copyWith(
-                                      color: colors.text.secondary,
+                                  child: Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: _pageInset,
+                                    ),
+                                    child: Semantics(
+                                      container: index == _page,
+                                      label: index == _page
+                                          ? 'Migration step ${index + 1} of '
+                                                '${_steps.length}. '
+                                                '${step.title}. ${step.body}'
+                                          : null,
+                                      child: ExcludeSemantics(
+                                        child: MouseRegion(
+                                          cursor: index == _page
+                                              ? MouseCursor.defer
+                                              : SystemMouseCursors.click,
+                                          child: GestureDetector(
+                                            behavior: HitTestBehavior.opaque,
+                                            onTap: index == _page
+                                                ? null
+                                                : () => _animateToPage(index),
+                                            child:
+                                                _IronwoodMigrationHowStepCard(
+                                                  key: ValueKey(
+                                                    'ironwood_migration_how_'
+                                                    'card_$index',
+                                                  ),
+                                                  index: index,
+                                                  title: step.title,
+                                                  body: step.body,
+                                                ),
+                                          ),
+                                        ),
+                                      ),
                                     ),
                                   ),
-                                ),
-                              ],
+                                );
+                              },
                             ),
                           ),
                         ),
                       ),
-                    ],
+                    ),
                   ),
-                );
-              },
+                ),
+              ),
             ),
           ),
           Positioned(
-            left: 166,
-            top: 454,
+            left: 306,
+            top: 494,
             width: 88,
             height: 8,
             child: Row(
               children: [
                 for (var index = 0; index < _steps.length; index++) ...[
-                  AnimatedContainer(
-                    duration: const Duration(milliseconds: 220),
-                    width: index == _page ? 40 : 20,
-                    height: 8,
-                    decoration: BoxDecoration(
-                      color: index == _page
-                          ? colors.background.inverse
-                          : colors.background.overlay,
-                      borderRadius: BorderRadius.circular(AppRadii.full),
+                  Semantics(
+                    button: true,
+                    selected: index == _page,
+                    label:
+                        'Show migration step ${index + 1} of ${_steps.length}',
+                    child: MouseRegion(
+                      cursor: SystemMouseCursors.click,
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () => _animateToPage(index),
+                        child: AnimatedContainer(
+                          key: ValueKey(
+                            'ironwood_migration_how_indicator_$index',
+                          ),
+                          duration: const Duration(milliseconds: 220),
+                          width: index == _page ? 40 : 20,
+                          height: 8,
+                          decoration: BoxDecoration(
+                            color: index == _page
+                                ? colors.background.inverse
+                                : colors.background.overlay,
+                            borderRadius: BorderRadius.circular(AppRadii.full),
+                          ),
+                        ),
+                      ),
                     ),
                   ),
                   if (index < _steps.length - 1) const SizedBox(width: 4),
@@ -476,7 +546,7 @@ class _IronwoodMigrationHowItWorksContentState
             ),
           ),
           Positioned(
-            left: 95,
+            left: 235,
             top: 596,
             width: 230,
             child: AppButton(
@@ -496,6 +566,159 @@ class _IronwoodMigrationHowItWorksContentState
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _IronwoodMigrationCarouselScrollBehavior extends ScrollBehavior {
+  const _IronwoodMigrationCarouselScrollBehavior();
+
+  @override
+  Set<PointerDeviceKind> get dragDevices => {
+    ...super.dragDevices,
+    PointerDeviceKind.mouse,
+  };
+}
+
+class _IronwoodMigrationHowStepCard extends StatelessWidget {
+  const _IronwoodMigrationHowStepCard({
+    required this.index,
+    required this.title,
+    required this.body,
+    super.key,
+  });
+
+  final int index;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return SizedBox(
+      width: _IronwoodMigrationHowItWorksContentState._cardWidth,
+      height: _IronwoodMigrationHowItWorksContentState._cardHeight,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppRadii.large),
+        child: ColoredBox(
+          color: colors.background.ground,
+          child: Column(
+            children: [
+              SizedBox(
+                height: 160,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(AppRadii.medium),
+                  child: Stack(
+                    children: [
+                      _IronwoodMigrationHowStepIllustration(index: index),
+                      Positioned(
+                        left: 19,
+                        top: 24,
+                        child: Text(
+                          'Step ${index + 1}',
+                          style: AppTypography.labelLarge.copyWith(
+                            color: colors.text.secondary,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              SizedBox(
+                height: 120,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          style: AppTypography.labelLarge.copyWith(
+                            color: colors.text.accent,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        SizedBox(
+                          width: index == 0 ? 287 : 364,
+                          child: Text(
+                            body,
+                            style: AppTypography.bodyMedium.copyWith(
+                              color: colors.text.secondary,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _IronwoodMigrationHowStepIllustration extends StatelessWidget {
+  const _IronwoodMigrationHowStepIllustration({required this.index});
+
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    final geometry = switch (index) {
+      0 => (
+        containerLeft: 226.0,
+        containerWidth: 170.0,
+        imageLeft: -11.764,
+        imageTop: 8.672,
+        imageWidth: 199.529,
+        imageHeight: 131.728,
+      ),
+      1 => (
+        containerLeft: 226.0,
+        containerWidth: 170.0,
+        imageLeft: -42.007,
+        imageTop: -4.8,
+        imageWidth: 254.507,
+        imageHeight: 169.664,
+      ),
+      _ => (
+        containerLeft: 174.0,
+        containerWidth: 160.0,
+        imageLeft: -51.92,
+        imageTop: 0.0,
+        imageWidth: 264.24,
+        imageHeight: 174.0,
+      ),
+    };
+
+    return Positioned(
+      left: geometry.containerLeft,
+      top: 0,
+      width: geometry.containerWidth,
+      height: 160,
+      child: ClipRect(
+        child: Stack(
+          children: [
+            Positioned(
+              left: geometry.imageLeft,
+              top: geometry.imageTop,
+              width: geometry.imageWidth,
+              height: geometry.imageHeight,
+              child: Image.asset(
+                _ironwoodMigrationHowStepAssets[index],
+                fit: BoxFit.fill,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -281,7 +281,6 @@ class _MigrationCompleteStatusContent extends StatelessWidget {
             child: AppButton(
               key: const ValueKey('ironwood_migration_status_action_button'),
               onPressed: onDone,
-              variant: AppButtonVariant.secondary,
               height: 36,
               minWidth: 96,
               expand: true,

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -1424,6 +1424,8 @@ class _MigrationPreparationAnimatedRingPainter extends CustomPainter {
   final Animation<double> progress;
   final bool reduceMotion;
 
+  double get outerDiameter => _migrationStatusRingOuterDiameter;
+
   List<_MigrationRingVisualSegment> get segments {
     final eased = Curves.easeOutBack.transform(progress.value);
     return [
@@ -1445,6 +1447,7 @@ class _MigrationPreparationAnimatedRingPainter extends CustomPainter {
       rotation: 0,
       motionPhase: 0,
       reduceMotion: reduceMotion,
+      outerDiameter: outerDiameter,
     ).paint(canvas, size);
   }
 
@@ -1490,8 +1493,8 @@ class _MigrationRingVisualSegment {
   final double presence;
 }
 
-// At the ring's 104 px radius this produces roughly one logical pixel of
-// center-line arc. With rounded 12 px caps it reads as a single dot instead of
+// At the ring's 121.6 px center-line radius this produces roughly one logical
+// pixel of arc. With rounded 12.8 px caps it reads as a single dot instead of
 // disappearing, while remaining small enough not to distort normal notes.
 const _migrationRingMinimumSegmentWeight = 0.0025;
 
@@ -1700,18 +1703,23 @@ bool _sameVisualSegments(
   return true;
 }
 
+const _migrationStatusRingOuterDiameter = 256.0;
+const _migrationStatusRingMaxStrokeWidth = 12.8;
+
 class _MigrationRingVisualPainter extends CustomPainter {
   const _MigrationRingVisualPainter({
     required this.segments,
     required this.rotation,
     required this.motionPhase,
     required this.reduceMotion,
+    this.outerDiameter = _migrationStatusRingOuterDiameter,
   });
 
   final List<_MigrationRingVisualSegment> segments;
   final double rotation;
   final double motionPhase;
   final bool reduceMotion;
+  final double outerDiameter;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -1722,11 +1730,6 @@ class _MigrationRingVisualPainter extends CustomPainter {
     );
     if (positiveWeight <= 0) return;
 
-    final rect = Rect.fromCenter(
-      center: size.center(Offset.zero),
-      width: 208,
-      height: 208,
-    );
     // Presence is animated separately from value. A tiny live note must keep
     // its full gap, while a segment that is actually entering or leaving the
     // morph gradually acquires or surrenders that gap.
@@ -1738,9 +1741,28 @@ class _MigrationRingVisualPainter extends CustomPainter {
       (sum, value) => sum + value,
     );
     if (effectiveCount <= 0) return;
+    final availableOuterDiameter = math.min(
+      outerDiameter,
+      math.min(size.width, size.height),
+    );
+    if (availableOuterDiameter <= 0) return;
+    final estimatedRadius = math.max(
+      1.0,
+      (availableOuterDiameter - _migrationStatusRingMaxStrokeWidth) / 2,
+    );
+    final availablePerSegment = math.pi * 2 * estimatedRadius / effectiveCount;
+    final strokeWidth = math.min(
+      _migrationStatusRingMaxStrokeWidth,
+      math.max(1.0, availablePerSegment - 1),
+    );
+    final centerLineDiameter = availableOuterDiameter - strokeWidth;
+    if (centerLineDiameter <= 0) return;
+    final rect = Rect.fromCenter(
+      center: size.center(Offset.zero),
+      width: centerLineDiameter,
+      height: centerLineDiameter,
+    );
     final radius = rect.width / 2;
-    final availablePerSegment = math.pi * 2 * radius / effectiveCount;
-    final strokeWidth = math.min(12.0, math.max(1.0, availablePerSegment - 1));
     final dotCenterLineSweep = 1 / radius;
     final gap = math.min(
       0.17,
@@ -1840,8 +1862,6 @@ class _MigrationPreparationRingPainter extends CustomPainter {
   final List<double> weights;
   final double rotation;
 
-  static const _ringOuterDiameter = 220.0;
-
   // Decorative only: the ratios intentionally do not represent note value or
   // confirmation progress, but they still form one complete ring.
   static const initialSegmentRatios = <double>[
@@ -1862,13 +1882,17 @@ class _MigrationPreparationRingPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
       ..color = color
-      ..strokeWidth = 12
+      ..strokeWidth = _migrationStatusRingMaxStrokeWidth
       ..strokeCap = StrokeCap.round
       ..style = PaintingStyle.stroke;
+    final outerDiameter = math.min(
+      _migrationStatusRingOuterDiameter,
+      math.min(size.width, size.height),
+    );
     final rect = Rect.fromCenter(
       center: size.center(Offset.zero),
-      width: _ringOuterDiameter - paint.strokeWidth,
-      height: _ringOuterDiameter - paint.strokeWidth,
+      width: outerDiameter - paint.strokeWidth,
+      height: outerDiameter - paint.strokeWidth,
     );
     final fullSweep = math.pi * 2;
     final radius = rect.width / 2;

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -20,12 +20,12 @@ const _migrationPreparationCarouselItems = [
     tileColor: _migrationCarouselGreen,
     icon: AppIcons.wallet,
   ),
-  AppCarouselItem.image(
+  AppCarouselItem.icon(
     message:
         'We may have to do multiple rounds of note splitting depending on '
         'your balance.',
     tileColor: _migrationCarouselCrimson,
-    imageAsset: _ironwoodMigrationExpectationRunningAsset,
+    icon: AppIcons.migrationSplit,
   ),
 ];
 
@@ -352,6 +352,7 @@ class _MigrationLiveStatusContent extends StatelessWidget {
                 top: 54,
                 width: 396,
                 child: _MigrationStageHeader(
+                  key: const ValueKey('ironwood_migration_stage_header'),
                   stage: isPreparing
                       ? _MigrationStage.preparation
                       : isComplete
@@ -496,18 +497,24 @@ class _MigrationLiveStatusContent extends StatelessWidget {
                 ),
               ),
               Positioned(
-                left: 28,
+                left: 12,
                 top: isPreparing ? 382 : 390,
-                width: 364,
+                width: 396,
                 child: isPreparing
                     ? Column(
                         children: [
                           _MigrationSummaryMetric(
+                            key: const ValueKey(
+                              'ironwood_migration_summary_overall_progress',
+                            ),
                             label: 'Overall progress',
                             value: _overallPreparationProgressDisplay(status),
                           ),
                           const SizedBox(height: 16),
                           _MigrationSummaryMetric(
+                            key: const ValueKey(
+                              'ironwood_migration_summary_estimated_completion',
+                            ),
                             label: 'Est. completion',
                             value: _preparationCompletionEstimateDisplay(
                               status,
@@ -517,6 +524,9 @@ class _MigrationLiveStatusContent extends StatelessWidget {
                           ),
                           const SizedBox(height: 16),
                           _MigrationSummaryMetric(
+                            key: const ValueKey(
+                              'ironwood_migration_summary_current_block',
+                            ),
                             label: 'Current block',
                             value: formatGroupedInteger(currentHeight),
                             valueIcon: AppIcons.block,
@@ -527,12 +537,18 @@ class _MigrationLiveStatusContent extends StatelessWidget {
                     : Column(
                         children: [
                           _MigrationSummaryMetric(
+                            key: const ValueKey(
+                              'ironwood_migration_summary_left_to_migrate',
+                            ),
                             label: 'Left to migrate',
                             value:
                                 '${_formatZecAmountCompact(leftToMigrate > BigInt.zero ? leftToMigrate : BigInt.zero)} ZEC',
                           ),
                           const SizedBox(height: 16),
                           _MigrationSummaryMetric(
+                            key: const ValueKey(
+                              'ironwood_migration_summary_estimated_completion',
+                            ),
                             label: 'Est. completion',
                             value: _migrationCompletionEstimateDisplay(
                               status,
@@ -887,6 +903,7 @@ class _MigrationRingDetail extends StatelessWidget {
 
 class _MigrationSummaryMetric extends StatelessWidget {
   const _MigrationSummaryMetric({
+    super.key,
     required this.label,
     required this.value,
     this.secondary = false,
@@ -909,22 +926,33 @@ class _MigrationSummaryMetric extends StatelessWidget {
     );
     return Row(
       children: [
-        Expanded(child: Text(label, style: style)),
+        Text(label, style: style),
         const SizedBox(width: 16),
-        if (valueIcon != null) ...[
-          AppIcon(valueIcon!, size: 16, color: context.colors.icon.regular),
-          const SizedBox(width: 4),
-        ],
-        Flexible(
-          child: FittedBox(
-            fit: BoxFit.scaleDown,
+        Expanded(
+          child: Align(
             alignment: Alignment.centerRight,
-            child: Text(
-              value,
-              maxLines: 1,
-              softWrap: false,
-              textAlign: TextAlign.right,
-              style: style,
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (valueIcon != null) ...[
+                    AppIcon(
+                      valueIcon!,
+                      size: 16,
+                      color: context.colors.icon.regular,
+                    ),
+                    const SizedBox(width: 4),
+                  ],
+                  Text(
+                    value,
+                    maxLines: 1,
+                    softWrap: false,
+                    textAlign: TextAlign.right,
+                    style: style,
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -180,6 +180,37 @@ class _MigrationCompleteStatusContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final usesLargeText = MediaQuery.textScalerOf(context).scale(1) > 1;
+    final copy = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          'Your\n${_formatZecAmountCompact(totalZatoshi)} ZEC\n'
+          'are on Ironwood!',
+          textAlign: TextAlign.center,
+          style: AppTypography.headlineLarge.copyWith(
+            color: colors.text.accent,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Migration completed successfully and you can\n'
+          'spend your funds as usual.',
+          textAlign: TextAlign.center,
+          style: AppTypography.bodyMedium.copyWith(
+            color: colors.text.secondary,
+          ),
+        ),
+      ],
+    );
+    final action = AppButton(
+      key: const ValueKey('ironwood_migration_status_action_button'),
+      onPressed: onDone,
+      height: 36,
+      minWidth: 96,
+      expand: true,
+      child: const Text('Done'),
+    );
     return SizedBox(
       key: const ValueKey('ironwood_migration_complete_content'),
       width: 420,
@@ -244,49 +275,40 @@ class _MigrationCompleteStatusContent extends StatelessWidget {
               ],
             ),
           ),
-          Positioned(
-            left: 65,
-            top: 343.5,
-            width: 290,
-            height: 153,
-            child: SizedBox(
-              key: const ValueKey('ironwood_migration_complete_copy'),
+          if (!usesLargeText) ...[
+            Positioned(
+              left: 65,
+              top: 343.5,
+              width: 290,
+              height: 153,
+              child: SizedBox(
+                key: const ValueKey('ironwood_migration_complete_copy'),
+                child: copy,
+              ),
+            ),
+            Positioned(left: 162, top: 544.5, width: 96, child: action),
+          ] else
+            Positioned(
+              left: 12,
+              top: 296,
+              width: 396,
+              bottom: 8,
               child: Column(
                 children: [
-                  Text(
-                    'Your\n${_formatZecAmountCompact(totalZatoshi)} ZEC\n'
-                    'are on Ironwood!',
-                    textAlign: TextAlign.center,
-                    style: AppTypography.headlineLarge.copyWith(
-                      color: colors.text.accent,
+                  Expanded(
+                    child: SingleChildScrollView(
+                      child: SizedBox(
+                        key: const ValueKey('ironwood_migration_complete_copy'),
+                        width: 396,
+                        child: copy,
+                      ),
                     ),
                   ),
-                  const SizedBox(height: 12),
-                  Text(
-                    'Migration completed successfully and you can\n'
-                    'spend your funds as usual.',
-                    textAlign: TextAlign.center,
-                    style: AppTypography.bodyMedium.copyWith(
-                      color: colors.text.secondary,
-                    ),
-                  ),
+                  const SizedBox(height: 8),
+                  SizedBox(width: 96, child: action),
                 ],
               ),
             ),
-          ),
-          Positioned(
-            left: 162,
-            top: 544.5,
-            width: 96,
-            child: AppButton(
-              key: const ValueKey('ironwood_migration_status_action_button'),
-              onPressed: onDone,
-              height: 36,
-              minWidth: 96,
-              expand: true,
-              child: const Text('Done'),
-            ),
-          ),
         ],
       ),
     );

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -181,56 +181,102 @@ class _MigrationCompleteStatusContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     return SizedBox(
+      key: const ValueKey('ironwood_migration_complete_content'),
       width: 420,
       height: 656,
       child: Stack(
+        key: const ValueKey('ironwood_migration_complete_stack'),
+        clipBehavior: Clip.none,
         children: [
           Positioned(
-            left: 70,
-            top: 54,
-            width: 280,
-            height: 210,
+            left: 12,
+            top: 75.5,
+            width: 396,
+            height: 220,
             child: Stack(
-              fit: StackFit.expand,
+              key: const ValueKey('ironwood_migration_complete_hero'),
+              clipBehavior: Clip.none,
               children: [
-                CustomPaint(painter: _MigrationCompleteRibbonPainter()),
-                Image.asset(
-                  'assets/illustrations/ironwood_migration_done_coins.png',
-                  fit: BoxFit.contain,
+                Positioned(
+                  left: 93.58984375,
+                  top: 25.9231032198,
+                  width: 226.6364541916,
+                  height: 171.011320144,
+                  child: SizedBox(
+                    key: const ValueKey('ironwood_migration_complete_ribbon'),
+                    child: Center(
+                      child: Transform.rotate(
+                        angle: -15.62 * math.pi / 180,
+                        child: SizedBox(
+                          width: 201.426,
+                          height: 121.245,
+                          child: Stack(
+                            clipBehavior: Clip.none,
+                            children: [
+                              Positioned(
+                                left: -16.195,
+                                top: -30,
+                                width: 230.312,
+                                height: 169.943,
+                                child: SvgPicture.asset(
+                                  'assets/illustrations/ironwood_migration_done_ribbon.svg',
+                                  fit: BoxFit.fill,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                Positioned(
+                  left: 98,
+                  top: 0,
+                  width: 200,
+                  height: 200,
+                  child: Image.asset(
+                    key: const ValueKey('ironwood_migration_complete_coins'),
+                    'assets/illustrations/ironwood_migration_done_coins.png',
+                    fit: BoxFit.fill,
+                  ),
                 ),
               ],
             ),
           ),
           Positioned(
-            left: 40,
-            top: 270,
-            width: 340,
-            child: Column(
-              children: [
-                Text(
-                  'Your\n${_formatZecAmountCompact(totalZatoshi)} ZEC\n'
-                  'are on Ironwood!',
-                  textAlign: TextAlign.center,
-                  style: AppTypography.headlineLarge.copyWith(
-                    color: colors.text.accent,
-                    height: 1.08,
+            left: 65,
+            top: 343.5,
+            width: 290,
+            height: 153,
+            child: SizedBox(
+              key: const ValueKey('ironwood_migration_complete_copy'),
+              child: Column(
+                children: [
+                  Text(
+                    'Your\n${_formatZecAmountCompact(totalZatoshi)} ZEC\n'
+                    'are on Ironwood!',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.headlineLarge.copyWith(
+                      color: colors.text.accent,
+                    ),
                   ),
-                ),
-                const SizedBox(height: 20),
-                Text(
-                  'Migration completed successfully and you can\n'
-                  'spend your funds as usual.',
-                  textAlign: TextAlign.center,
-                  style: AppTypography.bodyMedium.copyWith(
-                    color: colors.text.secondary,
+                  const SizedBox(height: 12),
+                  Text(
+                    'Migration completed successfully and you can\n'
+                    'spend your funds as usual.',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.secondary,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
           Positioned(
             left: 162,
-            top: 510,
+            top: 544.5,
             width: 96,
             child: AppButton(
               key: const ValueKey('ironwood_migration_status_action_button'),
@@ -246,30 +292,6 @@ class _MigrationCompleteStatusContent extends StatelessWidget {
       ),
     );
   }
-}
-
-class _MigrationCompleteRibbonPainter extends CustomPainter {
-  @override
-  void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = const Color(0xFF009C5D)
-      ..style = PaintingStyle.fill;
-    final path = Path()
-      ..moveTo(size.width * 0.18, size.height * 0.38)
-      ..lineTo(size.width * 0.43, size.height * 0.20)
-      ..lineTo(size.width * 0.72, size.height * 0.31)
-      ..lineTo(size.width * 0.72, size.height * 0.52)
-      ..lineTo(size.width * 0.88, size.height * 0.60)
-      ..lineTo(size.width * 0.62, size.height * 0.80)
-      ..lineTo(size.width * 0.34, size.height * 0.69)
-      ..lineTo(size.width * 0.34, size.height * 0.52)
-      ..close();
-    canvas.drawPath(path, paint);
-  }
-
-  @override
-  bool shouldRepaint(covariant _MigrationCompleteRibbonPainter oldDelegate) =>
-      false;
 }
 
 class _MigrationLiveStatusContent extends StatelessWidget {

--- a/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
 
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart'
     show
         Colors,

--- a/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
@@ -55,7 +55,6 @@ import '../providers/ironwood_migration_announcement_provider.dart';
 import '../providers/ironwood_migration_coordinator_provider.dart';
 import '../providers/ironwood_migration_privacy_lock_provider.dart';
 import '../services/ironwood_migration_service.dart';
-import '../widgets/ironwood_migration_analyzing_progress_bar.dart';
 import '../widgets/ironwood_migration_shimmer_text.dart';
 import '../widgets/mobile/mobile_ironwood_keystone_signing_view.dart';
 

--- a/lib/widgetbook/carousel_use_cases.dart
+++ b/lib/widgetbook/carousel_use_cases.dart
@@ -28,12 +28,12 @@ const _preparationItems = [
     tileColor: _walletTile,
     icon: AppIcons.wallet,
   ),
-  AppCarouselItem.image(
+  AppCarouselItem.icon(
     message:
         'We may have to do multiple rounds of note splitting depending on '
         'your balance.',
     tileColor: _helmetTile,
-    imageAsset: _helmetAsset,
+    icon: AppIcons.migrationSplit,
   ),
 ];
 

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -975,6 +975,17 @@ Widget buildIronwoodMigrationPreparationScheduleUseCase(BuildContext context) {
   );
 }
 
+Widget buildIronwoodMigrationPreparationScheduleLargeTextUseCase(
+  BuildContext context,
+) {
+  return MediaQuery(
+    data: MediaQuery.of(
+      context,
+    ).copyWith(textScaler: const TextScaler.linear(1.5)),
+    child: buildIronwoodMigrationPreparationScheduleUseCase(context),
+  );
+}
+
 Widget buildIronwoodMigrationManageScheduleUseCase(BuildContext context) {
   return _buildIronwoodMigrationUseCase(
     initialLocation: '/migration/private/schedule',

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -355,6 +355,10 @@ class WidgetbookApp extends StatelessWidget {
                       builder: buildIronwoodMigrationAnalyzingUseCase,
                     ),
                     WidgetbookUseCase(
+                      name: 'Private review',
+                      builder: buildIronwoodMigrationPrivateReviewUseCase,
+                    ),
+                    WidgetbookUseCase(
                       name: 'Preparing',
                       builder:
                           buildIronwoodMigrationPrivateStatusWaitingUseCase,

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -339,6 +339,10 @@ class WidgetbookApp extends StatelessWidget {
                   name: 'Desktop',
                   useCases: [
                     WidgetbookUseCase(
+                      name: 'How it works',
+                      builder: buildIronwoodMigrationHowItWorksUseCase,
+                    ),
+                    WidgetbookUseCase(
                       name: 'Preparing',
                       builder:
                           buildIronwoodMigrationPrivateStatusWaitingUseCase,

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -343,6 +343,18 @@ class WidgetbookApp extends StatelessWidget {
                       builder: buildIronwoodMigrationHowItWorksUseCase,
                     ),
                     WidgetbookUseCase(
+                      name: 'What to expect',
+                      builder: buildIronwoodMigrationWhatToExpectUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Migration options',
+                      builder: buildIronwoodMigrationOptionsUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Finding private batches',
+                      builder: buildIronwoodMigrationAnalyzingUseCase,
+                    ),
+                    WidgetbookUseCase(
                       name: 'Preparing',
                       builder:
                           buildIronwoodMigrationPrivateStatusWaitingUseCase,

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -363,6 +363,11 @@ class WidgetbookApp extends StatelessWidget {
                       builder: buildIronwoodMigrationPreparationScheduleUseCase,
                     ),
                     WidgetbookUseCase(
+                      name: 'Preparation schedule · Large text',
+                      builder:
+                          buildIronwoodMigrationPreparationScheduleLargeTextUseCase,
+                    ),
+                    WidgetbookUseCase(
                       name: 'Migration schedule',
                       builder: buildIronwoodMigrationScheduleUseCase,
                     ),

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -359,6 +359,14 @@ class WidgetbookApp extends StatelessWidget {
                       builder: buildIronwoodMigrationPrivateReviewUseCase,
                     ),
                     WidgetbookUseCase(
+                      name: 'Preparation schedule',
+                      builder: buildIronwoodMigrationPreparationScheduleUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Migration schedule',
+                      builder: buildIronwoodMigrationScheduleUseCase,
+                    ),
+                    WidgetbookUseCase(
                       name: 'Preparing',
                       builder:
                           buildIronwoodMigrationPrivateStatusWaitingUseCase,
@@ -367,6 +375,10 @@ class WidgetbookApp extends StatelessWidget {
                       name: 'Migrating',
                       builder:
                           buildIronwoodMigrationPrivateStatusMigratingUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Migration complete',
+                      builder: buildIronwoodMigrationCompleteUseCase,
                     ),
                   ],
                 ),

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -46,6 +47,150 @@ void main() {
 
   setUp(() {
     FlutterSecureStorage.setMockInitialValues({});
+  });
+
+  testWidgets(
+    'how-it-works carousel exposes the Figma geometry and desktop cursor',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1080, 720);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _migrationOptionsHarness(initialLocation: '/migration/how-it-works'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('How the Migration Works'), findsOneWidget);
+      expect(
+        tester.getSize(
+          find.byKey(
+            const ValueKey('ironwood_migration_how_carousel_viewport'),
+          ),
+        ),
+        const Size(700, 320),
+      );
+      final cardSize = tester.getSize(
+        find.byKey(const ValueKey('ironwood_migration_how_card_0')),
+      );
+      expect(cardSize.width, moreOrLessEquals(396));
+      expect(cardSize.height, moreOrLessEquals(280));
+      expect(
+        tester.getTopLeft(
+          find.byKey(const ValueKey('ironwood_migration_how_card_0')),
+        ),
+        const Offset(474, 220),
+      );
+      expect(
+        tester
+            .widget<Opacity>(
+              find.byKey(
+                const ValueKey('ironwood_migration_how_card_opacity_0'),
+              ),
+            )
+            .opacity,
+        1,
+      );
+      expect(
+        tester
+            .widget<Opacity>(
+              find.byKey(
+                const ValueKey('ironwood_migration_how_card_opacity_1'),
+              ),
+            )
+            .opacity,
+        moreOrLessEquals(0.3),
+      );
+
+      final dragRegion = tester.widget<MouseRegion>(
+        find.byKey(
+          const ValueKey('ironwood_migration_how_carousel_drag_region'),
+        ),
+      );
+      expect(dragRegion.cursor, SystemMouseCursors.grab);
+    },
+  );
+
+  testWidgets('how-it-works carousel supports card and indicator clicks', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1080, 720);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      _migrationOptionsHarness(initialLocation: '/migration/how-it-works'),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Step 2').hitTestable());
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('0.1 ZEC / 1 ZEC / 5 ZEC'), findsOneWidget);
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('ironwood_migration_how_indicator_1')),
+      ),
+      const Size(40, 8),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('ironwood_migration_how_indicator_2')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('ironwood_migration_how_indicator_2')),
+      ),
+      const Size(40, 8),
+    );
+  });
+
+  testWidgets('how-it-works carousel supports mouse dragging', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1080, 720);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      _migrationOptionsHarness(initialLocation: '/migration/how-it-works'),
+    );
+    await tester.pumpAndSettle();
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    final firstCard = find.byKey(
+      const ValueKey('ironwood_migration_how_card_0'),
+    );
+    final center = tester.getCenter(firstCard);
+    await mouse.addPointer(location: center);
+    await mouse.down(center);
+    await tester.pump();
+
+    expect(
+      tester
+          .widget<MouseRegion>(
+            find.byKey(
+              const ValueKey('ironwood_migration_how_carousel_drag_region'),
+            ),
+          )
+          .cursor,
+      SystemMouseCursors.grabbing,
+    );
+
+    await mouse.moveBy(const Offset(-412, 0));
+    await mouse.up();
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('ironwood_migration_how_indicator_1')),
+      ),
+      const Size(40, 8),
+    );
   });
 
   testWidgets('what-to-expect screen shows the four migration expectations', (
@@ -4345,7 +4490,14 @@ Widget _migrationOptionsHarness({
       ),
       GoRoute(
         path: '/migration/how-it-works',
-        builder: (_, _) => const Text('how it works'),
+        builder: (_, _) => IronwoodMigrationFlowScreen(
+          step: IronwoodMigrationFlowStep.howItWorks,
+          previewData: IronwoodMigrationFlowData(
+            amountZatoshi: BigInt.from(10_000_000),
+            accountName: 'Account 1',
+            profilePictureId: kDefaultProfilePictureId,
+          ),
+        ),
       ),
       GoRoute(path: '/home', builder: (_, _) => const Text('home')),
       GoRoute(path: '/swap', builder: (_, _) => const Text('swap')),

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -2361,7 +2361,12 @@ void main() {
       closeTo(544.5, 0.01),
     );
     expect(find.text('Back home'), findsNothing);
-    expect(find.widgetWithText(AppButton, 'Done'), findsOneWidget);
+    final doneButton = find.widgetWithText(AppButton, 'Done');
+    expect(doneButton, findsOneWidget);
+    expect(
+      tester.widget<AppButton>(doneButton).variant,
+      AppButtonVariant.primary,
+    );
   });
 
   testWidgets('private complete fallback without run details returns home', (

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -150,6 +150,63 @@ void main() {
     );
   });
 
+  testWidgets(
+    'how-it-works carousel cards and indicators support keyboard activation',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1080, 720);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _migrationOptionsHarness(initialLocation: '/migration/how-it-works'),
+      );
+      await tester.pumpAndSettle();
+
+      final secondCardAction = find.byKey(
+        const ValueKey('ironwood_migration_how_card_action_1'),
+      );
+      expect(secondCardAction, findsOneWidget);
+      Focus.of(tester.element(secondCardAction)).requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getSize(
+          find.byKey(const ValueKey('ironwood_migration_how_indicator_1')),
+        ),
+        const Size(40, 8),
+      );
+
+      final thirdIndicatorAction = find.byKey(
+        const ValueKey('ironwood_migration_how_indicator_action_2'),
+      );
+      expect(thirdIndicatorAction, findsOneWidget);
+      expect(
+        tester
+            .getSize(
+              find.byKey(
+                const ValueKey('ironwood_migration_how_indicator_hit_target_2'),
+              ),
+            )
+            .height,
+        greaterThanOrEqualTo(32),
+      );
+      Focus.of(tester.element(thirdIndicatorAction)).requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getSize(
+          find.byKey(const ValueKey('ironwood_migration_how_indicator_2')),
+        ),
+        const Size(40, 8),
+      );
+    },
+  );
+
   testWidgets('how-it-works carousel supports mouse dragging', (tester) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = const Size(1080, 720);
@@ -168,6 +225,14 @@ void main() {
     );
     final center = tester.getCenter(firstCard);
     await mouse.addPointer(location: center);
+    expect(
+      tester
+          .widget<MouseRegion>(
+            find.byKey(const ValueKey('ironwood_migration_how_card_cursor_1')),
+          )
+          .cursor,
+      SystemMouseCursors.click,
+    );
     await mouse.down(center);
     await tester.pump();
 
@@ -181,8 +246,31 @@ void main() {
           .cursor,
       SystemMouseCursors.grabbing,
     );
+    final cardCursorRegions = find.byWidgetPredicate(
+      (widget) =>
+          widget is MouseRegion &&
+          widget.key is ValueKey<String> &&
+          (widget.key! as ValueKey<String>).value.startsWith(
+            'ironwood_migration_how_card_cursor_',
+          ),
+    );
+    expect(cardCursorRegions, findsAtLeastNWidgets(2));
+    for (final region in tester.widgetList<MouseRegion>(cardCursorRegions)) {
+      expect(region.cursor, MouseCursor.defer);
+    }
 
     await mouse.moveBy(const Offset(-412, 0));
+    await tester.pump();
+    expect(
+      tester
+          .widget<MouseRegion>(
+            find.byKey(
+              const ValueKey('ironwood_migration_how_carousel_drag_region'),
+            ),
+          )
+          .cursor,
+      SystemMouseCursors.grabbing,
+    );
     await mouse.up();
     await tester.pumpAndSettle();
 
@@ -568,6 +656,18 @@ void main() {
           .value,
       '100%',
     );
+    expect(
+      tester
+          .widget<Semantics>(
+            find.descendant(
+              of: analyzingDonut,
+              matching: find.byType(Semantics),
+            ),
+          )
+          .properties
+          .liveRegion,
+      isNot(isTrue),
+    );
 
     await tester.pump(const Duration(milliseconds: 16));
     await tester.pump();
@@ -583,6 +683,69 @@ void main() {
     expect(reviewDonut, findsOneWidget);
     expect(tester.getRect(reviewDonut), analyzingDonutRect);
   });
+
+  testWidgets(
+    'private review keeps donut and message progress when the plan arrives',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final planCompleter = Completer<rust_sync.OrchardMigrationPrivatePlan?>();
+      addTearDown(() {
+        if (!planCompleter.isCompleted) {
+          planCompleter.complete(_privatePlan());
+        }
+      });
+      await tester.pumpWidget(
+        _migrationOptionsHarness(
+          initialLocation: '/migration/private/review',
+          migrationService: _privatePlanService(() => planCompleter.future),
+          usePrivatePreview: false,
+          analyzingMinimumDuration: const Duration(seconds: 6),
+          disableAnimations: false,
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 1930));
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final analyzingDonut = find.byKey(
+        const ValueKey('ironwood_migration_analyzing_donut'),
+      );
+      String donutValue() => tester
+          .widget<Semantics>(
+            find.descendant(
+              of: analyzingDonut,
+              matching: find.byType(Semantics),
+            ),
+          )
+          .properties
+          .value!;
+      int percent(String value) =>
+          int.parse(value.substring(0, value.length - 1));
+
+      expect(find.text('Finding private batches...'), findsOneWidget);
+      final progressBeforePlan = percent(donutValue());
+      expect(progressBeforePlan, greaterThan(0));
+
+      planCompleter.complete(_privatePlan());
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Finding private batches...'), findsOneWidget);
+      expect(percent(donutValue()), greaterThanOrEqualTo(progressBeforePlan));
+
+      await tester.pump(const Duration(milliseconds: 3670));
+      await tester.pump(const Duration(milliseconds: 849));
+      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump();
+
+      expect(find.text('Ironwood Migration'), findsOneWidget);
+    },
+  );
 
   testWidgets('private review shows plan without preparing a transaction', (
     tester,
@@ -2368,6 +2531,60 @@ void main() {
       AppButtonVariant.primary,
     );
   });
+
+  testWidgets(
+    'private complete status keeps copy clear of the action at large text scale',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final flutterErrors = <FlutterErrorDetails>[];
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = flutterErrors.add;
+      addTearDown(() => FlutterError.onError = originalOnError);
+
+      await tester.pumpWidget(
+        _privateStatusHarness(
+          status: _migrationStatus(
+            phase: kIronwoodMigrationCompletePhase,
+            activeRunId: 'run-1',
+            targetValuesZatoshi: const [60_000_000],
+            broadcastedTxCount: 1,
+            confirmedTxCount: 1,
+            totalCount: 1,
+            parts: [
+              _migrationPart(
+                0,
+                60_000_000,
+                rust_sync.MigrationPartState.completed,
+              ),
+            ],
+          ),
+          textScaler: const TextScaler.linear(1.5),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        flutterErrors.where(
+          (details) => details.toString().contains('transfer_status.dart'),
+        ),
+        isEmpty,
+      );
+      final body = find.text(
+        'Migration completed successfully and you can\n'
+        'spend your funds as usual.',
+      );
+      final action = find.byKey(
+        const ValueKey('ironwood_migration_status_action_button'),
+      );
+      expect(
+        tester.getRect(body).bottom,
+        lessThanOrEqualTo(tester.getRect(action).top),
+      );
+    },
+  );
 
   testWidgets('private complete fallback without run details returns home', (
     tester,
@@ -4933,6 +5150,8 @@ Widget _migrationOptionsHarness({
   Duration analyzingMinimumDuration = Duration.zero,
   bool disableAnimations = true,
   bool useImmediatePreview = true,
+  bool usePrivatePreview = true,
+  TextScaler textScaler = TextScaler.noScaling,
   rust_sync.KeystoneMigrationSigningRequest? previewCombinedSigningRequest,
   List<String> previewCombinedSigningUrParts = const [],
   rust_sync.OrchardMigrationPrivatePlan? previewPrivatePlan,
@@ -4975,7 +5194,9 @@ Widget _migrationOptionsHarness({
             accountName: 'Account 1',
             profilePictureId: kDefaultProfilePictureId,
           ),
-          previewPrivatePlan: previewPrivatePlan ?? _privatePlan(),
+          previewPrivatePlan: usePrivatePreview
+              ? previewPrivatePlan ?? _privatePlan()
+              : null,
         ),
       ),
       GoRoute(
@@ -5111,7 +5332,7 @@ Widget _migrationOptionsHarness({
       builder: (context, child) => MediaQuery(
         data: MediaQuery.of(context).copyWith(
           disableAnimations: disableAnimations,
-          textScaler: TextScaler.noScaling,
+          textScaler: textScaler,
         ),
         child: AppTheme(data: AppThemeData.light, child: child!),
       ),
@@ -5351,6 +5572,7 @@ Widget _privateStatusHarness({
   rust_sync.MigrationStatus? coordinatorStatus,
   SyncState? syncState,
   bool disableAnimations = false,
+  TextScaler textScaler = TextScaler.noScaling,
 }) {
   return _migrationEntryHarness(
     ctaState: IronwoodHomeMigrationCtaState.resume(
@@ -5367,6 +5589,7 @@ Widget _privateStatusHarness({
     coordinatorStatus: coordinatorStatus,
     syncState: syncState,
     disableAnimations: disableAnimations,
+    textScaler: textScaler,
   );
 }
 
@@ -5504,6 +5727,7 @@ Widget _migrationEntryHarness({
   rust_sync.MigrationStatus? coordinatorStatus,
   SyncState? syncState,
   bool disableAnimations = false,
+  TextScaler textScaler = TextScaler.noScaling,
   Future<void> Function({required String accountUuid, required String runId})?
   onStop,
 }) {
@@ -5625,7 +5849,7 @@ Widget _migrationEntryHarness({
       builder: (context, child) => MediaQuery(
         data: MediaQuery.of(context).copyWith(
           disableAnimations: disableAnimations,
-          textScaler: TextScaler.noScaling,
+          textScaler: textScaler,
         ),
         child: AppTheme(data: AppThemeData.light, child: child!),
       ),
@@ -5881,6 +6105,21 @@ IronwoodMigrationService _immediatePlanService(
         ({required dbPath, required network, required accountUuid}) async =>
             _privatePlan(),
     getImmediatePlan:
+        ({required dbPath, required network, required accountUuid}) =>
+            getPlan(),
+    secureStore: AppSecureStore.testing(storage: const FlutterSecureStorage()),
+  );
+}
+
+IronwoodMigrationService _privatePlanService(
+  Future<rust_sync.OrchardMigrationPrivatePlan?> Function() getPlan,
+) {
+  return IronwoodMigrationService(
+    getWalletDbPath: () async => '/tmp/wallet.db',
+    getStatus:
+        ({required dbPath, required network, required accountUuid}) async =>
+            _migrationStatus(),
+    getPrivatePlan:
         ({required dbPath, required network, required accountUuid}) =>
             getPlan(),
     secureStore: AppSecureStore.testing(storage: const FlutterSecureStorage()),

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -2565,6 +2565,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
+      FlutterError.onError = originalOnError;
 
       expect(
         flutterErrors.where(
@@ -3753,6 +3754,77 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Transaction 3'), findsOneWidget);
   });
+
+  testWidgets(
+    'preparation schedule summary grows with accessibility text scaling',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final flutterErrors = <FlutterErrorDetails>[];
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = flutterErrors.add;
+      addTearDown(() => FlutterError.onError = originalOnError);
+
+      final status = _migrationStatus(
+        phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+        activeRunId: 'run-1',
+        preparationMeanDelayBlocks: 24,
+        preparationTransactions: [
+          _preparationTransaction(
+            0,
+            500_000_000,
+            rust_sync.MigrationPreparationTransactionState.scheduled,
+            scheduledHeight: 1_010,
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        _migrationEntryHarness(
+          ctaState: IronwoodHomeMigrationCtaState.resume(
+            network: 'test',
+            accountUuid: 'account-1',
+            status: status,
+          ),
+          initialLocation: '/migration/private/preparation-schedule',
+          syncState: SyncState(
+            accountUuid: 'account-1',
+            hasAccountScopedData: true,
+            scannedHeight: 1_000,
+            chainTipHeight: 1_000,
+          ),
+          disableAnimations: true,
+          textScaler: const TextScaler.linear(1.5),
+        ),
+      );
+      await tester.pumpAndSettle();
+      FlutterError.onError = originalOnError;
+
+      expect(
+        flutterErrors.where(
+          (details) => details.toString().contains('schedule.dart'),
+        ),
+        isEmpty,
+      );
+      final summary = find.byKey(
+        const ValueKey('ironwood_migration_preparation_schedule_summary'),
+      );
+      final scheduleList = find.byKey(
+        const ValueKey('ironwood_migration_preparation_schedule_list'),
+      );
+      final summaryRect = tester.getRect(summary);
+      expect(summaryRect.height, greaterThan(104));
+      expect(
+        tester.getRect(find.text('Current block')).bottom,
+        lessThanOrEqualTo(summaryRect.bottom),
+      );
+      expect(
+        tester.getRect(scheduleList).top,
+        greaterThanOrEqualTo(summaryRect.bottom + 12),
+      );
+    },
+  );
 
   testWidgets('migration schedule stops before opening the Immediate review', (
     tester,

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -1378,6 +1378,62 @@ void main() {
   );
 
   testWidgets(
+    'preparing and migrating rings fill the 256px Figma chart frame',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _privateStatusHarness(status: _status(), disableAnimations: true),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final paintFinder = find.byKey(
+        const ValueKey('ironwood_migration_ring_paint'),
+      );
+      final preparingPaint = tester.widget<CustomPaint>(paintFinder);
+      expect(preparingPaint.size, const Size.square(256));
+      final dynamic preparingPainter = preparingPaint.painter;
+      expect(preparingPainter.outerDiameter, 256);
+
+      await tester.pumpWidget(
+        _privateStatusHarness(
+          disableAnimations: true,
+          status: _migrationStatus(
+            phase: kIronwoodMigrationBroadcastScheduledPhase,
+            activeRunId: 'run-figma-ring',
+            targetValuesZatoshi: const [10_000_000, 20_000_000],
+            totalCount: 2,
+            parts: [
+              _migrationPart(
+                0,
+                10_000_000,
+                rust_sync.MigrationPartState.migrating,
+              ),
+              _migrationPart(
+                1,
+                20_000_000,
+                rust_sync.MigrationPartState.scheduled,
+                scheduledHeight: 1_200,
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final migratingPaint = tester.widget<CustomPaint>(paintFinder);
+      expect(migratingPaint.size, const Size.square(256));
+      final dynamic migratingPainter = migratingPaint.painter;
+      expect(migratingPainter.outerDiameter, 256);
+    },
+  );
+
+  testWidgets(
     'preparation ring reshapes and spins without rebuilding the paint layer',
     (tester) async {
       tester.view.devicePixelRatio = 1;

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -623,6 +623,28 @@ void main() {
       final stageRect = tester.getRect(
         find.byKey(const ValueKey('ironwood_migration_stage_header')),
       );
+      final titleFinder = find.byKey(
+        const ValueKey('ironwood_migration_review_title'),
+      );
+      expect(titleFinder, findsOneWidget);
+      final title = tester.widget<Text>(titleFinder);
+      final titleRect = tester.getRect(titleFinder);
+      expect(title.textAlign, TextAlign.center);
+      expect(title.style?.fontFamily, AppTypography.headlineSmall.fontFamily);
+      expect(title.style?.fontSize, AppTypography.headlineSmall.fontSize);
+      expect(title.style?.fontWeight, AppTypography.headlineSmall.fontWeight);
+      expect(titleRect.left, closeTo(stageRect.left, 0.01));
+      expect(titleRect.right, closeTo(stageRect.right, 0.01));
+      expect(stageRect.top - titleRect.top, closeTo(38, 0.01));
+
+      final reviewDonutFinder = find.byKey(
+        const ValueKey('ironwood_migration_review_donut'),
+      );
+      final reviewDonut = tester.widget<CustomPaint>(reviewDonutFinder);
+      expect(tester.getSize(reviewDonutFinder), const Size.square(256));
+      final dynamic reviewPainter = reviewDonut.painter;
+      expect(reviewPainter.outerDiameter, 256);
+
       final completionRect = tester.getRect(
         find.byKey(const ValueKey('ironwood_migration_review_completion_row')),
       );
@@ -2281,6 +2303,63 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Your\n0.6 ZEC\nare on Ironwood!'), findsOneWidget);
+    final completeRoot = find.byKey(
+      const ValueKey('ironwood_migration_complete_content'),
+    );
+    final completeRootRect = tester.getRect(completeRoot);
+    expect(tester.getSize(completeRoot), const Size(420, 656));
+    expect(
+      tester
+          .widget<Stack>(
+            find.byKey(const ValueKey('ironwood_migration_complete_stack')),
+          )
+          .clipBehavior,
+      Clip.none,
+    );
+    expect(
+      tester.getRect(
+        find.byKey(const ValueKey('ironwood_migration_complete_hero')),
+      ),
+      Rect.fromLTWH(
+        completeRootRect.left + 12,
+        completeRootRect.top + 75.5,
+        396,
+        220,
+      ),
+    );
+    expect(
+      tester.getRect(
+        find.byKey(const ValueKey('ironwood_migration_complete_coins')),
+      ),
+      Rect.fromLTWH(
+        completeRootRect.left + 110,
+        completeRootRect.top + 75.5,
+        200,
+        200,
+      ),
+    );
+    expect(
+      tester.getRect(
+        find.byKey(const ValueKey('ironwood_migration_complete_copy')),
+      ),
+      Rect.fromLTWH(
+        completeRootRect.left + 65,
+        completeRootRect.top + 343.5,
+        290,
+        153,
+      ),
+    );
+    expect(
+      tester
+              .getRect(
+                find.byKey(
+                  const ValueKey('ironwood_migration_status_action_button'),
+                ),
+              )
+              .top -
+          completeRootRect.top,
+      closeTo(544.5, 0.01),
+    );
     expect(find.text('Back home'), findsNothing);
     expect(find.widgetWithText(AppButton, 'Done'), findsOneWidget);
   });
@@ -3350,13 +3429,74 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Preparation Schedule'), findsOneWidget);
+    final preparationRoot = find.byKey(
+      const ValueKey('ironwood_migration_preparation_schedule_content'),
+    );
+    final preparationTitle = find.byKey(
+      const ValueKey('ironwood_migration_preparation_schedule_title'),
+    );
+    final preparationSummary = find.byKey(
+      const ValueKey('ironwood_migration_preparation_schedule_summary'),
+    );
+    final preparationList = find.byKey(
+      const ValueKey('ironwood_migration_preparation_schedule_list'),
+    );
+    final preparationRootRect = tester.getRect(preparationRoot);
+    expect(tester.getSize(preparationRoot), const Size(420, 656));
+    expect(
+      tester.getRect(preparationTitle).top - preparationRootRect.top,
+      closeTo(28, 0.01),
+    );
+    expect(tester.widget<Text>(preparationTitle).textAlign, TextAlign.center);
+    expect(
+      tester.getRect(preparationSummary),
+      Rect.fromLTWH(
+        preparationRootRect.left + 12,
+        preparationRootRect.top + 72,
+        396,
+        104,
+      ),
+    );
+    expect(
+      tester.getRect(preparationList),
+      Rect.fromLTWH(
+        preparationRootRect.left + 12,
+        preparationRootRect.top + 188,
+        396,
+        468,
+      ),
+    );
+    final firstPreparationSurface = find.byKey(
+      const ValueKey('ironwood_migration_preparation_schedule_surface_0'),
+    );
+    expect(
+      tester.getRect(firstPreparationSurface),
+      Rect.fromLTWH(
+        preparationRootRect.left + 12,
+        preparationRootRect.top + 232,
+        396,
+        56,
+      ),
+    );
+    final firstOutput = find.byKey(
+      const ValueKey('ironwood_migration_preparation_output_0_0'),
+    );
+    final secondOutput = find.byKey(
+      const ValueKey('ironwood_migration_preparation_output_0_1'),
+    );
+    expect(tester.getSize(firstOutput).height, 24);
+    expect(tester.getSize(secondOutput).height, 24);
+    expect(
+      tester.getRect(secondOutput).top - tester.getRect(firstOutput).bottom,
+      8,
+    );
     expect(find.text('Current round'), findsOneWidget);
     expect(find.text('1 of 2'), findsOneWidget);
     expect(find.text('Ready to migrate'), findsOneWidget);
     expect(find.text('Current block'), findsOneWidget);
     expect(find.text('1,000'), findsOneWidget);
     expect(find.text('#1,010'), findsOneWidget);
-    expect(find.text('Expected by #1,171'), findsOneWidget);
+    expect(find.text('Expected by #1,171'), findsNothing);
     expect(find.text('Expected #1,171'), findsOneWidget);
     expect(find.text('3. 2 ZEC'), findsOneWidget);
     expect(find.text('4. 3 ZEC'), findsOneWidget);
@@ -4158,6 +4298,70 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Left to migrate'), findsOneWidget);
+    final scheduleRoot = find.byKey(
+      const ValueKey('ironwood_migration_schedule_content'),
+    );
+    final scheduleTitle = find.byKey(
+      const ValueKey('ironwood_migration_schedule_title'),
+    );
+    final scheduleSummary = find.byKey(
+      const ValueKey('ironwood_migration_schedule_summary'),
+    );
+    final scheduleList = find.byKey(
+      const ValueKey('ironwood_migration_schedule_list'),
+    );
+    final scheduleRootRect = tester.getRect(scheduleRoot);
+    expect(tester.getSize(scheduleRoot), const Size(420, 656));
+    expect(
+      tester.getRect(scheduleTitle).top - scheduleRootRect.top,
+      closeTo(16, 0.01),
+    );
+    expect(tester.widget<Text>(scheduleTitle).textAlign, TextAlign.center);
+    expect(
+      tester.getRect(scheduleSummary),
+      Rect.fromLTWH(
+        scheduleRootRect.left + 28,
+        scheduleRootRect.top + 72,
+        364,
+        80,
+      ),
+    );
+    expect(
+      tester.getRect(scheduleList),
+      Rect.fromLTWH(
+        scheduleRootRect.left + 12,
+        scheduleRootRect.top + 180,
+        396,
+        476,
+      ),
+    );
+    final firstScheduleSurface = find.byKey(
+      const ValueKey('ironwood_migration_schedule_surface_0'),
+    );
+    expect(
+      tester.getRect(firstScheduleSurface),
+      Rect.fromLTWH(
+        scheduleRootRect.left + 12,
+        scheduleRootRect.top + 196,
+        396,
+        56,
+      ),
+    );
+    final scheduleDecoration =
+        tester.widget<DecoratedBox>(firstScheduleSurface).decoration
+            as BoxDecoration;
+    expect(scheduleDecoration.borderRadius, BorderRadius.circular(16));
+    final completedStatus = find.byKey(
+      const ValueKey('ironwood_migration_schedule_status_0'),
+    );
+    final completedIcon = find.descendant(
+      of: completedStatus,
+      matching: find.byType(AppIcon),
+    );
+    expect(
+      tester.getRect(completedIcon).left,
+      lessThan(tester.getRect(find.text('Completed at block 4,209,997')).left),
+    );
     expect(find.text('0.5 ZEC'), findsOneWidget);
     expect(find.text('in ~50 minutes'), findsOneWidget);
     expect(find.text('Completed at block 4,209,997'), findsOneWidget);

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -232,6 +232,93 @@ void main() {
     expect(find.text('Immediate'), findsOneWidget);
   });
 
+  testWidgets(
+    'what-to-expect illustrations preserve the Figma overflow geometry',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1080, 720);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _migrationOptionsHarness(initialLocation: '/migration/what-to-expect'),
+      );
+      await tester.pumpAndSettle();
+
+      for (var index = 0; index < 4; index++) {
+        expect(
+          tester.getSize(
+            find.byKey(ValueKey('ironwood_migration_expectation_tile_$index')),
+          ),
+          const Size.square(48),
+        );
+      }
+
+      final firstTile = tester.getRect(
+        find.byKey(const ValueKey('ironwood_migration_expectation_tile_0')),
+      );
+      final firstViewport = tester.getRect(
+        find.byKey(const ValueKey('ironwood_migration_expectation_viewport_0')),
+      );
+      expect(firstViewport.top, firstTile.top);
+      expect(firstViewport.bottom, firstTile.bottom + 6);
+
+      for (final index in [1, 2]) {
+        final tile = tester.getRect(
+          find.byKey(ValueKey('ironwood_migration_expectation_tile_$index')),
+        );
+        final viewport = tester.getRect(
+          find.byKey(
+            ValueKey('ironwood_migration_expectation_viewport_$index'),
+          ),
+        );
+        expect(viewport.top, tile.top - 6);
+        expect(viewport.bottom, tile.bottom);
+      }
+
+      expect(
+        tester.getRect(
+          find.byKey(
+            const ValueKey('ironwood_migration_expectation_viewport_3'),
+          ),
+        ),
+        tester.getRect(
+          find.byKey(const ValueKey('ironwood_migration_expectation_tile_3')),
+        ),
+      );
+    },
+  );
+
+  testWidgets('migration options use the exact Figma shield and fast icons', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1080, 720);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(_migrationOptionsHarness());
+    await tester.pumpAndSettle();
+
+    final privateIcon = find.descendant(
+      of: find.byKey(const ValueKey('ironwood_migration_private_option')),
+      matching: find.byWidgetPredicate(
+        (widget) => widget is AppIcon && widget.name == AppIcons.shieldKeyhole,
+      ),
+    );
+    final immediateIcon = find.descendant(
+      of: find.byKey(const ValueKey('ironwood_migration_fast_option')),
+      matching: find.byWidgetPredicate(
+        (widget) => widget is AppIcon && widget.name == AppIcons.migrationFast,
+      ),
+    );
+
+    expect(privateIcon, findsOneWidget);
+    expect(immediateIcon, findsOneWidget);
+    expect(tester.getSize(privateIcon), const Size.square(20));
+    expect(tester.getSize(immediateIcon), const Size.square(20));
+  });
+
   testWidgets('option selection does not move card content', (tester) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = const Size(1440, 900);
@@ -416,6 +503,12 @@ void main() {
       find.byKey(const ValueKey('ironwood_migration_analyzing_screen')),
       findsOneWidget,
     );
+    final analyzingDonut = find.byKey(
+      const ValueKey('ironwood_migration_analyzing_donut'),
+    );
+    expect(analyzingDonut, findsOneWidget);
+    expect(tester.getSize(analyzingDonut), const Size.square(256));
+    final analyzingDonutRect = tester.getRect(analyzingDonut);
     expect(find.text('Analyzing your balance...'), findsOneWidget);
     expect(find.text('Ironwood Migration'), findsNothing);
 
@@ -443,6 +536,39 @@ void main() {
     expect(find.text('Ironwood Migration'), findsNothing);
 
     await tester.pump(const Duration(milliseconds: 81));
+
+    expect(
+      find.byKey(const ValueKey('ironwood_migration_analyzing_screen')),
+      findsOneWidget,
+    );
+    expect(find.text('Ironwood Migration'), findsNothing);
+
+    await tester.pump(const Duration(milliseconds: 849));
+    expect(
+      find.byKey(const ValueKey('ironwood_migration_analyzing_screen')),
+      findsOneWidget,
+    );
+    expect(find.text('Ironwood Migration'), findsNothing);
+
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(
+      find.byKey(const ValueKey('ironwood_migration_analyzing_screen')),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .widget<Semantics>(
+            find.descendant(
+              of: analyzingDonut,
+              matching: find.byType(Semantics),
+            ),
+          )
+          .properties
+          .value,
+      '100%',
+    );
+
+    await tester.pump(const Duration(milliseconds: 16));
     await tester.pump();
 
     expect(
@@ -450,6 +576,11 @@ void main() {
       findsNothing,
     );
     expect(find.text('Ironwood Migration'), findsOneWidget);
+    final reviewDonut = find.byKey(
+      const ValueKey('ironwood_migration_review_donut'),
+    );
+    expect(reviewDonut, findsOneWidget);
+    expect(tester.getRect(reviewDonut), analyzingDonutRect);
   });
 
   testWidgets('private review shows plan without preparing a transaction', (

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -16,6 +16,7 @@ import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/core/widgets/app_carousel.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
@@ -604,6 +605,53 @@ void main() {
     expect(find.text('Review shuffle'), findsNothing);
     expect(find.widgetWithText(AppButton, 'Start migration'), findsOneWidget);
   });
+
+  testWidgets(
+    'private review aligns its summary and keep-running content to the stage header',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _migrationOptionsHarness(initialLocation: '/migration/private/review'),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final stageRect = tester.getRect(
+        find.byKey(const ValueKey('ironwood_migration_stage_header')),
+      );
+      final completionRect = tester.getRect(
+        find.byKey(const ValueKey('ironwood_migration_review_completion_row')),
+      );
+      final keepRunningRect = tester.getRect(
+        find.byKey(const ValueKey('ironwood_migration_keep_running_content')),
+      );
+      expect(completionRect.left, closeTo(stageRect.left, 0.01));
+      expect(completionRect.right, closeTo(stageRect.right, 0.01));
+      expect(keepRunningRect.left, closeTo(stageRect.left, 0.01));
+      expect(keepRunningRect.right, closeTo(stageRect.right, 0.01));
+
+      final iconTile = find.byKey(
+        const ValueKey('ironwood_migration_keep_running_icon_tile'),
+      );
+      expect(tester.getSize(iconTile), const Size.square(48));
+      final tileDecoration =
+          tester.widget<DecoratedBox>(iconTile).decoration as BoxDecoration;
+      expect(tileDecoration.color, const Color(0xFFB90A4A));
+      expect(tileDecoration.borderRadius, BorderRadius.circular(12));
+      expect(find.text('Keep Vizor running'), findsOneWidget);
+      expect(
+        find.text(
+          'Preparation continues while the app is minimized, then migration '
+          'starts automatically.',
+        ),
+        findsOneWidget,
+      );
+    },
+  );
 
   testWidgets('private review starts software migration and opens status', (
     tester,
@@ -2739,6 +2787,111 @@ void main() {
         ),
         findsOneWidget,
       );
+    },
+  );
+
+  testWidgets(
+    'preparing and migrating summary rows align labels left and values right',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      void expectRowAlignment(Finder row) {
+        final texts = find.descendant(of: row, matching: find.byType(Text));
+        expect(texts, findsNWidgets(2));
+        final rowRect = tester.getRect(row);
+        final stageRect = tester.getRect(
+          find.byKey(const ValueKey('ironwood_migration_stage_header')),
+        );
+        expect(rowRect.left, closeTo(stageRect.left, 0.01));
+        expect(rowRect.right, closeTo(stageRect.right, 0.01));
+        expect(tester.getRect(texts.at(0)).left, closeTo(rowRect.left, 0.01));
+        expect(tester.getRect(texts.at(1)).right, closeTo(rowRect.right, 0.01));
+      }
+
+      await tester.pumpWidget(
+        _privateStatusHarness(status: _status(), disableAnimations: true),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expectRowAlignment(
+        find.byKey(
+          const ValueKey('ironwood_migration_summary_overall_progress'),
+        ),
+      );
+      expectRowAlignment(
+        find.byKey(
+          const ValueKey('ironwood_migration_summary_estimated_completion'),
+        ),
+      );
+      expectRowAlignment(
+        find.byKey(const ValueKey('ironwood_migration_summary_current_block')),
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await tester.pumpWidget(
+        _privateStatusHarness(
+          disableAnimations: true,
+          status: _migrationStatus(
+            phase: kIronwoodMigrationBroadcastScheduledPhase,
+            activeRunId: 'run-figma-summary',
+            targetValuesZatoshi: const [10_000_000, 20_000_000],
+            totalCount: 2,
+            parts: [
+              _migrationPart(
+                0,
+                10_000_000,
+                rust_sync.MigrationPartState.migrating,
+              ),
+              _migrationPart(
+                1,
+                20_000_000,
+                rust_sync.MigrationPartState.scheduled,
+                scheduledHeight: 1_200,
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expectRowAlignment(
+        find.byKey(
+          const ValueKey('ironwood_migration_summary_left_to_migrate'),
+        ),
+      );
+      expectRowAlignment(
+        find.byKey(
+          const ValueKey('ironwood_migration_summary_estimated_completion'),
+        ),
+      );
+    },
+  );
+
+  testWidgets(
+    'preparation carousel uses the Figma split icon for multiple rounds',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _privateStatusHarness(status: _status(), disableAnimations: true),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final carousel = tester.widget<AppCarousel>(find.byType(AppCarousel));
+      final multipleRoundsItem = carousel.items[2];
+      expect(multipleRoundsItem.icon, AppIcons.migrationSplit);
+      expect(multipleRoundsItem.iconSize, 20);
+      expect(multipleRoundsItem.imageAsset, isNull);
     },
   );
 


### PR DESCRIPTION
## Problem

The desktop Ironwood migration flow had several visual and interaction mismatches with the current designs:

- The “How migration works” cards behaved like a static list instead of a draggable carousel.
- “What to expect” illustrations were clipped where the artwork should extend beyond its tile.
- Migration option icons did not match the design-system glyphs.
- Private-plan preparation used a linear loader disconnected from the following donut screen.
- Preparing, Migrating, and Private review rings rendered smaller than their 256 px frames.
- Private review and status titles, metrics, and keep-running content did not share the same alignment grid.
- Preparation and Migration schedule titles, summaries, cards, output rows, and status icons did not match the Figma spacing.
- The migration-complete hero used a small polygon in place of the full curved ribbon, making the center illustration look clipped.

## Solution

- Rebuilt “How migration works” as a centered carousel with click, mouse drag, grab/grabbing cursors, card and indicator navigation, inactive-card opacity, and edge fades.
- Preserved the designed illustration overflow and replaced the migration option artwork with the design-system icons.
- Replaced the private-plan linear loader with a 256 px donut that fills to 100% before review opens, while keeping mobile behavior unchanged.
- Made Preparing, Migrating, and Private review rings fill their 256 px frame and aligned titles and metric rows to the shared 396 px content grid.
- Updated the private review keep-running treatment to the 48 px scarlet app-icon tile and corrected the preparation carousel Split icon.
- Matched Preparation schedule to the 420×656 Figma structure: title and summary positions, 396 px cards, 56 px surfaces, 24 px output rows with 8 px gaps, and icon-first statuses.
- Matched Migration schedule title, summary, list start, 16 px card radius, and icon-first statuses to Figma.
- Restored the migration-complete hero with the exact curved ribbon SVG, 200 px coin layer, unclipped overflow, and Figma vertical spacing.
- Registered Private review, both schedule screens, and Migration complete alongside the other desktop migration states in Widgetbook.

## Validation

- `fvm flutter test test/features/migration/ironwood_migration_flow_screen_test.dart` — 101 tests passed
- Mobile shared-state regression test passed with `VIZOR_FORM_FACTOR=mobile`
- Deterministic Figma captures checked Private review, Preparation schedule, Migration schedule, Migration complete, status rings, loading donut, carousel, illustration overflow, and option icons
- `fvm flutter build macos --debug -t lib/widgetbook.dart` — passed
- Latest Widgetbook build opened; all three new desktop use cases are registered and Preparation schedule was visually checked
- `fvm flutter analyze` — no errors; existing unused-code warnings remain