### PR TITLE
fix(migration): drain an overdue backlog at a catch-up cadence

### DIFF
--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -4368,8 +4368,11 @@ fn reschedule_overdue_pending_txs_with_options(
 
     txids.shuffle(&mut OsRng);
     let timing_policy = timing_policy_for_run_with_conn(&conn, run_id, network)?;
+    // Every row selected above is already overdue, so this is a catch-up
+    // ladder rather than a fresh plan. Drawing it at the planning cadence
+    // makes the backlog outlive the foreground session that would drain it.
     let (mean_delay_blocks, max_delay_blocks) =
-        schedule_parameters_with_policy(network, timing_policy);
+        catch_up_schedule_parameters_with_policy(network, timing_policy);
     let offsets = random_schedule_block_offsets_with_rng(
         txids.len(),
         mean_delay_blocks,

--- a/rust/src/wallet/sync/migration/policy.rs
+++ b/rust/src/wallet/sync/migration/policy.rs
@@ -14,6 +14,11 @@ pub(crate) const REGTEST_TRANSFER_MAX_DELAY_BLOCKS: u32 = 4;
 pub(crate) const FAST_TESTNET_TRANSFER_MEAN_DELAY_BLOCKS: u32 = 12;
 pub(crate) const FAST_TESTNET_TRANSFER_MAX_DELAY_BLOCKS: u32 = 48;
 pub(crate) const FAST_TESTNET_ANCHOR_BUCKET_MODULUS: u32 = 12;
+// Cadence for redrawing a backlog of transfers that are already overdue,
+// as opposed to drawing a fresh plan. See
+// `catch_up_schedule_parameters_with_policy`.
+pub(crate) const CATCH_UP_TRANSFER_MEAN_DELAY_BLOCKS: u32 = 8;
+pub(crate) const CATCH_UP_TRANSFER_MAX_DELAY_BLOCKS: u32 = 32;
 pub(crate) const MIN_IRONWOOD_MIGRATION_OUTPUT_ZATOSHI: u64 = 1;
 // Mirrors the per-child ZIP-317 migration fee estimate used by send planning:
 // 3 logical actions (a 2-action padded Orchard bundle and a 1-action
@@ -73,6 +78,36 @@ pub(crate) fn configured_timing_policy(network: WalletNetwork) -> MigrationTimin
 
 pub(crate) fn schedule_parameters(network: WalletNetwork) -> (u32, u32) {
     schedule_parameters_with_policy(network, configured_timing_policy(network))
+}
+
+/// Timing parameters for redrawing transfers that are *already overdue*,
+/// rather than for drawing a fresh plan.
+///
+/// The two cases have different requirements. A fresh plan spaces transfers so
+/// that an observer cannot tell they belong to one wallet, and can afford the
+/// full mean because nothing is waiting yet. A backlog redraw re-times parts
+/// that have already served a randomized delay and are still pending only
+/// because the wallet was closed when they came due. Drawing those at the
+/// planning mean puts the tail of the ladder hours past the current tip, which
+/// a foreground session rarely outlives; the backlog is then redrawn from the
+/// tip at the next open, discarding the wait again. The observable result is
+/// one transfer per app open, so emission times track the user's app usage
+/// instead of the schedule — the correlation the schedule exists to prevent.
+///
+/// Catch-up keeps the randomized, never-zero separation that stops a burst,
+/// at a cadence one session can drain. It is clamped to never exceed the
+/// configured plan cadence, so networks that are already faster than this
+/// (regtest, fast testnet) keep their own parameters.
+pub(crate) fn catch_up_schedule_parameters_with_policy(
+    network: WalletNetwork,
+    timing_policy: MigrationTimingPolicy,
+) -> (u32, u32) {
+    let (mean_delay_blocks, max_delay_blocks) =
+        schedule_parameters_with_policy(network, timing_policy);
+    (
+        mean_delay_blocks.min(CATCH_UP_TRANSFER_MEAN_DELAY_BLOCKS),
+        max_delay_blocks.min(CATCH_UP_TRANSFER_MAX_DELAY_BLOCKS),
+    )
 }
 
 fn schedule_parameters_with_policy(

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -1501,6 +1501,132 @@ fn on_open_reschedule_redraws_overdue_transfers_across_wallet_runs() {
 }
 
 #[test]
+fn catch_up_cadence_never_exceeds_the_planning_cadence() {
+    for (network, timing_policy) in [
+        (WalletNetwork::Main, MigrationTimingPolicy::Standard),
+        (WalletNetwork::Main, MigrationTimingPolicy::Standard90Minutes),
+        (
+            WalletNetwork::Main,
+            MigrationTimingPolicy::Standard90MinutesLatestAnchor,
+        ),
+        (WalletNetwork::Test, MigrationTimingPolicy::Standard90Minutes),
+        (WalletNetwork::Test, MigrationTimingPolicy::FastTestnet),
+        (WalletNetwork::Regtest, MigrationTimingPolicy::Standard),
+        (WalletNetwork::Regtest, MigrationTimingPolicy::FastTestnet),
+    ] {
+        let (plan_mean, plan_max) = schedule_parameters_with_policy(network, timing_policy);
+        let (catch_up_mean, catch_up_max) =
+            catch_up_schedule_parameters_with_policy(network, timing_policy);
+        // `random_schedule_block_offsets_with_rng` asserts both are non-zero
+        // and rejects samples above the max, so an inverted or empty window
+        // would panic or spin.
+        assert!(catch_up_mean > 0 && catch_up_max > 0);
+        assert!(catch_up_mean <= catch_up_max);
+        assert!(catch_up_mean <= plan_mean);
+        assert!(catch_up_max <= plan_max);
+    }
+
+    // Mainnet is the case the catch-up window actually shortens.
+    assert_eq!(
+        catch_up_schedule_parameters_with_policy(
+            WalletNetwork::Main,
+            MigrationTimingPolicy::Standard90Minutes
+        ),
+        (
+            CATCH_UP_TRANSFER_MEAN_DELAY_BLOCKS,
+            CATCH_UP_TRANSFER_MAX_DELAY_BLOCKS
+        )
+    );
+    // Networks that already draw faster than catch-up keep their own cadence.
+    assert_eq!(
+        catch_up_schedule_parameters_with_policy(
+            WalletNetwork::Regtest,
+            MigrationTimingPolicy::Standard
+        ),
+        schedule_parameters_with_policy(WalletNetwork::Regtest, MigrationTimingPolicy::Standard)
+    );
+}
+
+#[test]
+fn overdue_reschedule_redraws_a_backlog_at_the_catch_up_cadence() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    create_outbox_test_run(
+        &db_path,
+        "run-1",
+        &[100, 200, 300, 400, 500],
+        &[Some(90), Some(90), Some(90), Some(90), Some(90)],
+    );
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    // Adopt the mainnet planning cadence (mean 66, max 576) so the redraw is
+    // exercised against the policy the reported wallets run.
+    conn.execute(
+        &format!(
+            "UPDATE {RUNS_TABLE} SET network = 'main', timing_policy = 'standard_90m'
+             WHERE run_id = 'run-1'"
+        ),
+        [],
+    )
+    .unwrap();
+    // Every part is overdue at the tip, as it is for a wallet reopened after
+    // being closed past its whole schedule.
+    conn.execute(
+        &format!(
+            "UPDATE {PENDING_TXS_TABLE}
+             SET scheduled_height = 503, schedule_start_height = 502
+             WHERE status = 'scheduled'"
+        ),
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    reschedule_overdue_pending_txs(&db_path, "run-1", WalletNetwork::Main, 503).unwrap();
+
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let redrawn = conn
+        .prepare(&format!(
+            "SELECT scheduled_height, schedule_start_height FROM {PENDING_TXS_TABLE}
+             WHERE run_id = 'run-1' AND status = 'scheduled'
+             ORDER BY scheduled_height ASC"
+        ))
+        .unwrap()
+        .query_map([], |row| {
+            Ok((row.get::<_, u32>(0)?, row.get::<_, Option<u32>>(1)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    drop(conn);
+
+    assert_eq!(redrawn.len(), 5);
+    // Re-anchored at the tip that observed them as overdue.
+    assert!(redrawn
+        .iter()
+        .all(|(_, start_height)| *start_height == Some(503)));
+
+    let (_, plan_max) =
+        schedule_parameters_with_policy(WalletNetwork::Main, MigrationTimingPolicy::Standard90Minutes);
+    let mut previous_height = 503;
+    for (scheduled_height, _) in &redrawn {
+        let gap = scheduled_height.checked_sub(previous_height).unwrap();
+        // Still separated by a random draw rather than emitted as a burst...
+        assert!(gap <= CATCH_UP_TRANSFER_MAX_DELAY_BLOCKS);
+        // ...but bounded well inside a single planning-cadence step, which is
+        // what makes the backlog drainable within one foreground session.
+        assert!(gap < plan_max);
+        previous_height = *scheduled_height;
+    }
+    // The whole backlog now lands inside the window a single planning draw
+    // could have spent on one part.
+    assert!(previous_height <= 503 + 5 * CATCH_UP_TRANSFER_MAX_DELAY_BLOCKS);
+}
+
+#[test]
 fn on_open_storage_recovery_keeps_accepted_tx_and_redraws_every_other_run() {
     let temp_dir = tempfile::tempdir().unwrap();
     let db_path = temp_dir


### PR DESCRIPTION
## Summary

Redrawing a backlog of *already overdue* migration transfers reused the **planning** cadence (mean 66 / max 576 blocks on mainnet). This gives the redraw its own shorter window (mean 8 / max 32), clamped to never exceed the configured plan cadence.

- `migration/policy.rs` — new `catch_up_schedule_parameters_with_policy()`; `.min()` against the plan cadence means regtest (1/4) and fast testnet keep their own faster parameters and can never be slowed by it.
- `migration.rs` — one line in `reschedule_overdue_pending_txs_with_options`, which by definition only ever selects rows with `scheduled_height <= tip`.

Unchanged: planning cadence, the ZIP 318 one-transfer-per-open allowance, its wallet-global scope, `minimum_delay_blocks: 1`, and the canonical-expiry `needs_resign` check.

## Motivation

The initial hypothesis was ZIP 318 anchor age selection. It isn't: `zip318_anchor_candidate_boundaries_with_policy` enumerates every legal boundary, `send.rs` narrows that to boundaries with an available witness and draws from *that* set (re-drawing if a previously preferred boundary is no longer witnessable), weighted `1 << (AGE_CAP - age)` toward the youngest legal anchor. It already picks from what is possible and never stalls waiting for a chosen age.

The actual mechanism:

1. Every part in a redraw is overdue and has already served a randomized delay; it is still pending only because the wallet was closed when it came due.
2. Re-timing the ladder at the planning mean puts its tail hours past the current tip — longer than a typical foreground session.
3. The next open finds the same backlog overdue, sends the one transfer the on-open allowance permits, and redraws the rest from the new tip, discarding the wait again.

The observable result is **one migration transfer per app open**, so emission times track the user's app-open pattern rather than the schedule. That is precisely the correlation the schedule exists to prevent — random-but-fast leaks less here than slow-but-correlated-with-user-behavior. Transfers still keep a random, never-zero separation, so nothing is emitted as a burst; a backlog now drains inside a single foreground session.

## Scope: iOS is not covered

The iOS outbox redraws the backlog natively (`BackgroundMigrationOutbox.rescheduleOverdueItems`) using `timingMeanBlocks`/`timingMaxBlocks` from `export_scheduled_migration_outbox`. That export is deliberately left on the planning cadence: `batchId` is `network:accountUuid:runId` (stable across app versions) and `stageMigrationOutboxBatch` throws `conflictingBatch` when a stored batch's timing differs from the incoming one, so changing it would break re-staging for any in-flight iOS run whose backlog has already reached the network — the stale-batch discard path only covers runs with nothing accepted yet.

Matching iOS requires batch timing to be updatable while no item is `submitting` (Swift change + tests). **Desktop and non-outbox Android are fixed by this PR.**

## Follow-up noticed, not fixed here

`reschedule_overdue_pending_txs` (per-run entry point) passes `minimum_delay_blocks: 0`, and a sampled delay of `0` is possible, so two parts can be redrawn to the same height; the wallet-wide path passes `1` specifically to prevent that. Only reachable via `MigrationBroadcastPolicy::FOREGROUND`, which nothing in Dart currently wires up — not reachable in the shipped app, so left out of this diff.

## Tests

New (`rust/src/wallet/sync/migration/tests.rs`):

- `catch_up_cadence_never_exceeds_the_planning_cadence` — across all seven network/policy pairs: non-zero and non-inverted window (both required by `random_schedule_block_offsets_with_rng`, which asserts on mean and rejection-samples against max) and never slower than the plan. Pins mainnet to 8/32 and regtest to its own values.
- `overdue_reschedule_redraws_a_backlog_at_the_catch_up_cadence` — five parts all overdue at the tip on a mainnet-cadence run (`standard_90m`): each gap <= 32 and strictly inside one planning step, all re-anchored at the observing tip, whole backlog within `tip + 5*32`.

Evidence:

- `cd rust && cargo test` — **519 passed, 1 failed**. The failure is `expired_broadcasted_without_local_raw_stays_broadcasted_for_store_retry` (`no such column: mined_height`), which reproduces identically on a stashed clean tree — pre-existing on `main`, unrelated to this change.
- `fvm flutter test test/features/migration` — 308 passed.
- `fvm flutter analyze` — 23 issues, all pre-existing warnings in files this change does not touch.

Not run: a regtest E2E over a multi-part backlog. The fix assumes the coordinator poll loop re-advances when a redrawn part comes due mid-session — traced by reading (`Timer.periodic(_migrationStatusPollInterval)` -> `refreshNow` -> `_shouldAdvance` -> `_advance`, with the desktop gate keying on the `(txid, scheduledHeight)` pair captured at foreground entry, so a redrawn part no longer counts as open-overdue and consumes no allowance), but not exercised against a live chain. That would be the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)