### PR TITLE
Diversify migration submission endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,23 +55,26 @@ fvm flutter build macos --release \
 change source. Open-source builds should use the public CoinGecko base URL
 above; production builds can point this define at a Vizor-operated proxy.
 
-Ironwood migrations can submit both their locally complete preparation
-transactions and their Phase 2 pool-crossing transactions through a separate
-JSON-RPC relay. Managed mainnet configurations use
+Ironwood migrations choose a separate transaction-submission target for both
+their locally complete preparation transactions and their Phase 2
+pool-crossing transactions. The candidate pool contains a configured JSON-RPC
+relay plus managed lightwalletd endpoints on the same network whose host is
+different from the sync host. Mainnet includes
 `https://zakura-broadcast.valargroup.dev` by default. Set the matching build
-define to override it or to enable relaying on another network:
+define to override that relay or to enable one on another network:
 
 - `VIZOR_ZCASH_TRANSACTION_RELAY_URL_MAIN`
 - `VIZOR_ZCASH_TRANSACTION_RELAY_URL_TEST`
 - `VIZOR_ZCASH_TRANSACTION_RELAY_URL_REGTEST`
 - `VIZOR_ZCASH_TRANSACTION_RELAY_URL_IRONWOOD_MASQUERADE`
 
-An unset or empty testnet, regtest, or Ironwood Masquerade value keeps the
-existing lightwalletd path for new migrations. The relay is used only with a
-built-in lightwalletd preset; a custom lightwalletd selection always keeps the
-existing submission flow. A migration keeps the submission route it started
-with, so changing or removing the define does not reroute its later preparation
-or Phase 2 transactions. Test builds can opt into the testnet Zakura relay with
+The target is selected once and persisted with the migration run, so changing
+the sync endpoint or build define does not reroute later preparation or Phase 2
+transactions. Managed alternatives are available even when the sync endpoint
+is custom, and an alternate lightwalletd target is rejected if its host matches
+the current sync host. Regtest and Ironwood Masquerade builds keep the existing
+lightwalletd path only when no compatible separate target exists. Test builds
+can opt into the testnet Zakura relay with
 `VIZOR_ZCASH_TRANSACTION_RELAY_URL_TEST=https://zakura-broadcast.testnet.valargroup.dev`.
 Production relays should use HTTPS, expose only transaction submission, disable
 request-body logging, and avoid redirects.

--- a/ios/Runner/BackgroundMigrationOutbox.swift
+++ b/ios/Runner/BackgroundMigrationOutbox.swift
@@ -84,7 +84,7 @@ struct BackgroundMigrationOutboxBatch: Codable, Equatable {
   let accountUuid: String
   let runId: String
   var lightwalletdUrl: String
-  let transactionRelayUrl: String?
+  let transactionSubmissionTarget: String?
   let timingMeanBlocks: UInt64
   let timingMaxBlocks: UInt64
   let createdAt: Date
@@ -120,6 +120,39 @@ struct BackgroundMigrationOutboxBatch: Codable, Equatable {
   }
 }
 
+enum BackgroundMigrationSubmissionTarget: Equatable {
+  private static let relayPrefix = "relay:"
+  private static let lightwalletdPrefix = "lightwalletd:"
+
+  case relay(String)
+  case lightwalletd(String)
+
+  init?(encoded: String, syncLightwalletdUrl: String) {
+    if encoded.hasPrefix(Self.relayPrefix) {
+      let endpoint = String(encoded.dropFirst(Self.relayPrefix.count))
+      guard NativeTransactionRelayClient.relayURL(endpoint) != nil else {
+        return nil
+      }
+      self = .relay(endpoint)
+      return
+    }
+    if encoded.hasPrefix(Self.lightwalletdPrefix) {
+      let endpoint = String(encoded.dropFirst(Self.lightwalletdPrefix.count))
+      guard
+        NativeLightwalletdClient.transactionSubmissionURL(
+          endpoint: endpoint,
+          syncEndpoint: syncLightwalletdUrl
+        ) != nil
+      else {
+        return nil
+      }
+      self = .lightwalletd(endpoint)
+      return
+    }
+    return nil
+  }
+}
+
 struct BackgroundMigrationOutboxScheduleUpdate: Codable, Equatable {
   let itemId: String
   let scheduledHeight: UInt64
@@ -147,7 +180,7 @@ struct BackgroundMigrationOutboxSelection: Equatable {
   let accountUuid: String
   let scopeKey: String
   let lightwalletdUrl: String
-  let transactionRelayUrl: String?
+  let transactionSubmissionTarget: String?
   let item: BackgroundMigrationOutboxItem
 }
 
@@ -216,7 +249,12 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
       !batch.accountUuid.isEmpty,
       !batch.runId.isEmpty,
       !batch.lightwalletdUrl.isEmpty,
-      batch.transactionRelayUrl?.isEmpty != true,
+      batch.transactionSubmissionTarget.map({
+        BackgroundMigrationSubmissionTarget(
+          encoded: $0,
+          syncLightwalletdUrl: batch.lightwalletdUrl
+        ) != nil
+      }) ?? true,
       batch.timingMeanBlocks > 0,
       batch.timingMaxBlocks > 0,
       batch.timingMeanBlocks <= batch.timingMaxBlocks,
@@ -244,7 +282,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
       guard existing.network == batch.network,
         existing.accountUuid == batch.accountUuid,
         existing.runId == batch.runId,
-        existing.transactionRelayUrl == batch.transactionRelayUrl,
+        existing.transactionSubmissionTarget == batch.transactionSubmissionTarget,
         existing.timingMeanBlocks == batch.timingMeanBlocks,
         existing.timingMaxBlocks == batch.timingMaxBlocks
       else {
@@ -824,7 +862,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
       accountUuid: batch.accountUuid,
       scopeKey: batch.scopeKey,
       lightwalletdUrl: batch.lightwalletdUrl,
-      transactionRelayUrl: batch.transactionRelayUrl,
+      transactionSubmissionTarget: batch.transactionSubmissionTarget,
       item: item
     )
   }

--- a/ios/Runner/BackgroundMigrationOutbox.swift
+++ b/ios/Runner/BackgroundMigrationOutbox.swift
@@ -120,6 +120,83 @@ struct BackgroundMigrationOutboxBatch: Codable, Equatable {
   }
 }
 
