### PR TITLE
Coalesce wallet-summary reads behind a process-wide cache

### DIFF
--- a/rust/src/wallet/db.rs
+++ b/rust/src/wallet/db.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::{Mutex, OnceLock},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Mutex, OnceLock,
+    },
     time::{Duration, Instant},
 };
 
@@ -17,6 +20,27 @@ pub(crate) const ACCOUNT_MUTATION_DB_BUSY_TIMEOUT: Duration = Duration::from_sec
 /// The sync loop should absorb brief read/write overlap without stretching cancel too far.
 pub(crate) const SYNC_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
 pub(crate) const READ_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Seqlock-style write epoch for in-process wallet-summary cache invalidation.
+///
+/// Even values mean no write is in progress. Entering
+/// [`with_wallet_db_write_lock`] makes the epoch odd; the matching RAII
+/// drop (including unwind) makes it even again. Summary readers publish
+/// only when the epoch is even and unchanged across the load.
+static WALLET_DB_WRITE_EPOCH: AtomicU64 = AtomicU64::new(0);
+
+struct WriteEpochGuard;
+
+impl Drop for WriteEpochGuard {
+    fn drop(&mut self) {
+        WALLET_DB_WRITE_EPOCH.fetch_add(1, Ordering::Release);
+    }
+}
+
+/// Current wallet-DB write epoch. Even = idle; odd = a locked write is active.
+pub(crate) fn wallet_db_write_epoch() -> u64 {
+    WALLET_DB_WRITE_EPOCH.load(Ordering::Acquire)
+}
 
 pub(crate) fn open_wallet_db_with_timeout(
     db_path: &str,
@@ -88,6 +112,11 @@ pub(crate) fn with_wallet_db_write_lock<T>(
     // Serializes wallet-DB writes across FRB foreground calls, C-FFI
     // background sync calls, and Rust sync tasks inside this process. This
     // does not coordinate with a separate OS process that opens the same DB.
+    //
+    // Also drives a seqlock-style epoch so the process-wide wallet-summary
+    // cache can reject loads that overlapped a write. The epoch is global
+    // (not keyed by path), which may over-invalidate unrelated wallets —
+    // correctness over precision.
     static WALLET_DB_WRITE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     let lock = WALLET_DB_WRITE_LOCK.get_or_init(|| Mutex::new(()));
@@ -108,6 +137,10 @@ pub(crate) fn with_wallet_db_write_lock<T>(
         );
     }
 
+    // Odd while the write closure runs; Drop makes it even on every exit.
+    WALLET_DB_WRITE_EPOCH.fetch_add(1, Ordering::AcqRel);
+    let _epoch_guard = WriteEpochGuard;
+
     let hold_start = Instant::now();
     let result = write();
     let held = hold_start.elapsed();
@@ -118,6 +151,7 @@ pub(crate) fn with_wallet_db_write_lock<T>(
         );
     }
 
+    drop(_epoch_guard);
     drop(guard);
     result
 }
@@ -144,6 +178,7 @@ pub(crate) fn open_readonly_conn_with_timeout(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
 
     #[test]
     fn configure_wallet_connection_enables_wal_mode() {
@@ -180,5 +215,31 @@ mod tests {
         });
 
         assert!(called);
+    }
+
+    #[test]
+    fn write_lock_epoch_is_odd_inside_critical_section() {
+        // Under `cargo test` parallelism other suites may hold the write lock,
+        // so only assert the epoch parity that is exclusive to our section.
+        with_wallet_db_write_lock("test_epoch", || {
+            assert_eq!(wallet_db_write_epoch() % 2, 1);
+        });
+    }
+
+    #[test]
+    fn write_lock_epoch_completes_on_unwind() {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            with_wallet_db_write_lock("test_panic", || {
+                panic!("force unwind while write epoch is odd");
+            });
+        }));
+        assert!(result.is_err());
+
+        // The Drop guard must have made the epoch even again and released the
+        // mutex; otherwise this acquisition would hang or see a stuck odd epoch
+        // owned by the panicked section.
+        with_wallet_db_write_lock("test_after_panic", || {
+            assert_eq!(wallet_db_write_epoch() % 2, 1);
+        });
     }
 }

