### PR TITLE
Add secret passphrase shortcut to desktop account menus

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -936,7 +936,9 @@ List<RouteBase> _desktopRoutes() => [
   GoRoute(path: '/settings', builder: (_, _) => const SettingsScreen()),
   GoRoute(
     path: '/settings/secret-passphrase',
-    builder: (_, _) => const SettingsSeedPhraseScreen(),
+    builder: (_, state) => SettingsSeedPhraseScreen(
+      accountUuid: state.extra is String ? state.extra as String : null,
+    ),
   ),
   GoRoute(
     path: '/settings/change-password',

--- a/lib/src/core/widgets/app_context_menu.dart
+++ b/lib/src/core/widgets/app_context_menu.dart
@@ -190,6 +190,7 @@ class AppContextMenuItem extends StatefulWidget {
     required this.label,
     required this.onTap,
     this.destructive = false,
+    this.scaleLabelToFit = false,
     super.key,
   });
 
@@ -197,6 +198,7 @@ class AppContextMenuItem extends StatefulWidget {
   final String label;
   final VoidCallback onTap;
   final bool destructive;
+  final bool scaleLabelToFit;
 
   @override
   State<AppContextMenuItem> createState() => _AppContextMenuItemState();
@@ -245,13 +247,7 @@ class _AppContextMenuItemState extends State<AppContextMenuItem> {
                 color: iconColor,
               ),
               const SizedBox(width: AppSpacing.xxs),
-              Expanded(
-                child: Text(
-                  widget.label,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTypography.labelMedium.copyWith(color: itemColor),
-                ),
-              ),
+              Expanded(child: _buildLabel(itemColor)),
             ],
           ),
         ),
@@ -263,6 +259,24 @@ class _AppContextMenuItemState extends State<AppContextMenuItem> {
     if (!mounted) return;
     if (_isHovered == value) return;
     setState(() => _isHovered = value);
+  }
+
+  Widget _buildLabel(Color itemColor) {
+    final label = Text(
+      widget.label,
+      maxLines: 1,
+      softWrap: false,
+      overflow: widget.scaleLabelToFit
+          ? TextOverflow.visible
+          : TextOverflow.ellipsis,
+      style: AppTypography.labelMedium.copyWith(color: itemColor),
+    );
+    if (!widget.scaleLabelToFit) return label;
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      alignment: Alignment.centerLeft,
+      child: label,
+    );
   }
 }
 

--- a/lib/src/core/widgets/app_context_menu.dart
+++ b/lib/src/core/widgets/app_context_menu.dart
@@ -190,7 +190,6 @@ class AppContextMenuItem extends StatefulWidget {
     required this.label,
     required this.onTap,
     this.destructive = false,
-    this.scaleLabelToFit = false,
     super.key,
   });
 
@@ -198,7 +197,6 @@ class AppContextMenuItem extends StatefulWidget {
   final String label;
   final VoidCallback onTap;
   final bool destructive;
-  final bool scaleLabelToFit;
 
   @override
   State<AppContextMenuItem> createState() => _AppContextMenuItemState();
@@ -247,7 +245,15 @@ class _AppContextMenuItemState extends State<AppContextMenuItem> {
                 color: iconColor,
               ),
               const SizedBox(width: AppSpacing.xxs),
-              Expanded(child: _buildLabel(itemColor)),
+              Expanded(
+                child: Text(
+                  widget.label,
+                  maxLines: 1,
+                  softWrap: false,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTypography.labelMedium.copyWith(color: itemColor),
+                ),
+              ),
             ],
           ),
         ),
@@ -259,24 +265,6 @@ class _AppContextMenuItemState extends State<AppContextMenuItem> {
     if (!mounted) return;
     if (_isHovered == value) return;
     setState(() => _isHovered = value);
-  }
-
-  Widget _buildLabel(Color itemColor) {
-    final label = Text(
-      widget.label,
-      maxLines: 1,
-      softWrap: false,
-      overflow: widget.scaleLabelToFit
-          ? TextOverflow.visible
-          : TextOverflow.ellipsis,
-      style: AppTypography.labelMedium.copyWith(color: itemColor),
-    );
-    if (!widget.scaleLabelToFit) return label;
-    return FittedBox(
-      fit: BoxFit.scaleDown,
-      alignment: Alignment.centerLeft,
-      child: label,
-    );
   }
 }
 

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -1267,7 +1267,7 @@ class _AccountContextMenu extends StatelessWidget {
     required this.onDismiss,
   });
 
-  static const _width = 192.0;
+  static const _width = 232.0;
 
   final bool showSendZec;
   final VoidCallback? onViewSecretPassphrase;

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -1267,7 +1267,7 @@ class _AccountContextMenu extends StatelessWidget {
     required this.onDismiss,
   });
 
-  static const _width = 208.0;
+  static const _width = 192.0;
 
   final bool showSendZec;
   final VoidCallback? onViewSecretPassphrase;
