### PR TITLE
Add Keystone QR scanning help

### DIFF
--- a/assets/icons/keystone_scan_help_pointer.svg
+++ b/assets/icons/keystone_scan_help_pointer.svg
@@ -1,0 +1,3 @@
+<svg preserveAspectRatio="none" overflow="visible" width="8" height="24" viewBox="0 0 8 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 0C8 5.5 3.77099 6.58472 0.823449 9.78018C-0.274483 10.9705 -0.274483 13.0295 0.823449 14.2198C3.77099 17.4153 7.96642 19.5 8 24L8 0Z" fill="#F7F7F7"/>
+</svg>

--- a/lib/src/features/keystone/widgets/keystone_scan_help_overlay.dart
+++ b/lib/src/features/keystone/widgets/keystone_scan_help_overlay.dart
@@ -196,7 +196,7 @@ class _KeystoneScanHelpTooltip extends StatelessWidget {
                     ),
                     children: [
                       const TextSpan(
-                        text: 'Check Keystone firmware version at ',
+                        text: 'Update to the latest Keystone firmware at ',
                       ),
                       WidgetSpan(
                         alignment: PlaceholderAlignment.baseline,

--- a/lib/src/features/keystone/widgets/keystone_scan_help_overlay.dart
+++ b/lib/src/features/keystone/widgets/keystone_scan_help_overlay.dart
@@ -1,0 +1,301 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_icon.dart';
+
+const _tooltipGap = 11.0;
+const _tooltipWidth = 224.0;
+const _tooltipPointerWidth = 8.0;
+const _tooltipPointerHeight = 24.0;
+final _keystoneFirmwareUri = Uri.parse('https://keyst.one/firmware');
+
+Future<void> _openKeystoneFirmware() async {
+  try {
+    await launchUrl(_keystoneFirmwareUri, mode: LaunchMode.externalApplication);
+  } on Exception {
+    // The tooltip remains usable when the operating system cannot open a URL.
+  }
+}
+
+/// Anchors the desktop Keystone scan-help tooltip beside a request QR without
+/// changing the QR's layout or centering.
+///
+/// The tooltip is shown when [visible] becomes true and stays dismissed for
+/// the remainder of that visible session after the user closes it.
+class KeystoneScanHelpOverlay extends StatefulWidget {
+  const KeystoneScanHelpOverlay({
+    required this.visible,
+    required this.child,
+    super.key,
+  });
+
+  final bool visible;
+  final Widget child;
+
+  @override
+  State<KeystoneScanHelpOverlay> createState() =>
+      _KeystoneScanHelpOverlayState();
+}
+
+class _KeystoneScanHelpOverlayState extends State<KeystoneScanHelpOverlay> {
+  final LayerLink _layerLink = LayerLink();
+  final OverlayPortalController _overlayController = OverlayPortalController();
+  bool _dismissed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.visible) _scheduleShow();
+  }
+
+  @override
+  void didUpdateWidget(covariant KeystoneScanHelpOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!widget.visible) {
+      _hide();
+      return;
+    }
+    if (!oldWidget.visible) {
+      _dismissed = false;
+      _scheduleShow();
+    }
+  }
+
+  void _scheduleShow() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted ||
+          !widget.visible ||
+          _dismissed ||
+          _overlayController.isShowing) {
+        return;
+      }
+      _overlayController.show();
+    });
+  }
+
+  void _dismiss() {
+    _dismissed = true;
+    _hide();
+  }
+
+  void _hide() {
+    if (_overlayController.isShowing) _overlayController.hide();
+  }
+
+  @override
+  void dispose() {
+    _hide();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return OverlayPortal(
+      controller: _overlayController,
+      overlayChildBuilder: (_) => AppTheme(
+        data: context.appTheme,
+        child: CompositedTransformFollower(
+          link: _layerLink,
+          showWhenUnlinked: false,
+          targetAnchor: Alignment.centerRight,
+          followerAnchor: Alignment.centerLeft,
+          offset: const Offset(_tooltipGap, 0),
+          child: _KeystoneScanHelpTooltip(onDismiss: _dismiss),
+        ),
+      ),
+      child: CompositedTransformTarget(link: _layerLink, child: widget.child),
+    );
+  }
+}
+
+class _KeystoneScanHelpTooltip extends StatelessWidget {
+  const _KeystoneScanHelpTooltip({required this.onDismiss});
+
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return DefaultTextStyle.merge(
+      style: const TextStyle(decoration: TextDecoration.none),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          SvgPicture.asset(
+            'assets/icons/keystone_scan_help_pointer.svg',
+            width: _tooltipPointerWidth,
+            height: _tooltipPointerHeight,
+            fit: BoxFit.fill,
+            colorFilter: ColorFilter.mode(
+              colors.background.inverse,
+              BlendMode.srcIn,
+            ),
+          ),
+          Container(
+            key: const ValueKey('keystone_scan_help_tooltip'),
+            width: _tooltipWidth,
+            constraints: const BoxConstraints(minHeight: 72),
+            padding: const EdgeInsets.all(AppSpacing.s),
+            decoration: BoxDecoration(
+              color: colors.background.inverse,
+              borderRadius: BorderRadius.circular(AppRadii.medium),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  height: 24,
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          'Scanning issues?',
+                          style: AppTypography.bodyMediumStrong.copyWith(
+                            color: colors.text.inverse,
+                          ),
+                        ),
+                      ),
+                      _KeystoneTooltipAction(
+                        key: const ValueKey('keystone_scan_help_close'),
+                        semanticLabel: 'Close scan help',
+                        onActivate: onDismiss,
+                        builder: (context, focused) => DecoratedBox(
+                          decoration: BoxDecoration(
+                            border: focused
+                                ? Border.all(color: colors.text.inverse)
+                                : null,
+                            borderRadius: BorderRadius.circular(AppRadii.full),
+                          ),
+                          child: SizedBox.square(
+                            dimension: 24,
+                            child: Center(
+                              child: AppIcon(
+                                AppIcons.cross,
+                                size: 16,
+                                color: colors.icon.inverse,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                RichText(
+                  text: TextSpan(
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.inverse.withValues(alpha: 0.6),
+                    ),
+                    children: [
+                      const TextSpan(
+                        text: 'Check Keystone firmware version at ',
+                      ),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.baseline,
+                        baseline: TextBaseline.alphabetic,
+                        child: _KeystoneTooltipAction(
+                          key: const ValueKey('keystone_firmware_link'),
+                          semanticLabel: 'Open Keystone firmware page',
+                          link: true,
+                          onActivate: () => unawaited(_openKeystoneFirmware()),
+                          builder: (context, focused) => Text(
+                            'keyst.one/firmware',
+                            style: AppTypography.bodyMediumStrong.copyWith(
+                              color: colors.text.inverse.withValues(alpha: 0.6),
+                              decoration: focused
+                                  ? TextDecoration.underline
+                                  : null,
+                              decorationColor: focused
+                                  ? colors.text.inverse.withValues(alpha: 0.6)
+                                  : null,
+                              decorationStyle: focused
+                                  ? TextDecorationStyle.solid
+                                  : null,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+typedef _TooltipActionBuilder =
+    Widget Function(BuildContext context, bool focused);
+
+class _KeystoneTooltipAction extends StatefulWidget {
+  const _KeystoneTooltipAction({
+    required this.semanticLabel,
+    required this.onActivate,
+    required this.builder,
+    this.link = false,
+    super.key,
+  });
+
+  final String semanticLabel;
+  final VoidCallback onActivate;
+  final _TooltipActionBuilder builder;
+  final bool link;
+
+  @override
+  State<_KeystoneTooltipAction> createState() => _KeystoneTooltipActionState();
+}
+
+class _KeystoneTooltipActionState extends State<_KeystoneTooltipAction> {
+  bool _focused = false;
+
+  void _setFocused(bool focused) {
+    if (_focused == focused) return;
+    setState(() => _focused = focused);
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    final key = event.logicalKey;
+    final activates =
+        key == LogicalKeyboardKey.enter ||
+        key == LogicalKeyboardKey.numpadEnter ||
+        key == LogicalKeyboardKey.space;
+    if (!activates) return KeyEventResult.ignored;
+
+    if (event is KeyUpEvent) widget.onActivate();
+    return KeyEventResult.handled;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: !widget.link,
+      link: widget.link,
+      label: widget.semanticLabel,
+      excludeSemantics: true,
+      onTap: widget.onActivate,
+      child: Focus(
+        onFocusChange: _setFocused,
+        onKeyEvent: _handleKeyEvent,
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: widget.onActivate,
+            child: widget.builder(context, _focused),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/keystone/widgets/keystone_signing_modal.dart
+++ b/lib/src/features/keystone/widgets/keystone_signing_modal.dart
@@ -5,6 +5,7 @@ import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_modal_card.dart'
     show AppModalActions, appModalShadow;
 import 'keystone_pczt_qr_stage.dart';
+import 'keystone_scan_help_overlay.dart';
 
 enum KeystoneSigningModalPhase { preparing, ready, failed }
 
@@ -95,18 +96,23 @@ class KeystoneSigningModal extends StatelessWidget {
             ),
             child: Column(
               children: [
-                KeystonePcztQrStage(
-                  phase: switch (phase) {
-                    KeystoneSigningModalPhase.preparing =>
-                      KeystonePcztQrStagePhase.preparing,
-                    KeystoneSigningModalPhase.ready =>
-                      KeystonePcztQrStagePhase.ready,
-                    KeystoneSigningModalPhase.failed =>
-                      KeystonePcztQrStagePhase.failed,
-                  },
-                  urParts: urParts,
-                  error: error,
-                  size: qrSize,
+                KeystoneScanHelpOverlay(
+                  visible:
+                      phase == KeystoneSigningModalPhase.ready &&
+                      urParts.isNotEmpty,
+                  child: KeystonePcztQrStage(
+                    phase: switch (phase) {
+                      KeystoneSigningModalPhase.preparing =>
+                        KeystonePcztQrStagePhase.preparing,
+                      KeystoneSigningModalPhase.ready =>
+                        KeystonePcztQrStagePhase.ready,
+                      KeystoneSigningModalPhase.failed =>
+                        KeystonePcztQrStagePhase.failed,
+                    },
+                    urParts: urParts,
+                    error: error,
+                    size: qrSize,
+                  ),
                 ),
                 if (instruction != null && instruction.isNotEmpty) ...[
                   const SizedBox(height: AppSpacing.sm),

--- a/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
@@ -468,7 +468,6 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
   // scanner card reports it; the mobile view renders it under the viewfinder.
   int _scanProgress = 0;
   bool _requestCompleted = false;
-  bool _showImmediateScanHelp = true;
   Future<void>? _completionOperation;
   IronwoodMigrationPrivacyLockSuppressionNotifier?
   _privacyLockSuppressionNotifier;
@@ -1169,43 +1168,37 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
           ? null
           : AppPaneModalOverlay(
               onDismiss: () => unawaited(_returnToReview()),
-              child: _ImmediateKeystoneRequestModal(
-                showScanHelp: ready && _showImmediateScanHelp,
-                onDismissScanHelp: () {
-                  setState(() => _showImmediateScanHelp = false);
-                },
-                modal: KeystoneSigningModal(
-                  key: const ValueKey(
-                    'ironwood_immediate_keystone_signing_modal',
-                  ),
-                  phase: modalPhase,
-                  urParts: _urParts,
-                  error: _error,
-                  title: 'Confirm Migration with Keystone',
-                  subtitle: 'Scan with your Keystone',
-                  instruction: failed
-                      ? null
-                      : 'After you scanned, click Get signature.',
-                  primaryLabel: failed
-                      ? 'Try again'
-                      : ready
-                      ? 'Get signature'
-                      : 'Preparing',
-                  onPrimary: failed
-                      ? () => unawaited(_retryRequest())
-                      : ready && _urParts.isNotEmpty
-                      ? () {
-                          setState(() {
-                            _stage = _KeystoneDenominationSignStage.scanning;
-                            _error = null;
-                            _decoding = false;
-                          });
-                        }
-                      : null,
-                  secondaryLabel: 'Cancel',
-                  onSecondary: () => unawaited(_returnToReview()),
-                  qrSize: 200,
+              child: KeystoneSigningModal(
+                key: const ValueKey(
+                  'ironwood_immediate_keystone_signing_modal',
                 ),
+                phase: modalPhase,
+                urParts: _urParts,
+                error: _error,
+                title: 'Confirm Migration with Keystone',
+                subtitle: 'Scan with your Keystone',
+                instruction: failed
+                    ? null
+                    : 'After you scanned, click Get signature.',
+                primaryLabel: failed
+                    ? 'Try again'
+                    : ready
+                    ? 'Get signature'
+                    : 'Preparing',
+                onPrimary: failed
+                    ? () => unawaited(_retryRequest())
+                    : ready && _urParts.isNotEmpty
+                    ? () {
+                        setState(() {
+                          _stage = _KeystoneDenominationSignStage.scanning;
+                          _error = null;
+                          _decoding = false;
+                        });
+                      }
+                    : null,
+                secondaryLabel: 'Cancel',
+                onSecondary: () => unawaited(_returnToReview()),
+                qrSize: 200,
               ),
             ),
       child: showingScanner
@@ -1527,12 +1520,15 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
                 key: const ValueKey('keystone_migration_enlarge_qr'),
                 onTap: () => unawaited(_showEnlargedRequestQr()),
                 behavior: HitTestBehavior.opaque,
-                child: KeystonePcztQrStage(
-                  phase: KeystonePcztQrStagePhase.ready,
-                  urParts: _urParts,
-                  error: _error,
-                  size: 264,
-                  frameInterval: _keystoneMigrationQrFrameInterval,
+                child: KeystoneScanHelpOverlay(
+                  visible: _urParts.isNotEmpty && !proofFailed,
+                  child: KeystonePcztQrStage(
+                    phase: KeystonePcztQrStagePhase.ready,
+                    urParts: _urParts,
+                    error: _error,
+                    size: 264,
+                    frameInterval: _keystoneMigrationQrFrameInterval,
+                  ),
                 ),
               ),
             ),
@@ -1717,100 +1713,6 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class _ImmediateKeystoneRequestModal extends StatelessWidget {
-  const _ImmediateKeystoneRequestModal({
-    required this.modal,
-    required this.showScanHelp,
-    required this.onDismissScanHelp,
-  });
-
-  final Widget modal;
-  final bool showScanHelp;
-  final VoidCallback onDismissScanHelp;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 560,
-      height: 430,
-      child: Stack(
-        clipBehavior: Clip.none,
-        alignment: Alignment.center,
-        children: [
-          modal,
-          if (showScanHelp)
-            Positioned(
-              right: -64,
-              top: 150,
-              child: Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  Positioned(
-                    left: -6,
-                    top: 40,
-                    child: Transform.rotate(
-                      angle: math.pi / 4,
-                      child: const SizedBox(
-                        width: 12,
-                        height: 12,
-                        child: ColoredBox(color: Color(0xFFFFFFFF)),
-                      ),
-                    ),
-                  ),
-                  Container(
-                    width: 224,
-                    padding: const EdgeInsets.all(AppSpacing.sm),
-                    decoration: BoxDecoration(
-                      color: const Color(0xFFFFFFFF),
-                      borderRadius: BorderRadius.circular(AppRadii.medium),
-                    ),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            Expanded(
-                              child: Text(
-                                'Scanning issues?',
-                                style: AppTypography.bodyMediumStrong.copyWith(
-                                  color: const Color(0xFF161819),
-                                ),
-                              ),
-                            ),
-                            GestureDetector(
-                              behavior: HitTestBehavior.opaque,
-                              onTap: onDismissScanHelp,
-                              child: const Padding(
-                                padding: EdgeInsets.all(AppSpacing.xxs),
-                                child: AppIcon(
-                                  AppIcons.cross,
-                                  size: 12,
-                                  color: Color(0xFF161819),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: AppSpacing.xs),
-                        Text(
-                          'Check Keystone firmware\nversion at keyst.one/firmware',
-                          style: AppTypography.bodyMedium.copyWith(
-                            color: const Color(0xFF717678),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-        ],
       ),
     );
   }

--- a/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
@@ -364,13 +364,6 @@ extension _KeystonePrivateSignStepCopy on _KeystonePrivateSignStep {
       'Scan this request QR with Keystone. Keystone will show a new signed QR when it finishes.',
   };
 
-  String get messageUnit => switch (this) {
-    _KeystonePrivateSignStep.immediate => 'migration transaction',
-    _KeystonePrivateSignStep.combined => 'transaction',
-    _KeystonePrivateSignStep.denominations => 'split transaction',
-    _KeystonePrivateSignStep.batch => 'migration transaction',
-  };
-
   Future<rust_sync.KeystoneMigrationSigningRequest> prepare(
     IronwoodMigrationService service, {
     required String accountUuid,
@@ -1470,8 +1463,6 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
 
   Widget _buildQrContent(BuildContext context) {
     final colors = context.colors;
-    final request = _request;
-    final signingRound = _currentSigningRound;
     final signingRoundLabel = _signingRoundLabel;
     final proofStatusText = _proofStatusText;
     final proofFailed = ironwoodMigrationKeystoneProofFailed(_proofStatus);
@@ -1535,11 +1526,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
           ),
           const SizedBox(height: AppSpacing.base),
           Text(
-            request == null || signingRound == null
-                ? 'Preparing migration request'
-                : '${signingRound.length} ${widget.step.messageUnit}'
-                      '${signingRound.length == 1 ? '' : 's'} to sign'
-                      ' · click QR to enlarge',
+            'Click QR to enlarge',
             textAlign: TextAlign.center,
             style: AppTypography.bodyMedium.copyWith(
               color: colors.text.secondary,

--- a/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
@@ -48,6 +48,7 @@ import '../../../rust/wallet/keystone.dart' as rust_keystone_wallet;
 import '../../../services/qr_scanner.dart';
 import '../../keystone/widgets/keystone_pczt_qr_stage.dart';
 import '../../keystone/widgets/keystone_qr_scanner_card.dart';
+import '../../keystone/widgets/keystone_scan_help_overlay.dart';
 import '../../keystone/widgets/keystone_signing_modal.dart';
 import '../models/ironwood_migration_presentation.dart';
 import '../models/mobile_ironwood_migration_status_entry.dart';

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -14,6 +14,7 @@ import '../../../providers/voting/voting_state.dart';
 import '../../../rust/third_party/zcash_voting/delegate.dart' as rust_delegate;
 import '../../../services/voting/pir_snapshot_resolver.dart';
 import '../../keystone/widgets/keystone_pczt_qr_stage.dart';
+import '../../keystone/widgets/keystone_scan_help_overlay.dart';
 import '../voting_error_messages.dart';
 import '../voting_flow_models.dart';
 import '../voting_formatters.dart';
@@ -979,10 +980,15 @@ class _KeystoneSigningPanelState extends State<_KeystoneSigningPanel> {
               _KeystoneSigningMemo(displayMemo: request.displayMemo),
             ],
             const SizedBox(height: AppSpacing.sm),
-            KeystonePcztQrStage(
-              phase: qrPhase,
-              urParts: urParts,
-              error: qrError,
+            KeystoneScanHelpOverlay(
+              visible:
+                  qrPhase == KeystonePcztQrStagePhase.ready &&
+                  urParts.isNotEmpty,
+              child: KeystonePcztQrStage(
+                phase: qrPhase,
+                urParts: urParts,
+                error: qrError,
+              ),
             ),
             if (scanError != null) ...[
               const SizedBox(height: AppSpacing.xs),

--- a/test/features/keystone/keystone_pczt_qr_stage_test.dart
+++ b/test/features/keystone/keystone_pczt_qr_stage_test.dart
@@ -5,12 +5,14 @@ import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/keystone/widgets/keystone_pczt_qr_stage.dart';
 import 'package:zcash_wallet/src/features/keystone/widgets/keystone_signing_modal.dart';
 
-Widget _app(Widget child) {
+Widget _app(Widget content) {
   return AppTheme(
     data: AppThemeData.light,
     child: Directionality(
       textDirection: TextDirection.ltr,
-      child: Center(child: child),
+      child: Overlay(
+        initialEntries: [OverlayEntry(builder: (_) => Center(child: content))],
+      ),
     ),
   );
 }
@@ -107,11 +109,13 @@ void main() {
         ),
       ),
     );
+    await tester.pump();
 
     expect(tester.getSize(find.byType(PrettyQrView)), const Size(264, 264));
     final qrView = tester.widget<PrettyQrView>(find.byType(PrettyQrView));
     final decoration = (qrView as dynamic).decoration as PrettyQrDecoration;
     expect(decoration.quietZone, const PrettyQrQuietZone.modules(3));
     expect(find.byType(CustomPaint), findsNothing);
+    expect(find.text('Scanning issues?'), findsOneWidget);
   });
 }

--- a/test/features/keystone/keystone_scan_help_overlay_test.dart
+++ b/test/features/keystone/keystone_scan_help_overlay_test.dart
@@ -31,7 +31,6 @@ void main() {
   ) async {
     await tester.binding.setSurfaceSize(const Size(1080, 720));
     addTearDown(() => tester.binding.setSurfaceSize(null));
-
     await tester.pumpWidget(_app(visible: true));
     await tester.pump();
 
@@ -73,6 +72,20 @@ void main() {
         tester.element(find.text('Scanning issues?')),
       ).style.decoration,
       TextDecoration.none,
+    );
+    expect(
+      find.textContaining(
+        'Update to the latest Keystone firmware at',
+        findRichText: true,
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining(
+        'Check Keystone firmware version at',
+        findRichText: true,
+      ),
+      findsNothing,
     );
     expect(
       find.textContaining('keyst.one/firmware', findRichText: true),

--- a/test/features/keystone/keystone_scan_help_overlay_test.dart
+++ b/test/features/keystone/keystone_scan_help_overlay_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/keystone/widgets/keystone_scan_help_overlay.dart';
+
+Widget _app({required bool visible}) {
+  return MaterialApp(
+    builder: (_, child) => AppTheme(data: AppThemeData.dark, child: child!),
+    home: Center(
+      child: KeystoneScanHelpOverlay(
+        visible: visible,
+        child: const SizedBox(key: ValueKey('qr'), width: 200, height: 200),
+      ),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() async {
+    final regular = FontLoader('Geist')
+      ..addFont(rootBundle.load('assets/fonts/Geist-Regular.ttf'));
+    final medium = FontLoader('Geist')
+      ..addFont(rootBundle.load('assets/fonts/Geist-Medium.ttf'));
+    await Future.wait([regular.load(), medium.load()]);
+  });
+
+  testWidgets('anchors the Figma scan-help tooltip beside the QR', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1080, 720));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(_app(visible: true));
+    await tester.pump();
+
+    final qrRect = tester.getRect(find.byKey(const ValueKey('qr')));
+    final tooltip = find.byKey(const ValueKey('keystone_scan_help_tooltip'));
+    final tooltipRect = tester.getRect(tooltip);
+    final tooltipContainer = tester.widget<Container>(tooltip);
+    final tooltipDecoration = tooltipContainer.decoration! as BoxDecoration;
+
+    expect(tooltipRect.width, 224);
+    if (kAppFormFactor == AppFormFactor.desktop) {
+      // The referenced Figma tooltip uses desktop typography and is 98px tall.
+      expect(tooltipRect.height, 98);
+    } else {
+      expect(tooltipRect.height, greaterThanOrEqualTo(72));
+    }
+    // Figma: 11px QR-to-pointer gap plus the 8px pointer asset.
+    expect(tooltipRect.left - qrRect.right, 19);
+    expect(tooltipRect.center.dy, qrRect.center.dy);
+    expect(tooltipContainer.padding, const EdgeInsets.all(AppSpacing.s));
+    expect(
+      tooltipDecoration.color,
+      AppThemeData.dark.colors.background.inverse,
+    );
+    expect(
+      tooltipDecoration.borderRadius,
+      BorderRadius.circular(AppRadii.medium),
+    );
+    expect(find.text('Scanning issues?'), findsOneWidget);
+    final title = tester.widget<Text>(find.text('Scanning issues?'));
+    expect(
+      title.style,
+      AppTypography.bodyMediumStrong.copyWith(
+        color: AppThemeData.dark.colors.text.inverse,
+      ),
+    );
+    expect(
+      DefaultTextStyle.of(
+        tester.element(find.text('Scanning issues?')),
+      ).style.decoration,
+      TextDecoration.none,
+    );
+    expect(
+      find.textContaining('keyst.one/firmware', findRichText: true),
+      findsOneWidget,
+    );
+    final firmwareLink = tester.widget<Text>(find.text('keyst.one/firmware'));
+    expect(
+      firmwareLink.style,
+      AppTypography.bodyMediumStrong.copyWith(
+        color: AppThemeData.dark.colors.text.inverse.withValues(alpha: 0.6),
+      ),
+    );
+  });
+
+  testWidgets('dismisses for the current visible session', (tester) async {
+    await tester.pumpWidget(_app(visible: true));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('keystone_scan_help_close')));
+    await tester.pump();
+    expect(find.text('Scanning issues?'), findsNothing);
+
+    await tester.pumpWidget(_app(visible: true));
+    await tester.pump();
+    expect(find.text('Scanning issues?'), findsNothing);
+
+    await tester.pumpWidget(_app(visible: false));
+    await tester.pump();
+    await tester.pumpWidget(_app(visible: true));
+    await tester.pump();
+    expect(find.text('Scanning issues?'), findsOneWidget);
+  });
+
+  testWidgets('close action supports keyboard focus and activation', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app(visible: true));
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    final closeAction = find.byKey(const ValueKey('keystone_scan_help_close'));
+    final focusedBox = tester.widget<DecoratedBox>(
+      find.descendant(of: closeAction, matching: find.byType(DecoratedBox)),
+    );
+    final focusedDecoration = focusedBox.decoration as BoxDecoration;
+    final focusRingColor = focusedDecoration.border!.top.color;
+    expect(focusRingColor, AppThemeData.dark.colors.text.inverse);
+    expect(focusRingColor, isNot(AppThemeData.dark.colors.background.inverse));
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(find.text('Scanning issues?'), findsNothing);
+  });
+
+  testWidgets('stays hidden while the QR is not ready', (tester) async {
+    await tester.pumpWidget(_app(visible: false));
+    await tester.pump();
+
+    expect(find.text('Scanning issues?'), findsNothing);
+  });
+
+  testWidgets('opens the Keystone firmware page in the default browser', (
+    tester,
+  ) async {
+    const channel = MethodChannel('plugins.flutter.io/url_launcher');
+    final launchedUrls = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, (
+      call,
+    ) async {
+      if (call.method == 'launch') {
+        launchedUrls.add(
+          (call.arguments as Map<Object?, Object?>)['url']! as String,
+        );
+      }
+      return true;
+    });
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        null,
+      ),
+    );
+
+    await tester.pumpWidget(_app(visible: true));
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('keystone_firmware_link')));
+    await tester.pump();
+
+    expect(launchedUrls, ['https://keyst.one/firmware']);
+  });
+
+  testWidgets('firmware link supports keyboard focus and activation', (
+    tester,
+  ) async {
+    const channel = MethodChannel('plugins.flutter.io/url_launcher');
+    final launchedUrls = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, (
+      call,
+    ) async {
+      if (call.method == 'launch') {
+        launchedUrls.add(
+          (call.arguments as Map<Object?, Object?>)['url']! as String,
+        );
+      }
+      return true;
+    });
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        null,
+      ),
+    );
+
+    await tester.pumpWidget(_app(visible: true));
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+    await tester.sendKeyRepeatEvent(LogicalKeyboardKey.space);
+    await tester.sendKeyRepeatEvent(LogicalKeyboardKey.space);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+
+    expect(launchedUrls, ['https://keyst.one/firmware']);
+  });
+}

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -1071,10 +1071,7 @@ void main() {
         ),
         findsOneWidget,
       );
-      expect(
-        find.text('1 transaction to sign · click QR to enlarge'),
-        findsOneWidget,
-      );
+      expect(find.text('Click QR to enlarge'), findsOneWidget);
       final backToReviewButton = find.widgetWithText(
         AppButton,
         'Back to review',

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -1063,6 +1063,7 @@ void main() {
       expect(find.text('Step 1 of 2'), findsNothing);
       expect(find.text('Round 1 of 2'), findsOneWidget);
       expect(find.text('Scan request with Keystone'), findsOneWidget);
+      expect(find.text('Scanning issues?'), findsOneWidget);
       expect(
         find.text(
           'Scan this request with Keystone to sign the preparation '

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -387,6 +387,7 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Get signature'), findsOneWidget);
+    expect(find.text('Scanning issues?'), findsOneWidget);
     expect(find.text('status-route'), findsNothing);
     expect(rustApi.createPcztCalls, 1);
   });

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -3057,6 +3057,8 @@ void main() {
     expect(find.text('Memo'), findsOneWidget);
     expect(find.textContaining('Amount: 0.00000100 ZEC'), findsOneWidget);
     expect(find.text('Scan signature'), findsOneWidget);
+    await tester.pump();
+    expect(find.text('Scanning issues?'), findsOneWidget);
     expect(find.text('Software account required'), findsNothing);
     await tester.tap(find.text('Scan signature'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary

- add the Figma-aligned `Scanning issues?` help tooltip beside desktop Keystone request QR codes
- make the Keystone firmware URL clickable and keyboard accessible
- reuse the tooltip across send, migration, swap/shield signing, and voting flows without adding it to enlarged QR views
- simplify the migration QR hint to `Click QR to enlarge`

## Why

Users who cannot scan a Keystone request QR need an immediate path to check and update their device firmware. The shared overlay keeps that guidance consistent across desktop signing flows while preserving scan-optimized black-on-white QR rendering.

## Validation

- Keystone scan-help widget tests in desktop and mobile-token configurations
- targeted send, migration, and voting integration tests
- migration signing screen static analysis
- `git diff --check`
