### PR TITLE
Fall back to the newest ZIP 318 anchor when no aged boundary is usable

### DIFF
--- a/rust/src/wallet/sync/migration/denomination_policy.rs
+++ b/rust/src/wallet/sync/migration/denomination_policy.rs
@@ -315,6 +315,15 @@ pub(crate) fn zip318_anchor_candidate_boundaries_with_policy(
         }
         candidates.push(boundary);
     }
+    // If every aged boundary is older than the note/activation lower bound,
+    // but the newest boundary meets it, use that age-0 boundary as the sole
+    // fallback candidate. This commonly occurs just after NU6.3 activation.
+    if candidates.is_empty()
+        && anchor_bucket_min_age(network, timing_policy) > 0
+        && latest_boundary >= lower_bound
+    {
+        candidates.push(latest_boundary);
+    }
     candidates
 }
 
@@ -335,6 +344,10 @@ pub(crate) fn zip318_anchor_boundary_is_candidate(
     )
 }
 
+/// Validates only normally aged candidates, so the age-0 fallback is rejected
+/// even when `zip318_anchor_candidate_boundaries_with_policy` emitted it. If a
+/// persisted age-0 pick is rejected, the caller performs a fresh draw; because
+/// that fallback is the only candidate, the draw selects it again.
 pub(crate) fn zip318_anchor_boundary_is_candidate_with_policy(
     network: WalletNetwork,
     timing_policy: MigrationTimingPolicy,
@@ -410,6 +423,11 @@ pub(crate) fn zip318_draw_anchor_boundary_from_available_with_policy(
     )?;
     if available_candidates.is_empty() {
         return None;
+    }
+    // If the only available candidate is the newest boundary, select it immediately.
+    // This permits age 0 when none of the aged boundaries are usable.
+    if available_candidates == [latest_boundary] {
+        return Some(latest_boundary);
     }
 
     let mut weighted = Vec::with_capacity(available_candidates.len());

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -2188,6 +2188,50 @@ fn anchor_bucket_draw_stays_within_candidate_set() {
 }
 
 #[test]
+fn anchor_bucket_draw_uses_age_zero_only_as_the_sole_fallback() {
+    let latest_boundary = 5616;
+    let fallback_candidates = zip318_anchor_candidate_boundaries_with_policy(
+        WalletNetwork::Test,
+        MigrationTimingPolicy::Standard,
+        5700,
+        5600,
+        5000,
+    );
+    assert_eq!(fallback_candidates, vec![latest_boundary]);
+    assert_eq!(
+        zip318_draw_anchor_boundary_for_note_with_policy(
+            WalletNetwork::Test,
+            MigrationTimingPolicy::Standard,
+            5700,
+            5600,
+            5000,
+        ),
+        Some(latest_boundary)
+    );
+
+    let aged_candidates = zip318_anchor_candidate_boundaries_with_policy(
+        WalletNetwork::Test,
+        MigrationTimingPolicy::Standard,
+        5700,
+        5000,
+        5000,
+    );
+    assert!(!aged_candidates.contains(&latest_boundary));
+    for _ in 0..32 {
+        let selected = zip318_draw_anchor_boundary_for_note_with_policy(
+            WalletNetwork::Test,
+            MigrationTimingPolicy::Standard,
+            5700,
+            5000,
+            5000,
+        )
+        .unwrap();
+        assert!(aged_candidates.contains(&selected));
+        assert_ne!(selected, latest_boundary);
+    }
+}
+
+#[test]
 fn anchor_bucket_draw_renormalizes_over_available_checkpoint_boundaries() {
     let candidates = zip318_anchor_candidate_boundaries(WalletNetwork::Test, 5700, 5000, 5000);
     let available = vec![candidates[1], candidates[3]];

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -1953,7 +1953,7 @@ fn planner_accepts_only_zip318_one_two_five_denominations() {
 }
 
 #[test]
-fn anchor_bucket_candidates_exclude_latest_and_pre_activation_boundaries() {
+fn anchor_bucket_candidates_prefer_aged_boundaries_with_latest_fallback() {
     assert_eq!(ZIP318_ANCHOR_AGE_CAP, 4);
 
     assert_eq!(
@@ -1973,8 +1973,20 @@ fn anchor_bucket_candidates_exclude_latest_and_pre_activation_boundaries() {
         zip318_anchor_candidate_boundaries(WalletNetwork::Test, 5700, 5000, 5000),
         vec![5472, 5328, 5184, 5040]
     );
+    // No aged boundary clears the note height: fall back to the newest
+    // boundary instead of returning an empty set.
     assert_eq!(
         zip318_anchor_candidate_boundaries(WalletNetwork::Test, 5700, 5600, 5000),
+        vec![5616]
+    );
+    // Same fallback when NU6.3 activation excludes every aged boundary.
+    assert_eq!(
+        zip318_anchor_candidate_boundaries(WalletNetwork::Test, 5700, 5000, 5500),
+        vec![5616]
+    );
+    // Even the newest boundary is below the note height: genuinely empty.
+    assert_eq!(
+        zip318_anchor_candidate_boundaries(WalletNetwork::Test, 5700, 5650, 5000),
         Vec::<u32>::new()
     );
     assert_eq!(
@@ -1994,6 +2006,16 @@ fn anchor_bucket_candidates_exclude_latest_and_pre_activation_boundaries() {
         5616,
         5700,
         5000,
+        5000
+    ));
+    // Intentional asymmetry: the lone newest-boundary fallback is emitted by
+    // the candidate builder but not accepted by the aged-candidate check; a
+    // rejected persisted pick re-draws the same single candidate instead.
+    assert!(!zip318_anchor_boundary_is_candidate(
+        WalletNetwork::Test,
+        5616,
+        5700,
+        5600,
         5000
     ));
     assert_eq!(
@@ -2144,8 +2166,15 @@ fn anchor_bucket_draw_stays_within_candidate_set() {
             zip318_draw_anchor_boundary_for_note(WalletNetwork::Test, 5700, 5000, 5000).unwrap();
         assert!(candidates.contains(&boundary));
     }
+    // The lone newest-boundary fallback is drawable even though its age is
+    // below the policy minimum.
     assert_eq!(
         zip318_draw_anchor_boundary_for_note(WalletNetwork::Test, 5700, 5600, 5000),
+        Some(5616)
+    );
+    // Nothing usable at all: the draw still yields no boundary.
+    assert_eq!(
+        zip318_draw_anchor_boundary_for_note(WalletNetwork::Test, 5700, 5650, 5000),
         None
     );
     assert_eq!(


### PR DESCRIPTION
## Summary

Ironwood migration anchor selection now uses whatever ZIP 318 boundary is possible at finalization time instead of stalling when the aged candidate set is empty:

- `zip318_anchor_candidate_boundaries_with_policy`: when no aged (age >= 1) boundary clears the `max(note_mined_height, NU6.3 activation + 1)` lower bound but the newest boundary does, emit the newest (age-0) boundary as the lone fallback candidate. Aged selection is unchanged whenever any aged boundary is usable — age 0 never mixes into a non-empty aged set.
- `zip318_draw_anchor_boundary_from_available_with_policy`: return the lone newest-boundary fallback directly; the weighted draw's age check would otherwise reject it. No false trigger: the newest boundary only ever appears in the candidate list alone.
- `zip318_anchor_boundary_is_candidate_with_policy` is intentionally left validating aged candidates only (documented in a comment + pinned by a test): a persisted fallback pick rejected there falls through to a fresh draw that re-selects the same single candidate.

## Motivation

Right after NU6.3 activation every aged boundary predates the activation height, so the candidate set came back empty and migration children were deferred bucket-by-bucket (up to ~3h per retry on mainnet) even though a valid age-0 anchor existed the whole time. The same stall hit any note whose containing bucket had not aged yet at finalization time. Selection now degrades gracefully: only age 0 possible → use 0; only 1 → use 1; 2+ possible → weighted draw over the aged set as before.

Checkpoint retention and witness listing consume the same candidate list, so the fallback boundary's checkpoint is retained automatically with no changes outside `denomination_policy.rs`.

## Tests

- `cd rust && cargo test --lib`: 517 passed; 1 failed — `expired_broadcasted_without_local_raw_stays_broadcasted_for_store_retry`, which fails identically on clean `main` (pre-existing, unrelated).
- Updated `anchor_bucket_candidates_exclude_latest_and_pre_activation_boundaries` and `anchor_bucket_draw_stays_within_candidate_set`: fallback emitted when the note height or activation excludes all aged boundaries, genuinely-empty case still empty, draw returns the lone fallback, and `is_candidate` asymmetry pinned.
- `cargo fmt --check` on the touched hunks is clean (remaining diffs it reports are pre-existing drift on `main` in untouched regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)