### PR TITLE
Drop raw blobs from the history bases query

### DIFF
--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -419,7 +419,7 @@ pub(crate) struct ExportBirthdayAnchor {
     pub block_height: u64,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct TxBase {
     txid: Vec<u8>,
     transaction_id: i64,
@@ -575,6 +575,33 @@ pub fn get_transaction_history(
         &uuid_bytes,
         bases.iter().map(|base| base.txid.as_slice()),
     )?;
+    drop(read_tx);
+
+    Ok(assemble_history(
+        &bases,
+        &outputs_by_txid,
+        &uuid_bytes,
+        limit,
+    ))
+}
+
+/// Turn raw history rows into the display list.
+///
+/// This is the whole classification pipeline — summarize, suppress
+/// funding steps, classify, filter, sort, truncate — with no database
+/// access, so it can be exercised directly from `TxBase` / `TxOutput`
+/// values instead of through SQL fixtures. `read_history_bases` and
+/// `read_history_outputs` own the SQL side; their agreement with
+/// librustzcash's own schema is pinned by the regtest equivalence
+/// check rather than by synthetic in-memory tables, which cannot
+/// express states the real schema forbids (a spend, for instance,
+/// always implies a funding receive that is itself a history row).
+fn assemble_history(
+    bases: &[TxBase],
+    outputs_by_txid: &HashMap<Vec<u8>, Vec<TxOutput>>,
+    uuid_bytes: &[u8],
+    limit: Option<u32>,
+) -> Vec<TransactionInfo> {
     let summaries: HashMap<Vec<u8>, ActivitySummary> = bases
         .iter()
         .map(|base| {
@@ -584,16 +611,16 @@ pub fn get_transaction_history(
                 .unwrap_or(&[]);
             (
                 base.txid.clone(),
-                summarize_activity_outputs(base, outputs, uuid_bytes.as_slice()),
+                summarize_activity_outputs(base, outputs, uuid_bytes),
             )
         })
         .collect();
-    let external_send_keys = build_external_send_keys(&bases, &summaries);
+    let external_send_keys = build_external_send_keys(bases, &summaries);
     let suppressed_funding_step_fees =
-        build_suppressed_funding_step_fees(&bases, &summaries, &external_send_keys);
+        build_suppressed_funding_step_fees(bases, &summaries, &external_send_keys);
 
     let mut visible = Vec::new();
-    for base in &bases {
+    for base in bases {
         let summary = summaries.get(&base.txid).cloned().unwrap_or_default();
         if suppressed_funding_step_fees
             .suppressed_funding_txids
@@ -633,7 +660,7 @@ pub fn get_transaction_history(
         visible.truncate(limit as usize);
     }
 
-    Ok(visible.into_iter().map(|tx| tx.info).collect())
+    visible.into_iter().map(|tx| tx.info).collect()
 }
 
 pub fn get_previous_transaction_count_for_address(
@@ -1000,13 +1027,118 @@ fn read_history_base_by_txid(
     Ok(row)
 }
 
+/// Account-scoped stand-in for `v_transactions`, minus `transactions.raw`.
+///
+/// `v_transactions` selects `transactions.raw` and aggregates over it.
+/// SQLite cannot eliminate that column from inside the view's aggregate,
+/// so every reference materializes every raw transaction blob even when
+/// the caller never reads them, and the outer `account_uuid` predicate
+/// cannot be pushed through the view's `UNION` CTEs to reduce the work.
+/// On a 9-account wallet (1008 txs, ~37 MB of raw blobs) that costs
+/// ~1.8s of CPU per reference; the same rows without `raw`, with the
+/// account filter applied before grouping, cost ~0.04s.
+///
+/// This mirrors the upstream view definition exactly except that it
+/// drops `raw` and the columns this module does not read, and filters
+/// by `?1`. The `notes` and `sent_note_counts` CTEs are copied verbatim
+/// so their `UNION` de-duplication keeps identical row identity.
+///
+/// Mirrored from `zcash_client_sqlite` 0.22.0-rc.4, `VIEW_TRANSACTIONS`:
+/// <https://github.com/zcash/librustzcash/blob/65a3add2f1d9b9ea455a71a9c33f9219dbc9e614/zcash_client_sqlite/src/wallet/db.rs#L1320-L1438>
+///
+/// `history_bases_match_v_transactions` pins the two row-for-row. If a
+/// `zcash_client_sqlite` upgrade changes `v_transactions`, that test is
+/// the tripwire — re-check this SQL against the new view definition and
+/// update the permalink above to the new release tag.
+const HISTORY_BASES_CTE: &str = r#"
+        WITH vt AS (
+            WITH
+            notes AS (
+                SELECT ro.account_id              AS account_id,
+                       ro.transaction_id          AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       ro.value                   AS value,
+                       ro.value                   AS received_value,
+                       0                          AS spent_value,
+                       0                          AS spent_note_count,
+                       CASE WHEN ro.is_change THEN 1 ELSE 0 END AS change_note_count,
+                       CASE WHEN ro.is_change THEN 0 ELSE 1 END AS received_count,
+                       CASE
+                         WHEN (ro.memo IS NULL OR ro.memo = X'F6') THEN 0
+                         ELSE 1
+                       END AS memo_present,
+                       CASE WHEN ro.pool = 0 THEN 1 ELSE 0 END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                UNION
+                SELECT ro.account_id              AS account_id,
+                       ros.transaction_id         AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       -ro.value                  AS value,
+                       0                          AS received_value,
+                       ro.value                   AS spent_value,
+                       1                          AS spent_note_count,
+                       0                          AS change_note_count,
+                       0                          AS received_count,
+                       0                          AS memo_present,
+                       CASE WHEN ro.pool != 0 THEN 1 ELSE 0 END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                JOIN v_received_output_spends ros
+                     ON ros.pool = ro.pool
+                     AND ros.received_output_id = ro.id_within_pool_table
+            ),
+            sent_note_counts AS (
+                SELECT sent_notes.from_account_id     AS account_id,
+                       sent_notes.transaction_id      AS transaction_id,
+                       COUNT(DISTINCT sent_notes.id)  AS sent_notes
+                FROM sent_notes
+                LEFT JOIN v_received_outputs ro ON sent_notes.id = ro.sent_note_id
+                WHERE COALESCE(ro.is_change, 0) = 0
+                GROUP BY account_id, sent_notes.transaction_id
+            ),
+            blocks_max_height AS (
+                SELECT MAX(blocks.height) AS max_height FROM blocks
+            )
+            SELECT transactions.txid          AS txid,
+                   transactions.mined_height  AS mined_height,
+                   transactions.tx_index      AS tx_index,
+                   transactions.expiry_height AS expiry_height,
+                   transactions.fee           AS fee_paid,
+                   blocks.time                AS block_time,
+                   SUM(notes.value)           AS account_balance_delta,
+                   SUM(notes.spent_value)     AS total_spent,
+                   SUM(notes.received_value)  AS total_received,
+                   (
+                        transactions.mined_height IS NULL
+                        AND transactions.expiry_height BETWEEN 1 AND blocks_max_height.max_height
+                   ) AS expired_unmined,
+                   (
+                        SUM(notes.does_not_match_shielding) = 0
+                        AND SUM(notes.spent_note_count) > 0
+                        AND (SUM(notes.received_count) + SUM(notes.change_note_count)) > 0
+                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                   ) AS is_shielding
+            FROM notes
+            JOIN accounts ON accounts.id = notes.account_id
+            JOIN transactions ON transactions.id_tx = notes.transaction_id
+            LEFT JOIN blocks_max_height
+            LEFT JOIN blocks ON blocks.height = transactions.mined_height
+            LEFT JOIN sent_note_counts
+                 ON sent_note_counts.account_id = notes.account_id
+                 AND sent_note_counts.transaction_id = notes.transaction_id
+            WHERE accounts.uuid = ?1
+            GROUP BY notes.account_id, notes.transaction_id
+        )
+"#;
+
 fn read_history_bases(
     conn: &rusqlite::Connection,
     account_uuid: &[u8],
 ) -> Result<Vec<TxBase>, String> {
     let mut stmt = conn
-        .prepare(
-            r#"
+        .prepare(&format!(
+            r#"{HISTORY_BASES_CTE}
         SELECT
             vt.txid,
             COALESCE(tx.id_tx, -1) AS transaction_id,
@@ -1032,11 +1164,10 @@ fn read_history_bases(
                 WHERE spent_tx.txid = vt.txid
                   AND spent_note.note_version = ?2
             ) AS spent_orchard_note
-        FROM v_transactions vt
+        FROM vt
         LEFT JOIN transactions tx ON tx.txid = vt.txid
-        WHERE vt.account_uuid = ?1
-        "#,
-        )
+        "#
+        ))
         .map_err(|e| format!("SQL error: {e}"))?;
 
     let rows = stmt
@@ -2983,6 +3114,197 @@ mod tests {
         assert_eq!(got.block_height, 333_100);
     }
 
+    /// Read `TxBase` rows straight out of a synthetic `v_transactions`
+    /// table, the way `read_history_bases` did before it inlined the
+    /// view's aggregates as `HISTORY_BASES_CTE`.
+    ///
+    /// The fixtures below populate `v_transactions` with hand-written
+    /// aggregates so a case can be stated directly ("this tx spent
+    /// 1_265_000 and received 1_150_000"). The real schema cannot
+    /// express that in isolation — it derives those sums from notes, so
+    /// a spend always drags in the funding receive as another history
+    /// row, and `account_balance_delta` is forced to
+    /// `total_received - total_spent`. Rebuilding these fixtures on the
+    /// real schema would therefore change what each case asserts.
+    ///
+    /// So the seam is drawn here: this oracle supplies `TxBase` values,
+    /// `assemble_history` (the code under test) does the classifying,
+    /// and `HISTORY_BASES_CTE`'s agreement with the upstream view is
+    /// pinned separately against a librustzcash-built database.
+    fn read_history_bases_via_v_transactions(
+        conn: &rusqlite::Connection,
+        account_uuid: &[u8],
+    ) -> Result<Vec<TxBase>, String> {
+        let mut stmt = conn
+            .prepare(
+                r#"
+            SELECT
+                vt.txid,
+                COALESCE(tx.id_tx, -1) AS transaction_id,
+                vt.mined_height,
+                vt.expired_unmined,
+                vt.account_balance_delta,
+                COALESCE(vt.fee_paid, 0) AS fee_paid,
+                COALESCE(vt.block_time, 0) AS block_time,
+                COALESCE(vt.total_spent, 0) AS total_spent,
+                COALESCE(vt.total_received, 0) AS total_received,
+                COALESCE(vt.is_shielding, 0) AS is_shielding,
+                vt.expiry_height,
+                COALESCE(vt.tx_index, -1) AS tx_index,
+                tx.created,
+                CAST(COALESCE(strftime('%s', tx.created), 0) AS INTEGER) AS created_time,
+                EXISTS (
+                    SELECT 1
+                    FROM transactions spent_tx
+                    JOIN orchard_received_note_spends spent
+                        ON spent.transaction_id = spent_tx.id_tx
+                    JOIN orchard_received_notes spent_note
+                        ON spent_note.id = spent.orchard_received_note_id
+                    WHERE spent_tx.txid = vt.txid
+                      AND spent_note.note_version = ?2
+                ) AS spent_orchard_note
+            FROM v_transactions vt
+            LEFT JOIN transactions tx ON tx.txid = vt.txid
+            WHERE vt.account_uuid = ?1
+            "#,
+            )
+            .map_err(|e| format!("SQL error: {e}"))?;
+
+        let rows = stmt
+            .query_map(
+                rusqlite::params![account_uuid, ORCHARD_NOTE_VERSION],
+                |row| {
+                    Ok(TxBase {
+                        txid: row.get(0)?,
+                        transaction_id: row.get(1)?,
+                        mined_height: row.get(2)?,
+                        expired_unmined: row.get(3)?,
+                        account_balance_delta: row.get(4)?,
+                        fee: row.get::<_, i64>(5)?.unsigned_abs(),
+                        block_time: row.get::<_, i64>(6)?.unsigned_abs(),
+                        total_spent: row.get::<_, i64>(7)?.unsigned_abs(),
+                        total_received: row.get::<_, i64>(8)?.unsigned_abs(),
+                        is_shielding: row.get(9)?,
+                        expiry_height: row.get(10)?,
+                        tx_index: row.get(11)?,
+                        created: row.get(12)?,
+                        created_time: row.get::<_, i64>(13)?.unsigned_abs(),
+                        spent_orchard_note: row.get(14)?,
+                    })
+                },
+            )
+            .map_err(|e| format!("Query error: {e}"))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Row error: {e}"))
+    }
+
+    /// `get_transaction_history` with its bases read from the synthetic
+    /// `v_transactions` fixture instead of `HISTORY_BASES_CTE`.
+    ///
+    /// Everything else is production code: the real
+    /// `read_history_outputs` and the real `assemble_history`.
+    fn history_from_fixture(
+        db_path: &str,
+        _network: WalletNetwork,
+        limit: Option<u32>,
+        account_uuid: &str,
+    ) -> Result<Vec<TransactionInfo>, String> {
+        let uuid = uuid::Uuid::parse_str(account_uuid).map_err(|e| format!("Invalid UUID: {e}"))?;
+        let uuid_bytes = uuid.as_bytes().to_vec();
+
+        let conn = open_readonly_conn(db_path)?;
+        let read_tx = conn
+            .unchecked_transaction()
+            .map_err(|e| format!("SQL error: {e}"))?;
+        let bases = read_history_bases_via_v_transactions(&read_tx, &uuid_bytes)?;
+        if bases.is_empty() {
+            return Ok(Vec::new());
+        }
+        let outputs_by_txid = read_history_outputs(
+            &read_tx,
+            &uuid_bytes,
+            bases.iter().map(|base| base.txid.as_slice()),
+        )?;
+        drop(read_tx);
+
+        Ok(assemble_history(
+            &bases,
+            &outputs_by_txid,
+            &uuid_bytes,
+            limit,
+        ))
+    }
+
+    /// Pin `HISTORY_BASES_CTE` to the upstream `v_transactions` view.
+    ///
+    /// This is the tripwire for a `zcash_client_sqlite` upgrade that
+    /// changes the view: the CTE inlines the view's aggregates minus
+    /// `transactions.raw`, so the two must return identical rows.
+    ///
+    /// It needs a database built by librustzcash itself — the synthetic
+    /// fixtures in this module define `v_transactions` as a table and
+    /// have none of the note-level schema the CTE reads. Point it at a
+    /// regtest wallet (`./run-regtest-rust-tests.sh` leaves one behind)
+    /// or any real wallet DB:
+    ///
+    /// ```text
+    /// VIZOR_HISTORY_EQUIV_DB=/path/to/zcash_wallet.db \
+    ///   cargo test --lib history_bases_match_v_transactions -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "requires a librustzcash-built wallet DB via VIZOR_HISTORY_EQUIV_DB"]
+    fn history_bases_match_v_transactions() {
+        let db_path = std::env::var("VIZOR_HISTORY_EQUIV_DB")
+            .expect("set VIZOR_HISTORY_EQUIV_DB to a librustzcash-built wallet DB");
+        let conn = open_readonly_conn(&db_path).unwrap();
+
+        let accounts: Vec<Vec<u8>> = conn
+            .prepare("SELECT uuid FROM accounts ORDER BY id")
+            .unwrap()
+            .query_map([], |row| row.get::<_, Vec<u8>>(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert!(
+            !accounts.is_empty(),
+            "{db_path} has no accounts; point at a synced wallet"
+        );
+
+        let mut compared = 0usize;
+        for account in &accounts {
+            let sort = |mut rows: Vec<TxBase>| {
+                rows.sort_by(|a, b| a.txid.cmp(&b.txid));
+                rows
+            };
+            let via_cte = sort(read_history_bases(&conn, account).unwrap());
+            let via_view = sort(read_history_bases_via_v_transactions(&conn, account).unwrap());
+
+            assert_eq!(
+                via_cte.len(),
+                via_view.len(),
+                "account {}: row count differs between HISTORY_BASES_CTE and v_transactions",
+                hex::encode(account)
+            );
+            for (cte, view) in via_cte.iter().zip(via_view.iter()) {
+                assert_eq!(
+                    cte,
+                    view,
+                    "account {} tx {}: HISTORY_BASES_CTE diverged from v_transactions; \
+                     re-check the mirrored SQL against the upstream view definition",
+                    hex::encode(account),
+                    hex::encode(&cte.txid),
+                );
+            }
+            compared += via_cte.len();
+        }
+        println!(
+            "compared {compared} rows across {} accounts",
+            accounts.len()
+        );
+        assert!(compared > 0, "{db_path} has no history rows to compare");
+    }
+
     /// Old `read_history_outputs` filter: DISTINCT txid from
     /// `v_transactions` for the active account. Kept only as the
     /// equivalence oracle for the `rarray(bases)` path.
@@ -3300,7 +3622,11 @@ mod tests {
 
             let conn = open_readonly_conn(db.path().to_str().unwrap()).unwrap();
             let account_bytes = account.as_bytes().as_slice();
-            let bases = read_history_bases(&conn, account_bytes).unwrap();
+            // Bases come from the fixture oracle, not `HISTORY_BASES_CTE`:
+            // this case is about the outputs filter, and the synthetic
+            // schema cannot feed the CTE. The CTE's own agreement with
+            // `v_transactions` is pinned against a real wallet database.
+            let bases = read_history_bases_via_v_transactions(&conn, account_bytes).unwrap();
             let base_txids: HashSet<Vec<u8>> = bases.iter().map(|base| base.txid.clone()).collect();
             let distinct_txids = distinct_v_transactions_txids(&conn, account_bytes).unwrap();
             assert_eq!(
@@ -3384,7 +3710,7 @@ mod tests {
             false,
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             Some(1),
@@ -3436,7 +3762,7 @@ mod tests {
             15_000,
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -3500,7 +3826,7 @@ mod tests {
             10_000,
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -3558,7 +3884,7 @@ mod tests {
             Some(0),
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -3611,7 +3937,7 @@ mod tests {
         insert_received_note_version(&db, &migration_tx, output_index, IRONWOOD_NOTE_VERSION);
         insert_spent_note_version(&db, &migration_tx, ORCHARD_NOTE_VERSION);
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -3659,7 +3985,7 @@ mod tests {
         );
         insert_spent_note_version(&db, &migration_tx, ORCHARD_NOTE_VERSION);
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -3704,7 +4030,7 @@ mod tests {
             false,
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -3748,7 +4074,7 @@ mod tests {
             false,
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -3804,7 +4130,7 @@ mod tests {
             Some(1),
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -3865,7 +4191,7 @@ mod tests {
             None,
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -3937,7 +4263,7 @@ mod tests {
             Some(1),
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -3998,7 +4324,7 @@ mod tests {
             Some(1),
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -4038,7 +4364,7 @@ mod tests {
             true,
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -4106,7 +4432,7 @@ mod tests {
             None,
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -4820,7 +5146,7 @@ mod tests {
             Some(0),
         );
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -4836,7 +5162,7 @@ mod tests {
         assert_eq!(got[2].txid_hex, hex::encode(older_failed));
         assert!(got[2].expired_unmined);
 
-        let limited = get_transaction_history(
+        let limited = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             Some(1),
@@ -4886,7 +5212,7 @@ mod tests {
         );
         insert_output(&db, &pending, 3, None, Some(account), 2_000_000, false);
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             Some(1),
@@ -4938,7 +5264,7 @@ mod tests {
         );
         insert_output(&db, &pending, 3, Some(account), None, 1_000_000, false);
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             Some(1),
@@ -4975,7 +5301,7 @@ mod tests {
         clear_tx_index(&db, &txid);
         insert_output(&db, &txid, 0, Some(account), None, 10_000_000, false);
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,
@@ -5010,7 +5336,7 @@ mod tests {
         set_history_fee(&db, &txid, 10_000);
         insert_output(&db, &txid, 3, Some(account), Some(account), 9_000_000, true);
 
-        let got = get_transaction_history(
+        let got = history_from_fixture(
             db.path().to_str().unwrap(),
             WalletNetwork::Test,
             None,

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -3114,23 +3114,16 @@ mod tests {
         assert_eq!(got.block_height, 333_100);
     }
 
-    /// Read `TxBase` rows straight out of a synthetic `v_transactions`
-    /// table, the way `read_history_bases` did before it inlined the
-    /// view's aggregates as `HISTORY_BASES_CTE`.
+    /// Read `TxBase` from a synthetic `v_transactions` table.
     ///
-    /// The fixtures below populate `v_transactions` with hand-written
-    /// aggregates so a case can be stated directly ("this tx spent
-    /// 1_265_000 and received 1_150_000"). The real schema cannot
-    /// express that in isolation — it derives those sums from notes, so
-    /// a spend always drags in the funding receive as another history
-    /// row, and `account_balance_delta` is forced to
-    /// `total_received - total_spent`. Rebuilding these fixtures on the
-    /// real schema would therefore change what each case asserts.
-    ///
-    /// So the seam is drawn here: this oracle supplies `TxBase` values,
-    /// `assemble_history` (the code under test) does the classifying,
-    /// and `HISTORY_BASES_CTE`'s agreement with the upstream view is
-    /// pinned separately against a librustzcash-built database.
+    /// This is needed because the synthetic `v_transactions` table
+    /// doesn't have the note-derived aggregates that the real
+    /// `HISTORY_BASES_CTE` does. 
+    /// 
+    /// This helper allows us to test `read_history_bases` against the
+    /// synthetic `v_transactions` table.
+    /// 
+    /// The equivalency test checks that the two paths return the same rows.
     fn read_history_bases_via_v_transactions(
         conn: &rusqlite::Connection,
         account_uuid: &[u8],

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -1027,29 +1027,17 @@ fn read_history_base_by_txid(
     Ok(row)
 }
 
-/// Account-scoped stand-in for `v_transactions`, minus `transactions.raw`.
+/// Account-scoped stand-in for `v_transactions`, without `transactions.raw`.
 ///
-/// `v_transactions` selects `transactions.raw` and aggregates over it.
-/// SQLite cannot eliminate that column from inside the view's aggregate,
-/// so every reference materializes every raw transaction blob even when
-/// the caller never reads them, and the outer `account_uuid` predicate
-/// cannot be pushed through the view's `UNION` CTEs to reduce the work.
-/// On a 9-account wallet (1008 txs, ~37 MB of raw blobs) that costs
-/// ~1.8s of CPU per reference; the same rows without `raw`, with the
-/// account filter applied before grouping, cost ~0.04s.
+/// The upstream view aggregates `raw`, so SQLite materializes every blob
+/// and cannot push an outer account filter into the view. This copy drops
+/// `raw`, filters by `?1` early, and keeps the `notes` / `sent_note_counts`
+/// CTEs verbatim so row identity matches.
 ///
-/// This mirrors the upstream view definition exactly except that it
-/// drops `raw` and the columns this module does not read, and filters
-/// by `?1`. The `notes` and `sent_note_counts` CTEs are copied verbatim
-/// so their `UNION` de-duplication keeps identical row identity.
-///
-/// Mirrored from `zcash_client_sqlite` 0.22.0-rc.4, `VIEW_TRANSACTIONS`:
+/// Source: `zcash_client_sqlite` 0.22.0-rc.4 `VIEW_TRANSACTIONS`
 /// <https://github.com/zcash/librustzcash/blob/65a3add2f1d9b9ea455a71a9c33f9219dbc9e614/zcash_client_sqlite/src/wallet/db.rs#L1320-L1438>
 ///
-/// `history_bases_match_v_transactions` pins the two row-for-row. If a
-/// `zcash_client_sqlite` upgrade changes `v_transactions`, that test is
-/// the tripwire — re-check this SQL against the new view definition and
-/// update the permalink above to the new release tag.
+/// `history_bases_match_v_transactions` is the tripwire if the view changes.
 const HISTORY_BASES_CTE: &str = r#"
         WITH vt AS (
             WITH


### PR DESCRIPTION
Stacked on #407 — review that one first; this PR's diff is only the second commit.

## Summary

`read_history_bases` selected from `v_transactions`. That view selects `transactions.raw` and aggregates over it, and SQLite cannot eliminate the column from inside the view's aggregate — so every reference materialized every raw transaction blob even though this path never reads them. The `account_uuid` predicate also could not be pushed through the view's `UNION` CTEs, so filtered and unfiltered counts cost the same.

This mirrors the view's aggregates as `HISTORY_BASES_CTE`, minus `raw` and the columns this module does not read, with the account filter applied before grouping. The `notes` and `sent_note_counts` CTEs are copied verbatim so their `UNION` de-duplication keeps identical row identity.

## Measurements

9-account wallet, 1008 txs, ~5714 Orchard notes, ~37 MB of raw blobs. macOS release build.

| | before #407 | after #407 | this PR |
|---|---|---|---|
| bases query (CPU, isolated) | ~1.8 s | ~1.8 s | **~0.04 s** |
| `get_transaction_history` | 2363–3732 ms | 1102–1198 ms | **46–436 ms (median ~112)** |
| account switch to rendered data | 2754 / 4472 ms | 1451 / 1911 ms | **335 / 374 / 444 / 793 / 976 / 1145 / 1363 ms** |

`getBalance` (205–1249 ms) is now the largest remaining cost and is the natural next target.

## Why the tests moved

The history fixtures define `v_transactions` as a **table** of hand-written aggregates, so a case can be stated directly — "this tx spent 1_265_000 and received 1_150_000". The real schema cannot express that in isolation:

- `notes` builds spent rows by joining `v_received_outputs` to `v_received_output_spends`, so a spent note must have been *received* by an earlier tx on the same account — which is then a history row too.
- `account_balance_delta` is `SUM(notes.value)`, structurally equal to `total_received - total_spent`. Three existing call sites declare values that violate this.
- A tx with no notes cannot appear at all, since the view is `FROM notes JOIN ...`.

25 of the 34 fixture-based tests spend, so rebuilding the fixtures on the real schema would have changed what each of them asserts — and those assertions are the specification of the display logic.

So the seam moved instead:

- `assemble_history` — the whole classification pipeline (summarize, suppress funding steps, classify, filter, sort, truncate) as a pure function over `TxBase` / `TxOutput`, no database.
- `history_from_fixture` — test entry point that feeds bases from the previous `v_transactions` query into the **real** `read_history_outputs` and the **real** `assemble_history`. Existing tests keep their fixtures and assertions verbatim; only the entry point changed, at 20 call sites.
- `history_bases_match_v_transactions` — `#[ignore]`d tripwire comparing `HISTORY_BASES_CTE` to the upstream view field-by-field on a librustzcash-built database.

## Tests

- `cargo test --lib`: **518 passed, 1 failed**. The failure, `expired_broadcasted_without_local_raw_stays_broadcasted_for_store_retry`, is pre-existing and reproduces identically on `main` at 319fc593 — verified in a clean worktree. This is parity with `main`.
- Equivalence tripwire against a 9-account mainnet wallet:

  ```
  VIZOR_HISTORY_EQUIV_DB=/path/to/zcash_wallet.db \
    cargo test --lib history_bases_match_v_transactions -- --ignored --nocapture
  → compared 1026 rows across 9 accounts ... ok
  ```

  Also confirmed it *fails* when the mirrored SQL is perturbed (`SUM(notes.spent_value) + 1`), naming the offending account and txid — so it is a real tripwire, not a vacuous pass.
- The same comparison was run independently through `sqlite3` across all 9 accounts before any Rust was written: md5-identical result sets, 1026 rows.

## Maintenance

`HISTORY_BASES_CTE` carries a permalink to the exact upstream definition it mirrors — `zcash_client_sqlite` 0.22.0-rc.4, `VIEW_TRANSACTIONS`, [`librustzcash@65a3add … db.rs#L1320-L1438`](https://github.com/zcash/librustzcash/blob/65a3add2f1d9b9ea455a71a9c33f9219dbc9e614/zcash_client_sqlite/src/wallet/db.rs#L1320-L1438). The vendored crate source was verified byte-identical to that revision. On a `zcash_client_sqlite` upgrade, run the tripwire and re-check the mirrored SQL.

Unrelated, noticed while here: `AGENTS.md` says `zcash_client_sqlite 0.20.2` but `Cargo.lock` pins `0.22.0-rc.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)