### PR TITLE
perf: instruments for diagnosing wallet-summary latency across wallets

### DIFF
--- a/rust/src/wallet/mod.rs
+++ b/rust/src/wallet/mod.rs
@@ -8,4 +8,5 @@ pub mod sync;
 pub mod sync_engine;
 pub(crate) mod transparent_receive_cache;
 pub mod voting;
+pub(crate) mod wallet_shape_diagnostics;
 pub(crate) mod wallet_summary_cache;

--- a/rust/src/wallet/wallet_shape_diagnostics.rs
+++ b/rust/src/wallet/wallet_shape_diagnostics.rs
@@ -1,0 +1,270 @@
+//! One-shot wallet-shape dump for field diagnosis of summary latency.
+//!
+//! Timing alone is not comparable between machines: a 2-second summary on a
+//! user's phone and a 165ms summary on a developer's laptop can be the same
+//! query over wildly different row counts, or the same row counts on
+//! different hardware. This logs the *inputs* that determine summary cost, so
+//! a report from the field can be placed on the scaling curve produced by
+//! `rust/tests/summary_scaling.rs` instead of guessed at.
+//!
+//! The two numbers that matter most are the `blocks` row count and the
+//! `scan_queue` split by priority — those are what `subtree_scan_progress`
+//! scans and filters on, and they vary by orders of magnitude between
+//! wallets. Everything else here is context for the balance half of the
+//! summary, which scales with accounts and notes instead.
+//!
+//! Emission is deliberately rare: once per process, plus once per slow load
+//! above [`SLOW_LOAD_LOG_THRESHOLD_MS`] and then rate-limited. It is wired
+//! into the summary cache's load path so it needs no FRB surface and no Dart
+//! change — it ships with whatever build carries the cache.
+//!
+//! Read-only throughout. This must never repair, migrate, or write to the
+//! wallet DB; a diagnostic that mutates the thing it is measuring is worse
+//! than no diagnostic.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use crate::wallet::db::open_readonly_conn_with_timeout;
+
+/// A load slower than this is worth a shape dump even if one was already
+/// emitted, because it is the case we are trying to explain.
+const SLOW_LOAD_LOG_THRESHOLD_MS: f64 = 500.0;
+
+/// Minimum number of loads between two slow-path dumps, so a persistently
+/// slow wallet logs its shape occasionally rather than on every miss.
+const SLOW_LOG_EVERY_N_LOADS: u64 = 25;
+
+static SHAPE_LOGGED: AtomicBool = AtomicBool::new(false);
+static LOADS_SINCE_SLOW_LOG: AtomicU64 = AtomicU64::new(0);
+
+/// Counters for the cache's own effectiveness, reported alongside the shape.
+///
+/// A shape is only actionable together with a hit rate: 250ms per miss is
+/// irrelevant at 92% hits and severe at 40%, and the required hit rate rises
+/// with miss cost.
+static HITS: AtomicU64 = AtomicU64::new(0);
+static LOADS: AtomicU64 = AtomicU64::new(0);
+static STORES: AtomicU64 = AtomicU64::new(0);
+static STALE_DISCARDS: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn record_hit() {
+    HITS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_store() {
+    STORES.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_stale_discard() {
+    STALE_DISCARDS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Formats the cache counters. Kept separate from the shape dump so the
+/// ratio can also be logged on its own.
+fn cache_stats_line() -> String {
+    let hits = HITS.load(Ordering::Relaxed);
+    let loads = LOADS.load(Ordering::Relaxed);
+    let requests = hits + loads;
+    let hit_pct = if requests > 0 {
+        (hits as f64 / requests as f64) * 100.0
+    } else {
+        0.0
+    };
+    format!(
+        "requests={requests} hits={hits} ({hit_pct:.1}%) loads={loads} \
+         stores={} stale_discards={}",
+        STORES.load(Ordering::Relaxed),
+        STALE_DISCARDS.load(Ordering::Relaxed),
+    )
+}
+
+fn scalar_i64(conn: &rusqlite::Connection, sql: &str) -> Option<i64> {
+    conn.query_row(sql, [], |row| row.get::<_, Option<i64>>(0))
+        .ok()
+        .flatten()
+}
+
+/// `scan_queue` rows grouped by priority, as `"10:3 20:47"`.
+///
+/// The count of rows with priority above `Scanned` (10) is the fragmentation
+/// term: each one widens the correlated `NOT EXISTS` that the progress
+/// aggregate evaluates per block row.
+fn scan_queue_by_priority(conn: &rusqlite::Connection) -> String {
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT priority, COUNT(*) FROM scan_queue GROUP BY priority ORDER BY priority",
+    ) else {
+        return "unavailable".to_string();
+    };
+    let Ok(rows) = stmt.query_map([], |row| {
+        Ok(format!(
+            "{}:{}",
+            row.get::<_, i64>(0)?,
+            row.get::<_, i64>(1)?
+        ))
+    }) else {
+        return "unavailable".to_string();
+    };
+    let parts: Vec<String> = rows.filter_map(Result::ok).collect();
+    if parts.is_empty() {
+        "none".to_string()
+    } else {
+        parts.join(" ")
+    }
+}
+
+/// Emits the shape dump unconditionally. Prefer [`maybe_log_wallet_shape`].
+pub(crate) fn log_wallet_shape(db_path: &str, reason: &str) {
+    // Read-only, fail-fast: a diagnostic must never block a user-facing read
+    // behind a busy timeout, and must never be the reason a wallet is opened
+    // writable.
+    let conn = match open_readonly_conn_with_timeout(db_path, None) {
+        Ok(conn) => conn,
+        Err(error) => {
+            log::warn!("wallet shape ({reason}): could not open read-only: {error}");
+            return;
+        }
+    };
+
+    let blocks = scalar_i64(&conn, "SELECT COUNT(*) FROM blocks").unwrap_or(-1);
+    let min_height = scalar_i64(&conn, "SELECT MIN(height) FROM blocks").unwrap_or(-1);
+    let max_height = scalar_i64(&conn, "SELECT MAX(height) FROM blocks").unwrap_or(-1);
+    let accounts = scalar_i64(&conn, "SELECT COUNT(*) FROM accounts").unwrap_or(-1);
+    let queue_rows = scalar_i64(&conn, "SELECT COUNT(*) FROM scan_queue").unwrap_or(-1);
+    let queue_by_priority = scan_queue_by_priority(&conn);
+
+    // Per-pool note counts drive the balance half of the summary. A missing
+    // table (older schema, pool not yet activated) reports -1 rather than
+    // failing the dump.
+    let sapling_notes =
+        scalar_i64(&conn, "SELECT COUNT(*) FROM sapling_received_notes").unwrap_or(-1);
+    let orchard_notes =
+        scalar_i64(&conn, "SELECT COUNT(*) FROM orchard_received_notes").unwrap_or(-1);
+    let ironwood_notes =
+        scalar_i64(&conn, "SELECT COUNT(*) FROM ironwood_received_notes").unwrap_or(-1);
+    let transactions = scalar_i64(&conn, "SELECT COUNT(*) FROM transactions").unwrap_or(-1);
+
+    // `librustzcash` never runs ANALYZE, so `sqlite_stat1` is normally
+    // absent and the planner works from default row-count guesses. Whether
+    // it is present at all is worth knowing before blaming the query.
+    let has_stat1 = scalar_i64(
+        &conn,
+        "SELECT COUNT(*) FROM sqlite_master WHERE name = 'sqlite_stat1'",
+    )
+    .unwrap_or(0)
+        > 0;
+    let page_size = scalar_i64(&conn, "PRAGMA page_size").unwrap_or(-1);
+    let page_count = scalar_i64(&conn, "PRAGMA page_count").unwrap_or(-1);
+    let db_mib = if page_size > 0 && page_count > 0 {
+        (page_size as f64 * page_count as f64) / (1024.0 * 1024.0)
+    } else {
+        -1.0
+    };
+
+    log::info!(
+        "wallet shape ({reason}): blocks={blocks} heights={min_height}..={max_height} \
+         scan_queue={queue_rows} by_priority=[{queue_by_priority}] accounts={accounts} \
+         txs={transactions} notes=[sapling={sapling_notes} orchard={orchard_notes} \
+         ironwood={ironwood_notes}] db_mib={db_mib:.1} page_size={page_size} \
+         sqlite_stat1={has_stat1} | cache: {}",
+        cache_stats_line()
+    );
+}
+
+/// Logs the shape once per process, and again after a slow load.
+///
+/// `elapsed_ms` is the duration of the summary computation that just
+/// finished. Call this only on the load path — a cache hit did no SQLite
+/// work and has nothing to explain.
+pub(crate) fn maybe_log_wallet_shape(db_path: &str, elapsed_ms: f64) {
+    LOADS.fetch_add(1, Ordering::Relaxed);
+
+    if !SHAPE_LOGGED.swap(true, Ordering::Relaxed) {
+        LOADS_SINCE_SLOW_LOG.store(0, Ordering::Relaxed);
+        spawn_shape_dump(db_path, "first load".to_string());
+        return;
+    }
+
+    if elapsed_ms < SLOW_LOAD_LOG_THRESHOLD_MS {
+        return;
+    }
+
+    // Rate-limit: a wallet that is slow on every miss should say so
+    // periodically, not on every miss.
+    let since = LOADS_SINCE_SLOW_LOG.fetch_add(1, Ordering::Relaxed) + 1;
+    if since >= SLOW_LOG_EVERY_N_LOADS {
+        LOADS_SINCE_SLOW_LOG.store(0, Ordering::Relaxed);
+        spawn_shape_dump(db_path, format!("slow load {elapsed_ms:.0}ms"));
+    }
+}
+
+/// Runs the dump off the calling thread.
+///
+/// The counting queries are themselves full scans — `COUNT(*)` over a
+/// multi-million-row `blocks` table is precisely the work whose cost we are
+/// investigating — so charging them to a caller that is already waiting on a
+/// slow summary would make the diagnostic part of the problem. Rate limiting
+/// keeps this to a handful of short-lived threads per session.
+fn spawn_shape_dump(db_path: &str, reason: String) {
+    let db_path = db_path.to_string();
+    std::thread::Builder::new()
+        .name("wallet-shape-diag".into())
+        .spawn(move || log_wallet_shape(&db_path, &reason))
+        .map(|_| ())
+        .unwrap_or_else(|error| {
+            log::warn!("wallet shape: could not spawn diagnostic thread: {error}");
+        });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The dump must survive a DB that has none of the tables it asks about,
+    /// because it runs on whatever the field build finds — including a
+    /// partially migrated or unexpected schema.
+    #[test]
+    fn shape_dump_tolerates_missing_tables() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.db");
+        let path = path.to_str().unwrap();
+        rusqlite::Connection::open(path).unwrap();
+
+        // Must not panic: every scalar falls back rather than unwrapping.
+        log_wallet_shape(path, "test");
+    }
+
+    #[test]
+    fn shape_dump_tolerates_missing_file() {
+        log_wallet_shape("/nonexistent/path/to/wallet.db", "test");
+    }
+
+    #[test]
+    fn scan_queue_grouping_reports_priorities() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("queue.db");
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute(
+            "CREATE TABLE scan_queue (block_range_start INTEGER, block_range_end INTEGER, priority INTEGER)",
+            [],
+        )
+        .unwrap();
+        for (start, end, priority) in [(0, 10, 10), (10, 20, 10), (20, 30, 20)] {
+            conn.execute(
+                "INSERT INTO scan_queue VALUES (?1, ?2, ?3)",
+                rusqlite::params![start, end, priority],
+            )
+            .unwrap();
+        }
+
+        assert_eq!(scan_queue_by_priority(&conn), "10:2 20:1");
+    }
+
+    #[test]
+    fn cache_stats_line_reports_hit_rate() {
+        HITS.store(9, Ordering::Relaxed);
+        LOADS.store(1, Ordering::Relaxed);
+        let line = cache_stats_line();
+        assert!(line.contains("requests=10"), "{line}");
+        assert!(line.contains("(90.0%)"), "{line}");
+    }
+}

