### PR TITLE
Bound Keystone migration signing rounds

### DIFF
--- a/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
@@ -1810,14 +1810,12 @@ List<rust_sync.KeystoneSignedMigrationMessage> _signedMigrationMessagesFor(
 // The Keystone firmware enforces two independent caps on one signing round:
 // the message count (`signingBatchLimit`) and a 512 KiB ceiling that covers
 // both the canonical PCZT byte total and the request-id + Postcard envelope
-// (`ZCASH_SIGN_BATCH_MAX_TOTAL_BYTES` in rust/src/wallet/keystone.rs). Rounds
-// must stay under both, or QR encoding rejects the round after the user has
-// already approved the migration.
-const _keystoneSigningRoundMaxTotalBytes = 512 * 1024;
-// Headroom for the request id and per-message Postcard framing, which the
-// firmware counts against the same ceiling as the raw PCZT payloads.
-const _keystoneSigningRoundByteBudget =
-    _keystoneSigningRoundMaxTotalBytes - 16 * 1024;
+// (`ZCASH_SIGN_BATCH_MAX_TOTAL_BYTES` in rust/src/wallet/keystone.rs). For each
+// action with an empty memo, Keystone restores a 580-byte ciphertext plus two
+// 32-byte derived fields before retaining the checked batch. Keep that
+// normalized payload at or below 490 KiB so the retained envelope has
+// sufficient headroom.
+const _keystoneSigningRoundByteBudget = 490 * 1024;
 
 @visibleForTesting
 List<List<rust_sync.KeystoneMigrationMessage>> keystoneSigningRoundsForTest(
@@ -1837,7 +1835,7 @@ List<List<rust_sync.KeystoneMigrationMessage>> _keystoneSigningRounds(
   var round = <rust_sync.KeystoneMigrationMessage>[];
   var roundBytes = 0;
   for (final message in messages) {
-    final messageBytes = message.redactedPczt.length + message.id.length;
+    final messageBytes = message.normalizedPcztSize;
     // A round cannot be split below one message, so a transaction that alone
     // exceeds the budget can never be encoded. Fail here rather than let the
     // firmware limit reject the request after the user approves the migration.

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -7,7 +7,7 @@ import '../frb_generated.dart';
 import 'keystone.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `catch`, `fetch_block_time`, `migration_status_from_balance`, `parse_network_and_migrate`, `run_full_sync_internal`, `to_wallet_migration_schedule`, `to_wallet_signed_messages`
+// These functions are ignored because they are not marked as `pub`: `catch`, `fetch_block_time`, `migration_status_from_balance`, `parse_network_and_migrate`, `run_full_sync_internal`, `to_api_keystone_migration_request`, `to_wallet_migration_schedule`, `to_wallet_signed_messages`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `MempoolObserverState`
 
 /// Set the desired sync mode. 0=none, 1=foreground, 2=background.
@@ -1229,13 +1229,18 @@ class KeystoneMigrationMessage {
   final String id;
   final Uint8List redactedPczt;
 
+  /// Standalone PCZT size after Keystone restores compact fields.
+  final int normalizedPcztSize;
+
   const KeystoneMigrationMessage({
     required this.id,
     required this.redactedPczt,
+    required this.normalizedPcztSize,
   });
 
   @override
-  int get hashCode => id.hashCode ^ redactedPczt.hashCode;
+  int get hashCode =>
+      id.hashCode ^ redactedPczt.hashCode ^ normalizedPcztSize.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1243,7 +1248,8 @@ class KeystoneMigrationMessage {
       other is KeystoneMigrationMessage &&
           runtimeType == other.runtimeType &&
           id == other.id &&
-          redactedPczt == other.redactedPczt;
+          redactedPczt == other.redactedPczt &&
+          normalizedPcztSize == other.normalizedPcztSize;
 }
 
 class KeystoneMigrationProofStatus {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -8495,11 +8495,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   KeystoneMigrationMessage dco_decode_keystone_migration_message(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return KeystoneMigrationMessage(
       id: dco_decode_String(arr[0]),
       redactedPczt: dco_decode_list_prim_u_8_strict(arr[1]),
+      normalizedPcztSize: dco_decode_u_32(arr[2]),
     );
   }
 
@@ -10903,7 +10904,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_id = sse_decode_String(deserializer);
     var var_redactedPczt = sse_decode_list_prim_u_8_strict(deserializer);
-    return KeystoneMigrationMessage(id: var_id, redactedPczt: var_redactedPczt);
+    var var_normalizedPcztSize = sse_decode_u_32(deserializer);
+    return KeystoneMigrationMessage(
+      id: var_id,
+      redactedPczt: var_redactedPczt,
+      normalizedPcztSize: var_normalizedPcztSize,
+    );
   }
 
   @protected
@@ -13836,6 +13842,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.id, serializer);
     sse_encode_list_prim_u_8_strict(self.redactedPczt, serializer);
+    sse_encode_u_32(self.normalizedPcztSize, serializer);
   }
 
   @protected

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -2547,6 +2547,7 @@ class _IronwoodMigrationHarnessState extends State<_IronwoodMigrationHarness> {
                   rust_sync.KeystoneMigrationMessage(
                     id: 'preview-immediate-transaction',
                     redactedPczt: Uint8List.fromList(const [1, 2, 3]),
+                    normalizedPcztSize: 3,
                   ),
                 ],
                 signingBatchLimit: 1,
@@ -2568,10 +2569,12 @@ class _IronwoodMigrationHarnessState extends State<_IronwoodMigrationHarness> {
                 rust_sync.KeystoneMigrationMessage(
                   id: 'preview-private-split-1',
                   redactedPczt: Uint8List.fromList(const [1, 2, 3]),
+                  normalizedPcztSize: 3,
                 ),
                 rust_sync.KeystoneMigrationMessage(
                   id: 'preview-private-split-2',
                   redactedPczt: Uint8List.fromList(const [4, 5, 6]),
+                  normalizedPcztSize: 3,
                 ),
               ],
               signingBatchLimit: 1,

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -688,12 +688,33 @@ pub struct IronwoodMigrationResult {
 pub struct KeystoneMigrationMessage {
     pub id: String,
     pub redacted_pczt: Vec<u8>,
+    /// Standalone PCZT size after Keystone restores compact fields.
+    pub normalized_pczt_size: u32,
 }
 
 pub struct KeystoneMigrationSigningRequest {
     pub request_id: String,
     pub messages: Vec<KeystoneMigrationMessage>,
     pub signing_batch_limit: u32,
+}
+
+fn to_api_keystone_migration_request(
+    request: wallet_sync::KeystoneMigrationSigningRequest,
+) -> KeystoneMigrationSigningRequest {
+    let messages = request
+        .messages
+        .into_iter()
+        .map(|message| KeystoneMigrationMessage {
+            id: message.id,
+            redacted_pczt: message.redacted_pczt,
+            normalized_pczt_size: message.normalized_pczt_size,
+        })
+        .collect();
+    KeystoneMigrationSigningRequest {
+        request_id: request.request_id,
+        messages,
+        signing_batch_limit: request.signing_batch_limit,
+    }
 }
 
 /// One signed message in the compact "signatures-only" Keystone response: the
@@ -1218,18 +1239,7 @@ pub fn prepare_orchard_migration_immediate_pczt(
                 input_note_count: approved_input_note_count,
             },
         )?;
-        Ok(KeystoneMigrationSigningRequest {
-            request_id: request.request_id,
-            signing_batch_limit: request.signing_batch_limit,
-            messages: request
-                .messages
-                .into_iter()
-                .map(|message| KeystoneMigrationMessage {
-                    id: message.id,
-                    redacted_pczt: message.redacted_pczt,
-                })
-                .collect(),
-        })
+        Ok(to_api_keystone_migration_request(request))
     })
 }
 
