### PR TITLE
Add secret passphrase shortcut to mobile account menus

### DIFF
--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -98,7 +98,9 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
       path: '/settings/seed-phrase',
       pageBuilder: (context, state) => CupertinoPage(
         key: state.pageKey,
-        child: const MobileSeedPhraseScreen(),
+        child: MobileSeedPhraseScreen(
+          accountUuid: state.extra is String ? state.extra as String : null,
+        ),
       ),
     ),
     GoRoute(

--- a/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
+++ b/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
@@ -126,7 +126,7 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
     );
     final anchorRect = anchorTopLeft & anchorRenderObject.size;
     final overlaySize = overlayRenderObject.size;
-    final menuWidth = account.isHardware ? 173.0 : 232.0;
+    const menuWidth = 176.0;
     const menuPadding = EdgeInsets.symmetric(
       horizontal: AppSpacing.xxs,
       vertical: AppSpacing.sm,
@@ -182,9 +182,22 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
       required _AccountAction action,
       Color? textColor,
       Color? iconColor,
+      bool scaleLabelToFit = false,
     }) {
       final itemTextColor = textColor ?? colors.text.inverse;
       final itemIconColor = iconColor ?? colors.icon.inverse;
+      final labelText = Text(
+        label,
+        maxLines: 1,
+        softWrap: false,
+        overflow: scaleLabelToFit
+            ? TextOverflow.visible
+            : TextOverflow.ellipsis,
+        style: AppTypography.labelLarge.copyWith(
+          color: itemTextColor,
+          fontWeight: FontWeight.w400,
+        ),
+      );
       return Semantics(
         button: true,
         label: label,
@@ -208,15 +221,13 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
                 ),
                 const SizedBox(width: AppSpacing.xs),
                 Expanded(
-                  child: Text(
-                    label,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: AppTypography.labelLarge.copyWith(
-                      color: itemTextColor,
-                      fontWeight: FontWeight.w400,
-                    ),
-                  ),
+                  child: scaleLabelToFit
+                      ? FittedBox(
+                          fit: BoxFit.scaleDown,
+                          alignment: Alignment.centerLeft,
+                          child: labelText,
+                        )
+                      : labelText,
                 ),
               ],
             ),
@@ -230,8 +241,9 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
         item(
           key: const ValueKey('mobile_account_menu_secret_passphrase'),
           iconName: AppIcons.key,
-          label: 'View secret passphrase',
+          label: 'View secret phrase',
           action: _AccountAction.viewSecretPassphrase,
+          scaleLabelToFit: true,
         ),
       item(
         key: const ValueKey('mobile_account_menu_copy'),

--- a/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
+++ b/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
@@ -126,7 +126,7 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
     );
     final anchorRect = anchorTopLeft & anchorRenderObject.size;
     final overlaySize = overlayRenderObject.size;
-    const menuWidth = 176.0;
+    const menuWidth = 208.0;
     const menuPadding = EdgeInsets.symmetric(
       horizontal: AppSpacing.xxs,
       vertical: AppSpacing.sm,
@@ -182,22 +182,9 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
       required _AccountAction action,
       Color? textColor,
       Color? iconColor,
-      bool scaleLabelToFit = false,
     }) {
       final itemTextColor = textColor ?? colors.text.inverse;
       final itemIconColor = iconColor ?? colors.icon.inverse;
-      final labelText = Text(
-        label,
-        maxLines: 1,
-        softWrap: false,
-        overflow: scaleLabelToFit
-            ? TextOverflow.visible
-            : TextOverflow.ellipsis,
-        style: AppTypography.labelLarge.copyWith(
-          color: itemTextColor,
-          fontWeight: FontWeight.w400,
-        ),
-      );
       return Semantics(
         button: true,
         label: label,
@@ -221,13 +208,16 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
                 ),
                 const SizedBox(width: AppSpacing.xs),
                 Expanded(
-                  child: scaleLabelToFit
-                      ? FittedBox(
-                          fit: BoxFit.scaleDown,
-                          alignment: Alignment.centerLeft,
-                          child: labelText,
-                        )
-                      : labelText,
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    softWrap: false,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: itemTextColor,
+                      fontWeight: FontWeight.w400,
+                    ),
+                  ),
                 ),
               ],
             ),
@@ -243,7 +233,6 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
           iconName: AppIcons.key,
           label: 'View secret phrase',
           action: _AccountAction.viewSecretPassphrase,
