### PR TITLE
Compact desktop sidebar balance labels

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -147,6 +147,11 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     builder: buildDesktopHomeIronwoodMigrationInProgressUseCase,
   ),
   FigmaCompareScenario(
+    id: 'desktop-home-sidebar-compact-balances',
+    description: 'Desktop home sidebar with compact K balance labels',
+    builder: buildDesktopHomeSidebarCompactBalancesUseCase,
+  ),
+  FigmaCompareScenario(
     id: 'ironwood-migration-intro',
     description: 'Ironwood migration intro screen',
     builder: buildIronwoodMigrationIntroUseCase,

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -34,6 +34,50 @@ import '../widgets/app_toast.dart';
 import 'app_desktop_shell.dart';
 import 'desktop_sidebar_spacing.dart';
 
+final _sidebarThousandZatoshi = zatoshiPerZec * BigInt.from(1000);
+final _sidebarMillionZatoshi = zatoshiPerZec * BigInt.from(1000000);
+
+String _formatSidebarBalance(BigInt zatoshi) {
+  final absolute = zatoshi.abs();
+  if (absolute >= _sidebarMillionZatoshi) {
+    return _formatSidebarCompactBalance(
+      zatoshi,
+      unitZatoshi: _sidebarMillionZatoshi,
+      suffix: 'M',
+    );
+  }
+  if (absolute >= _sidebarThousandZatoshi) {
+    return _formatSidebarCompactBalance(
+      zatoshi,
+      unitZatoshi: _sidebarThousandZatoshi,
+      suffix: 'K',
+    );
+  }
+
+  final minimumVisibleZatoshi = BigInt.from(10000);
+  if (absolute > BigInt.zero && absolute < minimumVisibleZatoshi) {
+    return '${zatoshi.isNegative ? '-' : ''}<0.0001';
+  }
+  return ZecAmount.fromZatoshi(
+    zatoshi,
+  ).pretty(maxFractionDigits: 4, hideZeroFraction: true).amountText;
+}
+
+String _formatSidebarCompactBalance(
+  BigInt zatoshi, {
+  required BigInt unitZatoshi,
+  required String suffix,
+}) {
+  final scaledThousandths = (zatoshi.abs() * BigInt.from(1000)) ~/ unitZatoshi;
+  final whole = scaledThousandths ~/ BigInt.from(1000);
+  var fraction = (scaledThousandths % BigInt.from(1000))
+      .toString()
+      .padLeft(3, '0')
+      .replaceFirst(RegExp(r'0+$'), '');
+  if (fraction.isNotEmpty) fraction = '.$fraction';
+  return '${zatoshi.isNegative ? '-' : ''}$whole$fraction$suffix';
+}
+
 class AppMainSidebar extends ConsumerStatefulWidget {
   const AppMainSidebar({this.disabledRoutePaths = const {}, super.key});
 
@@ -335,7 +379,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
         !accountSync.hasAccountScopedData &&
         accountSync.failure == null;
     final balanceText =
-        '${ZecAmount.fromZatoshi(accountSync.displayTotalBalance).balance.amountText} '
+        '${_formatSidebarBalance(accountSync.displayTotalBalance)} '
         '$kZcashDefaultCurrencyTicker';
     final privacyModeEnabled = ref.watch(privacyModeProvider);
     final balanceLabel = hideAmountIfPrivacyMode(
@@ -535,11 +579,11 @@ class _SidebarMigrationHomeSection extends StatelessWidget {
         status.phase == kIronwoodMigrationReadyToMigratePhase &&
         (signingPartIndices == null || signingPartIndices.isNotEmpty);
     final orchardLabel = hideAmountIfPrivacyMode(
-      '${ZecAmount.fromZatoshi(orchardBalance).balance.amountText} ZEC',
+      '${_formatSidebarBalance(orchardBalance)} ZEC',
       privacyModeEnabled: privacyModeEnabled,
     );
     final ironwoodLabel = hideAmountIfPrivacyMode(
-      '${ZecAmount.fromZatoshi(ironwoodBalance).balance.amountText} ZEC',
+      '${_formatSidebarBalance(ironwoodBalance)} ZEC',
       privacyModeEnabled: privacyModeEnabled,
     );
 

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -792,6 +792,25 @@ Widget buildDesktopHomeIronwoodMigrationInProgressUseCase(
   );
 }
 
+Widget buildDesktopHomeSidebarCompactBalancesUseCase(BuildContext context) {
+  final status = _previewMigrationStatus(
+    kIronwoodMigrationBroadcastScheduledPhase,
+    activeRunId: 'preview-sidebar-compact-balances',
+  );
+  return _buildDesktopHomeUseCase(
+    accountState: _accountsDesignState,
+    syncState: _homeSyncedState(
+      orchardBalance: BigInt.from(1_234_567_890_000),
+      ironwoodBalance: BigInt.from(5_240_000_000),
+    ),
+    migrationCta: IronwoodHomeMigrationCtaState.resume(
+      network: 'main',
+      accountUuid: _accountsDesignState.activeAccountUuid!,
+      status: status,
+    ),
+  );
+}
+
 Widget buildDesktopHomeIronwoodMigrationAnnouncementUseCase(
   BuildContext context,
 ) {

--- a/test/app_main_sidebar_test.dart
+++ b/test/app_main_sidebar_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
     as frb;
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
@@ -19,6 +21,14 @@ import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 void main() {
+  setUpAll(() async {
+    final loader = FontLoader('Geist')
+      ..addFont(rootBundle.load('assets/fonts/Geist-Regular.ttf'))
+      ..addFont(rootBundle.load('assets/fonts/Geist-Medium.ttf'))
+      ..addFont(rootBundle.load('assets/fonts/Geist-SemiBold.ttf'));
+    await loader.load();
+  });
+
   const failureLabels = {
     SyncFailureKind.endpoint: 'Syncing failed. Endpoint error...',
     SyncFailureKind.databaseBusy: 'Syncing failed. Wallet data busy...',
@@ -108,6 +118,109 @@ void main() {
           .widget<Text>(find.byKey(const ValueKey('sidebar_ironwood_balance')))
           .data,
       contains('12'),
+    );
+  });
+
+  testWidgets('sidebar limits visible balance fractions to four places', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _sidebarHarness(
+        SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          isSyncComplete: true,
+          displayTotalBalance: BigInt.from(8_242_330_885),
+          displayOrchardBalance: BigInt.from(285_885),
+          displayIronwoodBalance: BigInt.from(5_240_000_000),
+        ),
+        migrationCoordinatorState: IronwoodMigrationCoordinatorState(
+          statuses: {'account-1': _readyMigrationStatus},
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('82.4233 ZEC'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(find.byKey(const ValueKey('sidebar_orchard_balance')))
+          .data,
+      '0.0028 ZEC',
+    );
+    expect(
+      tester
+          .widget<Text>(find.byKey(const ValueKey('sidebar_ironwood_balance')))
+          .data,
+      '52.4 ZEC',
+    );
+  });
+
+  testWidgets('sidebar keeps tiny positive balances visibly nonzero', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _sidebarHarness(
+        SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          isSyncComplete: true,
+          displayTotalBalance: BigInt.one,
+          displayOrchardBalance: BigInt.one,
+          displayIronwoodBalance: BigInt.one,
+        ),
+        migrationCoordinatorState: IronwoodMigrationCoordinatorState(
+          statuses: {'account-1': _readyMigrationStatus},
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('<0.0001 ZEC'), findsNWidgets(3));
+  });
+
+  testWidgets('sidebar abbreviates thousand and million ZEC balances', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _sidebarHarness(
+        SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          isSyncComplete: true,
+          displayTotalBalance: BigInt.from(1_000_000_000_000),
+          displayOrchardBalance: BigInt.from(1_234_567_890_000),
+          displayIronwoodBalance: BigInt.from(123_456_789_000_000),
+        ),
+        migrationCoordinatorState: IronwoodMigrationCoordinatorState(
+          statuses: {'account-1': _readyMigrationStatus},
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('10K ZEC'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(find.byKey(const ValueKey('sidebar_orchard_balance')))
+          .data,
+      '12.345K ZEC',
+    );
+    expect(
+      tester
+          .widget<Text>(find.byKey(const ValueKey('sidebar_ironwood_balance')))
+          .data,
+      '1.234M ZEC',
+    );
+    expect(
+      tester.renderObject<RenderParagraph>(find.text('Home')).didExceedMaxLines,
+      isFalse,
+    );
+    expect(
+      tester
+          .renderObject<RenderParagraph>(find.text('Ironwood'))
+          .didExceedMaxLines,
+      isFalse,
     );
   });
 


### PR DESCRIPTION
## Problem

Long decimal balances and large ZEC holdings could squeeze or truncate the Home and Ironwood labels in the desktop sidebar.

## Solution

- Limit regular sidebar balances to four fractional digits and trim trailing zeros.
- Display tiny positive balances as `<0.0001 ZEC`.
- Compact balances from 1,000 ZEC with `K` and from 1,000,000 ZEC with `M`.
- Apply the same formatter to total, Orchard, and Ironwood sidebar balances.
- Add deterministic desktop coverage using the production Geist font and verify labels do not exceed one line.

## Validation

- `fvm flutter test test/app_main_sidebar_test.dart`
- Focused `fvm flutter analyze` for all changed Dart files
- `scripts/figma-compare.sh widget --scenario desktop-home-sidebar-compact-balances --theme light`
- `git diff --check`

Linear: VZR-133