@@ -1790,18 +1800,7 @@ pub fn prepare_orchard_migration_denominations_pczt(
                 space_preparation_broadcasts,
             ),
         )?;
-        Ok(KeystoneMigrationSigningRequest {
-            request_id: request.request_id,
-            signing_batch_limit: request.signing_batch_limit,
-            messages: request
-                .messages
-                .into_iter()
-                .map(|message| KeystoneMigrationMessage {
-                    id: message.id,
-                    redacted_pczt: message.redacted_pczt,
-                })
-                .collect(),
-        })
+        Ok(to_api_keystone_migration_request(request))
     })
 }
 
@@ -1937,18 +1936,7 @@ pub fn prepare_orchard_migration_single_qr_pczt(
                 space_preparation_broadcasts,
             ),
         )?;
-        Ok(KeystoneMigrationSigningRequest {
-            request_id: request.request_id,
-            signing_batch_limit: request.signing_batch_limit,
-            messages: request
-                .messages
-                .into_iter()
-                .map(|message| KeystoneMigrationMessage {
-                    id: message.id,
-                    redacted_pczt: message.redacted_pczt,
-                })
-                .collect(),
-        })
+        Ok(to_api_keystone_migration_request(request))
     })
 }
 
@@ -1996,18 +1984,7 @@ pub fn prepare_orchard_migration_batch_pczt(
         let network = parse_network_and_migrate(&db_path, &network)?;
         let request =
             wallet_sync::prepare_orchard_migration_batch_pczt(&db_path, network, &account_uuid)?;
-        Ok(KeystoneMigrationSigningRequest {
-            request_id: request.request_id,
-            signing_batch_limit: request.signing_batch_limit,
-            messages: request
-                .messages
-                .into_iter()
-                .map(|message| KeystoneMigrationMessage {
-                    id: message.id,
-                    redacted_pczt: message.redacted_pczt,
-                })
-                .collect(),
-        })
+        Ok(to_api_keystone_migration_request(request))
     })
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -7237,9 +7237,11 @@ impl SseDecode for crate::api::sync::KeystoneMigrationMessage {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_id = <String>::sse_decode(deserializer);
         let mut var_redactedPczt = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_normalizedPcztSize = <u32>::sse_decode(deserializer);
         return crate::api::sync::KeystoneMigrationMessage {
             id: var_id,
             redacted_pczt: var_redactedPczt,
+            normalized_pczt_size: var_normalizedPcztSize,
         };
     }
 }