-          scaleLabelToFit: true,
         ),
       item(
         key: const ValueKey('mobile_account_menu_copy'),

--- a/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
+++ b/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
@@ -37,11 +37,13 @@ class MobileAccountsScreen extends ConsumerStatefulWidget {
   const MobileAccountsScreen({
     this.initialSheetAccountUuid,
     this.initialSheet,
+    this.initialOpenMenuAccountUuid,
     super.key,
   });
 
   final String? initialSheetAccountUuid;
   final MobileAccountsInitialSheet? initialSheet;
+  final String? initialOpenMenuAccountUuid;
 
   @override
   ConsumerState<MobileAccountsScreen> createState() =>
@@ -54,6 +56,7 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
   var _busy = false;
   OverlayEntry? _rowMenuEntry;
   String? _openRowMenuAccountUuid;
+  var _didOpenInitialRowMenu = false;
 
   @override
   void initState() {
@@ -95,8 +98,9 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
   }
 
   /// Anchored dark popup at the row's ⋯ button — Figma `Accounts` row
-  /// menu: copy address / send ZEC / edit, with removal separated below
-  /// a divider when the eligibility rule allows it.
+  /// menu: secret passphrase (software only) / copy address / send ZEC / edit,
+  /// with removal separated below a divider when the eligibility rule allows
+  /// it.
   void _showRowMenu(AccountInfo account, BuildContext anchorContext) {
     if (_rowMenuEntry != null) {
       final wasOpenForAccount = _openRowMenuAccountUuid == account.uuid;
@@ -122,19 +126,21 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
     );
     final anchorRect = anchorTopLeft & anchorRenderObject.size;
     final overlaySize = overlayRenderObject.size;
-    const menuWidth = 173.0;
+    final menuWidth = account.isHardware ? 173.0 : 232.0;
     const menuPadding = EdgeInsets.symmetric(
       horizontal: AppSpacing.xxs,
       vertical: AppSpacing.sm,
     );
-    final menuHeight = switch ((isCurrentAccount, canRemove)) {
+    final baseMenuHeight = switch ((isCurrentAccount, canRemove)) {
       (true, true) => 139.0,
       (true, false) => 92.0,
       (false, true) => 173.0,
       (false, false) => 126.0,
     };
+    final menuHeight = baseMenuHeight + (account.isHardware ? 0 : 34);
     const bottomNavClearance = kMobileTabBarHeight + AppSpacing.lg;
     final colors = context.colors;
+    final appTheme = AppTheme.of(context);
     final menuMaxTop = math.max(
       AppSpacing.sm,
       overlaySize.height - bottomNavClearance - menuHeight,
@@ -155,6 +161,8 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         switch (action) {
+          case _AccountAction.viewSecretPassphrase:
+            context.push('/settings/seed-phrase', extra: account.uuid);
           case _AccountAction.copy:
             unawaited(_copyAddress(account));
           case _AccountAction.send:
@@ -218,6 +226,13 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
     }
 
     final menuItems = [
+      if (!account.isHardware)
+        item(
+          key: const ValueKey('mobile_account_menu_secret_passphrase'),
+          iconName: AppIcons.key,
+          label: 'View secret passphrase',
+          action: _AccountAction.viewSecretPassphrase,
+        ),
       item(
         key: const ValueKey('mobile_account_menu_copy'),
         iconName: AppIcons.copy,
@@ -265,31 +280,34 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
             right: menuRight,
             // Material ancestor: root overlays have none, and Text
             // would otherwise fall back to the debug underline style.
-            child: Material(
-              type: MaterialType.transparency,
-              child: DefaultTextStyle.merge(
-                style: const TextStyle(decoration: TextDecoration.none),
-                child: SizedBox(
-                  key: const ValueKey('mobile_account_menu_card'),
-                  width: menuWidth,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: colors.background.inverse,
-                      borderRadius: BorderRadius.circular(AppRadii.medium),
-                      border: Border.all(color: colors.border.inverseOpacity),
-                      boxShadow: appContextMenuShadow,
-                    ),
-                    child: Padding(
-                      padding: menuPadding,
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          for (var i = 0; i < menuItems.length; i++) ...[
-                            if (i > 0) const SizedBox(height: AppSpacing.xs),
-                            menuItems[i],
+            child: AppTheme(
+              data: appTheme,
+              child: Material(
+                type: MaterialType.transparency,
+                child: DefaultTextStyle.merge(
+                  style: const TextStyle(decoration: TextDecoration.none),
+                  child: SizedBox(
+                    key: const ValueKey('mobile_account_menu_card'),
+                    width: menuWidth,
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: colors.background.inverse,
+                        borderRadius: BorderRadius.circular(AppRadii.medium),
+                        border: Border.all(color: colors.border.inverseOpacity),
+                        boxShadow: appContextMenuShadow,
+                      ),
+                      child: Padding(
+                        padding: menuPadding,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            for (var i = 0; i < menuItems.length; i++) ...[
+                              if (i > 0) const SizedBox(height: AppSpacing.xs),
+                              menuItems[i],
+                            ],
                           ],
-                        ],
+                        ),
                       ),
                     ),
                   ),
@@ -315,6 +333,20 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
       _openRowMenuAccountUuid = null;
     }
     entry.remove();
+  }
+
+  void _openInitialRowMenuIfNeeded(
+    AccountInfo account,
+    BuildContext anchorContext,
+  ) {
+    if (_didOpenInitialRowMenu ||
+        widget.initialOpenMenuAccountUuid != account.uuid) {
+      return;
+    }
+    _didOpenInitialRowMenu = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _showRowMenu(account, anchorContext);
+    });
   }
 
   Future<String?> _loadShieldedAddress(AccountInfo account) async {
@@ -549,36 +581,43 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
       minRowHeight: 44,
       textStyle: AppTypography.labelLarge,
       trailing: Builder(
-        builder: (anchorContext) => Semantics(
-          button: true,
-          label: 'Account options for ${account.name}',
-          excludeSemantics: true,
-          child: GestureDetector(
-            key: ValueKey('mobile_accounts_menu_${account.uuid}'),
-            behavior: HitTestBehavior.opaque,
-            onTap: enabled ? () => _showRowMenu(account, anchorContext) : null,
-            child: SizedBox(
-              width: 44,
-              height: 44,
-              child: Center(
-                child: DecoratedBox(
-                  key: ValueKey('mobile_accounts_menu_button_${account.uuid}'),
-                  decoration: BoxDecoration(
-                    color: menuOpen
-                        ? colors.state.hover
-                        : const Color(0x00000000),
-                    borderRadius: BorderRadius.circular(AppRadii.xSmall),
-                  ),
-                  child: SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: Center(
-                      child: Transform.rotate(
-                        angle: -math.pi / 2,
-                        child: AppIcon(
-                          AppIcons.options,
-                          size: AppIconSize.medium,
-                          color: colors.icon.accent,
+        builder: (anchorContext) {
+          _openInitialRowMenuIfNeeded(account, anchorContext);
+          return Semantics(
+            button: true,
+            label: 'Account options for ${account.name}',
+            excludeSemantics: true,
+            child: GestureDetector(
+              key: ValueKey('mobile_accounts_menu_${account.uuid}'),
+              behavior: HitTestBehavior.opaque,
+              onTap: enabled
+                  ? () => _showRowMenu(account, anchorContext)
+                  : null,
+              child: SizedBox(
+                width: 44,
+                height: 44,
+                child: Center(
+                  child: DecoratedBox(
+                    key: ValueKey(
+                      'mobile_accounts_menu_button_${account.uuid}',
+                    ),
+                    decoration: BoxDecoration(
+                      color: menuOpen
+                          ? colors.state.hover
+                          : const Color(0x00000000),
+                      borderRadius: BorderRadius.circular(AppRadii.xSmall),
+                    ),
+                    child: SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: Center(
+                        child: Transform.rotate(
+                          angle: -math.pi / 2,
+                          child: AppIcon(
+                            AppIcons.options,
+                            size: AppIconSize.medium,
+                            color: colors.icon.accent,
+                          ),
                         ),
                       ),
                     ),
@@ -586,14 +625,14 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
                 ),
               ),
             ),
-          ),
-        ),
+          );
+        },
       ),
     );
   }
 }
 
-enum _AccountAction { copy, send, edit, remove }
+enum _AccountAction { viewSecretPassphrase, copy, send, edit, remove }
 
 class _AccountsGroupCard extends StatelessWidget {
   const _AccountsGroupCard({

--- a/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
@@ -127,13 +127,24 @@ class _MobileSeedPhraseScreenState
 
   Future<void> _tryBiometricGate() async {
     if (_checking || _stage != _SeedStage.confirmAccess) return;
+    final expectedAccountUuid = _targetAccount(
+      ref.read(accountProvider).value,
+    )?.uuid;
+    final accessCheckGeneration = ++_accessCheckGeneration;
     final biometric = await ref.read(biometricUnlockProvider.future);
-    if (!mounted || !biometric.usable) return;
+    if (!mounted) return;
+    if (accessCheckGeneration != _accessCheckGeneration ||
+        _targetAccountChanged(expectedAccountUuid)) {
+      _showTargetAccountChangedError();
+      return;
+    }
+    if (!biometric.usable) return;
     final wasEnabled = biometric.enabled;
     // The biometric sheet pushes the app to `inactive`; suppress the privacy
     // shield for its duration so the phrase revealed on success doesn't flash
     // the blur cover during the inactive→resumed transition. The environment
     // controller releases the suppression on resume.
+    setState(() => _checking = true);
     _privacyController.beginAuthPrompt();
     String? readResult;
     try {
@@ -144,15 +155,21 @@ class _MobileSeedPhraseScreenState
       _privacyController.endAuthPrompt();
     }
     if (!mounted) return;
+    if (accessCheckGeneration != _accessCheckGeneration ||
+        _targetAccountChanged(expectedAccountUuid)) {
+      _showTargetAccountChangedError();
+      return;
+    }
     final passcode = readResult;
     if (passcode == null) {
       final now = ref.read(biometricUnlockProvider).value;
-      if (wasEnabled && now != null && !now.enabled) {
-        setState(() {
-          _entry = '';
+      setState(() {
+        _entry = '';
+        _checking = false;
+        if (wasEnabled && now != null && !now.enabled) {
           _gateError = biometric.availability.kind.changedMessage;
-        });
-      }
+        }
+      });
       return;
     }
     setState(() {
@@ -285,11 +302,15 @@ class _MobileSeedPhraseScreenState
   }
 
   void _handleTargetAccountChanged() {
+    _accessCheckGeneration += 1;
+    _birthdayLoadGeneration += 1;
     if (_stage == _SeedStage.confirmAccess && !_checking && _mnemonic == null) {
       return;
     }
-    _accessCheckGeneration += 1;
-    _birthdayLoadGeneration += 1;
+    _showTargetAccountChangedError();
+  }
+
+  void _showTargetAccountChangedError() {
     setState(() {
       _stage = _SeedStage.confirmAccess;
       _entry = '';

--- a/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
@@ -47,6 +47,8 @@ class MobileSeedPhraseScreen extends ConsumerStatefulWidget {
     this.screenshotStream,
     this.privacyOverlayController,
     this.loadBirthday = true,
+    this.birthdayHeightLoader,
+    this.birthdayBlockTimeLoader,
     super.key,
   });
 
@@ -61,6 +63,12 @@ class MobileSeedPhraseScreen extends ConsumerStatefulWidget {
 
   @visibleForTesting
   final bool loadBirthday;
+
+  @visibleForTesting
+  final Future<int> Function(String accountUuid)? birthdayHeightLoader;
+
+  @visibleForTesting
+  final Future<int> Function(int height)? birthdayBlockTimeLoader;
 
   @override
   ConsumerState<MobileSeedPhraseScreen> createState() =>
@@ -79,6 +87,7 @@ class _MobileSeedPhraseScreenState
   int? _birthdayHeight;
   int? _birthdayBlockTime;
   bool _birthdayLoading = false;
+  int _birthdayLoadGeneration = 0;
 
   StreamSubscription<void>? _screenshotSub;
   bool _screenshotSheetShowing = false;
@@ -269,6 +278,7 @@ class _MobileSeedPhraseScreenState
     if (_stage == _SeedStage.confirmAccess && !_checking && _mnemonic == null) {
       return;
     }
+    _birthdayLoadGeneration += 1;
     setState(() {
       _stage = _SeedStage.confirmAccess;
       _entry = '';
@@ -306,48 +316,73 @@ class _MobileSeedPhraseScreenState
       _handleTargetAccountChanged();
       return;
     }
+    final birthdayLoadGeneration = ++_birthdayLoadGeneration;
     setState(() {
       _mnemonic = mnemonic;
       _revealError = revealError;
       _stage = _SeedStage.reveal;
       _checking = false;
-      _birthdayLoading = mnemonic != null;
+      _birthdayLoading = mnemonic != null && widget.loadBirthday;
     });
     if (mnemonic != null && account != null && widget.loadBirthday) {
-      unawaited(_loadBirthday(account.uuid));
+      unawaited(_loadBirthday(account.uuid, birthdayLoadGeneration));
     }
   }
 
-  Future<void> _loadBirthday(String accountUuid) async {
-    try {
-      final dbPath = await getWalletDbPath();
-      final endpoint = ref.read(rpcEndpointProvider);
-      final height = await rust_sync.getExportBirthdayHeight(
-        dbPath: dbPath,
-        network: endpoint.networkName,
-        accountUuid: accountUuid,
-      );
-      if (!mounted) return;
-      setState(() => _birthdayHeight = height.toInt());
+  bool _canApplyBirthdayLoad(String accountUuid, int generation) {
+    return mounted &&
+        generation == _birthdayLoadGeneration &&
+        _stage == _SeedStage.reveal &&
+        _mnemonic != null &&
+        !_targetAccountChanged(accountUuid);
+  }
 
-      final blockTime = await ref
-          .read(rpcEndpointFailoverProvider.notifier)
-          .runWithEndpointFallback(
-            operation: 'birthday block time',
-            action: (endpoint) => rust_sync.getBlockTime(
-              lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-              height: height,
-            ),
-          )
-          .timeout(const Duration(seconds: 10));
-      if (!mounted) return;
+  Future<int> _fetchBirthdayHeight(String accountUuid) async {
+    final loader = widget.birthdayHeightLoader;
+    if (loader != null) return loader(accountUuid);
+
+    final dbPath = await getWalletDbPath();
+    final endpoint = ref.read(rpcEndpointProvider);
+    final height = await rust_sync.getExportBirthdayHeight(
+      dbPath: dbPath,
+      network: endpoint.networkName,
+      accountUuid: accountUuid,
+    );
+    return height.toInt();
+  }
+
+  Future<int> _fetchBirthdayBlockTime(int height) async {
+    final loader = widget.birthdayBlockTimeLoader;
+    if (loader != null) return loader(height);
+
+    final blockTime = await ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .runWithEndpointFallback(
+          operation: 'birthday block time',
+          action: (endpoint) => rust_sync.getBlockTime(
+            lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+            height: BigInt.from(height),
+          ),
+        )
+        .timeout(const Duration(seconds: 10));
+    return blockTime.toInt();
+  }
+
+  Future<void> _loadBirthday(String accountUuid, int generation) async {
+    try {
+      final height = await _fetchBirthdayHeight(accountUuid);
+      if (!_canApplyBirthdayLoad(accountUuid, generation)) return;
+      setState(() => _birthdayHeight = height);
+
+      final blockTime = await _fetchBirthdayBlockTime(height);
+      if (!_canApplyBirthdayLoad(accountUuid, generation)) return;
       setState(() {
-        _birthdayBlockTime = blockTime.toInt() > 0 ? blockTime.toInt() : null;
+        _birthdayBlockTime = blockTime > 0 ? blockTime : null;
         _birthdayLoading = false;
       });
     } catch (e, st) {
       log('MobileSeedPhrase: birthday load failed: $e\n$st');
-      if (!mounted) return;
+      if (!_canApplyBirthdayLoad(accountUuid, generation)) return;
       setState(() => _birthdayLoading = false);
     }
   }

--- a/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
@@ -81,6 +81,7 @@ class _MobileSeedPhraseScreenState
   var _entry = '';
   var _checking = false;
   String? _gateError;
+  int _accessCheckGeneration = 0;
 
   String? _mnemonic;
   String? _revealError;
@@ -178,6 +179,10 @@ class _MobileSeedPhraseScreenState
   }
 
   Future<void> _confirmPasscode() async {
+    final expectedAccountUuid = _targetAccount(
+      ref.read(accountProvider).value,
+    )?.uuid;
+    final accessCheckGeneration = ++_accessCheckGeneration;
     setState(() => _checking = true);
     try {
       final valid = await ref
@@ -193,7 +198,12 @@ class _MobileSeedPhraseScreenState
         });
         return;
       }
-      await _reveal();
+      if (accessCheckGeneration != _accessCheckGeneration ||
+          _targetAccountChanged(expectedAccountUuid)) {
+        _handleTargetAccountChanged();
+        return;
+      }
+      await _reveal(expectedAccountUuid);
     } catch (e, st) {
       log('MobileSeedPhrase: passcode confirm failed: $e\n$st');
       if (!mounted) return;
@@ -269,7 +279,7 @@ class _MobileSeedPhraseScreenState
     return null;
   }
 
-  bool _targetAccountChanged(String expectedAccountUuid) {
+  bool _targetAccountChanged(String? expectedAccountUuid) {
     final accountState = ref.read(accountProvider).value;
     return _targetAccount(accountState)?.uuid != expectedAccountUuid;
   }
@@ -278,6 +288,7 @@ class _MobileSeedPhraseScreenState
     if (_stage == _SeedStage.confirmAccess && !_checking && _mnemonic == null) {
       return;
     }
+    _accessCheckGeneration += 1;
     _birthdayLoadGeneration += 1;
     setState(() {
       _stage = _SeedStage.confirmAccess;
@@ -292,9 +303,13 @@ class _MobileSeedPhraseScreenState
     });
   }
 
-  Future<void> _reveal() async {
+  Future<void> _reveal(String? expectedAccountUuid) async {
     final accountState = ref.read(accountProvider).value;
     final account = _targetAccount(accountState);
+    if (account?.uuid != expectedAccountUuid) {
+      _handleTargetAccountChanged();
+      return;
+    }
     String? revealError;
     String? mnemonic;
     if (account == null) {
@@ -312,7 +327,7 @@ class _MobileSeedPhraseScreenState
       }
     }
     if (!mounted) return;
-    if (account != null && _targetAccountChanged(account.uuid)) {
+    if (_targetAccountChanged(expectedAccountUuid)) {
       _handleTargetAccountChanged();
       return;
     }

--- a/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
@@ -43,11 +43,14 @@ enum _SeedStage { confirmAccess, reveal }
 /// state, and the wallet birthday loads best-effort alongside it.
 class MobileSeedPhraseScreen extends ConsumerStatefulWidget {
   const MobileSeedPhraseScreen({
+    this.accountUuid,
     this.screenshotStream,
     this.privacyOverlayController,
     this.loadBirthday = true,
     super.key,
   });
+
+  final String? accountUuid;
 
   /// Test seam — production listens to the platform screenshot events.
   @visibleForTesting
@@ -247,12 +250,47 @@ class _MobileSeedPhraseScreenState
 
   // ── Reveal ─────────────────────────────────────────────────────────
 
+  AccountInfo? _targetAccount(AccountState? accountState) {
+    if (accountState == null) return null;
+    final requestedUuid = widget.accountUuid;
+    if (requestedUuid == null) return accountState.activeAccount;
+    for (final account in accountState.accounts) {
+      if (account.uuid == requestedUuid) return account;
+    }
+    return null;
+  }
+
+  bool _targetAccountChanged(String expectedAccountUuid) {
+    final accountState = ref.read(accountProvider).value;
+    return _targetAccount(accountState)?.uuid != expectedAccountUuid;
+  }
+
+  void _handleTargetAccountChanged() {
+    if (_stage == _SeedStage.confirmAccess && !_checking && _mnemonic == null) {
+      return;
+    }
+    setState(() {
+      _stage = _SeedStage.confirmAccess;
+      _entry = '';
+      _checking = false;
+      _gateError = 'Selected account changed. Enter your passcode again.';
+      _mnemonic = null;
+      _revealError = null;
+      _birthdayHeight = null;
+      _birthdayBlockTime = null;
+      _birthdayLoading = false;
+    });
+  }
+
   Future<void> _reveal() async {
-    final account = ref.read(accountProvider).value?.activeAccount;
+    final accountState = ref.read(accountProvider).value;
+    final account = _targetAccount(accountState);
     String? revealError;
     String? mnemonic;
     if (account == null) {
-      revealError = 'No active account is selected.';
+      revealError = widget.accountUuid == null
+          ? 'No active account is selected.'
+          : 'The selected account is no longer available.';
     } else if (account.isHardware) {
       revealError = 'Secret passphrase is not available for hardware accounts.';
     } else {
@@ -264,6 +302,10 @@ class _MobileSeedPhraseScreenState
       }
     }
     if (!mounted) return;
+    if (account != null && _targetAccountChanged(account.uuid)) {
+      _handleTargetAccountChanged();
+      return;
+    }
     setState(() {
       _mnemonic = mnemonic;
       _revealError = revealError;
@@ -373,6 +415,13 @@ class _MobileSeedPhraseScreenState
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<AccountInfo?>(
+      accountProvider.select((state) => _targetAccount(state.value)),
+      (previous, next) {
+        if (previous?.uuid == next?.uuid) return;
+        _handleTargetAccountChanged();
+      },
+    );
     final colors = context.colors;
     return Scaffold(
       backgroundColor: colors.background.window,

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -601,6 +601,20 @@ Widget buildMobileAccountsUseCase(BuildContext context) {
   return _buildMobileAccountsUseCase(_accountsDesignState);
 }
 
+Widget buildMobileAccountsSoftwareMenuUseCase(BuildContext context) {
+  return _buildMobileAccountsUseCase(
+    _accountsDesignState,
+    initialOpenMenuAccountUuid: 'preview-account-3',
+  );
+}
+
+Widget buildMobileAccountsKeystoneMenuUseCase(BuildContext context) {
+  return _buildMobileAccountsUseCase(
+    _accountsDesignState,
+    initialOpenMenuAccountUuid: 'preview-account-2',
+  );
+}
+
 Widget buildMobileAccountsEditAccountUseCase(BuildContext context) {
   return _buildMobileAccountsUseCase(
     _accountsDesignState,
@@ -1662,6 +1676,7 @@ Widget _buildMobileAccountsUseCase(
   AccountState accountState, {
   String? initialSheetAccountUuid,
   MobileAccountsInitialSheet? initialSheet,
+  String? initialOpenMenuAccountUuid,
   rust_sync.MigrationStatus? migrationStatus,
 }) {
   return ProviderScope(
@@ -1688,6 +1703,7 @@ Widget _buildMobileAccountsUseCase(
         child: _MobileAccountsHarness(
           initialSheetAccountUuid: initialSheetAccountUuid,
           initialSheet: initialSheet,
+          initialOpenMenuAccountUuid: initialOpenMenuAccountUuid,
         ),
       ),
     ),
@@ -2078,10 +2094,12 @@ class _MobileAccountsHarness extends StatefulWidget {
   const _MobileAccountsHarness({
     this.initialSheetAccountUuid,
     this.initialSheet,
+    this.initialOpenMenuAccountUuid,
   });
 
   final String? initialSheetAccountUuid;
   final MobileAccountsInitialSheet? initialSheet;
+  final String? initialOpenMenuAccountUuid;
 
   @override
   State<_MobileAccountsHarness> createState() => _MobileAccountsHarnessState();
@@ -2101,6 +2119,7 @@ class _MobileAccountsHarnessState extends State<_MobileAccountsHarness> {
           builder: (_, _) => MobileAccountsScreen(
             initialSheetAccountUuid: widget.initialSheetAccountUuid,
             initialSheet: widget.initialSheet,
+            initialOpenMenuAccountUuid: widget.initialOpenMenuAccountUuid,
           ),
         ),
         GoRoute(
@@ -2111,6 +2130,14 @@ class _MobileAccountsHarnessState extends State<_MobileAccountsHarness> {
         GoRoute(
           path: '/send',
           builder: (_, _) => const _PreviewRoutePlaceholder(label: '/send'),
+        ),
+        GoRoute(
+          path: '/settings/seed-phrase',
+          builder: (_, state) => _PreviewRoutePlaceholder(
+            label:
+                '/settings/seed-phrase '
+                '(${state.extra as String? ?? 'active account'})',
+          ),
         ),
       ],
     );

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -584,6 +584,14 @@ class WidgetbookApp extends StatelessWidget {
                       builder: buildMobileAccountsUseCase,
                     ),
                     WidgetbookUseCase(
+                      name: 'Software account menu',
+                      builder: buildMobileAccountsSoftwareMenuUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Keystone account menu',
+                      builder: buildMobileAccountsKeystoneMenuUseCase,
+                    ),
+                    WidgetbookUseCase(
                       name: 'Edit account',
                       builder: buildMobileAccountsEditAccountUseCase,
                     ),

--- a/test/features/accounts/mobile_accounts_screen_test.dart
+++ b/test/features/accounts/mobile_accounts_screen_test.dart
@@ -350,11 +350,11 @@ void main() {
     );
     expect(
       tester.getSize(find.byKey(const ValueKey('mobile_account_menu_card'))),
-      const Size(232, 207),
+      const Size(176, 207),
     );
     expect(
       tester.getSize(find.byKey(const ValueKey('mobile_account_menu_copy'))),
-      const Size(224, 26),
+      const Size(168, 26),
     );
     await tester.tapAt(const Offset(10, 10));
     await tester.pumpAndSettle();
@@ -367,7 +367,7 @@ void main() {
     expect(find.text('Remove account'), findsOneWidget);
     expect(
       tester.getSize(find.byKey(const ValueKey('mobile_account_menu_card'))),
-      const Size(232, 173),
+      const Size(176, 173),
     );
   });
 
@@ -390,7 +390,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('mobile_accounts_menu_b')));
     await tester.pumpAndSettle();
 
-    expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(find.text('View secret phrase'), findsOneWidget);
     final shortcutIcon = tester.widget<AppIcon>(
       find.descendant(
         of: find.byKey(const ValueKey('mobile_account_menu_secret_passphrase')),
@@ -426,7 +426,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('mobile_accounts_menu_b')));
     await tester.pumpAndSettle();
 
-    expect(find.text('View secret passphrase'), findsNothing);
+    expect(find.text('View secret phrase'), findsNothing);
     expect(
       find.byKey(const ValueKey('mobile_account_menu_secret_passphrase')),
       findsNothing,

--- a/test/features/accounts/mobile_accounts_screen_test.dart
+++ b/test/features/accounts/mobile_accounts_screen_test.dart
@@ -29,14 +29,19 @@ import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 import '../../fakes/fake_sync_notifier.dart';
 
-AccountInfo _account(String uuid, String name, {bool isSeedAnchor = false}) =>
-    AccountInfo(
-      uuid: uuid,
-      name: name,
-      order: 0,
-      profilePictureId: kDefaultProfilePictureId,
-      isSeedAnchor: isSeedAnchor,
-    );
+AccountInfo _account(
+  String uuid,
+  String name, {
+  bool isSeedAnchor = false,
+  bool isHardware = false,
+}) => AccountInfo(
+  uuid: uuid,
+  name: name,
+  order: 0,
+  profilePictureId: kDefaultProfilePictureId,
+  isSeedAnchor: isSeedAnchor,
+  isHardware: isHardware,
+);
 
 AppBootstrapState _bootstrap(AccountState accounts) => AppBootstrapState(
   initialLocation: '/accounts',
@@ -68,6 +73,11 @@ Widget _app(
       GoRoute(
         path: '/add-account',
         builder: (_, _) => const Text('add account route'),
+      ),
+      GoRoute(
+        path: '/settings/seed-phrase',
+        builder: (_, state) =>
+            Text('seed phrase route ${state.extra as String?}'),
       ),
       GoRoute(path: '/welcome', builder: (_, _) => const Text('welcome route')),
     ],
@@ -340,11 +350,11 @@ void main() {
     );
     expect(
       tester.getSize(find.byKey(const ValueKey('mobile_account_menu_card'))),
-      const Size(173, 173),
+      const Size(232, 207),
     );
     expect(
       tester.getSize(find.byKey(const ValueKey('mobile_account_menu_copy'))),
-      const Size(165, 26),
+      const Size(224, 26),
     );
     await tester.tapAt(const Offset(10, 10));
     await tester.pumpAndSettle();
@@ -357,7 +367,69 @@ void main() {
     expect(find.text('Remove account'), findsOneWidget);
     expect(
       tester.getSize(find.byKey(const ValueKey('mobile_account_menu_card'))),
-      const Size(173, 139),
+      const Size(232, 173),
+    );
+  });
+
+  testWidgets('software account menu opens its secret passphrase', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        AccountState(
+          accounts: [
+            _account('a', 'Knight', isSeedAnchor: true),
+            _account('b', 'Viking'),
+          ],
+          activeAccountUuid: 'a',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_accounts_menu_b')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('View secret passphrase'), findsOneWidget);
+    final shortcutIcon = tester.widget<AppIcon>(
+      find.descendant(
+        of: find.byKey(const ValueKey('mobile_account_menu_secret_passphrase')),
+        matching: find.byType(AppIcon),
+      ),
+    );
+    expect(shortcutIcon.name, AppIcons.key);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_account_menu_secret_passphrase')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('seed phrase route b'), findsOneWidget);
+  });
+
+  testWidgets('hardware account menu hides the secret passphrase shortcut', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        AccountState(
+          accounts: [
+            _account('a', 'Knight', isSeedAnchor: true),
+            _account('b', 'Keystone', isHardware: true),
+          ],
+          activeAccountUuid: 'a',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_accounts_menu_b')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('View secret passphrase'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('mobile_account_menu_secret_passphrase')),
+      findsNothing,
     );
   });
 

--- a/test/features/accounts/mobile_accounts_screen_test.dart
+++ b/test/features/accounts/mobile_accounts_screen_test.dart
@@ -350,11 +350,11 @@ void main() {
     );
     expect(
       tester.getSize(find.byKey(const ValueKey('mobile_account_menu_card'))),
-      const Size(176, 207),
+      const Size(208, 207),
     );
     expect(
       tester.getSize(find.byKey(const ValueKey('mobile_account_menu_copy'))),
-      const Size(168, 26),
+      const Size(200, 26),
     );
     await tester.tapAt(const Offset(10, 10));
     await tester.pumpAndSettle();
@@ -367,7 +367,7 @@ void main() {
     expect(find.text('Remove account'), findsOneWidget);
     expect(
       tester.getSize(find.byKey(const ValueKey('mobile_account_menu_card'))),
-      const Size(176, 173),
+      const Size(208, 173),
     );
   });
 
@@ -391,6 +391,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('View secret phrase'), findsOneWidget);
+    expect(
+      find.ancestor(
+        of: find.text('View secret phrase'),
+        matching: find.byType(FittedBox),
+      ),
+      findsNothing,
+    );
     final shortcutIcon = tester.widget<AppIcon>(
       find.descendant(
         of: find.byKey(const ValueKey('mobile_account_menu_secret_passphrase')),

--- a/test/features/settings/mobile_seed_phrase_screen_test.dart
+++ b/test/features/settings/mobile_seed_phrase_screen_test.dart
@@ -47,6 +47,15 @@ class _FakeSecurityNotifier extends AppSecurityNotifier {
   Future<bool> confirmPassword(String password) async => true;
 }
 
+class _ControlledSecurityNotifier extends AppSecurityNotifier {
+  _ControlledSecurityNotifier(this.result);
+
+  final Future<bool> result;
+
+  @override
+  Future<bool> confirmPassword(String password) => result;
+}
+
 class _FakeAccountNotifier extends AccountNotifier {
   _FakeAccountNotifier([this.initialState = _accountState]);
 
@@ -122,6 +131,7 @@ Widget _app({
   _FakeBiometricController? biometric,
   String? accountUuid,
   AccountNotifier Function()? accountNotifier,
+  AppSecurityNotifier Function()? securityNotifier,
   Future<int> Function(String accountUuid)? birthdayHeightLoader,
   Future<int> Function(int height)? birthdayBlockTimeLoader,
 }) {
@@ -129,7 +139,9 @@ Widget _app({
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
       accountProvider.overrideWith(accountNotifier ?? _FakeAccountNotifier.new),
-      appSecurityProvider.overrideWith(_FakeSecurityNotifier.new),
+      appSecurityProvider.overrideWith(
+        securityNotifier ?? _FakeSecurityNotifier.new,
+      ),
       if (biometric == null)
         biometricUnlockServiceProvider.overrideWithValue(_FakeBiometricUnlock())
       else
@@ -275,6 +287,41 @@ void main() {
 
     expect(find.text('222'), findsOneWidget);
     expect(requestedBlockTimes, [222]);
+  });
+
+  testWidgets('requires another confirmation when the account changes', (
+    tester,
+  ) async {
+    const accountState = AccountState(
+      accounts: [
+        AccountInfo(uuid: 'account-1', name: 'Current', order: 0),
+        AccountInfo(uuid: 'account-2', name: 'Other', order: 1),
+      ],
+      activeAccountUuid: 'account-1',
+    );
+    final accountNotifier = _FakeAccountNotifier(accountState);
+    final confirmation = Completer<bool>();
+
+    await tester.pumpWidget(
+      _app(
+        accountNotifier: () => accountNotifier,
+        securityNotifier: () =>
+            _ControlledSecurityNotifier(confirmation.future),
+      ),
+    );
+    await _revealSecret(tester);
+
+    accountNotifier.setActiveAccount('account-2');
+    await tester.pump();
+    confirmation.complete(true);
+    await tester.pumpAndSettle();
+
+    expect(accountNotifier.requestedMnemonicUuids, isEmpty);
+    expect(find.text('abandon'), findsNothing);
+    expect(
+      find.text('Selected account changed. Enter your passcode again.'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('confirm gate keeps biometric retry after prompt cancel', (

--- a/test/features/settings/mobile_seed_phrase_screen_test.dart
+++ b/test/features/settings/mobile_seed_phrase_screen_test.dart
@@ -61,6 +61,10 @@ class _FakeAccountNotifier extends AccountNotifier {
     requestedMnemonicUuids.add(uuid);
     return _mnemonic;
   }
+
+  void setActiveAccount(String uuid) {
+    state = AsyncData(state.requireValue.copyWith(activeAccountUuid: uuid));
+  }
 }
 
 class _FakeBiometricUnlock extends BiometricUnlock {
@@ -118,6 +122,8 @@ Widget _app({
   _FakeBiometricController? biometric,
   String? accountUuid,
   AccountNotifier Function()? accountNotifier,
+  Future<int> Function(String accountUuid)? birthdayHeightLoader,
+  Future<int> Function(int height)? birthdayBlockTimeLoader,
 }) {
   return ProviderScope(
     overrides: [
@@ -137,7 +143,9 @@ Widget _app({
         accountUuid: accountUuid,
         screenshotStream: screenshotStream,
         privacyOverlayController: privacyOverlayController,
-        loadBirthday: false,
+        loadBirthday: birthdayHeightLoader != null,
+        birthdayHeightLoader: birthdayHeightLoader,
+        birthdayBlockTimeLoader: birthdayBlockTimeLoader,
       ),
     ),
   );
@@ -217,6 +225,56 @@ void main() {
     expect(accountNotifier.requestedMnemonicUuids, ['account-2']);
     expect(accountNotifier.state.requireValue.activeAccountUuid, 'account-1');
     expect(find.text('abandon'), findsOneWidget);
+  });
+
+  testWidgets('ignores a stale birthday load after the account changes', (
+    tester,
+  ) async {
+    const accountState = AccountState(
+      accounts: [
+        AccountInfo(uuid: 'account-1', name: 'Current', order: 0),
+        AccountInfo(uuid: 'account-2', name: 'Other', order: 1),
+      ],
+      activeAccountUuid: 'account-1',
+    );
+    final accountNotifier = _FakeAccountNotifier(accountState);
+    final birthdayLoads = <String, Completer<int>>{
+      'account-1': Completer<int>(),
+      'account-2': Completer<int>(),
+    };
+    final requestedBlockTimes = <int>[];
+
+    await tester.pumpWidget(
+      _app(
+        accountNotifier: () => accountNotifier,
+        birthdayHeightLoader: (uuid) => birthdayLoads[uuid]!.future,
+        birthdayBlockTimeLoader: (height) async {
+          requestedBlockTimes.add(height);
+          return 0;
+        },
+      ),
+    );
+    await _revealSecret(tester);
+
+    accountNotifier.setActiveAccount('account-2');
+    await tester.pump();
+    expect(
+      find.text('Selected account changed. Enter your passcode again.'),
+      findsOneWidget,
+    );
+
+    await _revealSecret(tester);
+    birthdayLoads['account-1']!.complete(111);
+    await tester.pump();
+
+    expect(find.text('111'), findsNothing);
+    expect(requestedBlockTimes, isEmpty);
+
+    birthdayLoads['account-2']!.complete(222);
+    await tester.pumpAndSettle();
+
+    expect(find.text('222'), findsOneWidget);
+    expect(requestedBlockTimes, [222]);
   });
 
   testWidgets('confirm gate keeps biometric retry after prompt cancel', (

--- a/test/features/settings/mobile_seed_phrase_screen_test.dart
+++ b/test/features/settings/mobile_seed_phrase_screen_test.dart
@@ -48,11 +48,19 @@ class _FakeSecurityNotifier extends AppSecurityNotifier {
 }
 
 class _FakeAccountNotifier extends AccountNotifier {
-  @override
-  FutureOr<AccountState> build() => _accountState;
+  _FakeAccountNotifier([this.initialState = _accountState]);
+
+  final AccountState initialState;
+  final requestedMnemonicUuids = <String>[];
 
   @override
-  Future<String?> getMnemonicForAccount(String uuid) async => _mnemonic;
+  FutureOr<AccountState> build() => initialState;
+
+  @override
+  Future<String?> getMnemonicForAccount(String uuid) async {
+    requestedMnemonicUuids.add(uuid);
+    return _mnemonic;
+  }
 }
 
 class _FakeBiometricUnlock extends BiometricUnlock {
@@ -108,11 +116,13 @@ Widget _app({
   Stream<void>? screenshotStream,
   SensitivePrivacyOverlayController? privacyOverlayController,
   _FakeBiometricController? biometric,
+  String? accountUuid,
+  AccountNotifier Function()? accountNotifier,
 }) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
-      accountProvider.overrideWith(_FakeAccountNotifier.new),
+      accountProvider.overrideWith(accountNotifier ?? _FakeAccountNotifier.new),
       appSecurityProvider.overrideWith(_FakeSecurityNotifier.new),
       if (biometric == null)
         biometricUnlockServiceProvider.overrideWithValue(_FakeBiometricUnlock())
@@ -124,6 +134,7 @@ Widget _app({
     child: MaterialApp(
       builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
       home: MobileSeedPhraseScreen(
+        accountUuid: accountUuid,
         screenshotStream: screenshotStream,
         privacyOverlayController: privacyOverlayController,
         loadBirthday: false,
@@ -184,6 +195,28 @@ void main() {
     await tester.tap(find.text('Cancel'));
     await tester.pumpAndSettle();
     expect(find.text('Forgot Passcode?'), findsNothing);
+  });
+
+  testWidgets('reveals the requested account without making it active', (
+    tester,
+  ) async {
+    const accountState = AccountState(
+      accounts: [
+        AccountInfo(uuid: 'account-1', name: 'Current', order: 0),
+        AccountInfo(uuid: 'account-2', name: 'Other', order: 1),
+      ],
+      activeAccountUuid: 'account-1',
+    );
+    final accountNotifier = _FakeAccountNotifier(accountState);
+
+    await tester.pumpWidget(
+      _app(accountUuid: 'account-2', accountNotifier: () => accountNotifier),
+    );
+    await _revealSecret(tester);
+
+    expect(accountNotifier.requestedMnemonicUuids, ['account-2']);
+    expect(accountNotifier.state.requireValue.activeAccountUuid, 'account-1');
+    expect(find.text('abandon'), findsOneWidget);
   });
 
   testWidgets('confirm gate keeps biometric retry after prompt cancel', (

--- a/test/features/settings/mobile_seed_phrase_screen_test.dart
+++ b/test/features/settings/mobile_seed_phrase_screen_test.dart
@@ -87,6 +87,7 @@ class _FakeBiometricController {
 
   BiometricUnlockState initialState;
   String? passcode;
+  Future<String?>? readResult;
   var reads = 0;
   String? lastReason;
 }
@@ -103,6 +104,8 @@ class _FakeBiometricNotifier extends BiometricUnlockNotifier {
   Future<String?> readPasscode({required String reason}) async {
     controller.reads += 1;
     controller.lastReason = reason;
+    final result = controller.readResult;
+    if (result != null) return result;
     return controller.passcode;
   }
 }
@@ -359,6 +362,41 @@ void main() {
     expect(find.bySemanticsLabel('Sign in with fingerprint'), findsOneWidget);
     expect(find.bySemanticsLabel('Sign in with Face ID'), findsNothing);
     expect(find.byIcon(Icons.fingerprint), findsOneWidget);
+  });
+
+  testWidgets('biometric confirmation rejects an account change', (
+    tester,
+  ) async {
+    const accountState = AccountState(
+      accounts: [
+        AccountInfo(uuid: 'account-1', name: 'Current', order: 0),
+        AccountInfo(uuid: 'account-2', name: 'Other', order: 1),
+      ],
+      activeAccountUuid: 'account-1',
+    );
+    final accountNotifier = _FakeAccountNotifier(accountState);
+    final biometricResult = Completer<String?>();
+    final biometric = _FakeBiometricController(
+      initialState: _faceBiometricState,
+    )..readResult = biometricResult.future;
+
+    await tester.pumpWidget(
+      _app(biometric: biometric, accountNotifier: () => accountNotifier),
+    );
+    await tester.pumpAndSettle();
+    expect(biometric.reads, 1);
+
+    accountNotifier.setActiveAccount('account-2');
+    await tester.pump();
+    biometricResult.complete('111111');
+    await tester.pumpAndSettle();
+
+    expect(accountNotifier.requestedMnemonicUuids, isEmpty);
+    expect(find.text('abandon'), findsNothing);
+    expect(
+      find.text('Selected account changed. Enter your passcode again.'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('shows the screenshot warning after the phrase is revealed', (

--- a/test/widgetbook/accounts_use_cases_test.dart
+++ b/test/widgetbook/accounts_use_cases_test.dart
@@ -111,6 +111,36 @@ void main() {
     expect(find.text('Send ZEC'), findsOneWidget);
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Remove account'), findsOneWidget);
+    expect(find.text('View secret passphrase'), findsNothing);
+
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_accounts_menu_preview-account-3')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('View secret passphrase'), findsOneWidget);
+  });
+
+  testWidgets('mobile account menu use cases distinguish software and '
+      'Keystone accounts', (tester) async {
+    await _pumpMobileAccountsUseCase(
+      tester,
+      buildMobileAccountsSoftwareMenuUseCase,
+    );
+
+    expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    await _pumpMobileAccountsUseCase(
+      tester,
+      buildMobileAccountsKeystoneMenuUseCase,
+    );
+
+    expect(find.text('View secret passphrase'), findsNothing);
+    expect(find.text('Copy address'), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('mobile accounts menu opens the edit sheet', (tester) async {

--- a/test/widgetbook/accounts_use_cases_test.dart
+++ b/test/widgetbook/accounts_use_cases_test.dart
@@ -111,36 +111,6 @@ void main() {
     expect(find.text('Send ZEC'), findsOneWidget);
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Remove account'), findsOneWidget);
-    expect(find.text('View secret passphrase'), findsNothing);
-
-    await tester.tapAt(const Offset(10, 10));
-    await tester.pumpAndSettle();
-    await tester.tap(
-      find.byKey(const ValueKey('mobile_accounts_menu_preview-account-3')),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.text('View secret passphrase'), findsOneWidget);
-  });
-
-  testWidgets('mobile account menu use cases distinguish software and '
-      'Keystone accounts', (tester) async {
-    await _pumpMobileAccountsUseCase(
-      tester,
-      buildMobileAccountsSoftwareMenuUseCase,
-    );
-
-    expect(find.text('View secret passphrase'), findsOneWidget);
-    expect(tester.takeException(), isNull);
-
-    await _pumpMobileAccountsUseCase(
-      tester,
-      buildMobileAccountsKeystoneMenuUseCase,
-    );
-
-    expect(find.text('View secret passphrase'), findsNothing);
-    expect(find.text('Copy address'), findsOneWidget);
-    expect(tester.takeException(), isNull);
   });
 
   testWidgets('mobile accounts menu opens the edit sheet', (tester) async {

--- a/test/widgetbook/mobile_accounts_use_cases_test.dart
+++ b/test/widgetbook/mobile_accounts_use_cases_test.dart
@@ -18,7 +18,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('View secret passphrase'), findsNothing);
+    expect(find.text('View secret phrase'), findsNothing);
 
     await tester.tapAt(const Offset(10, 10));
     await tester.pumpAndSettle();
@@ -27,7 +27,20 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(find.text('View secret phrase'), findsOneWidget);
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('mobile_account_menu_card')))
+          .width,
+      176,
+    );
+    expect(
+      find.ancestor(
+        of: find.text('View secret phrase'),
+        matching: find.byType(FittedBox),
+      ),
+      findsOneWidget,
+    );
     expect(tester.takeException(), isNull);
   });
 
@@ -38,7 +51,7 @@ void main() {
       buildMobileAccountsSoftwareMenuUseCase,
     );
 
-    expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(find.text('View secret phrase'), findsOneWidget);
     expect(tester.takeException(), isNull);
 
     await _pumpMobileAccountsUseCase(
@@ -46,7 +59,7 @@ void main() {
       buildMobileAccountsKeystoneMenuUseCase,
     );
 
-    expect(find.text('View secret passphrase'), findsNothing);
+    expect(find.text('View secret phrase'), findsNothing);
     expect(find.text('Copy address'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });

--- a/test/widgetbook/mobile_accounts_use_cases_test.dart
+++ b/test/widgetbook/mobile_accounts_use_cases_test.dart
@@ -1,0 +1,73 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/widgetbook/screen_use_cases.dart';
+
+void main() {
+  testWidgets('mobile accounts menu hides the shortcut for Keystone', (
+    tester,
+  ) async {
+    await _pumpMobileAccountsUseCase(tester, buildMobileAccountsUseCase);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_accounts_menu_preview-account-2')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('View secret passphrase'), findsNothing);
+
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_accounts_menu_preview-account-3')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('mobile account menu use cases distinguish software and '
+      'Keystone accounts', (tester) async {
+    await _pumpMobileAccountsUseCase(
+      tester,
+      buildMobileAccountsSoftwareMenuUseCase,
+    );
+
+    expect(find.text('View secret passphrase'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    await _pumpMobileAccountsUseCase(
+      tester,
+      buildMobileAccountsKeystoneMenuUseCase,
+    );
+
+    expect(find.text('View secret passphrase'), findsNothing);
+    expect(find.text('Copy address'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpMobileAccountsUseCase(
+  WidgetTester tester,
+  WidgetBuilder builder,
+) async {
+  tester.view.physicalSize = const Size(393, 852);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      key: UniqueKey(),
+      builder: (context, child) =>
+          AppTheme(data: AppThemeData.light, child: child!),
+      home: Builder(builder: builder),
+    ),
+  );
+  await tester.pumpAndSettle();
+}

--- a/test/widgetbook/mobile_accounts_use_cases_test.dart
+++ b/test/widgetbook/mobile_accounts_use_cases_test.dart
@@ -32,14 +32,18 @@ void main() {
       tester
           .getSize(find.byKey(const ValueKey('mobile_account_menu_card')))
           .width,
-      176,
+      208,
     );
     expect(
       find.ancestor(
         of: find.text('View secret phrase'),
         matching: find.byType(FittedBox),
       ),
-      findsOneWidget,
+      findsNothing,
+    );
+    expect(
+      tester.widget<Text>(find.text('View secret phrase')).overflow,
+      TextOverflow.ellipsis,
     );
     expect(tester.takeException(), isNull);
   });


### PR DESCRIPTION
Stacked on #447.

## Problem

Mobile users cannot reach a secret passphrase from an account action menu. The shortcut needs to target the selected software account, including non-active accounts, while remaining unavailable for Keystone accounts.

## Solution

- Add a key-icon `View secret phrase` action to current and other software account menus.
- Route the selected account UUID through the existing passcode-gated mobile reveal flow without changing the active account.
- Keep the action absent for Keystone hardware accounts.
- Use a 208px menu so the label is complete at the default mobile font size while preserving OS text scaling; oversized labels use ellipsis instead of shrinking.
- Reject stale passcode and biometric results if the selected account changes during authentication.
- Add deterministic mobile-lane Widgetbook states for software and Keystone menus.

## Verification

- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/accounts/mobile_accounts_screen_test.dart test/features/settings/mobile_seed_phrase_screen_test.dart test/widgetbook/mobile_accounts_use_cases_test.dart --concurrency=1`
- Focused `fvm flutter analyze` for changed implementation and test files
- Mobile-token Widgetbook verification for software and Keystone menu states
