### PR TITLE
Shorten migration plan analysis delay

### DIFF
--- a/lib/src/features/migration/screens/ironwood_migration_flow/models.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/models.dart
@@ -13,7 +13,7 @@ enum IronwoodMigrationFlowStep {
 enum IronwoodMigrationReviewPreviewStage { review, analyzing }
 
 const _privateStatusStartVerificationTimeout = Duration(seconds: 2);
-const _defaultMigrationAnalyzingMinimumDuration = Duration(seconds: 6);
+const _defaultMigrationAnalyzingMinimumDuration = Duration(milliseconds: 750);
 const _keystoneMigrationProofPollInterval = Duration(seconds: 1);
 const _scheduledBlockProgressCap = 0.70;
 const _migrationEstimatedSecondsPerBlock = 75;

--- a/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/private_review.dart
@@ -491,7 +491,7 @@ class _MigrationAnalyzingDonutPainter extends CustomPainter {
 abstract final class _MigrationAnalyzingMotion {
   static const period = Duration(seconds: 2);
   static const preparationPeriod = Duration(milliseconds: 9500);
-  static const completionPeriod = Duration(milliseconds: 850);
+  static const completionPeriod = Duration(milliseconds: 250);
   static const reducedMotionProgress = 0.28;
   static const messageAdvanceProgress = 0.96;
   static const cycleResetProgress = 0.2;

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -632,7 +632,7 @@ void main() {
     );
     expect(find.text('Ironwood Migration'), findsNothing);
 
-    await tester.pump(const Duration(milliseconds: 849));
+    await tester.pump(const Duration(milliseconds: 249));
     expect(
       find.byKey(const ValueKey('ironwood_migration_analyzing_screen')),
       findsOneWidget,
@@ -738,7 +738,7 @@ void main() {
       expect(percent(donutValue()), greaterThanOrEqualTo(progressBeforePlan));
 
       await tester.pump(const Duration(milliseconds: 3670));
-      await tester.pump(const Duration(milliseconds: 849));
+      await tester.pump(const Duration(milliseconds: 249));
       await tester.pump(const Duration(milliseconds: 1));
       await tester.pump(const Duration(milliseconds: 16));
       await tester.pump();


### PR DESCRIPTION
## What changed

- reduce the private migration plan analyzing minimum from 6 seconds to 750 ms
- reduce the completion transition from 850 ms to 250 ms
- update timing assertions for the shorter completion transition

## Why

Migration planning is usually a fast local database calculation, but the UI
always held the analyzing screen for roughly 6.85 seconds. This made quick
plans feel like expensive network or cryptographic work.

Fast plans now reach review in approximately one second, while plans that
actually take longer continue showing the analyzing state for their real
duration.

## Validation

- `fvm flutter test test/features/migration/ironwood_migration_flow_screen_test.dart`
  — 107 tests passed
- `fvm flutter analyze` — no errors; 23 existing unused-code warnings
