### PR TITLE
perf(desktop): trigger a migration advance when a transfer comes due

### DIFF
--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -1307,12 +1307,36 @@ class IronwoodMigrationCoordinator
       status.broadcastedTxCount,
       status.confirmedTxCount,
       status.signedChildPcztCount,
+      // Crossing a scheduled height is what makes a transfer broadcastable,
+      // but it changes nothing else in the status. Without it here the
+      // transfer waits out `_migrationAdvanceInterval` before an advance even
+      // attempts it (mean 15s, up to 30s at the 15s poll cadence).
+      _dueScheduledBroadcastCount(status),
       for (final part in status.parts) ...[
         part.partIndex,
         part.state.name,
         part.confirmationCount,
       ],
     ].join(':');
+  }
+
+  /// Scheduled transfers whose target height the wallet has already observed.
+  ///
+  /// Counted rather than flagged so that a second transfer coming due is also
+  /// a key change. The count is stable between crossings, so an advance that
+  /// cannot broadcast yet still falls back to the ordinary interval instead of
+  /// re-firing on every poll.
+  int _dueScheduledBroadcastCount(rust_sync.MigrationStatus status) {
+    final currentHeight = _observedBroadcastHeight();
+    if (currentHeight <= 0) return 0;
+    return status.scheduledBroadcasts
+        .where(
+          (broadcast) =>
+              broadcast.status.toLowerCase() == 'scheduled' &&
+              broadcast.scheduledHeight > 0 &&
+              broadcast.scheduledHeight <= currentHeight,
+        )
+        .length;
   }
 
   void _invalidateMigrationProviders(String? activeAccountUuid) {

--- a/test/features/migration/ironwood_migration_desktop_advance_trigger_test.dart
+++ b/test/features/migration/ironwood_migration_desktop_advance_trigger_test.dart
@@ -1,0 +1,315 @@
+// Desktop lane (untagged): `kAppFormFactor` resolves to desktop here, which is
+// what selects the desktop branches of `_shouldAdvance` / `_advance`.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    as frb;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
+import 'package:zcash_wallet/src/features/migration/services/ironwood_migration_service.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/rpc_endpoint_failover_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import '../../fakes/fake_sync_notifier.dart';
+
+const _uuid = 'software-account';
+const _endpoint = RpcEndpointConfig(
+  networkName: 'test',
+  lightwalletdUrl: 'https://example.test:443',
+);
+
+/// Height the transfer is scheduled for, and the tip before/after it is due.
+const _scheduledHeight = 1100;
+const _beforeDueHeight = 1099;
+const _secondScheduledHeight = 1150;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+  });
+
+  test('desktop: crossing a scheduled height advances immediately', () async {
+    final broadcasts = <String>[];
+    final harness = _Harness(broadcasts: broadcasts);
+    addTearDown(harness.dispose);
+
+    // Poll 1, tip below the scheduled height: the first advance always runs
+    // because there is no previous advance to rate-limit against.
+    await harness.pump(tipHeight: _beforeDueHeight);
+    expect(
+      broadcasts.length,
+      1,
+      reason: 'first poll should advance (no prior advance to gate on)',
+    );
+
+    // Poll 2, tip has now crossed the scheduled height. Nothing else about the
+    // status changed, so before this fix the transfer waited out the 30s
+    // `_migrationAdvanceInterval` (measured: 15s mean, 30s worst case).
+    await harness.pump(tipHeight: _scheduledHeight);
+
+    expect(
+      broadcasts.length,
+      2,
+      reason: 'becoming due must trigger the broadcast attempt immediately',
+    );
+  });
+
+  test('desktop: a due transfer does not re-advance every poll', () async {
+    final broadcasts = <String>[];
+    final harness = _Harness(broadcasts: broadcasts);
+    addTearDown(harness.dispose);
+
+    await harness.pump(tipHeight: _beforeDueHeight);
+    await harness.pump(tipHeight: _scheduledHeight);
+    expect(broadcasts.length, 2);
+
+    // The transfer is still due and still un-broadcast (the fake keeps the run
+    // in `broadcast_scheduled`). The due count is unchanged, so the key is
+    // unchanged and retries fall back to the ordinary interval rather than
+    // firing on every poll.
+    await harness.pump(tipHeight: _scheduledHeight);
+    await harness.pump(tipHeight: _scheduledHeight + 1);
+
+    expect(
+      broadcasts.length,
+      2,
+      reason: 'a still-due transfer must not hot-loop the advance path',
+    );
+  });
+
+  test('desktop: a second transfer coming due advances again', () async {
+    final broadcasts = <String>[];
+    final harness = _Harness(broadcasts: broadcasts);
+    addTearDown(harness.dispose);
+
+    harness.setStatus(_statusWithTwoTransfers());
+    await harness.pump(tipHeight: _beforeDueHeight);
+    expect(broadcasts.length, 1);
+
+    // First transfer becomes due.
+    await harness.pump(tipHeight: _scheduledHeight);
+    expect(broadcasts.length, 2);
+
+    // Second transfer becomes due: the due count goes 1 -> 2, so this is a
+    // fresh key and fires immediately rather than waiting out the interval.
+    await harness.pump(tipHeight: _secondScheduledHeight);
+    expect(
+      broadcasts.length,
+      3,
+      reason: 'each transfer coming due is its own trigger',
+    );
+  });
+
+  test(
+    'desktop: an unrelated status change still re-triggers advance',
+    () async {
+      final broadcasts = <String>[];
+      final harness = _Harness(broadcasts: broadcasts);
+      addTearDown(harness.dispose);
+
+      await harness.pump(tipHeight: _beforeDueHeight);
+      expect(broadcasts.length, 1);
+
+      // Control: the pre-existing progress-key mechanism is unchanged.
+      harness.setStatus(_status(broadcastedTxCount: 1));
+      await harness.pump(tipHeight: _beforeDueHeight);
+
+      expect(broadcasts.length, 2);
+    },
+  );
+}
+
+rust_sync.MigrationStatus _status({
+  int broadcastedTxCount = 0,
+  int scheduledHeight = _scheduledHeight,
+}) {
+  return rust_sync.MigrationStatus(
+    phase: 'broadcast_scheduled',
+    activeRunId: 'run-1',
+    targetValuesZatoshi: frb.Uint64List.fromList([100000000]),
+    preparedNoteCount: 1,
+    denominationConfirmationCount: 3,
+    denominationConfirmationTarget: 3,
+    denominationSplitCompletedCount: 1,
+    denominationSplitTotalCount: 1,
+    pendingTxCount: 1,
+    broadcastedTxCount: broadcastedTxCount,
+    confirmedTxCount: 0,
+    totalCount: 1,
+    signedChildPcztCount: 0,
+    pendingSplitStageCount: 0,
+    canAbandon: true,
+    signingBatchLimit: 35,
+    scheduleMeanDelayBlocks: 144,
+    scheduleMaxDelayBlocks: 576,
+    scheduledBroadcasts: [
+      rust_sync.MigrationScheduledBroadcast(
+        txidHex: 'scheduled-tx',
+        valueZatoshi: BigInt.from(100000000),
+        scheduledAtMs: 0,
+        scheduledHeight: scheduledHeight,
+        status: 'scheduled',
+      ),
+    ],
+    parts: const [],
+  );
+}
+
+rust_sync.MigrationStatus _statusWithTwoTransfers() {
+  final base = _status();
+  return rust_sync.MigrationStatus(
+    phase: base.phase,
+    activeRunId: base.activeRunId,
+    targetValuesZatoshi: base.targetValuesZatoshi,
+    preparedNoteCount: base.preparedNoteCount,
+    denominationConfirmationCount: base.denominationConfirmationCount,
+    denominationConfirmationTarget: base.denominationConfirmationTarget,
+    denominationSplitCompletedCount: base.denominationSplitCompletedCount,
+    denominationSplitTotalCount: base.denominationSplitTotalCount,
+    pendingTxCount: 2,
+    broadcastedTxCount: base.broadcastedTxCount,
+    confirmedTxCount: base.confirmedTxCount,
+    totalCount: 2,
+    signedChildPcztCount: base.signedChildPcztCount,
+    pendingSplitStageCount: base.pendingSplitStageCount,
+    canAbandon: base.canAbandon,
+    signingBatchLimit: base.signingBatchLimit,
+    scheduleMeanDelayBlocks: base.scheduleMeanDelayBlocks,
+    scheduleMaxDelayBlocks: base.scheduleMaxDelayBlocks,
+    scheduledBroadcasts: [
+      ...base.scheduledBroadcasts,
+      rust_sync.MigrationScheduledBroadcast(
+        txidHex: 'scheduled-tx-2',
+        valueZatoshi: BigInt.from(100000000),
+        scheduledAtMs: 0,
+        scheduledHeight: _secondScheduledHeight,
+        status: 'scheduled',
+      ),
+    ],
+    parts: const [],
+  );
+}
+
+/// Drives the real coordinator through repeated `refreshNow()` passes with a
+/// controllable chain tip, counting how many times a broadcast is attempted.
+class _Harness {
+  _Harness({required this.broadcasts}) {
+    _current = _status();
+    final service = IronwoodMigrationService(
+      getWalletDbPath: () async => '/tmp/wallet.db',
+      getStatus:
+          ({required dbPath, required network, required accountUuid}) async =>
+              _current,
+      getPrivatePlan:
+          ({required dbPath, required network, required accountUuid}) async =>
+              null,
+      secureStore: AppSecureStore.testing(
+        storage: const FlutterSecureStorage(),
+      ),
+      getEndpoint: () => _endpoint,
+      getSessionPassword: () => 'test-password',
+      isMacOS: () => true,
+      isMobile: () => false,
+      isIOS: () => false,
+      supportsBackgroundMigration: () => false,
+      isHardwareAccount: (uuid) => false,
+      scheduleBackgroundMigration: () async => false,
+      broadcastDueMigration:
+          ({
+            required dbPath,
+            required lightwalletdUrl,
+            required network,
+            required accountUuid,
+            required password,
+            required saltBase64,
+          }) async {
+            broadcasts.add(accountUuid);
+            // Hold the run in `broadcast_scheduled` so the status -- and
+            // therefore the progress key -- is identical across polls. Only
+            // the chain tip moves.
+            return rust_sync.IronwoodMigrationResult(
+              txids: '',
+              status: 'broadcast_scheduled',
+              broadcastedCount: 0,
+              totalCount: 1,
+              feeZatoshi: BigInt.zero,
+              migratedZatoshi: BigInt.from(100000000),
+            );
+          },
+    );
+
+    container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        syncProvider.overrideWith(() => _sync),
+        rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue(
+          (_) async => BigInt.from(_tipHeight),
+        ),
+        ironwoodMigrationServiceProvider.overrideWithValue(service),
+      ],
+    );
+    _subscription = container.listen(
+      ironwoodMigrationCoordinatorProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+  }
+
+  final List<String> broadcasts;
+  late final ProviderContainer container;
+  late final ProviderSubscription<IronwoodMigrationCoordinatorState>
+  _subscription;
+  final FakeSyncNotifier _sync = FakeSyncNotifier(SyncState());
+  late rust_sync.MigrationStatus _current;
+  int _tipHeight = _beforeDueHeight;
+
+  void setStatus(rust_sync.MigrationStatus status) => _current = status;
+
+  /// One coordinator poll at the given chain tip.
+  Future<void> pump({required int tipHeight}) async {
+    _tipHeight = tipHeight;
+    // `FakeSyncNotifier.build` is async; the notifier cannot take a new state
+    // until the provider has been read at least once and built.
+    await container.read(syncProvider.future);
+    _sync.emit(SyncState(scannedHeight: tipHeight, chainTipHeight: tipHeight));
+    await container
+        .read(ironwoodMigrationCoordinatorProvider.notifier)
+        .refreshNow();
+  }
+
+  void dispose() {
+    _subscription.close();
+    container.dispose();
+  }
+}
+
+AppBootstrapState _bootstrap() {
+  return AppBootstrapState(
+    initialLocation: '/home',
+    initialAccountState: const AccountState(
+      accounts: [
+        AccountInfo(uuid: _uuid, name: 'Software', order: 0, isSeedAnchor: true),
+      ],
+      activeAccountUuid: _uuid,
+      activeAddress: 'u1test',
+    ),
+    initialSyncSnapshot: AppSyncSnapshot.empty,
+    network: _endpoint.networkName,
+    rpcEndpointConfig: _endpoint,
+    themeMode: ThemeMode.system,
+    privacyModeEnabled: false,
+    isPasswordConfigured: true,
+    isUnlocked: true,
+    passwordRotationRecoveryFailed: false,
+  );
+}


