### PR TITLE
Recover due Keystone migration broadcasts

### DIFF
--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -1122,12 +1122,17 @@ class IronwoodMigrationCoordinator
         kAppFormFactor != AppFormFactor.mobile ||
         state.childProofBatchPermits.contains(accountUuid);
     final canPrepareNextProof = _canPrepareNextProof(status);
+    // A finalized due transaction is independent of whether the next signed
+    // child has reached its proof window.
+    final canBroadcastDueTransaction =
+        !usesNativeOutbox && _hasDueScheduledBroadcast(status);
     final phaseCanAdvance =
         (status.phase == kIronwoodMigrationWaitingDenomConfirmationsPhase &&
             status.pendingSplitStageCount > 0) ||
         (status.phase == kIronwoodMigrationReadyToMigratePhase &&
-            hasChildProofBatchPermit &&
-            (!isHardware || canPrepareNextProof)) ||
+            (canBroadcastDueTransaction ||
+                (hasChildProofBatchPermit &&
+                    (!isHardware || canPrepareNextProof)))) ||
         (kAppFormFactor == AppFormFactor.mobile &&
             ((status.phase == kIronwoodMigrationBroadcastScheduledPhase &&
                     ((usesNativeOutbox &&

--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -1122,8 +1122,9 @@ class IronwoodMigrationCoordinator
         kAppFormFactor != AppFormFactor.mobile ||
         state.childProofBatchPermits.contains(accountUuid);
     final canPrepareNextProof = _canPrepareNextProof(status);
-    // A finalized due transaction is independent of whether the next signed
-    // child has reached its proof window.
+    // Broadcasting a finalized due transaction is independent of whether the
+    // next signed child has reached its proof window. `_runAdvance` separately
+    // keeps software proof preparation behind the one-shot proof permit.
     final canBroadcastDueTransaction =
         !usesNativeOutbox && _hasDueScheduledBroadcast(status);
     final phaseCanAdvance =
@@ -1279,10 +1280,13 @@ class IronwoodMigrationCoordinator
     String accountUuid, {
     rust_sync.MigrationStatus? status,
   }) async {
+    final hasChildProofBatchPermit =
+        kAppFormFactor != AppFormFactor.mobile ||
+        state.childProofBatchPermits.contains(accountUuid);
     final consumesProofBatchPermit =
         kAppFormFactor == AppFormFactor.mobile &&
         status != null &&
-        state.childProofBatchPermits.contains(accountUuid) &&
+        hasChildProofBatchPermit &&
         _isChildProofBatchAdvance(status);
     if (consumesProofBatchPermit) {
       state = state.copyWith(
@@ -1300,7 +1304,10 @@ class IronwoodMigrationCoordinator
     try {
       return await ref
           .read(ironwoodMigrationServiceProvider)
-          .continueSoftwarePrivateMigration(accountUuid: accountUuid);
+          .continueSoftwarePrivateMigration(
+            accountUuid: accountUuid,
+            prepareNextProof: hasChildProofBatchPermit,
+          );
     } finally {
       if (ref.mounted) {
         state = state.copyWith(

--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -1288,6 +1288,8 @@ class IronwoodMigrationCoordinator
         status != null &&
         hasChildProofBatchPermit &&
         _isChildProofBatchAdvance(status);
+    final prepareNextProof =
+        kAppFormFactor != AppFormFactor.mobile || consumesProofBatchPermit;
     if (consumesProofBatchPermit) {
       state = state.copyWith(
         childProofBatchPermits: {...state.childProofBatchPermits}
@@ -1306,7 +1308,7 @@ class IronwoodMigrationCoordinator
           .read(ironwoodMigrationServiceProvider)
           .continueSoftwarePrivateMigration(
             accountUuid: accountUuid,
-            prepareNextProof: hasChildProofBatchPermit,
+            prepareNextProof: prepareNextProof,
           );
     } finally {
       if (ref.mounted) {

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -1595,6 +1595,7 @@ class IronwoodMigrationService {
 
   Future<rust_sync.IronwoodMigrationResult> continueSoftwarePrivateMigration({
     required String accountUuid,
+    bool prepareNextProof = true,
   }) async {
     final dbPath = await getWalletDbPath();
     final endpoint = getEndpoint();
@@ -1638,7 +1639,8 @@ class IronwoodMigrationService {
       );
     }
     final isHardware = isHardwareAccount(accountUuid);
-    if (isHardware ||
+    if (!prepareNextProof ||
+        isHardware ||
         broadcastResult.status != kIronwoodMigrationReadyToMigratePhase) {
       return broadcastResult;
     }

--- a/test/features/migration/ironwood_migration_coordinator_provider_test.dart
+++ b/test/features/migration/ironwood_migration_coordinator_provider_test.dart
@@ -459,6 +459,48 @@ void main() {
   );
 
   test(
+    'due software migration broadcasts without preparing the next proof',
+    () async {
+      final statuses = {
+        _softwareUuid: _status(
+          'ready_to_migrate',
+          scheduledHeight: 1_000,
+          signedChildPcztCount: 1,
+          nextActionHeight: 1_000,
+          proofReady: false,
+        ),
+        _hardwareUuid: _status('complete', activeRunId: null),
+      };
+      final softwareStarts = <String>[];
+      final broadcasts = <String>[];
+      final container = _container(
+        statuses: statuses,
+        softwareStarts: softwareStarts,
+        broadcasts: broadcasts,
+        usesNativeOutbox: false,
+        syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_001),
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        ironwoodMigrationCoordinatorProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+
+      final coordinator = container.read(
+        ironwoodMigrationCoordinatorProvider.notifier,
+      );
+      coordinator.grantForegroundProgressPermit(_softwareUuid);
+      await coordinator.refreshNow();
+
+      expect(broadcasts, [_softwareUuid]);
+      expect(softwareStarts, isEmpty);
+    },
+  );
+
+  test(
     'manual retry runs again after an automatic attempt in flight',
     () async {
       final statuses = {

--- a/test/features/migration/ironwood_migration_coordinator_provider_test.dart
+++ b/test/features/migration/ironwood_migration_coordinator_provider_test.dart
@@ -459,7 +459,7 @@ void main() {
   );
 
   test(
-    'due software migration broadcasts without preparing the next proof',
+    'due software broadcast retains a blocked proof permit',
     () async {
       final statuses = {
         _softwareUuid: _status(
@@ -492,11 +492,17 @@ void main() {
       final coordinator = container.read(
         ironwoodMigrationCoordinatorProvider.notifier,
       );
-      coordinator.grantForegroundProgressPermit(_softwareUuid);
+      coordinator.grantChildProofBatchPermit(_softwareUuid);
       await coordinator.refreshNow();
 
       expect(broadcasts, [_softwareUuid]);
       expect(softwareStarts, isEmpty);
+      expect(
+        container
+            .read(ironwoodMigrationCoordinatorProvider)
+            .childProofBatchPermits,
+        contains(_softwareUuid),
+      );
     },
   );
 

--- a/test/features/migration/ironwood_migration_coordinator_provider_test.dart
+++ b/test/features/migration/ironwood_migration_coordinator_provider_test.dart
@@ -419,6 +419,46 @@ void main() {
   });
 
   test(
+    'due Keystone migration broadcasts while the next proof is not ready',
+    () async {
+      final statuses = {
+        _softwareUuid: _status('complete', activeRunId: null),
+        _hardwareUuid: _status(
+          'ready_to_migrate',
+          scheduledHeight: 1_000,
+          signedChildPcztCount: 1,
+          nextActionHeight: 1_000,
+          proofReady: false,
+        ),
+      };
+      final broadcasts = <String>[];
+      final container = _container(
+        statuses: statuses,
+        softwareStarts: [],
+        broadcasts: broadcasts,
+        usesNativeOutbox: false,
+        syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_001),
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        ironwoodMigrationCoordinatorProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+
+      final coordinator = container.read(
+        ironwoodMigrationCoordinatorProvider.notifier,
+      );
+      coordinator.grantForegroundProgressPermit(_hardwareUuid);
+      await coordinator.refreshNow();
+
+      expect(broadcasts, [_hardwareUuid]);
+    },
+  );
+
+  test(
     'manual retry runs again after an automatic attempt in flight',
     () async {
       final statuses = {


### PR DESCRIPTION
## Summary

- allow a due finalized migration transaction to advance from `ready_to_migrate` independently of the next signed child's proof readiness
- preserve the existing proof-readiness and batch-permit gates for future proof preparation
- add regression coverage for a due Keystone transaction when `proofReady` is false

## Motivation / Why

Fixes a coordinator deadlock in overlapping Keystone migration stages.

The migration could have two independent pieces of work:
A finalized Keystone transaction was due for broadcast.
The next Keystone transaction was still waiting for its proof window.

The coordinator incorrectly treated both as one operation. Because the next proof was not ready, it refused to advance, so the already-ready transaction was never broadcast.

The fix allows a due Keystone transaction to broadcast independently of the next proof’s readiness.

## Tests

- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/migration/ironwood_migration_coordinator_provider_test.dart --plain-name "due Keystone migration broadcasts while the next proof is not ready"`
- `fvm flutter analyze lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart test/features/migration/ironwood_migration_coordinator_provider_test.dart`