### PR TITLE
perf: derive the migration payload key once per read, not once per row

### DIFF
--- a/rust/src/wallet/secret_payload.rs
+++ b/rust/src/wallet/secret_payload.rs
@@ -64,15 +64,53 @@ pub fn derive_password_verifier_base64(
     Ok(STANDARD.encode(key.as_slice()))
 }
 
+/// A payload key derived once for one `(password, salt)` pair.
+///
+/// [`derive_key`] runs `KDF_ITERATIONS` PBKDF2-HMAC-SHA256 iterations, which
+/// measures ~27ms per derivation on an M-series Mac in release. Loops handling
+/// one payload per row re-derived the same key on every iteration; build this
+/// once outside the loop instead.
+///
+/// Deliberately not a process-wide cache. The key lives exactly as long as the
+/// call that needs it, so this does not widen the window in which key material
+/// is resident relative to the password the caller already holds.
+pub struct PayloadKey {
+    key: Zeroizing<[u8; KEY_LEN]>,
+}
+
+impl PayloadKey {
+    pub fn new(password: &[u8], salt: &[u8]) -> Self {
+        Self {
+            key: derive_key(password, salt),
+        }
+    }
+
+    fn cipher(&self) -> Result<Aes256Gcm, String> {
+        Aes256Gcm::new_from_slice(self.key.as_slice())
+            .map_err(|e| format!("Failed to initialize AES-GCM: {e}"))
+    }
+
+    pub fn encrypt(&self, clear_text: Zeroizing<Vec<u8>>) -> Result<String, String> {
+        encrypt_with_cipher(self.cipher()?, clear_text)
+    }
+
+    pub fn decrypt(&self, raw_payload: &[u8]) -> Result<Zeroizing<Vec<u8>>, String> {
+        decrypt_with_cipher(self.cipher()?, raw_payload)
+    }
+}
+
 pub fn encrypt_payload(
     clear_text: Zeroizing<Vec<u8>>,
     password: &[u8],
     salt: &[u8],
 ) -> Result<String, String> {
-    let key = derive_key(password, salt);
-    let cipher = Aes256Gcm::new_from_slice(key.as_slice())
-        .map_err(|e| format!("Failed to initialize AES-GCM: {e}"))?;
-    drop(key);
+    PayloadKey::new(password, salt).encrypt(clear_text)
+}
+
+fn encrypt_with_cipher(
+    cipher: Aes256Gcm,
+    clear_text: Zeroizing<Vec<u8>>,
+) -> Result<String, String> {
     let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
     let cipher_text_and_tag = Zeroizing::new(
         cipher
@@ -103,6 +141,13 @@ pub fn decrypt_payload(
     password: &[u8],
     salt: &[u8],
 ) -> Result<Zeroizing<Vec<u8>>, String> {
+    PayloadKey::new(password, salt).decrypt(raw_payload)
+}
+
+fn decrypt_with_cipher(
+    cipher: Aes256Gcm,
+    raw_payload: &[u8],
+) -> Result<Zeroizing<Vec<u8>>, String> {
     let payload: EncryptedPayload<'_> = serde_json::from_slice(raw_payload)
         .map_err(|e| format!("Failed to parse encrypted payload: {e}"))?;
     if payload.version != 1 {
@@ -131,10 +176,6 @@ pub fn decrypt_payload(
         ));
     }
 
-    let key = derive_key(password, salt);
-    let cipher = Aes256Gcm::new_from_slice(key.as_slice())
-        .map_err(|e| format!("Failed to initialize AES-GCM: {e}"))?;
-    drop(key);
     let mut ciphertext_and_tag = Zeroizing::new(Vec::with_capacity(cipher_text.len() + mac.len()));
     ciphertext_and_tag.extend_from_slice(cipher_text.as_slice());
     ciphertext_and_tag.extend_from_slice(mac.as_slice());
@@ -169,6 +210,80 @@ fn derive_key(password: &[u8], salt: &[u8]) -> Zeroizing<[u8; KEY_LEN]> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const BENCH_PASSWORD: &[u8] = b"correct horse battery staple";
+    const BENCH_SALT: [u8; 16] = [7u8; 16];
+
+    /// A `PayloadKey` and the free functions must be interchangeable, so
+    /// converting a loop cannot change what it reads or writes.
+    #[test]
+    fn payload_key_matches_the_free_functions() {
+        let clear = Zeroizing::new(b"migration payload".to_vec());
+        let key = PayloadKey::new(BENCH_PASSWORD, &BENCH_SALT);
+
+        // Written by the loop helper, read by the free function.
+        let via_key = key.encrypt(clear.clone()).unwrap();
+        let back = decrypt_payload(via_key.as_bytes(), BENCH_PASSWORD, &BENCH_SALT).unwrap();
+        assert_eq!(back.as_slice(), clear.as_slice());
+
+        // Written by the free function, read by the loop helper.
+        let via_free = encrypt_payload(clear.clone(), BENCH_PASSWORD, &BENCH_SALT).unwrap();
+        let back = key.decrypt(via_free.as_bytes()).unwrap();
+        assert_eq!(back.as_slice(), clear.as_slice());
+    }
+
+    #[test]
+    fn payload_key_rejects_a_wrong_password() {
+        let clear = Zeroizing::new(b"migration payload".to_vec());
+        let sealed = encrypt_payload(clear, BENCH_PASSWORD, &BENCH_SALT).unwrap();
+
+        let wrong = PayloadKey::new(b"not the password", &BENCH_SALT);
+
+        assert!(wrong.decrypt(sealed.as_bytes()).is_err());
+    }
+
+    /// Cost of one migration read that decrypts a payload per row.
+    ///
+    /// Run with:
+    /// `cargo test --release -p zcash_wallet kdf_reuse -- --ignored --nocapture`
+    #[test]
+    #[ignore = "timing benchmark; run explicitly"]
+    fn kdf_reuse_benchmark() {
+        use std::time::Instant;
+
+        // `denomination_stages_for_run` decrypts three payloads per stage.
+        const ROWS: usize = 20;
+        const PER_ROW: usize = 3;
+
+        let clear = Zeroizing::new(vec![0x5au8; 512]);
+        let sealed = encrypt_payload(clear, BENCH_PASSWORD, &BENCH_SALT).unwrap();
+
+        let started = Instant::now();
+        for _ in 0..ROWS * PER_ROW {
+            decrypt_payload(sealed.as_bytes(), BENCH_PASSWORD, &BENCH_SALT).unwrap();
+        }
+        let per_call = started.elapsed();
+
+        let started = Instant::now();
+        let key = PayloadKey::new(BENCH_PASSWORD, &BENCH_SALT);
+        for _ in 0..ROWS * PER_ROW {
+            key.decrypt(sealed.as_bytes()).unwrap();
+        }
+        let derived_once = started.elapsed();
+
+        println!(
+            "kdf: {ROWS} rows x {PER_ROW} payloads ({} derivations -> 1)",
+            ROWS * PER_ROW
+        );
+        println!("  per-call derivation : {per_call:?}");
+        println!("  derived once        : {derived_once:?}");
+        println!(
+            "  saved               : {:?} ({:.1}x)",
+            per_call.saturating_sub(derived_once),
+            per_call.as_secs_f64() / derived_once.as_secs_f64().max(f64::MIN_POSITIVE),
+        );
+        assert!(derived_once < per_call);
+    }
 
     #[test]
     fn decrypt_payload_accepts_dart_generated_fixture() {

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -2222,13 +2222,10 @@ fn insert_pending_txs_with_tx(
         }
     }
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration pending salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
 
     for (pending, block_offset, schedule_origin) in scheduled_pending {
-        let encrypted_raw_tx = secret_payload::encrypt_payload(
-            Zeroizing::new(pending.raw_tx),
-            password,
-            salt.as_slice(),
-        )?;
+        let encrypted_raw_tx = payload_key.encrypt(Zeroizing::new(pending.raw_tx))?;
         let metadata_json = serde_json::to_string(&pending.metadata)
             .map_err(|e| format!("Encode migration pending metadata: {e}"))?;
         let scheduled_at_ms = scheduled_start_ms
@@ -2361,6 +2358,7 @@ fn insert_signed_child_pczts_with_tx(
         SignedChildInsertMode::Replacement => None,
     };
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration PCZT salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     for child in signed_children {
         let canonical_expiry = zip318_canonical_migration_expiry_height(child.scheduled_height)?;
         if child.expiry_height != canonical_expiry {
@@ -2395,25 +2393,17 @@ fn insert_signed_child_pczts_with_tx(
             }
         }
         if matches!(mode, SignedChildInsertMode::Replacement) {
-            let recovery_origin = recovery_origin
-                .ok_or("Migration recovery schedule origin is missing")?;
+            let recovery_origin =
+                recovery_origin.ok_or("Migration recovery schedule origin is missing")?;
             child
                 .scheduled_height
                 .checked_sub(recovery_origin)
                 .ok_or("Signed migration schedule starts below zero")?;
         }
-        let encrypted_base_pczt = secret_payload::encrypt_payload(
-            Zeroizing::new(child.base_pczt),
-            password,
-            salt.as_slice(),
-        )?;
-        let encrypted_compact_sigs = secret_payload::encrypt_payload(
-            Zeroizing::new(crate::wallet::keystone::encode_compact_action_sigs(
-                &child.sigs,
-            )?),
-            password,
-            salt.as_slice(),
-        )?;
+        let encrypted_base_pczt = payload_key.encrypt(Zeroizing::new(child.base_pczt))?;
+        let encrypted_compact_sigs = payload_key.encrypt(Zeroizing::new(
+            crate::wallet::keystone::encode_compact_action_sigs(&child.sigs)?,
+        ))?;
         let selected_note_json = serde_json::to_string(&child.selected_note)
             .map_err(|e| format!("Encode migration signed PCZT note: {e}"))?;
         let metadata_json = serde_json::to_string(&child.metadata)
@@ -2510,6 +2500,7 @@ pub(crate) fn signed_child_pczts_for_run(
     salt_base64: &str,
 ) -> Result<Vec<SignedMigrationPczt>, String> {
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration PCZT salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
     let mut stmt = conn
@@ -2570,16 +2561,8 @@ pub(crate) fn signed_child_pczts_for_run(
                 "Signed migration child {message_id} expiry is not canonical for scheduled height {scheduled_height}"
             ));
         }
-        let base_pczt = secret_payload::decrypt_payload(
-            encrypted_base_pczt.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
-        let sigs_blob = secret_payload::decrypt_payload(
-            encrypted_compact_sigs.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
+        let base_pczt = payload_key.decrypt(encrypted_base_pczt.as_bytes())?;
+        let sigs_blob = payload_key.decrypt(encrypted_compact_sigs.as_bytes())?;
         let sigs = crate::wallet::keystone::decode_compact_action_sigs(sigs_blob.as_slice())?;
         let selected_note = serde_json::from_str::<PreparedOrchardNoteRef>(&selected_note_json)
             .map_err(|e| format!("Decode signed migration PCZT note: {e}"))?;
@@ -3155,6 +3138,7 @@ pub(crate) fn export_scheduled_migration_outbox(
             .map(|ready_height| persisted.unwrap_or(ready_height).max(ready_height))
     };
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration pending salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let mut stmt = conn
         .prepare_cached(&format!(
             "SELECT part_index, txid_hex, encrypted_raw_tx,
@@ -3210,11 +3194,7 @@ pub(crate) fn export_scheduled_migration_outbox(
                 "Migration outbox transaction {txid_hex} expiry is not canonical for scheduled height {scheduled_height}"
             ));
         }
-        let raw_tx = secret_payload::decrypt_payload(
-            encrypted_raw_tx.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
+        let raw_tx = payload_key.decrypt(encrypted_raw_tx.as_bytes())?;
         let item_id = txid_hex.to_ascii_lowercase();
         items.push(MigrationOutboxItem {
             item_id,
@@ -3920,6 +3900,7 @@ pub(crate) fn replace_resigned_pending_parts(
         .map_err(|e| format!("Decode replacement migration schedule: {e}"))?;
     let scheduled_start_ms = now_ms()?;
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration pending salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let tx = conn
         .unchecked_transaction()
         .map_err(|e| format!("Begin migration part replacement: {e}"))?;
@@ -4012,11 +3993,7 @@ pub(crate) fn replace_resigned_pending_parts(
             .scheduled_height
             .checked_sub(schedule_start_height)
             .ok_or("Replacement migration schedule starts below zero")?;
-        let encrypted_raw_tx = secret_payload::encrypt_payload(
-            Zeroizing::new(pending.raw_tx),
-            password,
-            salt.as_slice(),
-        )?;
+        let encrypted_raw_tx = payload_key.encrypt(Zeroizing::new(pending.raw_tx))?;
         let metadata_json = serde_json::to_string(&pending.metadata)
             .map_err(|e| format!("Encode replacement migration metadata: {e}"))?;
         // `rebuild_block_offset` counts from the generation origin and so
@@ -4790,6 +4767,7 @@ pub(crate) fn broadcasted_pending_txs_missing_local_identity(
     salt_base64: &str,
 ) -> Result<Vec<DuePendingMigrationTx>, String> {
     let salt = secret_payload::decode_base64(salt_base64.as_bytes(), "migration pending salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
     let mut stmt = conn
@@ -4815,11 +4793,7 @@ pub(crate) fn broadcasted_pending_txs_missing_local_identity(
         if local_transaction_raw(&conn, &txid_hex)?.is_some() {
             continue;
         }
-        let raw_tx = secret_payload::decrypt_payload(
-            encrypted_raw_tx.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
+        let raw_tx = payload_key.decrypt(encrypted_raw_tx.as_bytes())?;
         missing.push(DuePendingMigrationTx {
             txid_hex,
             raw_tx: raw_tx.to_vec(),

--- a/rust/src/wallet/sync/migration/stages.rs
+++ b/rust/src/wallet/sync/migration/stages.rs
@@ -564,6 +564,7 @@ pub(crate) fn denomination_stages_for_run(
     ensure_schema(conn)?;
     let salt =
         secret_payload::decode_base64(salt_base64.as_bytes(), "migration denomination stage salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let mut stmt = conn
         .prepare_cached(&format!(
             "SELECT stage_index, encrypted_base_pczt, encrypted_compact_sigs,
@@ -613,19 +614,12 @@ pub(crate) fn denomination_stages_for_run(
             confirmed_mined_height,
             confirmed_block_hash,
         ) = row.map_err(|e| format!("Read migration denomination stage: {e}"))?;
-        let base_pczt = secret_payload::decrypt_payload(
-            encrypted_base_pczt.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
-        let sigs_blob = secret_payload::decrypt_payload(
-            encrypted_compact_sigs.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
+        let base_pczt = payload_key.decrypt(encrypted_base_pczt.as_bytes())?;
+        let sigs_blob = payload_key.decrypt(encrypted_compact_sigs.as_bytes())?;
         let raw_tx = encrypted_raw_tx
             .map(|encrypted| {
-                secret_payload::decrypt_payload(encrypted.as_bytes(), password, salt.as_slice())
+                payload_key
+                    .decrypt(encrypted.as_bytes())
                     .map(|raw| raw.to_vec())
             })
             .transpose()?;
@@ -778,6 +772,7 @@ pub(crate) fn pending_raw_denomination_stages(
     ensure_schema(conn)?;
     let salt =
         secret_payload::decode_base64(salt_base64.as_bytes(), "migration denomination stage salt")?;
+    let payload_key = secret_payload::PayloadKey::new(password, salt.as_slice());
     let mut stmt = conn
         .prepare_cached(&format!(
             "SELECT stage_index, expected_txid_hex, encrypted_raw_tx,
@@ -816,11 +811,7 @@ pub(crate) fn pending_raw_denomination_stages(
             expiry_height,
             fee_zatoshi,
         ) = row.map_err(|e| format!("Read pending migration denomination stage: {e}"))?;
-        let raw_tx = secret_payload::decrypt_payload(
-            encrypted_raw_tx.as_bytes(),
-            password,
-            salt.as_slice(),
-        )?;
+        let raw_tx = payload_key.decrypt(encrypted_raw_tx.as_bytes())?;
         pending.push(PendingRawDenominationStage {
             stage_index,
             expected_txid_hex,

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -322,7 +322,10 @@ fn stop_candidates_include_broadcasted_rows_missing_local_raw() {
         1,
         "only broadcasted-without-local-raw rows remain stop-reconcilable"
     );
-    assert_eq!(candidates[0].kind, MigrationStopCandidateKind::MigrationTransaction);
+    assert_eq!(
+        candidates[0].kind,
+        MigrationStopCandidateKind::MigrationTransaction
+    );
     assert_eq!(candidates[0].txid_hex, *unstored_txid);
     assert_eq!(
         candidates[0].attempt_state,
@@ -4744,23 +4747,20 @@ fn expired_broadcasted_without_local_raw_stays_broadcasted_for_store_retry() {
     mark_pending_broadcasted(&db_path, "store-retry-run", &txid_hex).unwrap();
 
     // Past expiry, but no local transactions.raw yet: do not resign.
-    assert!(
-        !pending_row_is_expired_for_resign(
-            &open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap(),
-            "broadcasted",
-            expiry_height,
-            expiry_height,
-            &txid_hex,
-        )
-        .unwrap()
-    );
+    assert!(!pending_row_is_expired_for_resign(
+        &open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap(),
+        "broadcasted",
+        expiry_height,
+        expiry_height,
+        &txid_hex,
+    )
+    .unwrap());
     assert_eq!(
         expired_unconfirmed_pending_count(&db_path, "store-retry-run", expiry_height).unwrap(),
         0
     );
     assert_eq!(
-        mark_expired_pending_parts_for_resign(&db_path, "store-retry-run", expiry_height)
-            .unwrap(),
+        mark_expired_pending_parts_for_resign(&db_path, "store-retry-run", expiry_height).unwrap(),
         0
     );
     let status: String = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT)
@@ -4806,16 +4806,14 @@ fn expired_broadcasted_without_local_raw_stays_broadcasted_for_store_retry() {
     .unwrap();
     drop(conn);
 
-    assert!(
-        pending_row_is_expired_for_resign(
-            &open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap(),
-            "broadcasted",
-            expiry_height,
-            expiry_height,
-            &txid_hex,
-        )
-        .unwrap()
-    );
+    assert!(pending_row_is_expired_for_resign(
+        &open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap(),
+        "broadcasted",
+        expiry_height,
+        expiry_height,
+        &txid_hex,
+    )
+    .unwrap());
     assert!(
         broadcasted_pending_txs_missing_local_identity(
             &db_path,
@@ -4832,8 +4830,7 @@ fn expired_broadcasted_without_local_raw_stays_broadcasted_for_store_retry() {
         1
     );
     assert_eq!(
-        mark_expired_pending_parts_for_resign(&db_path, "store-retry-run", expiry_height)
-            .unwrap(),
+        mark_expired_pending_parts_for_resign(&db_path, "store-retry-run", expiry_height).unwrap(),
         1
     );
     let status: String = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT)
@@ -5004,7 +5001,11 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
              VALUES ('gen-run', 'account-1', 'main', ?1, ?2, 1, 1,
                      '[100,100,100,100,100,100,100,100,100,100]', ?3)"
         ),
-        params![db_path, PHASE_READY_TO_MIGRATE, format!("[{schedule_json}]")],
+        params![
+            db_path,
+            PHASE_READY_TO_MIGRATE,
+            format!("[{schedule_json}]")
+        ],
     )
     .unwrap();
     let rows = insert_needs_resign_fixture_rows(&conn, "gen-run", 0..10);
@@ -5018,7 +5019,11 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
     assert_eq!(generation.offsets_by_txid.len(), 10);
     let (_, max_delay_blocks) =
         schedule_parameters_with_policy(WalletNetwork::Main, MigrationTimingPolicy::Standard);
-    let mut ladder = generation.offsets_by_txid.values().copied().collect::<Vec<_>>();
+    let mut ladder = generation
+        .offsets_by_txid
+        .values()
+        .copied()
+        .collect::<Vec<_>>();
     ladder.sort_unstable();
     let generation_max_offset = *ladder.last().unwrap();
     assert!(generation_max_offset <= max_delay_blocks * 10);
@@ -5045,13 +5050,8 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
     // The replacement boundary enforces the exact persisted offset, not only
     // the generation origin.
     let persisted_offset = generation.offsets_by_txid[&rows[9].0.to_ascii_lowercase()];
-    let (wrong_offset_replacement, wrong_offset_child) = rebuild_replacement_for(
-        &rows[9].0,
-        &rows[9].1,
-        9,
-        5_001,
-        5_001 + persisted_offset,
-    );
+    let (wrong_offset_replacement, wrong_offset_child) =
+        rebuild_replacement_for(&rows[9].0, &rows[9].1, 9, 5_001, 5_001 + persisted_offset);
     assert_eq!(
         replace_resigned_pending_parts(
             &db_path,
@@ -5212,12 +5212,7 @@ fn rebuild_generation_spans_batches_with_one_ladder() {
     assert_eq!(rebuilt.len(), 10);
     assert!(rebuilt.iter().all(|(_, _, start, _)| *start == 5_000));
     assert!(rebuilt.iter().all(|(part_index, target, _, _)| {
-        *target
-            == if *part_index < 8 {
-                5_001
-            } else {
-                late_tip + 1
-            }
+        *target == if *part_index < 8 { 5_001 } else { late_tip + 1 }
     }));
     rebuilt.sort_by_key(|(_, _, _, scheduled)| *scheduled);
     let rebuilt_ladder = rebuilt
@@ -5301,8 +5296,7 @@ fn rebuild_generation_retains_consumed_max_for_late_needs_resign_parts() {
 
     // Consume the part that held the generation's largest offset. The one
     // remaining needs_resign row only carries offset 10.
-    let (replacement, child) =
-        rebuild_replacement_for(&rows[1].0, &rows[1].1, 1, 2_001, 3_000);
+    let (replacement, child) = rebuild_replacement_for(&rows[1].0, &rows[1].1, 1, 2_001, 3_000);
     replace_resigned_pending_parts(
         &db_path,
         "late-run",
@@ -5425,8 +5419,7 @@ fn multi_part_rebuild_replacements_persist_with_fresh_offsets() {
                 selected_note: note.clone(),
             };
             let scheduled_height = scheduled_heights[index];
-            let expiry_height =
-                zip318_canonical_migration_expiry_height(scheduled_height).unwrap();
+            let expiry_height = zip318_canonical_migration_expiry_height(scheduled_height).unwrap();
             let value_zatoshi = 100 + 100 * index as u64;
             (
                 PendingMigrationTxReplacement {
@@ -9061,12 +9054,8 @@ fn expiry_recovery_promotes_locally_mined_scheduled_part_instead_of_resign() {
         .join("wallet.db")
         .to_string_lossy()
         .to_string();
-    let txids = create_outbox_test_run(
-        &db_path,
-        "expiry-mined",
-        &[100, 200],
-        &[Some(90), Some(90)],
-    );
+    let txids =
+        create_outbox_test_run(&db_path, "expiry-mined", &[100, 200], &[Some(90), Some(90)]);
     let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
     // Force past-expiry bookkeeping while leaving status as `scheduled`.
     conn.execute(

--- a/rust/src/wallet/wallet_summary_cache.rs
+++ b/rust/src/wallet/wallet_summary_cache.rs
@@ -499,6 +499,7 @@ mod tests {
         crate::wallet::sync::update_chain_tip(db_path, WalletNetwork::Regtest, 1_100).unwrap();
 
         let loads = AtomicUsize::new(0);
+        let epoch_before = wallet_db_write_epoch();
         let first = get_or_load_with(db_path, WalletNetwork::Regtest, || {
             loads.fetch_add(1, Ordering::SeqCst);
             let db = open_wallet_db_for_read_with_timeout(
@@ -525,7 +526,14 @@ mod tests {
         // before any blocks are scanned; the important property is that the
         // successful None (or Some) was cached across the second call.
         assert_eq!(first, second);
-        assert_eq!(loads.load(Ordering::SeqCst), 1);
+        // This test reads the real global write epoch, so a parallel suite
+        // writing between these two loads legitimately invalidates the cache.
+        // The reload assertions below absorb that as a lower bound, but a
+        // cache *hit* cannot be expressed that way -- so only assert it when
+        // no write intervened.
+        if epoch_before == wallet_db_write_epoch() && epoch_before % 2 == 0 {
+            assert_eq!(loads.load(Ordering::SeqCst), 1);
+        }
 
         crate::wallet::sync::update_chain_tip(db_path, WalletNetwork::Regtest, 1_200).unwrap();
 


### PR DESCRIPTION
Standalone against `perf-summary-main-2`. Replaces #436, which was stacked behind a PR that has since been dropped.

## The defect

`secret_payload::derive_key` runs `KDF_ITERATIONS = 100_000` PBKDF2-HMAC-SHA256 iterations — **~24ms per call** in release on an M-series Mac, the fastest hardware this ships on.

Eight migration functions handle one payload per row and called it **inside the loop**, re-deriving the same key from the same password and salt every iteration:

| function | derivations per row |
|---|---|
| `denomination_stages_for_run` | **3** |
| `signed_child_pczts_for_run` | 2 |
| `insert_signed_child_pczts_with_tx` | 2 |
| `export_scheduled_migration_outbox` | 1 |
| `broadcasted_pending_txs_missing_local_identity` | 1 |
| `insert_pending_txs_with_tx` | 1 |
| `replace_resigned_pending_parts` | 1 |
| `pending_raw_denomination_stages` | 1 |

`export_scheduled_migration_outbox` and `broadcasted_pending_txs_missing_local_identity` run on **every broadcast pass**, so the cost recurs per poll rather than once per run.

## Measured

`kdf_reuse_benchmark` at 20 rows x 3 payloads — the shape of a denomination-stage read:

```
kdf: 20 rows x 3 payloads (60 derivations -> 1)
  per-call derivation : 1.493623875s
  derived once        :   24.081166ms
  saved               :  1.469542709s (62.0x)
```

`cargo test --release --lib kdf_reuse -- --ignored --nocapture`. It is `#[ignore]`d so a timing test never gates CI.

## The change

`PayloadKey` derives once, then exposes `encrypt`/`decrypt` against the held key. `encrypt_payload` and `decrypt_payload` become one-line delegates, so **every existing call site is untouched** — only the eight loops opt in.

**Deliberately not a process-wide key cache.** A global would keep derived key material resident across unrelated operations. `PayloadKey` is scoped to the call that builds it, so key material lives no longer than the password the caller already holds, and stays in `Zeroizing`.

## Correctness

Two always-on tests, because a loop conversion must not change what it reads or writes:

- `payload_key_matches_the_free_functions` — round-trips **both** directions: written by `PayloadKey` / read by the free function, and vice versa.
- `payload_key_rejects_a_wrong_password` — a wrong password still fails to decrypt.

## Second commit: a test race this surfaced

`real_wallet_write_forces_summary_reload` is the one cache test that reads the **real global** write epoch rather than injecting a local one, so a parallel suite writing between its two loads legitimately invalidates the cache and its exact `assert_eq!(loads, 1)` fails.

The race is pre-existing. It surfaced here because deriving the key once makes the migration suites markedly faster, shifting the interleaving:

| | failures |
|---|---|
| base, unmodified | 0 / 10 |
| with the KDF change | **1 / 6** |
| with the KDF change + the guard | 0 / 10 |

Its sibling assertions already absorb this as a lower bound (`assert!(loads >= 2)`, *"Parallel tests may also bump the global epoch"*), but a cache *hit* cannot be expressed that way — so the exact-count assertion is now guarded on the epoch being unchanged. Test-only; the cache itself is not touched.

## Testing

- `cargo test --lib`: **538 passed, 0 failed**, 4 ignored (536 on base + the 2 correctness tests).
- 10 consecutive full-suite runs: 0 failures.
- `cargo fmt` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)