--- a/rust/src/wallet/wallet_summary_cache.rs
+++ b/rust/src/wallet/wallet_summary_cache.rs
@@ -10,6 +10,7 @@ use std::{
     collections::HashMap,
     path::Path,
     sync::{Arc, Mutex, OnceLock},
+    time::Instant,
 };
 
 use zcash_client_backend::data_api::{wallet::ConfirmationsPolicy, WalletRead, WalletSummary};
@@ -18,6 +19,7 @@ use zcash_client_sqlite::AccountUuid;
 use crate::wallet::{
     db::{open_wallet_db_for_read_with_timeout, wallet_db_write_epoch, READ_DB_BUSY_TIMEOUT},
     network::WalletNetwork,
+    wallet_shape_diagnostics,
 };
 
 type CachedSummary = Option<WalletSummary<AccountUuid>>;
@@ -102,6 +104,7 @@ where
     if let Some(cached) = entry.cached.as_ref() {
         let current = epoch_fn();
         if current == cached.epoch && current % 2 == 0 && Path::new(db_path).exists() {
+            wallet_shape_diagnostics::record_hit();
             return Ok(cached.summary.clone());
         }
         // Stale epoch, write in progress, or DB file replaced/deleted.
@@ -109,6 +112,7 @@ where
     }
 
     let epoch_before = epoch_fn();
