### PR TITLE
Coalesce concurrent balance refreshes

### DIFF
--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -1438,11 +1438,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _stopMempoolObserver();
     _mempoolRefreshInFlight = false;
     _mempoolRefreshQueued = false;
-    // Drop any queued follow-up pass. `_balanceRefreshInFlight` is left to
-    // the running pass's `finally`: clearing it here would let a new pass
-    // start alongside the one still unwinding. The loop's `!_requiresUnlock`
-    // guard stops it after the current iteration, and `_refreshBalance`
-    // bails immediately while locked.
+    // Drop any queued follow-up. Leave `_balanceRefreshInFlight` to the
+    // running pass's `finally` so a new pass cannot start alongside it.
     _balanceRefreshQueued = false;
     _balanceRefreshQueuedReleaseSnapshot = false;
     state = AsyncData(SyncState());

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -598,15 +598,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   StreamSubscription? _mempoolSub;
   bool _mempoolRefreshInFlight = false;
   bool _mempoolRefreshQueued = false;
-  // Single-flight for balance/history refreshes. Every trigger (account
-  // switch, unlock, resume, mempool, sync completion, recovery) funnels
-  // through `_requestBalanceRefresh`, so overlapping triggers cannot each
-  // pay for a full `getBalance` + `getTransactionHistory` pass.
-  //
-  // Trailing, not just joining: a request that arrives mid-flight queues
-  // one more pass instead of adopting the in-flight result, because that
-  // result may have been read before the event that triggered it (a send,
-  // say). Callers still await data that reflects their trigger.
+  // Coalesce balance/history refreshes through `_requestBalanceRefresh`.
+  // Mid-flight requests queue one trailing pass so callers don't adopt a
+  // stale in-flight result.
   bool _balanceRefreshInFlight = false;
   bool _balanceRefreshQueued = false;
   bool _balanceRefreshQueuedReleaseSnapshot = false;

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -598,6 +598,19 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   StreamSubscription? _mempoolSub;
   bool _mempoolRefreshInFlight = false;
   bool _mempoolRefreshQueued = false;
