### PR TITLE
Align mobile Home empty activity with Figma

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -103,6 +103,13 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     mobile: true,
   ),
   FigmaCompareScenario(
+    id: 'mobile-home-no-balance',
+    description: 'Mobile home with no balance or activity',
+    builder: buildMobileHomeNoBalanceUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
     id: 'mobile-home-ironwood-migration-required',
     description:
         'Mobile home balance card in Ironwood migration-required state',

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -2026,26 +2026,37 @@ class _EmptyActivity extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return Column(
-      children: [
-        const SizedBox(height: AppSpacing.sm),
-        Text(
-          'No activity, yet...',
-          style: AppTypography.headlineSmall.copyWith(
-            color: colors.text.accent,
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: AppSpacing.s,
+      ),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: SizedBox(
+          width: 340,
+          child: Column(
+            children: [
+              Text(
+                'No activity, yet...',
+                style: AppTypography.headlineSmall.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.xxs),
+              Text(
+                'How about running your\nfirst ZEC tx?',
+                textAlign: TextAlign.center,
+                style: AppTypography.bodyMedium.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.xxs),
+              const _MobileRestImage(),
+            ],
           ),
         ),
-        const SizedBox(height: AppSpacing.xxs),
-        Text(
-          'How about running your\nfirst ZEC tx?',
-          textAlign: TextAlign.center,
-          style: AppTypography.bodyMedium.copyWith(
-            color: colors.text.secondary,
-          ),
-        ),
-        const SizedBox(height: AppSpacing.md),
-        const _MobileRestImage(),
-      ],
+      ),
     );
   }
 }

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -2034,7 +2034,7 @@ class _EmptyActivity extends StatelessWidget {
       child: Align(
         alignment: Alignment.centerLeft,
         child: SizedBox(
-          width: 340,
+          width: _MobileRestImage.canvasWidth,
           child: Column(
             children: [
               Text(
@@ -2064,27 +2064,42 @@ class _EmptyActivity extends StatelessWidget {
 class _MobileRestImage extends StatelessWidget {
   const _MobileRestImage();
 
+  static const canvasWidth = 340.0;
+  static const _canvasHeight = 220.0;
+  static const _imageLeft = 47.0;
+  static const _imageTop = 28.0;
+  static const _imageWidth = 246.0;
+  static const _imageHeight = 192.0;
+
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      key: const ValueKey('mobile_home_rest_canvas'),
-      width: 340,
-      height: 220,
-      child: Stack(
-        children: [
-          Positioned(
-            left: 47,
-            top: 28,
-            child: Image.asset(
-              'assets/illustrations/home_rest_character.png',
-              key: const ValueKey('mobile_home_rest_image'),
-              width: 246,
-              height: 192,
-              fit: BoxFit.contain,
-            ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final scale =
+            constraints.hasBoundedWidth && constraints.maxWidth < canvasWidth
+            ? constraints.maxWidth / canvasWidth
+            : 1.0;
+        return SizedBox(
+          key: const ValueKey('mobile_home_rest_canvas'),
+          width: canvasWidth * scale,
+          height: _canvasHeight * scale,
+          child: Stack(
+            children: [
+              Positioned(
+                left: _imageLeft * scale,
+                top: _imageTop * scale,
+                child: Image.asset(
+                  'assets/illustrations/home_rest_character.png',
+                  key: const ValueKey('mobile_home_rest_image'),
+                  width: _imageWidth * scale,
+                  height: _imageHeight * scale,
+                  fit: BoxFit.contain,
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -716,6 +716,26 @@ void main() {
     );
   });
 
+  testWidgets('empty activity keeps its illustration visible at 320 width', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(320, 568));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(_app(_syncedState()));
+    await tester.pump();
+
+    final canvasRect = tester.getRect(
+      find.byKey(const ValueKey('mobile_home_rest_canvas')),
+    );
+    final imageRect = tester.getRect(
+      find.byKey(const ValueKey('mobile_home_rest_image')),
+    );
+
+    expect(imageRect.left, greaterThanOrEqualTo(canvasRect.left));
+    expect(imageRect.right, lessThanOrEqualTo(canvasRect.right));
+  });
+
   testWidgets('includes Ironwood funds in the mobile shielded balance', (
     tester,
   ) async {

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -680,6 +680,42 @@ void main() {
     expect(find.text('No activity, yet...'), findsOneWidget);
   });
 
+  testWidgets('empty activity uses the Figma inner inset', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(393, 852));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(_app(_syncedState()));
+    await tester.pump();
+
+    final receiveRect = tester.getRect(
+      find.byKey(const ValueKey('mobile_home_receive')),
+    );
+    final canvasRect = tester.getRect(
+      find.byKey(const ValueKey('mobile_home_rest_canvas')),
+    );
+    final titleRect = tester.getRect(find.text('No activity, yet...'));
+    final bodyRect = tester.getRect(
+      find.text('How about running your\nfirst ZEC tx?'),
+    );
+
+    expect(
+      canvasRect.left,
+      moreOrLessEquals(receiveRect.left + AppSpacing.xs, epsilon: 0.1),
+    );
+    expect(
+      titleRect.top,
+      moreOrLessEquals(receiveRect.bottom + 36, epsilon: 0.1),
+    );
+    expect(
+      bodyRect.top - titleRect.bottom,
+      moreOrLessEquals(AppSpacing.xxs, epsilon: 0.1),
+    );
+    expect(
+      canvasRect.top - bodyRect.bottom,
+      moreOrLessEquals(AppSpacing.xxs, epsilon: 0.1),
+    );
+  });
+
   testWidgets('includes Ironwood funds in the mobile shielded balance', (
     tester,
   ) async {

--- a/test/figma_compare/figma_compare_test.dart
+++ b/test/figma_compare/figma_compare_test.dart
@@ -21,6 +21,7 @@ void main() {
         'customise-account',
         'mobile-customise-account',
         'mobile-home-default',
+        'mobile-home-no-balance',
         'ironwood-migration-announcement-modal',
       ]),
     );


### PR DESCRIPTION
## Problem

The mobile Home zero-balance/no-activity state did not use the Recent Activity frame spacing from Figma node 4394:90024. It had no horizontal inset, 16 px above the copy, and 24 px between the body copy and illustration, so the empty-state block looked offset and the illustration sat too low.

## Solution

- Apply the Figma 8 px horizontal and 12 px vertical insets with existing spacing tokens.
- Use the Figma 4 px gap between the copy and the existing 340 x 220 Rest illustration canvas.
- Register a deterministic mobile-home-no-balance Figma comparison scenario.
- Add geometry regression coverage for the empty-state inset and gaps.

## Verification

- Mobile Home test suite: 47 tests passed.
- 393 x 852 dark mobile Figma comparison capture passed for mobile-home-no-balance.
- Comparison scenario registration test passed.
- All four changed files pass targeted Flutter analysis.
- git diff --check passed.

## Broader repo checks

- The full Figma comparison test file still reports 17 unrelated desktop Ironwood overflow failures.
- Full-project Flutter analysis still reports 23 unrelated migration unused-code warnings.