--- a/rust/src/wallet/mod.rs
+++ b/rust/src/wallet/mod.rs
@@ -8,3 +8,4 @@ pub mod sync;
 pub mod sync_engine;
 pub(crate) mod transparent_receive_cache;
 pub mod voting;
+pub(crate) mod wallet_summary_cache;

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -2,7 +2,6 @@ use zcash_client_backend::{
     data_api::{
         chain::{scan_cached_blocks, CommitmentTreeRoot},
         scanning::ScanPriority,
-        wallet::ConfirmationsPolicy,
         WalletCommitmentTrees, WalletRead, WalletWrite,
     },
     proto::service::TreeState,
@@ -164,10 +163,7 @@ pub fn get_next_subtree_indices(
     db_path: &str,
     network: WalletNetwork,
 ) -> Result<(u64, u64, u64), String> {
-    let db = open_wallet_db_for_read(db_path, network)?;
-    let summary = db
-        .get_wallet_summary(ConfirmationsPolicy::default())
-        .map_err(|e| format!("{e}"))?;
+    let summary = crate::wallet::wallet_summary_cache::get_wallet_summary_cached(db_path, network)?;
     match summary {
         Some(s) => Ok((
             s.next_sapling_subtree_index(),

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -2395,11 +2395,10 @@ fn migration_scanned_height_read_only(
     db_path: &str,
     network: WalletNetwork,
 ) -> Result<u32, String> {
+    // Height-only: do not pay for a full WalletSummary here.
     let db = open_wallet_db_readonly_with_timeout(db_path, network, READ_DB_BUSY_TIMEOUT)?;
-    Ok(db
-        .get_wallet_summary(ConfirmationsPolicy::default())
-        .map_err(|e| format!("{e}"))?
-        .map(|summary| u32::from(summary.fully_scanned_height()))
+    Ok(super::wallet_scan_heights(&db)?
+        .map(|(scanned_height, _)| scanned_height as u32)
         .unwrap_or(0))
 }
 

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -24,7 +24,7 @@ use std::{
 
 use rusqlite::{types::Value, vtab::array::Array, OptionalExtension};
 use transparent::address::TransparentAddress;
-use zcash_client_backend::data_api::{wallet::ConfirmationsPolicy, WalletRead, WalletWrite};
+use zcash_client_backend::data_api::{WalletRead, WalletWrite};
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::{
     consensus::{BlockHeight, BranchId},
@@ -130,10 +130,7 @@ pub fn get_wallet_balances(
         .map(|uuid| parse_account_uuid(uuid))
         .collect::<Result<Vec<_>, _>>()?;
 
-    let db = open_wallet_db_for_read(db_path, network)?;
-    let summary = db
-        .get_wallet_summary(ConfirmationsPolicy::default())
-        .map_err(|e| format!("{e}"))?;
+    let summary = crate::wallet::wallet_summary_cache::get_wallet_summary_cached(db_path, network)?;
 
     let Some(summary) = summary else {
         return Ok(target_ids
@@ -3146,11 +3143,11 @@ mod tests {
     ///
     /// This is needed because the synthetic `v_transactions` table
     /// doesn't have the note-derived aggregates that the real
-    /// `HISTORY_BASES_CTE` does. 
-    /// 
+    /// `HISTORY_BASES_CTE` does.
+    ///
     /// This helper allows us to test `read_history_bases` against the
     /// synthetic `v_transactions` table.
-    /// 
+    ///
     /// The equivalency test checks that the two paths return the same rows.
     fn read_history_bases_via_v_transactions(
         conn: &rusqlite::Connection,

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -21,9 +21,7 @@ use tonic::{
     Request, Response, Status,
 };
 use zcash_client_backend::{
-    data_api::{
-        chain::CommitmentTreeRoot, wallet::ConfirmationsPolicy, WalletCommitmentTrees, WalletRead,
-    },
+    data_api::{chain::CommitmentTreeRoot, WalletCommitmentTrees},
     proto::service::{
         self, compact_tx_streamer_client::CompactTxStreamerClient, BlockId, BlockRange, ChainSpec,
         Empty, GetAddressUtxosArg, GetAddressUtxosReply, GetSubtreeRootsArg, RawTransaction,
@@ -333,14 +331,15 @@ pub(crate) async fn next_stream_message<T>(
 pub(super) async fn download_subtree_roots(
     client: &mut CompactTxStreamerClient<Channel>,
     db: &mut WalletDatabase,
+    db_path: &str,
     network: WalletNetwork,
     chain_tip: BlockHeight,
 ) -> Result<(), SyncError> {
     let ironwood_enabled = ironwood_sync_enabled(network, chain_tip);
     let (sap_start, orch_start, ironwood_start) = {
-        let summary = db
-            .get_wallet_summary(ConfirmationsPolicy::default())
-            .map_err(|e| SyncError::db(format!("get_wallet_summary: {e}")))?;
+        let summary =
+            crate::wallet::wallet_summary_cache::get_wallet_summary_cached(db_path, network)
+                .map_err(SyncError::db)?;
         match summary {
             Some(s) => (
                 s.next_sapling_subtree_index(),

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -1656,7 +1656,7 @@ async fn run_sync_impl(
     }
 
     // 3. Download subtree roots (incremental)
-    download_subtree_roots(&mut client, &mut db, network, tip_height).await?;
+    download_subtree_roots(&mut client, &mut db, db_data_path, network, tip_height).await?;
 
     if migration_anchor_retention_required {
         with_wallet_db_write_lock(

--- a/rust/src/wallet/wallet_summary_cache.rs
+++ b/rust/src/wallet/wallet_summary_cache.rs
@@ -1,0 +1,546 @@
+//! Process-wide coalescing cache for `WalletDb::get_wallet_summary`.
+//!
+//! Concurrent callers for the same `(db_path, network)` share one load by
+//! holding a per-key mutex through the SQLite computation. Successful
+//! results (including `None`) are retained until a wallet-DB write advances
+//! the seqlock epoch in [`crate::wallet::db::with_wallet_db_write_lock`].
+//! Errors are never cached.
+
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Arc, Mutex, OnceLock},
+};
+
+use zcash_client_backend::data_api::{wallet::ConfirmationsPolicy, WalletRead, WalletSummary};
+use zcash_client_sqlite::AccountUuid;
+
+use crate::wallet::{
+    db::{open_wallet_db_for_read_with_timeout, wallet_db_write_epoch, READ_DB_BUSY_TIMEOUT},
+    network::WalletNetwork,
+};
+
+type CachedSummary = Option<WalletSummary<AccountUuid>>;
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct CacheKey {
+    db_path: String,
+    network: WalletNetwork,
+}
+
+struct CacheEntry {
+    /// Epoch observed when this value was published. Must still match the
+    /// live write epoch (and be even) for a hit.
+    epoch: u64,
+    summary: CachedSummary,
+}
+
+struct EntrySlot {
+    cached: Option<CacheEntry>,
+}
+
+fn entry_map() -> &'static Mutex<HashMap<CacheKey, Arc<Mutex<EntrySlot>>>> {
+    static MAP: OnceLock<Mutex<HashMap<CacheKey, Arc<Mutex<EntrySlot>>>>> = OnceLock::new();
+    MAP.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn slot_for(key: CacheKey) -> Arc<Mutex<EntrySlot>> {
+    let mut map = match entry_map().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    map.entry(key)
+        .or_insert_with(|| Arc::new(Mutex::new(EntrySlot { cached: None })))
+        .clone()
+}
+
+/// Cached `get_wallet_summary` for the default confirmation policy.
+pub(crate) fn get_wallet_summary_cached(
+    db_path: &str,
+    network: WalletNetwork,
+) -> Result<CachedSummary, String> {
+    get_or_load_with(db_path, network, || {
+        let db = open_wallet_db_for_read_with_timeout(db_path, network, READ_DB_BUSY_TIMEOUT)?;
+        db.get_wallet_summary(ConfirmationsPolicy::default())
+            .map_err(|e| format!("{e}"))
+    })
+}
+
+/// Testable load path: production passes the real SQLite loader; unit tests
+/// inject barriers, counters, and local epochs.
+pub(crate) fn get_or_load_with<F>(
+    db_path: &str,
+    network: WalletNetwork,
+    loader: F,
+) -> Result<CachedSummary, String>
+where
+    F: FnOnce() -> Result<CachedSummary, String>,
+{
+    get_or_load_with_epoch(db_path, network, wallet_db_write_epoch, loader)
+}
+
+fn get_or_load_with_epoch<E, F>(
+    db_path: &str,
+    network: WalletNetwork,
+    epoch_fn: E,
+    loader: F,
+) -> Result<CachedSummary, String>
+where
+    E: Fn() -> u64,
+    F: FnOnce() -> Result<CachedSummary, String>,
+{
+    let key = CacheKey {
+        db_path: db_path.to_string(),
+        network,
+    };
+    let slot = slot_for(key);
+    let mut entry = match slot.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    if let Some(cached) = entry.cached.as_ref() {
+        let current = epoch_fn();
+        if current == cached.epoch && current % 2 == 0 && Path::new(db_path).exists() {
+            return Ok(cached.summary.clone());
+        }
+        // Stale epoch, write in progress, or DB file replaced/deleted.
+        entry.cached = None;
+    }
+
+    let epoch_before = epoch_fn();
+    let loaded = match loader() {
+        Ok(value) => value,
+        Err(error) => {
+            // Never cache errors — the next caller must retry.
+            entry.cached = None;
+            return Err(error);
+        }
+    };
+
+    let epoch_after = epoch_fn();
+    if epoch_before == epoch_after && epoch_before % 2 == 0 {
+        entry.cached = Some(CacheEntry {
+            epoch: epoch_before,
+            summary: loaded.clone(),
+        });
+    } else {
+        entry.cached = None;
+    }
+
+    Ok(loaded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicU64, AtomicUsize, Ordering},
+            Barrier,
+        },
+        thread,
+        time::Duration,
+    };
+
+    use zcash_client_backend::data_api::{Progress, Ratio, WalletSummary};
+    use zcash_protocol::consensus::BlockHeight;
+
+    use crate::wallet::db::with_wallet_db_write_lock;
+
+    fn unique_path(label: &str) -> String {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        format!(
+            "/tmp/vizor-summary-cache-test-{}-{}-{label}",
+            std::process::id(),
+            n,
+        )
+    }
+
+    fn touch_file(path: &str) {
+        std::fs::write(path, b"placeholder").unwrap();
+    }
+
+    fn remove_file(path: &str) {
+        let _ = std::fs::remove_file(path);
+    }
+
+    fn summary_with_tip(tip: u32) -> WalletSummary<AccountUuid> {
+        WalletSummary::new(
+            HashMap::new(),
+            BlockHeight::from_u32(tip),
+            BlockHeight::from_u32(tip),
+            Progress::new(Ratio::new(0, 0), None),
+            0,
+            0,
+            0,
+        )
+    }
+
+    fn load_with_local_epoch<F>(
+        db_path: &str,
+        network: WalletNetwork,
+        epoch: &AtomicU64,
+        loader: F,
+    ) -> Result<CachedSummary, String>
+    where
+        F: FnOnce() -> Result<CachedSummary, String>,
+    {
+        get_or_load_with_epoch(db_path, network, || epoch.load(Ordering::Acquire), loader)
+    }
+
+    #[test]
+    fn concurrent_same_path_callers_share_one_load() {
+        let path = unique_path("concurrent");
+        touch_file(&path);
+        let epoch = Arc::new(AtomicU64::new(0));
+        let loads = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(4));
+        let entered_load = Arc::new(Barrier::new(2));
+        let finish_load = Arc::new(Barrier::new(2));
+
+        let mut handles = Vec::new();
+        for _ in 0..4 {
+            let path = path.clone();
+            let epoch = Arc::clone(&epoch);
+            let loads = Arc::clone(&loads);
+            let start = Arc::clone(&start);
+            let entered_load = Arc::clone(&entered_load);
+            let finish_load = Arc::clone(&finish_load);
+            handles.push(thread::spawn(move || {
+                start.wait();
+                load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+                    // Only the first acquirer of the entry mutex runs this.
+                    loads.fetch_add(1, Ordering::SeqCst);
+                    entered_load.wait();
+                    finish_load.wait();
+                    Ok(Some(summary_with_tip(100)))
+                })
+            }));
+        }
+
+        entered_load.wait();
+        thread::sleep(Duration::from_millis(50));
+        finish_load.wait();
+
+        let mut results = Vec::new();
+        for handle in handles {
+            results.push(handle.join().unwrap().unwrap());
+        }
+
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+        for result in &results {
+            assert_eq!(u32::from(result.as_ref().unwrap().chain_tip_height()), 100);
+        }
+
+        remove_file(&path);
+    }
+
+    #[test]
+    fn sequential_same_path_calls_hit_cache() {
+        let path = unique_path("sequential");
+        touch_file(&path);
+        let epoch = AtomicU64::new(0);
+        let loads = AtomicUsize::new(0);
+
+        let first = load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(42)))
+        })
+        .unwrap();
+        let second = load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(99)))
+        })
+        .unwrap();
+
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            first.as_ref().unwrap().chain_tip_height(),
+            second.as_ref().unwrap().chain_tip_height()
+        );
+        assert_eq!(u32::from(first.as_ref().unwrap().chain_tip_height()), 42);
+
+        remove_file(&path);
+    }
+
+    #[test]
+    fn different_paths_and_networks_do_not_coalesce() {
+        let path_a = unique_path("path-a");
+        let path_b = unique_path("path-b");
+        touch_file(&path_a);
+        touch_file(&path_b);
+        let epoch = AtomicU64::new(0);
+        let loads = AtomicUsize::new(0);
+
+        let a = load_with_local_epoch(&path_a, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(1)))
+        })
+        .unwrap();
+        let b = load_with_local_epoch(&path_b, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(2)))
+        })
+        .unwrap();
+        let c = load_with_local_epoch(&path_a, WalletNetwork::Test, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(3)))
+        })
+        .unwrap();
+
+        assert_eq!(loads.load(Ordering::SeqCst), 3);
+        assert_eq!(u32::from(a.as_ref().unwrap().chain_tip_height()), 1);
+        assert_eq!(u32::from(b.as_ref().unwrap().chain_tip_height()), 2);
+        assert_eq!(u32::from(c.as_ref().unwrap().chain_tip_height()), 3);
+
+        remove_file(&path_a);
+        remove_file(&path_b);
+    }
+
+    #[test]
+    fn summary_none_is_cacheable() {
+        let path = unique_path("none");
+        touch_file(&path);
+        let epoch = AtomicU64::new(0);
+        let loads = AtomicUsize::new(0);
+
+        let first = load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(None)
+        })
+        .unwrap();
+        let second = load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(1)))
+        })
+        .unwrap();
+
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+        assert!(first.is_none());
+        assert!(second.is_none());
+
+        remove_file(&path);
+    }
+
+    #[test]
+    fn loader_error_is_not_cached() {
+        let path = unique_path("error");
+        touch_file(&path);
+        let epoch = AtomicU64::new(0);
+        let loads = AtomicUsize::new(0);
+
+        let err = load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Err("boom".to_string())
+        });
+        assert_eq!(err.unwrap_err(), "boom");
+
+        let ok = load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(7)))
+        })
+        .unwrap();
+
+        assert_eq!(loads.load(Ordering::SeqCst), 2);
+        assert_eq!(u32::from(ok.as_ref().unwrap().chain_tip_height()), 7);
+
+        remove_file(&path);
+    }
+
+    #[test]
+    fn missing_file_evicts_cached_entry() {
+        let path = unique_path("missing");
+        touch_file(&path);
+        let epoch = AtomicU64::new(0);
+        let loads = AtomicUsize::new(0);
+
+        load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(5)))
+        })
+        .unwrap();
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+
+        remove_file(&path);
+
+        let result = load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Err("file gone".to_string())
+        });
+        assert_eq!(result.unwrap_err(), "file gone");
+        assert_eq!(loads.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn write_overlapping_read_cannot_publish_stale_result() {
+        let path = unique_path("stale");
+        touch_file(&path);
+        let epoch = Arc::new(AtomicU64::new(0));
+        let loads = Arc::new(AtomicUsize::new(0));
+        let entered = Arc::new(Barrier::new(2));
+        let release_loader = Arc::new(Barrier::new(2));
+
+        let path_reader = path.clone();
+        let epoch_reader = Arc::clone(&epoch);
+        let loads_reader = Arc::clone(&loads);
+        let entered_reader = Arc::clone(&entered);
+        let release_reader = Arc::clone(&release_loader);
+        let reader = thread::spawn(move || {
+            load_with_local_epoch(&path_reader, WalletNetwork::Main, &epoch_reader, || {
+                loads_reader.fetch_add(1, Ordering::SeqCst);
+                entered_reader.wait();
+                // Simulate a write overlapping the load: bump the local
+                // epoch odd then even before the loader finishes.
+                epoch_reader.fetch_add(1, Ordering::AcqRel);
+                epoch_reader.fetch_add(1, Ordering::AcqRel);
+                release_reader.wait();
+                Ok(Some(summary_with_tip(1)))
+            })
+        });
+
+        entered.wait();
+        release_loader.wait();
+
+        let stale_result = reader.join().unwrap().unwrap();
+        assert_eq!(
+            u32::from(stale_result.as_ref().unwrap().chain_tip_height()),
+            1
+        );
+
+        // The stale load must not have been published. A follow-up read
+        // reloads and observes the post-write value.
+        let fresh = load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(2)))
+        })
+        .unwrap();
+        assert_eq!(loads.load(Ordering::SeqCst), 2);
+        assert_eq!(u32::from(fresh.as_ref().unwrap().chain_tip_height()), 2);
+
+        remove_file(&path);
+    }
+
+    #[test]
+    fn successful_write_invalidates_cached_summary() {
+        let path = unique_path("invalidate");
+        touch_file(&path);
+        let epoch = AtomicU64::new(0);
+        let loads = AtomicUsize::new(0);
+
+        load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(10)))
+        })
+        .unwrap();
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+
+        epoch.fetch_add(1, Ordering::AcqRel);
+        epoch.fetch_add(1, Ordering::AcqRel);
+
+        let after = load_with_local_epoch(&path, WalletNetwork::Main, &epoch, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(11)))
+        })
+        .unwrap();
+        assert_eq!(loads.load(Ordering::SeqCst), 2);
+        assert_eq!(u32::from(after.as_ref().unwrap().chain_tip_height()), 11);
+
+        remove_file(&path);
+    }
+
+    #[test]
+    fn real_write_lock_epoch_invalidates_production_cache_path() {
+        let path = unique_path("real-epoch");
+        touch_file(&path);
+        let loads = AtomicUsize::new(0);
+
+        // Use the production epoch source so a real write-lock cycle is what
+        // invalidates the published entry.
+        get_or_load_with(&path, WalletNetwork::Main, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(10)))
+        })
+        .unwrap();
+
+        with_wallet_db_write_lock("test.real_epoch_write", || {});
+
+        get_or_load_with(&path, WalletNetwork::Main, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(summary_with_tip(11)))
+        })
+        .unwrap();
+
+        // Parallel tests may also bump the global epoch, so require at least
+        // one invalidation reload rather than an exact count.
+        assert!(loads.load(Ordering::SeqCst) >= 2);
+
+        remove_file(&path);
+    }
+
+    #[test]
+    fn real_wallet_write_forces_summary_reload() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+        let phrase = crate::wallet::keys::generate_mnemonic();
+        let seed = crate::wallet::keys::mnemonic_to_seed(&phrase).unwrap();
+
+        crate::wallet::keys::init_db_and_create_account(
+            db_path,
+            WalletNetwork::Regtest,
+            &seed,
+            Some(1_000),
+            "test",
+        )
+        .unwrap();
+        crate::wallet::sync::update_chain_tip(db_path, WalletNetwork::Regtest, 1_100).unwrap();
+
+        let loads = AtomicUsize::new(0);
+        let first = get_or_load_with(db_path, WalletNetwork::Regtest, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            let db = open_wallet_db_for_read_with_timeout(
+                db_path,
+                WalletNetwork::Regtest,
+                READ_DB_BUSY_TIMEOUT,
+            )?;
+            db.get_wallet_summary(ConfirmationsPolicy::default())
+                .map_err(|e| format!("{e}"))
+        })
+        .unwrap();
+        let second = get_or_load_with(db_path, WalletNetwork::Regtest, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            let db = open_wallet_db_for_read_with_timeout(
+                db_path,
+                WalletNetwork::Regtest,
+                READ_DB_BUSY_TIMEOUT,
+            )?;
+            db.get_wallet_summary(ConfirmationsPolicy::default())
+                .map_err(|e| format!("{e}"))
+        })
+        .unwrap();
+        // Fresh wallets can still return Ok(None) from get_wallet_summary
+        // before any blocks are scanned; the important property is that the
+        // successful None (or Some) was cached across the second call.
+        assert_eq!(first, second);
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+
+        crate::wallet::sync::update_chain_tip(db_path, WalletNetwork::Regtest, 1_200).unwrap();
+
+        let third = get_or_load_with(db_path, WalletNetwork::Regtest, || {
+            loads.fetch_add(1, Ordering::SeqCst);
+            let db = open_wallet_db_for_read_with_timeout(
+                db_path,
+                WalletNetwork::Regtest,
+                READ_DB_BUSY_TIMEOUT,
+            )?;
+            db.get_wallet_summary(ConfirmationsPolicy::default())
+                .map_err(|e| format!("{e}"))
+        })
+        .unwrap();
+        assert!(loads.load(Ordering::SeqCst) >= 2);
+        let _ = third;
+    }
+}


### PR DESCRIPTION
## Summary
- Add a process-wide `(db_path, network)` wallet-summary cache that coalesces concurrent loads and reuses successful results until the next write.
- Drive cache freshness from a seqlock-style epoch in `with_wallet_db_write_lock`, so overlapping reads cannot publish stale summaries.
- Route balance/migration-status and subtree-index summary callers through the cache; replace the height-only summary read in migration proof readiness with `wallet_scan_heights`.

## Test plan
- [x] `cd rust && cargo test --lib wallet_summary_cache`
- [x] `cd rust && cargo test --lib` (536 passed)
- [ ] Re-run the local summary-burst repro and confirm overlapping migration-status/balance calls collapse to one expensive load