### PR TITLE
fix(desktop): let user-driven migration writes outlast a sync batch

### DIFF
--- a/rust/src/wallet/db.rs
+++ b/rust/src/wallet/db.rs
@@ -14,11 +14,19 @@ use crate::wallet::network::WalletNetwork;
 pub(crate) type WalletDatabase = WalletDb<rusqlite::Connection, WalletNetwork, SystemClock, OsRng>;
 
 /// User-driven wallet operations can afford a longer wait for a short sync write.
+///
+/// This is the tier for any write a user is waiting on, including migration
+/// stop, scheduled broadcast, and coordinator advance. `scan_cached_blocks`
+/// runs a whole batch inside one transaction, so on a large wallet the writer
+/// can be held for seconds; a user-driven write must outlast that rather than
+/// fail. The two `wallet::db::tests` busy-timeout tests pin both directions.
 pub(crate) const WALLET_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(10);
 /// Account creation/import runs after sync is paused, so a shorter wait exposes real stalls.
 pub(crate) const ACCOUNT_MUTATION_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 /// The sync loop should absorb brief read/write overlap without stretching cancel too far.
 pub(crate) const SYNC_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
+/// Reads only. A write opened with this gives up while a sync batch is still
+/// committing -- use [`WALLET_DB_BUSY_TIMEOUT`] for writes a user is waiting on.
 pub(crate) const READ_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Seqlock-style write epoch for in-process wallet-summary cache invalidation.
@@ -156,6 +164,28 @@ pub(crate) fn with_wallet_db_write_lock<T>(
     result
 }
 