+extension BackgroundMigrationOutboxBatch {
+  private enum CodingKeys: String, CodingKey {
+    case batchId
+    case network
+    case accountUuid
+    case runId
+    case lightwalletdUrl
+    case transactionSubmissionTarget
+    case timingMeanBlocks
+    case timingMaxBlocks
+    case createdAt
+    case armedAt
+    case nextProofHeight
+    case proofReadyNotificationPendingAt
+    case proofReadyNotifiedAt
+    case proofReadyHeightNoticePendingAt
+    case proofReadyHeightNoticedAt
+    case broadcastCompleteNotificationPendingAt
+    case broadcastCompleteNotifiedAt
+    case items
+  }
+
+  private enum LegacyCodingKeys: String, CodingKey {
+    case transactionRelayUrl
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let legacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
+    // Relay-only snapshots stored the raw URL under the legacy key.
+    let legacyRelayUrl = try legacyContainer.decodeIfPresent(
+      String.self,
+      forKey: .transactionRelayUrl
+    )
+
+    batchId = try container.decode(String.self, forKey: .batchId)
+    network = try container.decode(String.self, forKey: .network)
+    accountUuid = try container.decode(String.self, forKey: .accountUuid)
+    runId = try container.decode(String.self, forKey: .runId)
+    lightwalletdUrl = try container.decode(String.self, forKey: .lightwalletdUrl)
+    transactionSubmissionTarget = try container.decodeIfPresent(
+      String.self,
+      forKey: .transactionSubmissionTarget
+    ) ?? legacyRelayUrl.map { "relay:\($0)" }
+    timingMeanBlocks = try container.decode(UInt64.self, forKey: .timingMeanBlocks)
+    timingMaxBlocks = try container.decode(UInt64.self, forKey: .timingMaxBlocks)
+    createdAt = try container.decode(Date.self, forKey: .createdAt)
+    armedAt = try container.decodeIfPresent(Date.self, forKey: .armedAt)
+    nextProofHeight = try container.decodeIfPresent(UInt64.self, forKey: .nextProofHeight)
+    proofReadyNotificationPendingAt = try container.decodeIfPresent(
+      Date.self,
+      forKey: .proofReadyNotificationPendingAt
+    )
+    proofReadyNotifiedAt = try container.decodeIfPresent(
+      Date.self,
+      forKey: .proofReadyNotifiedAt
+    )
+    proofReadyHeightNoticePendingAt = try container.decodeIfPresent(
+      Date.self,
+      forKey: .proofReadyHeightNoticePendingAt
+    )
+    proofReadyHeightNoticedAt = try container.decodeIfPresent(
+      Date.self,
+      forKey: .proofReadyHeightNoticedAt
+    )
+    broadcastCompleteNotificationPendingAt = try container.decodeIfPresent(
+      Date.self,
+      forKey: .broadcastCompleteNotificationPendingAt
+    )
+    broadcastCompleteNotifiedAt = try container.decodeIfPresent(
+      Date.self,
+      forKey: .broadcastCompleteNotifiedAt
+    )
+    items = try container.decode([BackgroundMigrationOutboxItem].self, forKey: .items)
+  }
+}
+
 enum BackgroundMigrationSubmissionTarget: Equatable {
   private static let relayPrefix = "relay:"
   private static let lightwalletdPrefix = "lightwalletd:"

--- a/ios/Runner/BackgroundMigrationOutboxChannel.swift
+++ b/ios/Runner/BackgroundMigrationOutboxChannel.swift
@@ -243,7 +243,7 @@ enum BackgroundMigrationOutboxChannel {
       accountUuid: try string(arguments, "accountUuid"),
       runId: try string(arguments, "runId"),
       lightwalletdUrl: try string(arguments, "lightwalletdUrl"),
-      transactionRelayUrl: try optionalString(arguments, "transactionRelayUrl"),
+      transactionSubmissionTarget: try optionalString(arguments, "transactionSubmissionTarget"),
       timingMeanBlocks: try uint64(arguments, "timingMeanBlocks"),
       timingMaxBlocks: try uint64(arguments, "timingMaxBlocks"),
       createdAt: Date(

--- a/ios/Runner/BackgroundMigrationOutboxRunner.swift
+++ b/ios/Runner/BackgroundMigrationOutboxRunner.swift
@@ -272,15 +272,43 @@ enum BackgroundMigrationOutboxRunner {
       )
     }
 
+    let submissionTarget = selection.transactionSubmissionTarget.flatMap {
+      BackgroundMigrationSubmissionTarget(
+        encoded: $0,
+        syncLightwalletdUrl: selection.lightwalletdUrl
+      )
+    }
+    if selection.transactionSubmissionTarget != nil && submissionTarget == nil {
+      recordUncertain(
+        store: store,
+        itemId: selection.item.itemId,
+        error: "Migration transaction submission target is invalid.",
+        at: now
+      )
+      return BackgroundMigrationOutboxRunResult(
+        transport: .needsUserAction,
+        proofReady: proofReady,
+        broadcastComplete: broadcastComplete,
+        transportAccountUuid: selection.accountUuid
+      )
+    }
+
     let submissionResult: Result<NativeLightwalletdSendResponse, NativeLightwalletdError>
-    if let relayUrl = selection.transactionRelayUrl {
+    switch submissionTarget {
+    case .some(.relay(let relayUrl)):
       submissionResult = dependencies.sendTransactionRelay(
         relayUrl,
         selection.item.txidHex,
         selection.item.rawTransaction,
         cancellation
       )
-    } else {
+    case .some(.lightwalletd(let submissionLightwalletdUrl)):
+      submissionResult = dependencies.sendTransaction(
+        submissionLightwalletdUrl,
+        selection.item.rawTransaction,
+        cancellation
+      )
+    case nil:
       submissionResult = dependencies.sendTransaction(
         selection.lightwalletdUrl,
         selection.item.rawTransaction,

--- a/ios/Runner/NativeLightwalletdClient.swift
+++ b/ios/Runner/NativeLightwalletdClient.swift
@@ -1,6 +1,14 @@
 import Foundation
 import Network
 
+private func isNativeLocalHost(_ host: String) -> Bool {
+  let host = host.lowercased()
+  if host == "localhost" || host == "::1" || host == "10.0.2.2" {
+    return true
+  }
+  return IPv4Address(host)?.rawValue.first == 127
+}
+
 final class BackgroundMigrationCancellation: @unchecked Sendable {
   private let condition = NSCondition()
   private var cancelled = false
@@ -561,6 +569,27 @@ enum NativeLightwalletdClient {
     return data[payloadStart..<payloadEnd]
   }
 
+  static func transactionSubmissionURL(
+    endpoint: String,
+    syncEndpoint: String
+  ) -> URL? {
+    guard let components = URLComponents(string: endpoint),
+      components.user == nil,
+      components.password == nil,
+      let submissionHost = components.host,
+      components.query == nil,
+      components.fragment == nil,
+      components.path.isEmpty || components.path == "/",
+      components.scheme == "https"
+        || (components.scheme == "http" && isNativeLocalHost(submissionHost)),
+      let syncHost = URLComponents(string: syncEndpoint)?.host,
+      submissionHost.caseInsensitiveCompare(syncHost) != .orderedSame
+    else {
+      return nil
+    }
+    return components.url
+  }
+
   private static func rpcURL(endpoint: String, methodPath: String) -> URL? {
     guard var components = URLComponents(string: endpoint),
       components.scheme == "https" || components.scheme == "http",
@@ -733,19 +762,11 @@ enum NativeTransactionRelayClient {
       let host = components.host,
       components.query == nil,
       components.fragment == nil,
-      components.scheme == "https" || (components.scheme == "http" && isLoopback(host))
+      components.scheme == "https" || (components.scheme == "http" && isNativeLocalHost(host))
     else {
       return nil
     }
     return components.url
-  }
-
-  private static func isLoopback(_ host: String) -> Bool {
-    let host = host.lowercased()
-    if host == "localhost" || host == "::1" {
-      return true
-    }
-    return IPv4Address(host)?.rawValue.first == 127
   }
 
   private static func isTxidHex(_ value: String) -> Bool {

--- a/ios/RunnerTests/BackgroundMigrationOutboxTests.swift
+++ b/ios/RunnerTests/BackgroundMigrationOutboxTests.swift
@@ -88,6 +88,50 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     XCTAssertNil(snapshot.announcedBroadcastCompleteBatchIds)
   }
 
+  func testSnapshotMigratesTheLegacyTransactionRelayUrl() throws {
+    let relayUrl = "https://relay.example/submit"
+    let snapshot = BackgroundMigrationOutboxSnapshot(
+      batches: [
+        makeBatch(
+          batchId: "batch-a",
+          account: "account-a",
+          transactionSubmissionTarget: "relay:\(relayUrl)"
+        )
+      ]
+    )
+    let encoded = try JSONEncoder().encode(snapshot)
+    var json = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+    )
+    var batches = try XCTUnwrap(json["batches"] as? [[String: Any]])
+    batches[0].removeValue(forKey: "transactionSubmissionTarget")
+    batches[0]["transactionRelayUrl"] = relayUrl
+    json["batches"] = batches
+
+    let legacySnapshot = try JSONSerialization.data(withJSONObject: json)
+    let decoded = try JSONDecoder().decode(
+      BackgroundMigrationOutboxSnapshot.self,
+      from: legacySnapshot
+    )
+
+    XCTAssertEqual(
+      decoded.batches.first?.transactionSubmissionTarget,
+      "relay:\(relayUrl)"
+    )
+    let migrated = try JSONEncoder().encode(decoded)
+    let migratedJson = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: migrated) as? [String: Any]
+    )
+    let migratedBatch = try XCTUnwrap(
+      (migratedJson["batches"] as? [[String: Any]])?.first
+    )
+    XCTAssertEqual(
+      migratedBatch["transactionSubmissionTarget"] as? String,
+      "relay:\(relayUrl)"
+    )
+    XCTAssertNil(migratedBatch["transactionRelayUrl"])
+  }
+
   func testDiscardBatchRemovesAnIdleRecordButKeepsTheAccountScope() throws {
     var snapshot = BackgroundMigrationOutboxSnapshot()
     let batch = makeBatch(batchId: "batch-a", account: "account-a")

--- a/ios/RunnerTests/BackgroundMigrationOutboxTests.swift
+++ b/ios/RunnerTests/BackgroundMigrationOutboxTests.swift
@@ -301,18 +301,18 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     }
   }
 
-  func testRestagingCannotChangeTheSavedRelay() throws {
+  func testRestagingCannotChangeTheSavedSubmissionTarget() throws {
     let original = makeBatch(
       batchId: "batch-a",
       account: "account-a",
       heights: [100],
-      transactionRelayUrl: "https://relay-one.example/submit"
+      transactionSubmissionTarget: "relay:https://relay-one.example/submit"
     )
     let replacement = makeBatch(
       batchId: "batch-a",
       account: "account-a",
       heights: [100],
-      transactionRelayUrl: "https://relay-two.example/submit"
+      transactionSubmissionTarget: "relay:https://relay-two.example/submit"
     )
     var snapshot = BackgroundMigrationOutboxSnapshot()
 
@@ -719,7 +719,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       batchId: "batch-a",
       account: "account-a",
       heights: [100],
-      transactionRelayUrl: relayUrl
+      transactionSubmissionTarget: "relay:\(relayUrl)"
     )
     try stageAndArm(batch, in: harness.store)
     var tipEndpoints: [String] = []
@@ -757,6 +757,60 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     XCTAssertEqual(relaySubmissions[0].2, batch.items[0].rawTransaction)
     guard case .accepted = outcome.transport else {
       return XCTFail("Expected an accepted relay submission, got \(outcome)")
+    }
+  }
+
+  func testRunnerUsesSavedAlternateLightwalletdForTransactionSubmission() throws {
+    let harness = try makeStoreHarness()
+    defer { harness.cleanup() }
+    let submissionUrl = "https://zcash.mysideoftheweb.com:19067"
+    let batch = makeBatch(
+      batchId: "batch-a",
+      account: "account-a",
+      heights: [100],
+      transactionSubmissionTarget: "lightwalletd:\(submissionUrl)"
+    )
+    try stageAndArm(batch, in: harness.store)
+    var tipEndpoints: [String] = []
+    var sendEndpoints: [String] = []
+    let dependencies = BackgroundMigrationOutboxRunnerDependencies(
+      latestBlockHeight: { endpoint, _ in
+        tipEndpoints.append(endpoint)
+        return .success(200)
+      },
+      sendTransaction: { endpoint, _, _ in
+        sendEndpoints.append(endpoint)
+        return .success(
+          NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
+        )
+      }
+    )
+
+    let outcome = BackgroundMigrationOutboxRunner.runOnce(
+      store: harness.store,
+      cancellation: BackgroundMigrationCancellation(),
+      now: now,
+      dependencies: dependencies
+    )
+
+    XCTAssertEqual(tipEndpoints, [batch.lightwalletdUrl])
+    XCTAssertEqual(sendEndpoints, [submissionUrl])
+    guard case .accepted = outcome.transport else {
+      return XCTFail("Expected an accepted alternate-lightwalletd submission, got \(outcome)")
+    }
+  }
+
+  func testStageRejectsSubmissionLightwalletdOnTheSyncHost() throws {
+    var snapshot = BackgroundMigrationOutboxSnapshot()
+    let batch = makeBatch(
+      batchId: "batch-a",
+      account: "account-a",
+      heights: [100],
+      transactionSubmissionTarget: "lightwalletd:https://testnet.zec.rocks:9067"
+    )
+
+    XCTAssertThrowsError(try snapshot.stage(batch)) { error in
+      XCTAssertEqual(error as? BackgroundMigrationOutboxError, .invalidBatch)
     }
   }
 
@@ -1673,7 +1727,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     account: String,
     heights: [UInt64] = [100, 101, 102],
     nextProofHeight: UInt64? = nil,
-    transactionRelayUrl: String? = nil
+    transactionSubmissionTarget: String? = nil
   ) -> BackgroundMigrationOutboxBatch {
     BackgroundMigrationOutboxBatch(
       batchId: batchId,
@@ -1681,7 +1735,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       accountUuid: account,
       runId: "run-\(account)",
       lightwalletdUrl: "https://testnet.zec.rocks:443",
-      transactionRelayUrl: transactionRelayUrl,
+      transactionSubmissionTarget: transactionSubmissionTarget,
       timingMeanBlocks: 144,
       timingMaxBlocks: 576,
       createdAt: now,

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -2642,6 +2642,40 @@ final class NativeTransactionRelayClientTests: XCTestCase {
   }
 }
 
+final class NativeLightwalletdSubmissionTargetTests: XCTestCase {
+  func testSubmissionURLRequiresDifferentHostFromSync() {
+    XCTAssertNotNil(
+      NativeLightwalletdClient.transactionSubmissionURL(
+        endpoint: "https://submit.example.com:443",
+        syncEndpoint: "https://sync.example.com:443"
+      )
+    )
+    XCTAssertNil(
+      NativeLightwalletdClient.transactionSubmissionURL(
+        endpoint: "https://SYNC.example.com:9067",
+        syncEndpoint: "https://sync.example.com:443"
+      )
+    )
+  }
+
+  func testSubmissionURLRejectsUnsafeOrigins() {
+    for endpoint in [
+      "http://example.com:9067",
+      "https://user@example.com:443",
+      "https://example.com:443/rpc",
+      "https://example.com:443?token=secret",
+    ] {
+      XCTAssertNil(
+        NativeLightwalletdClient.transactionSubmissionURL(
+          endpoint: endpoint,
+          syncEndpoint: "https://sync.example.com:443"
+        ),
+        endpoint
+      )
+    }
+  }
+}
+
 private final class FreshInstallCleanerHarness {
   var hasSentinel = false
   var markedInstalled = false

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -1,3 +1,5 @@
+import 'dart:math' show Random;
+
 import 'package:flutter/foundation.dart' show kDebugMode;
 
 import 'network_config.dart';
@@ -241,13 +243,17 @@ bool isCustomRpcEndpointConfig(RpcEndpointConfig config) {
   return config.effectivePresetId == kCustomRpcEndpointPresetId;
 }
 
-/// Returns the transaction relay for a managed endpoint.
+const _migrationRelaySubmissionPrefix = 'relay:';
+const _migrationLightwalletdSubmissionPrefix = 'lightwalletd:';
+
+/// Returns every valid migration submission target for [syncEndpoint].
 ///
-/// Custom endpoint intent always keeps transaction submission on the selected
-/// lightwalletd, even when its URL happens to match a built-in preset. Mainnet
-/// falls back to the Zakura broadcast endpoint when no build URL is supplied.
-String? transactionRelayUrlForPrimaryEndpoint(
-  RpcEndpointConfig primary, {
+/// Relay targets and managed lightwalletd targets are tagged so Rust and the
+/// native iOS outbox can persist both the URL and its transport. A
+/// lightwalletd candidate is excluded when its host matches the sync host,
+/// even if it uses a different port.
+List<String> transactionSubmissionTargetsForSyncEndpoint(
+  RpcEndpointConfig syncEndpoint, {
   String mainUrl = kVizorZcashTransactionRelayUrlMain,
   String testUrl = kVizorZcashTransactionRelayUrlTest,
   String regtestUrl = kVizorZcashTransactionRelayUrlRegtest,
@@ -255,38 +261,76 @@ String? transactionRelayUrlForPrimaryEndpoint(
       kVizorZcashTransactionRelayUrlIronwoodMasquerade,
   bool ironwoodMasquerade = kZcashIronwoodMasquerade,
 }) {
-  final RpcEndpointPreset? preset;
-  if (ironwoodMasquerade) {
-    preset = primary.presetId?.trim() == kIronwoodMasqueradeRpcEndpointPresetId
-        ? kIronwoodMasqueradeRpcEndpointPreset
-        : null;
-  } else {
-    if (isCustomRpcEndpointConfig(primary)) return null;
-    preset = explicitRpcEndpointPresetFor(primary);
-  }
-  if (preset == null) return null;
+  final String normalizedSyncEndpoint;
   try {
-    if (primary.normalizedLightwalletdUrl !=
-        normalizeRpcEndpointUrl(preset.url, allowDefaultPort: true)) {
-      return null;
-    }
+    normalizedSyncEndpoint = normalizeRpcEndpointUrl(
+      syncEndpoint.lightwalletdUrl,
+      allowDefaultPort: true,
+    );
   } on FormatException {
-    return null;
+    return const [];
   }
+  final syncHost = Uri.parse(normalizedSyncEndpoint).host.toLowerCase();
+  final targets = <String>[];
 
-  final configured = ironwoodMasquerade
+  final configuredRelay = ironwoodMasquerade
       ? ironwoodMasqueradeUrl
-      : switch (primary.network) {
+      : switch (syncEndpoint.network) {
           ZcashNetwork.mainnet => mainUrl,
           ZcashNetwork.testnet => testUrl,
           ZcashNetwork.regtest => regtestUrl,
         };
-  final trimmed = configured.trim();
-  if (trimmed.isNotEmpty) return trimmed;
-  if (!ironwoodMasquerade && primary.network == ZcashNetwork.mainnet) {
-    return kZakuraMainnetTransactionRelayUrl;
+  final relayUrl = configuredRelay.trim().isNotEmpty
+      ? configuredRelay.trim()
+      : !ironwoodMasquerade && syncEndpoint.network == ZcashNetwork.mainnet
+      ? kZakuraMainnetTransactionRelayUrl
+      : null;
+  if (relayUrl != null) {
+    targets.add('$_migrationRelaySubmissionPrefix$relayUrl');
   }
-  return null;
+
+  final managedPresets = ironwoodMasquerade
+      ? const [kIronwoodMasqueradeRpcEndpointPreset]
+      : rpcEndpointPresetsForNetwork(syncEndpoint.networkName);
+  final seenLightwalletdUrls = <String>{normalizedSyncEndpoint};
+  for (final preset in managedPresets) {
+    String normalized;
+    try {
+      normalized = normalizeRpcEndpointUrl(preset.url, allowDefaultPort: true);
+    } on FormatException {
+      continue;
+    }
+    final candidateHost = Uri.parse(normalized).host.toLowerCase();
+    if (candidateHost == syncHost || !seenLightwalletdUrls.add(normalized)) {
+      continue;
+    }
+    targets.add('$_migrationLightwalletdSubmissionPrefix$normalized');
+  }
+
+  return List.unmodifiable(targets);
+}
+
+/// Selects one immutable migration submission target for a new run.
+String? transactionSubmissionTargetForSyncEndpoint(
+  RpcEndpointConfig syncEndpoint, {
+  String mainUrl = kVizorZcashTransactionRelayUrlMain,
+  String testUrl = kVizorZcashTransactionRelayUrlTest,
+  String regtestUrl = kVizorZcashTransactionRelayUrlRegtest,
+  String ironwoodMasqueradeUrl =
+      kVizorZcashTransactionRelayUrlIronwoodMasquerade,
+  bool ironwoodMasquerade = kZcashIronwoodMasquerade,
+  Random? random,
+}) {
+  final targets = transactionSubmissionTargetsForSyncEndpoint(
+    syncEndpoint,
+    mainUrl: mainUrl,
+    testUrl: testUrl,
+    regtestUrl: regtestUrl,
+    ironwoodMasqueradeUrl: ironwoodMasqueradeUrl,
+    ironwoodMasquerade: ironwoodMasquerade,
+  );
+  if (targets.isEmpty) return null;
+  return targets[(random ?? Random.secure()).nextInt(targets.length)];
 }
 
 bool isRpcEndpointAllowedForBuild(String lightwalletdUrl) {

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -119,7 +119,8 @@ typedef IronwoodMigrationImmediatePlanGetter =
 
 typedef IronwoodMigrationWalletDbPathGetter = Future<String> Function();
 typedef IronwoodMigrationEndpointGetter = RpcEndpointConfig Function();
-typedef IronwoodMigrationTransactionRelayUrlGetter = String? Function();
+typedef IronwoodMigrationTransactionSubmissionTargetGetter =
+    String? Function(RpcEndpointConfig syncEndpoint);
 typedef IronwoodMigrationPasswordGetter = String Function();
 typedef IronwoodMigrationMnemonicBytesGetter =
     Future<List<int>?> Function(String accountUuid);
@@ -211,7 +212,7 @@ typedef IronwoodMigrationSoftwareStarter =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
       required String lightwalletdUrl,
-      String? transactionRelayUrl,
+      String? transactionSubmissionTarget,
       required String network,
       required String accountUuid,
       required List<int> mnemonicBytes,
@@ -252,7 +253,7 @@ typedef IronwoodMigrationMacosSoftwareStarter =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
       required String lightwalletdUrl,
-      String? transactionRelayUrl,
+      String? transactionSubmissionTarget,
       required String network,
       required String accountUuid,
       required String password,
@@ -432,13 +433,13 @@ typedef IronwoodMigrationPrivateDraftCreator =
       required String network,
       required String accountUuid,
       required List<rust_sync.MigrationScheduledTransfer> approvedSchedule,
-      String? transactionRelayUrl,
+      String? transactionSubmissionTarget,
     });
 typedef IronwoodMigrationKeystoneDenominationCompleter =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
       required String lightwalletdUrl,
-      String? transactionRelayUrl,
+      String? transactionSubmissionTarget,
       required String network,
       required String accountUuid,
       required String requestId,
@@ -451,7 +452,7 @@ typedef IronwoodMigrationKeystoneSingleQrCompleter =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
       required String lightwalletdUrl,
-      String? transactionRelayUrl,
+      String? transactionSubmissionTarget,
       required String network,
       required String accountUuid,
       required String requestId,
@@ -511,7 +512,7 @@ _defaultPrepareKeystoneSingleQrMigration({
 Future<rust_sync.IronwoodMigrationResult> _defaultStartSoftwareMigration({
   required String dbPath,
   required String lightwalletdUrl,
-  String? transactionRelayUrl,
+  String? transactionSubmissionTarget,
   required String network,
   required String accountUuid,
   required List<int> mnemonicBytes,
@@ -521,7 +522,7 @@ Future<rust_sync.IronwoodMigrationResult> _defaultStartSoftwareMigration({
 }) => rust_sync.migrateOrchardToIronwood(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
-  transactionRelayUrl: transactionRelayUrl,
+  transactionSubmissionTarget: transactionSubmissionTarget,
   network: network,
   accountUuid: accountUuid,
   mnemonicBytes: mnemonicBytes,
@@ -534,7 +535,7 @@ Future<rust_sync.IronwoodMigrationResult> _defaultStartSoftwareMigration({
 Future<rust_sync.IronwoodMigrationResult> _defaultStartMacosSoftwareMigration({
   required String dbPath,
   required String lightwalletdUrl,
-  String? transactionRelayUrl,
+  String? transactionSubmissionTarget,
   required String network,
   required String accountUuid,
   required String password,
@@ -543,7 +544,7 @@ Future<rust_sync.IronwoodMigrationResult> _defaultStartMacosSoftwareMigration({
 }) => rust_sync.migrateOrchardToIronwoodWithMacosStoredMnemonic(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
-  transactionRelayUrl: transactionRelayUrl,
+  transactionSubmissionTarget: transactionSubmissionTarget,
   network: network,
   accountUuid: accountUuid,
   password: password,
@@ -556,7 +557,7 @@ Future<rust_sync.IronwoodMigrationResult>
 _defaultCompleteKeystoneDenominationMigration({
   required String dbPath,
   required String lightwalletdUrl,
-  String? transactionRelayUrl,
+  String? transactionSubmissionTarget,
   required String network,
   required String accountUuid,
   required String requestId,
@@ -567,7 +568,7 @@ _defaultCompleteKeystoneDenominationMigration({
 }) => rust_sync.completeOrchardMigrationDenominationsPczt(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
-  transactionRelayUrl: transactionRelayUrl,
+  transactionSubmissionTarget: transactionSubmissionTarget,
   network: network,
   accountUuid: accountUuid,
   requestId: requestId,
@@ -581,7 +582,7 @@ Future<rust_sync.IronwoodMigrationResult>
 _defaultCompleteKeystoneSingleQrMigration({
   required String dbPath,
   required String lightwalletdUrl,
-  String? transactionRelayUrl,
+  String? transactionSubmissionTarget,
   required String network,
   required String accountUuid,
   required String requestId,
@@ -591,7 +592,7 @@ _defaultCompleteKeystoneSingleQrMigration({
 }) => rust_sync.completeOrchardMigrationSingleQrPczt(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
-  transactionRelayUrl: transactionRelayUrl,
+  transactionSubmissionTarget: transactionSubmissionTarget,
   network: network,
   accountUuid: accountUuid,
   requestId: requestId,
@@ -637,14 +638,14 @@ Future<String> _defaultCreatePrivateMigrationDraft({
   required String network,
   required String accountUuid,
   required List<rust_sync.MigrationScheduledTransfer> approvedSchedule,
-  String? transactionRelayUrl,
+  String? transactionSubmissionTarget,
 }) => rust_sync.createOrResumePrivateMigrationDraft(
   dbPath: dbPath,
   network: network,
   accountUuid: accountUuid,
   approvedSchedule: approvedSchedule,
   spacePreparationBroadcasts: kAppFormFactor == AppFormFactor.desktop,
-  transactionRelayUrl: transactionRelayUrl,
+  transactionSubmissionTarget: transactionSubmissionTarget,
 );
 
 class IronwoodMigrationService {
@@ -655,7 +656,8 @@ class IronwoodMigrationService {
     required this.secureStore,
     IronwoodMigrationBackgroundCredentialStore? backgroundCredentialStore,
     IronwoodMigrationEndpointGetter? getEndpoint,
-    IronwoodMigrationTransactionRelayUrlGetter? getTransactionRelayUrl,
+    IronwoodMigrationTransactionSubmissionTargetGetter?
+    getTransactionSubmissionTarget,
     IronwoodMigrationPasswordGetter? getSessionPassword,
     IronwoodMigrationMnemonicBytesGetter? getMnemonicBytesForAccount,
     IronwoodMigrationPlatformCheck? isMacOS,
@@ -725,7 +727,8 @@ class IronwoodMigrationService {
            backgroundCredentialStore ??
            IronwoodMigrationBackgroundCredentialStore.instance,
        getEndpoint = getEndpoint ?? _missingEndpoint,
-       getTransactionRelayUrl = getTransactionRelayUrl ?? (() => null),
+       getTransactionSubmissionTarget =
+           getTransactionSubmissionTarget ?? ((_) => null),
        getSessionPassword = getSessionPassword ?? _missingSessionPassword,
        getMnemonicBytesForAccount =
            getMnemonicBytesForAccount ?? _missingMnemonicBytesForAccount,
@@ -864,7 +867,8 @@ class IronwoodMigrationService {
   final AppSecureStore secureStore;
   final IronwoodMigrationBackgroundCredentialStore backgroundCredentialStore;
   final IronwoodMigrationEndpointGetter getEndpoint;
-  final IronwoodMigrationTransactionRelayUrlGetter getTransactionRelayUrl;
+  final IronwoodMigrationTransactionSubmissionTargetGetter
+  getTransactionSubmissionTarget;
   final IronwoodMigrationPasswordGetter getSessionPassword;
   final IronwoodMigrationMnemonicBytesGetter getMnemonicBytesForAccount;
   final IronwoodMigrationPlatformCheck isMacOS;
@@ -1452,7 +1456,9 @@ class IronwoodMigrationService {
   }) async {
     final dbPath = await getWalletDbPath();
     final endpoint = getEndpoint();
-    final transactionRelayUrl = getTransactionRelayUrl();
+    final transactionSubmissionTarget = getTransactionSubmissionTarget(
+      endpoint,
+    );
     final context = _MigrationCredentialContext(
       dbPath: dbPath,
       network: endpoint.networkName,
@@ -1467,7 +1473,7 @@ class IronwoodMigrationService {
         operation: (credential) => startMacosSoftwareMigration(
           dbPath: dbPath,
           lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-          transactionRelayUrl: transactionRelayUrl,
+          transactionSubmissionTarget: transactionSubmissionTarget,
           network: endpoint.networkName,
           accountUuid: accountUuid,
           password: credential.password,
@@ -1492,7 +1498,7 @@ class IronwoodMigrationService {
           resultFuture = startSoftwareMigration(
             dbPath: dbPath,
             lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-            transactionRelayUrl: transactionRelayUrl,
+            transactionSubmissionTarget: transactionSubmissionTarget,
             network: endpoint.networkName,
             accountUuid: accountUuid,
             mnemonicBytes: mnemonicBytes,
@@ -1896,7 +1902,9 @@ class IronwoodMigrationService {
             await startSoftwareMigration(
               dbPath: context.dbPath,
               lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-              transactionRelayUrl: getTransactionRelayUrl(),
+              transactionSubmissionTarget: getTransactionSubmissionTarget(
+                endpoint,
+              ),
               network: context.network,
               accountUuid: context.accountUuid,
               mnemonicBytes: mnemonicBytes,
@@ -2038,7 +2046,7 @@ class IronwoodMigrationService {
         network: endpoint.networkName,
         accountUuid: accountUuid,
         approvedSchedule: approvedSchedule,
-        transactionRelayUrl: getTransactionRelayUrl(),
+        transactionSubmissionTarget: getTransactionSubmissionTarget(endpoint),
       ),
     );
   }
@@ -2065,7 +2073,7 @@ class IronwoodMigrationService {
       operation: (credential) => completeKeystoneSingleQrMigration(
         dbPath: dbPath,
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-        transactionRelayUrl: getTransactionRelayUrl(),
+        transactionSubmissionTarget: getTransactionSubmissionTarget(endpoint),
         network: endpoint.networkName,
         accountUuid: accountUuid,
         requestId: requestId,
@@ -2099,7 +2107,7 @@ class IronwoodMigrationService {
       operation: (credential) => completeKeystoneDenominationMigration(
         dbPath: dbPath,
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-        transactionRelayUrl: getTransactionRelayUrl(),
+        transactionSubmissionTarget: getTransactionSubmissionTarget(endpoint),
         network: endpoint.networkName,
         accountUuid: accountUuid,
         requestId: requestId,
@@ -2684,7 +2692,7 @@ class IronwoodMigrationService {
       'accountUuid': context.accountUuid,
       'runId': batch.runId,
       'lightwalletdUrl': lightwalletdUrl,
-      'transactionRelayUrl': batch.transactionRelayUrl,
+      'transactionSubmissionTarget': batch.transactionSubmissionTarget,
       'timingMeanBlocks': batch.timingMeanBlocks,
       'timingMaxBlocks': batch.timingMaxBlocks,
       'createdAtMs': DateTime.now().millisecondsSinceEpoch,
@@ -2940,9 +2948,7 @@ final ironwoodMigrationServiceProvider = Provider<IronwoodMigrationService>((
             ),
     secureStore: AppSecureStore.instance,
     getEndpoint: () => ref.read(rpcEndpointFailoverProvider).current,
-    getTransactionRelayUrl: () => transactionRelayUrlForPrimaryEndpoint(
-      ref.read(rpcEndpointFailoverProvider).primary,
-    ),
+    getTransactionSubmissionTarget: transactionSubmissionTargetForSyncEndpoint,
     getSessionPassword: () => ref
         .read(appSecurityProvider.notifier)
         .requireSessionPasswordForNativeSecretUse(),

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -20,6 +20,8 @@ import 'ironwood_migration_operation_registry.dart';
 
 const _credentialRecoveryRequiredError =
     'Ironwood migration credential is missing for the active run.';
+const _migrationSubmissionSyncHostCollision =
+    'transaction submission lightwalletd must not use the sync host';
 
 bool ironwoodMigrationNeedsCredentialRecovery(String? error) {
   return error?.contains(_credentialRecoveryRequiredError) ?? false;
@@ -121,6 +123,11 @@ typedef IronwoodMigrationWalletDbPathGetter = Future<String> Function();
 typedef IronwoodMigrationEndpointGetter = RpcEndpointConfig Function();
 typedef IronwoodMigrationTransactionSubmissionTargetGetter =
     String? Function(RpcEndpointConfig syncEndpoint);
+typedef IronwoodMigrationDistinctSyncEndpointSwitcher =
+    Future<bool> Function({
+      required RpcEndpointConfig attemptedEndpoint,
+      required Object reason,
+    });
 typedef IronwoodMigrationPasswordGetter = String Function();
 typedef IronwoodMigrationMnemonicBytesGetter =
     Future<List<int>?> Function(String accountUuid);
@@ -658,6 +665,7 @@ class IronwoodMigrationService {
     IronwoodMigrationEndpointGetter? getEndpoint,
     IronwoodMigrationTransactionSubmissionTargetGetter?
     getTransactionSubmissionTarget,
+    IronwoodMigrationDistinctSyncEndpointSwitcher? switchToDistinctSyncEndpoint,
     IronwoodMigrationPasswordGetter? getSessionPassword,
     IronwoodMigrationMnemonicBytesGetter? getMnemonicBytesForAccount,
     IronwoodMigrationPlatformCheck? isMacOS,
@@ -729,6 +737,8 @@ class IronwoodMigrationService {
        getEndpoint = getEndpoint ?? _missingEndpoint,
        getTransactionSubmissionTarget =
            getTransactionSubmissionTarget ?? ((_) => null),
+       switchToDistinctSyncEndpoint =
+           switchToDistinctSyncEndpoint ?? _neverSwitchSyncEndpoint,
        getSessionPassword = getSessionPassword ?? _missingSessionPassword,
        getMnemonicBytesForAccount =
            getMnemonicBytesForAccount ?? _missingMnemonicBytesForAccount,
@@ -869,6 +879,8 @@ class IronwoodMigrationService {
   final IronwoodMigrationEndpointGetter getEndpoint;
   final IronwoodMigrationTransactionSubmissionTargetGetter
   getTransactionSubmissionTarget;
+  final IronwoodMigrationDistinctSyncEndpointSwitcher
+  switchToDistinctSyncEndpoint;
   final IronwoodMigrationPasswordGetter getSessionPassword;
   final IronwoodMigrationMnemonicBytesGetter getMnemonicBytesForAccount;
   final IronwoodMigrationPlatformCheck isMacOS;
@@ -1564,9 +1576,53 @@ class IronwoodMigrationService {
 
   Future<rust_sync.IronwoodMigrationResult> continueSoftwarePrivateMigration({
     required String accountUuid,
+  }) => _continueSoftwarePrivateMigration(
+    accountUuid: accountUuid,
+    maySwitchEndpoint: true,
+  );
+
+  Future<rust_sync.IronwoodMigrationResult> _continueSoftwarePrivateMigration({
+    required String accountUuid,
+    required bool maySwitchEndpoint,
+  }) async {
+    final endpoint = getEndpoint();
+    try {
+      final result = await _continueSoftwarePrivateMigrationAtEndpoint(
+        accountUuid: accountUuid,
+        endpoint: endpoint,
+      );
+      if (await _switchEndpointForSubmissionCollision(
+        endpoint: endpoint,
+        reason: result.message,
+        maySwitchEndpoint: maySwitchEndpoint,
+      )) {
+        return _continueSoftwarePrivateMigration(
+          accountUuid: accountUuid,
+          maySwitchEndpoint: false,
+        );
+      }
+      return result;
+    } catch (error, stackTrace) {
+      if (await _switchEndpointForSubmissionCollision(
+        endpoint: endpoint,
+        reason: error,
+        maySwitchEndpoint: maySwitchEndpoint,
+      )) {
+        return _continueSoftwarePrivateMigration(
+          accountUuid: accountUuid,
+          maySwitchEndpoint: false,
+        );
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+  }
+
+  Future<rust_sync.IronwoodMigrationResult>
+  _continueSoftwarePrivateMigrationAtEndpoint({
+    required String accountUuid,
+    required RpcEndpointConfig endpoint,
   }) async {
     final dbPath = await getWalletDbPath();
-    final endpoint = getEndpoint();
     final context = _MigrationCredentialContext(
       dbPath: dbPath,
       network: endpoint.networkName,
@@ -1664,6 +1720,26 @@ class IronwoodMigrationService {
           mnemonicBytes.fillRange(0, mnemonicBytes.length, 0);
         }
       },
+    );
+  }
+
+  Future<bool> _switchEndpointForSubmissionCollision({
+    required RpcEndpointConfig endpoint,
+    required Object? reason,
+    required bool maySwitchEndpoint,
+  }) {
+    if (!maySwitchEndpoint ||
+        reason == null ||
+        !reason.toString().toLowerCase().contains(
+          _migrationSubmissionSyncHostCollision,
+        )) {
+      return Future.value(false);
+    }
+    // Rust rejects this invariant before opening the submission transport, so
+    // changing only the sync endpoint and retrying once cannot double-submit.
+    return switchToDistinctSyncEndpoint(
+      attemptedEndpoint: endpoint,
+      reason: reason,
     );
   }
 
@@ -2949,6 +3025,14 @@ final ironwoodMigrationServiceProvider = Provider<IronwoodMigrationService>((
     secureStore: AppSecureStore.instance,
     getEndpoint: () => ref.read(rpcEndpointFailoverProvider).current,
     getTransactionSubmissionTarget: transactionSubmissionTargetForSyncEndpoint,
+    switchToDistinctSyncEndpoint:
+        ({required attemptedEndpoint, required reason}) => ref
+            .read(rpcEndpointFailoverProvider.notifier)
+            .switchToDistinctHostFor(
+              reason,
+              endpoint: attemptedEndpoint,
+              operation: 'migration submission separation',
+            ),
     getSessionPassword: () => ref
         .read(appSecurityProvider.notifier)
         .requireSessionPasswordForNativeSecretUse(),
@@ -2972,6 +3056,11 @@ RpcEndpointConfig _missingEndpoint() {
 String _missingSessionPassword() {
   throw StateError('Ironwood migration password getter is not configured.');
 }
+
+Future<bool> _neverSwitchSyncEndpoint({
+  required RpcEndpointConfig attemptedEndpoint,
+  required Object reason,
+}) async => false;
 
 Future<List<int>?> _missingMnemonicBytesForAccount(String accountUuid) {
   throw StateError('Ironwood migration mnemonic getter is not configured.');

--- a/lib/src/providers/rpc_endpoint_failover_provider.dart
+++ b/lib/src/providers/rpc_endpoint_failover_provider.dart
@@ -327,6 +327,42 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
     required String operation,
     bool Function(Object error) shouldFallback =
         shouldFallbackFromLightwalletdError,
+  }) => _switchToFallbackFor(
+    error,
+    endpoint: endpoint,
+    operation: operation,
+    shouldFallback: shouldFallback,
+    requireDifferentHost: false,
+    countPrimaryFailure: true,
+    eventMessage:
+        'Selected endpoint is unstable. Switched to fallback endpoint.',
+  );
+
+  /// Selects a healthy sync endpoint on a different host without treating the
+  /// current endpoint as unhealthy.
+  Future<bool> switchToDistinctHostFor(
+    Object reason, {
+    RpcEndpointConfig? endpoint,
+    required String operation,
+  }) => _switchToFallbackFor(
+    reason,
+    endpoint: endpoint,
+    operation: operation,
+    shouldFallback: (_) => true,
+    requireDifferentHost: true,
+    countPrimaryFailure: false,
+    eventMessage:
+        'Switched sync endpoint to keep migration submission separate.',
+  );
+
+  Future<bool> _switchToFallbackFor(
+    Object error, {
+    required RpcEndpointConfig? endpoint,
+    required String operation,
+    required bool Function(Object error) shouldFallback,
+    required bool requireDifferentHost,
+    required bool countPrimaryFailure,
+    required String eventMessage,
   }) async {
     final attempted = endpoint ?? state.current;
     final context = _captureContext();
@@ -337,11 +373,13 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
 
     final attemptedUrl = attempted.normalizedLightwalletdUrl;
     final failedPrimary = _sameEndpointIdentity(attempted, context.primary);
-    final nextFailureCount = failedPrimary
+    final nextFailureCount = failedPrimary && countPrimaryFailure
         ? state.primaryFailureCount + 1
         : state.primaryFailureCount;
     final settings = ref.read(rpcEndpointFailoverSettingsProvider);
-    if (failedPrimary && nextFailureCount < settings.primaryFailureThreshold) {
+    if (failedPrimary &&
+        countPrimaryFailure &&
+        nextFailureCount < settings.primaryFailureThreshold) {
       state = state.copyWith(
         primaryFailureCount: nextFailureCount,
         lastFailure: error.toString(),
@@ -349,20 +387,26 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       return false;
     }
 
+    final attemptedHost = Uri.parse(attemptedUrl).host.toLowerCase();
     final fallbackCandidates = context.fallbackCandidates
-        .where(
-          (candidate) => candidate.normalizedLightwalletdUrl != attemptedUrl,
-        )
+        .where((candidate) {
+          final candidateUrl = candidate.normalizedLightwalletdUrl;
+          if (candidateUrl == attemptedUrl) return false;
+          return !requireDifferentHost ||
+              Uri.parse(candidateUrl).host.toLowerCase() != attemptedHost;
+        })
         .toList(growable: false);
     if (fallbackCandidates.isEmpty) {
       log(
         'RpcEndpointFailover: no fallback endpoint for '
-        '${attempted.hostPort} after $operation failure: $error',
+        '${attempted.hostPort} after $operation: $error',
       );
-      state = state.copyWith(
-        primaryFailureCount: nextFailureCount,
-        lastFailure: error.toString(),
-      );
+      if (countPrimaryFailure) {
+        state = state.copyWith(
+          primaryFailureCount: nextFailureCount,
+          lastFailure: error.toString(),
+        );
+      }
       return false;
     }
 
@@ -379,7 +423,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
         lastFallbackError = fallbackError;
         log(
           'RpcEndpointFailover: fallback ${candidate.hostPort} failed health '
-          'check after $operation failure: $fallbackError',
+          'check after $operation: $fallbackError',
         );
       }
     }
@@ -388,12 +432,14 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       if (!_isCurrentContext(context)) return false;
       log(
         'RpcEndpointFailover: all fallback endpoints failed health checks '
-        'after $operation failure: $lastFallbackError',
+        'after $operation: $lastFallbackError',
       );
-      state = state.copyWith(
-        primaryFailureCount: nextFailureCount,
-        lastFailure: error.toString(),
-      );
+      if (countPrimaryFailure) {
+        state = state.copyWith(
+          primaryFailureCount: nextFailureCount,
+          lastFailure: error.toString(),
+        );
+      }
       return false;
     }
 
@@ -410,17 +456,17 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
     final event = RpcEndpointFailoverEvent(
       sequence: ++_eventSequence,
       kind: RpcEndpointFailoverEventKind.switchedToFallback,
-      message: 'Selected endpoint is unstable. Switched to fallback endpoint.',
+      message: eventMessage,
       endpoint: fallback,
     );
     log(
       'RpcEndpointFailover: switched ${attempted.hostPort} -> '
-      '${fallback.hostPort} after $operation failure: $error',
+      '${fallback.hostPort} after $operation: $error',
     );
     state = state.copyWith(
       current: fallback,
       primaryFailureCount: nextFailureCount,
-      lastFailure: error.toString(),
+      lastFailure: countPrimaryFailure ? error.toString() : state.lastFailure,
       switchedAt: now,
       lastPrimaryProbeAt: failedPrimary ? now : state.lastPrimaryProbeAt,
       lastEvent: event,

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -302,7 +302,7 @@ Future<ExecuteProposalResult> executeProposalWithMacosStoredMnemonic({
 Future<IronwoodMigrationResult> migrateOrchardToIronwood({
   required String dbPath,
   required String lightwalletdUrl,
-  String? transactionRelayUrl,
+  String? transactionSubmissionTarget,
   required String network,
   required String accountUuid,
   required List<int> mnemonicBytes,
@@ -313,7 +313,7 @@ Future<IronwoodMigrationResult> migrateOrchardToIronwood({
 }) => RustLib.instance.api.crateApiSyncMigrateOrchardToIronwood(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
-  transactionRelayUrl: transactionRelayUrl,
+  transactionSubmissionTarget: transactionSubmissionTarget,
   network: network,
   accountUuid: accountUuid,
   mnemonicBytes: mnemonicBytes,
@@ -554,20 +554,20 @@ Future<String> createOrResumePrivateMigrationDraft({
   required String accountUuid,
   required List<MigrationScheduledTransfer> approvedSchedule,
   required bool spacePreparationBroadcasts,
-  String? transactionRelayUrl,
+  String? transactionSubmissionTarget,
 }) => RustLib.instance.api.crateApiSyncCreateOrResumePrivateMigrationDraft(
   dbPath: dbPath,
   network: network,
   accountUuid: accountUuid,
   approvedSchedule: approvedSchedule,
   spacePreparationBroadcasts: spacePreparationBroadcasts,
-  transactionRelayUrl: transactionRelayUrl,
+  transactionSubmissionTarget: transactionSubmissionTarget,
 );
 
 Future<IronwoodMigrationResult> completeOrchardMigrationDenominationsPczt({
   required String dbPath,
   required String lightwalletdUrl,
-  String? transactionRelayUrl,
+  String? transactionSubmissionTarget,
   required String network,
   required String accountUuid,
   required String requestId,
@@ -579,7 +579,7 @@ Future<IronwoodMigrationResult> completeOrchardMigrationDenominationsPczt({
     RustLib.instance.api.crateApiSyncCompleteOrchardMigrationDenominationsPczt(
       dbPath: dbPath,
       lightwalletdUrl: lightwalletdUrl,
-      transactionRelayUrl: transactionRelayUrl,
+      transactionSubmissionTarget: transactionSubmissionTarget,
       network: network,
       accountUuid: accountUuid,
       requestId: requestId,
@@ -610,7 +610,7 @@ Future<KeystoneMigrationSigningRequest> prepareOrchardMigrationSingleQrPczt({
 Future<IronwoodMigrationResult> completeOrchardMigrationSingleQrPczt({
   required String dbPath,
   required String lightwalletdUrl,
-  String? transactionRelayUrl,
+  String? transactionSubmissionTarget,
   required String network,
   required String accountUuid,
   required String requestId,
@@ -620,7 +620,7 @@ Future<IronwoodMigrationResult> completeOrchardMigrationSingleQrPczt({
 }) => RustLib.instance.api.crateApiSyncCompleteOrchardMigrationSingleQrPczt(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
-  transactionRelayUrl: transactionRelayUrl,
+  transactionSubmissionTarget: transactionSubmissionTarget,
   network: network,
   accountUuid: accountUuid,
   requestId: requestId,
@@ -675,7 +675,7 @@ Future<IronwoodMigrationResult>
 migrateOrchardToIronwoodWithMacosStoredMnemonic({
   required String dbPath,
   required String lightwalletdUrl,
-  String? transactionRelayUrl,
+  String? transactionSubmissionTarget,
   required String network,
   required String accountUuid,
   required String password,
@@ -686,7 +686,7 @@ migrateOrchardToIronwoodWithMacosStoredMnemonic({
     .crateApiSyncMigrateOrchardToIronwoodWithMacosStoredMnemonic(
       dbPath: dbPath,
       lightwalletdUrl: lightwalletdUrl,
-      transactionRelayUrl: transactionRelayUrl,
+      transactionSubmissionTarget: transactionSubmissionTarget,
       network: network,
       accountUuid: accountUuid,
       password: password,
@@ -1312,7 +1312,7 @@ class KeystoneSignedMigrationMessage {
 
 class MigrationOutboxBatch {
   final String runId;
-  final String? transactionRelayUrl;
+  final String? transactionSubmissionTarget;
   final int timingMeanBlocks;
   final int timingMaxBlocks;
   final int? nextProofHeight;
@@ -1320,7 +1320,7 @@ class MigrationOutboxBatch {
 
   const MigrationOutboxBatch({
     required this.runId,
-    this.transactionRelayUrl,
+    this.transactionSubmissionTarget,
     required this.timingMeanBlocks,
     required this.timingMaxBlocks,
     this.nextProofHeight,
@@ -1330,7 +1330,7 @@ class MigrationOutboxBatch {
   @override
   int get hashCode =>
       runId.hashCode ^
-      transactionRelayUrl.hashCode ^
+      transactionSubmissionTarget.hashCode ^
       timingMeanBlocks.hashCode ^
       timingMaxBlocks.hashCode ^
       nextProofHeight.hashCode ^
@@ -1342,7 +1342,7 @@ class MigrationOutboxBatch {
       other is MigrationOutboxBatch &&
           runtimeType == other.runtimeType &&
           runId == other.runId &&
-          transactionRelayUrl == other.transactionRelayUrl &&
+          transactionSubmissionTarget == other.transactionSubmissionTarget &&
           timingMeanBlocks == other.timingMeanBlocks &&
           timingMaxBlocks == other.timingMaxBlocks &&
           nextProofHeight == other.nextProofHeight &&

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -206,7 +206,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncCompleteOrchardMigrationDenominationsPczt({
     required String dbPath,
     required String lightwalletdUrl,
-    String? transactionRelayUrl,
+    String? transactionSubmissionTarget,
     required String network,
     required String accountUuid,
     required String requestId,
@@ -230,7 +230,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncCompleteOrchardMigrationSingleQrPczt({
     required String dbPath,
     required String lightwalletdUrl,
-    String? transactionRelayUrl,
+    String? transactionSubmissionTarget,
     required String network,
     required String accountUuid,
     required String requestId,
@@ -272,7 +272,7 @@ abstract class RustLibApi extends BaseApi {
     required String accountUuid,
     required List<MigrationScheduledTransfer> approvedSchedule,
     required bool spacePreparationBroadcasts,
-    String? transactionRelayUrl,
+    String? transactionSubmissionTarget,
   });
 
   Future<Uint8List> crateApiSyncCreatePcztFromProposal({
@@ -747,7 +747,7 @@ abstract class RustLibApi extends BaseApi {
   Future<IronwoodMigrationResult> crateApiSyncMigrateOrchardToIronwood({
     required String dbPath,
     required String lightwalletdUrl,
-    String? transactionRelayUrl,
+    String? transactionSubmissionTarget,
     required String network,
     required String accountUuid,
     required List<int> mnemonicBytes,
@@ -774,7 +774,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncMigrateOrchardToIronwoodWithMacosStoredMnemonic({
     required String dbPath,
     required String lightwalletdUrl,
-    String? transactionRelayUrl,
+    String? transactionSubmissionTarget,
     required String network,
     required String accountUuid,
     required String password,
@@ -1851,7 +1851,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncCompleteOrchardMigrationDenominationsPczt({
     required String dbPath,
     required String lightwalletdUrl,
-    String? transactionRelayUrl,
+    String? transactionSubmissionTarget,
     required String network,
     required String accountUuid,
     required String requestId,
@@ -1866,7 +1866,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
-          sse_encode_opt_String(transactionRelayUrl, serializer);
+          sse_encode_opt_String(transactionSubmissionTarget, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(requestId, serializer);
@@ -1896,7 +1896,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
-          transactionRelayUrl,
+          transactionSubmissionTarget,
           network,
           accountUuid,
           requestId,
@@ -1917,7 +1917,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
-          "transactionRelayUrl",
+          "transactionSubmissionTarget",
           "network",
           "accountUuid",
           "requestId",
@@ -1995,7 +1995,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncCompleteOrchardMigrationSingleQrPczt({
     required String dbPath,
     required String lightwalletdUrl,
-    String? transactionRelayUrl,
+    String? transactionSubmissionTarget,
     required String network,
     required String accountUuid,
     required String requestId,
@@ -2009,7 +2009,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
-          sse_encode_opt_String(transactionRelayUrl, serializer);
+          sse_encode_opt_String(transactionSubmissionTarget, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(requestId, serializer);
@@ -2034,7 +2034,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
-          transactionRelayUrl,
+          transactionSubmissionTarget,
           network,
           accountUuid,
           requestId,
@@ -2054,7 +2054,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
-          "transactionRelayUrl",
+          "transactionSubmissionTarget",
           "network",
           "accountUuid",
           "requestId",
@@ -2257,7 +2257,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String accountUuid,
     required List<MigrationScheduledTransfer> approvedSchedule,
     required bool spacePreparationBroadcasts,
-    String? transactionRelayUrl,
+    String? transactionSubmissionTarget,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -2271,7 +2271,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_bool(spacePreparationBroadcasts, serializer);
-          sse_encode_opt_String(transactionRelayUrl, serializer);
+          sse_encode_opt_String(transactionSubmissionTarget, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -2290,7 +2290,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           accountUuid,
           approvedSchedule,
           spacePreparationBroadcasts,
-          transactionRelayUrl,
+          transactionSubmissionTarget,
         ],
         apiImpl: this,
       ),
@@ -2306,7 +2306,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "accountUuid",
           "approvedSchedule",
           "spacePreparationBroadcasts",
-          "transactionRelayUrl",
+          "transactionSubmissionTarget",
         ],
       );
 
@@ -5385,7 +5385,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<IronwoodMigrationResult> crateApiSyncMigrateOrchardToIronwood({
     required String dbPath,
     required String lightwalletdUrl,
-    String? transactionRelayUrl,
+    String? transactionSubmissionTarget,
     required String network,
     required String accountUuid,
     required List<int> mnemonicBytes,
@@ -5400,7 +5400,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
-          sse_encode_opt_String(transactionRelayUrl, serializer);
+          sse_encode_opt_String(transactionSubmissionTarget, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_list_prim_u_8_loose(mnemonicBytes, serializer);
@@ -5426,7 +5426,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
-          transactionRelayUrl,
+          transactionSubmissionTarget,
           network,
           accountUuid,
           mnemonicBytes,
@@ -5446,7 +5446,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
-          "transactionRelayUrl",
+          "transactionSubmissionTarget",
           "network",
           "accountUuid",
           "mnemonicBytes",
@@ -5532,7 +5532,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncMigrateOrchardToIronwoodWithMacosStoredMnemonic({
     required String dbPath,
     required String lightwalletdUrl,
-    String? transactionRelayUrl,
+    String? transactionSubmissionTarget,
     required String network,
     required String accountUuid,
     required String password,
@@ -5546,7 +5546,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
-          sse_encode_opt_String(transactionRelayUrl, serializer);
+          sse_encode_opt_String(transactionSubmissionTarget, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(password, serializer);
@@ -5572,7 +5572,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
-          transactionRelayUrl,
+          transactionSubmissionTarget,
           network,
           accountUuid,
           password,
@@ -5592,7 +5592,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
-          "transactionRelayUrl",
+          "transactionSubmissionTarget",
           "network",
           "accountUuid",
           "password",
@@ -8923,7 +8923,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return MigrationOutboxBatch(
       runId: dco_decode_String(arr[0]),
-      transactionRelayUrl: dco_decode_opt_String(arr[1]),
+      transactionSubmissionTarget: dco_decode_opt_String(arr[1]),
       timingMeanBlocks: dco_decode_u_32(arr[2]),
       timingMaxBlocks: dco_decode_u_32(arr[3]),
       nextProofHeight: dco_decode_opt_box_autoadd_u_32(arr[4]),
@@ -11561,14 +11561,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_runId = sse_decode_String(deserializer);
-    var var_transactionRelayUrl = sse_decode_opt_String(deserializer);
+    var var_transactionSubmissionTarget = sse_decode_opt_String(deserializer);
     var var_timingMeanBlocks = sse_decode_u_32(deserializer);
     var var_timingMaxBlocks = sse_decode_u_32(deserializer);
     var var_nextProofHeight = sse_decode_opt_box_autoadd_u_32(deserializer);
     var var_items = sse_decode_list_migration_outbox_item(deserializer);
     return MigrationOutboxBatch(
       runId: var_runId,
-      transactionRelayUrl: var_transactionRelayUrl,
+      transactionSubmissionTarget: var_transactionSubmissionTarget,
       timingMeanBlocks: var_timingMeanBlocks,
       timingMaxBlocks: var_timingMaxBlocks,
       nextProofHeight: var_nextProofHeight,
@@ -14350,7 +14350,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.runId, serializer);
-    sse_encode_opt_String(self.transactionRelayUrl, serializer);
+    sse_encode_opt_String(self.transactionSubmissionTarget, serializer);
     sse_encode_u_32(self.timingMeanBlocks, serializer);
     sse_encode_u_32(self.timingMaxBlocks, serializer);
     sse_encode_opt_box_autoadd_u_32(self.nextProofHeight, serializer);

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -742,7 +742,7 @@ pub struct MigrationOutboxItem {
 
 pub struct MigrationOutboxBatch {
     pub run_id: String,
-    pub transaction_relay_url: Option<String>,
+    pub transaction_submission_target: Option<String>,
     pub timing_mean_blocks: u32,
     pub timing_max_blocks: u32,
     pub next_proof_height: Option<u32>,
@@ -1101,7 +1101,7 @@ pub fn execute_proposal_with_macos_stored_mnemonic(
 pub fn migrate_orchard_to_ironwood(
     db_path: String,
     lightwalletd_url: String,
-    transaction_relay_url: Option<String>,
+    transaction_submission_target: Option<String>,
     network: String,
     account_uuid: String,
     mnemonic_bytes: Vec<u8>,
@@ -1121,7 +1121,7 @@ pub fn migrate_orchard_to_ironwood(
         let r = rt.block_on(wallet_sync::migrate_orchard_to_ironwood(
             &db_path,
             &lightwalletd_url,
-            transaction_relay_url.as_deref(),
+            transaction_submission_target.as_deref(),
             network,
             &account_uuid,
             seed,
@@ -1570,7 +1570,7 @@ pub fn export_orchard_migration_outbox(
         .map(|batch| {
             batch.map(|batch| MigrationOutboxBatch {
                 run_id: batch.run_id,
-                transaction_relay_url: batch.transaction_relay_url,
+                transaction_submission_target: batch.transaction_submission_target,
                 timing_mean_blocks: batch.timing_mean_blocks,
                 timing_max_blocks: batch.timing_max_blocks,
                 next_proof_height: batch.next_proof_height,
@@ -1738,7 +1738,7 @@ pub fn create_or_resume_private_migration_draft(
     account_uuid: String,
     approved_schedule: Vec<MigrationScheduledTransfer>,
     space_preparation_broadcasts: bool,
-    transaction_relay_url: Option<String>,
+    transaction_submission_target: Option<String>,
 ) -> Result<String, String> {
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
@@ -1750,7 +1750,7 @@ pub fn create_or_resume_private_migration_draft(
             wallet_sync::PreparationTimingPolicy::from_spacing_enabled(
                 space_preparation_broadcasts,
             ),
-            transaction_relay_url.as_deref(),
+            transaction_submission_target.as_deref(),
         )
     })
 }
@@ -1810,7 +1810,7 @@ fn to_wallet_signed_messages(
 pub async fn complete_orchard_migration_denominations_pczt(
     db_path: String,
     lightwalletd_url: String,
-    transaction_relay_url: Option<String>,
+    transaction_submission_target: Option<String>,
     network: String,
     account_uuid: String,
     request_id: String,
@@ -1825,7 +1825,7 @@ pub async fn complete_orchard_migration_denominations_pczt(
     let r = wallet_sync::complete_orchard_migration_denominations_pczt(
         &db_path,
         &lightwalletd_url,
-        transaction_relay_url.as_deref(),
+        transaction_submission_target.as_deref(),
         network,
         &account_uuid,
         &request_id,
@@ -1886,7 +1886,7 @@ pub fn prepare_orchard_migration_single_qr_pczt(
 pub async fn complete_orchard_migration_single_qr_pczt(
     db_path: String,
     lightwalletd_url: String,
-    transaction_relay_url: Option<String>,
+    transaction_submission_target: Option<String>,
     network: String,
     account_uuid: String,
     request_id: String,
@@ -1900,7 +1900,7 @@ pub async fn complete_orchard_migration_single_qr_pczt(
     let r = wallet_sync::complete_orchard_migration_single_qr_pczt(
         &db_path,
         &lightwalletd_url,
-        transaction_relay_url.as_deref(),
+        transaction_submission_target.as_deref(),
         network,
         &account_uuid,
         &request_id,
@@ -2004,7 +2004,7 @@ pub fn complete_orchard_migration_batch_pczt(
 pub fn migrate_orchard_to_ironwood_with_macos_stored_mnemonic(
     db_path: String,
     lightwalletd_url: String,
-    transaction_relay_url: Option<String>,
+    transaction_submission_target: Option<String>,
     network: String,
     account_uuid: String,
     password: String,
@@ -2025,7 +2025,7 @@ pub fn migrate_orchard_to_ironwood_with_macos_stored_mnemonic(
         let r = rt.block_on(wallet_sync::migrate_orchard_to_ironwood(
             &db_path,
             &lightwalletd_url,
-            transaction_relay_url.as_deref(),
+            transaction_submission_target.as_deref(),
             network,
             &account_uuid,
             seed,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -636,7 +636,7 @@ fn wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
-            let api_transaction_relay_url = <Option<String>>::sse_decode(&mut deserializer);
+            let api_transaction_submission_target = <Option<String>>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_request_id = <String>::sse_decode(&mut deserializer);
@@ -656,7 +656,7 @@ fn wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(
                             crate::api::sync::complete_orchard_migration_denominations_pczt(
                                 api_db_path,
                                 api_lightwalletd_url,
-                                api_transaction_relay_url,
+                                api_transaction_submission_target,
                                 api_network,
                                 api_account_uuid,
                                 api_request_id,
@@ -751,7 +751,7 @@ fn wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
-            let api_transaction_relay_url = <Option<String>>::sse_decode(&mut deserializer);
+            let api_transaction_submission_target = <Option<String>>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_request_id = <String>::sse_decode(&mut deserializer);
@@ -769,7 +769,7 @@ fn wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(
                             crate::api::sync::complete_orchard_migration_single_qr_pczt(
                                 api_db_path,
                                 api_lightwalletd_url,
-                                api_transaction_relay_url,
+                                api_transaction_submission_target,
                                 api_network,
                                 api_account_uuid,
                                 api_request_id,
@@ -977,7 +977,7 @@ fn wire__crate__api__sync__create_or_resume_private_migration_draft_impl(
             let api_approved_schedule =
                 <Vec<crate::api::sync::MigrationScheduledTransfer>>::sse_decode(&mut deserializer);
             let api_space_preparation_broadcasts = <bool>::sse_decode(&mut deserializer);
-            let api_transaction_relay_url = <Option<String>>::sse_decode(&mut deserializer);
+            let api_transaction_submission_target = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -987,7 +987,7 @@ fn wire__crate__api__sync__create_or_resume_private_migration_draft_impl(
                         api_account_uuid,
                         api_approved_schedule,
                         api_space_preparation_broadcasts,
-                        api_transaction_relay_url,
+                        api_transaction_submission_target,
                     )?;
                     Ok(output_ok)
                 })())
@@ -4069,7 +4069,7 @@ fn wire__crate__api__sync__migrate_orchard_to_ironwood_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
-            let api_transaction_relay_url = <Option<String>>::sse_decode(&mut deserializer);
+            let api_transaction_submission_target = <Option<String>>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_mnemonic_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
@@ -4084,7 +4084,7 @@ fn wire__crate__api__sync__migrate_orchard_to_ironwood_impl(
                     let output_ok = crate::api::sync::migrate_orchard_to_ironwood(
                         api_db_path,
                         api_lightwalletd_url,
-                        api_transaction_relay_url,
+                        api_transaction_submission_target,
                         api_network,
                         api_account_uuid,
                         api_mnemonic_bytes,
@@ -4174,7 +4174,7 @@ fn wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemoni
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
-            let api_transaction_relay_url = <Option<String>>::sse_decode(&mut deserializer);
+            let api_transaction_submission_target = <Option<String>>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_password = <String>::sse_decode(&mut deserializer);
@@ -4189,7 +4189,7 @@ fn wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemoni
                         crate::api::sync::migrate_orchard_to_ironwood_with_macos_stored_mnemonic(
                             api_db_path,
                             api_lightwalletd_url,
-                            api_transaction_relay_url,
+                            api_transaction_submission_target,
                             api_network,
                             api_account_uuid,
                             api_password,
@@ -7914,14 +7914,14 @@ impl SseDecode for crate::api::sync::MigrationOutboxBatch {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_runId = <String>::sse_decode(deserializer);
-        let mut var_transactionRelayUrl = <Option<String>>::sse_decode(deserializer);
+        let mut var_transactionSubmissionTarget = <Option<String>>::sse_decode(deserializer);
         let mut var_timingMeanBlocks = <u32>::sse_decode(deserializer);
         let mut var_timingMaxBlocks = <u32>::sse_decode(deserializer);
         let mut var_nextProofHeight = <Option<u32>>::sse_decode(deserializer);
         let mut var_items = <Vec<crate::api::sync::MigrationOutboxItem>>::sse_decode(deserializer);
         return crate::api::sync::MigrationOutboxBatch {
             run_id: var_runId,
-            transaction_relay_url: var_transactionRelayUrl,
+            transaction_submission_target: var_transactionSubmissionTarget,
             timing_mean_blocks: var_timingMeanBlocks,
             timing_max_blocks: var_timingMaxBlocks,
             next_proof_height: var_nextProofHeight,
@@ -10505,7 +10505,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::sync::MigrationOutboxBatch {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.run_id.into_into_dart().into_dart(),
-            self.transaction_relay_url.into_into_dart().into_dart(),
+            self.transaction_submission_target
+                .into_into_dart()
+                .into_dart(),
             self.timing_mean_blocks.into_into_dart().into_dart(),
             self.timing_max_blocks.into_into_dart().into_dart(),
             self.next_proof_height.into_into_dart().into_dart(),
@@ -13086,7 +13088,7 @@ impl SseEncode for crate::api::sync::MigrationOutboxBatch {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.run_id, serializer);
-        <Option<String>>::sse_encode(self.transaction_relay_url, serializer);
+        <Option<String>>::sse_encode(self.transaction_submission_target, serializer);
         <u32>::sse_encode(self.timing_mean_blocks, serializer);
         <u32>::sse_encode(self.timing_max_blocks, serializer);
         <Option<u32>>::sse_encode(self.next_proof_height, serializer);

--- a/rust/src/wallet/sync/broadcast.rs
+++ b/rust/src/wallet/sync/broadcast.rs
@@ -11,39 +11,39 @@ use zcash_protocol::consensus::BranchId;
 const TRANSACTION_RELAY_TIMEOUT: Duration = Duration::from_secs(15);
 const TRANSACTION_RELAY_MAX_RESPONSE_BYTES: usize = 64 * 1024;
 
-pub(crate) fn parse_separate_relay_transaction(
+pub(crate) fn parse_separate_submission_transaction(
     txid: TxId,
     raw_tx: &[u8],
     expiry_height: u32,
 ) -> Result<Transaction, String> {
     if expiry_height == 0 {
         return Err(format!(
-            "Separate-relay transaction {txid} has no expiry height"
+            "Separate-route transaction {txid} has no expiry height"
         ));
     }
     let mut reader = Cursor::new(raw_tx);
     let tx = Transaction::read(&mut reader, BranchId::Sapling)
-        .map_err(|e| format!("Parse separate-relay transaction {txid}: {e}"))?;
+        .map_err(|e| format!("Parse separate-route transaction {txid}: {e}"))?;
     if reader.position() != raw_tx.len() as u64 {
         return Err(format!(
-            "Separate-relay transaction {txid} has trailing bytes"
+            "Separate-route transaction {txid} has trailing bytes"
         ));
     }
     if tx.txid() != txid {
         return Err(format!(
-            "Separate-relay transaction bytes do not match {txid}"
+            "Separate-route transaction bytes do not match {txid}"
         ));
     }
     if u32::from(tx.expiry_height()) != expiry_height {
         return Err(format!(
-            "Separate-relay transaction {txid} does not match expiry height {expiry_height}"
+            "Separate-route transaction {txid} does not match expiry height {expiry_height}"
         ));
     }
     if tx.sapling_bundle().is_none()
         && tx.orchard_bundle().is_none()
         && tx.ironwood_bundle().is_none()
     {
-        return Err(format!("Separate-relay transaction {txid} is not shielded"));
+        return Err(format!("Separate-route transaction {txid} is not shielded"));
     }
     Ok(tx)
 }
@@ -174,7 +174,7 @@ pub(super) fn validate_transaction_relay_url(endpoint: &str) -> Result<Url, Stri
 
     match url.scheme() {
         "https" => {}
-        "http" if relay_host_is_loopback(&url) => {}
+        "http" if url_host_is_local(&url) => {}
         "http" => {
             return Err("Transaction relay URL requires HTTPS except for loopback".to_string());
         }
@@ -183,10 +183,59 @@ pub(super) fn validate_transaction_relay_url(endpoint: &str) -> Result<Url, Stri
     Ok(url)
 }
 
-fn relay_host_is_loopback(url: &Url) -> bool {
+pub(super) fn validate_lightwalletd_submission_url(endpoint: &str) -> Result<Url, String> {
+    let url = Url::parse(endpoint)
+        .map_err(|e| format!("Invalid transaction submission lightwalletd URL: {e}"))?;
+    if url.host().is_none() {
+        return Err("Transaction submission lightwalletd URL has no host".to_string());
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(
+            "Transaction submission lightwalletd URL must not contain credentials".to_string(),
+        );
+    }
+    if url.query().is_some() || url.fragment().is_some() || url.path() != "/" {
+        return Err(
+            "Transaction submission lightwalletd URL must contain only an origin".to_string(),
+        );
+    }
+    match url.scheme() {
+        "https" => {}
+        "http" if url_host_is_local(&url) => {}
+        "http" => {
+            return Err(
+                "Transaction submission lightwalletd URL requires HTTPS except for local hosts"
+                    .to_string(),
+            );
+        }
+        _ => {
+            return Err("Transaction submission lightwalletd URL must use HTTPS".to_string());
+        }
+    }
+    Ok(url)
+}
+
+pub(super) fn validate_distinct_lightwalletd_submission_url(
+    submission_endpoint: &str,
+    sync_endpoint: &str,
+) -> Result<Url, String> {
+    let submission = validate_lightwalletd_submission_url(submission_endpoint)?;
+    let sync =
+        Url::parse(sync_endpoint).map_err(|e| format!("Invalid sync lightwalletd URL: {e}"))?;
+    let submission_host = submission
+        .host_str()
+        .ok_or("Transaction submission lightwalletd URL has no host")?;
+    let sync_host = sync.host_str().ok_or("Sync lightwalletd URL has no host")?;
+    if submission_host.eq_ignore_ascii_case(sync_host) {
+        return Err("Transaction submission lightwalletd must not use the sync host".to_string());
+    }
+    Ok(submission)
+}
+
+fn url_host_is_local(url: &Url) -> bool {
     match url.host() {
         Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
-        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv4(address)) => address.is_loopback() || address.octets() == [10, 0, 2, 2],
         Some(Host::Ipv6(address)) => address.is_loopback(),
         None => false,
     }
@@ -500,6 +549,53 @@ mod tests {
             "http://[::1]:18232",
         ] {
             TransactionRelayClient::new(url).unwrap_or_else(|error| panic!("{url}: {error}"));
+        }
+    }
+
+    #[test]
+    fn alternate_lightwalletd_requires_a_different_host() {
+        let alternate = validate_distinct_lightwalletd_submission_url(
+            "https://submit.example.com:443",
+            "https://sync.example.com:443",
+        )
+        .expect("different hosts are accepted");
+        assert_eq!(alternate.host_str(), Some("submit.example.com"));
+
+        for alternate in [
+            "https://SYNC.example.com:9067",
+            "https://sync.example.com:443",
+        ] {
+            let error = validate_distinct_lightwalletd_submission_url(
+                alternate,
+                "https://sync.example.com:443",
+            )
+            .expect_err("same host must be rejected regardless of case or port");
+            assert!(error.contains("must not use the sync host"), "{error}");
+        }
+    }
+
+    #[test]
+    fn alternate_lightwalletd_url_rejects_unsafe_origins() {
+        for endpoint in [
+            "http://example.com:9067",
+            "https://user@example.com:443",
+            "https://example.com:443/rpc",
+            "https://example.com:443?token=secret",
+        ] {
+            assert!(
+                validate_lightwalletd_submission_url(endpoint).is_err(),
+                "{endpoint}"
+            );
+        }
+
+        for endpoint in [
+            "https://example.com:443",
+            "http://localhost:18232",
+            "http://127.0.0.1:18232",
+            "http://10.0.2.2:18232",
+        ] {
+            validate_lightwalletd_submission_url(endpoint)
+                .unwrap_or_else(|error| panic!("{endpoint}: {error}"));
         }
     }
 }

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -231,24 +231,26 @@ pub(crate) struct DuePendingMigrationTx {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum MigrationSubmissionPolicy {
     Lightwalletd,
+    LightwalletdUrl(String),
     SeparateRelay(String),
 }
 
 const LIGHTWALLETD_SUBMISSION_TARGET: &str = "lightwalletd";
+const LIGHTWALLETD_SUBMISSION_PREFIX: &str = "lightwalletd:";
 const SEPARATE_RELAY_SUBMISSION_PREFIX: &str = "relay:";
 
-fn migration_submission_target(transaction_relay_url: Option<&str>) -> Result<String, String> {
-    match transaction_relay_url {
-        Some(url) => {
-            let url = url.trim();
-            if url.is_empty() {
-                return Err("Migration transaction relay URL is empty".to_string());
-            }
-            let url = super::broadcast::validate_transaction_relay_url(url)?;
-            Ok(format!("{SEPARATE_RELAY_SUBMISSION_PREFIX}{url}"))
-        }
-        None => Ok(LIGHTWALLETD_SUBMISSION_TARGET.to_string()),
+fn migration_submission_target(
+    transaction_submission_target: Option<&str>,
+) -> Result<String, String> {
+    let Some(target) = transaction_submission_target else {
+        return Ok(LIGHTWALLETD_SUBMISSION_TARGET.to_string());
+    };
+    let target = target.trim();
+    if target.is_empty() {
+        return Err("Migration transaction submission target is empty".to_string());
     }
+    let policy = parse_migration_submission_target("new", target)?;
+    Ok(encode_migration_submission_policy(&policy))
 }
 
 fn parse_migration_submission_target(
@@ -257,6 +259,10 @@ fn parse_migration_submission_target(
 ) -> Result<MigrationSubmissionPolicy, String> {
     if target == LIGHTWALLETD_SUBMISSION_TARGET {
         return Ok(MigrationSubmissionPolicy::Lightwalletd);
+    }
+    if let Some(url) = target.strip_prefix(LIGHTWALLETD_SUBMISSION_PREFIX) {
+        let url = super::broadcast::validate_lightwalletd_submission_url(url)?;
+        return Ok(MigrationSubmissionPolicy::LightwalletdUrl(url.to_string()));
     }
     if let Some(url) = target.strip_prefix(SEPARATE_RELAY_SUBMISSION_PREFIX) {
         let url = super::broadcast::validate_transaction_relay_url(url)?;
@@ -267,15 +273,27 @@ fn parse_migration_submission_target(
     ))
 }
 
+fn encode_migration_submission_policy(policy: &MigrationSubmissionPolicy) -> String {
+    match policy {
+        MigrationSubmissionPolicy::Lightwalletd => LIGHTWALLETD_SUBMISSION_TARGET.to_string(),
+        MigrationSubmissionPolicy::LightwalletdUrl(url) => {
+            format!("{LIGHTWALLETD_SUBMISSION_PREFIX}{url}")
+        }
+        MigrationSubmissionPolicy::SeparateRelay(url) => {
+            format!("{SEPARATE_RELAY_SUBMISSION_PREFIX}{url}")
+        }
+    }
+}
+
 fn validate_denomination_stages_for_submission_policy(
     policy: &MigrationSubmissionPolicy,
     stages: &[DenominationStageInsert],
 ) -> Result<(), String> {
-    if matches!(policy, MigrationSubmissionPolicy::SeparateRelay(_))
+    if !matches!(policy, MigrationSubmissionPolicy::Lightwalletd)
         && stages.iter().any(|stage| stage.expiry_height == 0)
     {
         return Err(
-            "Separate-relay denomination transactions require a nonzero expiry height".to_string(),
+            "Separate-route denomination transactions require a nonzero expiry height".to_string(),
         );
     }
     Ok(())
@@ -377,13 +395,13 @@ fn migration_submission_record_with_conn(
     Ok(Some((run_id, policy, expiry_height)))
 }
 
-pub(crate) fn is_separate_relay_migration_transaction(
+pub(crate) fn is_separate_submission_migration_transaction(
     conn: &rusqlite::Connection,
     txid_hex: &str,
 ) -> Result<bool, String> {
     migration_submission_record_with_conn(conn, txid_hex).map(|record| {
         record.is_some_and(|(_, policy, _)| {
-            matches!(policy, MigrationSubmissionPolicy::SeparateRelay(_))
+            !matches!(policy, MigrationSubmissionPolicy::Lightwalletd)
         })
     })
 }
@@ -403,7 +421,7 @@ pub(crate) struct MigrationOutboxItem {
 #[derive(Debug)]
 pub(crate) struct MigrationOutboxBatch {
     pub run_id: String,
-    pub transaction_relay_url: Option<String>,
+    pub transaction_submission_target: Option<String>,
     pub timing_mean_blocks: u32,
     pub timing_max_blocks: u32,
     pub next_proof_height: Option<u32>,
@@ -1389,7 +1407,7 @@ pub(crate) fn create_run_with_staged_denominations_and_signed_children(
     denomination_stages: Vec<DenominationStageInsert>,
     approved_schedule: Option<&[MigrationScheduleEntry]>,
     preparation_timing_policy: PreparationTimingPolicy,
-    transaction_relay_url: Option<&str>,
+    transaction_submission_target: Option<&str>,
     password: &[u8],
     salt_base64: &str,
 ) -> Result<String, String> {
@@ -1423,7 +1441,7 @@ pub(crate) fn create_run_with_staged_denominations_and_signed_children(
     let target_values_json = serde_json::to_string(&plan.migration_outputs)
         .map_err(|e| format!("Encode migration targets: {e}"))?;
     let timing_policy = configured_timing_policy(network);
-    let migration_submission_target = migration_submission_target(transaction_relay_url)?;
+    let migration_submission_target = migration_submission_target(transaction_submission_target)?;
     let migration_submission_policy =
         parse_migration_submission_target(&run_id, &migration_submission_target)?;
     validate_denomination_stages_for_submission_policy(
@@ -1517,7 +1535,7 @@ pub(crate) fn create_or_resume_private_migration_draft(
     target_values_zatoshi: &[u64],
     approved_schedule: &[MigrationScheduleEntry],
     preparation_timing_policy: PreparationTimingPolicy,
-    transaction_relay_url: Option<&str>,
+    transaction_submission_target: Option<&str>,
 ) -> Result<String, String> {
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
@@ -1552,7 +1570,7 @@ pub(crate) fn create_or_resume_private_migration_draft(
         .map_err(|e| format!("Encode Keystone migration targets: {e}"))?;
     let schedule_json = serde_json::to_string(approved_schedule)
         .map_err(|e| format!("Encode Keystone migration schedule: {e}"))?;
-    let migration_submission_target = migration_submission_target(transaction_relay_url)?;
+    let migration_submission_target = migration_submission_target(transaction_submission_target)?;
     tx.execute(
         &format!(
             "INSERT INTO {RUNS_TABLE}
@@ -3309,9 +3327,9 @@ pub(crate) fn export_scheduled_migration_outbox(
         return Ok(None);
     };
     let timing_policy = timing_policy_for_run_with_conn(&conn, &run.run_id, network)?;
-    let transaction_relay_url = match migration_submission_policy(db_path, &run.run_id)? {
+    let transaction_submission_target = match migration_submission_policy(db_path, &run.run_id)? {
         MigrationSubmissionPolicy::Lightwalletd => None,
-        MigrationSubmissionPolicy::SeparateRelay(url) => Some(url),
+        policy => Some(encode_migration_submission_policy(&policy)),
     };
     let (timing_mean_blocks, timing_max_blocks) =
         schedule_parameters_with_policy(network, timing_policy);
@@ -3407,7 +3425,7 @@ pub(crate) fn export_scheduled_migration_outbox(
     }
     Ok(Some(MigrationOutboxBatch {
         run_id: run.run_id,
-        transaction_relay_url,
+        transaction_submission_target,
         timing_mean_blocks,
         timing_max_blocks,
         next_proof_height,

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -1242,17 +1242,29 @@ fn delete_account_migration_rows_rolls_back_with_account_transaction() {
 #[test]
 fn invalid_denomination_submission_target_fails_closed() {
     assert!(parse_migration_submission_target("run-1", "relay:").is_err());
+    assert!(parse_migration_submission_target("run-1", "lightwalletd:").is_err());
     assert!(parse_migration_submission_target("run-1", "invalid").is_err());
+
+    assert_eq!(
+        parse_migration_submission_target("run-1", "lightwalletd:https://submit.example.com:443")
+            .unwrap(),
+        MigrationSubmissionPolicy::LightwalletdUrl("https://submit.example.com/".to_string())
+    );
 }
 
 #[test]
-fn separate_relay_requires_expiring_denomination_transactions() {
-    let mut stage = pending_test_stage(&"11".repeat(32), vec![1, 2, 3]);
-    let relay =
-        MigrationSubmissionPolicy::SeparateRelay("https://relay.example/submit".to_string());
-    assert!(validate_denomination_stages_for_submission_policy(&relay, &[stage.clone()]).is_err());
-    stage.expiry_height = 1;
-    validate_denomination_stages_for_submission_policy(&relay, &[stage]).unwrap();
+fn separate_submission_requires_expiring_denomination_transactions() {
+    for policy in [
+        MigrationSubmissionPolicy::SeparateRelay("https://relay.example/submit".to_string()),
+        MigrationSubmissionPolicy::LightwalletdUrl("https://submit.example.com/".to_string()),
+    ] {
+        let mut stage = pending_test_stage(&"11".repeat(32), vec![1, 2, 3]);
+        assert!(
+            validate_denomination_stages_for_submission_policy(&policy, &[stage.clone()]).is_err()
+        );
+        stage.expiry_height = 1;
+        validate_denomination_stages_for_submission_policy(&policy, &[stage]).unwrap();
+    }
 }
 
 #[test]
@@ -5147,7 +5159,7 @@ fn private_migration_draft_persists_plan_and_finalizes_in_place() {
         &target_values,
         &approved_schedule,
         PreparationTimingPolicy::Immediate,
-        Some("https://relay.one/submit"),
+        Some("relay:https://relay.one/submit"),
     )
     .unwrap();
     let resumed_run_id = create_or_resume_private_migration_draft(
@@ -8050,8 +8062,8 @@ fn migration_outbox_export_decrypts_only_scheduled_children() {
 
     assert_eq!(batch.run_id, "outbox-export");
     assert_eq!(
-        batch.transaction_relay_url.as_deref(),
-        Some("https://relay.example/submit")
+        batch.transaction_submission_target.as_deref(),
+        Some("relay:https://relay.example/submit")
     );
     assert!(batch.timing_mean_blocks > 0);
     assert!(batch.timing_max_blocks >= batch.timing_mean_blocks);

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -1377,7 +1377,7 @@ async fn execute_stored_proposal(
 pub(crate) async fn migrate_orchard_to_ironwood(
     db_path: &str,
     lightwalletd_url: &str,
-    transaction_relay_url: Option<&str>,
+    transaction_submission_target: Option<&str>,
     network: WalletNetwork,
     account_uuid: &str,
     seed: SecretVec<u8>,
@@ -1581,7 +1581,7 @@ pub(crate) async fn migrate_orchard_to_ironwood(
             denomination_stages,
             Some(&approved_schedule),
             preparation_timing_policy,
-            transaction_relay_url,
+            transaction_submission_target,
             pending_password.as_slice(),
             pending_salt_base64,
         )?
@@ -4750,11 +4750,51 @@ enum DenominationStageBroadcastReadiness {
     Ready,
 }
 
-fn validate_separate_relay_denomination_stage(
+#[derive(Debug)]
+enum ResolvedMigrationSubmission {
+    Lightwalletd { url: String, is_separate: bool },
+    Relay(String),
+}
+
+impl ResolvedMigrationSubmission {
+    fn from_policy(
+        policy: &super::migration::MigrationSubmissionPolicy,
+        sync_lightwalletd_url: &str,
+    ) -> Result<Self, String> {
+        match policy {
+            super::migration::MigrationSubmissionPolicy::Lightwalletd => Ok(Self::Lightwalletd {
+                url: sync_lightwalletd_url.to_string(),
+                is_separate: false,
+            }),
+            super::migration::MigrationSubmissionPolicy::LightwalletdUrl(url) => {
+                let url = super::broadcast::validate_distinct_lightwalletd_submission_url(
+                    url,
+                    sync_lightwalletd_url,
+                )?;
+                Ok(Self::Lightwalletd {
+                    url: url.to_string(),
+                    is_separate: true,
+                })
+            }
+            super::migration::MigrationSubmissionPolicy::SeparateRelay(url) => {
+                Ok(Self::Relay(url.clone()))
+            }
+        }
+    }
+
+    fn is_separate(&self) -> bool {
+        match self {
+            Self::Lightwalletd { is_separate, .. } => *is_separate,
+            Self::Relay(_) => true,
+        }
+    }
+}
+
+fn validate_separate_submission_denomination_stage(
     stage: &super::migration::PendingRawDenominationStage,
 ) -> Result<(), String> {
     let expected_txid = parse_txid_hex(&stage.expected_txid_hex)?;
-    super::broadcast::parse_separate_relay_transaction(
+    super::broadcast::parse_separate_submission_transaction(
         expected_txid,
         &stage.raw_tx,
         stage.expiry_height,
@@ -4805,11 +4845,6 @@ async fn broadcast_pending_denomination_stages(
     policy: MigrationBroadcastPolicy<'_>,
 ) -> Result<Option<CreatedBroadcastResult>, String> {
     let submission_policy = super::migration::migration_submission_policy(db_path, run_id)?;
-    let persisted_relay_url = match submission_policy {
-        super::migration::MigrationSubmissionPolicy::Lightwalletd => None,
-        super::migration::MigrationSubmissionPolicy::SeparateRelay(url) => Some(url),
-    };
-    let transaction_relay_url = persisted_relay_url.as_deref();
     let progress = super::get_sync_progress(db_path, network)?;
     let scanned_height = u32::try_from(progress.scanned_height)
         .map_err(|_| "Migration scanned height exceeds u32".to_string())?;
@@ -4870,30 +4905,48 @@ async fn broadcast_pending_denomination_stages(
             ),
         }));
     }
-    // When configured, do not contact lightwalletd from this preparation path,
-    // including for a fresh height. The preceding wallet sync already persisted
-    // the tip used below.
-    let relay_client = match transaction_relay_url {
-        Some(url) => match super::broadcast::TransactionRelayClient::new(url) {
-            Ok(client) => Some(client),
+    let submission =
+        match ResolvedMigrationSubmission::from_policy(&submission_policy, lightwalletd_url) {
+            Ok(submission) => submission,
             Err(e) => {
                 return Ok(Some(CreatedBroadcastResult {
                     txids,
                     status: CreatedBroadcastResult::PENDING_BROADCAST,
                     broadcasted_count: 0,
                     total_count,
-                    message: Some(format!("Denomination split relay could not start: {e}")),
+                    message: Some(format!(
+                        "Denomination split submission target is invalid: {e}"
+                    )),
                 }));
             }
-        },
-        None => None,
+        };
+    // A JSON-RPC relay cannot provide a fresh chain height. The preceding
+    // wallet sync already persisted the tip used for that route.
+    let relay_client = match &submission {
+        ResolvedMigrationSubmission::Relay(url) => {
+            match super::broadcast::TransactionRelayClient::new(url) {
+                Ok(client) => Some(client),
+                Err(e) => {
+                    return Ok(Some(CreatedBroadcastResult {
+                        txids,
+                        status: CreatedBroadcastResult::PENDING_BROADCAST,
+                        broadcasted_count: 0,
+                        total_count,
+                        message: Some(format!("Denomination split relay could not start: {e}")),
+                    }));
+                }
+            }
+        }
+        ResolvedMigrationSubmission::Lightwalletd { .. } => None,
     };
     let mut lwd_client = None;
     let chain_tip_height = if relay_client.is_some() {
         known_chain_tip_height
     } else {
-        let mut client = match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await
-        {
+        let ResolvedMigrationSubmission::Lightwalletd { url, .. } = &submission else {
+            unreachable!("relay route was handled above")
+        };
+        let mut client = match crate::wallet::sync_engine::open_lwd_channel(url).await {
             Ok(client) => client,
             Err(e) => {
                 return Ok(Some(CreatedBroadcastResult {
@@ -4962,15 +5015,17 @@ async fn broadcast_pending_denomination_stages(
             run_id,
             &stage.expected_txid_hex,
         )?;
-        let broadcast_result = if let Some(client) = relay_client.as_ref() {
-            match validate_separate_relay_denomination_stage(stage) {
-                Ok(()) => {
-                    client
-                        .send_raw_transaction(&stage.raw_tx, &stage.expected_txid_hex)
-                        .await
-                }
-                Err(e) => Err(e),
-            }
+        let validation_result = if submission.is_separate() {
+            validate_separate_submission_denomination_stage(stage)
+        } else {
+            Ok(())
+        };
+        let broadcast_result = if let Err(e) = validation_result {
+            Err(e)
+        } else if let Some(client) = relay_client.as_ref() {
+            client
+                .send_raw_transaction(&stage.raw_tx, &stage.expected_txid_hex)
+                .await
         } else {
             broadcast_raw_transaction(
                 lwd_client
@@ -5081,18 +5136,18 @@ async fn broadcast_pending_denomination_stages(
     }))
 }
 
-fn validate_separate_relay_migration_transaction(
+fn validate_separate_submission_migration_transaction(
     pending: &super::migration::DuePendingMigrationTx,
 ) -> Result<(), String> {
     let expected_txid = parse_txid_hex(&pending.txid_hex)?;
-    let tx = super::broadcast::parse_separate_relay_transaction(
+    let tx = super::broadcast::parse_separate_submission_transaction(
         expected_txid,
         &pending.raw_tx,
         pending.expiry_height,
     )?;
     if tx.orchard_bundle().is_none() || tx.ironwood_bundle().is_none() {
         return Err(format!(
-            "Separate-relay migration transaction {} does not cross from Orchard to Ironwood",
+            "Separate-route migration transaction {} does not cross from Orchard to Ironwood",
             pending.txid_hex
         ));
     }
@@ -5227,10 +5282,34 @@ async fn broadcast_due_scheduled_migration_txs(
     }
 
     let submission_policy = super::migration::migration_submission_policy(db_path, run_id)?;
-    let relay_client = match submission_policy {
-        super::migration::MigrationSubmissionPolicy::Lightwalletd => None,
-        super::migration::MigrationSubmissionPolicy::SeparateRelay(url) => {
-            match super::broadcast::TransactionRelayClient::new(&url) {
+    let submission =
+        match ResolvedMigrationSubmission::from_policy(&submission_policy, lightwalletd_url) {
+            Ok(submission) => submission,
+            Err(e) => {
+                let message = format!("Migration submission target is invalid: {e}");
+                super::migration::mark_run_phase(
+                    db_path,
+                    run_id,
+                    super::migration::PHASE_FAILED_RECOVERABLE,
+                    Some(&message),
+                )?;
+                return Ok(MigrationBroadcastAdvance::without_acceptance(
+                    IronwoodMigrationResult {
+                        txids: String::new(),
+                        status: super::migration::PHASE_FAILED_RECOVERABLE.to_string(),
+                        broadcasted_count: 0,
+                        total_count: fallback_total_count,
+                        message: Some(message),
+                        fee_zatoshi: 0,
+                        migrated_zatoshi: fallback_migrated_zatoshi,
+                    },
+                ));
+            }
+        };
+    let relay_client = match &submission {
+        ResolvedMigrationSubmission::Lightwalletd { .. } => None,
+        ResolvedMigrationSubmission::Relay(url) => {
+            match super::broadcast::TransactionRelayClient::new(url) {
                 Ok(client) => Some(client),
                 Err(e) => {
                     let message = format!("Migration relay could not start: {e}");
@@ -5255,8 +5334,9 @@ async fn broadcast_due_scheduled_migration_txs(
             }
         }
     };
-    let mut lwd_client = if relay_client.is_none() {
-        match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await {
+    let mut lwd_client = if let ResolvedMigrationSubmission::Lightwalletd { url, .. } = &submission
+    {
+        match crate::wallet::sync_engine::open_lwd_channel(url).await {
             Ok(client) => Some(client),
             Err(e) => {
                 let message = format!("Migration broadcast could not start: {e}");
@@ -5296,15 +5376,17 @@ async fn broadcast_due_scheduled_migration_txs(
             break;
         }
         super::migration::mark_pending_broadcast_attempted(db_path, run_id, &pending.txid_hex)?;
-        let broadcast_result = if let Some(client) = relay_client.as_ref() {
-            match validate_separate_relay_migration_transaction(&pending) {
-                Ok(()) => {
-                    client
-                        .send_raw_transaction(&pending.raw_tx, &pending.txid_hex)
-                        .await
-                }
-                Err(error) => Err(error),
-            }
+        let validation_result = if submission.is_separate() {
+            validate_separate_submission_migration_transaction(&pending)
+        } else {
+            Ok(())
+        };
+        let broadcast_result = if let Err(error) = validation_result {
+            Err(error)
+        } else if let Some(client) = relay_client.as_ref() {
+            client
+                .send_raw_transaction(&pending.raw_tx, &pending.txid_hex)
+                .await
         } else {
             broadcast_raw_transaction(
                 lwd_client

--- a/rust/src/wallet/sync/send/ironwood_migration.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration.rs
@@ -4,7 +4,7 @@ pub(crate) fn create_or_resume_private_migration_draft(
     account_uuid: &str,
     approved_schedule: Vec<super::migration::MigrationScheduleEntry>,
     preparation_timing_policy: super::migration::PreparationTimingPolicy,
-    transaction_relay_url: Option<&str>,
+    transaction_submission_target: Option<&str>,
 ) -> Result<String, String> {
     let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
     let plan = get_orchard_migration_private_plan(
@@ -21,7 +21,7 @@ pub(crate) fn create_or_resume_private_migration_draft(
         &plan.target_values_zatoshi,
         &approved_schedule,
         preparation_timing_policy,
-        transaction_relay_url,
+        transaction_submission_target,
     )
 }
 
@@ -151,7 +151,7 @@ pub(crate) fn prepare_orchard_migration_denominations_pczt(
 pub(crate) async fn complete_orchard_migration_denominations_pczt(
     db_path: &str,
     lightwalletd_url: &str,
-    transaction_relay_url: Option<&str>,
+    transaction_submission_target: Option<&str>,
     network: WalletNetwork,
     account_uuid: &str,
     request_id: &str,
@@ -257,7 +257,7 @@ pub(crate) async fn complete_orchard_migration_denominations_pczt(
                 denomination_stages,
                 Some(&approved_schedule),
                 stored.preparation_timing_policy,
-                transaction_relay_url,
+                transaction_submission_target,
                 pending_password,
                 pending_salt_base64,
             )
@@ -453,7 +453,7 @@ pub(crate) fn prepare_orchard_migration_single_qr_pczt(
 pub(crate) async fn complete_orchard_migration_single_qr_pczt(
     db_path: &str,
     lightwalletd_url: &str,
-    transaction_relay_url: Option<&str>,
+    transaction_submission_target: Option<&str>,
     network: WalletNetwork,
     account_uuid: &str,
     request_id: &str,
@@ -587,7 +587,7 @@ pub(crate) async fn complete_orchard_migration_single_qr_pczt(
             denomination_stages,
             Some(&stored.approved_schedule),
             stored.preparation_timing_policy,
-            transaction_relay_url,
+            transaction_submission_target,
             pending_password,
             pending_salt_base64,
         )

--- a/rust/src/wallet/sync/send/ironwood_migration/status_advance.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/status_advance.rs
@@ -74,7 +74,7 @@ enum StagedDenominationAdvance {
     Ready,
 }
 
-fn restore_observed_separate_relay_transactions<F>(
+fn restore_observed_separate_submission_transactions<F>(
     conn: &rusqlite::Connection,
     stages: &[super::migration::DenominationStage],
     mut store: F,
@@ -97,7 +97,7 @@ where
         }
         store(raw_tx, identity.mined_height).map_err(|error| {
             format!(
-                "Restore observed separate-relay denomination transaction {}: {error}",
+                "Restore observed separate-route denomination transaction {}: {error}",
                 stage.expected_txid_hex
             )
         })?;
@@ -115,9 +115,9 @@ fn reconcile_mined_denomination_stages(
     pending_password: &[u8],
     pending_salt_base64: &str,
 ) -> Result<Vec<super::migration::DenominationStage>, String> {
-    let uses_separate_relay = matches!(
+    let uses_separate_submission = !matches!(
         super::migration::migration_submission_policy(db_path, run_id)?,
-        super::migration::MigrationSubmissionPolicy::SeparateRelay(_)
+        super::migration::MigrationSubmissionPolicy::Lightwalletd
     );
     super::migration::reconcile_denomination_stage_chain_state(db_path, run_id)?;
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
@@ -127,8 +127,8 @@ fn reconcile_mined_denomination_stages(
         pending_password,
         pending_salt_base64,
     )?;
-    if uses_separate_relay {
-        let restored = restore_observed_separate_relay_transactions(
+    if uses_separate_submission {
+        let restored = restore_observed_separate_submission_transactions(
             &conn,
             &stages,
             |raw_tx, mined_height| {
@@ -142,7 +142,7 @@ fn reconcile_mined_denomination_stages(
         )?;
         if restored > 0 {
             log::info!(
-                "migration: restored {restored} observed separate-relay denomination transaction(s) from retained local bytes"
+                "migration: restored {restored} observed separate-route denomination transaction(s) from retained local bytes"
             );
         }
     }

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -14,6 +14,33 @@ const MIGRATION_TEST_PASSWORD: &[u8] = b"correct horse battery staple";
 const MIGRATION_TEST_SALT: &str = "AQIDBAUGBwgJCgsMDQ4PEA==";
 
 #[test]
+fn resolves_alternate_lightwalletd_without_reusing_sync_host() {
+    let resolved = ResolvedMigrationSubmission::from_policy(
+        &migration::MigrationSubmissionPolicy::LightwalletdUrl(
+            "https://submit.example.com:443".to_string(),
+        ),
+        "https://sync.example.com:443",
+    )
+    .unwrap();
+    assert!(matches!(
+        resolved,
+        ResolvedMigrationSubmission::Lightwalletd {
+            is_separate: true,
+            ..
+        }
+    ));
+
+    let error = ResolvedMigrationSubmission::from_policy(
+        &migration::MigrationSubmissionPolicy::LightwalletdUrl(
+            "https://SYNC.example.com:9067".to_string(),
+        ),
+        "https://sync.example.com:443",
+    )
+    .expect_err("same-host submission must fail");
+    assert!(error.contains("must not use the sync host"), "{error}");
+}
+
+#[test]
 fn migration_stop_preserves_zero_as_the_no_expiry_sentinel() {
     assert!(!migration_stop_candidate_is_expired(0, u32::MAX));
     assert!(!migration_stop_candidate_is_expired(200, 199));
@@ -1780,7 +1807,7 @@ fn create_denomination_expiry_test_run(
 }
 
 #[test]
-fn observed_separate_relay_stage_restores_missing_wallet_raw() {
+fn observed_separate_submission_stage_restores_missing_wallet_raw() {
     let (_temp_dir, db_path, run_id) =
         create_denomination_expiry_test_run(migration::DenominationStageStatus::Pending);
     let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
@@ -1807,12 +1834,15 @@ fn observed_separate_relay_stage_restores_missing_wallet_raw() {
     .unwrap();
 
     let mut stored = Vec::new();
-    let restored =
-        restore_observed_separate_relay_transactions(&conn, &stages, |raw_tx, mined_height| {
+    let restored = restore_observed_separate_submission_transactions(
+        &conn,
+        &stages,
+        |raw_tx, mined_height| {
             stored.push((raw_tx.to_vec(), mined_height));
             Ok(())
-        })
-        .unwrap();
+        },
+    )
+    .unwrap();
 
     assert_eq!(restored, 1);
     assert_eq!(stored, vec![(vec![1, 2, 3, 4], 105)]);

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -1758,7 +1758,10 @@ pub(crate) fn get_resubmittable_txs_excluding(
                 .try_into()
                 .map_err(|_| "Resubmission transaction ID must be 32 bytes".to_string())?,
         );
-        if super::migration::is_separate_relay_migration_transaction(&read_tx, &txid.to_string())? {
+        if super::migration::is_separate_submission_migration_transaction(
+            &read_tx,
+            &txid.to_string(),
+        )? {
             continue;
         }
         let raw_tx = raw_stmt
@@ -4760,7 +4763,7 @@ mod tests {
     }
 
     #[test]
-    fn resubmit_excludes_separate_relay_migration_transactions() {
+    fn resubmit_excludes_separate_submission_migration_transactions() {
         let db = fresh_db();
         let preparation_txid = fake_txid(0x08);
         let preparation_txid_hex = TxId::from_bytes(preparation_txid).to_string();

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math' show Random;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 
@@ -270,58 +272,92 @@ void main() {
     });
   });
 
-  group('transactionRelayUrlForPrimaryEndpoint', () {
-    test('never relays a custom endpoint that matches a preset URL', () {
-      final preset = defaultRpcEndpointConfig('main');
-      final custom = RpcEndpointConfig(
-        networkName: preset.networkName,
-        lightwalletdUrl: preset.lightwalletdUrl,
+  group('transaction submission targets', () {
+    test('mainnet includes Zakura and alternate lightwalletd hosts', () {
+      final primary = defaultRpcEndpointConfig('main');
+      final targets = transactionSubmissionTargetsForSyncEndpoint(
+        primary,
+        mainUrl: '   ',
+      );
+
+      expect(targets.first, 'relay:https://zakura-broadcast.valargroup.dev');
+      expect(
+        targets.where((target) => target.startsWith('lightwalletd:')),
+        isNotEmpty,
+      );
+      final primaryHost = Uri.parse(primary.normalizedLightwalletdUrl).host;
+      for (final target in targets.where(
+        (target) => target.startsWith('lightwalletd:'),
+      )) {
+        expect(
+          Uri.parse(target.substring('lightwalletd:'.length)).host,
+          isNot(equals(primaryHost)),
+        );
+      }
+    });
+
+    test('custom sync endpoints still receive managed alternatives', () {
+      const primary = RpcEndpointConfig(
+        networkName: 'main',
+        lightwalletdUrl: 'https://custom.example:443',
         presetId: kCustomRpcEndpointPresetId,
       );
 
+      final targets = transactionSubmissionTargetsForSyncEndpoint(
+        primary,
+        mainUrl: 'https://relay.example/submit',
+      );
+
+      expect(targets.first, 'relay:https://relay.example/submit');
       expect(
-        transactionRelayUrlForPrimaryEndpoint(
-          custom,
-          mainUrl: 'https://relay.example/submit',
-        ),
-        isNull,
+        targets.where((target) => target.startsWith('lightwalletd:')),
+        isNotEmpty,
       );
     });
 
-    test('uses the network relay for a non-default managed preset', () {
+    test('same lightwalletd host is excluded even on another port', () {
       const primary = RpcEndpointConfig(
         networkName: 'main',
-        lightwalletdUrl: 'https://zec.rocks:443',
-        presetId: 'zec-rocks',
+        lightwalletdUrl: 'https://zec.rocks:9067',
+        presetId: kCustomRpcEndpointPresetId,
       );
 
+      final targets = transactionSubmissionTargetsForSyncEndpoint(primary);
+
+      expect(targets, isNot(contains('lightwalletd:https://zec.rocks:443')));
       expect(
-        transactionRelayUrlForPrimaryEndpoint(
-          primary,
-          mainUrl: '  https://relay.example/submit  ',
-        ),
-        'https://relay.example/submit',
+        targets.where((target) => target.startsWith('lightwalletd:')),
+        isNotEmpty,
       );
     });
 
-    test('does not trust a recognized preset id with a mismatched URL', () {
-      const stalePrimary = RpcEndpointConfig(
-        networkName: 'main',
-        lightwalletdUrl: 'https://unexpected.example:443',
-        presetId: 'zec-rocks',
+    test('testnet uses another lightwalletd when no relay is configured', () {
+      final targets = transactionSubmissionTargetsForSyncEndpoint(
+        defaultRpcEndpointConfig('test'),
+        testUrl: '   ',
       );
 
-      expect(isCustomRpcEndpointConfig(stalePrimary), isFalse);
+      expect(targets, ['lightwalletd:https://zcash.mysideoftheweb.com:19067']);
+    });
+
+    test('regtest keeps the legacy route only without a separate target', () {
       expect(
-        transactionRelayUrlForPrimaryEndpoint(
-          stalePrimary,
-          mainUrl: 'https://relay.example/submit',
+        transactionSubmissionTargetsForSyncEndpoint(
+          defaultRpcEndpointConfig('regtest'),
+          regtestUrl: '   ',
         ),
-        isNull,
+        isEmpty,
+      );
+      expect(
+        transactionSubmissionTargetsForSyncEndpoint(
+          defaultRpcEndpointConfig('regtest'),
+          regtestUrl: 'http://127.0.0.1:8080/submit',
+        ),
+        ['relay:http://127.0.0.1:8080/submit'],
       );
     });
 
-    test('uses a separate relay for Ironwood Masquerade builds', () {
+    test('Ironwood Masquerade uses its configured relay', () {
       const primary = RpcEndpointConfig(
         networkName: 'main',
         lightwalletdUrl: 'https://lwd.157.245.208.35.sslip.io:443',
@@ -329,76 +365,24 @@ void main() {
       );
 
       expect(
-        transactionRelayUrlForPrimaryEndpoint(
+        transactionSubmissionTargetsForSyncEndpoint(
           primary,
-          mainUrl: 'https://main.example/submit',
           ironwoodMasqueradeUrl: 'https://ironwood.example/submit',
           ironwoodMasquerade: true,
         ),
-        'https://ironwood.example/submit',
+        ['relay:https://ironwood.example/submit'],
       );
     });
 
-    test('selects the configured relay by network', () {
-      const urls = (
-        main: 'https://main.example/submit',
-        test: 'https://test.example/submit',
-        regtest: 'http://127.0.0.1:8080/submit',
-      );
+    test('selector chooses one candidate from the immutable pool', () {
+      final primary = defaultRpcEndpointConfig('main');
+      final targets = transactionSubmissionTargetsForSyncEndpoint(primary);
+      final expectedRandom = Random(7);
+      final expected = targets[expectedRandom.nextInt(targets.length)];
 
       expect(
-        transactionRelayUrlForPrimaryEndpoint(
-          defaultRpcEndpointConfig('main'),
-          mainUrl: urls.main,
-          testUrl: urls.test,
-          regtestUrl: urls.regtest,
-        ),
-        urls.main,
-      );
-      expect(
-        transactionRelayUrlForPrimaryEndpoint(
-          defaultRpcEndpointConfig('test'),
-          mainUrl: urls.main,
-          testUrl: urls.test,
-          regtestUrl: urls.regtest,
-        ),
-        urls.test,
-      );
-      expect(
-        transactionRelayUrlForPrimaryEndpoint(
-          defaultRpcEndpointConfig('regtest'),
-          mainUrl: urls.main,
-          testUrl: urls.test,
-          regtestUrl: urls.regtest,
-        ),
-        urls.regtest,
-      );
-    });
-
-    test('uses the Zakura endpoint when the main build URL is empty', () {
-      expect(
-        transactionRelayUrlForPrimaryEndpoint(
-          defaultRpcEndpointConfig('main'),
-          mainUrl: '   ',
-        ),
-        'https://zakura-broadcast.valargroup.dev',
-      );
-    });
-
-    test('keeps non-mainnet routing disabled when build URLs are empty', () {
-      expect(
-        transactionRelayUrlForPrimaryEndpoint(
-          defaultRpcEndpointConfig('test'),
-          testUrl: '   ',
-        ),
-        isNull,
-      );
-      expect(
-        transactionRelayUrlForPrimaryEndpoint(
-          defaultRpcEndpointConfig('regtest'),
-          regtestUrl: '   ',
-        ),
-        isNull,
+        transactionSubmissionTargetForSyncEndpoint(primary, random: Random(7)),
+        expected,
       );
     });
   });

--- a/test/features/migration/ironwood_migration_coordinator_provider_test.dart
+++ b/test/features/migration/ironwood_migration_coordinator_provider_test.dart
@@ -2021,7 +2021,7 @@ ProviderContainer _container({
         ({
           required dbPath,
           required lightwalletdUrl,
-          String? transactionRelayUrl,
+          String? transactionSubmissionTarget,
           required network,
           required accountUuid,
           required password,

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -868,7 +868,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
-            String? transactionRelayUrl,
+            String? transactionSubmissionTarget,
             required network,
             required accountUuid,
             required approvedSchedule,
@@ -3478,7 +3478,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
-            String? transactionRelayUrl,
+            String? transactionSubmissionTarget,
             required network,
             required accountUuid,
             required password,
@@ -6034,7 +6034,7 @@ IronwoodMigrationService _migrationServiceForStart({
         ({
           required dbPath,
           required lightwalletdUrl,
-          String? transactionRelayUrl,
+          String? transactionSubmissionTarget,
           required network,
           required accountUuid,
           required approvedSchedule,
@@ -6178,7 +6178,7 @@ IronwoodMigrationService _keystonePrivateReviewService({
         ({
           required dbPath,
           required lightwalletdUrl,
-          String? transactionRelayUrl,
+          String? transactionSubmissionTarget,
           required network,
           required accountUuid,
           required approvedSchedule,

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -901,14 +901,18 @@ void main() {
               expect(password, isNotEmpty);
               expect(saltBase64, isNotEmpty);
               return _outboxBatch(
-                transactionRelayUrl: 'https://relay.example/submit',
+                transactionSubmissionTarget:
+                    'relay:https://relay.example/submit',
               );
             },
         stageMigrationOutboxBatch: (batch) async {
           events.add('stage');
           expect(batch['batchId'], 'test:account-1:run-1');
           expect(batch['lightwalletdUrl'], 'https://lwd.example:443');
-          expect(batch['transactionRelayUrl'], 'https://relay.example/submit');
+          expect(
+            batch['transactionSubmissionTarget'],
+            'relay:https://relay.example/submit',
+          );
           return const {'txid-1': 'digest-1'};
         },
         armMigrationOutboxBatch:
@@ -1854,7 +1858,7 @@ void main() {
       final returnedMnemonicBytes = <Uint8List>[];
       final seenSalts = <String>[];
       final seenMnemonicPayloads = <List<int>>[];
-      final seenRelayUrls = <String?>[];
+      final seenSubmissionTargets = <String?>[];
       final service = IronwoodMigrationService(
         getWalletDbPath: () async => '/tmp/wallet.db',
         getStatus: ({required dbPath, required network, required accountUuid}) {
@@ -1871,7 +1875,8 @@ void main() {
           networkName: 'test',
           lightwalletdUrl: 'https://lwd.example:443',
         ),
-        getTransactionRelayUrl: () => 'https://relay.example/submit',
+        getTransactionSubmissionTarget: (_) =>
+            'relay:https://relay.example/submit',
         getSessionPassword: () => 'test-password',
         getMnemonicBytesForAccount: (_) async {
           final bytes = Uint8List.fromList([1, 2, 3, 4]);
@@ -1883,7 +1888,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -1893,7 +1898,7 @@ void main() {
             }) {
               seenSalts.add(saltBase64);
               seenMnemonicPayloads.add(List<int>.from(mnemonicBytes));
-              seenRelayUrls.add(transactionRelayUrl);
+              seenSubmissionTargets.add(transactionSubmissionTarget);
               return Future.value(_migrationResult());
             },
       );
@@ -1913,9 +1918,9 @@ void main() {
         [1, 2, 3, 4],
         [1, 2, 3, 4],
       ]);
-      expect(seenRelayUrls, [
-        'https://relay.example/submit',
-        'https://relay.example/submit',
+      expect(seenSubmissionTargets, [
+        'relay:https://relay.example/submit',
+        'relay:https://relay.example/submit',
       ]);
       expect(returnedMnemonicBytes, hasLength(2));
       for (final bytes in returnedMnemonicBytes) {
@@ -1986,7 +1991,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -2074,7 +2079,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required requestId,
@@ -2151,7 +2156,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -2644,7 +2649,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
-            transactionRelayUrl,
+            transactionSubmissionTarget,
             required network,
             required accountUuid,
             required password,
@@ -2718,7 +2723,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -2733,7 +2738,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -2836,7 +2841,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
-            transactionRelayUrl,
+            transactionSubmissionTarget,
             required network,
             required accountUuid,
             required password,
@@ -2890,7 +2895,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required password,
@@ -2998,7 +3003,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required requestId,
@@ -3165,7 +3170,7 @@ void main() {
         activeRunId: 'draft-run-1',
       );
       var createCount = 0;
-      String? seenRelayUrl;
+      String? seenSubmissionTarget;
       final service = IronwoodMigrationService(
         getWalletDbPath: () async => '/tmp/wallet.db',
         getStatus:
@@ -3179,7 +3184,8 @@ void main() {
         ),
         backgroundCredentialStore: store,
         getEndpoint: _testEndpoint,
-        getTransactionRelayUrl: () => 'https://relay.example/submit',
+        getTransactionSubmissionTarget: (_) =>
+            'relay:https://relay.example/submit',
         isMobile: () => true,
         isIOS: () => true,
         listMigrationOutboxReceipts: () async => const [],
@@ -3189,10 +3195,10 @@ void main() {
               required network,
               required accountUuid,
               required approvedSchedule,
-              String? transactionRelayUrl,
+              String? transactionSubmissionTarget,
             }) async {
               createCount += 1;
-              seenRelayUrl = transactionRelayUrl;
+              seenSubmissionTarget = transactionSubmissionTarget;
               return 'draft-run-1';
             },
       );
@@ -3204,7 +3210,7 @@ void main() {
 
       expect(runId, 'draft-run-1');
       expect(createCount, 1);
-      expect(seenRelayUrl, 'https://relay.example/submit');
+      expect(seenSubmissionTarget, 'relay:https://relay.example/submit');
       final manifest = await store.read(
         network: 'test',
         accountUuid: 'account-1',
@@ -3243,7 +3249,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required requestId,
@@ -3677,7 +3683,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required mnemonicBytes,
@@ -3789,7 +3795,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required mnemonicBytes,
@@ -3884,7 +3890,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required mnemonicBytes,
@@ -3948,7 +3954,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -4015,7 +4021,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -4121,7 +4127,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -4363,7 +4369,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -4657,7 +4663,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              transactionRelayUrl,
+              transactionSubmissionTarget,
               required network,
               required accountUuid,
               required requestId,
@@ -4781,7 +4787,7 @@ void main() {
               ({
                 required dbPath,
                 required lightwalletdUrl,
-                transactionRelayUrl,
+                transactionSubmissionTarget,
                 required network,
                 required accountUuid,
                 required mnemonicBytes,
@@ -5342,7 +5348,7 @@ IronwoodMigrationService _notificationAuthorizationService({
         ({
           required dbPath,
           required lightwalletdUrl,
-          transactionRelayUrl,
+          transactionSubmissionTarget,
           required network,
           required accountUuid,
           required approvedSchedule,
@@ -5393,11 +5399,11 @@ rust_sync.IronwoodMigrationResult _migrationResult({
 rust_sync.MigrationOutboxBatch _outboxBatch({
   String runId = 'run-1',
   List<String>? txids,
-  String? transactionRelayUrl,
+  String? transactionSubmissionTarget,
 }) {
   return rust_sync.MigrationOutboxBatch(
     runId: runId,
-    transactionRelayUrl: transactionRelayUrl,
+    transactionSubmissionTarget: transactionSubmissionTarget,
     timingMeanBlocks: 144,
     timingMaxBlocks: 576,
     nextProofHeight: 576,

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -2802,6 +2802,82 @@ void main() {
     expect(seenSalts[1], seenSalts[0]);
   });
 
+  test(
+    'continuation switches sync hosts and retries a submission collision once',
+    () async {
+      const collidingEndpoint = RpcEndpointConfig(
+        networkName: 'test',
+        lightwalletdUrl: 'https://submission.example:443',
+      );
+      const distinctEndpoint = RpcEndpointConfig(
+        networkName: 'test',
+        lightwalletdUrl: 'https://sync.example:443',
+      );
+      var currentEndpoint = collidingEndpoint;
+      var switchCount = 0;
+      final broadcastEndpoints = <String>[];
+      final service = IronwoodMigrationService(
+        getWalletDbPath: () async => '/tmp/wallet.db',
+        getStatus:
+            ({required dbPath, required network, required accountUuid}) async =>
+                _migrationStatus(activeRunId: 'run-1'),
+        getPrivatePlan:
+            ({required dbPath, required network, required accountUuid}) async =>
+                null,
+        secureStore: AppSecureStore.testing(
+          storage: const FlutterSecureStorage(),
+        ),
+        getEndpoint: () => currentEndpoint,
+        switchToDistinctSyncEndpoint:
+            ({required attemptedEndpoint, required reason}) async {
+              expect(attemptedEndpoint, same(collidingEndpoint));
+              expect(
+                reason.toString(),
+                contains(
+                  'Transaction submission lightwalletd must not use the sync host',
+                ),
+              );
+              switchCount++;
+              currentEndpoint = distinctEndpoint;
+              return true;
+            },
+        getSessionPassword: () => 'test-password',
+        isHardwareAccount: (_) => true,
+        broadcastDueMigration:
+            ({
+              required dbPath,
+              required lightwalletdUrl,
+              required network,
+              required accountUuid,
+              required password,
+              required saltBase64,
+            }) async {
+              broadcastEndpoints.add(lightwalletdUrl);
+              if (broadcastEndpoints.length == 1) {
+                return _migrationResult(
+                  status: 'failed_recoverable',
+                  message:
+                      'Migration submission target is invalid: '
+                      'Transaction submission lightwalletd must not use the sync host',
+                );
+              }
+              return _migrationResult();
+            },
+      );
+
+      final result = await service.continueSoftwarePrivateMigration(
+        accountUuid: 'account-1',
+      );
+
+      expect(result.status, 'broadcasted');
+      expect(switchCount, 1);
+      expect(broadcastEndpoints, [
+        collidingEndpoint.normalizedLightwalletdUrl,
+        distinctEndpoint.normalizedLightwalletdUrl,
+      ]);
+    },
+  );
+
   test('software continuation re-enters the macOS signing path', () async {
     List<rust_sync.MigrationScheduledTransfer>? seenSchedule;
     String? seenSalt;
@@ -5385,12 +5461,14 @@ _boundBackgroundCredentialStore({String runId = 'run-1'}) async {
 
 rust_sync.IronwoodMigrationResult _migrationResult({
   String status = 'broadcasted',
+  String? message,
 }) {
   return rust_sync.IronwoodMigrationResult(
     txids: 'txid',
     status: status,
     broadcastedCount: 1,
     totalCount: 1,
+    message: message,
     feeZatoshi: BigInt.from(10_000),
     migratedZatoshi: BigInt.from(100_000_000),
   );

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -1120,7 +1120,7 @@ IronwoodMigrationService _migrationService({
         ({
           required dbPath,
           required lightwalletdUrl,
-          String? transactionRelayUrl,
+          String? transactionSubmissionTarget,
           required network,
           required accountUuid,
           required mnemonicBytes,
@@ -1134,6 +1134,7 @@ IronwoodMigrationService _migrationService({
         ({
           required dbPath,
           required lightwalletdUrl,
+          String? transactionSubmissionTarget,
           required network,
           required accountUuid,
           required mnemonicBytes,
@@ -1152,7 +1153,7 @@ IronwoodMigrationService _migrationService({
         ({
           required dbPath,
           required lightwalletdUrl,
-          String? transactionRelayUrl,
+          String? transactionSubmissionTarget,
           required network,
           required accountUuid,
           required requestId,
@@ -1179,6 +1180,7 @@ IronwoodMigrationService _migrationService({
         ({
           required dbPath,
           required lightwalletdUrl,
+          String? transactionSubmissionTarget,
           required network,
           required accountUuid,
           required requestId,
@@ -1194,7 +1196,7 @@ IronwoodMigrationService _migrationService({
           required network,
           required accountUuid,
           required approvedSchedule,
-          String? transactionRelayUrl,
+          String? transactionSubmissionTarget,
         }) =>
             onCreatePrivateDraft?.call(accountUuid, approvedSchedule) ??
             Future.value('private-draft-run'),
@@ -3605,7 +3607,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
-              String? transactionRelayUrl,
+              String? transactionSubmissionTarget,
               required network,
               required accountUuid,
               required requestId,

--- a/test/providers/rpc_endpoint_failover_provider_test.dart
+++ b/test/providers/rpc_endpoint_failover_provider_test.dart
@@ -178,6 +178,37 @@ void main() {
   });
 
   test(
+    'switchToDistinctHostFor rotates without recording endpoint failure',
+    () async {
+      final primary = defaultRpcEndpointConfig('main');
+      final container = _container(
+        primary: primary,
+        chainNameByUrl: {'https://eu.zec.stardust.rest:443': 'main'},
+        heightByUrl: {'https://eu.zec.stardust.rest:443': BigInt.from(10)},
+        settings: const RpcEndpointFailoverSettings(primaryFailureThreshold: 3),
+      );
+      addTearDown(container.dispose);
+
+      final switched = await container
+          .read(rpcEndpointFailoverProvider.notifier)
+          .switchToDistinctHostFor(
+            'Transaction submission lightwalletd must not use the sync host',
+            operation: 'migration submission separation',
+          );
+
+      final state = container.read(rpcEndpointFailoverProvider);
+      expect(switched, isTrue);
+      expect(state.current.presetId, 'eu-zec-stardust');
+      expect(state.primaryFailureCount, 0);
+      expect(state.lastFailure, isNull);
+      expect(
+        state.lastEvent?.message,
+        'Switched sync endpoint to keep migration submission separate.',
+      );
+    },
+  );
+
+  test(
     'runWithEndpointFallback retries after current fallback fails',
     () async {
       final primary = defaultRpcEndpointConfig('main');


### PR DESCRIPTION
Choose one immutable migration transaction submission target from the configured Zakura relay and managed alternate lightwalletd endpoints. Alternate lightwalletd targets are filtered and revalidated by hostname; if sync failover later selects the saved submission host, Vizor moves sync to a healthy distinct host and safely retries before any submission transport opens. Legacy iOS outbox snapshots retain their saved relay route during upgrade.

This is stacked on the relay transport layer and completes the endpoint diversification requirement for that stack.