### PR TITLE
Fix desktop Keystone send status routing

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -65,6 +65,11 @@ import 'src/features/send/screens/keystone_send_scan_screen.dart';
 import 'src/features/send/screens/send_review_screen.dart';
 import 'src/features/send/screens/send_screen.dart';
 import 'src/features/send/screens/send_status_screen.dart';
+import 'src/features/send/services/send_flow.dart'
+    show
+        resolveSendStatusRoutePayload,
+        SendStatusRoutePayloadObserver,
+        sendStatusRoutePayloadProvider;
 import 'src/features/settings/screens/settings_screen.dart';
 import 'src/features/settings/screens/settings_change_password_screen.dart';
 import 'src/features/settings/screens/settings_endpoint_screen.dart';
@@ -241,6 +246,14 @@ final _routerProvider = Provider<_AppRouter>((ref) {
 
   router = GoRouter(
     navigatorKey: navigatorKey,
+    observers: kAppFormFactor == AppFormFactor.desktop
+        ? [
+            SendStatusRoutePayloadObserver(
+              onLeaveStatus: () =>
+                  ref.read(sendStatusRoutePayloadProvider.notifier).clear(),
+            ),
+          ]
+        : const [],
     initialLocation: bootstrap.initialLocation,
     refreshListenable: refresh,
     redirect: (context, state) =>
@@ -272,7 +285,7 @@ final _routerProvider = Provider<_AppRouter>((ref) {
               unlockScreen: const UnlockScreen(),
             ),
             ...appDesktopOnboardingRoutes(ref),
-            ..._desktopRoutes(),
+            ..._desktopRoutes(ref),
           ],
   );
 
@@ -737,7 +750,7 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
 ];
 
 /// Main application routes for the desktop (large-form-factor) tree.
-List<RouteBase> _desktopRoutes() => [
+List<RouteBase> _desktopRoutes(Ref ref) => [
   GoRoute(path: '/home', builder: (_, _) => const HomeScreen()),
   GoRoute(
     path: '/migration',
@@ -923,7 +936,16 @@ List<RouteBase> _desktopRoutes() => [
   GoRoute(
     path: '/send/status',
     builder: (_, state) {
-      final args = state.extra;
+      final routeArgs = state.extra;
+      final retainedArgs = ref.read(sendStatusRoutePayloadProvider);
+      final args = resolveSendStatusRoutePayload(
+        routePayload: routeArgs,
+        retainedPayload: retainedArgs,
+        sendFlowId: state.uri.queryParameters['flow'],
+      );
+      if (routeArgs == null && args != null) {
+        log('Send status: restored route payload after router refresh');
+      }
       if (args is KeystoneBroadcastArgs) {
         return SendStatusScreen(args: args.reviewArgs, keystone: args);
       }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -250,7 +250,9 @@ final _routerProvider = Provider<_AppRouter>((ref) {
         ? [
             SendStatusRoutePayloadObserver(
               onLeaveStatus: () =>
-                  ref.read(sendStatusRoutePayloadProvider.notifier).clear(),
+                  ref
+                      .read(sendStatusRoutePayloadProvider.notifier)
+                      .clearAfterNavigation(),
             ),
           ]
         : const [],

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -110,7 +110,11 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
       return;
     }
 
-    await context.push('/send/status', extra: widget.args);
+    ref.read(sendStatusRoutePayloadProvider.notifier).retain(widget.args);
+    await context.push(
+      sendStatusRouteLocation(widget.args.sendFlowId),
+      extra: widget.args,
+    );
   }
 
   void _handleCancel() {
@@ -264,13 +268,15 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     if (signatures == null || !mounted) return;
 
     _handoffToKeystone = true;
+    final statusArgs = KeystoneBroadcastArgs(
+      reviewArgs: widget.args,
+      pcztWithProofsBytes: pcztWithProofs,
+      pcztWithSignaturesBytes: signatures,
+    );
+    ref.read(sendStatusRoutePayloadProvider.notifier).retain(statusArgs);
     context.go(
-      '/send/status',
-      extra: KeystoneBroadcastArgs(
-        reviewArgs: widget.args,
-        pcztWithProofsBytes: pcztWithProofs,
-        pcztWithSignaturesBytes: signatures,
-      ),
+      sendStatusRouteLocation(widget.args.sendFlowId),
+      extra: statusArgs,
     );
   }
 

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -126,6 +126,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
 
   Future<void> _goHome() async {
     if (!mounted) return;
+    ref.read(sendStatusRoutePayloadProvider.notifier).clear();
     context.go('/home');
   }
 

--- a/lib/src/features/send/services/send_flow.dart
+++ b/lib/src/features/send/services/send_flow.dart
@@ -64,12 +64,34 @@ class KeystoneBroadcastArgs {
 }
 
 class SendStatusRoutePayloadNotifier extends Notifier<Object?> {
+  var _disposed = false;
+  var _revision = 0;
+
   @override
-  Object? build() => null;
+  Object? build() {
+    ref.onDispose(() => _disposed = true);
+    return null;
+  }
 
-  void retain(Object payload) => state = payload;
+  void retain(Object payload) {
+    _revision++;
+    state = payload;
+  }
 
-  void clear() => state = null;
+  void clear() {
+    _revision++;
+    state = null;
+  }
+
+  void clearAfterNavigation() {
+    final retainedRevision = _revision;
+    unawaited(
+      Future<void>(() {
+        if (_disposed || _revision != retainedRevision) return;
+        clear();
+      }),
+    );
+  }
 }
 
 final sendStatusRoutePayloadProvider =

--- a/lib/src/features/send/services/send_flow.dart
+++ b/lib/src/features/send/services/send_flow.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math' as math;
 
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
@@ -60,6 +61,70 @@ class KeystoneBroadcastArgs {
   final SendReviewArgs reviewArgs;
   final List<int> pcztWithProofsBytes;
   final List<int> pcztWithSignaturesBytes;
+}
+
+class SendStatusRoutePayloadNotifier extends Notifier<Object?> {
+  @override
+  Object? build() => null;
+
+  void retain(Object payload) => state = payload;
+
+  void clear() => state = null;
+}
+
+final sendStatusRoutePayloadProvider =
+    NotifierProvider<SendStatusRoutePayloadNotifier, Object?>(
+      SendStatusRoutePayloadNotifier.new,
+    );
+
+class SendStatusRoutePayloadObserver extends NavigatorObserver {
+  SendStatusRoutePayloadObserver({required this.onLeaveStatus});
+
+  final VoidCallback onLeaveStatus;
+
+  bool _isSendStatus(Route<dynamic>? route) =>
+      route?.settings.name?.startsWith('/send/status') ?? false;
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (_isSendStatus(route)) onLeaveStatus();
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (_isSendStatus(route)) onLeaveStatus();
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    if (_isSendStatus(oldRoute) && !_isSendStatus(newRoute)) {
+      onLeaveStatus();
+    }
+  }
+}
+
+String sendStatusRouteLocation(String sendFlowId) =>
+    Uri(path: '/send/status', queryParameters: {'flow': sendFlowId}).toString();
+
+Object? resolveSendStatusRoutePayload({
+  required Object? routePayload,
+  required Object? retainedPayload,
+  required String? sendFlowId,
+}) {
+  if (routePayload is SendReviewArgs || routePayload is KeystoneBroadcastArgs) {
+    return routePayload;
+  }
+  return switch (retainedPayload) {
+    SendReviewArgs(sendFlowId: final retainedFlowId)
+        when retainedFlowId == sendFlowId =>
+      retainedPayload,
+    KeystoneBroadcastArgs(
+      reviewArgs: SendReviewArgs(sendFlowId: final retainedFlowId),
+    )
+        when retainedFlowId == sendFlowId =>
+      retainedPayload,
+    _ => null,
+  };
 }
 
 String newSendFlowId() {

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -504,6 +504,80 @@ void main() {
     expect(clearCount, 1);
   });
 
+  testWidgets('status payload cleanup waits until navigation finishes', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(sendStatusRoutePayloadProvider.notifier);
+    final payload = _reviewArgs(addressType: 'unified');
+    notifier.retain(payload);
+
+    notifier.clearAfterNavigation();
+
+    expect(container.read(sendStatusRoutePayloadProvider), same(payload));
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(container.read(sendStatusRoutePayloadProvider), isNull);
+  });
+
+  testWidgets('deferred cleanup preserves a newer send flow', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(sendStatusRoutePayloadProvider.notifier);
+    final previousPayload = _reviewArgs(addressType: 'unified');
+    final nextPayload = _reviewArgs(addressType: 'transparent');
+    notifier.retain(previousPayload);
+
+    notifier.clearAfterNavigation();
+    notifier.retain(nextPayload);
+    await tester.pump(const Duration(milliseconds: 1));
+
+    expect(container.read(sendStatusRoutePayloadProvider), same(nextPayload));
+  });
+
+  testWidgets('status back navigation clears payload without a build error', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(sendStatusRoutePayloadProvider.notifier);
+    final payload = _reviewArgs(addressType: 'unified');
+    notifier.retain(payload);
+    final router = GoRouter(
+      initialLocation: '/send/status?flow=${payload.sendFlowId}',
+      observers: [
+        SendStatusRoutePayloadObserver(
+          onLeaveStatus: notifier.clearAfterNavigation,
+        ),
+      ],
+      routes: [
+        GoRoute(path: '/home', builder: (_, _) => const Text('home-route')),
+        GoRoute(
+          path: '/send/status',
+          builder: (context, _) => TextButton(
+            onPressed: () => context.go('/home'),
+            child: const Text('back-home'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('back-home'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('home-route'), findsOneWidget);
+    expect(container.read(sendStatusRoutePayloadProvider), isNull);
+  });
+
   test(
     'status route observer preserves payload for same-route replacement',
     () {

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -21,6 +21,11 @@ import 'package:zcash_wallet/src/features/address_book/models/address_book_conta
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
 import 'package:zcash_wallet/src/features/keystone/widgets/keystone_signing_modal.dart';
 import 'package:zcash_wallet/src/features/send/screens/send_review_screen.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart'
+    show
+        resolveSendStatusRoutePayload,
+        SendStatusRoutePayloadObserver,
+        sendStatusRoutePayloadProvider;
 import 'package:zcash_wallet/src/features/send/widgets/send_review_content_view.dart';
 import 'package:zcash_wallet/src/features/send/widgets/verify_address_modal.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
@@ -430,6 +435,93 @@ void main() {
     expect(rustApi.discardCalls, isEmpty);
   });
 
+  testWidgets('Keystone status survives a router refresh after handoff', (
+    tester,
+  ) async {
+    final routerRefresh = ChangeNotifier();
+    addTearDown(routerRefresh.dispose);
+    final statusExtras = <Object?>[];
+
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _harness(
+        _reviewArgs(addressType: 'unified'),
+        bootstrap: _bootstrap(isHardware: true),
+        statusExtras: statusExtras,
+        routerRefresh: routerRefresh,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Confirm with Keystone'));
+    await _flushRealAsync(tester);
+    await tester.tap(find.text('Get signature'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('keystone-scan-route'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('status-route'), findsOneWidget);
+    expect(statusExtras.last, isA<KeystoneBroadcastArgs>());
+
+    routerRefresh.notifyListeners();
+    await tester.pumpAndSettle();
+
+    expect(find.text('status-route'), findsOneWidget);
+    expect(find.text('send-route'), findsNothing);
+    expect(statusExtras.last, isA<KeystoneBroadcastArgs>());
+  });
+
+  test('retained status payload cannot restore a different send flow', () {
+    final reviewArgs = _reviewArgs(addressType: 'unified');
+    final retained = KeystoneBroadcastArgs(
+      reviewArgs: reviewArgs,
+      pcztWithProofsBytes: _fakeProofsBytes,
+      pcztWithSignaturesBytes: _fakeSignatureBytes,
+    );
+
+    expect(
+      resolveSendStatusRoutePayload(
+        routePayload: null,
+        retainedPayload: retained,
+        sendFlowId: 'different-send-flow',
+      ),
+      isNull,
+    );
+  });
+
+  test('status route observer clears payload when the route is removed', () {
+    var clearCount = 0;
+    final observer = SendStatusRoutePayloadObserver(
+      onLeaveStatus: () => clearCount++,
+    );
+    final statusRoute = MaterialPageRoute<void>(
+      settings: const RouteSettings(name: '/send/status'),
+      builder: (_) => const SizedBox.shrink(),
+    );
+
+    observer.didRemove(statusRoute, null);
+
+    expect(clearCount, 1);
+  });
+
+  test(
+    'status route observer preserves payload for same-route replacement',
+    () {
+      var clearCount = 0;
+      final observer = SendStatusRoutePayloadObserver(
+        onLeaveStatus: () => clearCount++,
+      );
+      MaterialPageRoute<void> statusRoute() => MaterialPageRoute<void>(
+        settings: const RouteSettings(name: '/send/status'),
+        builder: (_) => const SizedBox.shrink(),
+      );
+
+      observer.didReplace(oldRoute: statusRoute(), newRoute: statusRoute());
+
+      expect(clearCount, 0);
+    },
+  );
+
   testWidgets('Keystone reject while preparing discards the proposal', (
     tester,
   ) async {
@@ -518,9 +610,11 @@ Widget _harness(
   AppBootstrapState? bootstrap,
   AddressBookRepository? addressBookRepository,
   List<Object?>? statusExtras,
+  Listenable? routerRefresh,
 }) {
   final router = GoRouter(
     initialLocation: '/send/review',
+    refreshListenable: routerRefresh,
     routes: [
       GoRoute(path: '/send', builder: (_, _) => const Text('send-route')),
       GoRoute(
@@ -536,8 +630,19 @@ Widget _harness(
       ),
       GoRoute(
         path: '/send/status',
-        builder: (_, state) {
-          statusExtras?.add(state.extra);
+        builder: (context, state) {
+          final resolved = resolveSendStatusRoutePayload(
+            routePayload: state.extra,
+            retainedPayload: ProviderScope.containerOf(
+              context,
+            ).read(sendStatusRoutePayloadProvider),
+            sendFlowId: state.uri.queryParameters['flow'],
+          );
+          statusExtras?.add(resolved);
+          if (resolved is! SendReviewArgs &&
+              resolved is! KeystoneBroadcastArgs) {
+            return const Text('send-route');
+          }
           return const Text('status-route');
         },
       ),


### PR DESCRIPTION
## Summary

- retain desktop Send status route payloads across GoRouter refreshes
- bind retained payload restoration to the current send flow ID
- clear retained PCZT data when leaving the status route
- add regression coverage for Keystone handoff, router refresh, flow isolation, and route cleanup

## Root cause

After Keystone returned the signed PCZT, the desktop flow navigated to `/send/status` with `KeystoneBroadcastArgs` in `GoRouterState.extra`. A router refresh rebuilt the same location without `extra`, so the status route fell back to `SendScreen` while the hardware broadcast was still running.

## Impact

The desktop Keystone Send flow now stays on the status screen after signature handoff and continues the broadcast without returning to the Send composer. Software Send behavior remains supported by the same guarded payload retention.

## Validation

- `fvm flutter analyze lib/app.dart lib/src/features/send/screens/send_review_screen.dart lib/src/features/send/screens/send_status_screen.dart lib/src/features/send/services/send_flow.dart test/features/send/send_review_screen_test.dart`
- `fvm flutter test test/features/send/send_review_screen_test.dart test/features/send/send_status_screen_test.dart`
- `git diff --check`