+    let started = Instant::now();
     let loaded = match loader() {
         Ok(value) => value,
         Err(error) => {
@@ -118,15 +122,28 @@ where
         }
     };
 
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1_000.0;
     let epoch_after = epoch_fn();
     if epoch_before == epoch_after && epoch_before % 2 == 0 {
         entry.cached = Some(CacheEntry {
             epoch: epoch_before,
             summary: loaded.clone(),
         });
+        wallet_shape_diagnostics::record_store();
     } else {
         entry.cached = None;
+        wallet_shape_diagnostics::record_stale_discard();
     }
+
+    // Release the slot before diagnosing: the shape dump opens its own
+    // read-only connection and runs a dozen counting queries, and holding
+    // the per-key lock through that would make a diagnostic build stall
+    // exactly the callers it is meant to be measuring.
+    drop(entry);
+
+    // Every completed computation is a chance to explain itself: the first
+    // one dumps the wallet shape, and slow ones re-dump periodically.
+    wallet_shape_diagnostics::maybe_log_wallet_shape(db_path, elapsed_ms);
 
     Ok(loaded)
 }

--- a/rust/tests/summary_scaling.rs
+++ b/rust/tests/summary_scaling.rs
@@ -1,0 +1,397 @@
+//! Scaling curve for the `get_wallet_summary` scan-progress queries.
+//!
+//! # What this answers
+//!
+//! `get_wallet_summary` spends roughly half its time in
+//! `subtree_scan_progress` (`zcash_client_sqlite::wallet`), which runs one
+//! full aggregate over `blocks` per shielded pool, each filtered by a
+//! correlated `NOT EXISTS` against `scan_queue`. Profiling one wallet tells
+//! you what that costs *on that wallet*. This harness instead measures the
+//! cost as a function of the two inputs that vary between wallets:
+//!
+//!   * how many rows `blocks` holds (birthday age / sync depth), and
+//!   * how many priority segments `scan_queue` is split into (fragmentation).
+//!
+//! The output is a table you can read a formula off. Given a user's two
+//! counts you can then predict their progress latency without their DB —
+//! and decide whether a reported latency is explainable by their dataset at
+//! all, or whether it must be concurrency or device speed.
+//!
+//! It also reports fresh-connection vs reused-connection timings, which is
+//! the measurement for whether per-call connection setup and a cold SQLite
+//! page cache are material.
+//!
+//! # Running it
+//!
+//! Close the wallet app first — the source DB is copied byte-for-byte and
+//! must not be mid-write.
+//!
+//! ```bash
+//! VIZOR_SUMMARY_BENCH_DB=/path/to/zcash_wallet.db \
+//!   cargo test --release --test summary_scaling -- --ignored --nocapture
+//! ```
+//!
+//! Optional knobs (comma-separated):
+//!
+//! ```bash
+//! VIZOR_SUMMARY_BENCH_BLOCKS=0,500000,1000000,2000000   # 0 = leave as-is
+//! VIZOR_SUMMARY_BENCH_SEGMENTS=2,10,50,200
+//! VIZOR_SUMMARY_BENCH_REPS=5
+//! ```
+//!
+//! # What it is not
+//!
+//! The inflated rows are synthetic: plausible heights, monotonic tree sizes,
+//! fixed output counts. That is sufficient for *timing* the progress
+//! aggregates, which read only heights, output counts and queue ranges. It
+//! is **not** a valid wallet — never point a correctness test at an inflated
+//! DB, and never reuse one as a fixture.
+//!
+//! This covers the progress half of a summary only. The balance half (the
+//! unspent-notes scan across all accounts) scales with accounts and notes
+//! instead, and is measured in-app by the `debug-wallet-summary-timing`
+//! feature.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+use rusqlite::Connection;
+
+/// `ScanPriority::Scanned` as stored by `zcash_client_sqlite`. The progress
+/// filter excludes any block inside a queue range with a *higher* priority.
+const SCANNED_PRIORITY: i64 = 10;
+/// `ScanPriority::Historic` — any value above `Scanned` makes the range count
+/// as pending re-scan, which is what the `NOT EXISTS` filter has to reject.
+const UNSCANNED_PRIORITY: i64 = 20;
+
+/// One aggregate runs per pool, so a summary pays all three.
+const POOL_OUTPUT_COUNT_COLS: [&str; 3] = [
+    "sapling_output_count",
+    "orchard_action_count",
+    "ironwood_action_count",
+];
+
+/// Shape of the `blocks` table, read before and after inflation.
+#[derive(Debug, Clone, Copy)]
+struct BlockShape {
+    rows: u64,
+    min_height: u32,
+    max_height: u32,
+}
+
+fn env_list(key: &str, default: &[u64]) -> Vec<u64> {
+    match std::env::var(key) {
+        Ok(raw) => raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                s.parse::<u64>()
+                    .unwrap_or_else(|_| panic!("{key}: `{s}` is not a number"))
+            })
+            .collect(),
+        Err(_) => default.to_vec(),
+    }
+}
+
+fn block_shape(conn: &Connection) -> BlockShape {
+    conn.query_row(
+        "SELECT COUNT(*), IFNULL(MIN(height), 0), IFNULL(MAX(height), 0) FROM blocks",
+        [],
+        |row| {
+            Ok(BlockShape {
+                rows: row.get::<_, i64>(0)? as u64,
+                min_height: row.get::<_, i64>(1)? as u32,
+                max_height: row.get::<_, i64>(2)? as u32,
+            })
+        },
+    )
+    .expect("read blocks shape")
+}
+
+/// Copies the wallet DB (and any WAL sidecars) to `dest`.
+///
+/// A byte copy rather than `VACUUM INTO`: vacuuming defragments the file,
+/// which would quietly make every measurement faster than the wallet it was
+/// taken from. Requires that nothing is writing the source.
+fn open_readonly(path: &Path) -> Connection {
+    Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .expect("open DB read-only")
+}
+
+fn copy_db(source: &Path, dest: &Path) {
+    fs::copy(source, dest).expect("copy wallet DB");
+    for suffix in ["-wal", "-shm"] {
+        let from = PathBuf::from(format!("{}{suffix}", source.display()));
+        if from.exists() {
+            let to = PathBuf::from(format!("{}{suffix}", dest.display()));
+            fs::copy(&from, &to).expect("copy WAL sidecar");
+        }
+    }
+}
+
+/// Appends synthetic rows above the current tip until `blocks` holds
+/// `target` rows.
+///
+/// Rows are appended *above* the tip rather than below the birthday because
+/// the progress aggregates filter on `:start_height <= height`; rows below
+/// the start height would be skipped and the scan would not grow.
+///
+/// Commitment tree sizes stay monotonically increasing so the shape matches
+/// what the real queries expect to read, and each row carries a non-zero
+/// output count so `SUM(...)` has real work to do.
+fn inflate_blocks(conn: &mut Connection, target: u64) -> BlockShape {
+    let shape = block_shape(conn);
+    if target <= shape.rows {
+        return shape;
+    }
+    let to_add = target - shape.rows;
+
+    // Continue the tree sizes from the current tip so the column stays
+    // monotonic; a missing value (empty wallet) just starts from zero.
+    let (mut sapling_size, mut orchard_size, mut ironwood_size) = conn
+        .query_row(
+            "SELECT IFNULL(MAX(sapling_commitment_tree_size), 0),
+                    IFNULL(MAX(orchard_commitment_tree_size), 0),
+                    IFNULL(MAX(ironwood_commitment_tree_size), 0)
+             FROM blocks",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .expect("read tree sizes");
+
+    const OUTPUTS_PER_BLOCK: i64 = 2;
+    let hash = vec![0u8; 32];
+    let tree: Vec<u8> = Vec::new();
+
+    let tx = conn.transaction().expect("begin inflate");
+    {
+        let mut stmt = tx
+            .prepare(
+                "INSERT INTO blocks (
+                     height, hash, time, sapling_tree,
+                     sapling_commitment_tree_size, orchard_commitment_tree_size,
+                     sapling_output_count, orchard_action_count,
+                     ironwood_commitment_tree_size, ironwood_action_count
+                 ) VALUES (?1, ?2, 0, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            )
+            .expect("prepare insert");
+        for i in 1..=to_add {
+            let height = shape.max_height as i64 + i as i64;
+            sapling_size += OUTPUTS_PER_BLOCK;
+            orchard_size += OUTPUTS_PER_BLOCK;
+            ironwood_size += OUTPUTS_PER_BLOCK;
+            stmt.execute(rusqlite::params![
+                height,
+                hash,
+                tree,
+                sapling_size,
+                orchard_size,
+                OUTPUTS_PER_BLOCK,
+                OUTPUTS_PER_BLOCK,
+                ironwood_size,
+                OUTPUTS_PER_BLOCK,
+            ])
+            .expect("insert synthetic block");
+        }
+    }
+    tx.commit().expect("commit inflate");
+
+    block_shape(conn)
+}
+
+/// Replaces `scan_queue` with `segments` contiguous ranges spanning the whole
+/// block range, alternating scanned/pending priority.
+///
+/// Alternating means roughly half the blocks fall inside a pending range and
+/// must be rejected by the `NOT EXISTS` filter — the realistic fragmented
+/// case, and the one where the correlated subquery does the most work.
+fn set_scan_queue_segments(conn: &Connection, shape: BlockShape, segments: u64) {
+    assert!(segments >= 1, "need at least one scan_queue segment");
+    conn.execute("DELETE FROM scan_queue", [])
+        .expect("clear scan_queue");
+
+    let start = shape.min_height as u64;
+    let end = shape.max_height as u64 + 1;
+    let span = end.saturating_sub(start).max(segments);
+    let step = span / segments;
+
+    let mut stmt = conn
+        .prepare("INSERT INTO scan_queue (block_range_start, block_range_end, priority) VALUES (?1, ?2, ?3)")
+        .expect("prepare scan_queue insert");
+    for i in 0..segments {
+        let range_start = start + i * step;
+        // The last segment absorbs any remainder so the ranges stay
+        // contiguous and cover the full span.
+        let range_end = if i + 1 == segments {
+            end.max(range_start + 1)
+        } else {
+            range_start + step
+        };
+        let priority = if i % 2 == 0 {
+            SCANNED_PRIORITY
+        } else {
+            UNSCANNED_PRIORITY
+        };
+        stmt.execute(rusqlite::params![
+            range_start as i64,
+            range_end as i64,
+            priority
+        ])
+        .expect("insert scan_queue segment");
+    }
+}
+
+/// The progress aggregate, copied from `subtree_scan_progress`.
+///
+/// Mirrored rather than called because the upstream function is private.
+/// This is a timing harness, so a faithful copy of the SQL is sufficient;
+/// it is deliberately not used for any correctness assertion.
+fn progress_sql(output_count_col: &str) -> String {
+    format!(
+        "SELECT SUM({output_count_col})
+         FROM blocks
+         WHERE :start_height <= height
+         AND NOT EXISTS (
+             SELECT 1 FROM scan_queue
+             WHERE block_range_start <= blocks.height
+               AND blocks.height < block_range_end
+               AND priority > :scanned_priority
+         )"
+    )
+}
+
+fn run_progress_query(conn: &Connection, sql: &str, start_height: u32) -> Duration {
+    let started = Instant::now();
+    let _: Option<i64> = conn
+        .query_row(
+            sql,
+            rusqlite::named_params! {
+                ":start_height": start_height,
+                ":scanned_priority": SCANNED_PRIORITY,
+            },
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .expect("run progress query");
+    started.elapsed()
+}
+
+fn median(mut values: Vec<Duration>) -> Duration {
+    values.sort();
+    values[values.len() / 2]
+}
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1_000.0
+}
+
+/// Total of all three pools — one summary pays every pool's aggregate.
+fn measure_cell(db_path: &Path, shape: BlockShape, reps: usize) -> (f64, f64) {
+    let start_height = shape.min_height;
+
+    // Fresh connection per rep: the cost the app actually pays today, since
+    // every read opens a new connection with an empty 2 MiB page cache.
+    let mut cold = Vec::new();
+    for _ in 0..reps {
+        let conn = Connection::open(db_path).expect("open cold");
+        let mut total = Duration::ZERO;
+        for col in POOL_OUTPUT_COUNT_COLS {
+            total += run_progress_query(&conn, &progress_sql(col), start_height);
+        }
+        cold.push(total);
+    }
+
+    // Reused connection: the cost if connections were pooled, or the page
+    // cache were large enough to survive. The gap between the two is the
+    // value of fixing connection handling.
+    let conn = Connection::open(db_path).expect("open warm");
+    let mut warm = Vec::new();
+    for _ in 0..reps {
+        let mut total = Duration::ZERO;
+        for col in POOL_OUTPUT_COUNT_COLS {
+            total += run_progress_query(&conn, &progress_sql(col), start_height);
+        }
+        warm.push(total);
+    }
+
+    (ms(median(cold)), ms(median(warm)))
+}
+
+#[test]
+#[ignore = "requires a real wallet DB via VIZOR_SUMMARY_BENCH_DB"]
+fn summary_progress_scaling_curve() {
+    let source = std::env::var("VIZOR_SUMMARY_BENCH_DB")
+        .expect("set VIZOR_SUMMARY_BENCH_DB to a wallet DB (app must be closed)");
+    let source = PathBuf::from(source);
+    assert!(source.exists(), "no such wallet DB: {}", source.display());
+
+    let block_targets = env_list("VIZOR_SUMMARY_BENCH_BLOCKS", &[0, 500_000, 1_000_000, 2_000_000]);
+    let segment_counts = env_list("VIZOR_SUMMARY_BENCH_SEGMENTS", &[2, 10, 50, 200]);
+    let reps = env_list("VIZOR_SUMMARY_BENCH_REPS", &[5])[0] as usize;
+
+    // The source is the user's live wallet: only ever opened read-only, and
+    // every mutation happens on the temp copy.
+    let baseline = block_shape(&open_readonly(&source));
+
+    println!();
+    println!("source: {}", source.display());
+    println!(
+        "baseline blocks: {} rows, heights {}..={}",
+        baseline.rows, baseline.min_height, baseline.max_height
+    );
+    println!("reps per cell: {reps} (median reported)");
+    println!();
+    println!(
+        "{:>10}  {:>9}  {:>12}  {:>12}  {:>9}",
+        "blocks", "segments", "cold ms", "warm ms", "cold/warm"
+    );
+    println!("{}", "-".repeat(60));
+
+    for &target in &block_targets {
+        // A fresh copy per block target; segment variations reuse it, since
+        // rewriting scan_queue is cheap and does not disturb `blocks`.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let work = dir.path().join("bench_wallet.db");
+        copy_db(&source, &work);
+
+        let shape = {
+            let mut conn = Connection::open(&work).expect("open work DB");
+            if target == 0 {
+                block_shape(&conn)
+            } else {
+                inflate_blocks(&mut conn, target)
+            }
+        };
+
+        for &segments in &segment_counts {
+            {
+                let conn = Connection::open(&work).expect("open for queue rewrite");
+                set_scan_queue_segments(&conn, shape, segments);
+            }
+            let (cold, warm) = measure_cell(&work, shape, reps);
+            println!(
+                "{:>10}  {:>9}  {:>12.1}  {:>12.1}  {:>8.2}x",
+                shape.rows,
+                segments,
+                cold,
+                warm,
+                if warm > 0.0 { cold / warm } else { 0.0 }
+            );
+        }
+    }
+
+    println!();
+    println!("cold = fresh connection per call (what the app does today)");
+    println!("warm = reused connection (what pooling or a bigger page cache would buy)");
+    println!("all three pools summed: one get_wallet_summary pays this much progress cost");
+    println!();
+}


### PR DESCRIPTION
Stacked on #429. Two instruments, no behaviour change to any user-facing path.

The problem this addresses: summary latency measured on one wallet does not transfer to another. A user reported ~2s scan-progress queries; the same code measures 165ms here. Without knowing *why* they differ we were choosing between a librustzcash fork ([zcash/librustzcash#2869](https://github.com/zcash/librustzcash/pull/2869)), skipping progress computation, and connection tuning — on the strength of one wallet's numbers. That is how #420 shipped without helping the user who reported the problem.

## `rust/tests/summary_scaling.rs`

`#[ignore]`d harness that measures scan-progress cost as a function of the two inputs that vary between wallets: `blocks` row count and `scan_queue` fragmentation. It copies a real wallet DB, inflates the copy across a grid, and times the three per-pool aggregates.

```bash
VIZOR_SUMMARY_BENCH_DB=/path/to/zcash_wallet.db \
  cargo test --release --test summary_scaling -- --ignored --nocapture
# knobs: VIZOR_SUMMARY_BENCH_{BLOCKS,SEGMENTS,REPS}
```

Results on a 259,960-block, 11-account mainnet wallet:

```
    blocks   segments       cold ms       warm ms  cold/warm
    259960          2         115.6         113.7      1.02x
    259960         10         164.6         164.5      1.00x
    259960         50         351.5         350.7      1.00x
    259960        200        1062.7        1062.4      1.00x
    500000          2         223.0         221.5      1.01x
    500000         50         674.0         670.2      1.01x
   1000000          2         437.6         437.1      1.00x
   1000000         50        1329.4        1337.9      0.99x
   2000000          2         843.4         834.4      1.01x
   2000000         10        1197.3        1217.5      0.98x
   2000000         50        2625.0        2623.5      1.00x
   2000000        200        8176.5        8101.1      1.01x
```

Fits within ~2% on every cell:

```
progress_ms ≈ (blocks / 260k) × (105 + 4.8 × scan_queue_segments)
```

Linear in both, with the fragmentation term dominating once it is non-trivial. The 116ms baseline matches the traced 36–39ms × 3 pools, so the mirrored SQL is faithful to `subtree_scan_progress`.

## `rust/src/wallet/wallet_shape_diagnostics.rs`

Collects those same two integers in the field. Logs wallet shape plus summary-cache hit rate once per process, and again after slow loads (>500ms, rate-limited to every 25):

```
wallet shape (first load): blocks=259960 heights=3171958..=3431917 scan_queue=2
  by_priority=[10:1 20:1] accounts=11 txs=... notes=[sapling=... orchard=... ironwood=...]
  db_mib=82.0 page_size=4096 sqlite_stat1=false | cache: requests=48 hits=44 (91.7%) loads=4 ...
```

Wired into the cache's existing load path in `wallet_summary_cache.rs`, so it needs no FRB surface, no codegen, and no Dart change — it ships with whatever build carries the cache. Read-only throughout, runs off the caller's thread (the `COUNT(*)`s are themselves full scans over the table under investigation), and outside the cache mutex.

## Two findings

**Connection reuse buys nothing.** `cold/warm` is 0.98–1.02x across all 16 cells. Per-call connection setup and the default 2 MiB page cache are not material, so `cache_size`/`mmap_size` pragmas would not help. This closes off a line of investigation that looked plausible from the burst numbers alone.

**A 2s progress query is not reachable at this wallet's shape.** Solving the model:

| blocks | segments needed for 2s |
|---|---|
| 260k (this wallet) | ~395 |
| 1M | ~86 |
| 2M | ~32 |
| 3.4M (near-genesis) | ~10 |

At this wallet's 2 segments you would need ~4.5M blocks — more than the chain. So a 2s report predicts a substantially deeper `blocks` table than this wallet's 260k, which is checkable the moment a diagnostic build reports back.

## How this is meant to be used

Ship the cache plus these diagnostics, read the log line against the table:

- `blocks ≤ 400k` **and** `segments ≤ 10` → progress is under 200ms; the latency was concurrency, and the cache alone is sufficient.
- `blocks ≥ 1M` **or** `segments ≥ 50` → progress is ≥1s; the cache is necessary but not sufficient, and eliminating the progress computation becomes justified. Note that in that regime #2869 is worth 10–20x rather than the ~45% its value looks like from this wallet's isolated numbers.

## Testing

- `cargo check --lib --tests` clean on a worktree at `perf-summary-main-2` with no other local changes.
- `cargo test --lib -- wallet_summary_cache wallet_shape_diagnostics`: 14 passed, including the 10 pre-existing cache tests.
- Scaling harness executed end-to-end against a real 86MB wallet DB (table above). Source DB is opened strictly read-only; all mutation happens on a temp copy.

## Notes for review

- The shape dump is **not** feature-gated, so any build can be diagnosed. Gate it behind `debug-wallet-summary-timing` if it should not ship to users.
- The harness mirrors `subtree_scan_progress`'s SQL because the upstream function is private. It is used only for timing, never for a correctness assertion, and the inflated DBs are valid for timing only — they are not wallets and must not be reused as fixtures.
- `sqlite_stat1=false` in the log line confirms librustzcash never runs `ANALYZE`. Worth an `EXPLAIN QUERY PLAN` on the balance notes query before and after `ANALYZE` — that is the balance half of the summary, which this harness does not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)