### PR TITLE
Upgrade librustzcash to rc6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,7 +394,7 @@ The entire sync loop runs in Rust (`rust/src/wallet/sync_engine.rs`). A single c
 2. Download subtree roots (sapling + orchard, incremental with start_index optimization)
 3. Download compact blocks into memory (in-memory `MemoryBlockSource`, no file I/O)
 4. `scan_cached_blocks` from memory (100 blocks per batch)
-5. Enhancement: fetch full tx data (`GetStatus`, `Enhancement`, `TransactionsInvolvingAddress`). A status-only (`GetStatus`) request with durable evidence of prior compact-block mining is deferred only while a pending scan range could still restore it. Compact scanning then resolves it locally; normal pending transactions continue through status lookup and resubmission.
+5. Enhancement: fetch full tx data (`GetStatus`, `Enhancement`, `TransactionsInvolvingAddress`). librustzcash persistently requests `GetStatus` only when compact-block scanning cannot observe the transaction's mined state. During recovery, Vizor separately excludes previously mined transactions from resubmission while a pending scan range can still restore their mined heights.
 6. Progress streamed to Dart via FRB `StreamSink` per batch
 
 Single DB connection reused across entire sync (opened once, passed to all operations).

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4459,9 +4459,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.4"
+version = "0.24.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e019c2adb1eb2c3479603f4556e85c01022723f14ce8837a3bb225cb2af4d3f"
+checksum = "832ace878c125814bb9e82228d3661499124c6f2936e60fc1df3c6876eb54624"
 dependencies = [
  "async-trait",
  "base64",
@@ -4514,9 +4514,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.4"
+version = "0.22.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a496ad83b77e790bd0ea1013db14961b3ff825550097a2658837dc7e92a23d53"
+checksum = "c4a789c0038359968f93bfe3952d2b942e3bae5582f79c2f31137c6fd736a225"
 dependencies = [
  "bip32",
  "bitflags",
@@ -4573,9 +4573,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
+checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
 dependencies = [
  "bech32",
  "bip32",
@@ -4616,9 +4616,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e4169a96a25de216d4a7265fe772003aaeea05ed2566b14cfc0b8146b1f99e"
+checksum = "9010904169a92805128b3a8eab0dd4ff79fd164dd416af68aaeac5c7ebbd2522"
 dependencies = [
  "corez",
  "getset",
@@ -4632,6 +4632,7 @@ dependencies = [
  "zcash_keys",
  "zcash_primitives",
  "zcash_protocol",
+ "zip32",
 ]
 
 [[package]]
@@ -4689,9 +4690,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
+checksum = "9f074493fff337207e28bcfa5bbdf0e2a125c4203a4bdd07e72067eea81e9e7b"
 dependencies = [
  "corez",
  "document-features",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -88,7 +88,7 @@ package = "zcash_transparent"
 version = "0.10.0"
 
 [dependencies.zcash_client_backend]
-version = "0.24.0-rc.4"
+version = "0.24.0-rc.6"
 features = [
     "orchard",
     "transparent-inputs",
@@ -99,7 +99,7 @@ features = [
 ]
 
 [dependencies.zcash_client_sqlite]
-version = "0.22.0-rc.4"
+version = "0.22.0-rc.6"
 features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 # Voting clients need PIR lookup support and vote-commitment-tree sync.

--- a/rust/src/wallet/db.rs
+++ b/rust/src/wallet/db.rs
@@ -10,15 +10,6 @@ use crate::wallet::network::WalletNetwork;
 
 pub(crate) type WalletDatabase = WalletDb<rusqlite::Connection, WalletNetwork, SystemClock, OsRng>;
 
-const ORCHARD_IRONWOOD_MIGRATIONS_TABLE: &str = "orchard_ironwood_migrations";
-const ANCHOR_BUCKET_INTERVAL_COLUMN: &str = "anchor_bucket_interval";
-// mobile/v0.0.18 used the production ZIP 318 schedule, whose anchor grid is
-// fixed at 144 blocks. zcash_client_sqlite later made that implicit value
-// persistent without changing the already-applied migration ID
-// 7b2f6a41-9c3d-4e58-8a17-2f6b9d0c4e11, so init_wallet_db cannot repair an
-// existing mobile/v0.0.18 database by itself.
-const ZIP_318_ANCHOR_BUCKET_INTERVAL: u32 = 144;
-
 /// User-driven wallet operations can afford a longer wait for a short sync write.
 pub(crate) const WALLET_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(10);
 /// Account creation/import runs after sync is paused, so a shorter wait exposes real stalls.
@@ -35,7 +26,6 @@ pub(crate) fn open_wallet_db_with_timeout(
     let conn = rusqlite::Connection::open(db_path)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
     configure_wallet_connection(&conn, timeout, true)?;
-    repair_legacy_ironwood_pool_migration_schema(&conn)?;
     Ok(WalletDb::from_connection(conn, network, SystemClock, OsRng))
 }
 
@@ -47,7 +37,6 @@ pub(crate) fn open_wallet_db_for_read_with_timeout(
     let conn = rusqlite::Connection::open(db_path)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
     configure_wallet_connection(&conn, timeout, false)?;
-    repair_legacy_ironwood_pool_migration_schema(&conn)?;
     Ok(WalletDb::from_connection(conn, network, SystemClock, OsRng))
 }
 
@@ -67,59 +56,7 @@ pub(crate) fn open_wallet_raw_conn_with_timeout(
     let conn = rusqlite::Connection::open(db_path)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
     configure_wallet_connection(&conn, timeout, true)?;
-    repair_legacy_ironwood_pool_migration_schema(&conn)?;
     Ok(conn)
-}
-
-fn repair_legacy_ironwood_pool_migration_schema(conn: &rusqlite::Connection) -> Result<(), String> {
-    let table_exists: bool = conn
-        .query_row(
-            "SELECT EXISTS(
-                 SELECT 1 FROM sqlite_schema
-                 WHERE type = 'table' AND name = ?1
-             )",
-            [ORCHARD_IRONWOOD_MIGRATIONS_TABLE],
-            |row| row.get(0),
-        )
-        .map_err(|e| format!("Failed to inspect Ironwood migration schema: {e}"))?;
-    if !table_exists || ironwood_anchor_bucket_column_exists(conn)? {
-        return Ok(());
-    }
-
-    let alter_result = conn.execute_batch(&format!(
-        "ALTER TABLE {ORCHARD_IRONWOOD_MIGRATIONS_TABLE}
-         ADD COLUMN {ANCHOR_BUCKET_INTERVAL_COLUMN} INTEGER NOT NULL
-         DEFAULT {ZIP_318_ANCHOR_BUCKET_INTERVAL};"
-    ));
-    if let Err(error) = alter_result {
-        // A second connection may have repaired the schema after our initial
-        // inspection. Only accept the error when the required column now
-        // exists; otherwise preserve the original failure.
-        if !ironwood_anchor_bucket_column_exists(conn)? {
-            return Err(format!(
-                "Failed to upgrade legacy Ironwood migration schema: {error}"
-            ));
-        }
-    }
-
-    log::info!(
-        "wallet DB compatibility: ensured {ORCHARD_IRONWOOD_MIGRATIONS_TABLE}.{ANCHOR_BUCKET_INTERVAL_COLUMN}"
-    );
-    Ok(())
-}
-
-fn ironwood_anchor_bucket_column_exists(conn: &rusqlite::Connection) -> Result<bool, String> {
-    conn.query_row(
-        "SELECT EXISTS(
-             SELECT 1 FROM pragma_table_info(?1) WHERE name = ?2
-         )",
-        [
-            ORCHARD_IRONWOOD_MIGRATIONS_TABLE,
-            ANCHOR_BUCKET_INTERVAL_COLUMN,
-        ],
-        |row| row.get(0),
-    )
-    .map_err(|e| format!("Failed to inspect Ironwood migration columns: {e}"))
 }
 
 fn configure_wallet_connection(
@@ -238,74 +175,5 @@ mod tests {
         });
 
         assert!(called);
-    }
-
-    #[test]
-    fn repairs_mobile_v0_0_18_ironwood_pool_migration_schema() {
-        let conn = rusqlite::Connection::open_in_memory().unwrap();
-        conn.execute_batch(
-            "CREATE TABLE orchard_ironwood_migrations (
-                 id INTEGER PRIMARY KEY,
-                 account_id INTEGER NOT NULL,
-                 status TEXT NOT NULL,
-                 note_split_fee_buffer INTEGER NOT NULL,
-                 note_split_change INTEGER,
-                 note_split_prep_fees INTEGER NOT NULL,
-                 note_split_total_input INTEGER NOT NULL,
-                 note_split_total_migratable INTEGER NOT NULL
-             );
-             INSERT INTO orchard_ironwood_migrations (
-                 id, account_id, status, note_split_fee_buffer, note_split_change,
-                 note_split_prep_fees, note_split_total_input, note_split_total_migratable
-             ) VALUES (7, 11, 'committed', 1000, NULL, 2000, 3000, 4000);",
-        )
-        .unwrap();
-
-        repair_legacy_ironwood_pool_migration_schema(&conn).unwrap();
-        repair_legacy_ironwood_pool_migration_schema(&conn).unwrap();
-
-        assert!(ironwood_anchor_bucket_column_exists(&conn).unwrap());
-        let repaired: (i64, u32) = conn
-            .query_row(
-                "SELECT id, anchor_bucket_interval
-                 FROM orchard_ironwood_migrations",
-                [],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .unwrap();
-        assert_eq!(repaired, (7, ZIP_318_ANCHOR_BUCKET_INTERVAL));
-    }
-
-    #[test]
-    fn preserves_existing_ironwood_anchor_bucket_interval() {
-        let conn = rusqlite::Connection::open_in_memory().unwrap();
-        conn.execute_batch(
-            "CREATE TABLE orchard_ironwood_migrations (
-                 id INTEGER PRIMARY KEY,
-                 anchor_bucket_interval INTEGER NOT NULL
-             );
-             INSERT INTO orchard_ironwood_migrations
-                 (id, anchor_bucket_interval) VALUES (7, 12);",
-        )
-        .unwrap();
-
-        repair_legacy_ironwood_pool_migration_schema(&conn).unwrap();
-
-        let interval: u32 = conn
-            .query_row(
-                "SELECT anchor_bucket_interval
-                 FROM orchard_ironwood_migrations WHERE id = 7",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(interval, 12);
-    }
-
-    #[test]
-    fn legacy_ironwood_repair_is_noop_before_table_creation() {
-        let conn = rusqlite::Connection::open_in_memory().unwrap();
-        repair_legacy_ironwood_pool_migration_schema(&conn).unwrap();
-        assert!(!ironwood_anchor_bucket_column_exists(&conn).unwrap());
     }
 }

--- a/rust/src/wallet/sync/migration_wallet_ops.rs
+++ b/rust/src/wallet/sync/migration_wallet_ops.rs
@@ -18,7 +18,7 @@ use zcash_client_backend::{
             input_selection::{LockFilter, LockedInputPolicy, NonEmptyBTreeSet},
             ConfirmationsPolicy,
         },
-        InputSource, WalletRead, WalletWrite,
+        InputSource, OutputLockStore, WalletRead,
     },
     wallet::{LockOwner, OutputRef, ReceivedNote},
 };

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -474,10 +474,6 @@ pub(super) struct StoredProposal {
         zcash_client_sqlite::ReceivedNoteId,
     >,
     pub proposed_tx_version: Option<zcash_primitives::transaction::TxVersion>,
-    /// When `true`, the proposal was fee-counted with unpadded Orchard-pool
-    /// bundles (migration children only) and the PCZT must be built with
-    /// `BundlePadding::UNPADDED` to balance. See `zip317_helper`.
-    pub unpadded_orchard_pool_bundles: bool,
     pub network: WalletNetwork,
     pub account_id: AccountUuid,
     pub send_flow_id: String,

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -74,7 +74,7 @@
 use std::convert::Infallible;
 use std::sync::OnceLock;
 
-use zcash_client_backend::data_api::WalletWrite;
+use zcash_client_backend::data_api::OutputLockStore;
 use zcash_primitives::transaction::{builder::BundlePadding, Transaction, TxId};
 use zcash_proofs::prover::LocalTxProver;
 
@@ -308,14 +308,6 @@ pub async fn create_pczt_from_proposal(
         )
         .map_err(|e| format!("Revalidate hardware proposal input locks: {e:?}"))?;
         super::proposal_locks::update_expiry(db_path, current_lock.owner, live_expiry_height)?;
-        // Build with the padding policy the proposal was fee-counted against
-        // (see `StoredProposal::unpadded_orchard_pool_bundles`), so the
-        // builder's balance check matches the proposal's fee.
-        let bundle_padding = if stored.unpadded_orchard_pool_bundles {
-            BundlePadding::UNPADDED
-        } else {
-            BundlePadding::DEFAULT
-        };
         // The transaction version rides on the proposal; expiry is pinned to
         // the live chain tip obtained immediately before this DB operation.
         let proposal_for_pczt = stored
@@ -329,7 +321,7 @@ pub async fn create_pczt_from_proposal(
             OvkPolicy::Sender,
             &proposal_for_pczt,
             Some(live_expiry_height),
-            bundle_padding,
+            BundlePadding::DEFAULT,
         )
         .map_err(|e| format!("Create PCZT failed: {e}"))?;
         let pczt_bytes = pczt
@@ -1803,9 +1795,9 @@ mod tests {
         // compact-PCZT format. Every action sheds `cv_net` and `cmx`, both
         // wallet-decryptable output ciphertexts (the Ironwood migration output
         // AND the deterministic zero-value Orchard output) travel as stripped
-        // memo plaintext, true dummy spends shed `alpha`, and the v6 bundle
-        // anchors and `bsk`s are cleared. The wallet retains the unredacted PCZT
-        // for proof/extraction.
+        // memo plaintext, preauthorized dummy spends retain their signatures
+        // but shed `alpha`, and the v6 bundle anchors and `bsk`s are cleared.
+        // The wallet retains the unredacted PCZT for proof/extraction.
         #[test]
         fn batch_redaction_elides_verified_fields_and_signs_identically() {
             use crate::wallet::sync::pczt::redact_pczt_for_batch_signer;
@@ -1865,7 +1857,10 @@ mod tests {
                         .zip(base.ironwood().actions().iter()),
                 )
             {
-                assert!(action.spend().spend_auth_sig().is_none());
+                assert_eq!(
+                    action.spend().spend_auth_sig(),
+                    base_action.spend().spend_auth_sig(),
+                );
                 assert!(action.cv_net().is_none());
                 assert!(matches!(
                     action.output().enc_ciphertext(),

--- a/rust/src/wallet/sync/proposal_locks.rs
+++ b/rust/src/wallet/sync/proposal_locks.rs
@@ -11,7 +11,7 @@ use std::sync::LazyLock;
 use rand::{rngs::OsRng, RngCore};
 use rusqlite::{params, Connection};
 use zcash_client_backend::{
-    data_api::{WalletRead, WalletWrite},
+    data_api::{OutputLockStore, WalletRead},
     wallet::{LockOwner, OutputRef},
 };
 use zcash_primitives::transaction::TxId;

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -63,8 +63,8 @@ use zcash_client_backend::{
             ConfirmationsPolicy, TargetHeight,
         },
         Account as _, AccountMeta, Balance, CoinbaseFilter, InputSource, MaxSpendMode, NoteFilter,
-        NoteRetention, ReceivedNotes, TargetValue, TransparentKeyOrigin, WalletCommitmentTrees,
-        WalletRead, WalletWrite,
+        NoteRetention, OutputLockStore, ReceivedNotes, TargetValue, TransparentKeyOrigin,
+        WalletCommitmentTrees, WalletRead,
     },
     fees::{
         zip317::{MultiOutputChangeStrategy, Zip317FeeRule},
@@ -754,7 +754,6 @@ pub fn propose_send(
             &migration_locks,
             &spend_policy,
             proposed_tx_version,
-            false,
         )?;
         let (proposal, stored_tx_version) = propose_with_note_version_downgrade(
             pass1_proposal,
@@ -770,7 +769,6 @@ pub fn propose_send(
                     &migration_locks,
                     &spend_policy,
                     tx_version,
-                    false,
                 )
             },
         );
@@ -847,8 +845,6 @@ pub fn propose_send(
                 proposal_id: id,
                 proposal,
                 proposed_tx_version: stored_tx_version,
-                // Regular sends stay padded; only migration children opt in.
-                unpadded_orchard_pool_bundles: false,
                 network,
                 account_id,
                 send_flow_id: send_flow_id.to_string(),
@@ -892,7 +888,6 @@ pub fn estimate_fee(
         &migration_locks,
         &spend_policy,
         proposed_tx_version,
-        false,
     )?;
     // Same two-pass rule as `propose_send`, so the displayed estimate equals
     // the stored proposal's fee.
@@ -908,7 +903,6 @@ pub fn estimate_fee(
                 &migration_locks,
                 &spend_policy,
                 tx_version,
-                false,
             )
         });
 
@@ -3258,9 +3252,7 @@ fn build_shielding_proposal(
         .map_err(|e| format!("Failed to get transparent balances: {e}"))?;
     let (from_addrs, selected_value) = select_shielding_sources(balances, shielding_threshold)?;
 
-    // Regular shielding transactions stay padded (`DEFAULT`); only migration
-    // children opt in to unpadded Orchard-pool bundles.
-    let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None, None, false);
+    let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None);
     let proposal = propose_shielding::<_, _, _, _, Infallible>(
         db,
         &network,
@@ -3311,7 +3303,6 @@ fn propose_send_with_reserved_notes(
     migration_locks: &BTreeSet<(String, u32)>,
     spend_policy: &SpendPolicy,
     proposed_tx_version: Option<TxVersion>,
-    unpadded_orchard_pool_bundles: bool,
 ) -> Result<Proposal<WalletFeeRule, ReceivedNoteId>, String> {
     let confirmations_policy = ConfirmationsPolicy::default();
     let (target_height, anchor_height) = db
@@ -3323,11 +3314,8 @@ fn propose_send_with_reserved_notes(
         reserved,
         migration_locks,
     };
-    let (change_strategy, input_selector) = zip317_helper::<ReservedInputSource<'_>>(
-        None,
-        proposed_tx_version,
-        unpadded_orchard_pool_bundles,
-    );
+    let zip318 = db.pool_migration_params();
+    let (change_strategy, input_selector) = zip317_helper::<ReservedInputSource<'_>>(None);
 
     input_selector
         .propose_transaction(
@@ -3335,6 +3323,7 @@ fn propose_send_with_reserved_notes(
             &reserved_db,
             target_height,
             anchor_height,
+            &zip318,
             confirmations_policy,
             account_id,
             request,
@@ -3525,6 +3514,14 @@ impl InputSource for ReservedInputSource<'_> {
     type Error = <WalletDatabase as InputSource>::Error;
     type AccountId = <WalletDatabase as InputSource>::AccountId;
     type NoteRef = <WalletDatabase as InputSource>::NoteRef;
+
+    fn anchor_computable(
+        &self,
+        protocol: ShieldedPool,
+        height: BlockHeight,
+    ) -> Result<bool, Self::Error> {
+        self.inner.anchor_computable(protocol, height)
+    }
 
     fn get_spendable_note(
         &self,
@@ -5998,8 +5995,6 @@ where
 /// place so the two entry points can't drift.
 fn zip317_helper<DbT: InputSource>(
     change_memo: Option<MemoBytes>,
-    proposed_tx_version: Option<TxVersion>,
-    unpadded_orchard_pool_bundles: bool,
 ) -> (
     MultiOutputChangeStrategy<WalletFeeRule, DbT>,
     GreedyInputSelector<DbT>,
@@ -6014,18 +6009,6 @@ fn zip317_helper<DbT: InputSource>(
             Zatoshis::const_from_u64(1000_0000),
         ),
     );
-    // Migration children only: count exactly the requested actions so the
-    // proposal's fee matches the unpadded bundle the PCZT builder produces.
-    let change_strategy = if unpadded_orchard_pool_bundles {
-        change_strategy.with_unpadded_orchard_pool_bundles()
-    } else {
-        change_strategy
-    };
-    // No V5 legacy-change override is needed anymore: change-pool selection
-    // follows the input pools (an Orchard-input V5 send yields Orchard change)
-    // and enforces the Ironwood turnstile.
-    let _ = proposed_tx_version;
-
     (change_strategy, GreedyInputSelector::new())
 }
 

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -59,7 +59,7 @@ pub(super) async fn run_enhancement(
 ) -> Result<(), SyncError> {
     let mut failed_txids: HashSet<String> = HashSet::new();
 
-    backfill_stored_transparent_fees(client, db, db_path).await?;
+    backfill_stored_fees(client, db, db_path).await?;
 
     for _ in 0..3 {
         let requests = db
@@ -108,11 +108,10 @@ pub(super) async fn run_enhancement(
                                                 "sync: decrypt_and_store_transaction failed: {e}"
                                             );
                                         }
-                                        if let Err(e) =
-                                            fill_missing_transparent_fee(client, db_path, &tx).await
+                                        if let Err(e) = fill_missing_fee(client, db_path, &tx).await
                                         {
                                             log::warn!(
-                                                "sync: transparent fee enhancement failed for {txid_str}: {e}"
+                                                "sync: fee enhancement failed for {txid_str}: {e}"
                                             );
                                         }
                                     }
@@ -205,7 +204,7 @@ pub(super) async fn run_enhancement(
                                                             "sync: decrypt_and_store_transaction (addr) failed: {e}"
                                                         );
                                                     }
-                                                    if let Err(e) = fill_missing_transparent_fee(
+                                                    if let Err(e) = fill_missing_fee(
                                                         &mut fee_client,
                                                         db_path,
                                                         &tx,
@@ -213,7 +212,7 @@ pub(super) async fn run_enhancement(
                                                     .await
                                                     {
                                                         log::warn!(
-                                                            "sync: transparent fee enhancement (addr) failed for {}: {e}",
+                                                            "sync: fee enhancement (addr) failed for {}: {e}",
                                                             tx.txid()
                                                         );
                                                     }
@@ -242,7 +241,7 @@ pub(super) async fn run_enhancement(
 
 /// Backfills fees for stored transactions whose status requests are dormant
 /// while their mined heights are known.
-async fn backfill_stored_transparent_fees(
+async fn backfill_stored_fees(
     client: &mut CompactTxStreamerClient<Channel>,
     db: &WalletDatabase,
     db_path: &str,
@@ -251,10 +250,8 @@ async fn backfill_stored_transparent_fees(
         let txid_str = format!("{txid}");
         match db.get_transaction(txid) {
             Ok(Some(tx)) => {
-                if let Err(e) = fill_missing_transparent_fee(client, db_path, &tx).await {
-                    log::warn!(
-                        "sync: stored transparent fee enhancement failed for {txid_str}: {e}"
-                    );
+                if let Err(e) = fill_missing_fee(client, db_path, &tx).await {
+                    log::warn!("sync: stored fee enhancement failed for {txid_str}: {e}");
                 }
             }
             Ok(None) => {}
@@ -279,6 +276,7 @@ fn stored_transaction_ids_missing_fee(db_path: &str) -> Result<Vec<TxId>, SyncEr
              FROM transactions t
              WHERE t.raw IS NOT NULL
              AND t.fee IS NULL
+             AND (t.tx_index IS NULL OR t.tx_index != 0)
              AND EXISTS (
                  SELECT 1
                  FROM v_transactions vt
@@ -305,25 +303,31 @@ fn request_is_actionable(request: &TransactionDataRequest) -> bool {
     }
 }
 
-async fn fill_missing_transparent_fee(
+async fn fill_missing_fee(
     client: &mut CompactTxStreamerClient<Channel>,
     db_path: &str,
     tx: &Transaction,
 ) -> Result<(), SyncError> {
-    let Some(bundle) = tx.transparent_bundle() else {
-        return Ok(());
-    };
-    if bundle.vin.is_empty() || !should_fill_missing_transparent_fee(db_path, tx)? {
+    if !should_fill_missing_fee(db_path, tx)? {
         return Ok(());
     }
 
-    let prevout_values = fetch_transparent_prevout_values(client, tx).await?;
-    if prevout_values.is_empty() {
-        return Ok(());
-    }
+    // Fully shielded transactions need no parent lookup: their fee is
+    // determined entirely by the public shielded-pool value balances. Persist
+    // that fee too so these rows do not remain in the backfill query forever.
+    let prevout_values = match tx.transparent_bundle() {
+        Some(bundle) if !bundle.vin.is_empty() => {
+            let values = fetch_transparent_prevout_values(client, tx).await?;
+            if values.is_empty() {
+                return Ok(());
+            }
+            values
+        }
+        _ => BTreeMap::new(),
+    };
 
     let Some(fee) = fee_from_prevout_values(tx, &prevout_values)
-        .map_err(|e| SyncError::parse(format!("transparent fee computation failed: {e:?}")))?
+        .map_err(|e| SyncError::parse(format!("fee computation failed: {e:?}")))?
     else {
         return Ok(());
     };
@@ -393,15 +397,15 @@ async fn fetch_transparent_prevout_values(
     Ok(prevout_values)
 }
 
-fn should_fill_missing_transparent_fee(db_path: &str, tx: &Transaction) -> Result<bool, SyncError> {
+fn should_fill_missing_fee(db_path: &str, tx: &Transaction) -> Result<bool, SyncError> {
     let conn = rusqlite::Connection::open(db_path)
         .map_err(|e| SyncError::db(format!("open wallet DB for fee lookup: {e}")))?;
     conn.busy_timeout(SYNC_DB_BUSY_TIMEOUT)
         .map_err(|e| SyncError::db(format!("configure fee lookup busy timeout: {e}")))?;
 
-    // Backfill transaction-level transparent fees for every wallet-relevant
-    // transaction, including receives. Received receipts label this separately
-    // as a network fee because the sender paid it.
+    // Backfill transaction fees for every wallet-relevant transaction,
+    // including receives. Received receipts label this separately as a network
+    // fee because the sender paid it.
     let fillable_rows: i64 = conn
         .query_row(
             "SELECT COUNT(*)
@@ -416,7 +420,7 @@ fn should_fill_missing_transparent_fee(db_path: &str, tx: &Transaction) -> Resul
             rusqlite::params![tx.txid().as_ref()],
             |row| row.get(0),
         )
-        .map_err(|e| SyncError::db(format!("query transparent fee: {e}")))?;
+        .map_err(|e| SyncError::db(format!("query missing fee: {e}")))?;
 
     Ok(fillable_rows > 0)
 }
@@ -436,13 +440,13 @@ fn fee_from_prevout_values(
 
 fn persist_fee_if_missing(db_path: &str, tx: &Transaction, fee: Zatoshis) -> Result<(), SyncError> {
     let fee_zatoshi = i64::try_from(u64::from(fee))
-        .map_err(|_| SyncError::parse("transparent fee exceeded SQLite integer range"))?;
+        .map_err(|_| SyncError::parse("fee exceeded SQLite integer range"))?;
     let conn = rusqlite::Connection::open(db_path)
         .map_err(|e| SyncError::db(format!("open wallet DB for fee update: {e}")))?;
     conn.busy_timeout(SYNC_DB_BUSY_TIMEOUT)
         .map_err(|e| SyncError::db(format!("configure fee update busy timeout: {e}")))?;
 
-    with_wallet_db_write_lock("sync_engine.enhance.persist_transparent_fee", || {
+    with_wallet_db_write_lock("sync_engine.enhance.persist_fee", || {
         conn.execute(
             "UPDATE transactions
              SET fee = ?2
@@ -561,6 +565,23 @@ mod tests {
         transparent_fee_test_tx_and_bytes().0
     }
 
+    fn no_transparent_inputs_test_tx() -> Transaction {
+        use zcash_primitives::transaction::{Authorized, TransactionData, TxVersion};
+
+        TransactionData::<Authorized>::from_parts(
+            TxVersion::V5,
+            BranchId::Nu5,
+            0,
+            BlockHeight::from_u32(1),
+            None,
+            None,
+            None,
+            None,
+        )
+        .freeze()
+        .unwrap()
+    }
+
     fn transparent_fee_test_db(
         tx: &Transaction,
         account_balance_delta: i64,
@@ -646,6 +667,50 @@ mod tests {
     }
 
     #[test]
+    fn coinbase_transaction_is_not_selected_for_fee_backfill() {
+        let mined_height = BlockHeight::from_u32(500);
+        let (file, _db, tx) = scanned_transaction_missing_fee_test_db(mined_height);
+        let conn = rusqlite::Connection::open(file.path()).unwrap();
+        conn.execute(
+            "UPDATE transactions SET tx_index = 0 WHERE txid = ?1",
+            rusqlite::params![tx.txid().as_ref()],
+        )
+        .unwrap();
+
+        assert!(
+            stored_transaction_ids_missing_fee(file.path().to_str().unwrap())
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn fee_without_transparent_inputs_is_persisted() {
+        // Fully shielded transactions follow this path: no transparent
+        // prevouts are required to compute their fee from public value
+        // balances. This minimal transaction isolates that property.
+        let tx = no_transparent_inputs_test_tx();
+        let db = transparent_fee_test_db(&tx, 1);
+        let fee = fee_from_prevout_values(&tx, &BTreeMap::new())
+            .unwrap()
+            .unwrap();
+
+        assert!(should_fill_missing_fee(db.path().to_str().unwrap(), &tx).unwrap());
+        persist_fee_if_missing(db.path().to_str().unwrap(), &tx, fee).unwrap();
+        assert!(!should_fill_missing_fee(db.path().to_str().unwrap(), &tx).unwrap());
+
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        let stored_fee: i64 = conn
+            .query_row(
+                "SELECT fee FROM transactions WHERE txid = ?1",
+                rusqlite::params![tx.txid().as_ref()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored_fee, 0);
+    }
+
+    #[test]
     fn transparent_fee_uses_exact_prevout_output_index() {
         let tx = transparent_fee_test_tx();
         let prevout = tx.transparent_bundle().unwrap().vin[0].prevout().clone();
@@ -673,7 +738,7 @@ mod tests {
         let tx = transparent_fee_test_tx();
         let db = transparent_fee_test_db_with_optional_wallet_row(&tx, None);
 
-        assert!(!should_fill_missing_transparent_fee(db.path().to_str().unwrap(), &tx).unwrap());
+        assert!(!should_fill_missing_fee(db.path().to_str().unwrap(), &tx).unwrap());
     }
 
     #[test]
@@ -681,7 +746,7 @@ mod tests {
         let tx = transparent_fee_test_tx();
         let db = transparent_fee_test_db(&tx, 1_000_000);
 
-        assert!(should_fill_missing_transparent_fee(db.path().to_str().unwrap(), &tx).unwrap());
+        assert!(should_fill_missing_fee(db.path().to_str().unwrap(), &tx).unwrap());
     }
 
     #[test]
@@ -689,7 +754,7 @@ mod tests {
         let tx = transparent_fee_test_tx();
         let db = transparent_fee_test_db(&tx, -40_000);
 
-        assert!(should_fill_missing_transparent_fee(db.path().to_str().unwrap(), &tx).unwrap());
+        assert!(should_fill_missing_fee(db.path().to_str().unwrap(), &tx).unwrap());
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -34,7 +34,7 @@ use zcash_client_backend::{
     },
     proto::service::compact_tx_streamer_client::CompactTxStreamerClient,
 };
-use zcash_primitives::transaction::Transaction;
+use zcash_primitives::transaction::{Transaction, TxId};
 use zcash_protocol::consensus::{BlockHeight, BranchId};
 use zcash_protocol::value::{BalanceError, Zatoshis};
 
@@ -58,6 +58,8 @@ pub(super) async fn run_enhancement(
     network: WalletNetwork,
 ) -> Result<(), SyncError> {
     let mut failed_txids: HashSet<String> = HashSet::new();
+
+    backfill_stored_transparent_fees(client, db, db_path).await?;
 
     for _ in 0..3 {
         let requests = db
@@ -236,6 +238,60 @@ pub(super) async fn run_enhancement(
         }
     }
     Ok(())
+}
+
+/// Backfills fees for stored transactions whose status requests are dormant
+/// while their mined heights are known.
+async fn backfill_stored_transparent_fees(
+    client: &mut CompactTxStreamerClient<Channel>,
+    db: &WalletDatabase,
+    db_path: &str,
+) -> Result<(), SyncError> {
+    for txid in stored_transaction_ids_missing_fee(db_path)? {
+        let txid_str = format!("{txid}");
+        match db.get_transaction(txid) {
+            Ok(Some(tx)) => {
+                if let Err(e) = fill_missing_transparent_fee(client, db_path, &tx).await {
+                    log::warn!(
+                        "sync: stored transparent fee enhancement failed for {txid_str}: {e}"
+                    );
+                }
+            }
+            Ok(None) => {}
+            Err(e) => log::warn!(
+                "sync: could not read stored transaction for fee enhancement {txid_str}: {e}"
+            ),
+        }
+    }
+
+    Ok(())
+}
+
+fn stored_transaction_ids_missing_fee(db_path: &str) -> Result<Vec<TxId>, SyncError> {
+    let conn = rusqlite::Connection::open(db_path)
+        .map_err(|e| SyncError::db(format!("open wallet DB for fee scan: {e}")))?;
+    conn.busy_timeout(SYNC_DB_BUSY_TIMEOUT)
+        .map_err(|e| SyncError::db(format!("configure fee scan busy timeout: {e}")))?;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT t.txid
+             FROM transactions t
+             WHERE t.raw IS NOT NULL
+             AND t.fee IS NULL
+             AND EXISTS (
+                 SELECT 1
+                 FROM v_transactions vt
+                 WHERE vt.txid = t.txid
+             )",
+        )
+        .map_err(|e| SyncError::db(format!("prepare missing fee scan: {e}")))?;
+    let rows = stmt
+        .query_map([], |row| row.get(0).map(TxId::from_bytes))
+        .map_err(|e| SyncError::db(format!("query missing fees: {e}")))?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| SyncError::db(format!("read missing fee transaction: {e}")))
 }
 
 /// Whether servicing `request` can make progress right now. Transaction
@@ -434,6 +490,64 @@ fn transaction_status_from_raw_height(raw_height: u64) -> Result<TransactionStat
 mod tests {
     use super::*;
 
+    fn scanned_transaction_missing_fee_test_db(
+        mined_height: BlockHeight,
+    ) -> (tempfile::NamedTempFile, WalletDatabase, Transaction) {
+        let (tx, raw) = transparent_fee_test_tx_and_bytes();
+        let txid = tx.txid();
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let db_path = file.path().to_str().unwrap();
+        let mut db = crate::wallet::db::open_wallet_db_with_timeout(
+            db_path,
+            WalletNetwork::Regtest,
+            SYNC_DB_BUSY_TIMEOUT,
+        )
+        .unwrap();
+        zcash_client_sqlite::wallet::init::init_wallet_db(&mut db, None).unwrap();
+        db.update_chain_tip(mined_height + 10).unwrap();
+        drop(db);
+
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.execute(
+            "INSERT INTO transactions
+                (txid, mined_height, raw, fee, min_observed_height)
+             VALUES (?1, ?2, ?3, NULL, ?2)",
+            rusqlite::params![txid.as_ref(), u32::from(mined_height), raw],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO accounts
+                (uuid, account_kind, uivk, birthday_height, has_spend_key)
+             VALUES (randomblob(16), 1, 'test-uivk', 1, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sapling_received_notes
+                (transaction_id, output_index, account_id, diversifier, value,
+                 rcm, is_change, commitment_tree_position, recipient_key_scope)
+             SELECT id_tx, 0, 1, X'00', 1, X'00', 1, 1, 1
+             FROM transactions WHERE txid = ?1",
+            rusqlite::params![txid.as_ref()],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO tx_retrieval_queue (txid, query_type)
+             VALUES (?1, 0)",
+            rusqlite::params![txid.as_ref()],
+        )
+        .unwrap();
+        drop(conn);
+
+        let db = crate::wallet::db::open_wallet_db_with_timeout(
+            db_path,
+            WalletNetwork::Regtest,
+            SYNC_DB_BUSY_TIMEOUT,
+        )
+        .unwrap();
+        (file, db, tx)
+    }
+
     fn transparent_fee_test_tx_and_bytes() -> (Transaction, Vec<u8>) {
         let tx_bytes = hex::decode(
             "0400008085202f8901aee37187e843da597683c26c01457f5fd3b1a038996ef74dc8d60d483aaf395a000000006b483045022100874c70db77ea9e93f75cc83a9e141e17c8eb97588e29fe4e307631fdde4f162a02203493df62d648cd86a1189eaf9bcafc652bc14c5df02519d9e45e25b32aaffb5b012102106a2dcaaac2ae3b24358a03f4264e05db420c5b090399bc23885fa02fef7716ffffffff02764e1900000000001976a914fb451987556f7a19b726966ee6cff917e0bb3bfb88ac560ca400000000001976a9141634f5ff0b8f6603a17570436d6c12a91f4b1fed88ac00000000000000000000000000000000000000",
@@ -512,6 +626,23 @@ mod tests {
                 GetTransactionErrorAction::RetryAsNetwork,
             );
         }
+    }
+
+    #[test]
+    fn scanned_transaction_missing_fee_is_selected_when_status_request_is_dormant() {
+        let mined_height = BlockHeight::from_u32(500);
+        let (file, db, tx) = scanned_transaction_missing_fee_test_db(mined_height);
+        let txid = tx.txid();
+
+        assert!(!db
+            .transaction_data_requests()
+            .unwrap()
+            .contains(&TransactionDataRequest::GetStatus(txid)));
+        assert_eq!(
+            stored_transaction_ids_missing_fee(file.path().to_str().unwrap()).unwrap(),
+            vec![txid]
+        );
+        assert_eq!(db.get_transaction(txid).unwrap().unwrap().txid(), txid);
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -34,7 +34,7 @@ use zcash_client_backend::{
     },
     proto::service::compact_tx_streamer_client::CompactTxStreamerClient,
 };
-use zcash_primitives::transaction::{Transaction, TxId};
+use zcash_primitives::transaction::Transaction;
 use zcash_protocol::consensus::{BlockHeight, BranchId};
 use zcash_protocol::value::{BalanceError, Zatoshis};
 
@@ -44,9 +44,8 @@ use crate::wallet::network::WalletNetwork;
 use super::{lwd, SyncError, WalletDatabase};
 
 /// Services `db.transaction_data_requests()` against lightwalletd until
-/// the queue is empty or no request is actionable. Status-only requests
-/// in `deferred_status_txids` remain queued for compact scanning. Returns
-/// `SyncError::Db` if `db.transaction_data_requests()` itself fails.
+/// the queue is empty or no request is actionable. Returns `SyncError::Db`
+/// if `db.transaction_data_requests()` itself fails.
 /// Per-request failures are split by semantics: an explicit
 /// "txid not recognized" response is recorded via
 /// `set_transaction_status` so it doesn't get retried forever, while
@@ -57,7 +56,6 @@ pub(super) async fn run_enhancement(
     db: &mut WalletDatabase,
     db_path: &str,
     network: WalletNetwork,
-    deferred_status_txids: &HashSet<Vec<u8>>,
 ) -> Result<(), SyncError> {
     let mut failed_txids: HashSet<String> = HashSet::new();
 
@@ -73,9 +71,7 @@ pub(super) async fn run_enhancement(
         // requests without an `end` height, which we can't service
         // without synthesizing a range), break rather than looping
         // forever on the same inert queue.
-        let actionable = requests
-            .iter()
-            .any(|request| request_is_actionable(request, deferred_status_txids));
+        let actionable = requests.iter().any(request_is_actionable);
         if !actionable {
             break;
         }
@@ -83,57 +79,10 @@ pub(super) async fn run_enhancement(
         for req in &requests {
             match req {
                 TransactionDataRequest::GetStatus(txid)
-                    if deferred_status_txids.contains(txid.as_ref().as_slice()) =>
-                {
-                    continue
-                }
-                TransactionDataRequest::GetStatus(txid)
                 | TransactionDataRequest::Enhancement(txid) => {
                     let txid_str = format!("{txid}");
                     if failed_txids.contains(&txid_str) {
                         continue;
-                    }
-
-                    if matches!(req, TransactionDataRequest::GetStatus(_)) {
-                        match scanned_mined_height(db, *txid) {
-                            Ok(Some(mined_height)) => {
-                                let can_resolve_locally = match db.get_transaction(*txid) {
-                                    Ok(Some(tx)) => {
-                                        if let Err(e) =
-                                            fill_missing_transparent_fee(client, db_path, &tx).await
-                                        {
-                                            log::warn!(
-                                                "sync: transparent fee enhancement failed for {txid_str}: {e}"
-                                            );
-                                        }
-                                        true
-                                    }
-                                    Ok(None) => true,
-                                    Err(e) => {
-                                        log::error!(
-                                            "sync: could not read stored transaction for local status resolution: {e}"
-                                        );
-                                        false
-                                    }
-                                };
-                                if can_resolve_locally {
-                                    match resolve_status_from_scanned_height(
-                                        db,
-                                        *txid,
-                                        mined_height,
-                                    ) {
-                                        Ok(()) => continue,
-                                        Err(e) => log::error!(
-                                            "sync: could not resolve transaction status locally: {e}"
-                                        ),
-                                    }
-                                }
-                            }
-                            Ok(None) => {}
-                            Err(e) => log::error!(
-                                "sync: could not read locally restored transaction status: {e}"
-                            ),
-                        }
                     }
 
                     match lwd::get_transaction(client, txid.as_ref().to_vec()).await {
@@ -289,44 +238,15 @@ pub(super) async fn run_enhancement(
     Ok(())
 }
 
-/// Whether servicing `request` can make progress right now: full-data
-/// enhancements always can, status-only requests unless their transaction is
-/// deferred for compact scanning, and address-scoped requests only when they
-/// carry a bounded block range.
-fn request_is_actionable(
-    request: &TransactionDataRequest,
-    deferred_status_txids: &HashSet<Vec<u8>>,
-) -> bool {
+/// Whether servicing `request` can make progress right now. Transaction
+/// requests always can; address-scoped requests need a bounded block range.
+fn request_is_actionable(request: &TransactionDataRequest) -> bool {
     match request {
-        TransactionDataRequest::Enhancement(_) => true,
-        TransactionDataRequest::GetStatus(txid) => {
-            !deferred_status_txids.contains(txid.as_ref().as_slice())
-        }
+        TransactionDataRequest::Enhancement(_) | TransactionDataRequest::GetStatus(_) => true,
         TransactionDataRequest::TransactionsInvolvingAddress(req) => {
             req.block_range_end().is_some()
         }
     }
-}
-
-fn scanned_mined_height(db: &WalletDatabase, txid: TxId) -> Result<Option<BlockHeight>, SyncError> {
-    db.get_tx_height(txid)
-        .map_err(|e| SyncError::db(format!("get transaction height: {e}")))
-}
-
-/// Re-asserts a compact-scan-restored mined status after any missing fee has
-/// been backfilled, which also dequeues the `GetStatus` request.
-fn resolve_status_from_scanned_height(
-    db: &mut WalletDatabase,
-    txid: TxId,
-    mined_height: BlockHeight,
-) -> Result<(), SyncError> {
-    with_wallet_db_write_lock(
-        "sync_engine.enhance.set_known_mined_transaction_status",
-        || {
-            db.set_transaction_status(txid, TransactionStatus::Mined(mined_height))
-                .map_err(|e| SyncError::db(format!("set known mined transaction status: {e}")))
-        },
-    )
 }
 
 async fn fill_missing_transparent_fee(
@@ -514,69 +434,6 @@ fn transaction_status_from_raw_height(raw_height: u64) -> Result<TransactionStat
 mod tests {
     use super::*;
 
-    /// Builds a real migrated wallet DB containing one transaction with a
-    /// known mined height plus an explicit status-type retrieval-queue entry
-    /// for it, mirroring the post-recovery state `resolve_status_from_scanned_height`
-    /// services.
-    fn status_recovery_test_db(
-        mined_height: BlockHeight,
-        fee: Option<i64>,
-    ) -> (tempfile::NamedTempFile, WalletDatabase, Transaction) {
-        let (tx, raw) = transparent_fee_test_tx_and_bytes();
-        let txid = tx.txid();
-        let file = tempfile::NamedTempFile::new().unwrap();
-        let db_path = file.path().to_str().unwrap();
-        let mut db = crate::wallet::db::open_wallet_db_with_timeout(
-            db_path,
-            WalletNetwork::Regtest,
-            SYNC_DB_BUSY_TIMEOUT,
-        )
-        .unwrap();
-        zcash_client_sqlite::wallet::init::init_wallet_db(&mut db, None).unwrap();
-        db.update_chain_tip(mined_height + 10).unwrap();
-        drop(db);
-
-        let conn = rusqlite::Connection::open(db_path).unwrap();
-        conn.execute(
-            "INSERT INTO transactions
-                (txid, mined_height, raw, fee, min_observed_height)
-             VALUES (?1, ?2, ?3, ?4, ?2)",
-            rusqlite::params![txid.as_ref(), u32::from(mined_height), raw, fee],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO accounts
-                (uuid, account_kind, uivk, birthday_height, has_spend_key)
-             VALUES (randomblob(16), 1, 'test-uivk', 1, 0)",
-            [],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO sapling_received_notes
-                (transaction_id, output_index, account_id, diversifier, value,
-                 rcm, is_change, commitment_tree_position, recipient_key_scope)
-             SELECT id_tx, 0, 1, X'00', 1, X'00', 1, 1, 1
-             FROM transactions WHERE txid = ?1",
-            rusqlite::params![txid.as_ref()],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO tx_retrieval_queue (txid, query_type)
-             VALUES (?1, 0)",
-            rusqlite::params![txid.as_ref()],
-        )
-        .unwrap();
-        drop(conn);
-
-        let db = crate::wallet::db::open_wallet_db_with_timeout(
-            db_path,
-            WalletNetwork::Regtest,
-            SYNC_DB_BUSY_TIMEOUT,
-        )
-        .unwrap();
-        (file, db, tx)
-    }
-
     fn transparent_fee_test_tx_and_bytes() -> (Transaction, Vec<u8>) {
         let tx_bytes = hex::decode(
             "0400008085202f8901aee37187e843da597683c26c01457f5fd3b1a038996ef74dc8d60d483aaf395a000000006b483045022100874c70db77ea9e93f75cc83a9e141e17c8eb97588e29fe4e307631fdde4f162a02203493df62d648cd86a1189eaf9bcafc652bc14c5df02519d9e45e25b32aaffb5b012102106a2dcaaac2ae3b24358a03f4264e05db420c5b090399bc23885fa02fef7716ffffffff02764e1900000000001976a914fb451987556f7a19b726966ee6cff917e0bb3bfb88ac560ca400000000001976a9141634f5ff0b8f6603a17570436d6c12a91f4b1fed88ac00000000000000000000000000000000000000",
@@ -655,62 +512,6 @@ mod tests {
                 GetTransactionErrorAction::RetryAsNetwork,
             );
         }
-    }
-
-    #[test]
-    fn deferred_status_requests_do_not_block_full_data_enhancement() {
-        let deferred = HashSet::from([vec![1; 32]]);
-        assert!(!request_is_actionable(
-            &TransactionDataRequest::GetStatus(TxId::from_bytes([1; 32])),
-            &deferred,
-        ));
-        assert!(request_is_actionable(
-            &TransactionDataRequest::GetStatus(TxId::from_bytes([2; 32])),
-            &deferred,
-        ));
-        assert!(request_is_actionable(
-            &TransactionDataRequest::Enhancement(TxId::from_bytes([1; 32])),
-            &deferred,
-        ));
-    }
-
-    #[test]
-    fn scanned_height_resolves_status_without_transaction_download() {
-        let mined_height = BlockHeight::from_u32(500);
-        let (_file, mut db, tx) = status_recovery_test_db(mined_height, Some(0));
-        let txid = tx.txid();
-
-        assert!(db
-            .transaction_data_requests()
-            .unwrap()
-            .contains(&TransactionDataRequest::GetStatus(txid)));
-        assert_eq!(scanned_mined_height(&db, txid).unwrap(), Some(mined_height));
-        resolve_status_from_scanned_height(&mut db, txid, mined_height).unwrap();
-        assert!(!db
-            .transaction_data_requests()
-            .unwrap()
-            .contains(&TransactionDataRequest::GetStatus(txid)));
-        assert_eq!(db.get_tx_height(txid).unwrap(), Some(mined_height));
-    }
-
-    #[test]
-    fn scanned_status_loads_missing_fee_input_before_dequeue() {
-        let mined_height = BlockHeight::from_u32(500);
-        let (file, mut db, tx) = status_recovery_test_db(mined_height, None);
-        let txid = tx.txid();
-
-        assert_eq!(db.get_transaction(txid).unwrap().unwrap().txid(), txid);
-        assert!(should_fill_missing_transparent_fee(file.path().to_str().unwrap(), &tx).unwrap());
-        assert!(db
-            .transaction_data_requests()
-            .unwrap()
-            .contains(&TransactionDataRequest::GetStatus(txid)));
-
-        resolve_status_from_scanned_height(&mut db, txid, mined_height).unwrap();
-        assert!(!db
-            .transaction_data_requests()
-            .unwrap()
-            .contains(&TransactionDataRequest::GetStatus(txid)));
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -373,7 +373,7 @@ fn is_pending_scan_range(range: &ScanRange) -> bool {
     range.priority() != ScanPriority::Ignored && range.priority() != ScanPriority::Scanned
 }
 
-fn deferred_status_txids(
+fn recovery_resubmit_exclusions(
     db_path: &str,
     ranges: &[ScanRange],
 ) -> Result<HashSet<Vec<u8>>, SyncError> {
@@ -1651,12 +1651,13 @@ async fn run_sync_impl(
         let startup_ranges = db
             .suggest_scan_ranges()
             .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?;
-        let startup_deferred_status_txids = deferred_status_txids(db_data_path, &startup_ranges)?;
+        let startup_resubmit_exclusions =
+            recovery_resubmit_exclusions(db_data_path, &startup_ranges)?;
         let _ = crate::wallet::sync::resubmit_pending_transactions(
             db_data_path,
             &mut client,
             tip.height as u32,
-            &startup_deferred_status_txids,
+            &startup_resubmit_exclusions,
             || {
                 cancel.load(Ordering::Relaxed)
                     || desired_mode.load(Ordering::SeqCst) != running_mode
@@ -2351,22 +2352,15 @@ async fn run_sync_impl(
 
         // Truncation can temporarily clear a transaction's mined height while
         // retaining note positions that prove compact scanning found it mined.
-        // Let scanning restore those statuses without blocking normal pending
-        // transaction lookups.
+        // Exclude those transactions from recovery resubmission while scanning
+        // can still restore their mined heights.
         let post_scan_ranges = db
             .suggest_scan_ranges()
             .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?;
-        let deferred_status_txids = deferred_status_txids(db_data_path, &post_scan_ranges)?;
+        let resubmit_exclusions = recovery_resubmit_exclusions(db_data_path, &post_scan_ranges)?;
 
         // Enhancement
-        run_enhancement(
-            &mut client,
-            &mut db,
-            db_data_path,
-            network,
-            &deferred_status_txids,
-        )
-        .await?;
+        run_enhancement(&mut client, &mut db, db_data_path, network).await?;
 
         // Post-batch auto-resubmit. Matches zcash-android-wallet-sdk's
         // lines 593/701 call sites (end of verify batch / end of
@@ -2449,7 +2443,7 @@ async fn run_sync_impl(
                         db_data_path,
                         &mut client,
                         fresh_tip_height,
-                        &deferred_status_txids,
+                        &resubmit_exclusions,
                         || {
                             cancel.load(Ordering::Relaxed)
                                 || desired_mode.load(Ordering::SeqCst) != running_mode


### PR DESCRIPTION
Upgrade the released librustzcash client crates from rc4 to rc6 and adapt Vizor to the current output-locking, ZIP 318 proposal, and PCZT padding APIs.\n\nrc6 makes transaction status observation explicit and durable, so this removes Vizor’s now-redundant status deferral and local-resolution layer while retaining the separate recovery resubmission safeguard from the merged recovery fix. It also drops the local anchor-column compatibility shim now handled by the upstream SQLite migration.\n\nBecause mined status intents are dormant after compact scanning restores a transaction, Vizor now backfills missing fees from stored raw transactions independently of status requests. Fees that need no transparent prevout lookup are persisted locally, and coinbase rows are excluded so shielded history is not reparsed after every scan batch.