@@ -1291,6 +1291,7 @@ class _AccountContextMenu extends StatelessWidget {
           AppContextMenuItem(
             iconName: AppIcons.key,
             label: 'View secret passphrase',
+            scaleLabelToFit: true,
             onTap: onViewSecretPassphrase!,
           ),
           const SizedBox(height: AppSpacing.xxs),

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -1291,7 +1291,6 @@ class _AccountContextMenu extends StatelessWidget {
           AppContextMenuItem(
             iconName: AppIcons.key,
             label: 'View secret phrase',
-            scaleLabelToFit: true,
             onTap: onViewSecretPassphrase!,
           ),
           const SizedBox(height: AppSpacing.xxs),

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -978,6 +978,12 @@ class _AccountRowState extends State<_AccountRow> {
             _AccountRowMenuButton(
               key: ValueKey('accounts_row_menu_button_${widget.account.uuid}'),
               showSendZec: widget.showSendZec,
+              onViewSecretPassphrase: widget.account.isHardware
+                  ? null
+                  : () => context.push(
+                      '/settings/secret-passphrase',
+                      extra: widget.account.uuid,
+                    ),
               onCopyAddress: () => widget.onCopyAddress(widget.account),
               onSendZec: () => widget.onSendZec(widget.account),
               onEditAccount: () => widget.onEditAccount(widget.account),
@@ -1067,6 +1073,7 @@ class _AccountRowAvatar extends StatelessWidget {
 class _AccountRowMenuButton extends StatefulWidget {
   const _AccountRowMenuButton({
     required this.showSendZec,
+    required this.onViewSecretPassphrase,
     required this.onCopyAddress,
     required this.onSendZec,
     required this.onEditAccount,
@@ -1077,6 +1084,7 @@ class _AccountRowMenuButton extends StatefulWidget {
   });
 
   final bool showSendZec;
+  final VoidCallback? onViewSecretPassphrase;
   final VoidCallback onCopyAddress;
   final VoidCallback onSendZec;
   final VoidCallback onEditAccount;
@@ -1143,6 +1151,9 @@ class _AccountRowMenuButtonState extends State<_AccountRowMenuButton> {
                 data: appTheme,
                 child: _AccountContextMenu(
                   showSendZec: widget.showSendZec,
+                  onViewSecretPassphrase: widget.onViewSecretPassphrase == null
+                      ? null
+                      : _handleViewSecretPassphrase,
                   onCopyAddress: _handleCopyAddress,
                   onSendZec: _handleSendZec,
                   onEditAccount: _handleEditAccount,
@@ -1171,6 +1182,11 @@ class _AccountRowMenuButtonState extends State<_AccountRowMenuButton> {
   void _handleEditAccount() {
     _hideMenu();
     widget.onEditAccount();
+  }
+
+  void _handleViewSecretPassphrase() {
+    _hideMenu();
+    widget.onViewSecretPassphrase?.call();
   }
 
   void _handleCopyAddress() {
@@ -1242,6 +1258,7 @@ class _AccountRowMenuButtonState extends State<_AccountRowMenuButton> {
 class _AccountContextMenu extends StatelessWidget {
   const _AccountContextMenu({
     required this.showSendZec,
+    required this.onViewSecretPassphrase,
     required this.onCopyAddress,
     required this.onSendZec,
     required this.onEditAccount,
@@ -1250,9 +1267,10 @@ class _AccountContextMenu extends StatelessWidget {
     required this.onDismiss,
   });
 
-  static const _width = 160.0;
+  static const _width = 192.0;
 
   final bool showSendZec;
+  final VoidCallback? onViewSecretPassphrase;
   final VoidCallback onCopyAddress;
   final VoidCallback onSendZec;
   final VoidCallback onEditAccount;
@@ -1262,12 +1280,21 @@ class _AccountContextMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Figma: the current account's menu is Edit account / Copy address;
-    // other accounts get Copy address / Send ZEC / Edit account. Remove is
-    // shown for every account and becomes reset when it is the last one.
+    // Every software account starts with the secret-passphrase shortcut.
+    // The remaining order follows Figma: current accounts get Edit account /
+    // Copy address; other accounts get Copy address / Send ZEC / Edit account.
+    // Remove is shown for every account and becomes reset for the last one.
     return AppContextMenu(
       width: _width,
       children: [
+        if (onViewSecretPassphrase != null) ...[
+          AppContextMenuItem(
+            iconName: AppIcons.key,
+            label: 'View secret passphrase',
+            onTap: onViewSecretPassphrase!,
+          ),
+          const SizedBox(height: AppSpacing.xxs),
+        ],
         if (!showSendZec) ...[
           AppContextMenuItem(
             iconName: AppIcons.edit,

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -1267,7 +1267,7 @@ class _AccountContextMenu extends StatelessWidget {
     required this.onDismiss,
   });
 
-  static const _width = 192.0;
+  static const _width = 176.0;
 
   final bool showSendZec;
   final VoidCallback? onViewSecretPassphrase;
@@ -1290,7 +1290,7 @@ class _AccountContextMenu extends StatelessWidget {
         if (onViewSecretPassphrase != null) ...[
           AppContextMenuItem(
             iconName: AppIcons.key,
-            label: 'View secret passphrase',
+            label: 'View secret phrase',
             scaleLabelToFit: true,
             onTap: onViewSecretPassphrase!,
           ),

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -1267,7 +1267,7 @@ class _AccountContextMenu extends StatelessWidget {
     required this.onDismiss,
   });
 
-  static const _width = 232.0;
+  static const _width = 208.0;
 
   final bool showSendZec;
   final VoidCallback? onViewSecretPassphrase;

--- a/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
@@ -103,7 +103,7 @@ class _SettingsSeedPhraseScreenState
 
     setState(() {
       _clearSensitiveState(
-        passwordError: 'Active account changed. Enter your password again.',
+        passwordError: 'Selected account changed. Enter your password again.',
       );
     });
   }

--- a/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
@@ -25,8 +25,13 @@ import '../widgets/confirm_access_card.dart';
 import '../widgets/settings_pane_backdrop.dart';
 
 class SettingsSeedPhraseScreen extends ConsumerStatefulWidget {
-  const SettingsSeedPhraseScreen({this.privacyOverlayController, super.key});
+  const SettingsSeedPhraseScreen({
+    this.accountUuid,
+    this.privacyOverlayController,
+    super.key,
+  });
 
+  final String? accountUuid;
   final SensitivePrivacyOverlayController? privacyOverlayController;
 
   @override
@@ -89,7 +94,7 @@ class _SettingsSeedPhraseScreenState
     _copiedTarget = null;
   }
 
-  void _handleActiveAccountChanged() {
+  void _handleTargetAccountChanged() {
     if (_stage == _SettingsSeedPhraseStage.password &&
         !_isSubmitting &&
         _mnemonic == null) {
@@ -103,12 +108,20 @@ class _SettingsSeedPhraseScreenState
     });
   }
 
-  bool _activeAccountChanged(String expectedAccountUuid) {
-    final currentAccountUuid = ref
-        .read(accountProvider)
-        .value
-        ?.activeAccountUuid;
-    return currentAccountUuid != expectedAccountUuid;
+  AccountInfo? _targetAccount(AccountState? accountState) {
+    if (accountState == null) return null;
+    final requestedUuid = widget.accountUuid;
+    if (requestedUuid == null) return accountState.activeAccount;
+    for (final account in accountState.accounts) {
+      if (account.uuid == requestedUuid) return account;
+    }
+    return null;
+  }
+
+  bool _targetAccountChanged(String expectedAccountUuid) {
+    final accountState = ref.read(accountProvider).value;
+    final targetAccount = _targetAccount(accountState);
+    return targetAccount?.uuid != expectedAccountUuid;
   }
 
   void _handlePasswordChanged() {
@@ -140,13 +153,13 @@ class _SettingsSeedPhraseScreenState
 
     try {
       final accountState = ref.read(accountProvider).value;
-      final activeAccount = accountState?.activeAccount;
-      if (activeAccount == null) {
+      final targetAccount = _targetAccount(accountState);
+      if (targetAccount == null) {
         throw const _SeedPhraseUnavailableException(
-          'No active account is selected.',
+          'The selected account is no longer available.',
         );
       }
-      final activeAccountUuid = activeAccount.uuid;
+      final targetAccountUuid = targetAccount.uuid;
 
       final isValid = await ref
           .read(appSecurityProvider.notifier)
@@ -160,17 +173,18 @@ class _SettingsSeedPhraseScreenState
         return;
       }
 
-      if (_activeAccountChanged(activeAccountUuid)) {
+      if (_targetAccountChanged(targetAccountUuid)) {
         if (!mounted) return;
         setState(() {
           _clearSensitiveState(
-            passwordError: 'Active account changed. Enter your password again.',
+            passwordError:
+                'Selected account changed. Enter your password again.',
           );
         });
         return;
       }
 
-      if (activeAccount.isHardware) {
+      if (targetAccount.isHardware) {
         throw const _SeedPhraseUnavailableException(
           'Secret passphrase is not available for hardware accounts.',
         );
@@ -178,7 +192,7 @@ class _SettingsSeedPhraseScreenState
 
       final mnemonic = await ref
           .read(accountProvider.notifier)
-          .getMnemonicForAccount(activeAccountUuid);
+          .getMnemonicForAccount(targetAccountUuid);
       if (mnemonic == null || mnemonic.isEmpty) {
         throw const _SeedPhraseUnavailableException(
           'Secret passphrase is not available for this account.',
@@ -186,10 +200,11 @@ class _SettingsSeedPhraseScreenState
       }
 
       if (!mounted) return;
-      if (_activeAccountChanged(activeAccountUuid)) {
+      if (_targetAccountChanged(targetAccountUuid)) {
         setState(() {
           _clearSensitiveState(
-            passwordError: 'Active account changed. Enter your password again.',
+            passwordError:
+                'Selected account changed. Enter your password again.',
           );
         });
         return;
@@ -208,7 +223,7 @@ class _SettingsSeedPhraseScreenState
         _copiedTarget = null;
       });
       unawaited(
-        _loadBirthdayHeightForReveal(activeAccountUuid, birthdayLoadGeneration),
+        _loadBirthdayHeightForReveal(targetAccountUuid, birthdayLoadGeneration),
       );
     } on _SeedPhraseUnavailableException catch (e) {
       if (!mounted) return;
@@ -229,33 +244,33 @@ class _SettingsSeedPhraseScreenState
     }
   }
 
-  bool _canApplyBirthdayLoad(String activeAccountUuid, int generation) {
+  bool _canApplyBirthdayLoad(String targetAccountUuid, int generation) {
     if (!mounted) return false;
     if (_birthdayLoadGeneration != generation) return false;
     if (_stage != _SettingsSeedPhraseStage.reveal || _mnemonic == null) {
       return false;
     }
-    return !_activeAccountChanged(activeAccountUuid);
+    return !_targetAccountChanged(targetAccountUuid);
   }
 
   Future<void> _loadBirthdayHeightForReveal(
-    String activeAccountUuid,
+    String targetAccountUuid,
     int generation,
   ) async {
     try {
-      final height = await _loadBirthdayHeight(activeAccountUuid);
-      if (!_canApplyBirthdayLoad(activeAccountUuid, generation)) return;
+      final height = await _loadBirthdayHeight(targetAccountUuid);
+      if (!_canApplyBirthdayLoad(targetAccountUuid, generation)) return;
       setState(() {
         _birthdayHeight = height;
         _isBirthdayHeightLoading = false;
         _isBirthdayDateLoading = true;
       });
       unawaited(
-        _loadBirthdayDateForReveal(activeAccountUuid, generation, height),
+        _loadBirthdayDateForReveal(targetAccountUuid, generation, height),
       );
     } catch (e, st) {
       log('SettingsSeedPhraseScreen._loadBirthdayHeight: ERROR: $e\n$st');
-      if (!_canApplyBirthdayLoad(activeAccountUuid, generation)) return;
+      if (!_canApplyBirthdayLoad(targetAccountUuid, generation)) return;
       setState(() {
         _birthdayHeight = null;
         _birthdayBlockTime = null;
@@ -266,7 +281,7 @@ class _SettingsSeedPhraseScreenState
   }
 
   Future<void> _loadBirthdayDateForReveal(
-    String activeAccountUuid,
+    String targetAccountUuid,
     int generation,
     int height,
   ) async {
@@ -274,14 +289,14 @@ class _SettingsSeedPhraseScreenState
       final blockTime = await _loadBirthdayBlockTime(
         height,
       ).timeout(const Duration(seconds: 10));
-      if (!_canApplyBirthdayLoad(activeAccountUuid, generation)) return;
+      if (!_canApplyBirthdayLoad(targetAccountUuid, generation)) return;
       setState(() {
         _birthdayBlockTime = blockTime > 0 ? blockTime : null;
         _isBirthdayDateLoading = false;
       });
     } catch (e, st) {
       log('SettingsSeedPhraseScreen._loadBirthdayDate: ERROR: $e\n$st');
-      if (!_canApplyBirthdayLoad(activeAccountUuid, generation)) return;
+      if (!_canApplyBirthdayLoad(targetAccountUuid, generation)) return;
       setState(() {
         _birthdayBlockTime = null;
         _isBirthdayDateLoading = false;
@@ -289,13 +304,13 @@ class _SettingsSeedPhraseScreenState
     }
   }
 
-  Future<int> _loadBirthdayHeight(String activeAccountUuid) async {
+  Future<int> _loadBirthdayHeight(String targetAccountUuid) async {
     final dbPath = await getWalletDbPath();
     final endpoint = ref.read(rpcEndpointProvider);
     final height = await rust_sync.getExportBirthdayHeight(
       dbPath: dbPath,
       network: endpoint.networkName,
-      accountUuid: activeAccountUuid,
+      accountUuid: targetAccountUuid,
     );
     return height.toInt();
   }
@@ -352,11 +367,11 @@ class _SettingsSeedPhraseScreenState
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<String?>(
-      accountProvider.select((state) => state.value?.activeAccountUuid),
+    ref.listen<AccountInfo?>(
+      accountProvider.select((state) => _targetAccount(state.value)),
       (previous, next) {
-        if (previous == next) return;
-        _handleActiveAccountChanged();
+        if (previous?.uuid == next?.uuid) return;
+        _handleTargetAccountChanged();
       },
     );
 

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -427,7 +427,7 @@ Widget buildAccountsManyUseCase(BuildContext context) {
 Widget buildAccountsOtherMenuUseCase(BuildContext context) {
   return _buildAccountsUseCase(
     _accountsDesignState,
-    initialOpenMenuAccountUuid: 'preview-account-2',
+    initialOpenMenuAccountUuid: 'preview-account-3',
   );
 }
 
@@ -1839,6 +1839,14 @@ class _AccountsHarnessState extends State<_AccountsHarness> {
         GoRoute(
           path: '/settings',
           builder: (_, _) => const _PreviewRoutePlaceholder(label: '/settings'),
+        ),
+        GoRoute(
+          path: '/settings/secret-passphrase',
+          builder: (_, state) => _PreviewRoutePlaceholder(
+            label:
+                '/settings/secret-passphrase '
+                '(${state.extra as String? ?? 'active account'})',
+          ),
         ),
         GoRoute(
           path: '/about',

--- a/test/core/widgets/app_context_menu_test.dart
+++ b/test/core/widgets/app_context_menu_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
@@ -93,39 +94,45 @@ void main() {
     await gesture.removePointer();
   });
 
-  testWidgets('AppContextMenuItem can scale a long label to fit', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      MediaQuery(
-        data: const MediaQueryData(textScaler: TextScaler.linear(2)),
-        child: _ThemedHarness(
-          theme: AppThemeData.light,
-          child: AppContextMenu(
-            width: 176,
-            children: [
-              AppContextMenuItem(
-                iconName: AppIcons.key,
-                label: 'View secret phrase',
-                scaleLabelToFit: true,
-                onTap: () {},
-              ),
-            ],
+  testWidgets(
+    'AppContextMenuItem ellipsizes a scaled label without shrinking',
+    (tester) async {
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+          child: _ThemedHarness(
+            theme: AppThemeData.light,
+            child: AppContextMenu(
+              width: 176,
+              children: [
+                AppContextMenuItem(
+                  iconName: AppIcons.key,
+                  label: 'View secret phrase',
+                  onTap: () {},
+                ),
+              ],
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    expect(find.text('View secret phrase'), findsOneWidget);
-    expect(
-      find.ancestor(
-        of: find.text('View secret phrase'),
-        matching: find.byType(FittedBox),
-      ),
-      findsOneWidget,
-    );
-    expect(tester.takeException(), isNull);
-  });
+      expect(find.text('View secret phrase'), findsOneWidget);
+      expect(
+        find.ancestor(
+          of: find.text('View secret phrase'),
+          matching: find.byType(FittedBox),
+        ),
+        findsNothing,
+      );
+      expect(
+        tester
+            .renderObject<RenderParagraph>(find.text('View secret phrase'))
+            .didExceedMaxLines,
+        isTrue,
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets('AppContextMenuItem can be removed while hovered', (
     tester,

--- a/test/core/widgets/app_context_menu_test.dart
+++ b/test/core/widgets/app_context_menu_test.dart
@@ -102,11 +102,11 @@ void main() {
         child: _ThemedHarness(
           theme: AppThemeData.light,
           child: AppContextMenu(
-            width: 192,
+            width: 176,
             children: [
               AppContextMenuItem(
                 iconName: AppIcons.key,
-                label: 'View secret passphrase',
+                label: 'View secret phrase',
                 scaleLabelToFit: true,
                 onTap: () {},
               ),
@@ -116,10 +116,10 @@ void main() {
       ),
     );
 
-    expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(find.text('View secret phrase'), findsOneWidget);
     expect(
       find.ancestor(
-        of: find.text('View secret passphrase'),
+        of: find.text('View secret phrase'),
         matching: find.byType(FittedBox),
       ),
       findsOneWidget,

--- a/test/core/widgets/app_context_menu_test.dart
+++ b/test/core/widgets/app_context_menu_test.dart
@@ -93,6 +93,40 @@ void main() {
     await gesture.removePointer();
   });
 
+  testWidgets('AppContextMenuItem can scale a long label to fit', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+        child: _ThemedHarness(
+          theme: AppThemeData.light,
+          child: AppContextMenu(
+            width: 192,
+            children: [
+              AppContextMenuItem(
+                iconName: AppIcons.key,
+                label: 'View secret passphrase',
+                scaleLabelToFit: true,
+                onTap: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(
+      find.ancestor(
+        of: find.text('View secret passphrase'),
+        matching: find.byType(FittedBox),
+      ),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('AppContextMenuItem can be removed while hovered', (
     tester,
   ) async {

--- a/test/features/accounts/accounts_screen_test.dart
+++ b/test/features/accounts/accounts_screen_test.dart
@@ -343,7 +343,14 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('View secret passphrase'), findsOneWidget);
-    expect(tester.getSize(find.byType(AppContextMenu)).width, 208);
+    expect(tester.getSize(find.byType(AppContextMenu)).width, 192);
+    expect(
+      find.ancestor(
+        of: find.text('View secret passphrase'),
+        matching: find.byType(FittedBox),
+      ),
+      findsOneWidget,
+    );
     expect(
       tester
           .renderObject<RenderParagraph>(find.text('View secret passphrase'))

--- a/test/features/accounts/accounts_screen_test.dart
+++ b/test/features/accounts/accounts_screen_test.dart
@@ -335,6 +335,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(tester.getSize(find.byType(AppContextMenu)).width, 232);
     expect(find.text('Copy address'), findsOneWidget);
     expect(find.text('Send ZEC'), findsNothing);
     expect(find.text('Edit account'), findsOneWidget);

--- a/test/features/accounts/accounts_screen_test.dart
+++ b/test/features/accounts/accounts_screen_test.dart
@@ -349,7 +349,7 @@ void main() {
         of: find.text('View secret phrase'),
         matching: find.byType(FittedBox),
       ),
-      findsOneWidget,
+      findsNothing,
     );
     expect(
       tester

--- a/test/features/accounts/accounts_screen_test.dart
+++ b/test/features/accounts/accounts_screen_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:ui' show PointerDeviceKind;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -29,6 +30,13 @@ const _validDeletePassword = 'Correct123!';
 const _invalidDeletePassword = 'Wrong123!';
 
 void main() {
+  setUpAll(() async {
+    final geist = FontLoader('Geist')
+      ..addFont(rootBundle.load('assets/fonts/Geist-Regular.ttf'))
+      ..addFont(rootBundle.load('assets/fonts/Geist-Medium.ttf'));
+    await geist.load();
+  });
+
   testWidgets('accounts screen renders active account and other accounts', (
     tester,
   ) async {
@@ -335,7 +343,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('View secret passphrase'), findsOneWidget);
-    expect(tester.getSize(find.byType(AppContextMenu)).width, 232);
+    expect(tester.getSize(find.byType(AppContextMenu)).width, 208);
+    expect(
+      tester
+          .renderObject<RenderParagraph>(find.text('View secret passphrase'))
+          .didExceedMaxLines,
+      isFalse,
+    );
     expect(find.text('Copy address'), findsOneWidget);
     expect(find.text('Send ZEC'), findsNothing);
     expect(find.text('Edit account'), findsOneWidget);
@@ -1298,9 +1312,8 @@ Widget _accountsHarness({
       ),
       GoRoute(
         path: '/settings/secret-passphrase',
-        builder: (_, state) => Text(
-          'secret passphrase route ${state.extra as String?}',
-        ),
+        builder: (_, state) =>
+            Text('secret passphrase route ${state.extra as String?}'),
       ),
       GoRoute(path: '/about', builder: (_, _) => const Text('about route')),
     ],

--- a/test/features/accounts/accounts_screen_test.dart
+++ b/test/features/accounts/accounts_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:zcash_wallet/src/core/layout/app_pane_scroll_scaffold.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_back_link.dart';
+import 'package:zcash_wallet/src/core/widgets/app_context_menu.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_pane_modal_overlay.dart';
 import 'package:zcash_wallet/src/features/accounts/screens/accounts_screen.dart';
@@ -287,6 +288,7 @@ void main() {
     expect(find.text('Send ZEC'), findsOneWidget);
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Remove account'), findsOneWidget);
+    expect(find.text('View secret passphrase'), findsNothing);
     _expectVerticalTextOrder(tester, const [
       'Copy address',
       'Send ZEC',
@@ -316,7 +318,7 @@ void main() {
     expect(find.text('Remove account'), findsNothing);
   });
 
-  testWidgets('current account menu shows edit, copy, and remove actions', (
+  testWidgets('current account menu shows secret passphrase shortcut', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(1512, 982));
@@ -332,15 +334,96 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    expect(find.text('View secret passphrase'), findsOneWidget);
     expect(find.text('Copy address'), findsOneWidget);
     expect(find.text('Send ZEC'), findsNothing);
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Remove account'), findsOneWidget);
     _expectVerticalTextOrder(tester, const [
+      'View secret passphrase',
       'Edit account',
       'Copy address',
       'Remove account',
     ]);
+
+    final shortcutItem = find.ancestor(
+      of: find.text('View secret passphrase'),
+      matching: find.byType(AppContextMenuItem),
+    );
+    expect(shortcutItem, findsOneWidget);
+    expect(
+      tester
+          .widgetList<AppIcon>(
+            find.descendant(of: shortcutItem, matching: find.byType(AppIcon)),
+          )
+          .single
+          .name,
+      AppIcons.key,
+    );
+
+    await tester.tap(find.text('View secret passphrase'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('secret passphrase route account-1'), findsOneWidget);
+  });
+
+  testWidgets('other software account menu opens its secret passphrase', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(_accountsHarness());
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const ValueKey('accounts_row_menu_button_account-3')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('View secret passphrase'), findsOneWidget);
+
+    await tester.tap(find.text('View secret passphrase'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('secret passphrase route account-3'), findsOneWidget);
+  });
+
+  testWidgets('hardware current account hides secret passphrase shortcut', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    const accountState = AccountState(
+      accounts: [
+        AccountInfo(
+          uuid: 'hardware-account',
+          name: 'Keystone Vault',
+          order: 0,
+          isHardware: true,
+        ),
+      ],
+      activeAccountUuid: 'hardware-account',
+      activeAddress: 'u1hardwareaddress',
+    );
+    await tester.pumpWidget(
+      _accountsHarness(
+        accountNotifier: () => _FakeAccountNotifier(accountState),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const ValueKey('accounts_row_menu_button_hardware-account')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('View secret passphrase'), findsNothing);
   });
 
   testWidgets('current imported account can be removed', (tester) async {
@@ -1211,6 +1294,12 @@ Widget _accountsHarness({
       GoRoute(
         path: '/settings',
         builder: (_, _) => const Text('settings route'),
+      ),
+      GoRoute(
+        path: '/settings/secret-passphrase',
+        builder: (_, state) => Text(
+          'secret passphrase route ${state.extra as String?}',
+        ),
       ),
       GoRoute(path: '/about', builder: (_, _) => const Text('about route')),
     ],

--- a/test/features/accounts/accounts_screen_test.dart
+++ b/test/features/accounts/accounts_screen_test.dart
@@ -296,7 +296,7 @@ void main() {
     expect(find.text('Send ZEC'), findsOneWidget);
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Remove account'), findsOneWidget);
-    expect(find.text('View secret passphrase'), findsNothing);
+    expect(find.text('View secret phrase'), findsNothing);
     _expectVerticalTextOrder(tester, const [
       'Copy address',
       'Send ZEC',
@@ -342,18 +342,18 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('View secret passphrase'), findsOneWidget);
-    expect(tester.getSize(find.byType(AppContextMenu)).width, 192);
+    expect(find.text('View secret phrase'), findsOneWidget);
+    expect(tester.getSize(find.byType(AppContextMenu)).width, 176);
     expect(
       find.ancestor(
-        of: find.text('View secret passphrase'),
+        of: find.text('View secret phrase'),
         matching: find.byType(FittedBox),
       ),
       findsOneWidget,
     );
     expect(
       tester
-          .renderObject<RenderParagraph>(find.text('View secret passphrase'))
+          .renderObject<RenderParagraph>(find.text('View secret phrase'))
           .didExceedMaxLines,
       isFalse,
     );
@@ -362,14 +362,14 @@ void main() {
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Remove account'), findsOneWidget);
     _expectVerticalTextOrder(tester, const [
-      'View secret passphrase',
+      'View secret phrase',
       'Edit account',
       'Copy address',
       'Remove account',
     ]);
 
     final shortcutItem = find.ancestor(
-      of: find.text('View secret passphrase'),
+      of: find.text('View secret phrase'),
       matching: find.byType(AppContextMenuItem),
     );
     expect(shortcutItem, findsOneWidget);
@@ -383,7 +383,7 @@ void main() {
       AppIcons.key,
     );
 
-    await tester.tap(find.text('View secret passphrase'));
+    await tester.tap(find.text('View secret phrase'));
     await tester.pumpAndSettle();
 
     expect(find.text('secret passphrase route account-1'), findsOneWidget);
@@ -405,9 +405,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(find.text('View secret phrase'), findsOneWidget);
 
-    await tester.tap(find.text('View secret passphrase'));
+    await tester.tap(find.text('View secret phrase'));
     await tester.pumpAndSettle();
 
     expect(find.text('secret passphrase route account-3'), findsOneWidget);
@@ -445,7 +445,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('View secret passphrase'), findsNothing);
+    expect(find.text('View secret phrase'), findsNothing);
   });
 
   testWidgets('current imported account can be removed', (tester) async {

--- a/test/features/settings/settings_seed_phrase_screen_test.dart
+++ b/test/features/settings/settings_seed_phrase_screen_test.dart
@@ -56,6 +56,41 @@ void main() {
     expect(accountNotifier.state.requireValue.activeAccountUuid, 'account-1');
     expect(find.text('abandon'), findsOneWidget);
   });
+
+  testWidgets('describes removal of the requested account accurately', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+    final privacyController = SensitivePrivacyOverlayController(
+      initiallySafe: true,
+    );
+    addTearDown(privacyController.dispose);
+    late _FakeAccountNotifier accountNotifier;
+
+    await tester.pumpWidget(
+      _harness(
+        privacyController: privacyController,
+        accountNotifier: () => accountNotifier = _FakeAccountNotifier(),
+      ),
+    );
+    await tester.pump();
+
+    await tester.enterText(find.byType(EditableText), 'Correct123!');
+    await tester.pump();
+    await tester.tap(find.bySemanticsLabel('Confirm password'));
+    await tester.pump();
+    accountNotifier.removeRequestedAccount();
+    await tester.pump();
+
+    expect(
+      find.text('Selected account changed. Enter your password again.'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Active account changed'), findsNothing);
+  });
 }
 
 Widget _harness({
@@ -67,11 +102,10 @@ Widget _harness({
     routes: [
       GoRoute(
         path: '/settings/secret-passphrase',
-        builder:
-            (_, _) => SettingsSeedPhraseScreen(
-              accountUuid: 'account-2',
-              privacyOverlayController: privacyController,
-            ),
+        builder: (_, _) => SettingsSeedPhraseScreen(
+          accountUuid: 'account-2',
+          privacyOverlayController: privacyController,
+        ),
       ),
       GoRoute(path: '/accounts', builder: (_, _) => const SizedBox()),
       GoRoute(path: '/settings', builder: (_, _) => const SizedBox()),
@@ -116,6 +150,16 @@ class _FakeAccountNotifier extends AccountNotifier {
   Future<String?> getMnemonicForAccount(String uuid) async {
     requestedMnemonicUuids.add(uuid);
     return _mnemonic;
+  }
+
+  void removeRequestedAccount() {
+    state = AsyncData(
+      state.requireValue.copyWith(
+        accounts: state.requireValue.accounts
+            .where((account) => account.uuid != 'account-2')
+            .toList(),
+      ),
+    );
   }
 }
 

--- a/test/features/settings/settings_seed_phrase_screen_test.dart
+++ b/test/features/settings/settings_seed_phrase_screen_test.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/privacy/sensitive_privacy_overlay.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/settings/screens/settings_seed_phrase_screen.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+const _mnemonic =
+    'abandon ability able about above absent absorb abstract absurd abuse access accident';
+
+const _accountState = AccountState(
+  accounts: [
+    AccountInfo(uuid: 'account-1', name: 'Current', order: 0),
+    AccountInfo(uuid: 'account-2', name: 'Other', order: 1),
+  ],
+  activeAccountUuid: 'account-1',
+  activeAddress: 'u1currentaddress',
+);
+
+void main() {
+  testWidgets('reveals the requested account without making it active', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+    final privacyController = SensitivePrivacyOverlayController(
+      initiallySafe: true,
+    );
+    addTearDown(privacyController.dispose);
+    late _FakeAccountNotifier accountNotifier;
+
+    await tester.pumpWidget(
+      _harness(
+        privacyController: privacyController,
+        accountNotifier: () => accountNotifier = _FakeAccountNotifier(),
+      ),
+    );
+    await tester.pump();
+
+    await tester.enterText(find.byType(EditableText), 'Correct123!');
+    await tester.pump();
+    await tester.tap(find.bySemanticsLabel('Confirm password'));
+    await tester.pump();
+
+    expect(accountNotifier.requestedMnemonicUuids, ['account-2']);
+    expect(accountNotifier.state.requireValue.activeAccountUuid, 'account-1');
+    expect(find.text('abandon'), findsOneWidget);
+  });
+}
+
+Widget _harness({
+  required SensitivePrivacyOverlayController privacyController,
+  required AccountNotifier Function() accountNotifier,
+}) {
+  final router = GoRouter(
+    initialLocation: '/settings/secret-passphrase',
+    routes: [
+      GoRoute(
+        path: '/settings/secret-passphrase',
+        builder:
+            (_, _) => SettingsSeedPhraseScreen(
+              accountUuid: 'account-2',
+              privacyOverlayController: privacyController,
+            ),
+      ),
+      GoRoute(path: '/accounts', builder: (_, _) => const SizedBox()),
+      GoRoute(path: '/settings', builder: (_, _) => const SizedBox()),
+      GoRoute(path: '/home', builder: (_, _) => const SizedBox()),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap()),
+      accountProvider.overrideWith(accountNotifier),
+      appSecurityProvider.overrideWith(_FakeSecurityNotifier.new),
+      syncProvider.overrideWith(_FakeSyncNotifier.new),
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+    ),
+  );
+}
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/settings/secret-passphrase',
+  initialAccountState: _accountState,
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.light,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);
+
+class _FakeAccountNotifier extends AccountNotifier {
+  final requestedMnemonicUuids = <String>[];
+
+  @override
+  FutureOr<AccountState> build() => _accountState;
+
+  @override
+  Future<String?> getMnemonicForAccount(String uuid) async {
+    requestedMnemonicUuids.add(uuid);
+    return _mnemonic;
+  }
+}
+
+class _FakeSecurityNotifier extends AppSecurityNotifier {
+  @override
+  Future<bool> confirmPassword(String password) async => true;
+}
+
+class _FakeSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncState> build() async => SyncState();
+}

--- a/test/widgetbook/accounts_use_cases_test.dart
+++ b/test/widgetbook/accounts_use_cases_test.dart
@@ -16,6 +16,7 @@ void main() {
     expect(find.text('Send ZEC'), findsOneWidget);
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Remove account'), findsOneWidget);
+    expect(find.text('View secret passphrase'), findsOneWidget);
   });
 
   testWidgets('accounts current menu use case renders account actions', (
@@ -24,6 +25,7 @@ void main() {
     await _pumpAccountsUseCase(tester, buildAccountsCurrentMenuUseCase);
 
     expect(tester.takeException(), isNull);
+    expect(find.text('View secret passphrase'), findsOneWidget);
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Copy address'), findsOneWidget);
     expect(find.text('Send ZEC'), findsNothing);

--- a/test/widgetbook/accounts_use_cases_test.dart
+++ b/test/widgetbook/accounts_use_cases_test.dart
@@ -16,7 +16,7 @@ void main() {
     expect(find.text('Send ZEC'), findsOneWidget);
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Remove account'), findsOneWidget);
-    expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(find.text('View secret phrase'), findsOneWidget);
   });
 
   testWidgets('accounts current menu use case renders account actions', (
@@ -25,7 +25,7 @@ void main() {
     await _pumpAccountsUseCase(tester, buildAccountsCurrentMenuUseCase);
 
     expect(tester.takeException(), isNull);
-    expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(find.text('View secret phrase'), findsOneWidget);
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Copy address'), findsOneWidget);
     expect(find.text('Send ZEC'), findsNothing);


### PR DESCRIPTION
## Problem

Secret passphrases are only reachable through Settings, so users looking from Accounts cannot find them where Keplr muscle memory suggests. The shortcut needs to target the selected software account, not only the active or first account, and it must never appear for Keystone accounts.

## Solution

- Add a key-icon `View secret phrase` action to current and other software account menus.
- Pass the selected account UUID into the existing password-gated reveal flow without switching the active account.
- Keep the action absent for Keystone hardware accounts.
- Use a compact 176px menu while preserving OS text scaling; oversized labels use ellipsis instead of shrinking.
- Add account-menu, selected-account reveal, and Widgetbook coverage.

## Verification

- `fvm flutter test test/core/widgets/app_context_menu_test.dart test/features/accounts/accounts_screen_test.dart --concurrency=1`
- Focused current/other account menu Widgetbook tests
- Focused `fvm flutter analyze` for changed implementation and test files
- Visible macOS Widgetbook check for current software, other software, and Keystone menus
