### PR TITLE
perf: derive the migration payload key once per read, not once per row

### DIFF
--- a/rust/src/wallet/secret_payload.rs
+++ b/rust/src/wallet/secret_payload.rs
@@ -64,15 +64,53 @@ pub fn derive_password_verifier_base64(
     Ok(STANDARD.encode(key.as_slice()))
 }
 
+/// A payload key derived once for one `(password, salt)` pair.
+///
+/// [`derive_key`] runs `KDF_ITERATIONS` PBKDF2-HMAC-SHA256 iterations, which
+/// measures ~27ms per derivation on an M-series Mac in release. Loops handling
+/// one payload per row re-derived the same key on every iteration; build this
+/// once outside the loop instead.
+///
+/// Deliberately not a process-wide cache. The key lives exactly as long as the
+/// call that needs it, so this does not widen the window in which key material
+/// is resident relative to the password the caller already holds.
+pub struct PayloadKey {
+    key: Zeroizing<[u8; KEY_LEN]>,
+}
+
+impl PayloadKey {
+    pub fn new(password: &[u8], salt: &[u8]) -> Self {
+        Self {
+            key: derive_key(password, salt),
+        }
+    }
+
+    fn cipher(&self) -> Result<Aes256Gcm, String> {
+        Aes256Gcm::new_from_slice(self.key.as_slice())
+            .map_err(|e| format!("Failed to initialize AES-GCM: {e}"))
+    }
+
+    pub fn encrypt(&self, clear_text: Zeroizing<Vec<u8>>) -> Result<String, String> {
+        encrypt_with_cipher(self.cipher()?, clear_text)
+    }
+
+    pub fn decrypt(&self, raw_payload: &[u8]) -> Result<Zeroizing<Vec<u8>>, String> {
+        decrypt_with_cipher(self.cipher()?, raw_payload)
+    }
+}
+
 pub fn encrypt_payload(
     clear_text: Zeroizing<Vec<u8>>,
     password: &[u8],
     salt: &[u8],
 ) -> Result<String, String> {
-    let key = derive_key(password, salt);
-    let cipher = Aes256Gcm::new_from_slice(key.as_slice())
-        .map_err(|e| format!("Failed to initialize AES-GCM: {e}"))?;
-    drop(key);
+    PayloadKey::new(password, salt).encrypt(clear_text)
+}
+
+fn encrypt_with_cipher(
+    cipher: Aes256Gcm,
+    clear_text: Zeroizing<Vec<u8>>,
+) -> Result<String, String> {
     let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
     let cipher_text_and_tag = Zeroizing::new(
         cipher
@@ -103,6 +141,13 @@ pub fn decrypt_payload(
     password: &[u8],
     salt: &[u8],
 ) -> Result<Zeroizing<Vec<u8>>, String> {
+    PayloadKey::new(password, salt).decrypt(raw_payload)
+}
+
+fn decrypt_with_cipher(
+    cipher: Aes256Gcm,
+    raw_payload: &[u8],
+) -> Result<Zeroizing<Vec<u8>>, String> {
     let payload: EncryptedPayload<'_> = serde_json::from_slice(raw_payload)
         .map_err(|e| format!("Failed to parse encrypted payload: {e}"))?;
     if payload.version != 1 {
@@ -131,10 +176,6 @@ pub fn decrypt_payload(
         ));
     }
 
-    let key = derive_key(password, salt);
-    let cipher = Aes256Gcm::new_from_slice(key.as_slice())
-        .map_err(|e| format!("Failed to initialize AES-GCM: {e}"))?;
-    drop(key);
     let mut ciphertext_and_tag = Zeroizing::new(Vec::with_capacity(cipher_text.len() + mac.len()));
     ciphertext_and_tag.extend_from_slice(cipher_text.as_slice());
     ciphertext_and_tag.extend_from_slice(mac.as_slice());
@@ -169,6 +210,80 @@ fn derive_key(password: &[u8], salt: &[u8]) -> Zeroizing<[u8; KEY_LEN]> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const BENCH_PASSWORD: &[u8] = b"correct horse battery staple";
+    const BENCH_SALT: [u8; 16] = [7u8; 16];
+
+    /// A `PayloadKey` and the free functions must be interchangeable, so
+    /// converting a loop cannot change what it reads or writes.
+    #[test]
+    fn payload_key_matches_the_free_functions() {
+        let clear = Zeroizing::new(b"migration payload".to_vec());
+        let key = PayloadKey::new(BENCH_PASSWORD, &BENCH_SALT);
+
+        // Written by the loop helper, read by the free function.
+        let via_key = key.encrypt(clear.clone()).unwrap();
+        let back = decrypt_payload(via_key.as_bytes(), BENCH_PASSWORD, &BENCH_SALT).unwrap();
+        assert_eq!(back.as_slice(), clear.as_slice());
+
+        // Written by the free function, read by the loop helper.
+        let via_free = encrypt_payload(clear.clone(), BENCH_PASSWORD, &BENCH_SALT).unwrap();
+        let back = key.decrypt(via_free.as_bytes()).unwrap();
+        assert_eq!(back.as_slice(), clear.as_slice());
+    }
+
+    #[test]
+    fn payload_key_rejects_a_wrong_password() {
+        let clear = Zeroizing::new(b"migration payload".to_vec());
+        let sealed = encrypt_payload(clear, BENCH_PASSWORD, &BENCH_SALT).unwrap();
+
+        let wrong = PayloadKey::new(b"not the password", &BENCH_SALT);
+
+        assert!(wrong.decrypt(sealed.as_bytes()).is_err());
+    }
+
+    /// Cost of one migration read that decrypts a payload per row.
+    ///
+    /// Run with:
+    /// `cargo test --release -p zcash_wallet kdf_reuse -- --ignored --nocapture`
+    #[test]
+    #[ignore = "timing benchmark; run explicitly"]
+    fn kdf_reuse_benchmark() {
+        use std::time::Instant;
+
+        // `denomination_stages_for_run` decrypts three payloads per stage.
+        const ROWS: usize = 20;
+        const PER_ROW: usize = 3;
+
+        let clear = Zeroizing::new(vec![0x5au8; 512]);
+        let sealed = encrypt_payload(clear, BENCH_PASSWORD, &BENCH_SALT).unwrap();
+
+        let started = Instant::now();
+        for _ in 0..ROWS * PER_ROW {
+            decrypt_payload(sealed.as_bytes(), BENCH_PASSWORD, &BENCH_SALT).unwrap();
+        }
+        let per_call = started.elapsed();
+
+        let started = Instant::now();
+        let key = PayloadKey::new(BENCH_PASSWORD, &BENCH_SALT);
+        for _ in 0..ROWS * PER_ROW {
+            key.decrypt(sealed.as_bytes()).unwrap();
+        }
+        let derived_once = started.elapsed();
+
+        println!(
+            "kdf: {ROWS} rows x {PER_ROW} payloads ({} derivations -> 1)",
+            ROWS * PER_ROW
+        );
+        println!("  per-call derivation : {per_call:?}");
+        println!("  derived once        : {derived_once:?}");
+        println!(
+            "  saved               : {:?} ({:.1}x)",
+            per_call.saturating_sub(derived_once),
+            per_call.as_secs_f64() / derived_once.as_secs_f64().max(f64::MIN_POSITIVE),
+        );
+        assert!(derived_once < per_call);
+    }
 
     #[test]
     fn decrypt_payload_accepts_dart_generated_fixture() {

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -2222,13 +2222,10 @@ fn insert_pending_txs_with_tx(
         }
     }
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration pending salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
 
     for (pending, block_offset, schedule_origin) in scheduled_pending {
-        let encrypted_raw_tx = secret_payload::encrypt_payload(
-            Zeroizing::new(pending.raw_tx),
-            password,
-            salt.as_slice(),
-        )?;
+        let encrypted_raw_tx = payload_key.encrypt(Zeroizing::new(pending.raw_tx))?;
         let metadata_json = serde_json::to_string(&pending.metadata)
             .map_err(|e| format!("Encode migration pending metadata: {e}"))?;
         let scheduled_at_ms = scheduled_start_ms
@@ -2361,6 +2358,7 @@ fn insert_signed_child_pczts_with_tx(
         SignedChildInsertMode::Replacement => None,
     };
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration PCZT salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     for child in signed_children {
         let canonical_expiry = zip318_canonical_migration_expiry_height(child.scheduled_height)?;
         if child.expiry_height != canonical_expiry {
@@ -2395,25 +2393,17 @@ fn insert_signed_child_pczts_with_tx(
             }
         }
         if matches!(mode, SignedChildInsertMode::Replacement) {
-            let recovery_origin = recovery_origin
-                .ok_or("Migration recovery schedule origin is missing")?;
+            let recovery_origin =
+                recovery_origin.ok_or("Migration recovery schedule origin is missing")?;
             child
                 .scheduled_height
                 .checked_sub(recovery_origin)
                 .ok_or("Signed migration schedule starts below zero")?;
         }
-        let encrypted_base_pczt = secret_payload::encrypt_payload(
-            Zeroizing::new(child.base_pczt),
-            password,
-            salt.as_slice(),
-        )?;
-        let encrypted_compact_sigs = secret_payload::encrypt_payload(
-            Zeroizing::new(crate::wallet::keystone::encode_compact_action_sigs(
-                &child.sigs,
-            )?),
-            password,
-            salt.as_slice(),
-        )?;
+        let encrypted_base_pczt = payload_key.encrypt(Zeroizing::new(child.base_pczt))?;
+        let encrypted_compact_sigs = payload_key.encrypt(Zeroizing::new(
+            crate::wallet::keystone::encode_compact_action_sigs(&child.sigs)?,
+        ))?;
         let selected_note_json = serde_json::to_string(&child.selected_note)
             .map_err(|e| format!("Encode migration signed PCZT note: {e}"))?;
         let metadata_json = serde_json::to_string(&child.metadata)
@@ -2510,6 +2500,7 @@ pub(crate) fn signed_child_pczts_for_run(
     salt_base64: &str,
 ) -> Result<Vec<SignedMigrationPczt>, String> {
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration PCZT salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
     let mut stmt = conn
@@ -2570,16 +2561,8 @@ pub(crate) fn signed_child_pczts_for_run(
                 "Signed migration child {message_id} expiry is not canonical for scheduled height {scheduled_height}"
             ));
         }
-        let base_pczt = secret_payload::decrypt_payload(
-            encrypted_base_pczt.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
-        let sigs_blob = secret_payload::decrypt_payload(
-            encrypted_compact_sigs.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
+        let base_pczt = payload_key.decrypt(encrypted_base_pczt.as_bytes())?;
+        let sigs_blob = payload_key.decrypt(encrypted_compact_sigs.as_bytes())?;
         let sigs = crate::wallet::keystone::decode_compact_action_sigs(sigs_blob.as_slice())?;
         let selected_note = serde_json::from_str::<PreparedOrchardNoteRef>(&selected_note_json)
             .map_err(|e| format!("Decode signed migration PCZT note: {e}"))?;
@@ -3155,6 +3138,7 @@ pub(crate) fn export_scheduled_migration_outbox(
             .map(|ready_height| persisted.unwrap_or(ready_height).max(ready_height))
     };
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration pending salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let mut stmt = conn
         .prepare_cached(&format!(
             "SELECT part_index, txid_hex, encrypted_raw_tx,
@@ -3210,11 +3194,7 @@ pub(crate) fn export_scheduled_migration_outbox(
                 "Migration outbox transaction {txid_hex} expiry is not canonical for scheduled height {scheduled_height}"
             ));
         }
-        let raw_tx = secret_payload::decrypt_payload(
-            encrypted_raw_tx.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
+        let raw_tx = payload_key.decrypt(encrypted_raw_tx.as_bytes())?;
         let item_id = txid_hex.to_ascii_lowercase();
         items.push(MigrationOutboxItem {
             item_id,
@@ -3920,6 +3900,7 @@ pub(crate) fn replace_resigned_pending_parts(
         .map_err(|e| format!("Decode replacement migration schedule: {e}"))?;
     let scheduled_start_ms = now_ms()?;
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration pending salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let tx = conn
         .unchecked_transaction()
         .map_err(|e| format!("Begin migration part replacement: {e}"))?;
@@ -4012,11 +3993,7 @@ pub(crate) fn replace_resigned_pending_parts(
             .scheduled_height
             .checked_sub(schedule_start_height)
             .ok_or("Replacement migration schedule starts below zero")?;
-        let encrypted_raw_tx = secret_payload::encrypt_payload(
-            Zeroizing::new(pending.raw_tx),
-            password,
-            salt.as_slice(),
-        )?;
+        let encrypted_raw_tx = payload_key.encrypt(Zeroizing::new(pending.raw_tx))?;
         let metadata_json = serde_json::to_string(&pending.metadata)
             .map_err(|e| format!("Encode replacement migration metadata: {e}"))?;
         // `rebuild_block_offset` counts from the generation origin and so
@@ -4790,6 +4767,7 @@ pub(crate) fn broadcasted_pending_txs_missing_local_identity(
     salt_base64: &str,
 ) -> Result<Vec<DuePendingMigrationTx>, String> {
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration pending salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
     let mut stmt = conn
@@ -4815,11 +4793,7 @@ pub(crate) fn broadcasted_pending_txs_missing_local_identity(
         if local_transaction_raw(&conn, &txid_hex)?.is_some() {
             continue;
         }
-        let raw_tx = secret_payload::decrypt_payload(
-            encrypted_raw_tx.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
+        let raw_tx = payload_key.decrypt(encrypted_raw_tx.as_bytes())?;
         missing.push(DuePendingMigrationTx {
             txid_hex,
             raw_tx: raw_tx.to_vec(),

--- a/rust/src/wallet/sync/migration/stages.rs
+++ b/rust/src/wallet/sync/migration/stages.rs
@@ -564,6 +564,7 @@ pub(crate) fn denomination_stages_for_run(
     ensure_schema(conn)?;
     let salt =
         secret_payload::decode_base64(salt_base64.as_bytes(), "migration denomination stage salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let mut stmt = conn
         .prepare_cached(&format!(
             "SELECT stage_index, encrypted_base_pczt, encrypted_compact_sigs,
@@ -613,19 +614,12 @@ pub(crate) fn denomination_stages_for_run(
             confirmed_mined_height,
             confirmed_block_hash,
         ) = row.map_err(|e| format!("Read migration denomination stage: {e}"))?;
-        let base_pczt = secret_payload::decrypt_payload(
-            encrypted_base_pczt.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
-        let sigs_blob = secret_payload::decrypt_payload(
-            encrypted_compact_sigs.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
+        let base_pczt = payload_key.decrypt(encrypted_base_pczt.as_bytes())?;
+        let sigs_blob = payload_key.decrypt(encrypted_compact_sigs.as_bytes())?;
         let raw_tx = encrypted_raw_tx
             .map(|encrypted| {
-                secret_payload::decrypt_payload(encrypted.as_bytes(), password, salt.as_slice())
+                payload_key
+                    .decrypt(encrypted.as_bytes())
                     .map(|raw| raw.to_vec())
             })
             .transpose()?;
@@ -778,6 +772,7 @@ pub(crate) fn pending_raw_denomination_stages(
     ensure_schema(conn)?;
     let salt =
         secret_payload::decode_base64(salt_base64.as_bytes(), "migration denomination stage salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let mut stmt = conn
         .prepare_cached(&format!(
             "SELECT stage_index, expected_txid_hex, encrypted_raw_tx,
@@ -816,11 +811,7 @@ pub(crate) fn pending_raw_denomination_stages(
             expiry_height,
             fee_zatoshi,
         ) = row.map_err(|e| format!("Read pending migration denomination stage: {e}"))?;
-        let raw_tx = secret_payload::decrypt_payload(
-            encrypted_raw_tx.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
+        let raw_tx = payload_key.decrypt(encrypted_raw_tx.as_bytes())?;
         pending.push(PendingRawDenominationStage {
             stage_index,
             expected_txid_hex,


### PR DESCRIPTION
Stacked on #435. Final PR of the desktop stack.

## The defect

`secret_payload::derive_key` runs `KDF_ITERATIONS = 100_000` PBKDF2-HMAC-SHA256 iterations. Measured at **~25ms per derivation** in release on an M-series Mac — the *fastest* hardware this ships on.

Eight migration functions decrypt or encrypt one payload per row and called it **inside the loop**, re-deriving the same key from the same password and salt every iteration:

| function | derivations per row |
|---|---|
| `denomination_stages_for_run` | **3** |
| `signed_child_pczts_for_run` | 2 |
| `insert_signed_child_pczts_with_tx` | 2 |
| `export_scheduled_migration_outbox` | 1 |
| `broadcasted_pending_txs_missing_local_identity` | 1 |
| `insert_pending_txs_with_tx` | 1 |
| `replace_resigned_pending_parts` | 1 |
| `pending_raw_denomination_stages` | 1 |

These are on the paths in the bug reports — outbox export and `broadcasted_pending_txs_missing_local_identity` run on every broadcast pass, so the cost recurs per poll, not once per run.

## Measured

`kdf_reuse_benchmark`, 20 rows x 3 payloads — the shape of a denomination-stage read:

```
kdf: 20 rows x 3 payloads (60 derivations -> 1)
  per-call derivation : 1.488214167s
  derived once        :   25.127792ms
  saved               :  1.463086375s (59.2x)
```

Run it with `cargo test --release --lib kdf_reuse -- --ignored --nocapture`. It is `#[ignore]`d so a timing test never gates CI.

## The change

Add `PayloadKey`: derive once, then `encrypt`/`decrypt` against the held key. `encrypt_payload` and `decrypt_payload` become one-line delegates, so **every existing call site is untouched** — only the eight loops opt in.

**Deliberately not a process-wide key cache.** A global would keep derived key material resident across unrelated operations. `PayloadKey` is scoped to the call that builds it, so key material lives no longer than the password the caller already holds. It stays in `Zeroizing`.

## Correctness

Two always-on tests, because a loop conversion must not change what it reads or writes:

- `payload_key_matches_the_free_functions` — round-trips **both** directions: written by `PayloadKey` / read by the free function, and vice versa. Same ciphertext format, same key.
- `payload_key_rejects_a_wrong_password` — a wrong password still fails to decrypt.

## Testing

- `cargo test --lib`: **540 passed, 0 failed**, 4 ignored.
- Run 5x consecutively to check for flakes: 5/5 clean. (One transient failure was seen once mid-session while a release build ran concurrently, and did not reproduce; the two timing-sensitive tests added in #435 were hardened in that PR — the busy-timeout hold is now derived from the constant under test and the assertion matches `SQLITE_BUSY` specifically rather than any error.)
- `cargo fmt --check` reports only the 12 pre-existing drift sites in `migration/tests.rs`, which are present on the base branch and deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)