### PR DESCRIPTION
First of a desktop-focused perf stack. Each PR is self-contained and measured.

## The defect

`_shouldAdvance` bypasses its rate limit whenever `_advanceProgressKey` changes. That key is built from run id, phase, and per-part counts — **it contains no height**. Crossing a scheduled broadcast height changes none of those fields, so a transfer becoming due is invisible to the trigger.

The broadcast therefore waits out `_migrationAdvanceInterval` (30s), sampled at `_migrationStatusPollInterval` (15s), before it is even attempted.

This is desktop's timed-submit path: `_shouldAdvance` returns true by phase for `broadcast_scheduled` / `broadcasting` / `waiting_confirmations`, then `_advance` → `broadcastOneDueOrchardMigrationTransaction`.

## Measured

Delay from "transfer becomes due" to "broadcast attempted", over one full advance cycle (300k samples, `poll=15s`, `interval=30s`):

| | delay |
|---|---|
| min | 0.00s |
| mean | **15.00s** |
| median | 15.00s |
| p90 | 27.00s |
| max | **30.00s** |

Against ~75s Zcash blocks that is **20% of a block on average, 40% worst case** — enough to routinely push a transfer into the block after its scheduled height.

The defect is also demonstrated directly against the real coordinator. Before this change, `test/features/migration/ironwood_migration_desktop_advance_trigger_test.dart` showed:

- crossing the scheduled height → **no advance** (broadcast count stayed at 1)
- changing `broadcastedTxCount`, a field that *is* in the key → advance fired immediately

which isolates the cause: the trigger mechanism works, height just is not part of it.

## The change

Add `_dueScheduledBroadcastCount(status)` to `_advanceProgressKey` — the number of scheduled transfers whose height the wallet has already observed.

Counting rather than flagging means a **second** transfer coming due is also a key change. The count is stable between crossings, so an advance that cannot broadcast yet falls back to the ordinary 30s interval instead of re-firing on every poll.

Height comes from `_observedBroadcastHeight()` (`min(scanned, tip)`), matching the existing `_hasDueScheduledBroadcast`. That is deliberately conservative: if sync lags the tip the trigger waits, and the interval fallback still covers it. Rust independently gates on `chain_tip_height`, so this only ever advances the moment, never the decision.

## Scope

`_advanceProgressKey` is shared, so mobile gets the same immediate trigger. Mobile advances are additionally gated on `foregroundProgressPermits`, so this changes *when* a permitted advance runs, not whether one may.

## Testing

- New `ironwood_migration_desktop_advance_trigger_test.dart` (desktop lane, 4 tests): crossing advances immediately; a still-due transfer does **not** hot-loop; a second transfer coming due fires again; the pre-existing progress-key mechanism still works.
- Desktop lane `test/features/migration/ test/providers/`: **525 passed**, 3 skipped.
- Mobile lane, same paths: `196 passed, 15 failed` — **identical to this branch's base**, verified by re-running with the change stashed. Pre-existing, confirmed by the author.
- `flutter analyze` on both changed files: no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)