+/// Raw connection for a wallet write a user is waiting on.
+///
+/// Two settings, and both are needed for either to matter:
+///
+/// - [`WALLET_DB_BUSY_TIMEOUT`], so the write waits out a sync batch rather
+///   than failing. `scan_cached_blocks` runs a whole batch in one transaction,
+///   which on a large wallet holds the writer for seconds.
+/// - [`rusqlite::TransactionBehavior::Immediate`], so that wait can actually
+///   happen. SQLite deliberately does *not* invoke the busy handler when a
+///   deferred transaction tries to upgrade a read to a write, because two
+///   connections both waiting to upgrade would deadlock; such a transaction
+///   gets `SQLITE_BUSY` immediately no matter how large the timeout is. Taking
+///   the write lock at `BEGIN` puts the wait back under the timeout.
+///
+/// `unchecked_transaction()` reads this connection-level default, so callers
+/// need no change beyond opening through this function.
+pub(crate) fn open_wallet_write_conn(db_path: &str) -> Result<rusqlite::Connection, String> {
+    let mut conn = open_wallet_raw_conn_with_timeout(db_path, WALLET_DB_BUSY_TIMEOUT)?;
+    conn.set_transaction_behavior(rusqlite::TransactionBehavior::Immediate);
+    Ok(conn)
+}
+
 pub(crate) fn open_readonly_conn_with_timeout(
     db_path: &str,
     timeout: Option<Duration>,
@@ -204,6 +234,157 @@ mod tests {
             .pragma_query_value(None, "journal_mode", |row| row.get(0))
             .unwrap();
         assert_ne!(journal_mode.to_ascii_lowercase(), "wal");
+    }
+
+    /// Holds a write transaction on `path` for `hold`, then commits.
+    ///
+    /// Stands in for a scan batch: `scan_cached_blocks` runs a whole batch
+    /// inside one transaction, so on a large wallet the DB has an open writer
+    /// for as long as that batch takes.
+    fn hold_writer_for(
+        path: std::path::PathBuf,
+        hold: Duration,
+    ) -> (std::thread::JoinHandle<()>, std::sync::mpsc::Receiver<()>) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.busy_timeout(Duration::from_secs(30)).unwrap();
+            conn.execute_batch("BEGIN IMMEDIATE; CREATE TABLE IF NOT EXISTS held (v);")
+                .unwrap();
+            tx.send(()).unwrap();
+            std::thread::sleep(hold);
+            conn.execute_batch("COMMIT").unwrap();
+        });
+        (handle, rx)
+    }
+
+    fn try_write(path: &std::path::Path, timeout: Duration) -> Result<(), rusqlite::Error> {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        configure_wallet_connection(&conn, timeout, true).unwrap();
+        conn.execute_batch("CREATE TABLE IF NOT EXISTS other (v)")
+    }
+
+    fn wal_db(dir: &tempfile::TempDir) -> std::path::PathBuf {
+        let path = dir.path().join("wallet.db");
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        configure_wallet_connection(&conn, Duration::from_secs(5), true).unwrap();
+        path
+    }
+
+    /// A migration write opened with the *read* timeout gives up while a sync
+    /// batch still holds the writer. The user sees a failed stop or a failed
+    /// scheduled broadcast rather than a slow one.
+    #[test]
+    fn read_timeout_write_fails_under_a_long_sync_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = wal_db(&dir);
+
+        // 2x the read timeout, so a loaded CI box cannot accidentally satisfy
+        // the wait and flip this assertion.
+        let (writer, started) = hold_writer_for(path.clone(), READ_DB_BUSY_TIMEOUT * 2);
+        started.recv().unwrap();
+
+        let result = try_write(&path, READ_DB_BUSY_TIMEOUT);
+
+        assert!(
+            matches!(
+                result,
+                Err(rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error {
+                        code: rusqlite::ErrorCode::DatabaseBusy,
+                        ..
+                    },
+                    _
+                ))
+            ),
+            "expected SQLITE_BUSY from a read-timeout write under a longer sync write, got {result:?}"
+        );
+        writer.join().unwrap();
+    }
+
+    /// The user-operation timeout waits it out instead.
+    #[test]
+    fn wallet_timeout_write_survives_a_long_sync_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = wal_db(&dir);
+
+        // Same hold as the read-timeout case, so the pair differs only in the
+        // timeout under test.
+        let (writer, started) = hold_writer_for(path.clone(), READ_DB_BUSY_TIMEOUT * 2);
+        started.recv().unwrap();
+
+        let result = try_write(&path, WALLET_DB_BUSY_TIMEOUT);
+
+        assert!(
+            result.is_ok(),
+            "a 10s user-operation timeout absorbs a longer sync write, got {result:?}"
+        );
+        writer.join().unwrap();
+    }
+
+    /// Seeds a row so a transaction can read before it writes.
+    fn seeded_wal_db(dir: &tempfile::TempDir) -> std::path::PathBuf {
+        let path = wal_db(dir);
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE rows (id INTEGER PRIMARY KEY, v INTEGER); INSERT INTO rows VALUES (1, 1);",
+        )
+        .unwrap();
+        path
+    }
+
+    /// Why [`open_wallet_write_conn`] sets `Immediate`.
+    ///
+    /// A deferred transaction that reads before it writes has to upgrade its
+    /// read lock. SQLite skips the busy handler for that upgrade -- two
+    /// connections both waiting to upgrade would deadlock -- so it fails
+    /// instantly however large the timeout is. A long busy timeout alone does
+    /// not fix a read-then-write transaction.
+    #[test]
+    fn deferred_read_then_write_ignores_the_busy_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = seeded_wal_db(&dir);
+
+        let (writer, started) = hold_writer_for(path.clone(), READ_DB_BUSY_TIMEOUT * 2);
+        started.recv().unwrap();
+
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        configure_wallet_connection(&conn, WALLET_DB_BUSY_TIMEOUT, true).unwrap();
+        let tx = conn.unchecked_transaction().unwrap();
+        let _: i64 = tx
+            .query_row("SELECT v FROM rows WHERE id = 1", [], |row| row.get(0))
+            .unwrap();
+        let result = tx.execute("UPDATE rows SET v = 2 WHERE id = 1", []);
+
+        assert!(
+            result.is_err(),
+            "a deferred read-then-write should fail instantly despite a 10s timeout, got {result:?}"
+        );
+        writer.join().unwrap();
+    }
+
+    /// And that taking the write lock at `BEGIN` puts the wait back under the
+    /// timeout, which is what `open_wallet_write_conn` configures.
+    #[test]
+    fn immediate_read_then_write_waits_out_the_sync_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = seeded_wal_db(&dir);
+
+        let (writer, started) = hold_writer_for(path.clone(), READ_DB_BUSY_TIMEOUT * 2);
+        started.recv().unwrap();
+
+        let conn = open_wallet_write_conn(path.to_str().unwrap()).unwrap();
+        let tx = conn.unchecked_transaction().unwrap();
+        let _: i64 = tx
+            .query_row("SELECT v FROM rows WHERE id = 1", [], |row| row.get(0))
+            .unwrap();
+        let result = tx.execute("UPDATE rows SET v = 2 WHERE id = 1", []);
+
+        assert!(
+            result.is_ok(),
+            "an immediate transaction should wait out the sync write, got {result:?}"
+        );
+        writer.join().unwrap();
     }
 
     #[test]

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -11,8 +11,8 @@ use zcash_client_backend::data_api::{
 use zeroize::Zeroizing;
 
 use crate::wallet::db::{
-    open_readonly_conn_with_timeout, open_wallet_raw_conn_with_timeout, with_wallet_db_write_lock,
-    WALLET_DB_BUSY_TIMEOUT,
+    open_readonly_conn_with_timeout, open_wallet_raw_conn_with_timeout, open_wallet_write_conn,
+    with_wallet_db_write_lock,
 };
 use crate::wallet::network::WalletNetwork;
 use crate::wallet::secret_payload;
@@ -921,7 +921,7 @@ pub(crate) fn migration_reserves_orchard_inputs(
     account_uuid: &str,
     network: WalletNetwork,
 ) -> Result<bool, String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     let tx = conn
         .unchecked_transaction()
         .map_err(|e| format!("Begin migration reservation snapshot: {e}"))?;
@@ -1249,7 +1249,7 @@ pub(crate) fn create_run_with_staged_denominations_and_signed_children(
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     if let Some(run) = active_run(&conn, account_uuid, network)? {
         return Err(format!("Migration already active: {}", run.run_id));
@@ -1347,7 +1347,7 @@ pub(crate) fn create_or_resume_private_migration_draft(
     approved_schedule: &[MigrationScheduleEntry],
     preparation_timing_policy: PreparationTimingPolicy,
 ) -> Result<String, String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let tx = conn
         .unchecked_transaction()
@@ -1430,7 +1430,7 @@ pub(crate) fn finalize_private_migration_draft(
     if denomination_stages.is_empty() && prepared_notes.is_empty() {
         return Err("Migration run has no prepared funding notes".to_string());
     }
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let run = active_run(&conn, account_uuid, network)?
         .ok_or("Saved private migration draft was not found")?;
@@ -1509,7 +1509,7 @@ pub(crate) fn mark_run_phase(
     phase: &str,
     message: Option<&str>,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let now = now_ms()?;
     conn.execute(
@@ -1884,7 +1884,7 @@ pub(crate) fn insert_pending_txs(
     }
 
     with_wallet_db_write_lock("migration.insert_pending_txs", || {
-        let conn = open_wallet_raw_conn_with_timeout(db_path, WALLET_DB_BUSY_TIMEOUT)?;
+        let conn = open_wallet_write_conn(db_path)?;
         ensure_schema(&conn)?;
         let tx = conn
             .unchecked_transaction()
@@ -1911,7 +1911,7 @@ pub(crate) fn promote_signed_child_pczts_to_pending_txs(
     with_wallet_db_write_lock(
         "migration.promote_signed_child_pczts_to_pending_txs",
         || {
-            let conn = open_wallet_raw_conn_with_timeout(db_path, WALLET_DB_BUSY_TIMEOUT)?;
+            let conn = open_wallet_write_conn(db_path)?;
             ensure_schema(&conn)?;
             let tx = conn
                 .unchecked_transaction()
@@ -1961,7 +1961,7 @@ pub(crate) fn set_run_approved_schedule(
     schedule: &[MigrationScheduleEntry],
     target_values: &[u64],
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let timing_policy = timing_policy_for_run_with_conn(&conn, run_id, network)?;
     validate_schedule_with_policy(schedule, target_values, network, timing_policy)?;
@@ -2473,7 +2473,7 @@ pub(crate) fn persist_signed_child_pczts_for_run(
     if signed_children.is_empty() {
         return Err("Keystone migration returned no signed children".to_string());
     }
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let tx = conn
         .unchecked_transaction()
@@ -2777,7 +2777,7 @@ pub(crate) fn reset_migration_children_for_reorged_denominations(
     if denomination_txids.is_empty() {
         return Ok(false);
     }
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let tx = conn
         .unchecked_transaction()
@@ -2903,7 +2903,7 @@ fn reconcile_denomination_stage_chain_state_with_rng<R: RngCore + CryptoRng + ?S
     recovery_chain_tip_height: Option<u32>,
     rng: &mut R,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let records = denomination_stage_chain_records(&conn, run_id)?;
     if records.is_empty() {
@@ -3020,7 +3020,7 @@ fn reconcile_denomination_stage_chain_state_with_rng<R: RngCore + CryptoRng + ?S
         // stage resets, so it must tolerate the foreground scanner finishing
         // a concurrent wallet write. The read timeout can expire first on
         // mobile and strand an otherwise completed preparation run.
-        let conn = open_wallet_raw_conn_with_timeout(db_path, WALLET_DB_BUSY_TIMEOUT)?;
+        let conn = open_wallet_write_conn(db_path)?;
         let tx = conn
             .unchecked_transaction()
             .map_err(|e| format!("Begin denomination chain-state reconciliation: {e}"))?;
@@ -3084,7 +3084,7 @@ fn reconcile_denomination_stage_chain_state_with_rng<R: RngCore + CryptoRng + ?S
     }
 
     if !affected.is_empty() {
-        let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+        let conn = open_wallet_write_conn(db_path)?;
         let now = now_ms()?;
         let transitioned = conn
             .execute(
@@ -3476,7 +3476,7 @@ pub(crate) fn mark_pending_broadcast_attempted(
     run_id: &str,
     txid_hex: &str,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let updated = conn
         .execute(
@@ -3502,7 +3502,7 @@ pub(crate) fn mark_denomination_broadcast_attempted(
     run_id: &str,
     txid_hex: &str,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let updated = conn
         .execute(
@@ -3529,7 +3529,7 @@ pub(crate) fn clear_denomination_broadcast_attempted(
     run_id: &str,
     txid_hex: &str,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     conn.execute(
         &format!(
@@ -3615,7 +3615,7 @@ pub(crate) fn mark_due_parts_with_noncanonical_broadcast_height_for_resign(
     // window is promoted to `confirmed` instead of `needs_resign`, and
     // foreground sync cannot commit that chain identity between the check and
     // the status update.
-    let mut conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let mut conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let canonical_expiry = zip318_canonical_migration_expiry_height(chain_tip_height)?;
     let tx = conn
@@ -3703,7 +3703,7 @@ pub(crate) fn set_proof_retry_height(
     run_id: &str,
     retry_height: u32,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     conn.execute(
         &format!(
@@ -3806,7 +3806,7 @@ pub(crate) fn mark_expired_pending_parts_for_resign(
     // transaction so a mined-but-still-`scheduled` part past its expiry height
     // is promoted to `confirmed` instead of `needs_resign`, and foreground sync
     // cannot commit that chain identity between the check and the status update.
-    let mut conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let mut conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let tx = conn
         .transaction_with_behavior(TransactionBehavior::Immediate)
@@ -3904,7 +3904,7 @@ pub(crate) fn replace_resigned_pending_parts(
     if replacements.is_empty() {
         return Ok(());
     }
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let (schedule_json, recovery_origin) = conn
         .query_row(
@@ -4198,7 +4198,7 @@ pub(crate) fn retire_run_for_rebuild(
     run_id: &str,
     message: &str,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let now = now_ms()?;
     let tx = conn
@@ -4234,7 +4234,7 @@ pub(crate) fn abandon_run(
     network: WalletNetwork,
     expected_run_id: &str,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let run = conn
         .query_row(
@@ -4337,7 +4337,7 @@ pub(crate) fn abandon_run(
 }
 
 fn discard_unsubmitted_preparation_stages(db_path: &str, run_id: &str) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let tx = conn
         .unchecked_transaction()
@@ -4405,7 +4405,7 @@ pub(crate) fn ensure_rebuild_schedule_generation(
     network: WalletNetwork,
     origin_candidate_height: u32,
 ) -> Result<Option<RebuildScheduleGeneration>, String> {
-    let mut conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let mut conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let tx = conn
         .transaction_with_behavior(TransactionBehavior::Immediate)
@@ -4590,7 +4590,7 @@ fn reschedule_overdue_pending_txs_with_options(
     minimum_delay_blocks: u32,
     excluded_txid: Option<&str>,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let mut stmt = conn
         .prepare_cached(&format!(
@@ -4760,7 +4760,7 @@ pub(crate) fn mark_pending_broadcasted(
     run_id: &str,
     txid_hex: &str,
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let now = now_ms()?;
     let tx = conn
@@ -4880,7 +4880,7 @@ pub(crate) fn apply_accepted_migration_outbox_receipt(
     remote_height: u32,
     schedule_updates: &[MigrationOutboxScheduleUpdate],
 ) -> Result<(), String> {
-    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    let conn = open_wallet_write_conn(db_path)?;
     ensure_schema(&conn)?;
     let tx = conn
         .unchecked_transaction()


### PR DESCRIPTION
Stacked on #434.

## Correcting two premises

This PR began as "chunk the scan under the global write lock." Measuring first killed that: only **2 of 69** migration DB opens take `with_wallet_db_write_lock`, so migration work does not queue behind the process mutex at all — it contends at the SQLite level.

Then testing the *real code shape* corrected the replacement too. Raising the busy timeout alone would have fixed only part of the problem. Details below.

## The defect

`wallet/db.rs` has a deliberate timeout hierarchy:

| constant | value | intent |
|---|---|---|
| `WALLET_DB_BUSY_TIMEOUT` | 10s | "User-driven wallet operations can afford a longer wait for a short sync write." |
| `SYNC_DB_BUSY_TIMEOUT` | 2s | must not stretch cancel |
| `READ_DB_BUSY_TIMEOUT` | 2s | reads |

Migration writes opened with the 2s **read** timeout — including exactly the reported paths: `abandon_run` (stop), `mark_pending_broadcasted` / `mark_pending_broadcast_attempted` (scheduled broadcast), `replace_resigned_pending_parts` / `reschedule_overdue_pending_txs_with_options` (recover).

`scan_cached_blocks` runs a whole batch in one transaction (desktop `BATCH_SIZE_FOREGROUND = 2000`), so the writer is held for seconds on a large wallet. An overlapping migration write exhausts 2s and gets `SQLITE_BUSY` — an **error, not a delay**, which fits "when there's an issue, recover button" far better than slowness does.

## Why the timeout alone was not enough

These functions begin with `unchecked_transaction()`, which is **DEFERRED**. A deferred transaction that reads before it writes must upgrade its read lock, and SQLite **deliberately skips the busy handler for that upgrade** — two connections both waiting to upgrade would deadlock — so it returns `SQLITE_BUSY` instantly regardless of the timeout.

Probed directly against a real WAL database with a writer held longer than the timeout:

| transaction shape | 10s timeout |
|---|---|
| write-first deferred | **Ok** |
| read-then-write deferred | **Err(DatabaseBusy)**, immediately |

Of the 23 functions, **19 are write-first** (helped by the timeout) and **4 read first** — `replace_resigned_pending_parts`, `reconcile_denomination_stage_chain_state_with_rng`, `apply_accepted_migration_outbox_receipt`, `reset_migration_children_for_reorged_denominations`. Two of those are on the recover path. For them the timeout change would have been inert.

## The change

`open_wallet_write_conn` sets **both**:

- `WALLET_DB_BUSY_TIMEOUT`, so the write waits out a sync batch;
- `TransactionBehavior::Immediate`, so the wait can happen at all — the write lock is taken at `BEGIN`, so there is no upgrade for SQLite to bail out of.

`unchecked_transaction()` reads that connection-level default (rusqlite 0.37 `set_transaction_behavior`), so no call site needed restructuring and no borrow-checker churn. 27 migration write sites now open through it. Three functions already used `TransactionBehavior::Immediate` explicitly, which is what suggested the mechanism.

Deliberately excluded: `stage_migration_anchor_retention_references` and `finish_migration_anchor_retention_releases`. The sync engine calls them from inside `with_wallet_db_write_lock("sync_engine.retain_and_scan_blocks")` (`send.rs:2995`, `send.rs:3014`), where a 10s wait would stretch the scan and the cancel check after it.

## Measured

Four tests in `wallet::db::tests`, each against a real WAL file with a background thread holding `BEGIN IMMEDIATE` for `2 x READ_DB_BUSY_TIMEOUT`:

| test | asserts |
|---|---|
| `read_timeout_write_fails_under_a_long_sync_write` | 2s write → `SQLITE_BUSY` |
| `wallet_timeout_write_survives_a_long_sync_write` | 10s write → succeeds |
| `deferred_read_then_write_ignores_the_busy_timeout` | deferred read-then-write → fails despite 10s |
| `immediate_read_then_write_waits_out_the_sync_write` | same transaction under `Immediate` → succeeds |

The hold is derived from the constant under test rather than hardcoded, and the busy assertion matches `SQLITE_BUSY` specifically rather than any error.

## Trade-off

`Immediate` takes the write lock at `BEGIN` rather than at first write, so these transactions hold it marginally longer. They are short migration-table writes, and the alternative is failing outright on a shape where the timeout cannot help. Reviewers should sanity-check that none of the 27 holds a transaction open across expensive work.

## What this does not do

Scan chunking is **deferred, not dismissed**. Shortening the writer hold helps independently. But each sub-chunk needs a `ChainState` for its start height (a `get_tree_state` round trip), it sits on the reorg/continuity recovery path, and the benefit cannot be quantified without a real multi-account wallet or a regtest run.

Related: the uncommitted working-tree change raising desktop `BATCH_SIZE_SANDBLASTING` to 2000 pushes the other way — fewer round trips, longer writer holds. This PR makes that trade safer either way.

## Testing

- `cargo test --lib`: **540 passed, 0 failed**, 3 ignored (536 on base + 4 new).
- No behaviour change without contention: a busy timeout is an upper bound on waiting, not a delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)