### PR TITLE
Coordinate migration recovery schedules across rebuilds

### DIFF
--- a/integration_test/regtest_ironwood_migration_expiry_recovery_test.dart
+++ b/integration_test/regtest_ironwood_migration_expiry_recovery_test.dart
@@ -26,7 +26,7 @@ void main() {
   setUpAll(initializeZcashWalletRuntime);
 
   testWidgets(
-    're-signs multiple expired migration parts in the existing approved run',
+    're-signs expired migration parts across waves in the approved run',
     (tester) async {
       addTearDown(cleanupDesktopRegtestWallet);
       await cleanupDesktopRegtestWallet();
@@ -210,24 +210,16 @@ void main() {
 
       final syncNotifier = container.read(syncProvider.notifier);
       final syncPause = await syncNotifier.pauseForWalletMutation();
-      late rust_sync.MigrationStatus replacement;
+      late rust_sync.MigrationStatus firstReplacement;
+      late Set<String> firstReplacementTxids;
+      late String secondWaveOldTxid;
+      late ({int originHeight, int maxBlockOffset}) firstGeneration;
       try {
-        await _runSqlite(
+        await _forceScheduledPartsExpired(
           dbPath,
-          "UPDATE vizor_migration_pending_txs "
-          "SET expiry_height = $recoveryChainHeight "
-          "WHERE run_id = '${_sqlLiteral(originalRunId)}' "
-          "AND status = 'scheduled';",
-        );
-        expect(
-          (await _runSqlite(
-            dbPath,
-            "SELECT COUNT(*) FROM vizor_migration_pending_txs "
-            "WHERE run_id = '${_sqlLiteral(originalRunId)}' "
-            "AND status = 'scheduled' "
-            "AND expiry_height = $recoveryChainHeight;",
-          )).trim(),
-          '2',
+          originalRunId,
+          recoveryChainHeight,
+          expectedCount: 2,
         );
         e2eLog(
           'forced both parts of run $originalRunId to expire at tip '
@@ -243,7 +235,7 @@ void main() {
           e2eLog('replacement submission unavailable as expected: $error');
         }
 
-        replacement = await waitForDesktopRegtestMigrationStatus(
+        firstReplacement = await waitForDesktopRegtestMigrationStatus(
           tester,
           accountUuid,
           (status) =>
@@ -261,8 +253,24 @@ void main() {
           description: 'same-run replacement migration transactions',
           timeout: const Duration(minutes: 3),
         );
-        expect(replacement.targetValuesZatoshi, orderedEquals(originalTargets));
-        expect(replacement.scheduledBroadcasts, hasLength(2));
+        expect(
+          firstReplacement.targetValuesZatoshi,
+          orderedEquals(originalTargets),
+        );
+        expect(firstReplacement.scheduledBroadcasts, hasLength(2));
+        firstReplacementTxids = firstReplacement.scheduledBroadcasts
+            .map((broadcast) => broadcast.txidHex)
+            .toSet();
+        final firstReplacementSchedule =
+            firstReplacement.scheduledBroadcasts.toList()..sort(
+              (left, right) =>
+                  left.scheduledHeight.compareTo(right.scheduledHeight),
+            );
+        secondWaveOldTxid = firstReplacementSchedule.first.txidHex;
+        firstGeneration = await _migrationRecoveryGeneration(
+          dbPath,
+          originalRunId,
+        );
 
         final recovered = await _runSqlite(
           dbPath,
@@ -315,8 +323,142 @@ void main() {
         description: 'wallet sync after forced migration expiry',
         timeout: const Duration(minutes: 5),
       );
+
+      await ironwoodDriverPost(
+        _driverUrl,
+        '/mine',
+        payload: const {'blocks': 1},
+      );
+      final secondRecoveryChain = await ironwoodDriverGet(
+        _driverUrl,
+        '/status',
+      );
+      final secondRecoveryChainHeight =
+          (secondRecoveryChain['zcashdHeight'] as num).toInt();
+      expect(secondRecoveryChainHeight, greaterThan(recoveryChainHeight));
+      await syncNotifier.startSyncAnyway();
+      await pumpUntil(
+        tester,
+        () {
+          final sync = container.read(syncProvider).value;
+          return sync?.isSyncing == false &&
+              (sync?.scannedHeight ?? 0) >= secondRecoveryChainHeight;
+        },
+        description: 'wallet sync before the later recovery wave',
+        timeout: const Duration(minutes: 5),
+      );
+
+      await ironwoodDriverPost(_driverUrl, '/lightwalletd/stop');
+      final secondSyncPause = await syncNotifier.pauseForWalletMutation();
+      late rust_sync.MigrationStatus secondReplacement;
+      try {
+        await _forceScheduledPartsExpired(
+          dbPath,
+          originalRunId,
+          secondRecoveryChainHeight,
+          txidHex: secondWaveOldTxid,
+          expectedCount: 1,
+        );
+        e2eLog(
+          'forced one replacement part of run $originalRunId to expire at '
+          'the later tip $secondRecoveryChainHeight',
+        );
+
+        try {
+          await container
+              .read(ironwoodMigrationServiceProvider)
+              .continueSoftwarePrivateMigration(accountUuid: accountUuid);
+        } catch (error) {
+          expect(error.toString(), contains('transport error'));
+          e2eLog(
+            'second replacement submission unavailable as expected: $error',
+          );
+        }
+
+        secondReplacement = await waitForDesktopRegtestMigrationStatus(
+          tester,
+          accountUuid,
+          (status) {
+            final txids = status.scheduledBroadcasts
+                .map((broadcast) => broadcast.txidHex)
+                .toSet();
+            return status.activeRunId == originalRunId &&
+                status.scheduledBroadcasts.length ==
+                    firstReplacementTxids.length &&
+                status.scheduledBroadcasts.every(
+                  (broadcast) => broadcast.status == 'scheduled',
+                ) &&
+                txids.difference(firstReplacementTxids).length == 1 &&
+                firstReplacementTxids.difference(txids).length == 1;
+          },
+          description: 'later single-part recovery wave',
+          timeout: const Duration(minutes: 3),
+        );
+        final secondReplacementTxids = secondReplacement.scheduledBroadcasts
+            .map((broadcast) => broadcast.txidHex)
+            .toSet();
+        final secondWaveNewTxid = secondReplacementTxids
+            .difference(firstReplacementTxids)
+            .single;
+        final secondGeneration = await _migrationRecoveryGeneration(
+          dbPath,
+          originalRunId,
+        );
+        expect(secondGeneration.originHeight, firstGeneration.originHeight);
+        expect(
+          secondGeneration.maxBlockOffset,
+          greaterThanOrEqualTo(firstGeneration.maxBlockOffset),
+        );
+
+        final persistedSecondWave = (await _runSqlite(
+          dbPath,
+          "SELECT target_height || ':' || schedule_start_height || ':' || "
+          "(scheduled_height - schedule_start_height) || ':' || status "
+          "FROM vizor_migration_pending_txs "
+          "WHERE run_id = '${_sqlLiteral(originalRunId)}' "
+          "AND txid_hex = '${_sqlLiteral(secondWaveNewTxid)}';",
+        )).trim().split(':');
+        expect(persistedSecondWave, hasLength(4));
+        expect(
+          int.parse(persistedSecondWave[0]),
+          secondRecoveryChainHeight + 1,
+        );
+        expect(int.parse(persistedSecondWave[1]), firstGeneration.originHeight);
+        expect(
+          int.parse(persistedSecondWave[2]),
+          secondGeneration.maxBlockOffset,
+        );
+        expect(persistedSecondWave[3], 'scheduled');
+      } finally {
+        try {
+          await ironwoodDriverPost(
+            _driverUrl,
+            '/node/restart',
+            timeout: const Duration(minutes: 5),
+          );
+        } finally {
+          syncNotifier.resumeAfterWalletMutation(secondSyncPause);
+        }
+      }
+
+      await syncNotifier.startSyncAnyway();
+      await pumpUntil(
+        tester,
+        () {
+          final sync = container.read(syncProvider).value;
+          return sync?.isSyncing == false &&
+              (sync?.scannedHeight ?? 0) >= secondRecoveryChainHeight;
+        },
+        description: 'wallet sync after the later recovery wave',
+        timeout: const Duration(minutes: 5),
+      );
       coordinator.enableAutomaticAdvances();
       await coordinator.refreshNow(forceAdvance: true);
+      final retryStatus = await desktopRegtestMigrationStatus(accountUuid);
+      if (retryStatus.phase == 'failed_recoverable') {
+        e2eLog('retrying the expected offline recovery failure');
+        await coordinator.retry(accountUuid, status: retryStatus);
+      }
 
       final submitted = await advanceDesktopRegtestMigrationSchedule(
         tester,
@@ -341,7 +483,7 @@ void main() {
         timeout: const Duration(minutes: 5),
       );
     },
-    timeout: const Timeout(Duration(minutes: 20)),
+    timeout: const Timeout(Duration(minutes: 25)),
   );
 }
 
@@ -380,6 +522,53 @@ Future<void> _waitForNoPendingDenominationStages(
     await Future<void>.delayed(const Duration(milliseconds: 150));
   }
   fail('Timed out waiting for the scheduled denomination broadcast.');
+}
+
+Future<void> _forceScheduledPartsExpired(
+  String dbPath,
+  String runId,
+  int chainHeight, {
+  String? txidHex,
+  required int expectedCount,
+}) async {
+  final txidPredicate = txidHex == null
+      ? ''
+      : " AND txid_hex = '${_sqlLiteral(txidHex)}'";
+  await _runSqlite(
+    dbPath,
+    "UPDATE vizor_migration_pending_txs "
+    "SET expiry_height = $chainHeight "
+    "WHERE run_id = '${_sqlLiteral(runId)}' "
+    "AND status = 'scheduled'$txidPredicate;",
+  );
+  expect(
+    (await _runSqlite(
+      dbPath,
+      "SELECT COUNT(*) FROM vizor_migration_pending_txs "
+      "WHERE run_id = '${_sqlLiteral(runId)}' "
+      "AND status = 'scheduled' "
+      "AND expiry_height = $chainHeight$txidPredicate;",
+    )).trim(),
+    '$expectedCount',
+  );
+}
+
+Future<({int originHeight, int maxBlockOffset})> _migrationRecoveryGeneration(
+  String dbPath,
+  String runId,
+) async {
+  final fields = (await _runSqlite(
+    dbPath,
+    "SELECT recovery_schedule_origin_height || ':' || "
+    "recovery_schedule_max_block_offset "
+    "FROM vizor_migration_runs "
+    "WHERE run_id = '${_sqlLiteral(runId)}';",
+  )).trim().split(':');
+  expect(fields, hasLength(2));
+  return (
+    originHeight: int.parse(fields[0]),
+    maxBlockOffset: int.parse(fields[1]),
+  );
 }
 
 Future<String> _runSqlite(String dbPath, String sql) async {

--- a/integration_test/regtest_ironwood_migration_expiry_recovery_test.dart
+++ b/integration_test/regtest_ironwood_migration_expiry_recovery_test.dart
@@ -7,9 +7,11 @@ import 'package:go_router/go_router.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:zcash_wallet/app.dart';
 import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
-import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
+import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
+import 'package:zcash_wallet/src/features/migration/services/ironwood_migration_service.dart';
 import 'package:zcash_wallet/src/providers/chain_upgrade_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 import 'support/desktop_regtest_flow.dart';
 
@@ -24,7 +26,7 @@ void main() {
   setUpAll(initializeZcashWalletRuntime);
 
   testWidgets(
-    're-signs expired migration parts in the existing approved run',
+    're-signs multiple expired migration parts in the existing approved run',
     (tester) async {
       addTearDown(cleanupDesktopRegtestWallet);
       await cleanupDesktopRegtestWallet();
@@ -32,7 +34,15 @@ void main() {
       final initialChain = await ironwoodDriverGet(_driverUrl, '/status');
       expect(initialChain['ironwoodActive'], isFalse);
 
-      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+      await tester.pumpWidget(
+        await buildBootstrappedZcashWalletApp(
+          overrides: [
+            ironwoodMigrationCoordinatorProvider.overrideWith(
+              _ControlledMigrationCoordinator.new,
+            ),
+          ],
+        ),
+      );
       await importDesktopRegtestWallet(tester);
       await pumpUntil(
         tester,
@@ -41,7 +51,7 @@ void main() {
               tester,
               const ValueKey('home_desktop_balance_amount_text'),
             ) ==
-            '0.011',
+            '0.0412',
         description: 'pre-Ironwood Orchard balance to render',
         timeout: const Duration(minutes: 5),
       );
@@ -52,6 +62,9 @@ void main() {
           find.byKey(const ValueKey('home_desktop_balance_amount_text')),
         ),
       );
+      final coordinator =
+          container.read(ironwoodMigrationCoordinatorProvider.notifier)
+              as _ControlledMigrationCoordinator;
       await pumpUntil(
         tester,
         () {
@@ -74,6 +87,15 @@ void main() {
         timeout: const Duration(minutes: 5),
       );
       await dismissIronwoodAnnouncement(tester);
+      final plan = await rust_sync.getOrchardMigrationPrivatePlan(
+        dbPath: await getWalletDbPath(),
+        network: 'regtest',
+        accountUuid: await firstDesktopRegtestAccountUuid(),
+        spacePreparationBroadcasts: true,
+      );
+      expect(plan, isNotNull);
+      expect(plan!.plannedBatchCount, 2);
+      expect(plan.targetValuesZatoshi, hasLength(2));
       await openPrivateMigrationReview(tester);
       await startPrivateMigrationFromReview(tester);
       final accountUuid = await firstDesktopRegtestAccountUuid();
@@ -89,20 +111,16 @@ void main() {
       await pumpUntil(
         tester,
         () => tester.any(
-          find.byKey(
-            const ValueKey(
-              'ironwood_migration_status_waiting_denom_confirmations',
-            ),
-          ),
+          find.byKey(const ValueKey('ironwood_migration_active_status')),
         ),
         description: 'denomination confirmation status',
         timeout: const Duration(minutes: 5),
       );
 
       final original = await desktopRegtestMigrationStatus(accountUuid);
-      final originalRunId = original.activeRunId;
+      final originalRunId = original.activeRunId!;
       final originalTargets = original.targetValuesZatoshi.toList();
-      expect(originalRunId, isNotNull);
+      final dbPath = await getWalletDbPath();
 
       GoRouter.of(tester.element(navigator)).go('/home');
       await pumpUntil(
@@ -113,10 +131,43 @@ void main() {
         description: 'home while denomination preparation continues',
       );
 
+      final preparationHeight = int.parse(
+        (await _runSqlite(
+          dbPath,
+          "SELECT COALESCE(MIN(scheduled_height), 0) "
+          "FROM vizor_migration_denomination_stages "
+          "WHERE run_id = '${_sqlLiteral(originalRunId)}' "
+          "AND status = 'pending';",
+        )).trim(),
+      );
+      final preparationChain = await ironwoodDriverGet(_driverUrl, '/status');
+      final preparationChainHeight = (preparationChain['zcashdHeight'] as num)
+          .toInt();
+      if (preparationHeight > preparationChainHeight) {
+        await ironwoodDriverPost(
+          _driverUrl,
+          '/mine',
+          payload: {'blocks': preparationHeight - preparationChainHeight},
+        );
+      }
+      await pumpUntil(
+        tester,
+        () {
+          final sync = container.read(syncProvider).value;
+          return sync?.isSyncing == false &&
+              (sync?.scannedHeight ?? 0) >= preparationHeight;
+        },
+        description: 'wallet sync at denomination broadcast height',
+        timeout: const Duration(minutes: 5),
+      );
+      await container
+          .read(ironwoodMigrationServiceProvider)
+          .continueSoftwarePrivateMigration(accountUuid: accountUuid);
+      await _waitForNoPendingDenominationStages(tester, dbPath, originalRunId);
       await ironwoodDriverPost(
         _driverUrl,
         '/mine',
-        payload: const {'blocks': 12},
+        payload: const {'blocks': 10},
       );
       await waitForDesktopRegtestMigrationStatus(
         tester,
@@ -125,95 +176,147 @@ void main() {
         description: 'migration denomination readiness',
         timeout: const Duration(minutes: 10),
       );
+      final recoveryChain = await ironwoodDriverGet(_driverUrl, '/status');
+      final recoveryChainHeight = (recoveryChain['zcashdHeight'] as num)
+          .toInt();
+      await ironwoodDriverPost(_driverUrl, '/lightwalletd/stop');
+      try {
+        await container
+            .read(ironwoodMigrationServiceProvider)
+            .continueSoftwarePrivateMigration(accountUuid: accountUuid);
+      } catch (error) {
+        expect(error.toString(), contains('transport error'));
+        e2eLog('initial migration submission unavailable as expected: $error');
+      }
       final scheduled = await waitForDesktopRegtestMigrationStatus(
         tester,
         accountUuid,
-        (status) => status.scheduledBroadcasts.isNotEmpty,
-        description: 'persisted migration broadcast schedule',
+        (status) =>
+            status.scheduledBroadcasts.length == originalTargets.length &&
+            status.scheduledBroadcasts.every(
+              (broadcast) => broadcast.status == 'scheduled',
+            ),
+        description: 'persisted two-part migration broadcast schedule',
         timeout: const Duration(minutes: 10),
       );
       GoRouter.of(tester.element(navigator)).go('/migration/private/status');
       await tester.pump(const Duration(milliseconds: 500));
       expect(scheduled.activeRunId, originalRunId);
-      expect(scheduled.scheduledBroadcasts, isNotEmpty);
+      expect(scheduled.scheduledBroadcasts, hasLength(2));
       final originalTxids = scheduled.scheduledBroadcasts
           .map((broadcast) => broadcast.txidHex)
           .toSet();
-      final expiringTxid =
-          (scheduled.scheduledBroadcasts.toList()..sort(
-                (left, right) =>
-                    left.scheduledHeight.compareTo(right.scheduledHeight),
-              ))
-              .first
-              .txidHex;
+      expect(originalTxids, hasLength(2));
 
-      await stopRustWorkForCleanup();
-      final chain = await ironwoodDriverGet(_driverUrl, '/status');
-      final chainHeight = (chain['zcashdHeight'] as num).toInt();
-      final dbPath = await getWalletDbPath();
-      await _runSqlite(
-        dbPath,
-        "UPDATE vizor_migration_pending_txs "
-        "SET expiry_height = $chainHeight "
-        "WHERE run_id = '${_sqlLiteral(originalRunId!)}' "
-        "AND txid_hex = '${_sqlLiteral(expiringTxid)}';"
-        "UPDATE transactions SET expiry_height = $chainHeight "
-        "WHERE lower(hex(txid)) = '${_walletDbTxidHex(expiringTxid)}';",
-      );
-      e2eLog(
-        'forced one part of run $originalRunId to expire at tip $chainHeight',
-      );
+      final syncNotifier = container.read(syncProvider.notifier);
+      final syncPause = await syncNotifier.pauseForWalletMutation();
+      late rust_sync.MigrationStatus replacement;
+      try {
+        await _runSqlite(
+          dbPath,
+          "UPDATE vizor_migration_pending_txs "
+          "SET expiry_height = $recoveryChainHeight "
+          "WHERE run_id = '${_sqlLiteral(originalRunId)}' "
+          "AND status = 'scheduled';",
+        );
+        expect(
+          (await _runSqlite(
+            dbPath,
+            "SELECT COUNT(*) FROM vizor_migration_pending_txs "
+            "WHERE run_id = '${_sqlLiteral(originalRunId)}' "
+            "AND status = 'scheduled' "
+            "AND expiry_height = $recoveryChainHeight;",
+          )).trim(),
+          '2',
+        );
+        e2eLog(
+          'forced both parts of run $originalRunId to expire at tip '
+          '$recoveryChainHeight',
+        );
 
-      final statusRequest = IronwoodMigrationStatusRequest(
-        network: 'regtest',
-        accountUuid: accountUuid,
-      );
-      container.invalidate(ironwoodMigrationStatusProvider(statusRequest));
-      await container.read(
-        ironwoodMigrationStatusProvider(statusRequest).future,
-      );
-      await tester.pump();
+        try {
+          await container
+              .read(ironwoodMigrationServiceProvider)
+              .continueSoftwarePrivateMigration(accountUuid: accountUuid);
+        } catch (error) {
+          expect(error.toString(), contains('transport error'));
+          e2eLog('replacement submission unavailable as expected: $error');
+        }
 
-      final replacement = await waitForDesktopRegtestMigrationStatus(
+        replacement = await waitForDesktopRegtestMigrationStatus(
+          tester,
+          accountUuid,
+          (status) =>
+              status.activeRunId == originalRunId &&
+              status.scheduledBroadcasts.length == originalTxids.length &&
+              status.scheduledBroadcasts.every(
+                (broadcast) => broadcast.status == 'scheduled',
+              ) &&
+              status.scheduledBroadcasts
+                      .map((broadcast) => broadcast.txidHex)
+                      .toSet()
+                      .difference(originalTxids)
+                      .length ==
+                  originalTxids.length,
+          description: 'same-run replacement migration transactions',
+          timeout: const Duration(minutes: 3),
+        );
+        expect(replacement.targetValuesZatoshi, orderedEquals(originalTargets));
+        expect(replacement.scheduledBroadcasts, hasLength(2));
+
+        final recovered = await _runSqlite(
+          dbPath,
+          "SELECT "
+          "(SELECT COUNT(*) FROM vizor_migration_prepared_notes "
+          " WHERE run_id = '${_sqlLiteral(originalRunId)}' "
+          " AND lock_state = 'locked') || ':' || "
+          "(SELECT COUNT(*) FROM vizor_migration_pending_txs "
+          " WHERE run_id = '${_sqlLiteral(originalRunId)}' "
+          " AND status = 'needs_resign') || ':' || "
+          "(SELECT COUNT(*) FROM vizor_migration_pending_txs "
+          " WHERE run_id = '${_sqlLiteral(originalRunId)}' "
+          " AND status = 'scheduled') || ':' || "
+          "(SELECT COUNT(DISTINCT schedule_start_height) "
+          " FROM vizor_migration_pending_txs "
+          " WHERE run_id = '${_sqlLiteral(originalRunId)}' "
+          " AND status = 'scheduled') || ':' || "
+          "(SELECT COUNT(*) FROM vizor_migration_pending_txs AS pending "
+          " JOIN vizor_migration_runs AS run USING (run_id) "
+          " WHERE pending.run_id = '${_sqlLiteral(originalRunId)}' "
+          " AND pending.status = 'scheduled' "
+          " AND pending.schedule_start_height = "
+          "     run.recovery_schedule_origin_height "
+          " AND run.recovery_schedule_max_block_offset = "
+          "     (SELECT MAX(scheduled_height - schedule_start_height) "
+          "      FROM vizor_migration_pending_txs "
+          "      WHERE run_id = '${_sqlLiteral(originalRunId)}'));",
+        );
+        expect(recovered.trim(), '2:0:2:1:2');
+      } finally {
+        try {
+          await ironwoodDriverPost(
+            _driverUrl,
+            '/node/restart',
+            timeout: const Duration(minutes: 5),
+          );
+        } finally {
+          syncNotifier.resumeAfterWalletMutation(syncPause);
+        }
+      }
+
+      await syncNotifier.startSyncAnyway();
+      await pumpUntil(
         tester,
-        accountUuid,
-        (status) =>
-            status.activeRunId == originalRunId &&
-            status.scheduledBroadcasts.isNotEmpty &&
-            status.scheduledBroadcasts
-                    .map((broadcast) => broadcast.txidHex)
-                    .toSet()
-                    .difference(originalTxids)
-                    .length ==
-                1,
-        description: 'same-run replacement migration transactions',
-        timeout: const Duration(minutes: 3),
-      );
-      expect(replacement.targetValuesZatoshi, orderedEquals(originalTargets));
-      expect(replacement.phase, 'broadcast_scheduled');
-
-      final recovered = await _runSqlite(
-        dbPath,
-        "SELECT phase || ':' || "
-        "(SELECT COUNT(*) FROM vizor_migration_prepared_notes "
-        " WHERE run_id = '${_sqlLiteral(originalRunId)}' "
-        " AND lock_state = 'locked') || ':' || "
-        "(SELECT COUNT(*) FROM vizor_migration_pending_txs "
-        " WHERE run_id = '${_sqlLiteral(originalRunId)}' "
-        " AND status = 'needs_resign') "
-        "FROM vizor_migration_runs "
-        "WHERE run_id = '${_sqlLiteral(originalRunId)}';",
-      );
-      expect(
-        recovered.trim(),
-        'broadcast_scheduled:${originalTargets.length}:0',
-      );
-
-      await ironwoodDriverPost(
-        _driverUrl,
-        '/node/restart',
+        () {
+          final sync = container.read(syncProvider).value;
+          return sync?.isSyncing == false &&
+              (sync?.scannedHeight ?? 0) >= recoveryChainHeight;
+        },
+        description: 'wallet sync after forced migration expiry',
         timeout: const Duration(minutes: 5),
       );
+      coordinator.enableAutomaticAdvances();
+      await coordinator.refreshNow(forceAdvance: true);
 
       final submitted = await advanceDesktopRegtestMigrationSchedule(
         tester,
@@ -242,6 +345,43 @@ void main() {
   );
 }
 
+class _ControlledMigrationCoordinator extends IronwoodMigrationCoordinator {
+  var _automaticAdvancesEnabled = false;
+
+  void enableAutomaticAdvances() => _automaticAdvancesEnabled = true;
+
+  @override
+  Future<void> refreshNow({bool forceAdvance = false}) {
+    if (!_automaticAdvancesEnabled) return Future.value();
+    return super.refreshNow(forceAdvance: forceAdvance);
+  }
+
+  @override
+  Future<void> resumeBackgroundPreparations() {
+    if (!_automaticAdvancesEnabled) return Future.value();
+    return super.resumeBackgroundPreparations();
+  }
+}
+
+Future<void> _waitForNoPendingDenominationStages(
+  WidgetTester tester,
+  String dbPath,
+  String runId,
+) async {
+  final deadline = DateTime.now().add(const Duration(minutes: 2));
+  while (DateTime.now().isBefore(deadline)) {
+    final pending = await _runSqlite(
+      dbPath,
+      "SELECT COUNT(*) FROM vizor_migration_denomination_stages "
+      "WHERE run_id = '${_sqlLiteral(runId)}' AND status = 'pending';",
+    );
+    if (pending.trim() == '0') return;
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+  }
+  fail('Timed out waiting for the scheduled denomination broadcast.');
+}
+
 Future<String> _runSqlite(String dbPath, String sql) async {
   final result = await Process.run('sqlite3', [dbPath, sql]);
   if (result.exitCode != 0) {
@@ -251,10 +391,3 @@ Future<String> _runSqlite(String dbPath, String sql) async {
 }
 
 String _sqlLiteral(String value) => value.replaceAll("'", "''");
-
-String _walletDbTxidHex(String displayTxid) {
-  final bytePairs = RegExp(
-    '..',
-  ).allMatches(displayTxid).map((match) => match.group(0)!).toList();
-  return bytePairs.reversed.join();
-}

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -2377,44 +2377,30 @@ fn insert_signed_child_pczts_with_tx(
                 child.value_zatoshi,
             )
             .ok_or("Approved migration schedule is missing a signed child")?;
-            match mode {
-                SignedChildInsertMode::Initial => {
-                    let child_schedule_origin = child
-                        .scheduled_height
-                        .checked_sub(block_offset)
-                        .ok_or("Signed migration schedule starts below zero")?;
-                    if let Some(origin) = signed_schedule_origin {
-                        if origin != child_schedule_origin {
-                            return Err(
-                                "Signed migration children do not share one absolute schedule origin"
-                                    .to_string(),
-                            );
-                        }
-                    } else {
-                        signed_schedule_origin = Some(child_schedule_origin);
+            if matches!(mode, SignedChildInsertMode::Initial) {
+                let child_schedule_origin = child
+                    .scheduled_height
+                    .checked_sub(block_offset)
+                    .ok_or("Signed migration schedule starts below zero")?;
+                if let Some(origin) = signed_schedule_origin {
+                    if origin != child_schedule_origin {
+                        return Err(
+                            "Signed migration children do not share one absolute schedule origin"
+                                .to_string(),
+                        );
                     }
-                }
-                // Rebuilt children carry fresh offsets anchored at the run's
-                // recovery-schedule generation (see
-                // `ensure_rebuild_schedule_generation`), so a shared origin
-                // derived from original offsets no longer holds; require the
-                // generation origin plus a non-negative rebuild offset.
-                SignedChildInsertMode::Replacement => {
-                    let child_origin = child.target_height.saturating_sub(1);
-                    if let Some(origin) = recovery_origin {
-                        if child_origin != origin {
-                            return Err(
-                                "Rebuilt migration children must share the recovery schedule origin"
-                                    .to_string(),
-                            );
-                        }
-                    }
-                    child
-                        .scheduled_height
-                        .checked_sub(child_origin)
-                        .ok_or("Signed migration schedule starts below zero")?;
+                } else {
+                    signed_schedule_origin = Some(child_schedule_origin);
                 }
             }
+        }
+        if matches!(mode, SignedChildInsertMode::Replacement) {
+            let recovery_origin = recovery_origin
+                .ok_or("Migration recovery schedule origin is missing")?;
+            child
+                .scheduled_height
+                .checked_sub(recovery_origin)
+                .ok_or("Signed migration schedule starts below zero")?;
         }
         let encrypted_base_pczt = secret_payload::encrypt_payload(
             Zeroizing::new(child.base_pczt),
@@ -4000,31 +3986,29 @@ pub(crate) fn replace_resigned_pending_parts(
                     .to_string(),
             );
         }
-        // Rebuilt rows use their recovery generation rather than the original
-        // approved schedule.
-        let schedule_start_height = pending.target_height.saturating_sub(1);
-        pending
-            .scheduled_height
-            .checked_sub(schedule_start_height)
-            .ok_or("Replacement migration schedule starts below zero")?;
-        match (recovery_origin, original.4) {
+        // Rebuilt rows use their recovery generation rather than the live
+        // transaction construction target.
+        let schedule_start_height = match (recovery_origin, original.4) {
             (Some(origin), Some(persisted_offset)) => {
                 let persisted_scheduled_height = origin
                     .checked_add(persisted_offset)
                     .ok_or("Persisted migration recovery schedule overflow")?;
-                if schedule_start_height != origin
-                    || pending.scheduled_height != persisted_scheduled_height
-                {
+                if pending.scheduled_height != persisted_scheduled_height {
                     return Err(
                         "Replacement migration schedule does not match its persisted recovery offset"
                             .to_string(),
                     );
                 }
+                origin
             }
             // Runs created before recovery generations have neither field.
-            (None, None) => {}
+            (None, None) => pending.target_height.saturating_sub(1),
             _ => return Err("Migration recovery schedule metadata is incomplete".to_string()),
-        }
+        };
+        pending
+            .scheduled_height
+            .checked_sub(schedule_start_height)
+            .ok_or("Replacement migration schedule starts below zero")?;
         let encrypted_raw_tx = secret_payload::encrypt_payload(
             Zeroizing::new(pending.raw_tx),
             password,

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -4084,30 +4084,6 @@ pub(crate) fn replace_resigned_pending_parts(
         salt_base64,
         SignedChildInsertMode::Replacement,
     )?;
-    // A finished recovery set retires its schedule generation so a later
-    // `needs_resign` wave anchors a fresh ladder at its own time.
-    let remaining_resign: u32 = tx
-        .query_row(
-            &format!(
-                "SELECT COUNT(*) FROM {PENDING_TXS_TABLE}
-                 WHERE run_id = ?1 AND status = 'needs_resign'"
-            ),
-            params![run_id],
-            |row| row.get(0),
-        )
-        .map_err(|e| format!("Count remaining migration re-sign parts: {e}"))?;
-    if remaining_resign == 0 {
-        tx.execute(
-            &format!(
-                "UPDATE {RUNS_TABLE}
-                 SET recovery_schedule_origin_height = NULL,
-                     recovery_schedule_max_block_offset = NULL
-                 WHERE run_id = ?1"
-            ),
-            params![run_id],
-        )
-        .map_err(|e| format!("Retire migration rebuild schedule generation: {e}"))?;
-    }
     let now = now_ms()?;
     tx.execute(
         &format!(
@@ -4425,10 +4401,10 @@ pub(crate) struct RebuildScheduleGeneration {
 /// lacks one, anchored at one shared recovery origin (created at
 /// `origin_candidate_height` when absent). The generation persists its
 /// historical maximum so parts marked `needs_resign` after earlier batches
-/// were replaced still extend the same ladder. The generation is cleared
-/// when the last `needs_resign` row is replaced (see
-/// `replace_resigned_pending_parts`). Returns `None` when the run has no
-/// parts waiting for re-sign.
+/// or recovery waves still extend the same ladder. The cursor also advances
+/// to the current tip when the previous ladder has elapsed. The generation
+/// remains for the active run and is cleared when the run stops. Returns
+/// `None` when the run has no parts waiting for re-sign.
 pub(crate) fn ensure_rebuild_schedule_generation(
     db_path: &str,
     run_id: &str,
@@ -4504,7 +4480,7 @@ pub(crate) fn ensure_rebuild_schedule_generation(
     {
         return Err("Migration recovery schedule metadata is incomplete".to_string());
     }
-    let base_offset = match persisted_max_offset {
+    let persisted_base_offset = match persisted_max_offset {
         Some(max_offset) if max_offset >= observed_max_offset => max_offset,
         Some(_) => {
             return Err(
@@ -4513,14 +4489,8 @@ pub(crate) fn ensure_rebuild_schedule_generation(
         }
         None => observed_max_offset,
     };
-    if missing.is_empty() && persisted_origin.is_some() && persisted_max_offset.is_some() {
-        tx.commit()
-            .map_err(|e| format!("Commit migration rebuild schedule update: {e}"))?;
-        return Ok(Some(RebuildScheduleGeneration {
-            origin_height,
-            offsets_by_txid,
-        }));
-    }
+    let base_offset =
+        persisted_base_offset.max(origin_candidate_height.saturating_sub(origin_height));
 
     let mut generation_max_offset = base_offset;
     if !missing.is_empty() {

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -2334,8 +2334,8 @@ fn insert_signed_child_pczts_with_tx(
         return Ok(());
     }
 
-    let (schedule_json, target_values_json, persisted_signed_schedule_origin, recovery_origin) =
-        tx.query_row(
+    let (schedule_json, target_values_json, persisted_signed_schedule_origin, recovery_origin) = tx
+        .query_row(
             &format!(
                 "SELECT schedule_json, target_values_json, signed_schedule_origin_height,
                         recovery_schedule_origin_height

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -3916,11 +3916,14 @@ pub(crate) fn replace_resigned_pending_parts(
     }
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
-    let schedule_json = conn
+    let (schedule_json, recovery_origin) = conn
         .query_row(
-            &format!("SELECT schedule_json FROM {RUNS_TABLE} WHERE run_id = ?1"),
+            &format!(
+                "SELECT schedule_json, recovery_schedule_origin_height
+                 FROM {RUNS_TABLE} WHERE run_id = ?1"
+            ),
             params![run_id],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<u32>>(1)?)),
         )
         .map_err(|e| format!("Read replacement migration schedule: {e}"))?;
     let schedule: Vec<MigrationScheduleEntry> = serde_json::from_str(&schedule_json)
@@ -3957,7 +3960,8 @@ pub(crate) fn replace_resigned_pending_parts(
             .query_row(
                 &format!(
                     "SELECT value_zatoshi, selected_note_txid,
-                            selected_note_output_index, original_scheduled_height
+                            selected_note_output_index, original_scheduled_height,
+                            rebuild_block_offset
                      FROM {PENDING_TXS_TABLE}
                      WHERE run_id = ?1 AND txid_hex = ?2
                        AND status = 'needs_resign'"
@@ -3969,6 +3973,7 @@ pub(crate) fn replace_resigned_pending_parts(
                         row.get::<_, String>(1)?,
                         row.get::<_, u32>(2)?,
                         row.get::<_, Option<u32>>(3)?,
+                        row.get::<_, Option<u32>>(4)?,
                     ))
                 },
             )
@@ -3994,14 +3999,31 @@ pub(crate) fn replace_resigned_pending_parts(
                     .to_string(),
             );
         }
-        // The rebuild schedule is anchored at the rebuild-time chain target
-        // (see `rebuild_schedule_block_offsets`), so derive this row's origin
-        // and offset from its own heights rather than the original run entry.
+        // Rebuilt rows use their recovery generation rather than the original
+        // approved schedule.
         let schedule_start_height = pending.target_height.saturating_sub(1);
         let rebuild_block_offset = pending
             .scheduled_height
             .checked_sub(schedule_start_height)
             .ok_or("Replacement migration schedule starts below zero")?;
+        match (recovery_origin, original.4) {
+            (Some(origin), Some(persisted_offset)) => {
+                let persisted_scheduled_height = origin
+                    .checked_add(persisted_offset)
+                    .ok_or("Persisted migration recovery schedule overflow")?;
+                if schedule_start_height != origin
+                    || pending.scheduled_height != persisted_scheduled_height
+                {
+                    return Err(
+                        "Replacement migration schedule does not match its persisted recovery offset"
+                            .to_string(),
+                    );
+                }
+            }
+            // Runs created before recovery generations have neither field.
+            (None, None) => {}
+            _ => return Err("Migration recovery schedule metadata is incomplete".to_string()),
+        }
         let encrypted_raw_tx = secret_payload::encrypt_payload(
             Zeroizing::new(pending.raw_tx),
             password,
@@ -4078,7 +4100,8 @@ pub(crate) fn replace_resigned_pending_parts(
         tx.execute(
             &format!(
                 "UPDATE {RUNS_TABLE}
-                 SET recovery_schedule_origin_height = NULL
+                 SET recovery_schedule_origin_height = NULL,
+                     recovery_schedule_max_block_offset = NULL
                  WHERE run_id = ?1"
             ),
             params![run_id],
@@ -4328,7 +4351,8 @@ pub(crate) fn abandon_run(
     tx.execute(
         &format!(
             "UPDATE {RUNS_TABLE}
-             SET recovery_schedule_origin_height = NULL
+             SET recovery_schedule_origin_height = NULL,
+                 recovery_schedule_max_block_offset = NULL
              WHERE run_id = ?1"
         ),
         params![expected_run_id],
@@ -4399,10 +4423,10 @@ pub(crate) struct RebuildScheduleGeneration {
 
 /// Draws and persists a rebuild offset for every `needs_resign` part that
 /// lacks one, anchored at one shared recovery origin (created at
-/// `origin_candidate_height` when absent). Parts marked `needs_resign` after
-/// a generation exists extend the same ladder past its current maximum, so
-/// one cadence covers the whole recovery set across signing batches. The
-/// generation is cleared when the last `needs_resign` row is replaced (see
+/// `origin_candidate_height` when absent). The generation persists its
+/// historical maximum so parts marked `needs_resign` after earlier batches
+/// were replaced still extend the same ladder. The generation is cleared
+/// when the last `needs_resign` row is replaced (see
 /// `replace_resigned_pending_parts`). Returns `None` when the run has no
 /// parts waiting for re-sign.
 pub(crate) fn ensure_rebuild_schedule_generation(
@@ -4411,10 +4435,13 @@ pub(crate) fn ensure_rebuild_schedule_generation(
     network: WalletNetwork,
     origin_candidate_height: u32,
 ) -> Result<Option<RebuildScheduleGeneration>, String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let mut conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|e| format!("Begin migration rebuild schedule update: {e}"))?;
     let rows = {
-        let mut stmt = conn
+        let mut stmt = tx
             .prepare_cached(&format!(
                 "SELECT txid_hex, part_index, value_zatoshi, rebuild_block_offset
                  FROM {PENDING_TXS_TABLE}
@@ -4439,11 +4466,12 @@ pub(crate) fn ensure_rebuild_schedule_generation(
         return Ok(None);
     }
 
-    let timing_policy = timing_policy_for_run_with_conn(&conn, run_id, network)?;
-    let (schedule_json, target_values_json, persisted_origin) = conn
+    let timing_policy = timing_policy_for_run_with_conn(&tx, run_id, network)?;
+    let (schedule_json, target_values_json, persisted_origin, persisted_max_offset) = tx
         .query_row(
             &format!(
-                "SELECT schedule_json, target_values_json, recovery_schedule_origin_height
+                "SELECT schedule_json, target_values_json, recovery_schedule_origin_height,
+                        recovery_schedule_max_block_offset
                  FROM {RUNS_TABLE} WHERE run_id = ?1"
             ),
             params![run_id],
@@ -4452,6 +4480,7 @@ pub(crate) fn ensure_rebuild_schedule_generation(
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
                     row.get::<_, Option<u32>>(2)?,
+                    row.get::<_, Option<u32>>(3)?,
                 ))
             },
         )
@@ -4470,60 +4499,83 @@ pub(crate) fn ensure_rebuild_schedule_generation(
             None => missing.push((txid_hex, part_index, value_zatoshi)),
         }
     }
-    if missing.is_empty() && persisted_origin.is_some() {
+    let observed_max_offset = offsets_by_txid.values().copied().max().unwrap_or(0);
+    if persisted_origin.is_none() && (persisted_max_offset.is_some() || !offsets_by_txid.is_empty())
+    {
+        return Err("Migration recovery schedule metadata is incomplete".to_string());
+    }
+    let base_offset = match persisted_max_offset {
+        Some(max_offset) if max_offset >= observed_max_offset => max_offset,
+        Some(_) => {
+            return Err(
+                "Migration recovery schedule maximum is below a persisted part offset".to_string(),
+            )
+        }
+        None => observed_max_offset,
+    };
+    if missing.is_empty() && persisted_origin.is_some() && persisted_max_offset.is_some() {
+        tx.commit()
+            .map_err(|e| format!("Commit migration rebuild schedule update: {e}"))?;
         return Ok(Some(RebuildScheduleGeneration {
             origin_height,
             offsets_by_txid,
         }));
     }
 
-    let schedule: Vec<MigrationScheduleEntry> = serde_json::from_str(&schedule_json)
-        .map_err(|e| format!("Decode migration rebuild schedule: {e}"))?;
-    let target_values: Vec<u64> = serde_json::from_str(&target_values_json)
-        .map_err(|e| format!("Decode migration rebuild target values: {e}"))?;
-    let recovery_parts = missing
-        .iter()
-        .map(|(_, part_index, value_zatoshi)| (*part_index, *value_zatoshi))
-        .collect::<Vec<_>>();
-    let base_offset = offsets_by_txid.values().copied().max().unwrap_or(0);
-    let fresh_offsets = rebuild_schedule_block_offsets(
-        &schedule,
-        &target_values,
-        &recovery_parts,
-        network,
-        timing_policy,
-        &mut OsRng,
-    )?;
+    let mut generation_max_offset = base_offset;
+    if !missing.is_empty() {
+        let schedule: Vec<MigrationScheduleEntry> = serde_json::from_str(&schedule_json)
+            .map_err(|e| format!("Decode migration rebuild schedule: {e}"))?;
+        let target_values: Vec<u64> = serde_json::from_str(&target_values_json)
+            .map_err(|e| format!("Decode migration rebuild target values: {e}"))?;
+        let recovery_parts = missing
+            .iter()
+            .map(|(_, part_index, value_zatoshi)| (*part_index, *value_zatoshi))
+            .collect::<Vec<_>>();
+        let fresh_offsets = rebuild_schedule_block_offsets(
+            &schedule,
+            &target_values,
+            &recovery_parts,
+            network,
+            timing_policy,
+            &mut OsRng,
+        )?;
 
-    let tx = conn
-        .unchecked_transaction()
-        .map_err(|e| format!("Begin migration rebuild schedule update: {e}"))?;
-    if persisted_origin.is_none() {
-        tx.execute(
+        for ((txid_hex, _, _), fresh_offset) in missing.iter().zip(fresh_offsets) {
+            let assigned = base_offset
+                .checked_add(fresh_offset)
+                .ok_or("Migration rebuild schedule offset overflow")?;
+            let updated = tx
+                .execute(
+                    &format!(
+                        "UPDATE {PENDING_TXS_TABLE}
+                         SET rebuild_block_offset = ?1
+                         WHERE run_id = ?2 AND txid_hex = ?3
+                           AND status = 'needs_resign' AND rebuild_block_offset IS NULL"
+                    ),
+                    params![assigned, run_id, txid_hex],
+                )
+                .map_err(|e| format!("Persist migration rebuild schedule offset: {e}"))?;
+            if updated != 1 {
+                return Err("Migration recovery part changed while scheduling".to_string());
+            }
+            generation_max_offset = generation_max_offset.max(assigned);
+            offsets_by_txid.insert(txid_hex.to_ascii_lowercase(), assigned);
+        }
+    }
+    let updated = tx
+        .execute(
             &format!(
                 "UPDATE {RUNS_TABLE}
-                 SET recovery_schedule_origin_height = ?1
-                 WHERE run_id = ?2 AND recovery_schedule_origin_height IS NULL"
+                 SET recovery_schedule_origin_height = ?1,
+                     recovery_schedule_max_block_offset = ?2
+                 WHERE run_id = ?3"
             ),
-            params![origin_height, run_id],
+            params![origin_height, generation_max_offset, run_id],
         )
-        .map_err(|e| format!("Persist migration rebuild schedule origin: {e}"))?;
-    }
-    for ((txid_hex, _, _), fresh_offset) in missing.iter().zip(fresh_offsets) {
-        let assigned = base_offset
-            .checked_add(fresh_offset)
-            .ok_or("Migration rebuild schedule offset overflow")?;
-        tx.execute(
-            &format!(
-                "UPDATE {PENDING_TXS_TABLE}
-                 SET rebuild_block_offset = ?1
-                 WHERE run_id = ?2 AND txid_hex = ?3
-                   AND status = 'needs_resign' AND rebuild_block_offset IS NULL"
-            ),
-            params![assigned, run_id, txid_hex],
-        )
-        .map_err(|e| format!("Persist migration rebuild schedule offset: {e}"))?;
-        offsets_by_txid.insert(txid_hex.to_ascii_lowercase(), assigned);
+        .map_err(|e| format!("Persist migration rebuild schedule generation: {e}"))?;
+    if updated != 1 {
+        return Err("Migration run changed while scheduling recovery".to_string());
     }
     tx.commit()
         .map_err(|e| format!("Commit migration rebuild schedule update: {e}"))?;

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -2375,19 +2375,33 @@ fn insert_signed_child_pczts_with_tx(
                 child.value_zatoshi,
             )
             .ok_or("Approved migration schedule is missing a signed child")?;
-            let child_schedule_origin = child
-                .scheduled_height
-                .checked_sub(block_offset)
-                .ok_or("Signed migration schedule starts below zero")?;
-            if let Some(origin) = signed_schedule_origin {
-                if origin != child_schedule_origin {
-                    return Err(
-                        "Signed migration children do not share one absolute schedule origin"
-                            .to_string(),
-                    );
+            match mode {
+                SignedChildInsertMode::Initial => {
+                    let child_schedule_origin = child
+                        .scheduled_height
+                        .checked_sub(block_offset)
+                        .ok_or("Signed migration schedule starts below zero")?;
+                    if let Some(origin) = signed_schedule_origin {
+                        if origin != child_schedule_origin {
+                            return Err(
+                                "Signed migration children do not share one absolute schedule origin"
+                                    .to_string(),
+                            );
+                        }
+                    } else {
+                        signed_schedule_origin = Some(child_schedule_origin);
+                    }
                 }
-            } else {
-                signed_schedule_origin = Some(child_schedule_origin);
+                // Rebuilt children carry per-batch fresh offsets anchored at
+                // their own rebuild target (see `rebuild_schedule_block_offsets`),
+                // so a shared origin derived from original offsets no longer
+                // holds; require a non-negative rebuild offset instead.
+                SignedChildInsertMode::Replacement => {
+                    child
+                        .scheduled_height
+                        .checked_sub(child.target_height.saturating_sub(1))
+                        .ok_or("Signed migration schedule starts below zero")?;
+                }
             }
         }
         let encrypted_base_pczt = secret_payload::encrypt_payload(

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -3906,6 +3906,7 @@ pub(crate) fn replace_resigned_pending_parts(
     db_path: &str,
     run_id: &str,
     _network: WalletNetwork,
+    chain_tip_height: u32,
     mut replacements: Vec<PendingMigrationTxReplacement>,
     signed_children: Vec<SignedMigrationPcztInsert>,
     password: &[u8],
@@ -4002,7 +4003,7 @@ pub(crate) fn replace_resigned_pending_parts(
         // Rebuilt rows use their recovery generation rather than the original
         // approved schedule.
         let schedule_start_height = pending.target_height.saturating_sub(1);
-        let rebuild_block_offset = pending
+        pending
             .scheduled_height
             .checked_sub(schedule_start_height)
             .ok_or("Replacement migration schedule starts below zero")?;
@@ -4031,8 +4032,12 @@ pub(crate) fn replace_resigned_pending_parts(
         )?;
         let metadata_json = serde_json::to_string(&pending.metadata)
             .map_err(|e| format!("Encode replacement migration metadata: {e}"))?;
+        // `rebuild_block_offset` counts from the generation origin and so
+        // includes blocks that already elapsed for later waves; the time hint
+        // uses only the portion still ahead of the chain tip.
+        let remaining_offset_blocks = pending.scheduled_height.saturating_sub(chain_tip_height);
         let scheduled_at_ms = scheduled_start_ms
-            .checked_add(i64::from(rebuild_block_offset).saturating_mul(1000))
+            .checked_add(i64::from(remaining_offset_blocks).saturating_mul(1000))
             .ok_or("Replacement migration time overflow")?;
         let scheduled_height = pending.scheduled_height;
         let original_scheduled_height = original.3;
@@ -4402,9 +4407,11 @@ pub(crate) struct RebuildScheduleGeneration {
 /// `origin_candidate_height` when absent). The generation persists its
 /// historical maximum so parts marked `needs_resign` after earlier batches
 /// or recovery waves still extend the same ladder. The cursor also advances
-/// to the current tip when the previous ladder has elapsed. The generation
-/// remains for the active run and is cleared when the run stops. Returns
-/// `None` when the run has no parts waiting for re-sign.
+/// to the current tip when the previous ladder has elapsed, and a still
+/// unsigned part whose assigned height the chain has already passed is
+/// redrawn above the cursor rather than rebuilt due-on-arrival. The
+/// generation remains for the active run and is cleared when the run stops.
+/// Returns `None` when the run has no parts waiting for re-sign.
 pub(crate) fn ensure_rebuild_schedule_generation(
     db_path: &str,
     run_id: &str,
@@ -4463,21 +4470,31 @@ pub(crate) fn ensure_rebuild_schedule_generation(
         .map_err(|e| format!("Read migration rebuild schedule origin: {e}"))?;
     let origin_height = persisted_origin.unwrap_or(origin_candidate_height);
 
+    let elapsed_cursor = origin_candidate_height.saturating_sub(origin_height);
     let mut offsets_by_txid = BTreeMap::new();
-    let mut missing = Vec::new();
+    let mut to_assign = Vec::new();
+    let mut observed_max_offset = 0u32;
+    let mut any_persisted_offset = false;
     for (txid_hex, part_index, value_zatoshi, offset) in rows {
         let part_index =
             part_index.ok_or("Migration part waiting for re-sign is missing its part index")?;
         match offset {
             Some(offset) => {
-                offsets_by_txid.insert(txid_hex.to_ascii_lowercase(), offset);
+                any_persisted_offset = true;
+                observed_max_offset = observed_max_offset.max(offset);
+                // A height the chain already passed would rebuild the part
+                // due on arrival, defeating the recovery cadence; the part
+                // rejoins the draw above the cursor instead.
+                if offset < elapsed_cursor {
+                    to_assign.push((txid_hex, part_index, value_zatoshi, Some(offset)));
+                } else {
+                    offsets_by_txid.insert(txid_hex.to_ascii_lowercase(), offset);
+                }
             }
-            None => missing.push((txid_hex, part_index, value_zatoshi)),
+            None => to_assign.push((txid_hex, part_index, value_zatoshi, None)),
         }
     }
-    let observed_max_offset = offsets_by_txid.values().copied().max().unwrap_or(0);
-    if persisted_origin.is_none() && (persisted_max_offset.is_some() || !offsets_by_txid.is_empty())
-    {
+    if persisted_origin.is_none() && (persisted_max_offset.is_some() || any_persisted_offset) {
         return Err("Migration recovery schedule metadata is incomplete".to_string());
     }
     let persisted_base_offset = match persisted_max_offset {
@@ -4489,18 +4506,17 @@ pub(crate) fn ensure_rebuild_schedule_generation(
         }
         None => observed_max_offset,
     };
-    let base_offset =
-        persisted_base_offset.max(origin_candidate_height.saturating_sub(origin_height));
+    let base_offset = persisted_base_offset.max(elapsed_cursor);
 
     let mut generation_max_offset = base_offset;
-    if !missing.is_empty() {
+    if !to_assign.is_empty() {
         let schedule: Vec<MigrationScheduleEntry> = serde_json::from_str(&schedule_json)
             .map_err(|e| format!("Decode migration rebuild schedule: {e}"))?;
         let target_values: Vec<u64> = serde_json::from_str(&target_values_json)
             .map_err(|e| format!("Decode migration rebuild target values: {e}"))?;
-        let recovery_parts = missing
+        let recovery_parts = to_assign
             .iter()
-            .map(|(_, part_index, value_zatoshi)| (*part_index, *value_zatoshi))
+            .map(|(_, part_index, value_zatoshi, _)| (*part_index, *value_zatoshi))
             .collect::<Vec<_>>();
         let fresh_offsets = rebuild_schedule_block_offsets(
             &schedule,
@@ -4511,21 +4527,35 @@ pub(crate) fn ensure_rebuild_schedule_generation(
             &mut OsRng,
         )?;
 
-        for ((txid_hex, _, _), fresh_offset) in missing.iter().zip(fresh_offsets) {
+        for ((txid_hex, _, _, previous_offset), fresh_offset) in to_assign.iter().zip(fresh_offsets)
+        {
             let assigned = base_offset
                 .checked_add(fresh_offset)
                 .ok_or("Migration rebuild schedule offset overflow")?;
-            let updated = tx
-                .execute(
-                    &format!(
-                        "UPDATE {PENDING_TXS_TABLE}
-                         SET rebuild_block_offset = ?1
-                         WHERE run_id = ?2 AND txid_hex = ?3
-                           AND status = 'needs_resign' AND rebuild_block_offset IS NULL"
-                    ),
-                    params![assigned, run_id, txid_hex],
-                )
-                .map_err(|e| format!("Persist migration rebuild schedule offset: {e}"))?;
+            let updated = match previous_offset {
+                Some(previous_offset) => tx
+                    .execute(
+                        &format!(
+                            "UPDATE {PENDING_TXS_TABLE}
+                             SET rebuild_block_offset = ?1
+                             WHERE run_id = ?2 AND txid_hex = ?3
+                               AND status = 'needs_resign' AND rebuild_block_offset = ?4"
+                        ),
+                        params![assigned, run_id, txid_hex, previous_offset],
+                    )
+                    .map_err(|e| format!("Advance migration rebuild schedule offset: {e}"))?,
+                None => tx
+                    .execute(
+                        &format!(
+                            "UPDATE {PENDING_TXS_TABLE}
+                             SET rebuild_block_offset = ?1
+                             WHERE run_id = ?2 AND txid_hex = ?3
+                               AND status = 'needs_resign' AND rebuild_block_offset IS NULL"
+                        ),
+                        params![assigned, run_id, txid_hex],
+                    )
+                    .map_err(|e| format!("Persist migration rebuild schedule offset: {e}"))?,
+            };
             if updated != 1 {
                 return Err("Migration recovery part changed while scheduling".to_string());
             }

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -2334,10 +2334,11 @@ fn insert_signed_child_pczts_with_tx(
         return Ok(());
     }
 
-    let (schedule_json, target_values_json, persisted_signed_schedule_origin) = tx
-        .query_row(
+    let (schedule_json, target_values_json, persisted_signed_schedule_origin, recovery_origin) =
+        tx.query_row(
             &format!(
-                "SELECT schedule_json, target_values_json, signed_schedule_origin_height
+                "SELECT schedule_json, target_values_json, signed_schedule_origin_height,
+                        recovery_schedule_origin_height
                  FROM {RUNS_TABLE} WHERE run_id = ?1"
             ),
             params![run_id],
@@ -2346,6 +2347,7 @@ fn insert_signed_child_pczts_with_tx(
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
                     row.get::<_, Option<u32>>(2)?,
+                    row.get::<_, Option<u32>>(3)?,
                 ))
             },
         )
@@ -2392,14 +2394,24 @@ fn insert_signed_child_pczts_with_tx(
                         signed_schedule_origin = Some(child_schedule_origin);
                     }
                 }
-                // Rebuilt children carry per-batch fresh offsets anchored at
-                // their own rebuild target (see `rebuild_schedule_block_offsets`),
-                // so a shared origin derived from original offsets no longer
-                // holds; require a non-negative rebuild offset instead.
+                // Rebuilt children carry fresh offsets anchored at the run's
+                // recovery-schedule generation (see
+                // `ensure_rebuild_schedule_generation`), so a shared origin
+                // derived from original offsets no longer holds; require the
+                // generation origin plus a non-negative rebuild offset.
                 SignedChildInsertMode::Replacement => {
+                    let child_origin = child.target_height.saturating_sub(1);
+                    if let Some(origin) = recovery_origin {
+                        if child_origin != origin {
+                            return Err(
+                                "Rebuilt migration children must share the recovery schedule origin"
+                                    .to_string(),
+                            );
+                        }
+                    }
                     child
                         .scheduled_height
-                        .checked_sub(child.target_height.saturating_sub(1))
+                        .checked_sub(child_origin)
                         .ok_or("Signed migration schedule starts below zero")?;
                 }
             }
@@ -4050,6 +4062,29 @@ pub(crate) fn replace_resigned_pending_parts(
         salt_base64,
         SignedChildInsertMode::Replacement,
     )?;
+    // A finished recovery set retires its schedule generation so a later
+    // `needs_resign` wave anchors a fresh ladder at its own time.
+    let remaining_resign: u32 = tx
+        .query_row(
+            &format!(
+                "SELECT COUNT(*) FROM {PENDING_TXS_TABLE}
+                 WHERE run_id = ?1 AND status = 'needs_resign'"
+            ),
+            params![run_id],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("Count remaining migration re-sign parts: {e}"))?;
+    if remaining_resign == 0 {
+        tx.execute(
+            &format!(
+                "UPDATE {RUNS_TABLE}
+                 SET recovery_schedule_origin_height = NULL
+                 WHERE run_id = ?1"
+            ),
+            params![run_id],
+        )
+        .map_err(|e| format!("Retire migration rebuild schedule generation: {e}"))?;
+    }
     let now = now_ms()?;
     tx.execute(
         &format!(
@@ -4290,6 +4325,15 @@ pub(crate) fn abandon_run(
         params![expected_run_id],
     )
     .map_err(|e| format!("Release stopped migration note locks: {e}"))?;
+    tx.execute(
+        &format!(
+            "UPDATE {RUNS_TABLE}
+             SET recovery_schedule_origin_height = NULL
+             WHERE run_id = ?1"
+        ),
+        params![expected_run_id],
+    )
+    .map_err(|e| format!("Retire stopped migration rebuild schedule: {e}"))?;
     tx.commit()
         .map_err(|e| format!("Commit migration stop transition: {e}"))?;
     drop(conn);
@@ -4341,6 +4385,153 @@ fn discard_unsubmitted_preparation_stages(db_path: &str, run_id: &str) -> Result
     .map_err(|e| format!("Discard unsubmitted preparation transactions: {e}"))?;
     tx.commit()
         .map_err(|e| format!("Commit stopped preparation cleanup: {e}"))
+}
+
+/// One persisted recovery-schedule generation: every rebuilt part shares
+/// `origin_height` and carries its own cumulative offset, so all consumers
+/// (the software rebuild and each Keystone signing batch) schedule against
+/// the same ladder instead of anchoring per-batch ladders at their own tips.
+#[derive(Clone, Debug)]
+pub(crate) struct RebuildScheduleGeneration {
+    pub origin_height: u32,
+    pub offsets_by_txid: BTreeMap<String, u32>,
+}
+
+/// Draws and persists a rebuild offset for every `needs_resign` part that
+/// lacks one, anchored at one shared recovery origin (created at
+/// `origin_candidate_height` when absent). Parts marked `needs_resign` after
+/// a generation exists extend the same ladder past its current maximum, so
+/// one cadence covers the whole recovery set across signing batches. The
+/// generation is cleared when the last `needs_resign` row is replaced (see
+/// `replace_resigned_pending_parts`). Returns `None` when the run has no
+/// parts waiting for re-sign.
+pub(crate) fn ensure_rebuild_schedule_generation(
+    db_path: &str,
+    run_id: &str,
+    network: WalletNetwork,
+    origin_candidate_height: u32,
+) -> Result<Option<RebuildScheduleGeneration>, String> {
+    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    ensure_schema(&conn)?;
+    let rows = {
+        let mut stmt = conn
+            .prepare_cached(&format!(
+                "SELECT txid_hex, part_index, value_zatoshi, rebuild_block_offset
+                 FROM {PENDING_TXS_TABLE}
+                 WHERE run_id = ?1 AND status = 'needs_resign'
+                 ORDER BY scheduled_height ASC, txid_hex ASC"
+            ))
+            .map_err(|e| format!("Prepare migration rebuild schedule query: {e}"))?;
+        let rows = stmt
+            .query_map(params![run_id], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<u32>>(1)?,
+                    row.get::<_, u64>(2)?,
+                    row.get::<_, Option<u32>>(3)?,
+                ))
+            })
+            .map_err(|e| format!("Query migration rebuild schedule rows: {e}"))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Read migration rebuild schedule row: {e}"))?
+    };
+    if rows.is_empty() {
+        return Ok(None);
+    }
+
+    let timing_policy = timing_policy_for_run_with_conn(&conn, run_id, network)?;
+    let (schedule_json, target_values_json, persisted_origin) = conn
+        .query_row(
+            &format!(
+                "SELECT schedule_json, target_values_json, recovery_schedule_origin_height
+                 FROM {RUNS_TABLE} WHERE run_id = ?1"
+            ),
+            params![run_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<u32>>(2)?,
+                ))
+            },
+        )
+        .map_err(|e| format!("Read migration rebuild schedule origin: {e}"))?;
+    let origin_height = persisted_origin.unwrap_or(origin_candidate_height);
+
+    let mut offsets_by_txid = BTreeMap::new();
+    let mut missing = Vec::new();
+    for (txid_hex, part_index, value_zatoshi, offset) in rows {
+        let part_index =
+            part_index.ok_or("Migration part waiting for re-sign is missing its part index")?;
+        match offset {
+            Some(offset) => {
+                offsets_by_txid.insert(txid_hex.to_ascii_lowercase(), offset);
+            }
+            None => missing.push((txid_hex, part_index, value_zatoshi)),
+        }
+    }
+    if missing.is_empty() && persisted_origin.is_some() {
+        return Ok(Some(RebuildScheduleGeneration {
+            origin_height,
+            offsets_by_txid,
+        }));
+    }
+
+    let schedule: Vec<MigrationScheduleEntry> = serde_json::from_str(&schedule_json)
+        .map_err(|e| format!("Decode migration rebuild schedule: {e}"))?;
+    let target_values: Vec<u64> = serde_json::from_str(&target_values_json)
+        .map_err(|e| format!("Decode migration rebuild target values: {e}"))?;
+    let recovery_parts = missing
+        .iter()
+        .map(|(_, part_index, value_zatoshi)| (*part_index, *value_zatoshi))
+        .collect::<Vec<_>>();
+    let base_offset = offsets_by_txid.values().copied().max().unwrap_or(0);
+    let fresh_offsets = rebuild_schedule_block_offsets(
+        &schedule,
+        &target_values,
+        &recovery_parts,
+        network,
+        timing_policy,
+        &mut OsRng,
+    )?;
+
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| format!("Begin migration rebuild schedule update: {e}"))?;
+    if persisted_origin.is_none() {
+        tx.execute(
+            &format!(
+                "UPDATE {RUNS_TABLE}
+                 SET recovery_schedule_origin_height = ?1
+                 WHERE run_id = ?2 AND recovery_schedule_origin_height IS NULL"
+            ),
+            params![origin_height, run_id],
+        )
+        .map_err(|e| format!("Persist migration rebuild schedule origin: {e}"))?;
+    }
+    for ((txid_hex, _, _), fresh_offset) in missing.iter().zip(fresh_offsets) {
+        let assigned = base_offset
+            .checked_add(fresh_offset)
+            .ok_or("Migration rebuild schedule offset overflow")?;
+        tx.execute(
+            &format!(
+                "UPDATE {PENDING_TXS_TABLE}
+                 SET rebuild_block_offset = ?1
+                 WHERE run_id = ?2 AND txid_hex = ?3
+                   AND status = 'needs_resign' AND rebuild_block_offset IS NULL"
+            ),
+            params![assigned, run_id, txid_hex],
+        )
+        .map_err(|e| format!("Persist migration rebuild schedule offset: {e}"))?;
+        offsets_by_txid.insert(txid_hex.to_ascii_lowercase(), assigned);
+    }
+    tx.commit()
+        .map_err(|e| format!("Commit migration rebuild schedule update: {e}"))?;
+
+    Ok(Some(RebuildScheduleGeneration {
+        origin_height,
+        offsets_by_txid,
+    }))
 }
 
 pub(crate) fn reschedule_overdue_pending_txs(

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -3926,7 +3926,7 @@ pub(crate) fn replace_resigned_pending_parts(
         return Err("Replacement migration schedule does not match its denominations".to_string());
     }
 
-    for (replacement, schedule_entry) in scheduled_replacements {
+    for (replacement, _schedule_entry) in scheduled_replacements {
         let original = tx
             .query_row(
                 &format!(
@@ -3968,9 +3968,13 @@ pub(crate) fn replace_resigned_pending_parts(
                     .to_string(),
             );
         }
-        let schedule_start_height = pending
+        // The rebuild schedule is anchored at the rebuild-time chain target
+        // (see `rebuild_schedule_block_offsets`), so derive this row's origin
+        // and offset from its own heights rather than the original run entry.
+        let schedule_start_height = pending.target_height.saturating_sub(1);
+        let rebuild_block_offset = pending
             .scheduled_height
-            .checked_sub(schedule_entry.block_offset)
+            .checked_sub(schedule_start_height)
             .ok_or("Replacement migration schedule starts below zero")?;
         let encrypted_raw_tx = secret_payload::encrypt_payload(
             Zeroizing::new(pending.raw_tx),
@@ -3980,7 +3984,7 @@ pub(crate) fn replace_resigned_pending_parts(
         let metadata_json = serde_json::to_string(&pending.metadata)
             .map_err(|e| format!("Encode replacement migration metadata: {e}"))?;
         let scheduled_at_ms = scheduled_start_ms
-            .checked_add(i64::from(schedule_entry.block_offset).saturating_mul(1000))
+            .checked_add(i64::from(rebuild_block_offset).saturating_mul(1000))
             .ok_or("Replacement migration time overflow")?;
         let scheduled_height = pending.scheduled_height;
         let original_scheduled_height = original.3;

--- a/rust/src/wallet/sync/migration/schedule.rs
+++ b/rust/src/wallet/sync/migration/schedule.rs
@@ -109,6 +109,46 @@ where
         .collect()
 }
 
+/// Block offsets for re-signed (rebuilt) migration parts, aligned with
+/// `recoveries` (`(part_index, value_zatoshi)`) order. The rebuild path
+/// anchors these offsets at the rebuild-time chain target rather than the
+/// run's persisted schedule origin, so they are drawn fresh over the
+/// remaining count — mirroring `reschedule_overdue_pending_txs` — instead of
+/// replaying each part's original whole-run offset, which would push the
+/// survivors of a large run a full original-ladder span past the rebuild
+/// height.
+pub(crate) fn rebuild_schedule_block_offsets<R: RngCore + CryptoRng + ?Sized>(
+    schedule: &[MigrationScheduleEntry],
+    target_values: &[u64],
+    recoveries: &[(u32, u64)],
+    network: WalletNetwork,
+    timing_policy: MigrationTimingPolicy,
+    rng: &mut R,
+) -> Result<Vec<u32>, String> {
+    for (part_index, value_zatoshi) in recoveries {
+        schedule_block_offset_for_part(schedule, target_values, *part_index, *value_zatoshi)
+            .ok_or("Approved migration schedule is missing a recovery child")?;
+    }
+
+    let (mean_delay_blocks, max_delay_blocks) =
+        schedule_parameters_with_policy(network, timing_policy);
+    let offsets = random_schedule_block_offsets_with_rng(
+        recoveries.len(),
+        mean_delay_blocks,
+        max_delay_blocks,
+        rng,
+    );
+    // Hand out the cumulative slots in a shuffled order so the rebuilt
+    // broadcast order does not reveal which original part each transfer is.
+    let mut slots = (0..recoveries.len()).collect::<Vec<_>>();
+    slots.shuffle(rng);
+    let mut assigned = vec![0u32; recoveries.len()];
+    for (slot, offset) in slots.into_iter().zip(offsets) {
+        assigned[slot] = offset;
+    }
+    Ok(assigned)
+}
+
 pub(crate) fn validate_schedule(
     schedule: &[MigrationScheduleEntry],
     target_values: &[u64],

--- a/rust/src/wallet/sync/migration/schedule.rs
+++ b/rust/src/wallet/sync/migration/schedule.rs
@@ -109,14 +109,10 @@ where
         .collect()
 }
 
-/// Block offsets for re-signed (rebuilt) migration parts, aligned with
-/// `recoveries` (`(part_index, value_zatoshi)`) order. The rebuild path
-/// anchors these offsets at the rebuild-time chain target rather than the
-/// run's persisted schedule origin, so they are drawn fresh over the
-/// remaining count — mirroring `reschedule_overdue_pending_txs` — instead of
-/// replaying each part's original whole-run offset, which would push the
-/// survivors of a large run a full original-ladder span past the rebuild
-/// height.
+/// Fresh cumulative offsets for rebuilt migration parts, aligned with
+/// `recoveries` (`(part_index, value_zatoshi)`) order. The caller appends them
+/// to the run's persisted recovery ladder instead of replaying each part's
+/// original whole-run offset.
 pub(crate) fn rebuild_schedule_block_offsets<R: RngCore + CryptoRng + ?Sized>(
     schedule: &[MigrationScheduleEntry],
     target_values: &[u64],

--- a/rust/src/wallet/sync/migration/schema.rs
+++ b/rust/src/wallet/sync/migration/schema.rs
@@ -689,6 +689,13 @@ fn ensure_schema(conn: &rusqlite::Connection) -> Result<(), String> {
         "anchor_boundary_height",
         "INTEGER",
     )?;
+    add_column_if_missing(
+        conn,
+        RUNS_TABLE,
+        "recovery_schedule_origin_height",
+        "INTEGER",
+    )?;
+    add_column_if_missing(conn, PENDING_TXS_TABLE, "rebuild_block_offset", "INTEGER")?;
     stages::ensure_schema(conn)
 }
 

--- a/rust/src/wallet/sync/migration/schema.rs
+++ b/rust/src/wallet/sync/migration/schema.rs
@@ -695,6 +695,12 @@ fn ensure_schema(conn: &rusqlite::Connection) -> Result<(), String> {
         "recovery_schedule_origin_height",
         "INTEGER",
     )?;
+    add_column_if_missing(
+        conn,
+        RUNS_TABLE,
+        "recovery_schedule_max_block_offset",
+        "INTEGER",
+    )?;
     add_column_if_missing(conn, PENDING_TXS_TABLE, "rebuild_block_offset", "INTEGER")?;
     stages::ensure_schema(conn)
 }

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -4781,6 +4781,167 @@ fn expired_broadcasted_without_local_raw_stays_broadcasted_for_store_retry() {
 }
 
 #[test]
+fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    ensure_schema(&conn).unwrap();
+    let notes = [0u32, 1].map(|index| PreparedOrchardNoteRef {
+        txid_hex: format!("{:02x}", 0x17 + index).repeat(32),
+        output_index: index,
+        value_zatoshi: 110 + 100 * u64::from(index),
+        note_version: 2,
+        nullifier_hex: None,
+    });
+    // Distinct original whole-run offsets (10 and 40): the rebuilt heights
+    // below use fresh remaining-count offsets, so no single origin satisfies
+    // `scheduled - original_offset` for both children.
+    conn.execute(
+        &format!(
+            "INSERT INTO {RUNS_TABLE}
+             (run_id, account_uuid, network, db_fingerprint, phase,
+              created_at_ms, updated_at_ms, target_values_json, schedule_json,
+              signed_schedule_origin_height)
+             VALUES ('rebuild-run', 'account-1', 'regtest', ?1, ?2, 1, 1, '[100,200]',
+                     '[{{\"part_index\":0,\"value_zatoshi\":100,\"block_offset\":10}},{{\"part_index\":1,\"value_zatoshi\":200,\"block_offset\":40}}]',
+                     90)"
+        ),
+        params![db_path, PHASE_READY_TO_MIGRATE],
+    )
+    .unwrap();
+    for (index, note) in notes.iter().enumerate() {
+        let metadata = PendingMigrationTxMetadata {
+            tx_kind: "migration".to_string(),
+            funding_account_uuid: "account-1".to_string(),
+            selected_note: note.clone(),
+        };
+        conn.execute(
+            &format!(
+                "INSERT INTO {PENDING_TXS_TABLE}
+                 (run_id, txid_hex, part_index, encrypted_raw_tx, target_height,
+                  expiry_height, value_zatoshi, fee_zatoshi, selected_note_txid,
+                  selected_note_output_index, selected_note_value, scheduled_at_ms,
+                  scheduled_height, status, metadata_json)
+                 VALUES ('rebuild-run', ?1, ?2, 'encrypted', 90, 69120, ?3, 10, ?4,
+                         ?5, ?6, 1, ?7, 'needs_resign', ?8)"
+            ),
+            params![
+                format!("{:02x}", 0x22 + index).repeat(32),
+                index as u32,
+                100 + 100 * index as u64,
+                note.txid_hex,
+                note.output_index,
+                note.value_zatoshi,
+                90 + 30 * index as u32,
+                serde_json::to_string(&metadata).unwrap(),
+            ],
+        )
+        .unwrap();
+    }
+    drop(conn);
+
+    // Fresh remaining-count offsets 3 and 7 from the rebuild target 101.
+    let scheduled_heights = [103u32, 107];
+    let (replacements, replacement_children): (Vec<_>, Vec<_>) = notes
+        .iter()
+        .enumerate()
+        .map(|(index, note)| {
+            let metadata = PendingMigrationTxMetadata {
+                tx_kind: "migration".to_string(),
+                funding_account_uuid: "account-1".to_string(),
+                selected_note: note.clone(),
+            };
+            let scheduled_height = scheduled_heights[index];
+            let expiry_height =
+                zip318_canonical_migration_expiry_height(scheduled_height).unwrap();
+            let value_zatoshi = 100 + 100 * index as u64;
+            (
+                PendingMigrationTxReplacement {
+                    old_txid_hex: format!("{:02x}", 0x22 + index).repeat(32),
+                    replacement: PendingMigrationTxInsert {
+                        part_index: index as u32,
+                        txid_hex: format!("{:02x}", 0x44 + index).repeat(32),
+                        raw_tx: vec![index as u8; 4],
+                        target_height: 101,
+                        anchor_boundary_height: Some(90),
+                        expiry_height,
+                        scheduled_height,
+                        value_zatoshi,
+                        fee_zatoshi: 10,
+                        selected_note: note.clone(),
+                        metadata: metadata.clone(),
+                    },
+                },
+                SignedMigrationPcztInsert {
+                    message_id: format!("rebuild-child-{index}"),
+                    child_index: index as u32,
+                    base_pczt: vec![index as u8; 3],
+                    sigs: Vec::new(),
+                    target_height: 101,
+                    anchor_boundary_height: Some(90),
+                    expiry_height,
+                    scheduled_height,
+                    value_zatoshi,
+                    fee_zatoshi: 10,
+                    selected_note: note.clone(),
+                    metadata,
+                },
+            )
+        })
+        .unzip();
+
+    replace_resigned_pending_parts(
+        &db_path,
+        "rebuild-run",
+        WalletNetwork::Regtest,
+        replacements,
+        replacement_children,
+        TEST_PASSWORD,
+        TEST_SALT_BASE64,
+    )
+    .unwrap();
+
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let rows: Vec<(String, u32, u32, String)> = {
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT txid_hex, schedule_start_height, scheduled_height, status
+                 FROM {PENDING_TXS_TABLE}
+                 WHERE run_id = 'rebuild-run'
+                 ORDER BY scheduled_height ASC"
+            ))
+            .unwrap();
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })
+            .unwrap();
+        rows.collect::<Result<Vec<_>, _>>().unwrap()
+    };
+    assert_eq!(rows.len(), 2);
+    for (index, (txid_hex, schedule_start_height, scheduled_height, status)) in
+        rows.iter().enumerate()
+    {
+        assert_eq!(*txid_hex, format!("{:02x}", 0x44 + index).repeat(32));
+        assert_eq!(*schedule_start_height, 100);
+        assert_eq!(*scheduled_height, scheduled_heights[index]);
+        assert_eq!(status, "scheduled");
+    }
+    let signed_count: u32 = conn
+        .query_row(
+            &format!(
+                "SELECT COUNT(*) FROM {SIGNED_CHILD_PCZTS_TABLE}
+                 WHERE run_id = 'rebuild-run'"
+            ),
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(signed_count, 2);
+}
+
+#[test]
 fn pending_policy_checks_detect_fee_drift_and_only_mined_input_spends() {
     let temp_dir = tempfile::tempdir().unwrap();
     let db_path = temp_dir.path().join("wallet.db");

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -4672,9 +4672,12 @@ fn expired_broadcasted_without_local_raw_stays_broadcasted_for_store_retry() {
     // Once local raw is present, the same past-expiry broadcasted row resigns.
     let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
     conn.execute_batch(
+        // `mined_height` stays NULL: the row is stored but not mined, and the
+        // chain-identity fallback query still needs the column to exist.
         "CREATE TABLE transactions (
              txid BLOB PRIMARY KEY,
-             raw BLOB
+             raw BLOB,
+             mined_height INTEGER
          );",
     )
     .unwrap();

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -2619,6 +2619,55 @@ fn schedule_offsets_delay_every_transfer_and_cap_each_gap() {
 }
 
 #[test]
+fn rebuilt_parts_fit_a_remaining_count_schedule() {
+    let mut rng = StdRng::seed_from_u64(0x318);
+    // A large run on the standard mainnet policy: the original ladder spans
+    // roughly `mean * count` blocks.
+    let target_values = vec![100 * ZATOSHIS_PER_ZEC; 45];
+    let schedule = planned_transfer_schedule_with_policy(
+        target_values.iter().copied(),
+        WalletNetwork::Main,
+        MigrationTimingPolicy::Standard,
+        &mut rng,
+    );
+    // Six parts survive at scattered schedule positions (broadcast order is
+    // shuffled, so survivors spread across the whole ladder).
+    let recoveries = [4usize, 16, 26, 32, 41, 44].map(|schedule_order| {
+        let entry = &schedule[schedule_order];
+        (entry.part_index.unwrap(), entry.value_zatoshi)
+    });
+
+    let offsets = rebuild_schedule_block_offsets(
+        &schedule,
+        &target_values,
+        &recoveries,
+        WalletNetwork::Main,
+        MigrationTimingPolicy::Standard,
+        &mut rng,
+    )
+    .unwrap();
+
+    // Rebuilds anchor at the rebuild-time chain target, so the remaining
+    // parts must fit a schedule drawn over their own count instead of
+    // replaying day-0 positions from the 45-part ladder.
+    let (_, max_delay_blocks) =
+        schedule_parameters_with_policy(WalletNetwork::Main, MigrationTimingPolicy::Standard);
+    let remaining_bound = max_delay_blocks * recoveries.len() as u32;
+    let mut sorted = offsets.clone();
+    sorted.sort_unstable();
+    assert!(
+        *sorted.last().unwrap() <= remaining_bound,
+        "rebuilt offsets {offsets:?} replay the original 45-part ladder \
+         (remaining-count bound: {remaining_bound})",
+    );
+    assert!(
+        sorted.windows(2).all(|w| w[1] - w[0] <= max_delay_blocks),
+        "rebuilt offsets {offsets:?} must keep every gap within \
+         {max_delay_blocks} blocks",
+    );
+}
+
+#[test]
 fn preparation_schedule_is_planned_across_dependency_layers() {
     assert_eq!(ZIP318_PREPARATION_MEAN_DELAY_BLOCKS, 16);
     assert_eq!(ZIP318_PREPARATION_MAX_DELAY_BLOCKS, 96);

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -4925,6 +4925,7 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
             .unwrap();
     assert_eq!(repeated.origin_height, 5_000);
     assert_eq!(repeated.offsets_by_txid, generation.offsets_by_txid);
+    let persisted_generation_max = generation_max_offset.max(1_000);
 
     let replacement_for = |(txid_hex, note): &(String, PreparedOrchardNoteRef),
                            part_index: u32,
@@ -5010,11 +5011,12 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
         .unwrap();
     assert_eq!(
         mid_generation,
-        (Some(5_000), Some(generation_max_offset))
+        (Some(5_000), Some(persisted_generation_max))
     );
     drop(conn);
 
-    // The second batch consumes the same generation and retires it.
+    // The second batch consumes the same generation. Its cursor remains for
+    // later recovery waves in the active run.
     let (batch_two, batch_two_children): (Vec<_>, Vec<_>) = rows[8..]
         .iter()
         .enumerate()
@@ -5044,7 +5046,10 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap();
-    assert_eq!(final_generation, (None, None));
+    assert_eq!(
+        final_generation,
+        (Some(5_000), Some(persisted_generation_max))
+    );
     let mut rebuilt = {
         let mut stmt = conn
             .prepare(&format!(
@@ -5065,6 +5070,26 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
         .map(|(_, scheduled)| scheduled - 5_000)
         .collect::<Vec<_>>();
     assert_eq!(rebuilt_ladder, ladder, "both batches must extend one ladder");
+
+    // A later recovery wave keeps the generation and starts no earlier than
+    // the current tip relative to its origin.
+    let later_txid = format!("{:02x}", 0x90).repeat(32);
+    conn.execute(
+        &format!(
+            "UPDATE {PENDING_TXS_TABLE}
+             SET status = 'needs_resign', rebuild_block_offset = NULL
+             WHERE run_id = 'gen-run' AND txid_hex = ?1"
+        ),
+        params![later_txid],
+    )
+    .unwrap();
+    drop(conn);
+    let later =
+        ensure_rebuild_schedule_generation(&db_path, "gen-run", WalletNetwork::Main, 20_000)
+            .unwrap()
+            .unwrap();
+    assert_eq!(later.origin_height, 5_000);
+    assert!(later.offsets_by_txid[&later_txid] >= 15_000);
 }
 
 #[test]

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -4780,6 +4780,301 @@ fn expired_broadcasted_without_local_raw_stays_broadcasted_for_store_retry() {
     assert_eq!(status, "needs_resign");
 }
 
+fn insert_needs_resign_fixture_rows(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    part_indices: std::ops::Range<u32>,
+) -> Vec<(String, PreparedOrchardNoteRef)> {
+    part_indices
+        .map(|part_index| {
+            let note = PreparedOrchardNoteRef {
+                txid_hex: format!("{:02x}", 0x60 + part_index).repeat(32),
+                output_index: part_index,
+                value_zatoshi: 110,
+                note_version: 2,
+                nullifier_hex: None,
+            };
+            let metadata = PendingMigrationTxMetadata {
+                tx_kind: "migration".to_string(),
+                funding_account_uuid: "account-1".to_string(),
+                selected_note: note.clone(),
+            };
+            let txid_hex = format!("{:02x}", 0x30 + part_index).repeat(32);
+            conn.execute(
+                &format!(
+                    "INSERT INTO {PENDING_TXS_TABLE}
+                     (run_id, txid_hex, part_index, encrypted_raw_tx, target_height,
+                      expiry_height, value_zatoshi, fee_zatoshi, selected_note_txid,
+                      selected_note_output_index, selected_note_value, scheduled_at_ms,
+                      scheduled_height, status, metadata_json)
+                     VALUES (?1, ?2, ?3, 'encrypted', 90, 69120, 100, 10, ?4, ?5, 110,
+                             1, ?6, 'needs_resign', ?7)"
+                ),
+                params![
+                    run_id,
+                    txid_hex,
+                    part_index,
+                    note.txid_hex,
+                    note.output_index,
+                    90 + part_index,
+                    serde_json::to_string(&metadata).unwrap(),
+                ],
+            )
+            .unwrap();
+            (txid_hex, note)
+        })
+        .collect()
+}
+
+fn rebuild_replacement_for(
+    old_txid_hex: &str,
+    note: &PreparedOrchardNoteRef,
+    part_index: u32,
+    target_height: u32,
+    scheduled_height: u32,
+) -> (PendingMigrationTxReplacement, SignedMigrationPcztInsert) {
+    let metadata = PendingMigrationTxMetadata {
+        tx_kind: "migration".to_string(),
+        funding_account_uuid: "account-1".to_string(),
+        selected_note: note.clone(),
+    };
+    let expiry_height = zip318_canonical_migration_expiry_height(scheduled_height).unwrap();
+    (
+        PendingMigrationTxReplacement {
+            old_txid_hex: old_txid_hex.to_string(),
+            replacement: PendingMigrationTxInsert {
+                part_index,
+                txid_hex: format!("{:02x}", 0x90 + part_index).repeat(32),
+                raw_tx: vec![part_index as u8; 4],
+                target_height,
+                anchor_boundary_height: Some(90),
+                expiry_height,
+                scheduled_height,
+                value_zatoshi: 100,
+                fee_zatoshi: 10,
+                selected_note: note.clone(),
+                metadata: metadata.clone(),
+            },
+        },
+        SignedMigrationPcztInsert {
+            message_id: format!("rebuild-generation-child-{part_index}"),
+            child_index: part_index,
+            base_pczt: vec![part_index as u8; 3],
+            sigs: Vec::new(),
+            target_height,
+            anchor_boundary_height: Some(90),
+            expiry_height,
+            scheduled_height,
+            value_zatoshi: 100,
+            fee_zatoshi: 10,
+            selected_note: note.clone(),
+            metadata,
+        },
+    )
+}
+
+#[test]
+fn rebuild_generation_spans_batches_with_one_ladder() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    ensure_schema(&conn).unwrap();
+    let schedule_json = (0..10u32)
+        .map(|part_index| {
+            format!(
+                "{{\"part_index\":{part_index},\"value_zatoshi\":100,\"block_offset\":{}}}",
+                10 * (part_index + 1)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    conn.execute(
+        &format!(
+            "INSERT INTO {RUNS_TABLE}
+             (run_id, account_uuid, network, db_fingerprint, phase,
+              created_at_ms, updated_at_ms, target_values_json, schedule_json)
+             VALUES ('gen-run', 'account-1', 'main', ?1, ?2, 1, 1,
+                     '[100,100,100,100,100,100,100,100,100,100]', ?3)"
+        ),
+        params![db_path, PHASE_READY_TO_MIGRATE, format!("[{schedule_json}]")],
+    )
+    .unwrap();
+    let rows = insert_needs_resign_fixture_rows(&conn, "gen-run", 0..10);
+    drop(conn);
+
+    let generation =
+        ensure_rebuild_schedule_generation(&db_path, "gen-run", WalletNetwork::Main, 5_000)
+            .unwrap()
+            .unwrap();
+    assert_eq!(generation.origin_height, 5_000);
+    assert_eq!(generation.offsets_by_txid.len(), 10);
+    let (_, max_delay_blocks) =
+        schedule_parameters_with_policy(WalletNetwork::Main, MigrationTimingPolicy::Standard);
+    let mut ladder = generation.offsets_by_txid.values().copied().collect::<Vec<_>>();
+    ladder.sort_unstable();
+    assert!(*ladder.last().unwrap() <= max_delay_blocks * 10);
+    assert!(ladder.windows(2).all(|w| w[1] - w[0] <= max_delay_blocks));
+
+    // A later call (for example the next QR session at a new tip) reuses the
+    // persisted generation instead of anchoring a new ladder.
+    let repeated =
+        ensure_rebuild_schedule_generation(&db_path, "gen-run", WalletNetwork::Main, 6_000)
+            .unwrap()
+            .unwrap();
+    assert_eq!(repeated.origin_height, 5_000);
+    assert_eq!(repeated.offsets_by_txid, generation.offsets_by_txid);
+
+    let replacement_for = |(txid_hex, note): &(String, PreparedOrchardNoteRef),
+                           part_index: u32,
+                           target_height: u32| {
+        let offset = generation.offsets_by_txid[&txid_hex.to_ascii_lowercase()];
+        rebuild_replacement_for(txid_hex, note, part_index, target_height, 5_000 + offset)
+    };
+
+    // A child anchored at a different origin than the generation is rejected,
+    // even when its own pending bookkeeping is self-consistent.
+    let stray_offset = generation.offsets_by_txid[&rows[9].0.to_ascii_lowercase()];
+    let (stray_replacement, stray_child) =
+        rebuild_replacement_for(&rows[9].0, &rows[9].1, 9, 6_001, 6_000 + stray_offset);
+    assert_eq!(
+        replace_resigned_pending_parts(
+            &db_path,
+            "gen-run",
+            WalletNetwork::Main,
+            vec![stray_replacement],
+            vec![stray_child],
+            TEST_PASSWORD,
+            TEST_SALT_BASE64,
+        )
+        .unwrap_err(),
+        "Rebuilt migration children must share the recovery schedule origin"
+    );
+
+    // First signing batch covers eight parts; the generation survives it.
+    let (batch_one, batch_one_children): (Vec<_>, Vec<_>) = rows[..8]
+        .iter()
+        .enumerate()
+        .map(|(part_index, row)| replacement_for(row, part_index as u32, 5_001))
+        .unzip();
+    replace_resigned_pending_parts(
+        &db_path,
+        "gen-run",
+        WalletNetwork::Main,
+        batch_one,
+        batch_one_children,
+        TEST_PASSWORD,
+        TEST_SALT_BASE64,
+    )
+    .unwrap();
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let mid_origin: Option<u32> = conn
+        .query_row(
+            &format!(
+                "SELECT recovery_schedule_origin_height FROM {RUNS_TABLE}
+                 WHERE run_id = 'gen-run'"
+            ),
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(mid_origin, Some(5_000));
+    drop(conn);
+
+    // The second batch consumes the same generation and retires it.
+    let (batch_two, batch_two_children): (Vec<_>, Vec<_>) = rows[8..]
+        .iter()
+        .enumerate()
+        .map(|(offset, row)| replacement_for(row, 8 + offset as u32, 5_001))
+        .unzip();
+    replace_resigned_pending_parts(
+        &db_path,
+        "gen-run",
+        WalletNetwork::Main,
+        batch_two,
+        batch_two_children,
+        TEST_PASSWORD,
+        TEST_SALT_BASE64,
+    )
+    .unwrap();
+
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let final_origin: Option<u32> = conn
+        .query_row(
+            &format!(
+                "SELECT recovery_schedule_origin_height FROM {RUNS_TABLE}
+                 WHERE run_id = 'gen-run'"
+            ),
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(final_origin, None);
+    let mut rebuilt = {
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT schedule_start_height, scheduled_height FROM {PENDING_TXS_TABLE}
+                 WHERE run_id = 'gen-run'"
+            ))
+            .unwrap();
+        let rows = stmt
+            .query_map([], |row| Ok((row.get::<_, u32>(0)?, row.get::<_, u32>(1)?)))
+            .unwrap();
+        rows.collect::<Result<Vec<_>, _>>().unwrap()
+    };
+    assert_eq!(rebuilt.len(), 10);
+    assert!(rebuilt.iter().all(|(start, _)| *start == 5_000));
+    rebuilt.sort_by_key(|(_, scheduled)| *scheduled);
+    let rebuilt_ladder = rebuilt
+        .iter()
+        .map(|(_, scheduled)| scheduled - 5_000)
+        .collect::<Vec<_>>();
+    assert_eq!(rebuilt_ladder, ladder, "both batches must extend one ladder");
+}
+
+#[test]
+fn rebuild_generation_extends_for_late_needs_resign_parts() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    ensure_schema(&conn).unwrap();
+    conn.execute(
+        &format!(
+            "INSERT INTO {RUNS_TABLE}
+             (run_id, account_uuid, network, db_fingerprint, phase,
+              created_at_ms, updated_at_ms, target_values_json, schedule_json)
+             VALUES ('late-run', 'account-1', 'main', ?1, ?2, 1, 1, '[100,100,100]',
+                     '[{{\"part_index\":0,\"value_zatoshi\":100,\"block_offset\":10}},{{\"part_index\":1,\"value_zatoshi\":100,\"block_offset\":20}},{{\"part_index\":2,\"value_zatoshi\":100,\"block_offset\":30}}]')"
+        ),
+        params![db_path, PHASE_READY_TO_MIGRATE],
+    )
+    .unwrap();
+    insert_needs_resign_fixture_rows(&conn, "late-run", 0..2);
+
+    let generation =
+        ensure_rebuild_schedule_generation(&db_path, "late-run", WalletNetwork::Main, 2_000)
+            .unwrap()
+            .unwrap();
+    let drawn_max = generation.offsets_by_txid.values().copied().max().unwrap();
+
+    // A part expiring after the generation exists joins the same ladder past
+    // its current maximum instead of anchoring a second ladder.
+    insert_needs_resign_fixture_rows(&conn, "late-run", 2..3);
+    drop(conn);
+    let extended =
+        ensure_rebuild_schedule_generation(&db_path, "late-run", WalletNetwork::Main, 2_500)
+            .unwrap()
+            .unwrap();
+    assert_eq!(extended.origin_height, 2_000);
+    assert_eq!(extended.offsets_by_txid.len(), 3);
+    for (txid_hex, offset) in &generation.offsets_by_txid {
+        assert_eq!(extended.offsets_by_txid[txid_hex], *offset);
+    }
+    let late_txid = format!("{:02x}", 0x32).repeat(32);
+    assert!(extended.offsets_by_txid[&late_txid] > drawn_max);
+}
+
 #[test]
 fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
     let temp_dir = tempfile::tempdir().unwrap();

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -4398,6 +4398,7 @@ fn expired_pending_transaction_is_resigned_without_changing_its_denomination() {
         &db_path,
         "expired-run",
         WalletNetwork::Regtest,
+        100,
         vec![PendingMigrationTxReplacement {
             old_txid_hex: "22".repeat(32),
             replacement: PendingMigrationTxInsert {
@@ -4504,6 +4505,7 @@ fn expired_pending_transaction_is_resigned_without_changing_its_denomination() {
         &db_path,
         "expired-run",
         WalletNetwork::Regtest,
+        101,
         vec![PendingMigrationTxReplacement {
             old_txid_hex: "33".repeat(32),
             replacement: PendingMigrationTxInsert {
@@ -4917,15 +4919,16 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
     assert!(generation_max_offset <= max_delay_blocks * 10);
     assert!(ladder.windows(2).all(|w| w[1] - w[0] <= max_delay_blocks));
 
-    // A later call (for example the next QR session at a new tip) reuses the
-    // persisted generation instead of anchoring a new ladder.
+    // A later call (for example the next QR session) reuses the persisted
+    // generation instead of anchoring a new ladder while no assigned height
+    // has elapsed.
     let repeated =
-        ensure_rebuild_schedule_generation(&db_path, "gen-run", WalletNetwork::Main, 6_000)
+        ensure_rebuild_schedule_generation(&db_path, "gen-run", WalletNetwork::Main, 5_000)
             .unwrap()
             .unwrap();
     assert_eq!(repeated.origin_height, 5_000);
     assert_eq!(repeated.offsets_by_txid, generation.offsets_by_txid);
-    let persisted_generation_max = generation_max_offset.max(1_000);
+    let persisted_generation_max = generation_max_offset;
 
     let replacement_for = |(txid_hex, note): &(String, PreparedOrchardNoteRef),
                            part_index: u32,
@@ -4949,6 +4952,7 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
             &db_path,
             "gen-run",
             WalletNetwork::Main,
+            5_000,
             vec![wrong_offset_replacement],
             vec![wrong_offset_child],
             TEST_PASSWORD,
@@ -4971,6 +4975,7 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
             &db_path,
             "gen-run",
             WalletNetwork::Main,
+            5_000,
             vec![stray_replacement],
             vec![stray_child],
             TEST_PASSWORD,
@@ -4990,6 +4995,7 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
         &db_path,
         "gen-run",
         WalletNetwork::Main,
+        5_000,
         batch_one,
         batch_one_children,
         TEST_PASSWORD,
@@ -5015,17 +5021,39 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
     );
     drop(conn);
 
-    // The second batch consumes the same generation. Its cursor remains for
-    // later recovery waves in the active run.
+    // The signer returns after every remaining assigned height has elapsed:
+    // the still-unsigned parts are redrawn above the cursor instead of being
+    // rebuilt due-on-arrival, while the generation origin stays fixed.
+    let late_tip = 5_000 + persisted_generation_max + 500;
+    let late_return =
+        ensure_rebuild_schedule_generation(&db_path, "gen-run", WalletNetwork::Main, late_tip)
+            .unwrap()
+            .unwrap();
+    assert_eq!(late_return.origin_height, 5_000);
+    assert_eq!(late_return.offsets_by_txid.len(), 2);
+    for row in &rows[8..] {
+        let redrawn = late_return.offsets_by_txid[&row.0.to_ascii_lowercase()];
+        assert!(
+            redrawn > persisted_generation_max + 500,
+            "elapsed offset must be redrawn above the cursor, got {redrawn}"
+        );
+    }
+
+    // The second batch consumes the redrawn generation. Its cursor remains
+    // for later recovery waves in the active run.
     let (batch_two, batch_two_children): (Vec<_>, Vec<_>) = rows[8..]
         .iter()
         .enumerate()
-        .map(|(offset, row)| replacement_for(row, 8 + offset as u32, 5_001))
+        .map(|(offset, row)| {
+            let assigned = late_return.offsets_by_txid[&row.0.to_ascii_lowercase()];
+            rebuild_replacement_for(&row.0, &row.1, 8 + offset as u32, 5_001, 5_000 + assigned)
+        })
         .unzip();
     replace_resigned_pending_parts(
         &db_path,
         "gen-run",
         WalletNetwork::Main,
+        late_tip,
         batch_two,
         batch_two_children,
         TEST_PASSWORD,
@@ -5046,10 +5074,12 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap();
-    assert_eq!(
-        final_generation,
-        (Some(5_000), Some(persisted_generation_max))
-    );
+    let late_generation_max = rows[8..]
+        .iter()
+        .map(|row| late_return.offsets_by_txid[&row.0.to_ascii_lowercase()])
+        .max()
+        .unwrap();
+    assert_eq!(final_generation, (Some(5_000), Some(late_generation_max)));
     let mut rebuilt = {
         let mut stmt = conn
             .prepare(&format!(
@@ -5069,7 +5099,20 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
         .iter()
         .map(|(_, scheduled)| scheduled - 5_000)
         .collect::<Vec<_>>();
-    assert_eq!(rebuilt_ladder, ladder, "both batches must extend one ladder");
+    let mut expected_ladder = rows[..8]
+        .iter()
+        .map(|row| generation.offsets_by_txid[&row.0.to_ascii_lowercase()])
+        .chain(
+            rows[8..]
+                .iter()
+                .map(|row| late_return.offsets_by_txid[&row.0.to_ascii_lowercase()]),
+        )
+        .collect::<Vec<_>>();
+    expected_ladder.sort_unstable();
+    assert_eq!(
+        rebuilt_ladder, expected_ladder,
+        "both batches must extend one ladder"
+    );
 
     // A later recovery wave keeps the generation and starts no earlier than
     // the current tip relative to its origin.
@@ -5139,6 +5182,7 @@ fn rebuild_generation_retains_consumed_max_for_late_needs_resign_parts() {
         &db_path,
         "late-run",
         WalletNetwork::Main,
+        2_400,
         vec![replacement],
         vec![child],
         TEST_PASSWORD,
@@ -5151,17 +5195,20 @@ fn rebuild_generation_retains_consumed_max_for_late_needs_resign_parts() {
     drop(conn);
 
     // A later expiry extends from the persisted historical maximum rather
-    // than the maximum among rows still waiting for re-sign.
+    // than the maximum among rows still waiting for re-sign. Part 0's stored
+    // height (origin + 10) has already elapsed at the new tip, so it is
+    // redrawn above that maximum together with the late part.
     let extended =
         ensure_rebuild_schedule_generation(&db_path, "late-run", WalletNetwork::Main, 2_500)
             .unwrap()
             .unwrap();
     assert_eq!(extended.origin_height, 2_000);
     assert_eq!(extended.offsets_by_txid.len(), 2);
-    assert_eq!(extended.offsets_by_txid[&rows[0].0], 10);
+    let part_zero_offset = extended.offsets_by_txid[&rows[0].0];
+    assert!(part_zero_offset > 1_000);
     let late_txid = format!("{:02x}", 0x32).repeat(32);
     let late_offset = extended.offsets_by_txid[&late_txid];
-    assert!(late_offset >= 1_000);
+    assert!(late_offset > 1_000);
 
     let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
     let persisted_max: u32 = conn
@@ -5174,7 +5221,7 @@ fn rebuild_generation_retains_consumed_max_for_late_needs_resign_parts() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(persisted_max, late_offset);
+    assert_eq!(persisted_max, part_zero_offset.max(late_offset));
 }
 
 #[test]
@@ -5292,6 +5339,7 @@ fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
         &db_path,
         "rebuild-run",
         WalletNetwork::Regtest,
+        101,
         replacements,
         replacement_children,
         TEST_PASSWORD,

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -4913,7 +4913,8 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
         schedule_parameters_with_policy(WalletNetwork::Main, MigrationTimingPolicy::Standard);
     let mut ladder = generation.offsets_by_txid.values().copied().collect::<Vec<_>>();
     ladder.sort_unstable();
-    assert!(*ladder.last().unwrap() <= max_delay_blocks * 10);
+    let generation_max_offset = *ladder.last().unwrap();
+    assert!(generation_max_offset <= max_delay_blocks * 10);
     assert!(ladder.windows(2).all(|w| w[1] - w[0] <= max_delay_blocks));
 
     // A later call (for example the next QR session at a new tip) reuses the
@@ -4932,11 +4933,38 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
         rebuild_replacement_for(txid_hex, note, part_index, target_height, 5_000 + offset)
     };
 
+    // The replacement boundary enforces the exact persisted offset, not only
+    // the generation origin.
+    let persisted_offset = generation.offsets_by_txid[&rows[9].0.to_ascii_lowercase()];
+    let (wrong_offset_replacement, wrong_offset_child) = rebuild_replacement_for(
+        &rows[9].0,
+        &rows[9].1,
+        9,
+        5_001,
+        5_001 + persisted_offset,
+    );
+    assert_eq!(
+        replace_resigned_pending_parts(
+            &db_path,
+            "gen-run",
+            WalletNetwork::Main,
+            vec![wrong_offset_replacement],
+            vec![wrong_offset_child],
+            TEST_PASSWORD,
+            TEST_SALT_BASE64,
+        )
+        .unwrap_err(),
+        "Replacement migration schedule does not match its persisted recovery offset"
+    );
+
     // A child anchored at a different origin than the generation is rejected,
-    // even when its own pending bookkeeping is self-consistent.
+    // even when the replacement pending row matches its persisted offset.
     let stray_offset = generation.offsets_by_txid[&rows[9].0.to_ascii_lowercase()];
-    let (stray_replacement, stray_child) =
-        rebuild_replacement_for(&rows[9].0, &rows[9].1, 9, 6_001, 6_000 + stray_offset);
+    let (stray_replacement, mut stray_child) = replacement_for(&rows[9], 9, 5_001);
+    stray_child.target_height = 6_001;
+    stray_child.scheduled_height = 6_000 + stray_offset;
+    stray_child.expiry_height =
+        zip318_canonical_migration_expiry_height(stray_child.scheduled_height).unwrap();
     assert_eq!(
         replace_resigned_pending_parts(
             &db_path,
@@ -4968,17 +4996,22 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
     )
     .unwrap();
     let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
-    let mid_origin: Option<u32> = conn
+    let mid_generation: (Option<u32>, Option<u32>) = conn
         .query_row(
             &format!(
-                "SELECT recovery_schedule_origin_height FROM {RUNS_TABLE}
+                "SELECT recovery_schedule_origin_height,
+                        recovery_schedule_max_block_offset
+                 FROM {RUNS_TABLE}
                  WHERE run_id = 'gen-run'"
             ),
             [],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap();
-    assert_eq!(mid_origin, Some(5_000));
+    assert_eq!(
+        mid_generation,
+        (Some(5_000), Some(generation_max_offset))
+    );
     drop(conn);
 
     // The second batch consumes the same generation and retires it.
@@ -4999,17 +5032,19 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
     .unwrap();
 
     let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
-    let final_origin: Option<u32> = conn
+    let final_generation: (Option<u32>, Option<u32>) = conn
         .query_row(
             &format!(
-                "SELECT recovery_schedule_origin_height FROM {RUNS_TABLE}
+                "SELECT recovery_schedule_origin_height,
+                        recovery_schedule_max_block_offset
+                 FROM {RUNS_TABLE}
                  WHERE run_id = 'gen-run'"
             ),
             [],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap();
-    assert_eq!(final_origin, None);
+    assert_eq!(final_generation, (None, None));
     let mut rebuilt = {
         let mut stmt = conn
             .prepare(&format!(
@@ -5033,7 +5068,7 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
 }
 
 #[test]
-fn rebuild_generation_extends_for_late_needs_resign_parts() {
+fn rebuild_generation_retains_consumed_max_for_late_needs_resign_parts() {
     let temp_dir = tempfile::tempdir().unwrap();
     let db_path = temp_dir.path().join("wallet.db");
     let db_path = db_path.to_string_lossy().to_string();
@@ -5043,36 +5078,78 @@ fn rebuild_generation_extends_for_late_needs_resign_parts() {
         &format!(
             "INSERT INTO {RUNS_TABLE}
              (run_id, account_uuid, network, db_fingerprint, phase,
-              created_at_ms, updated_at_ms, target_values_json, schedule_json)
+              created_at_ms, updated_at_ms, target_values_json, schedule_json,
+              recovery_schedule_origin_height, recovery_schedule_max_block_offset)
              VALUES ('late-run', 'account-1', 'main', ?1, ?2, 1, 1, '[100,100,100]',
-                     '[{{\"part_index\":0,\"value_zatoshi\":100,\"block_offset\":10}},{{\"part_index\":1,\"value_zatoshi\":100,\"block_offset\":20}},{{\"part_index\":2,\"value_zatoshi\":100,\"block_offset\":30}}]')"
+                     '[{{\"part_index\":0,\"value_zatoshi\":100,\"block_offset\":10}},{{\"part_index\":1,\"value_zatoshi\":100,\"block_offset\":20}},{{\"part_index\":2,\"value_zatoshi\":100,\"block_offset\":30}}]',
+                     2000, 1000)"
         ),
         params![db_path, PHASE_READY_TO_MIGRATE],
     )
     .unwrap();
-    insert_needs_resign_fixture_rows(&conn, "late-run", 0..2);
+    let rows = insert_needs_resign_fixture_rows(&conn, "late-run", 0..2);
+    conn.execute(
+        &format!(
+            "UPDATE {PENDING_TXS_TABLE} SET rebuild_block_offset = 10
+             WHERE run_id = 'late-run' AND part_index = 0"
+        ),
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        &format!(
+            "UPDATE {PENDING_TXS_TABLE} SET rebuild_block_offset = 1000
+             WHERE run_id = 'late-run' AND part_index = 1"
+        ),
+        [],
+    )
+    .unwrap();
+    drop(conn);
 
-    let generation =
-        ensure_rebuild_schedule_generation(&db_path, "late-run", WalletNetwork::Main, 2_000)
-            .unwrap()
-            .unwrap();
-    let drawn_max = generation.offsets_by_txid.values().copied().max().unwrap();
+    // Consume the part that held the generation's largest offset. The one
+    // remaining needs_resign row only carries offset 10.
+    let (replacement, child) =
+        rebuild_replacement_for(&rows[1].0, &rows[1].1, 1, 2_001, 3_000);
+    replace_resigned_pending_parts(
+        &db_path,
+        "late-run",
+        WalletNetwork::Main,
+        vec![replacement],
+        vec![child],
+        TEST_PASSWORD,
+        TEST_SALT_BASE64,
+    )
+    .unwrap();
 
-    // A part expiring after the generation exists joins the same ladder past
-    // its current maximum instead of anchoring a second ladder.
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
     insert_needs_resign_fixture_rows(&conn, "late-run", 2..3);
     drop(conn);
+
+    // A later expiry extends from the persisted historical maximum rather
+    // than the maximum among rows still waiting for re-sign.
     let extended =
         ensure_rebuild_schedule_generation(&db_path, "late-run", WalletNetwork::Main, 2_500)
             .unwrap()
             .unwrap();
     assert_eq!(extended.origin_height, 2_000);
-    assert_eq!(extended.offsets_by_txid.len(), 3);
-    for (txid_hex, offset) in &generation.offsets_by_txid {
-        assert_eq!(extended.offsets_by_txid[txid_hex], *offset);
-    }
+    assert_eq!(extended.offsets_by_txid.len(), 2);
+    assert_eq!(extended.offsets_by_txid[&rows[0].0], 10);
     let late_txid = format!("{:02x}", 0x32).repeat(32);
-    assert!(extended.offsets_by_txid[&late_txid] > drawn_max);
+    let late_offset = extended.offsets_by_txid[&late_txid];
+    assert!(late_offset >= 1_000);
+
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let persisted_max: u32 = conn
+        .query_row(
+            &format!(
+                "SELECT recovery_schedule_max_block_offset FROM {RUNS_TABLE}
+                 WHERE run_id = 'late-run'"
+            ),
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(persisted_max, late_offset);
 }
 
 #[test]

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -4326,10 +4326,11 @@ fn expired_pending_transaction_is_resigned_without_changing_its_denomination() {
             "INSERT INTO {RUNS_TABLE}
              (run_id, account_uuid, network, db_fingerprint, phase,
               created_at_ms, updated_at_ms, target_values_json, schedule_json,
-              signed_schedule_origin_height)
+              signed_schedule_origin_height, recovery_schedule_origin_height,
+              recovery_schedule_max_block_offset)
              VALUES ('expired-run', 'account-1', 'regtest', ?1, ?2, 1, 1, '[100]',
                      '[{{\"part_index\":0,\"value_zatoshi\":100,\"block_offset\":1}}]',
-                     90)"
+                     90, 100, 1)"
         ),
         params![db_path, PHASE_BROADCAST_SCHEDULED],
     )
@@ -4350,9 +4351,9 @@ fn expired_pending_transaction_is_resigned_without_changing_its_denomination() {
              (run_id, txid_hex, encrypted_raw_tx, target_height, expiry_height,
               value_zatoshi, fee_zatoshi, selected_note_txid,
               selected_note_output_index, selected_note_value, scheduled_at_ms,
-              scheduled_height, status, metadata_json)
+              scheduled_height, status, metadata_json, rebuild_block_offset)
              VALUES ('expired-run', ?1, 'encrypted', 90, 100, 100, 10, ?2,
-                     0, 110, 1, 95, 'scheduled', ?3)"
+                     0, 110, 1, 95, 'scheduled', ?3, 1)"
         ),
         params![
             "22".repeat(32),
@@ -4493,6 +4494,8 @@ fn expired_pending_transaction_is_resigned_without_changing_its_denomination() {
         &format!(
             "UPDATE {RUNS_TABLE}
              SET signed_schedule_origin_height = NULL,
+                 recovery_schedule_origin_height = NULL,
+                 recovery_schedule_max_block_offset = NULL,
                  target_values_json = 'unrecoverable legacy metadata'
              WHERE run_id = 'expired-run'"
         ),
@@ -4876,6 +4879,46 @@ fn rebuild_replacement_for(
 }
 
 #[test]
+fn replacement_signed_children_require_recovery_origin() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    ensure_schema(&conn).unwrap();
+    conn.execute(
+        &format!(
+            "INSERT INTO {RUNS_TABLE}
+             (run_id, account_uuid, network, db_fingerprint, phase,
+              created_at_ms, updated_at_ms, target_values_json, schedule_json)
+             VALUES ('missing-origin', 'account-1', 'main', ?1, ?2, 1, 1,
+                     '[100]', '[{{\"part_index\":0,\"value_zatoshi\":100,\"block_offset\":3}}]')"
+        ),
+        params![db_path, PHASE_READY_TO_MIGRATE],
+    )
+    .unwrap();
+    let row = insert_needs_resign_fixture_rows(&conn, "missing-origin", 0..1)
+        .pop()
+        .unwrap();
+    drop(conn);
+    let (replacement, child) = rebuild_replacement_for(&row.0, &row.1, 0, 101, 103);
+
+    assert_eq!(
+        replace_resigned_pending_parts(
+            &db_path,
+            "missing-origin",
+            WalletNetwork::Main,
+            100,
+            vec![replacement],
+            vec![child],
+            TEST_PASSWORD,
+            TEST_SALT_BASE64,
+        )
+        .unwrap_err(),
+        "Migration recovery schedule origin is missing"
+    );
+}
+
+#[test]
 fn rebuild_generation_spans_batches_with_one_ladder() {
     let temp_dir = tempfile::tempdir().unwrap();
     let db_path = temp_dir.path().join("wallet.db");
@@ -4962,12 +5005,10 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
         "Replacement migration schedule does not match its persisted recovery offset"
     );
 
-    // A child anchored at a different origin than the generation is rejected,
-    // even when the replacement pending row matches its persisted offset.
-    let stray_offset = generation.offsets_by_txid[&rows[9].0.to_ascii_lowercase()];
-    let (stray_replacement, mut stray_child) = replacement_for(&rows[9], 9, 5_001);
-    stray_child.target_height = 6_001;
-    stray_child.scheduled_height = 6_000 + stray_offset;
+    // A live construction target may differ from the generation origin, but
+    // the signed child's scheduled height cannot precede that origin.
+    let (stray_replacement, mut stray_child) = replacement_for(&rows[9], 9, 6_001);
+    stray_child.scheduled_height = 4_999;
     stray_child.expiry_height =
         zip318_canonical_migration_expiry_height(stray_child.scheduled_height).unwrap();
     assert_eq!(
@@ -4982,7 +5023,7 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
             TEST_SALT_BASE64,
         )
         .unwrap_err(),
-        "Rebuilt migration children must share the recovery schedule origin"
+        "Signed migration schedule starts below zero"
     );
 
     // First signing batch covers eight parts; the generation survives it.
@@ -5046,7 +5087,13 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
         .enumerate()
         .map(|(offset, row)| {
             let assigned = late_return.offsets_by_txid[&row.0.to_ascii_lowercase()];
-            rebuild_replacement_for(&row.0, &row.1, 8 + offset as u32, 5_001, 5_000 + assigned)
+            rebuild_replacement_for(
+                &row.0,
+                &row.1,
+                8 + offset as u32,
+                late_tip + 1,
+                5_000 + assigned,
+            )
         })
         .unzip();
     replace_resigned_pending_parts(
@@ -5083,21 +5130,37 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
     let mut rebuilt = {
         let mut stmt = conn
             .prepare(&format!(
-                "SELECT schedule_start_height, scheduled_height FROM {PENDING_TXS_TABLE}
+                "SELECT part_index, target_height, schedule_start_height, scheduled_height
+                 FROM {PENDING_TXS_TABLE}
                  WHERE run_id = 'gen-run'"
             ))
             .unwrap();
         let rows = stmt
-            .query_map([], |row| Ok((row.get::<_, u32>(0)?, row.get::<_, u32>(1)?)))
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, u32>(0)?,
+                    row.get::<_, u32>(1)?,
+                    row.get::<_, u32>(2)?,
+                    row.get::<_, u32>(3)?,
+                ))
+            })
             .unwrap();
         rows.collect::<Result<Vec<_>, _>>().unwrap()
     };
     assert_eq!(rebuilt.len(), 10);
-    assert!(rebuilt.iter().all(|(start, _)| *start == 5_000));
-    rebuilt.sort_by_key(|(_, scheduled)| *scheduled);
+    assert!(rebuilt.iter().all(|(_, _, start, _)| *start == 5_000));
+    assert!(rebuilt.iter().all(|(part_index, target, _, _)| {
+        *target
+            == if *part_index < 8 {
+                5_001
+            } else {
+                late_tip + 1
+            }
+    }));
+    rebuilt.sort_by_key(|(_, _, _, scheduled)| *scheduled);
     let rebuilt_ladder = rebuilt
         .iter()
-        .map(|(_, scheduled)| scheduled - 5_000)
+        .map(|(_, _, _, scheduled)| scheduled - 5_000)
         .collect::<Vec<_>>();
     let mut expected_ladder = rows[..8]
         .iter()
@@ -5246,10 +5309,11 @@ fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
             "INSERT INTO {RUNS_TABLE}
              (run_id, account_uuid, network, db_fingerprint, phase,
               created_at_ms, updated_at_ms, target_values_json, schedule_json,
-              signed_schedule_origin_height)
+              signed_schedule_origin_height, recovery_schedule_origin_height,
+              recovery_schedule_max_block_offset)
              VALUES ('rebuild-run', 'account-1', 'regtest', ?1, ?2, 1, 1, '[100,200]',
                      '[{{\"part_index\":0,\"value_zatoshi\":100,\"block_offset\":10}},{{\"part_index\":1,\"value_zatoshi\":200,\"block_offset\":40}}]',
-                     90)"
+                     90, 100, 57)"
         ),
         params![db_path, PHASE_READY_TO_MIGRATE],
     )
@@ -5266,9 +5330,9 @@ fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
                  (run_id, txid_hex, part_index, encrypted_raw_tx, target_height,
                   expiry_height, value_zatoshi, fee_zatoshi, selected_note_txid,
                   selected_note_output_index, selected_note_value, scheduled_at_ms,
-                  scheduled_height, status, metadata_json)
+                  scheduled_height, status, metadata_json, rebuild_block_offset)
                  VALUES ('rebuild-run', ?1, ?2, 'encrypted', 90, 69120, ?3, 10, ?4,
-                         ?5, ?6, 1, ?7, 'needs_resign', ?8)"
+                         ?5, ?6, 1, ?7, 'needs_resign', ?8, ?9)"
             ),
             params![
                 format!("{:02x}", 0x22 + index).repeat(32),
@@ -5279,14 +5343,16 @@ fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
                 note.value_zatoshi,
                 90 + 30 * index as u32,
                 serde_json::to_string(&metadata).unwrap(),
+                53 + 4 * index as u32,
             ],
         )
         .unwrap();
     }
     drop(conn);
 
-    // Fresh remaining-count offsets 3 and 7 from the rebuild target 101.
-    let scheduled_heights = [103u32, 107];
+    // The live construction target has advanced beyond the persisted origin;
+    // fresh offsets 53 and 57 still schedule from that origin.
+    let scheduled_heights = [153u32, 157];
     let (replacements, replacement_children): (Vec<_>, Vec<_>) = notes
         .iter()
         .enumerate()
@@ -5307,7 +5373,7 @@ fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
                         part_index: index as u32,
                         txid_hex: format!("{:02x}", 0x44 + index).repeat(32),
                         raw_tx: vec![index as u8; 4],
-                        target_height: 101,
+                        target_height: 151,
                         anchor_boundary_height: Some(90),
                         expiry_height,
                         scheduled_height,
@@ -5322,7 +5388,7 @@ fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
                     child_index: index as u32,
                     base_pczt: vec![index as u8; 3],
                     sigs: Vec::new(),
-                    target_height: 101,
+                    target_height: 151,
                     anchor_boundary_height: Some(90),
                     expiry_height,
                     scheduled_height,
@@ -5339,7 +5405,7 @@ fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
         &db_path,
         "rebuild-run",
         WalletNetwork::Regtest,
-        101,
+        150,
         replacements,
         replacement_children,
         TEST_PASSWORD,
@@ -5348,10 +5414,10 @@ fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
     .unwrap();
 
     let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
-    let rows: Vec<(String, u32, u32, String)> = {
+    let rows: Vec<(String, u32, u32, u32, String)> = {
         let mut stmt = conn
             .prepare(&format!(
-                "SELECT txid_hex, schedule_start_height, scheduled_height, status
+                "SELECT txid_hex, target_height, schedule_start_height, scheduled_height, status
                  FROM {PENDING_TXS_TABLE}
                  WHERE run_id = 'rebuild-run'
                  ORDER BY scheduled_height ASC"
@@ -5359,16 +5425,23 @@ fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
             .unwrap();
         let rows = stmt
             .query_map([], |row| {
-                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
             })
             .unwrap();
         rows.collect::<Result<Vec<_>, _>>().unwrap()
     };
     assert_eq!(rows.len(), 2);
-    for (index, (txid_hex, schedule_start_height, scheduled_height, status)) in
+    for (index, (txid_hex, target_height, schedule_start_height, scheduled_height, status)) in
         rows.iter().enumerate()
     {
         assert_eq!(*txid_hex, format!("{:02x}", 0x44 + index).repeat(32));
+        assert_eq!(*target_height, 151);
         assert_eq!(*schedule_start_height, 100);
         assert_eq!(*scheduled_height, scheduled_heights[index]);
         assert_eq!(status, "scheduled");

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -4321,14 +4321,21 @@ fn rebuild_expired_software_migration_parts(
     let mut replacements = Vec::with_capacity(recoveries.len());
     let mut replacement_children = Vec::with_capacity(recoveries.len());
 
-    for (index, recovery) in recoveries.into_iter().enumerate() {
-        let schedule_block_offset = super::migration::schedule_block_offset_for_part(
-            &approved_schedule,
-            &target_values,
-            recovery.part_index,
-            recovery.value_zatoshi,
-        )
-        .ok_or("Approved migration schedule is missing a recovery child")?;
+    let recovery_parts = recoveries
+        .iter()
+        .map(|recovery| (recovery.part_index, recovery.value_zatoshi))
+        .collect::<Vec<_>>();
+    let rebuild_offsets = super::migration::rebuild_schedule_block_offsets(
+        &approved_schedule,
+        &target_values,
+        &recovery_parts,
+        network,
+        timing_policy,
+        &mut OsRng,
+    )?;
+    for ((index, recovery), schedule_block_offset) in
+        recoveries.into_iter().enumerate().zip(rebuild_offsets)
+    {
         let created = create_orchard_to_ironwood_pczt_from_note(
             db_path,
             network,

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -4413,6 +4413,7 @@ fn rebuild_expired_software_migration_parts(
         db_path,
         run_id,
         network,
+        chain_tip_height,
         replacements,
         replacement_children,
         pending_password,

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -1471,6 +1471,7 @@ pub(crate) async fn migrate_orchard_to_ironwood(
                             network,
                             account_uuid,
                             &run.run_id,
+                            chain_tip_height,
                             recoveries,
                             &usk,
                             pending_password.as_slice(),
@@ -4309,6 +4310,7 @@ fn rebuild_expired_software_migration_parts(
     network: WalletNetwork,
     account_uuid: &str,
     run_id: &str,
+    chain_tip_height: u32,
     recoveries: Vec<super::migration::PendingMigrationPartRecovery>,
     usk: &UnifiedSpendingKey,
     pending_password: &[u8],
@@ -4316,26 +4318,22 @@ fn rebuild_expired_software_migration_parts(
 ) -> Result<(), String> {
     let retained_message_ids = super::migration::signed_child_message_ids_by_part(db_path, run_id)?;
     let timing_policy = super::migration::timing_policy_for_run(db_path, run_id, network)?;
-    let approved_schedule = super::migration::approved_schedule_for_run(db_path, run_id)?;
-    let target_values = super::migration::target_values_for_run(db_path, run_id)?;
+    let generation = super::migration::ensure_rebuild_schedule_generation(
+        db_path,
+        run_id,
+        network,
+        chain_tip_height,
+    )?
+    .ok_or("Migration rebuild schedule generation is missing its recovery parts")?;
     let mut replacements = Vec::with_capacity(recoveries.len());
     let mut replacement_children = Vec::with_capacity(recoveries.len());
 
-    let recovery_parts = recoveries
-        .iter()
-        .map(|recovery| (recovery.part_index, recovery.value_zatoshi))
-        .collect::<Vec<_>>();
-    let rebuild_offsets = super::migration::rebuild_schedule_block_offsets(
-        &approved_schedule,
-        &target_values,
-        &recovery_parts,
-        network,
-        timing_policy,
-        &mut OsRng,
-    )?;
-    for ((index, recovery), schedule_block_offset) in
-        recoveries.into_iter().enumerate().zip(rebuild_offsets)
-    {
+    for (index, recovery) in recoveries.into_iter().enumerate() {
+        let schedule_block_offset = generation
+            .offsets_by_txid
+            .get(&recovery.old_txid_hex.to_ascii_lowercase())
+            .copied()
+            .ok_or("Migration rebuild schedule omitted a recovery part")?;
         let created = create_orchard_to_ironwood_pczt_from_note(
             db_path,
             network,
@@ -4344,6 +4342,7 @@ fn rebuild_expired_software_migration_parts(
             &recovery.selected_note,
             (index + 1) as u32,
             schedule_block_offset,
+            Some(generation.origin_height),
             timing_policy,
             true,
         )?

--- a/rust/src/wallet/sync/send/ironwood_migration.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration.rs
@@ -951,29 +951,22 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
         super::migration::approved_schedule_for_run(db_path, &run.run_id)?;
     let signed_schedule_origin =
         super::migration::signed_schedule_origin_for_run(db_path, &run.run_id)?;
-    // Recovery batches anchor at the rebuild-time chain target, so they draw
-    // a remaining-count schedule instead of replaying original whole-run
-    // offsets; see `rebuild_schedule_block_offsets`.
-    let recovery_rebuild_offsets = if initial_signing {
-        Vec::new()
+    // Recovery batches consume the run's persisted recovery-schedule
+    // generation, so every QR session extends one ladder instead of
+    // anchoring a fresh per-batch ladder at its own chain tip; see
+    // `ensure_rebuild_schedule_generation`.
+    let recovery_generation = if initial_signing {
+        None
     } else {
-        let recovery_parts = signing_part_indices
-            .iter()
-            .map(|part_index| {
-                run.target_values_zatoshi
-                    .get(*part_index as usize)
-                    .map(|value| (*part_index, *value))
-                    .ok_or("Migration part is outside the approved target list")
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        super::migration::rebuild_schedule_block_offsets(
-            &approved_schedule,
-            &run.target_values_zatoshi,
-            &recovery_parts,
-            network,
-            timing_policy,
-            &mut OsRng,
-        )?
+        Some(
+            super::migration::ensure_rebuild_schedule_generation(
+                db_path,
+                &run.run_id,
+                network,
+                chain_tip_height,
+            )?
+            .ok_or("Migration rebuild schedule generation is missing its recovery parts")?,
+        )
     };
     for (index, note_ref) in prepared_notes.iter().enumerate() {
         let part_index = *signing_part_indices
@@ -990,10 +983,16 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
             )
             .ok_or("Approved migration schedule is missing a child")?
         } else {
-            recovery_rebuild_offsets
-                .get(index)
-                .copied()
-                .ok_or("Migration recovery schedule omitted a rebuilt part")?
+            recovery_generation
+                .as_ref()
+                .zip(recoveries.get(index))
+                .and_then(|(generation, recovery)| {
+                    generation
+                        .offsets_by_txid
+                        .get(&recovery.old_txid_hex.to_ascii_lowercase())
+                        .copied()
+                })
+                .ok_or("Migration rebuild schedule omitted a rebuilt part")?
         };
         let migration_index = part_index + 1;
         let pczt_result = if initial_signing {
@@ -1007,6 +1006,9 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
                 signed_schedule_origin,
             )
         } else {
+            let recovery_origin_height = recovery_generation
+                .as_ref()
+                .map(|generation| generation.origin_height);
             with_wallet_db_write_lock("send.migration.prepare_exact_note_pczt", || {
                 create_orchard_to_ironwood_pczt_from_note(
                     db_path,
@@ -1016,6 +1018,7 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
                     note_ref,
                     migration_index,
                     schedule_block_offset,
+                    recovery_origin_height,
                     timing_policy,
                     true,
                 )

--- a/rust/src/wallet/sync/send/ironwood_migration.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration.rs
@@ -1331,10 +1331,14 @@ pub(crate) fn complete_orchard_migration_batch_pczt(
                     }
                 })
                 .collect();
+            let chain_tip_height =
+                u32::try_from(super::get_sync_progress(db_path, network)?.chain_tip_height)
+                    .map_err(|_| "Migration chain tip exceeds u32".to_string())?;
             super::migration::replace_resigned_pending_parts(
                 db_path,
                 &stored.run_id,
                 network,
+                chain_tip_height,
                 replacements,
                 Vec::new(),
                 pending_password,

--- a/rust/src/wallet/sync/send/ironwood_migration.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration.rs
@@ -951,19 +951,50 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
         super::migration::approved_schedule_for_run(db_path, &run.run_id)?;
     let signed_schedule_origin =
         super::migration::signed_schedule_origin_for_run(db_path, &run.run_id)?;
+    // Recovery batches anchor at the rebuild-time chain target, so they draw
+    // a remaining-count schedule instead of replaying original whole-run
+    // offsets; see `rebuild_schedule_block_offsets`.
+    let recovery_rebuild_offsets = if initial_signing {
+        Vec::new()
+    } else {
+        let recovery_parts = signing_part_indices
+            .iter()
+            .map(|part_index| {
+                run.target_values_zatoshi
+                    .get(*part_index as usize)
+                    .map(|value| (*part_index, *value))
+                    .ok_or("Migration part is outside the approved target list")
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        super::migration::rebuild_schedule_block_offsets(
+            &approved_schedule,
+            &run.target_values_zatoshi,
+            &recovery_parts,
+            network,
+            timing_policy,
+            &mut OsRng,
+        )?
+    };
     for (index, note_ref) in prepared_notes.iter().enumerate() {
         let part_index = *signing_part_indices
             .get(index)
             .ok_or("Migration signing selector omitted a prepared note")?;
-        let schedule_block_offset = super::migration::schedule_block_offset_for_part(
-            &approved_schedule,
-            &run.target_values_zatoshi,
-            part_index,
-            *run.target_values_zatoshi
-                .get(part_index as usize)
-                .ok_or("Migration part is outside the approved target list")?,
-        )
-        .ok_or("Approved migration schedule is missing a child")?;
+        let schedule_block_offset = if initial_signing {
+            super::migration::schedule_block_offset_for_part(
+                &approved_schedule,
+                &run.target_values_zatoshi,
+                part_index,
+                *run.target_values_zatoshi
+                    .get(part_index as usize)
+                    .ok_or("Migration part is outside the approved target list")?,
+            )
+            .ok_or("Approved migration schedule is missing a child")?
+        } else {
+            recovery_rebuild_offsets
+                .get(index)
+                .copied()
+                .ok_or("Migration recovery schedule omitted a rebuilt part")?
+        };
         let migration_index = part_index + 1;
         let pczt_result = if initial_signing {
             create_deferred_orchard_to_ironwood_pczt_from_prepared_note(

--- a/rust/src/wallet/sync/send/ironwood_migration/plan_child.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/plan_child.rs
@@ -546,7 +546,7 @@ fn create_orchard_to_ironwood_pczt_from_note(
         return Err("Prepared migration note is not an Orchard V2 note".to_string());
     }
 
-    let mut db = open_wallet_db(db_path, network)?;
+    let db = open_wallet_db(db_path, network)?;
     let account_id = parse_account_uuid(account_uuid)?;
     let account = db
         .get_account(account_id)
@@ -637,29 +637,20 @@ fn create_orchard_to_ironwood_pczt_from_note(
         recovery_schedule_origin_height,
         schedule_block_offset,
     )?;
-    let anchor_height_u32 = u32::from(anchor_height);
-    let nu6_3_activation_height = nu6_3_activation_height_u32(network)?;
-    let mined_height = orchard_selected
-        .mined_height()
-        .ok_or("Prepared migration note mined height unavailable")?;
-    let Some(anchor_boundary_height) =
-        super::migration::zip318_draw_anchor_boundary_for_note_with_policy(
+    drop(db);
+    let Some((anchor_boundary_height, orchard_anchor, orchard_witness)) =
+        orchard_anchor_and_witness_for_prepared_note(
+            db_path,
             network,
+            account_uuid,
+            note_ref,
+            None,
             timing_policy,
-            anchor_height_u32,
-            u32::from(mined_height),
-            nu6_3_activation_height,
-        )
+        )?
     else {
         return Ok(None);
     };
-
-    let (orchard_anchor, orchard_inputs) = migration_orchard_witnesses(
-        &mut db,
-        network,
-        BlockHeight::from(anchor_boundary_height),
-        std::slice::from_ref(&orchard_selected),
-    )?;
+    let orchard_inputs = [(orchard_note, orchard_witness)];
     let fee_rule = ConservativeZip317FeeRule;
     let make_builder = |ironwood_amount: Zatoshis| {
         let mut builder =

--- a/rust/src/wallet/sync/send/ironwood_migration/plan_child.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/plan_child.rs
@@ -628,15 +628,14 @@ fn create_orchard_to_ironwood_pczt_from_note(
     if u64::from(selected_value) != note_ref.value_zatoshi {
         return Err("Prepared note value changed during revalidation".to_string());
     }
-    // Rebuilds share the persisted recovery-schedule origin so every signing
-    // batch extends one ladder; note revalidation and anchor selection above
-    // and below stay on the current chain state either way.
-    let current_target_height: u32 = target_height.into();
-    let (child_target_height, scheduled_height) = initial_migration_schedule_heights(
-        current_target_height,
-        recovery_schedule_origin_height,
-        schedule_block_offset,
-    )?;
+    // The recovery origin controls only the broadcast ladder. Build at the
+    // live target so the transaction matches the current consensus branch.
+    let child_target_height: u32 = target_height.into();
+    let schedule_origin_height = recovery_schedule_origin_height
+        .ok_or("Migration rebuild schedule generation is missing its origin")?;
+    let scheduled_height = schedule_origin_height
+        .checked_add(schedule_block_offset)
+        .ok_or("Migration scheduled height overflow")?;
     drop(db);
     let Some((anchor_boundary_height, orchard_anchor, orchard_witness)) =
         orchard_anchor_and_witness_for_prepared_note(

--- a/rust/src/wallet/sync/send/ironwood_migration/plan_child.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/plan_child.rs
@@ -538,6 +538,7 @@ fn create_orchard_to_ironwood_pczt_from_note(
     note_ref: &super::migration::PreparedOrchardNoteRef,
     migration_index: u32,
     schedule_block_offset: u32,
+    recovery_schedule_origin_height: Option<u32>,
     timing_policy: super::migration::MigrationTimingPolicy,
     allow_replacing_local_spend: bool,
 ) -> Result<Option<CreatedMigrationPczt>, String> {
@@ -627,11 +628,15 @@ fn create_orchard_to_ironwood_pczt_from_note(
     if u64::from(selected_value) != note_ref.value_zatoshi {
         return Err("Prepared note value changed during revalidation".to_string());
     }
-    let target_height_u32: u32 = target_height.into();
-    let scheduled_height = target_height_u32
-        .saturating_sub(1)
-        .checked_add(schedule_block_offset)
-        .ok_or("Migration scheduled height overflow")?;
+    // Rebuilds share the persisted recovery-schedule origin so every signing
+    // batch extends one ladder; note revalidation and anchor selection above
+    // and below stay on the current chain state either way.
+    let current_target_height: u32 = target_height.into();
+    let (child_target_height, scheduled_height) = initial_migration_schedule_heights(
+        current_target_height,
+        recovery_schedule_origin_height,
+        schedule_block_offset,
+    )?;
     let anchor_height_u32 = u32::from(anchor_height);
     let nu6_3_activation_height = nu6_3_activation_height_u32(network)?;
     let mined_height = orchard_selected
@@ -660,7 +665,7 @@ fn create_orchard_to_ironwood_pczt_from_note(
         let mut builder =
             migration_child_builder(
                 network,
-                BlockHeight::from(target_height),
+                BlockHeight::from(child_target_height),
                 BlockHeight::from(scheduled_height),
                 orchard_anchor,
             )?;
@@ -729,7 +734,7 @@ fn create_orchard_to_ironwood_pczt_from_note(
         orchard_spend_action_indices: built_pczt.orchard_spend_action_indices,
         pczt_with_proofs: None,
         redacted_pczt: built_pczt.redacted_bytes,
-        target_height: target_height_u32,
+        target_height: child_target_height,
         anchor_boundary_height: Some(anchor_boundary_height),
         expiry_height,
         scheduled_height,

--- a/scripts/e2e/flutter-macos-ironwood-migration-expiry-recovery.sh
+++ b/scripts/e2e/flutter-macos-ironwood-migration-expiry-recovery.sh
@@ -5,6 +5,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 cd "$ROOT_DIR"
 
-E2E_ORCHARD_FUNDING_AMOUNT=0.011 \
+E2E_ORCHARD_FUNDING_AMOUNT=0.0412 \
 E2E_TEST_FILE=integration_test/regtest_ironwood_migration_expiry_recovery_test.dart \
   scripts/e2e/flutter-macos-ironwood-migration.sh


### PR DESCRIPTION
Migration parts that need re-signing now use one persisted recovery schedule generation per active run instead of replaying their original whole-run offsets. Software and Keystone rebuilds use the live consensus target while keeping broadcast timing coordinated across signing batches and later recovery waves.
Rust regressions cover multi-batch and late-return behavior; a macOS regtest exercises two software recovery waves through submission and completion.