@@ -10431,6 +10433,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::sync::KeystoneMigrationMessag
         [
             self.id.into_into_dart().into_dart(),
             self.redacted_pczt.into_into_dart().into_dart(),
+            self.normalized_pczt_size.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -12667,6 +12670,7 @@ impl SseEncode for crate::api::sync::KeystoneMigrationMessage {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.id, serializer);
         <Vec<u8>>::sse_encode(self.redacted_pczt, serializer);
+        <u32>::sse_encode(self.normalized_pczt_size, serializer);
     }
 }
 

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -105,10 +105,9 @@ pub(crate) const PHASE_AWAITING_PREPARATION: &str = "awaiting_preparation";
 pub(crate) const PHASE_AWAITING_DENOMINATION_SIGNATURE: &str = "awaiting_denomination_signature";
 pub(crate) const PHASE_WAITING_DENOM_CONFIRMATIONS: &str = "waiting_denom_confirmations";
 pub(crate) const PHASE_READY_TO_MIGRATE: &str = "ready_to_migrate";
-// Use Keystone's message-count ceiling for every migration signing path. The
-// QR encoder also applies the independent 512 KiB request limit.
-pub(crate) const MIGRATION_KEYSTONE_BATCH_MAX_PARTS: u32 =
-    crate::wallet::keystone::ZCASH_SIGN_BATCH_MAX_MESSAGES as u32;
+// Stay below Keystone's 40-message protocol ceiling. Dart also partitions each
+// signing round by the firmware-normalized PCZT size.
+pub(crate) const MIGRATION_KEYSTONE_BATCH_MAX_PARTS: u32 = 35;
 pub(crate) const PHASE_BROADCAST_SCHEDULED: &str = "broadcast_scheduled";
 pub(crate) const PHASE_BROADCASTING: &str = "broadcasting";
 pub(crate) const PHASE_WAITING_MIGRATION_CONFIRMATIONS: &str = "waiting_migration_confirmations";

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -6988,11 +6988,12 @@ fn ready_to_migrate_does_not_report_denomination_parts_as_completed_transfers() 
 }
 
 #[test]