+  // Single-flight for balance/history refreshes. Every trigger (account
+  // switch, unlock, resume, mempool, sync completion, recovery) funnels
+  // through `_requestBalanceRefresh`, so overlapping triggers cannot each
+  // pay for a full `getBalance` + `getTransactionHistory` pass.
+  //
+  // Trailing, not just joining: a request that arrives mid-flight queues
+  // one more pass instead of adopting the in-flight result, because that
+  // result may have been read before the event that triggered it (a send,
+  // say). Callers still await data that reflects their trigger.
+  bool _balanceRefreshInFlight = false;
+  bool _balanceRefreshQueued = false;
+  bool _balanceRefreshQueuedReleaseSnapshot = false;
+  Future<void>? _balanceRefreshChain;
 
   @override
   Future<SyncState> build() async {
@@ -606,7 +619,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _lifecycleListener = AppLifecycleListener(
       onResume: () {
         _isInForeground = true;
-        _refreshBalance();
+        unawaited(_requestBalanceRefresh());
         _checkAndSync();
       },
       onHide: () {
@@ -1431,6 +1444,13 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _stopMempoolObserver();
     _mempoolRefreshInFlight = false;
     _mempoolRefreshQueued = false;
+    // Drop any queued follow-up pass. `_balanceRefreshInFlight` is left to
+    // the running pass's `finally`: clearing it here would let a new pass
+    // start alongside the one still unwinding. The loop's `!_requiresUnlock`
+    // guard stops it after the current iteration, and `_refreshBalance`
+    // bails immediately while locked.
+    _balanceRefreshQueued = false;
+    _balanceRefreshQueuedReleaseSnapshot = false;
     state = AsyncData(SyncState());
 
     // Sign-out should cancel the current Rust run immediately so unlock
@@ -1685,7 +1705,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       do {
         _mempoolRefreshQueued = false;
         try {
-          await _refreshBalance();
+          await _requestBalanceRefresh();
         } catch (e, st) {
           log('Mempool: refresh failed: $e\n$st');
         }
@@ -2097,9 +2117,55 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
   /// Public: refresh balance and recent transactions (e.g. after send).
   Future<void> refreshAfterSend() =>
-      _refreshBalance(releaseSnapshotOnAuthoritativeBalance: true);
+      _requestBalanceRefresh(releaseSnapshotOnAuthoritativeBalance: true);
 
-  Future<void> refreshAfterUnlock() => _refreshBalance();
+  Future<void> refreshAfterUnlock() => _requestBalanceRefresh();
+
+  /// Coalesce concurrent refresh triggers into one running pass.
+  ///
+  /// Returns a future that completes once a pass that started *after*
+  /// this call's trigger has finished, so awaiting it still yields data
+  /// reflecting the caller's event.
+  Future<void> _requestBalanceRefresh({
+    bool releaseSnapshotOnAuthoritativeBalance = false,
+  }) {
+    if (releaseSnapshotOnAuthoritativeBalance) {
+      _balanceRefreshQueuedReleaseSnapshot = true;
+    }
+    if (_balanceRefreshInFlight) {
+      _balanceRefreshQueued = true;
+      // Non-null whenever a pass is in flight; the fallback keeps this
+      // total if the two ever drift.
+      return _balanceRefreshChain ?? Future<void>.value();
+    }
+
+    _balanceRefreshInFlight = true;
+    final chain = _runCoalescedBalanceRefresh();
+    _balanceRefreshChain = chain;
+    return chain;
+  }
+
+  Future<void> _runCoalescedBalanceRefresh() async {
+    try {
+      do {
+        _balanceRefreshQueued = false;
+        final releaseSnapshot = _balanceRefreshQueuedReleaseSnapshot;
+        _balanceRefreshQueuedReleaseSnapshot = false;
+        try {
+          await _refreshBalance(
+            releaseSnapshotOnAuthoritativeBalance: releaseSnapshot,
+          );
+        } catch (e, st) {
+          log('SyncNotifier: coalesced balance refresh failed: $e\n$st');
+        }
+      } while (_balanceRefreshQueued && !_requiresUnlock);
+    } finally {
+      _balanceRefreshInFlight = false;
+      _balanceRefreshQueued = false;
+      _balanceRefreshQueuedReleaseSnapshot = false;
+      _balanceRefreshChain = null;
+    }
+  }
 
   Future<void> _ensureAuthoritativeBalanceRecovery() {
     final existing = _authoritativeBalanceRecovery;
@@ -2145,7 +2211,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       if (syncInProgress) continue;
 
       try {
-        await _refreshBalance();
+        await _requestBalanceRefresh();
       } catch (e, st) {
         log('SyncNotifier: authoritative balance recovery failed: $e\n$st');
       }


### PR DESCRIPTION
Third in the stack — #407 → #408 → this. Review those first; this PR's diff is only the third commit.

## Summary

Account switch, unlock, resume, mempool updates, and authoritative balance recovery each called `_refreshBalance` directly. Overlapping triggers therefore ran concurrent passes, each paying a full `getBalance` + `getTransactionHistory`. Profiling an account switch showed the queries from separate passes interleaving and contending on the wallet DB.

Every trigger now funnels through `_requestBalanceRefresh`, following the `_mempoolRefresh*` single-flight already in this file.

## Trailing, not joining

A request arriving mid-flight schedules **one more pass** rather than adopting the in-flight result. That result may have been read before the event which triggered the new request — a send, for example — so joining would hand `refreshAfterSend` a pre-send balance. Callers awaiting the returned future still observe data reflecting their own trigger.

The trade-off is explicit: two genuinely distinct triggers now run sequentially rather than concurrently. Total work is unchanged and no longer self-contending, but a switch that queues a follow-up waits for both passes. One such switch appears in the measurements below at 1450 ms.

## Lock handling

`clearSensitiveStateForLock` drops the queued follow-up but deliberately leaves `_balanceRefreshInFlight` to the running pass's `finally`. Clearing it there would let a new pass start alongside the one still unwinding — which is why this does not simply mirror the adjacent `_mempoolRefresh*` reset. The loop's `!_requiresUnlock` guard ends it after the current iteration, and `_refreshBalance` already bails immediately while locked.

## Measurements

macOS release, 9-account mainnet wallet, 14 switches.

| | before | after |
|---|---|---|
| `getTransactionHistory` | 46–436 ms (median ~112) | **48–251 ms (median ~70)** |
| `ui.TOTAL_TO_DATA` median | 793 ms | 629 ms |
| `getBalance` | 205–1249 ms | 295–1704 ms |

The structural result is the reliable one: interleaved passes are gone, and every refresh is now a strictly sequential `getBalance → getTransactionHistory`. `getTransactionHistory` tightened as contention dropped.

The median shift (793 → 629 ms) is **suggestive rather than proven** — sample sizes differ and background sync activity varied between runs. The observed max got worse (1974 ms), driven by a single 1704 ms `getBalance`, which is sync contention on that call and not attributable to this change.

## What this does not fix

`getBalance` is now 75–86% of every switch and is untouched here. This change confirms it is **one** call rather than several overlapping ones, which is what we needed to know before deciding how to attack it.

`get_wallet_summary` computes balances for *all* accounts internally and returns an `account_balances` map, while we read one account's slice. Returning the whole map and populating every account from it is the obvious next step and carries no staleness risk. Still unmeasured: whether the cost is that per-account fan-out or the `v_{pool}_shards_scan_state` views, which fan-out reuse would not help.

## Tests

- `flutter analyze`: clean.
- `flutter test test/providers/`: 207 passed.
- Behaviour verified by hand across 14 account switches on a 9-account mainnet wallet; no `coalesced balance refresh failed` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)