-fn migration_batch_signing_selector_uses_the_keystone_message_limit() {
+fn migration_batch_signing_selector_uses_the_product_message_limit() {
     assert_eq!(crate::wallet::keystone::ZCASH_SIGN_BATCH_MAX_MESSAGES, 40);
-    assert_eq!(
-        MIGRATION_KEYSTONE_BATCH_MAX_PARTS,
-        crate::wallet::keystone::ZCASH_SIGN_BATCH_MAX_MESSAGES as u32
+    assert_eq!(MIGRATION_KEYSTONE_BATCH_MAX_PARTS, 35);
+    assert!(
+        MIGRATION_KEYSTONE_BATCH_MAX_PARTS
+            < crate::wallet::keystone::ZCASH_SIGN_BATCH_MAX_MESSAGES as u32
     );
     assert_eq!(
         select_migration_batch_signing_part_indices(3, 0, 0, &[]).unwrap(),
@@ -7005,15 +7006,15 @@ fn migration_batch_signing_selector_uses_the_keystone_message_limit() {
     let forty_five_parts = (0..45).collect::<Vec<_>>();
     assert_eq!(
         select_migration_batch_signing_part_indices(45, 45, 0, &forty_five_parts).unwrap(),
-        (0..40).collect::<Vec<_>>()
+        (0..35).collect::<Vec<_>>()
     );
     assert_eq!(
         select_migration_batch_signing_part_indices(45, 0, 0, &[]).unwrap(),
-        (0..40).collect::<Vec<_>>()
+        (0..35).collect::<Vec<_>>()
     );
     assert_eq!(
-        select_migration_batch_signing_part_indices(45, 40, 0, &[]).unwrap(),
-        vec![40, 41, 42, 43, 44]
+        select_migration_batch_signing_part_indices(45, 35, 0, &[]).unwrap(),
+        vec![35, 36, 37, 38, 39, 40, 41, 42, 43, 44]
     );
     assert_eq!(
         select_migration_batch_signing_part_indices(0, 0, 0, &[]).unwrap_err(),

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -524,6 +524,32 @@ pub(crate) struct OrchardMigrationPrivatePlan {
 pub(crate) struct KeystoneMigrationMessage {
     pub id: String,
     pub redacted_pczt: Vec<u8>,
+    pub normalized_pczt_size: u32,
+}
+
+impl KeystoneMigrationMessage {
+    fn new(id: String, redacted_pczt: Vec<u8>) -> Result<Self, String> {
+        // Keystone restores each compact empty memo to a 580-byte ciphertext,
+        // along with the derived commitments, before retaining the checked
+        // batch. Budget the resulting standalone PCZT.
+        let mut normalized = pczt::Pczt::parse(&redacted_pczt)
+            .map_err(|e| format!("Parse compact Zcash batch PCZT: {e:?}"))?;
+        normalized
+            .resolve_fields()
+            .map_err(|e| format!("Resolve compact Zcash batch PCZT fields: {e:?}"))?;
+        let normalized_pczt_size = u32::try_from(
+            normalized
+                .serialize()
+                .map_err(|e| format!("Serialize normalized Zcash batch PCZT: {e:?}"))?
+                .len(),
+        )
+        .map_err(|_| "Normalized Zcash batch PCZT size exceeds u32".to_string())?;
+        Ok(Self {
+            id,
+            redacted_pczt,
+            normalized_pczt_size,
+        })
+    }
 }
 
 pub(crate) struct KeystoneMigrationSigningRequest {

--- a/rust/src/wallet/sync/send/ironwood_migration.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration.rs
@@ -107,11 +107,10 @@ pub(crate) fn prepare_orchard_migration_denominations_pczt(
     let messages = split
         .stages
         .iter()
-        .map(|stage| KeystoneMigrationMessage {
-            id: stage.id.clone(),
-            redacted_pczt: stage.redacted_pczt.clone(),
+        .map(|stage| {
+            KeystoneMigrationMessage::new(stage.id.clone(), stage.redacted_pczt.clone())
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, String>>()?;
     if !messages.is_empty() {
         validate_keystone_migration_messages(&messages)?;
     }
@@ -416,17 +415,25 @@ pub(crate) fn prepare_orchard_migration_single_qr_pczt(
 
     let request_id = new_keystone_migration_request_id("single");
     let mut messages = Vec::with_capacity(total_messages);
-    messages.extend(split.stages.iter().map(|stage| KeystoneMigrationMessage {
-        id: stage.id.clone(),
-        redacted_pczt: stage.redacted_pczt.clone(),
-    }));
+    messages.extend(
+        split
+            .stages
+            .iter()
+            .map(|stage| {
+                KeystoneMigrationMessage::new(stage.id.clone(), stage.redacted_pczt.clone())
+            })
+            .collect::<Result<Vec<_>, String>>()?,
+    );
     messages.extend(
         child_messages
             .iter()
-            .map(|message| KeystoneMigrationMessage {
-                id: message.id.clone(),
-                redacted_pczt: message.redacted_pczt.clone(),
-            }),
+            .map(|message| {
+                KeystoneMigrationMessage::new(
+                    message.id.clone(),
+                    message.redacted_pczt.clone(),
+                )
+            })
+            .collect::<Result<Vec<_>, String>>()?,
     );
     validate_keystone_migration_messages(&messages)?;
 
@@ -708,10 +715,10 @@ pub(crate) fn prepare_orchard_migration_immediate_pczt(
     let redacted_pczt = super::pczt::redact_pczt_for_batch_signer(&built.base_pczt)?;
     let request_id = new_keystone_migration_request_id("immediate");
     let message_id = format!("{request_id}-transaction");
-    let messages = vec![KeystoneMigrationMessage {
-        id: message_id.clone(),
+    let messages = vec![KeystoneMigrationMessage::new(
+        message_id.clone(),
         redacted_pczt,
-    }];
+    )?];
     validate_keystone_migration_messages(&messages)?;
     let base_pczt = built.base_pczt.clone();
     let mut store = keystone_immediate_migration_requests()
@@ -1094,11 +1101,10 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
     let request_id = new_keystone_migration_request_id("batch");
     let messages = created
         .iter()
-        .map(|message| KeystoneMigrationMessage {
-            id: message.id.clone(),
-            redacted_pczt: message.redacted_pczt.clone(),
+        .map(|message| {
+            KeystoneMigrationMessage::new(message.id.clone(), message.redacted_pczt.clone())
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, String>>()?;
     validate_keystone_migration_messages(&messages)?;
     let proof_worker_messages = created
         .iter()

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -467,6 +467,7 @@ fn keystone_migration_signing_accepts_multiple_firmware_rounds() {
         .map(|index| KeystoneMigrationMessage {
             id: format!("message-{index}"),
             redacted_pczt: vec![index as u8, 1],
+            normalized_pczt_size: 2,
         })
         .collect::<Vec<_>>();
 
@@ -2450,6 +2451,13 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
     );
     assert_eq!(built.orchard_spend_action_indices.len(), 11);
 
+    let compact = crate::wallet::sync::pczt::redact_pczt_for_batch_signer(&built.bytes).unwrap();
+    let normalized_size = KeystoneMigrationMessage::new("size-test".to_string(), compact.clone())
+        .unwrap()
+        .normalized_pczt_size;
+    assert_eq!(compact.len(), 7_113);
+    assert_eq!(normalized_size, 17_423);
+
     let signed = sign_orchard_migration_pczt_with_usk(
         &built.bytes,
         &built.orchard_spend_action_indices,
@@ -2616,10 +2624,10 @@ fn batch_signer_redaction_compacts_and_preserves_signable_spends() {
     );
     // The v6 sighash does not commit to anchors.
     assert!(batch_parsed.orchard().anchor().is_none());
-    // Every action sheds `cv_net`. A ciphertext rides as stripped memo
-    // plaintext whenever the wire note fields can decrypt it; only a
-    // dummy output's randomized ciphertext may fail that swap and stay
-    // encrypted on the wire.
+    // Every action sheds `cv_net`. An empty memo replaces a 580-byte ciphertext
+    // with an empty plaintext representation; `resolve_fields` also restores
+    // the 32-byte `cv_net` and `cmx` fields. Only a dummy output's randomized
+    // ciphertext may fail that swap and stay encrypted on the wire.
     for action in batch_parsed.orchard().actions() {
         assert!(action.cv_net().is_none());
         assert!(action.output().cmx().is_none());
@@ -2644,6 +2652,14 @@ fn batch_signer_redaction_compacts_and_preserves_signable_spends() {
     // the original values byte-identically.
     let mut refilled = batch_parsed;
     refilled.resolve_fields().unwrap();
+    let normalized_size = KeystoneMigrationMessage::new("size-test".to_string(), batch.clone())
+        .unwrap()
+        .normalized_pczt_size;
+    assert_eq!(
+        normalized_size as usize,
+        refilled.clone().serialize().unwrap().len()
+    );
+    assert!(normalized_size as usize > batch.len());
     for (reb, orig) in refilled
         .orchard()
         .actions()

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -1042,10 +1042,12 @@ void main() {
           rust_sync.KeystoneMigrationMessage(
             id: 'split-1',
             redactedPczt: Uint8List.fromList([1]),
+            normalizedPcztSize: 1,
           ),
           rust_sync.KeystoneMigrationMessage(
             id: 'split-2',
             redactedPczt: Uint8List.fromList([2]),
+            normalizedPcztSize: 1,
           ),
         ],
         signingBatchLimit: 1,
@@ -1177,6 +1179,7 @@ void main() {
         rust_sync.KeystoneMigrationMessage(
           id: id,
           redactedPczt: Uint8List(bytes),
+          normalizedPcztSize: bytes,
         );
 
     test('chunks by the signing batch limit', () {
@@ -1186,39 +1189,71 @@ void main() {
       expect(rounds.map((round) => round.length), [2, 2, 1]);
     });
 
-    test('splits the first message beyond the 40-message firmware cap', () {
-      final messages = [for (var i = 0; i < 41; i++) message('m$i', 10)];
+    test('splits the first message beyond the 35-message product cap', () {
+      final messages = [for (var i = 0; i < 36; i++) message('m$i', 10)];
       expect(
         keystoneSigningRoundsForTest(
-          messages.take(40).toList(),
-          40,
+          messages.take(35).toList(),
+          35,
         ).map((round) => round.length),
-        [40],
+        [35],
       );
       expect(
-        keystoneSigningRoundsForTest(messages, 40).map((round) => round.length),
-        [40, 1],
+        keystoneSigningRoundsForTest(messages, 35).map((round) => round.length),
+        [35, 1],
       );
     });
 
-    test('splits a round that would exceed the firmware byte ceiling', () {
-      // 40 messages of 26 KiB total over 1 MiB — the count fits in one round
-      // but the firmware rejects anything over 512 KiB per round.
+    test('splits a round whose normalized size exceeds 490 KiB', () {
+      // The count fits in one round, but Keystone's restored PCZTs do not fit
+      // within the retained batch budget.
       final rounds = keystoneSigningRoundsForTest([
-        for (var i = 0; i < 40; i++) message('m$i', 26 * 1024),
-      ], 40);
+        for (var i = 0; i < 35; i++) message('m$i', 26 * 1024),
+      ], 35);
       expect(rounds.length, greaterThan(1));
       for (final round in rounds) {
         final bytes = round.fold<int>(
           0,
-          (total, item) => total + item.redactedPczt.length + item.id.length,
+          (total, item) => total + item.normalizedPcztSize,
         );
-        expect(bytes, lessThanOrEqualTo(512 * 1024 - 16 * 1024));
+        expect(bytes, lessThanOrEqualTo(490 * 1024));
       }
       expect(rounds.expand((round) => round).map((item) => item.id).toList(), [
-        for (var i = 0; i < 40; i++) 'm$i',
+        for (var i = 0; i < 35; i++) 'm$i',
       ]);
     });
+
+    test(
+      'splits 16-action PCZTs before Keystone expands them past 512 KiB',
+      () {
+        // These sizes are pinned by the Rust production-builder redaction test.
+        const compactSize = 7113;
+        const normalizedSize = 17423;
+        final messages = [
+          for (var i = 0; i < 30; i++)
+            rust_sync.KeystoneMigrationMessage(
+              id: 'split-$i',
+              redactedPczt: Uint8List(compactSize),
+              normalizedPcztSize: normalizedSize,
+            ),
+        ];
+
+        expect(
+          messages.fold<int>(
+            0,
+            (total, message) => total + message.redactedPczt.length,
+          ),
+          lessThan(490 * 1024),
+        );
+        expect(
+          keystoneSigningRoundsForTest(
+            messages,
+            35,
+          ).map((round) => round.length),
+          [28, 2],
+        );
+      },
+    );
 
     test('rejects a message no round could ever carry', () {
       // Giving it its own round does not help: the firmware rejects the round
@@ -1228,17 +1263,17 @@ void main() {
         () => keystoneSigningRoundsForTest([
           message('big', 600 * 1024),
           message('small', 10),
-        ], 40),
+        ], 35),
         throwsA(isA<StateError>()),
       );
     });
 
     test('still packs a message that only just fits', () {
-      const budget = 512 * 1024 - 16 * 1024;
+      const budget = 490 * 1024;
       final rounds = keystoneSigningRoundsForTest([
-        message('big', budget - 'big'.length),
+        message('big', budget),
         message('small', 10),
-      ], 40);
+      ], 35);
       expect(
         rounds.map((round) => round.map((item) => item.id).toList()).toList(),
         [

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -5448,6 +5448,7 @@ rust_sync.KeystoneMigrationSigningRequest _keystoneSigningRequest() {
       rust_sync.KeystoneMigrationMessage(
         id: 'message-1',
         redactedPczt: Uint8List.fromList([1, 2, 3]),
+        normalizedPcztSize: 3,
       ),
     ],
     signingBatchLimit: 35,

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -1231,6 +1231,7 @@ rust_sync.KeystoneMigrationSigningRequest _keystoneDenominationRequest() {
       rust_sync.KeystoneMigrationMessage(
         id: 'split-1',
         redactedPczt: Uint8List.fromList([1, 2, 3]),
+        normalizedPcztSize: 3,
       ),
     ],
     signingBatchLimit: 50,
@@ -3429,10 +3430,12 @@ void main() {
         rust_sync.KeystoneMigrationMessage(
           id: 'split-1',
           redactedPczt: Uint8List.fromList([1]),
+          normalizedPcztSize: 1,
         ),
         rust_sync.KeystoneMigrationMessage(
           id: 'split-2',
           redactedPczt: Uint8List.fromList([2]),
+          normalizedPcztSize: 1,
         ),
       ],
       signingBatchLimit: 1,
@@ -3514,6 +3517,7 @@ void main() {
         rust_sync.KeystoneMigrationMessage(
           id: 'immediate-transaction',
           redactedPczt: Uint8List.fromList([1]),
+          normalizedPcztSize: 1,
         ),
       ],
       signingBatchLimit: 1,
@@ -3604,6 +3608,7 @@ void main() {
                 rust_sync.KeystoneMigrationMessage(
                   id: 'split-1',
                   redactedPczt: Uint8List.fromList([1]),
+                  normalizedPcztSize: 1,
                 ),
               ],
               signingBatchLimit: 40,
@@ -3728,6 +3733,7 @@ void main() {
                     rust_sync.KeystoneMigrationMessage(
                       id: 'child-1',
                       redactedPczt: Uint8List.fromList([1]),
+                      normalizedPcztSize: 1,
                     ),
                   ],
                   signingBatchLimit: 40,
@@ -3971,6 +3977,7 @@ void main() {
                   rust_sync.KeystoneMigrationMessage(
                     id: 'message-$prepareCount',
                     redactedPczt: Uint8List.fromList([prepareCount]),
+                    normalizedPcztSize: 1,
                   ),
                 ],
                 signingBatchLimit: 50,


### PR DESCRIPTION
## Summary

- cap one Keystone migration request at 35 transactions, below the firmware's 40-message protocol ceiling
- compute each compact PCZT's standalone size after applying the same `resolve_fields()` normalization as Keystone
- partition QR signing rounds by both the 35-transaction cap and a 490 KiB normalized-byte budget
- carry overflow transactions into subsequent signing rounds instead of dropping them

## Root cause

Keystone applies its 512 KiB limit twice: first to the incoming compact request, and again after validating each PCZT, restoring compact fields, and rebuilding the checked batch.

Migration denomination transactions contain 16 Orchard actions with empty memos. Compact redaction replaces each 580-byte encrypted ciphertext with an empty memo representation and omits the 32-byte `cv_net` and `cmx` fields. The production-padding fixture therefore measures 7,113 bytes on the QR wire but 17,423 bytes after Keystone normalization.

Thirty such transactions total 522,690 normalized bytes before the outer envelope, which explains the reported failure near the firmware limit even though the compact request is much smaller. A percentage discount on compact bytes would not be reliable because the expansion depends on PCZT contents.

## Impact

The representative 30-transaction case is split into rounds of 28 and 2. Smaller transactions can still use up to 35 messages in one round. Every transaction remains in the signing session.

## Validation

- `flutter_rust_bridge_codegen generate`
- `cargo test padded_denomination_split_builds_exactly_sixteen_actions --lib`
- `cargo test batch_signer_redaction_compacts_and_preserves_signable_spends --lib`
- `cargo test migration_batch_signing_selector_uses_the_product_message_limit --lib`
- `fvm flutter test test/features/migration/ironwood_migration_flow_screen_test.dart` (109 tests)
- `fvm flutter analyze` (23 pre-existing unused-code warnings; no new analyzer issues)
