### PR TITLE
Rebase migration schedule onto finalization height

### DIFF
--- a/lib/src/features/migration/models/ironwood_migration_presentation.dart
+++ b/lib/src/features/migration/models/ironwood_migration_presentation.dart
@@ -292,8 +292,7 @@ MigrationNextActionPresentation migrationNextActionPresentation({
   final proofWindowIsNext =
       nextProofWindowHeight != null &&
       proofWindowPartIndices.isNotEmpty &&
-      (earliestScheduledHeight == null ||
-          nextProofWindowHeight < earliestScheduledHeight);
+      earliestScheduledHeight == null;
   if (proofWindowIsNext) {
     final windowAmount = parts
         .where((part) => proofWindowPartIndices.contains(part.partIndex))
@@ -375,10 +374,15 @@ MigrationNextActionPresentation migrationNextActionPresentation({
     (part) => part.state == rust_sync.MigrationPartState.preparing,
   );
   if (preparing != null) {
+    final scheduledHeight =
+        preparing.effectiveScheduledHeight ??
+        preparing.scheduledHeight ??
+        status.nextActionHeight;
     return MigrationNextActionPresentation(
       label: 'Next migration',
       amountZatoshi: preparing.valueZatoshi,
-      detail: 'Schedule pending',
+      detail: scheduledHeight == null ? 'Schedule pending' : 'at',
+      scheduledHeight: scheduledHeight,
     );
   }
 

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -468,6 +468,7 @@ struct MigrationTimingPendingPart {
 struct MigrationTimingSignedChild {
     part_index: u32,
     target_height: u32,
+    scheduled_height: Option<u32>,
 }
 
 pub(crate) fn migration_status(
@@ -3702,6 +3703,296 @@ pub(crate) fn set_proof_retry_height(
     Ok(())
 }
 
+/// One-time rebase of the approved absolute child schedule onto the height at
+/// which proof finalization can actually run.
+///
+/// The signed schedule is planned before denomination notes can be proved.
+/// Once `proof_retry_height` records readiness, shift every unpromoted signed
+/// child to the current scanned height so time spent waiting for foreground
+/// finalization does not consume the approved offsets. If any child would leave
+/// its already-signed ZIP-318 expiry bucket, leave the schedule untouched so
+/// the normal overdue catch-up / resign path can run.
+///
+/// Returns `true` only when child heights were rewritten. Idempotent once the
+/// durable `initial_schedule_rebased_origin_height` marker is set.
+pub(crate) fn rebase_initial_signed_schedule_for_anchor_readiness(
+    db_path: &str,
+    run_id: &str,
+    current_scanned_height: u32,
+) -> Result<bool, String> {
+    with_wallet_db_write_lock("migration.rebase_initial_signed_schedule", || {
+        let conn = open_wallet_raw_conn_with_timeout(db_path, WALLET_DB_BUSY_TIMEOUT)?;
+        ensure_schema(&conn)?;
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| format!("Begin initial migration schedule rebase: {e}"))?;
+        let applied = rebase_initial_signed_schedule_for_anchor_readiness_with_tx(
+            &tx,
+            run_id,
+            current_scanned_height,
+        )?;
+        tx.commit()
+            .map_err(|e| format!("Commit initial migration schedule rebase: {e}"))?;
+        Ok(applied)
+    })
+}
+
+fn rebase_initial_signed_schedule_for_anchor_readiness_with_tx(
+    tx: &rusqlite::Transaction<'_>,
+    run_id: &str,
+    current_scanned_height: u32,
+) -> Result<bool, String> {
+    let (
+        schedule_json,
+        target_values_json,
+        proof_retry_height,
+        signed_schedule_origin,
+        rebased_origin,
+    ) = tx
+        .query_row(
+            &format!(
+                "SELECT schedule_json, target_values_json, proof_retry_height,
+                        signed_schedule_origin_height,
+                        initial_schedule_rebased_origin_height
+                 FROM {RUNS_TABLE}
+                 WHERE run_id = ?1"
+            ),
+            params![run_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<u32>>(2)?,
+                    row.get::<_, Option<u32>>(3)?,
+                    row.get::<_, Option<u32>>(4)?,
+                ))
+            },
+        )
+        .map_err(|e| format!("Read migration schedule for initial rebase: {e}"))?;
+
+    // If already rebased, do nothing.
+    if rebased_origin.is_some() {
+        return Ok(false);
+    }
+    let Some(proof_retry_height) = proof_retry_height else {
+        return Ok(false);
+    };
+    // This function can be reached while the prepared note is known but its
+    // anchor is still aging. Do not freeze the one-time marker until the
+    // wallet has actually scanned through proof readiness.
+    if current_scanned_height < proof_retry_height {
+        return Ok(false);
+    }
+    let Some(signed_schedule_origin) = signed_schedule_origin else {
+        return Ok(false);
+    };
+
+    // If at least one child has been turned into a pending transaction, do nothing.
+    if count_for_run(tx, PENDING_TXS_TABLE, run_id)? > 0 {
+        return Ok(false);
+    }
+
+    // Decode the schedule and targets.
+    let schedule: Vec<MigrationScheduleEntry> = serde_json::from_str(&schedule_json)
+        .map_err(|e| format!("Decode migration schedule for initial rebase: {e}"))?;
+    if schedule.is_empty() {
+        return Ok(false);
+    }
+    let target_values: Vec<u64> = serde_json::from_str(&target_values_json)
+        .map_err(|e| format!("Decode migration targets for initial rebase: {e}"))?;
+
+    let mut stmt = tx
+        .prepare_cached(&format!(
+            "SELECT message_id, child_index, value_zatoshi, scheduled_height, expiry_height
+             FROM {SIGNED_CHILD_PCZTS_TABLE}
+             WHERE run_id = ?1
+             ORDER BY child_index ASC, message_id ASC"
+        ))
+        .map_err(|e| format!("Prepare signed children for initial rebase: {e}"))?;
+    let rows = stmt
+        .query_map(params![run_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, u32>(1)?,
+                row.get::<_, u64>(2)?,
+                row.get::<_, u32>(3)?,
+                row.get::<_, u32>(4)?,
+            ))
+        })
+        .map_err(|e| format!("Query signed children for initial rebase: {e}"))?;
+    let mut children = Vec::new();
+    for row in rows {
+        children.push(row.map_err(|e| format!("Read signed child for initial rebase: {e}"))?);
+    }
+    drop(stmt);
+    if children.is_empty() {
+        return Ok(false);
+    }
+    // A resumable Keystone request can retain unsigned children while older
+    // or partially committed siblings are already present. Rebasing that
+    // subset would make the outstanding request's original schedule origin
+    // impossible to insert. Wait until every planned initial part is durable;
+    // current requests commit all remaining parts atomically, so this only
+    // delays legacy/incremental recovery states.
+    let planned_part_count = u32::try_from(target_values.len())
+        .map_err(|_| "Migration target count exceeds u32 during initial rebase")?;
+    let committed_part_indices = children
+        .iter()
+        .map(|(_, child_index, _, _, _)| *child_index)
+        .collect::<BTreeSet<_>>();
+    if committed_part_indices
+        .iter()
+        .copied()
+        .ne(0..planned_part_count)
+    {
+        return Ok(false);
+    }
+
+    // Start the schedule when finalization can actually run, rather than at
+    // the earlier chain-derived proof-readiness height.
+    let new_origin = signed_schedule_origin.max(current_scanned_height);
+    if new_origin == signed_schedule_origin {
+        // Nothing to shift, but freeze the attempt so later calls cannot
+        // reinterpret the already-approved schedule.
+        mark_initial_schedule_rebased_with_tx(
+            tx,
+            run_id,
+            signed_schedule_origin,
+            new_origin,
+            "already at finalization origin",
+        )?;
+        return Ok(false);
+    }
+
+    // Validate and calculate every child update.
+    let mut updates = Vec::with_capacity(children.len());
+    for (message_id, child_index, value_zatoshi, scheduled_height, expiry_height) in children {
+        // Find the block offset for this child.
+        let Some(block_offset) =
+            schedule_block_offset_for_part(&schedule, &target_values, child_index, value_zatoshi)
+        else {
+            // Retained replacement / legacy children can fall outside the
+            // approved schedule. Freeze the rebase attempt and leave catch-up
+            // / resign to handle the schedule.
+            mark_initial_schedule_rebased_with_tx(
+                tx,
+                run_id,
+                signed_schedule_origin,
+                new_origin,
+                "child missing from approved schedule",
+            )?;
+            return Ok(false);
+        };
+        let Some(expected_origin) = scheduled_height.checked_sub(block_offset) else {
+            mark_initial_schedule_rebased_with_tx(
+                tx,
+                run_id,
+                signed_schedule_origin,
+                new_origin,
+                "child schedule underflows origin",
+            )?;
+            return Ok(false);
+        };
+        if expected_origin != signed_schedule_origin {
+            // Mixed origins are reachable after recovery/reorg paths keep
+            // children keyed off recovery_schedule_origin_height. Never turn
+            // that into a permanent finalize hard-error.
+            mark_initial_schedule_rebased_with_tx(
+                tx,
+                run_id,
+                signed_schedule_origin,
+                new_origin,
+                &format!("mixed child origin {expected_origin}"),
+            )?;
+            return Ok(false);
+        }
+        let Some(new_scheduled_height) = new_origin.checked_add(block_offset) else {
+            mark_initial_schedule_rebased_with_tx(
+                tx,
+                run_id,
+                signed_schedule_origin,
+                new_origin,
+                "rebased scheduled height overflow",
+            )?;
+            return Ok(false);
+        };
+        let new_expiry = zip318_canonical_migration_expiry_height(new_scheduled_height)?;
+        if new_expiry != expiry_height {
+            // Crossing a ZIP-318 expiry bucket would invalidate the already-
+            // signed PCZT. Leave the schedule alone for catch-up / resign.
+            // Do not freeze the marker: a replacement signed schedule may use
+            // an expiry bucket compatible with the then-current height.
+            log::info!(
+                "migration: skipped initial schedule rebase for run {run_id}: \
+                 expiry bucket would change (origin {signed_schedule_origin} -> {new_origin})"
+            );
+            return Ok(false);
+        }
+        updates.push((message_id, new_scheduled_height));
+    }
+
+    let now = now_ms()?;
+    for (message_id, new_scheduled_height) in &updates {
+        let updated = tx
+            .execute(
+                &format!(
+                    "UPDATE {SIGNED_CHILD_PCZTS_TABLE}
+                     SET scheduled_height = ?1
+                     WHERE run_id = ?2 AND message_id = ?3"
+                ),
+                params![new_scheduled_height, run_id, message_id],
+            )
+            .map_err(|e| format!("Update rebased migration scheduled height: {e}"))?;
+        if updated != 1 {
+            // PK is (run_id, message_id), so this only happens if the row
+            // disappeared mid-transaction. Abort without committing writes.
+            return Err("Failed to rebase exactly one signed migration child".to_string());
+        }
+    }
+    tx.execute(
+        &format!(
+            "UPDATE {RUNS_TABLE}
+             SET signed_schedule_origin_height = ?1,
+                 initial_schedule_rebased_origin_height = ?1,
+                 updated_at_ms = ?2
+             WHERE run_id = ?3
+               AND initial_schedule_rebased_origin_height IS NULL"
+        ),
+        params![new_origin, now, run_id],
+    )
+    .map_err(|e| format!("Persist rebased migration schedule origin: {e}"))?;
+    log::info!(
+        "migration: rebased initial schedule for run {run_id} \
+         from origin {signed_schedule_origin} to {new_origin}"
+    );
+    Ok(true)
+}
+
+fn mark_initial_schedule_rebased_with_tx(
+    tx: &rusqlite::Transaction<'_>,
+    run_id: &str,
+    old_origin: u32,
+    new_origin: u32,
+    reason: &str,
+) -> Result<(), String> {
+    tx.execute(
+        &format!(
+            "UPDATE {RUNS_TABLE}
+             SET initial_schedule_rebased_origin_height = ?1,
+                 updated_at_ms = ?2
+             WHERE run_id = ?3
+               AND initial_schedule_rebased_origin_height IS NULL"
+        ),
+        params![old_origin, now_ms()?, run_id],
+    )
+    .map_err(|e| format!("Mark migration initial schedule rebase complete: {e}"))?;
+    log::info!(
+        "migration: froze initial schedule rebase for run {run_id}: {reason} \
+         (origin {old_origin} -> {new_origin})"
+    );
+    Ok(())
+}
+
 /// Whether a past-expiry pending row should flip to `needs_resign`.
 ///
 /// `scheduled` always resigns. `broadcasted` only resigns once local storage
@@ -5236,17 +5527,25 @@ pub(crate) fn locked_migration_note_refs(
 fn migration_timing_projection_for_run(
     conn: &rusqlite::Connection,
     run_id: &str,
+    current_scanned_height: u32,
     total_count: u32,
     confirmation_target: u32,
 ) -> Result<MigrationTimingProjection, String> {
-    let (schedule_json, proof_retry_height) = conn
+    let (schedule_json, proof_retry_height, rebased_origin) = conn
         .query_row(
             &format!(
-                "SELECT schedule_json, proof_retry_height
+                "SELECT schedule_json, proof_retry_height,
+                        initial_schedule_rebased_origin_height
                  FROM {RUNS_TABLE} WHERE run_id = ?1"
             ),
             params![run_id],
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<u32>>(1)?)),
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<u32>>(1)?,
+                    row.get::<_, Option<u32>>(2)?,
+                ))
+            },
         )
         .map_err(|e| format!("Read migration timing projection: {e}"))?;
     let schedule = serde_json::from_str::<Vec<MigrationScheduleEntry>>(&schedule_json)
@@ -5295,7 +5594,7 @@ fn migration_timing_projection_for_run(
 
     let mut stmt = conn
         .prepare_cached(&format!(
-            "SELECT c.child_index, c.target_height
+            "SELECT c.child_index, c.target_height, c.scheduled_height
              FROM {SIGNED_CHILD_PCZTS_TABLE} c
              WHERE c.run_id = ?1
                AND NOT EXISTS (
@@ -5310,6 +5609,7 @@ fn migration_timing_projection_for_run(
             Ok(MigrationTimingSignedChild {
                 part_index: row.get(0)?,
                 target_height: row.get(1)?,
+                scheduled_height: row.get(2)?,
             })
         })
         .map_err(|e| format!("Query migration timing signed children: {e}"))?
@@ -5321,6 +5621,8 @@ fn migration_timing_projection_for_run(
         &pending,
         &signed_children,
         proof_retry_height,
+        rebased_origin,
+        current_scanned_height,
         total_count,
         confirmation_target,
     )
@@ -5331,6 +5633,8 @@ fn calculate_migration_timing_projection(
     pending: &[MigrationTimingPendingPart],
     signed_children: &[MigrationTimingSignedChild],
     proof_retry_height: Option<u32>,
+    rebased_origin: Option<u32>,
+    current_scanned_height: u32,
     total_count: u32,
     confirmation_target: u32,
 ) -> Result<MigrationTimingProjection, String> {
@@ -5347,28 +5651,28 @@ fn calculate_migration_timing_projection(
         .filter(|part| part.status == "scheduled")
         .min_by_key(|part| part.scheduled_height)
         .map(|part| (part.scheduled_height, part.part_index));
+    // The run-wide rebase marker applies only to the initial signed cohort.
+    // Before any child is promoted, its persisted rebased height supersedes
+    // the readiness height that triggered that one-time rebase. Once a
+    // pending row exists, however, proof_retry_height belongs to a later
+    // proof wave and is again the next action for unpromoted children.
+    let initial_rebased_schedule_pending_promotion = rebased_origin.is_some() && pending.is_empty();
     let proof_next = proof_retry_height
-        .filter(|_| !signed_children.is_empty())
+        .filter(|_| !initial_rebased_schedule_pending_promotion && !signed_children.is_empty())
         .map(|height| {
             (
                 height,
                 signed_children.iter().map(|child| child.part_index).min(),
             )
         });
-    let next_action = match (scheduled_next, proof_next) {
-        (Some(scheduled), Some(proof)) => Some(if scheduled.0 <= proof.0 {
-            scheduled
-        } else {
-            proof
-        }),
-        (Some(scheduled), None) => Some(scheduled),
-        (None, Some(proof)) => Some(proof),
-        (None, None) => None,
+    let mut next_proof_window_part_indices = if proof_next.is_some() {
+        signed_children
+            .iter()
+            .map(|child| child.part_index)
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
     };
-    let mut next_proof_window_part_indices = signed_children
-        .iter()
-        .map(|child| child.part_index)
-        .collect::<Vec<_>>();
     next_proof_window_part_indices.sort_by_key(|part_index| {
         (
             schedule_order_by_part
@@ -5382,52 +5686,93 @@ fn calculate_migration_timing_projection(
     let projected_signed_parts = if signed_children.is_empty() {
         Vec::new()
     } else {
-        // Promotion reuses the first persisted schedule origin. Before any
-        // child is promoted it uses the latest signed construction height.
+        // Before the one-time rebase decision, estimate from construction
+        // height and proof readiness. Once that decision is frozen, or any
+        // child has already been promoted, each signed child's persisted
+        // height is authoritative: recovery can leave children with mixed
+        // origins that cannot be reconstructed from one run-wide marker.
         let persisted_schedule_origin = pending.first().map(|part| {
             part.schedule_start_height
                 .unwrap_or_else(|| part.target_height.saturating_sub(1))
         });
-        let schedule_origin = persisted_schedule_origin
+        let use_persisted_child_schedule =
+            persisted_schedule_origin.is_some() || rebased_origin.is_some();
+        let fallback_schedule_origin = persisted_schedule_origin
+            .or(rebased_origin)
             .or_else(|| {
                 signed_children
                     .iter()
                     .map(|child| child.target_height.saturating_sub(1))
                     .max()
-                    .map(|height| height.max(proof_retry_height.unwrap_or(0)))
+                    .map(|height| {
+                        height
+                            .max(proof_retry_height.unwrap_or(0))
+                            .max(current_scanned_height)
+                    })
             })
             .ok_or("Migration timing projection has no schedule origin")?;
         let indexed_schedule = schedule.iter().all(|entry| entry.part_index.is_some());
         signed_children
             .iter()
-            .map(|child| {
-                let offset = if indexed_schedule {
-                    schedule
-                        .iter()
-                        .find(|entry| entry.part_index == Some(child.part_index))
-                        .map(|entry| entry.block_offset)
-                } else {
-                    schedule.iter().map(|entry| entry.block_offset).max()
-                }
-                .ok_or("Migration timing projection is missing a signed-child schedule")?;
-                schedule_origin
-                    .checked_add(offset)
-                    .ok_or("Migration projected broadcast height overflow")
-                    .map(|height| {
-                        let scheduled_height = if persisted_schedule_origin.is_some() {
-                            height.max(proof_retry_height.unwrap_or(0))
-                        } else {
-                            height
-                        };
-                        MigrationTimingProjectedSignedPart {
+            .map(
+                |child| -> Result<MigrationTimingProjectedSignedPart, String> {
+                    let offset = if indexed_schedule {
+                        schedule
+                            .iter()
+                            .find(|entry| entry.part_index == Some(child.part_index))
+                            .map(|entry| entry.block_offset)
+                    } else {
+                        schedule.iter().map(|entry| entry.block_offset).max()
+                    }
+                    .ok_or("Migration timing projection is missing a signed-child schedule")?;
+                    if let Some(scheduled_height) = child
+                        .scheduled_height
+                        .filter(|_| use_persisted_child_schedule)
+                    {
+                        let schedule_start_height = scheduled_height
+                            .checked_sub(offset)
+                            .ok_or("Migration persisted signed-child schedule underflows origin")?;
+                        // The persisted height remains the source of the
+                        // child's schedule origin, but it cannot be an
+                        // effective broadcast height before proofs are ready.
+                        let scheduled_height =
+                            scheduled_height.max(proof_retry_height.unwrap_or(0));
+                        Ok(MigrationTimingProjectedSignedPart {
                             part_index: child.part_index,
-                            schedule_start_height: schedule_origin,
+                            schedule_start_height,
                             scheduled_height,
-                        }
-                    })
-            })
+                        })
+                    } else {
+                        let scheduled_height = fallback_schedule_origin
+                            .checked_add(offset)
+                            .ok_or("Migration projected broadcast height overflow")?;
+                        let scheduled_height = if persisted_schedule_origin.is_some() {
+                            scheduled_height.max(proof_retry_height.unwrap_or(0))
+                        } else {
+                            scheduled_height
+                        };
+                        Ok(MigrationTimingProjectedSignedPart {
+                            part_index: child.part_index,
+                            schedule_start_height: fallback_schedule_origin,
+                            scheduled_height,
+                        })
+                    }
+                },
+            )
             .collect::<Result<Vec<_>, _>>()?
     };
+    let projected_next = initial_rebased_schedule_pending_promotion
+        .then(|| {
+            projected_signed_parts
+                .iter()
+                .min_by_key(|part| part.scheduled_height)
+                .map(|part| (part.scheduled_height, Some(part.part_index)))
+        })
+        .flatten();
+    let next_action = [scheduled_next, proof_next, projected_next]
+        .into_iter()
+        .flatten()
+        .min_by_key(|candidate| candidate.0);
     // The send loop broadcasts one overdue transaction, then gives every
     // other overdue transaction a fresh randomized height. Until those rows
     // are persisted, an exact completion height would be misleading.
@@ -5502,10 +5847,17 @@ fn calculate_migration_timing_projection(
 fn migration_timing_projection_or_default(
     conn: &rusqlite::Connection,
     run_id: &str,
+    current_scanned_height: u32,
     total_count: u32,
     confirmation_target: u32,
 ) -> MigrationTimingProjection {
-    match migration_timing_projection_for_run(conn, run_id, total_count, confirmation_target) {
+    match migration_timing_projection_for_run(
+        conn,
+        run_id,
+        current_scanned_height,
+        total_count,
+        confirmation_target,
+    ) {
         Ok(projection) => projection,
         Err(error) => {
             log::warn!("migration: timing projection unavailable for run {run_id}: {error}");
@@ -5641,6 +5993,7 @@ fn status_for_run(
     let timing_projection = migration_timing_projection_or_default(
         conn,
         &run.run_id,
+        current_scanned_height,
         total_count,
         denomination_confirmation_target,
     );

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -1905,7 +1905,8 @@ pub(crate) fn insert_pending_txs(
 pub(crate) fn promote_signed_child_pczts_to_pending_txs(
     db_path: &str,
     run_id: &str,
-    pending_txs: Vec<PendingMigrationTxInsert>,
+    mut pending_txs: Vec<PendingMigrationTxInsert>,
+    current_scanned_height: u32,
     remaining_child_retry_height: u32,
     password: &[u8],
     salt_base64: &str,
@@ -1922,6 +1923,33 @@ pub(crate) fn promote_signed_child_pczts_to_pending_txs(
             let tx = conn
                 .unchecked_transaction()
                 .map_err(|e| format!("Begin signed migration PCZT promotion: {e}"))?;
+            if !migration_part_assignment_complete_with_conn(&tx, run_id)? {
+                return Err(
+                    "Migration signing batches are incomplete before proof promotion".to_string(),
+                );
+            }
+            let rebased = rebase_initial_signed_schedule_for_anchor_readiness_with_tx(
+                &tx,
+                run_id,
+                current_scanned_height,
+            )?;
+            if rebased {
+                for pending in &mut pending_txs {
+                    pending.scheduled_height = tx
+                        .query_row(
+                            &format!(
+                                "SELECT scheduled_height
+                                 FROM {SIGNED_CHILD_PCZTS_TABLE}
+                                 WHERE run_id = ?1 AND child_index = ?2"
+                            ),
+                            params![run_id, pending.part_index],
+                            |row| row.get(0),
+                        )
+                        .map_err(|e| {
+                            format!("Read rebased signed migration child schedule: {e}")
+                        })?;
+                }
+            }
             insert_pending_txs_with_tx(&tx, run_id, pending_txs, password, salt_base64)?;
             tx.execute(
                 &format!(
@@ -2667,6 +2695,28 @@ pub(crate) fn signed_child_pczt_count(db_path: &str, run_id: &str) -> Result<u32
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
     unpromoted_signed_child_pczt_count_with_conn(&conn, run_id)
+}
+
+pub(crate) fn migration_part_assignment_complete(
+    db_path: &str,
+    run_id: &str,
+) -> Result<bool, String> {
+    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    ensure_schema(&conn)?;
+    migration_part_assignment_complete_with_conn(&conn, run_id)
+}
+
+fn migration_part_assignment_complete_with_conn(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+) -> Result<bool, String> {
+    let planned_count = planned_part_count_with_conn(conn, run_id)?;
+    let pending_count = count_for_run(conn, PENDING_TXS_TABLE, run_id)?;
+    let signed_count = unpromoted_signed_child_pczt_count_with_conn(conn, run_id)?;
+    let assigned_count = pending_count
+        .checked_add(signed_count)
+        .ok_or("Migration assigned part count overflow")?;
+    Ok(planned_count > 0 && assigned_count == planned_count)
 }
 
 fn unpromoted_signed_child_pczt_count_with_conn(
@@ -3715,6 +3765,7 @@ pub(crate) fn set_proof_retry_height(
 ///
 /// Returns `true` only when child heights were rewritten. Idempotent once the
 /// durable `initial_schedule_rebased_origin_height` marker is set.
+#[cfg(test)]
 pub(crate) fn rebase_initial_signed_schedule_for_anchor_readiness(
     db_path: &str,
     run_id: &str,
@@ -3828,12 +3879,10 @@ fn rebase_initial_signed_schedule_for_anchor_readiness_with_tx(
     if children.is_empty() {
         return Ok(false);
     }
-    // A resumable Keystone request can retain unsigned children while older
-    // or partially committed siblings are already present. Rebasing that
-    // subset would make the outstanding request's original schedule origin
-    // impossible to insert. Wait until every planned initial part is durable;
-    // current requests commit all remaining parts atomically, so this only
-    // delays legacy/incremental recovery states.
+    // Keystone signs at most one message-count-limited batch per QR request.
+    // Finalization waits until every batch is durable, so reject any partial
+    // legacy/request state here: its missing siblings could otherwise arrive
+    // later with the old origin.
     let planned_part_count = u32::try_from(target_values.len())
         .map_err(|_| "Migration target count exceeds u32 during initial rebase")?;
     let committed_part_indices = children

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -1928,27 +1928,27 @@ pub(crate) fn promote_signed_child_pczts_to_pending_txs(
                     "Migration signing batches are incomplete before proof promotion".to_string(),
                 );
             }
-            let rebased = rebase_initial_signed_schedule_for_anchor_readiness_with_tx(
+            rebase_initial_signed_schedule_for_anchor_readiness_with_tx(
                 &tx,
                 run_id,
                 current_scanned_height,
             )?;
-            if rebased {
-                for pending in &mut pending_txs {
-                    pending.scheduled_height = tx
-                        .query_row(
-                            &format!(
-                                "SELECT scheduled_height
-                                 FROM {SIGNED_CHILD_PCZTS_TABLE}
-                                 WHERE run_id = ?1 AND child_index = ?2"
-                            ),
-                            params![run_id, pending.part_index],
-                            |row| row.get(0),
-                        )
-                        .map_err(|e| {
-                            format!("Read rebased signed migration child schedule: {e}")
-                        })?;
-                }
+            // The foreground finalizer loads every signed child before this
+            // per-child promotion loop begins. The first promotion can rebase
+            // all durable child rows, so every later promotion must refresh
+            // its height even though it did not perform the rebase itself.
+            for pending in &mut pending_txs {
+                pending.scheduled_height = tx
+                    .query_row(
+                        &format!(
+                            "SELECT scheduled_height
+                             FROM {SIGNED_CHILD_PCZTS_TABLE}
+                             WHERE run_id = ?1 AND child_index = ?2"
+                        ),
+                        params![run_id, pending.part_index],
+                        |row| row.get(0),
+                    )
+                    .map_err(|e| format!("Read current signed migration child schedule: {e}"))?;
             }
             insert_pending_txs_with_tx(&tx, run_id, pending_txs, password, salt_base64)?;
             tx.execute(

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -5651,14 +5651,13 @@ fn calculate_migration_timing_projection(
         .filter(|part| part.status == "scheduled")
         .min_by_key(|part| part.scheduled_height)
         .map(|part| (part.scheduled_height, part.part_index));
-    // The run-wide rebase marker applies only to the initial signed cohort.
-    // Before any child is promoted, its persisted rebased height supersedes
-    // the readiness height that triggered that one-time rebase. Once a
-    // pending row exists, however, proof_retry_height belongs to a later
-    // proof wave and is again the next action for unpromoted children.
+    // Rebasing changes the approved broadcast schedule, but it does not prove
+    // or promote any child. Keep an already-due proof retry visible while
+    // signed children remain so a cancellation or restart between the rebase
+    // transaction and the first promotion resumes proof creation immediately.
     let initial_rebased_schedule_pending_promotion = rebased_origin.is_some() && pending.is_empty();
     let proof_next = proof_retry_height
-        .filter(|_| !initial_rebased_schedule_pending_promotion && !signed_children.is_empty())
+        .filter(|_| !signed_children.is_empty())
         .map(|height| {
             (
                 height,

--- a/rust/src/wallet/sync/migration/schema.rs
+++ b/rust/src/wallet/sync/migration/schema.rs
@@ -516,6 +516,7 @@ fn ensure_schema(conn: &rusqlite::Connection) -> Result<(), String> {
             preparation_timing_policy TEXT NOT NULL DEFAULT 'immediate',
             proof_retry_height INTEGER,
             signed_schedule_origin_height INTEGER,
+            initial_schedule_rebased_origin_height INTEGER,
             last_error TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_vizor_migration_runs_active
@@ -634,6 +635,12 @@ fn ensure_schema(conn: &rusqlite::Connection) -> Result<(), String> {
         conn,
         RUNS_TABLE,
         "signed_schedule_origin_height",
+        "INTEGER",
+    )?;
+    add_column_if_missing(
+        conn,
+        RUNS_TABLE,
+        "initial_schedule_rebased_origin_height",
         "INTEGER",
     )?;
     add_column_if_missing(conn, PENDING_TXS_TABLE, "scheduled_height", "INTEGER")?;

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -2484,8 +2484,8 @@ fn initial_schedule_rebase_starts_at_finalization_and_preserves_approved_offsets
     .unwrap();
     assert_eq!(projection.next_action_height, Some(340));
     assert_eq!(projection.next_action_part_index, Some(0));
-    assert_eq!(projection.next_proof_window_height, None);
-    assert!(projection.next_proof_window_part_indices.is_empty());
+    assert_eq!(projection.next_proof_window_height, Some(340));
+    assert_eq!(projection.next_proof_window_part_indices, vec![0, 1, 2]);
     assert_eq!(
         projection.projected_signed_parts,
         vec![
@@ -2503,6 +2503,69 @@ fn initial_schedule_rebase_starts_at_finalization_and_preserves_approved_offsets
                 part_index: 2,
                 schedule_start_height: 340,
                 scheduled_height: 436,
+            },
+        ]
+    );
+}
+
+#[test]
+fn timing_projection_keeps_due_proof_retry_after_rebase_before_promotion() {
+    let schedule = vec![
+        MigrationScheduleEntry {
+            part_index: Some(0),
+            value_zatoshi: 100,
+            block_offset: 48,
+        },
+        MigrationScheduleEntry {
+            part_index: Some(1),
+            value_zatoshi: 200,
+            block_offset: 96,
+        },
+    ];
+    let signed_children = vec![
+        MigrationTimingSignedChild {
+            part_index: 0,
+            target_height: 101,
+            scheduled_height: Some(248),
+        },
+        MigrationTimingSignedChild {
+            part_index: 1,
+            target_height: 101,
+            scheduled_height: Some(296),
+        },
+    ];
+
+    // The rebase committed at height 200, but cancellation or a crash kept
+    // every signed child unpromoted. Proof creation must remain due now rather
+    // than waiting for the first randomized broadcast offset at height 248.
+    let projection = calculate_migration_timing_projection(
+        &schedule,
+        &[],
+        &signed_children,
+        Some(200),
+        Some(200),
+        200,
+        2,
+        3,
+    )
+    .unwrap();
+
+    assert_eq!(projection.next_action_height, Some(200));
+    assert_eq!(projection.next_action_part_index, Some(0));
+    assert_eq!(projection.next_proof_window_height, Some(200));
+    assert_eq!(projection.next_proof_window_part_indices, vec![0, 1]);
+    assert_eq!(
+        projection.projected_signed_parts,
+        vec![
+            MigrationTimingProjectedSignedPart {
+                part_index: 0,
+                schedule_start_height: 200,
+                scheduled_height: 248,
+            },
+            MigrationTimingProjectedSignedPart {
+                part_index: 1,
+                schedule_start_height: 200,
+                scheduled_height: 296,
             },
         ]
     );

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -2407,6 +2407,37 @@ fn signed_child_schedule_snapshot(
     (origin, rebased, children)
 }
 
+fn rebase_fixture_pending(
+    part_index: u32,
+    value_zatoshi: u64,
+    scheduled_height: u32,
+) -> PendingMigrationTxInsert {
+    let selected_note = PreparedOrchardNoteRef {
+        txid_hex: format!("{:064x}", 100 + part_index),
+        output_index: 0,
+        value_zatoshi: value_zatoshi + 10,
+        note_version: 2,
+        nullifier_hex: Some(format!("{:064x}", 200 + part_index)),
+    };
+    PendingMigrationTxInsert {
+        part_index,
+        txid_hex: format!("{:064x}", 300 + part_index),
+        raw_tx: vec![part_index as u8, 0xaa, 0x55],
+        target_height: 101,
+        anchor_boundary_height: Some(90),
+        expiry_height: zip318_canonical_migration_expiry_height(scheduled_height).unwrap(),
+        scheduled_height,
+        value_zatoshi,
+        fee_zatoshi: 10,
+        selected_note: selected_note.clone(),
+        metadata: PendingMigrationTxMetadata {
+            tx_kind: "migration".to_string(),
+            funding_account_uuid: "account-1".to_string(),
+            selected_note,
+        },
+    }
+}
+
 #[test]
 fn initial_schedule_rebase_starts_at_finalization_and_preserves_approved_offsets() {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -2653,6 +2684,174 @@ fn initial_schedule_rebase_waits_for_every_planned_child() {
     assert_eq!(origin, Some(340));
     assert_eq!(rebased, Some(340));
     assert_eq!(children, vec![(0, 340, 69_120), (1, 388, 69_120)]);
+}
+
+#[test]
+fn keystone_batches_finish_signing_before_atomic_rebase_promotion() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    let planned_part_count = MIGRATION_KEYSTONE_BATCH_MAX_PARTS + 2;
+    let parts = (0..planned_part_count)
+        .map(|part_index| (part_index, 100 + u64::from(part_index), part_index))
+        .collect::<Vec<_>>();
+    create_signed_children_rebase_fixture(
+        &db_path,
+        "rebase-keystone-batch",
+        100,
+        &parts,
+        Some(200),
+    );
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    conn.execute(
+        &format!(
+            "DELETE FROM {SIGNED_CHILD_PCZTS_TABLE}
+             WHERE run_id = 'rebase-keystone-batch' AND child_index >= ?1"
+        ),
+        params![MIGRATION_KEYSTONE_BATCH_MAX_PARTS],
+    )
+    .unwrap();
+    drop(conn);
+
+    assert!(!migration_part_assignment_complete(&db_path, "rebase-keystone-batch").unwrap());
+    assert_eq!(
+        promote_signed_child_pczts_to_pending_txs(
+            &db_path,
+            "rebase-keystone-batch",
+            vec![rebase_fixture_pending(0, 100, 100)],
+            200,
+            250,
+            TEST_PASSWORD,
+            TEST_SALT_BASE64,
+        )
+        .unwrap_err(),
+        "Migration signing batches are incomplete before proof promotion"
+    );
+    let (origin, rebased, _) = signed_child_schedule_snapshot(&db_path, "rebase-keystone-batch");
+    assert_eq!(origin, Some(100));
+    assert_eq!(rebased, None);
+    let later_children = (MIGRATION_KEYSTONE_BATCH_MAX_PARTS..planned_part_count)
+        .map(|part_index| {
+            let value_zatoshi = 100 + u64::from(part_index);
+            let scheduled_height = 100 + part_index;
+            let selected_note = PreparedOrchardNoteRef {
+                txid_hex: format!("{:064x}", 100 + part_index),
+                output_index: 0,
+                value_zatoshi: value_zatoshi + 10,
+                note_version: 2,
+                nullifier_hex: Some(format!("{:064x}", 200 + part_index)),
+            };
+            SignedMigrationPcztInsert {
+                message_id: format!("child-{part_index}"),
+                child_index: part_index,
+                base_pczt: vec![1, 2, 3],
+                sigs: Vec::new(),
+                target_height: 101,
+                anchor_boundary_height: None,
+                expiry_height: zip318_canonical_migration_expiry_height(scheduled_height).unwrap(),
+                scheduled_height,
+                value_zatoshi,
+                fee_zatoshi: 10,
+                selected_note: selected_note.clone(),
+                metadata: PendingMigrationTxMetadata {
+                    tx_kind: "migration".to_string(),
+                    funding_account_uuid: "account-1".to_string(),
+                    selected_note,
+                },
+            }
+        })
+        .collect();
+    persist_signed_child_pczts_for_run(
+        &db_path,
+        "rebase-keystone-batch",
+        later_children,
+        TEST_PASSWORD,
+        TEST_SALT_BASE64,
+    )
+    .unwrap();
+    assert!(migration_part_assignment_complete(&db_path, "rebase-keystone-batch").unwrap());
+
+    promote_signed_child_pczts_to_pending_txs(
+        &db_path,
+        "rebase-keystone-batch",
+        vec![rebase_fixture_pending(0, 100, 100)],
+        200,
+        250,
+        TEST_PASSWORD,
+        TEST_SALT_BASE64,
+    )
+    .unwrap();
+
+    let (origin, rebased, children) =
+        signed_child_schedule_snapshot(&db_path, "rebase-keystone-batch");
+    assert_eq!(origin, Some(200));
+    assert_eq!(rebased, Some(200));
+    assert_eq!(children.len(), planned_part_count as usize);
+    assert_eq!(children.first(), Some(&(0, 200, 69_120)));
+    assert_eq!(
+        children.last(),
+        Some(&(planned_part_count - 1, 200 + planned_part_count - 1, 69_120,))
+    );
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let stored_schedule: (u32, u32) = conn
+        .query_row(
+            &format!(
+                "SELECT schedule_start_height, scheduled_height
+                 FROM {PENDING_TXS_TABLE}
+                 WHERE run_id = 'rebase-keystone-batch' AND part_index = 0"
+            ),
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(stored_schedule, (200, 200));
+}
+
+#[test]
+fn failed_first_promotion_rolls_back_initial_schedule_rebase() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    create_signed_children_rebase_fixture(
+        &db_path,
+        "rebase-promotion-rollback",
+        100,
+        &[(0, 100, 0), (1, 200, 48)],
+        Some(200),
+    );
+    let mut invalid_pending = rebase_fixture_pending(0, 100, 100);
+    invalid_pending.value_zatoshi = 999;
+
+    assert_eq!(
+        promote_signed_child_pczts_to_pending_txs(
+            &db_path,
+            "rebase-promotion-rollback",
+            vec![invalid_pending],
+            340,
+            400,
+            TEST_PASSWORD,
+            TEST_SALT_BASE64,
+        )
+        .unwrap_err(),
+        "Approved migration schedule no longer matches prepared values"
+    );
+
+    let (origin, rebased, children) =
+        signed_child_schedule_snapshot(&db_path, "rebase-promotion-rollback");
+    assert_eq!(origin, Some(100));
+    assert_eq!(rebased, None);
+    assert_eq!(children, vec![(0, 100, 69_120), (1, 148, 69_120)]);
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    assert_eq!(
+        count_for_run(&conn, PENDING_TXS_TABLE, "rebase-promotion-rollback").unwrap(),
+        0
+    );
 }
 
 #[test]
@@ -4952,6 +5151,7 @@ fn approved_schedule_keeps_unpromoted_anchor_retention_candidates() {
         &db_path,
         "run-1",
         vec![pending(0, 100, 501)],
+        501,
         1_200,
         TEST_PASSWORD,
         TEST_SALT_BASE64,
@@ -5012,6 +5212,7 @@ fn approved_schedule_keeps_unpromoted_anchor_retention_candidates() {
         &db_path,
         "run-1",
         vec![pending(1, 200, 999)],
+        999,
         1_400,
         TEST_PASSWORD,
         TEST_SALT_BASE64,

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -2785,6 +2785,20 @@ fn keystone_batches_finish_signing_before_atomic_rebase_promotion() {
     )
     .unwrap();
 
+    // The foreground finalizer loaded this child before the first promotion
+    // rebased every durable child row. Its stale caller-provided height must be
+    // refreshed from storage even though this second promotion does not rebase.
+    promote_signed_child_pczts_to_pending_txs(
+        &db_path,
+        "rebase-keystone-batch",
+        vec![rebase_fixture_pending(1, 101, 101)],
+        200,
+        250,
+        TEST_PASSWORD,
+        TEST_SALT_BASE64,
+    )
+    .unwrap();
+
     let (origin, rebased, children) =
         signed_child_schedule_snapshot(&db_path, "rebase-keystone-batch");
     assert_eq!(origin, Some(200));
@@ -2796,18 +2810,20 @@ fn keystone_batches_finish_signing_before_atomic_rebase_promotion() {
         Some(&(planned_part_count - 1, 200 + planned_part_count - 1, 69_120,))
     );
     let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
-    let stored_schedule: (u32, u32) = conn
-        .query_row(
-            &format!(
-                "SELECT schedule_start_height, scheduled_height
-                 FROM {PENDING_TXS_TABLE}
-                 WHERE run_id = 'rebase-keystone-batch' AND part_index = 0"
-            ),
-            [],
-            |row| Ok((row.get(0)?, row.get(1)?)),
-        )
+    let mut stmt = conn
+        .prepare(&format!(
+            "SELECT part_index, schedule_start_height, scheduled_height
+             FROM {PENDING_TXS_TABLE}
+             WHERE run_id = 'rebase-keystone-batch'
+             ORDER BY part_index"
+        ))
         .unwrap();
-    assert_eq!(stored_schedule, (200, 200));
+    let stored_schedules = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .unwrap()
+        .collect::<Result<Vec<(u32, u32, u32)>, _>>()
+        .unwrap();
+    assert_eq!(stored_schedules, vec![(0, 200, 200), (1, 200, 201)]);
 }
 
 #[test]

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -2210,7 +2210,7 @@ fn planner_drains_balance_beyond_the_old_run_cap() {
 }
 
 #[test]
-fn timing_projection_starts_approved_offsets_after_initial_proof_readiness() {
+fn timing_projection_clamps_pre_rebase_origin_to_current_scanned_height() {
     let schedule = vec![
         MigrationScheduleEntry {
             part_index: Some(0),
@@ -2232,26 +2232,37 @@ fn timing_projection_starts_approved_offsets_after_initial_proof_readiness() {
         MigrationTimingSignedChild {
             part_index: 0,
             target_height: 101,
+            scheduled_height: Some(100),
         },
         MigrationTimingSignedChild {
             part_index: 1,
             target_height: 101,
+            scheduled_height: Some(148),
         },
         MigrationTimingSignedChild {
             part_index: 2,
             target_height: 101,
+            scheduled_height: Some(196),
         },
     ];
 
-    let projection =
-        calculate_migration_timing_projection(&schedule, &[], &signed_children, Some(200), 3, 3)
-            .unwrap();
+    let projection = calculate_migration_timing_projection(
+        &schedule,
+        &[],
+        &signed_children,
+        Some(200),
+        None,
+        340,
+        3,
+        3,
+    )
+    .unwrap();
 
     assert_eq!(projection.next_action_height, Some(200));
     assert_eq!(projection.next_action_part_index, Some(0));
     assert_eq!(projection.next_proof_window_height, Some(200));
     assert_eq!(projection.next_proof_window_part_indices, vec![0, 1, 2]);
-    assert_eq!(projection.estimated_completion_height, Some(299));
+    assert_eq!(projection.estimated_completion_height, Some(439));
     assert_eq!(
         projection.schedule_order_by_part,
         BTreeMap::from([(0, 0), (1, 1), (2, 2)])
@@ -2261,20 +2272,658 @@ fn timing_projection_starts_approved_offsets_after_initial_proof_readiness() {
         vec![
             MigrationTimingProjectedSignedPart {
                 part_index: 0,
-                schedule_start_height: 200,
-                scheduled_height: 200,
+                schedule_start_height: 340,
+                scheduled_height: 340,
             },
             MigrationTimingProjectedSignedPart {
                 part_index: 1,
-                schedule_start_height: 200,
-                scheduled_height: 248,
+                schedule_start_height: 340,
+                scheduled_height: 388,
             },
             MigrationTimingProjectedSignedPart {
                 part_index: 2,
-                schedule_start_height: 200,
-                scheduled_height: 296,
+                schedule_start_height: 340,
+                scheduled_height: 436,
             },
         ]
+    );
+}
+
+fn create_signed_children_rebase_fixture(
+    db_path: &str,
+    run_id: &str,
+    origin: u32,
+    parts: &[(u32, u64, u32)],
+    proof_retry_height: Option<u32>,
+) {
+    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    ensure_schema(&conn).unwrap();
+    let schedule = parts
+        .iter()
+        .map(
+            |(part_index, value_zatoshi, block_offset)| MigrationScheduleEntry {
+                part_index: Some(*part_index),
+                value_zatoshi: *value_zatoshi,
+                block_offset: *block_offset,
+            },
+        )
+        .collect::<Vec<_>>();
+    let target_values = parts
+        .iter()
+        .map(|(_, value_zatoshi, _)| *value_zatoshi)
+        .collect::<Vec<_>>();
+    conn.execute(
+        &format!(
+            "INSERT INTO {RUNS_TABLE}
+             (run_id, account_uuid, network, db_fingerprint, phase,
+              created_at_ms, updated_at_ms, target_values_json, schedule_json,
+              timing_policy, proof_retry_height, signed_schedule_origin_height)
+             VALUES (?1, 'account-1', 'main', ?2, ?3, 1, 1, ?4, ?5,
+                     'standard_90m', ?6, ?7)"
+        ),
+        params![
+            run_id,
+            db_path,
+            PHASE_READY_TO_MIGRATE,
+            serde_json::to_string(&target_values).unwrap(),
+            serde_json::to_string(&schedule).unwrap(),
+            proof_retry_height,
+            origin,
+        ],
+    )
+    .unwrap();
+    for (part_index, value_zatoshi, block_offset) in parts {
+        let scheduled_height = origin + block_offset;
+        let expiry_height = zip318_canonical_migration_expiry_height(scheduled_height).unwrap();
+        let selected_note = PreparedOrchardNoteRef {
+            txid_hex: format!("{:064x}", 100 + part_index),
+            output_index: 0,
+            value_zatoshi: value_zatoshi + 10,
+            note_version: 2,
+            nullifier_hex: Some(format!("{:064x}", 200 + part_index)),
+        };
+        let metadata = PendingMigrationTxMetadata {
+            tx_kind: "migration".to_string(),
+            funding_account_uuid: "account-1".to_string(),
+            selected_note: selected_note.clone(),
+        };
+        conn.execute(
+            &format!(
+                "INSERT INTO {SIGNED_CHILD_PCZTS_TABLE}
+                 (run_id, message_id, child_index, encrypted_base_pczt,
+                  encrypted_compact_sigs, target_height, expiry_height,
+                  scheduled_height, value_zatoshi, fee_zatoshi,
+                  selected_note_json, metadata_json)
+                 VALUES (?1, ?2, ?3, 'base', 'sigs', ?4, ?5, ?6, ?7, 10, ?8, ?9)"
+            ),
+            params![
+                run_id,
+                format!("child-{part_index}"),
+                part_index,
+                origin + 1,
+                expiry_height,
+                scheduled_height,
+                value_zatoshi,
+                serde_json::to_string(&selected_note).unwrap(),
+                serde_json::to_string(&metadata).unwrap(),
+            ],
+        )
+        .unwrap();
+    }
+}
+
+fn signed_child_schedule_snapshot(
+    db_path: &str,
+    run_id: &str,
+) -> (Option<u32>, Option<u32>, Vec<(u32, u32, u32)>) {
+    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let (origin, rebased): (Option<u32>, Option<u32>) = conn
+        .query_row(
+            &format!(
+                "SELECT signed_schedule_origin_height,
+                        initial_schedule_rebased_origin_height
+                 FROM {RUNS_TABLE}
+                 WHERE run_id = ?1"
+            ),
+            params![run_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    let mut stmt = conn
+        .prepare(&format!(
+            "SELECT child_index, scheduled_height, expiry_height
+             FROM {SIGNED_CHILD_PCZTS_TABLE}
+             WHERE run_id = ?1
+             ORDER BY child_index ASC"
+        ))
+        .unwrap();
+    let children = stmt
+        .query_map(params![run_id], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    (origin, rebased, children)
+}
+
+#[test]
+fn initial_schedule_rebase_starts_at_finalization_and_preserves_approved_offsets() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    create_signed_children_rebase_fixture(
+        &db_path,
+        "rebase-same-bucket",
+        100,
+        &[(0, 100, 0), (1, 200, 48), (2, 300, 96)],
+        Some(200),
+    );
+
+    assert!(rebase_initial_signed_schedule_for_anchor_readiness(
+        &db_path,
+        "rebase-same-bucket",
+        340,
+    )
+    .unwrap());
+
+    let (origin, rebased, children) =
+        signed_child_schedule_snapshot(&db_path, "rebase-same-bucket");
+    assert_eq!(origin, Some(340));
+    assert_eq!(rebased, Some(340));
+    assert_eq!(
+        children,
+        vec![(0, 340, 69_120), (1, 388, 69_120), (2, 436, 69_120),]
+    );
+
+    let projection = calculate_migration_timing_projection(
+        &[
+            MigrationScheduleEntry {
+                part_index: Some(0),
+                value_zatoshi: 100,
+                block_offset: 0,
+            },
+            MigrationScheduleEntry {
+                part_index: Some(1),
+                value_zatoshi: 200,
+                block_offset: 48,
+            },
+            MigrationScheduleEntry {
+                part_index: Some(2),
+                value_zatoshi: 300,
+                block_offset: 96,
+            },
+        ],
+        &[],
+        &[
+            MigrationTimingSignedChild {
+                part_index: 0,
+                target_height: 101,
+                scheduled_height: Some(340),
+            },
+            MigrationTimingSignedChild {
+                part_index: 1,
+                target_height: 101,
+                scheduled_height: Some(388),
+            },
+            MigrationTimingSignedChild {
+                part_index: 2,
+                target_height: 101,
+                scheduled_height: Some(436),
+            },
+        ],
+        Some(340),
+        Some(340),
+        500,
+        3,
+        3,
+    )
+    .unwrap();
+    assert_eq!(projection.next_action_height, Some(340));
+    assert_eq!(projection.next_action_part_index, Some(0));
+    assert_eq!(projection.next_proof_window_height, None);
+    assert!(projection.next_proof_window_part_indices.is_empty());
+    assert_eq!(
+        projection.projected_signed_parts,
+        vec![
+            MigrationTimingProjectedSignedPart {
+                part_index: 0,
+                schedule_start_height: 340,
+                scheduled_height: 340,
+            },
+            MigrationTimingProjectedSignedPart {
+                part_index: 1,
+                schedule_start_height: 340,
+                scheduled_height: 388,
+            },
+            MigrationTimingProjectedSignedPart {
+                part_index: 2,
+                schedule_start_height: 340,
+                scheduled_height: 436,
+            },
+        ]
+    );
+}
+
+#[test]
+fn initial_schedule_rebase_waits_for_every_planned_child() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    create_signed_children_rebase_fixture(
+        &db_path,
+        "rebase-partial-request",
+        100,
+        &[(0, 100, 0), (1, 200, 48)],
+        Some(200),
+    );
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    conn.execute(
+        &format!(
+            "DELETE FROM {SIGNED_CHILD_PCZTS_TABLE}
+             WHERE run_id = 'rebase-partial-request' AND child_index = 1"
+        ),
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    assert!(!rebase_initial_signed_schedule_for_anchor_readiness(
+        &db_path,
+        "rebase-partial-request",
+        340,
+    )
+    .unwrap());
+    let (origin, rebased, children) =
+        signed_child_schedule_snapshot(&db_path, "rebase-partial-request");
+    assert_eq!(origin, Some(100));
+    assert_eq!(rebased, None);
+    assert_eq!(children, vec![(0, 100, 69_120)]);
+
+    let selected_note = PreparedOrchardNoteRef {
+        txid_hex: format!("{:064x}", 101),
+        output_index: 0,
+        value_zatoshi: 210,
+        note_version: 2,
+        nullifier_hex: Some(format!("{:064x}", 201)),
+    };
+    persist_signed_child_pczts_for_run(
+        &db_path,
+        "rebase-partial-request",
+        vec![SignedMigrationPcztInsert {
+            message_id: "child-1".to_string(),
+            child_index: 1,
+            base_pczt: vec![1, 2, 3],
+            sigs: Vec::new(),
+            target_height: 101,
+            anchor_boundary_height: None,
+            expiry_height: 69_120,
+            scheduled_height: 148,
+            value_zatoshi: 200,
+            fee_zatoshi: 10,
+            selected_note: selected_note.clone(),
+            metadata: PendingMigrationTxMetadata {
+                tx_kind: "migration".to_string(),
+                funding_account_uuid: "account-1".to_string(),
+                selected_note,
+            },
+        }],
+        TEST_PASSWORD,
+        TEST_SALT_BASE64,
+    )
+    .unwrap();
+
+    assert!(rebase_initial_signed_schedule_for_anchor_readiness(
+        &db_path,
+        "rebase-partial-request",
+        340,
+    )
+    .unwrap());
+    let (origin, rebased, children) =
+        signed_child_schedule_snapshot(&db_path, "rebase-partial-request");
+    assert_eq!(origin, Some(340));
+    assert_eq!(rebased, Some(340));
+    assert_eq!(children, vec![(0, 340, 69_120), (1, 388, 69_120)]);
+}
+
+#[test]
+fn initial_schedule_rebase_waits_for_proof_readiness_before_freezing_origin() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    create_signed_children_rebase_fixture(
+        &db_path,
+        "rebase-before-ready",
+        100,
+        &[(0, 100, 0), (1, 200, 24)],
+        Some(300),
+    );
+
+    assert!(!rebase_initial_signed_schedule_for_anchor_readiness(
+        &db_path,
+        "rebase-before-ready",
+        250,
+    )
+    .unwrap());
+    let (origin, rebased, children) =
+        signed_child_schedule_snapshot(&db_path, "rebase-before-ready");
+    assert_eq!(origin, Some(100));
+    assert_eq!(rebased, None);
+    assert_eq!(children, vec![(0, 100, 69_120), (1, 124, 69_120)]);
+
+    assert!(rebase_initial_signed_schedule_for_anchor_readiness(
+        &db_path,
+        "rebase-before-ready",
+        340,
+    )
+    .unwrap());
+    let (origin, rebased, children) =
+        signed_child_schedule_snapshot(&db_path, "rebase-before-ready");
+    assert_eq!(origin, Some(340));
+    assert_eq!(rebased, Some(340));
+    assert_eq!(children, vec![(0, 340, 69_120), (1, 364, 69_120)]);
+}
+
+#[test]
+fn initial_schedule_rebase_is_idempotent_across_restart() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    create_signed_children_rebase_fixture(
+        &db_path,
+        "rebase-restart",
+        100,
+        &[(0, 100, 0), (1, 200, 24)],
+        Some(200),
+    );
+
+    assert!(
+        rebase_initial_signed_schedule_for_anchor_readiness(&db_path, "rebase-restart", 200)
+            .unwrap()
+    );
+    assert!(
+        !rebase_initial_signed_schedule_for_anchor_readiness(&db_path, "rebase-restart", 300)
+            .unwrap()
+    );
+
+    let (origin, rebased, children) = signed_child_schedule_snapshot(&db_path, "rebase-restart");
+    assert_eq!(origin, Some(200));
+    assert_eq!(rebased, Some(200));
+    assert_eq!(children, vec![(0, 200, 69_120), (1, 224, 69_120)]);
+}
+
+#[test]
+fn initial_schedule_rebase_skips_atomically_when_expiry_bucket_would_change() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    create_signed_children_rebase_fixture(
+        &db_path,
+        "rebase-expiry",
+        100,
+        &[(0, 100, 0), (1, 200, 48)],
+        Some(ZIP318_EXPIRY_MODULUS),
+    );
+
+    assert!(!rebase_initial_signed_schedule_for_anchor_readiness(
+        &db_path,
+        "rebase-expiry",
+        ZIP318_EXPIRY_MODULUS,
+    )
+    .unwrap());
+
+    let (origin, rebased, children) = signed_child_schedule_snapshot(&db_path, "rebase-expiry");
+    assert_eq!(origin, Some(100));
+    assert_eq!(rebased, None);
+    assert_eq!(children, vec![(0, 100, 69_120), (1, 148, 69_120)]);
+}
+
+#[test]
+fn initial_schedule_rebase_skips_mixed_origin_children_without_stalling() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    create_signed_children_rebase_fixture(
+        &db_path,
+        "rebase-mixed-origin",
+        100,
+        &[(0, 100, 0), (1, 200, 48)],
+        Some(250),
+    );
+    // Simulate a retained replacement / legacy child whose absolute schedule
+    // was built from recovery_schedule_origin_height instead of the run origin.
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    conn.execute(
+        &format!(
+            "UPDATE {SIGNED_CHILD_PCZTS_TABLE}
+             SET scheduled_height = 348
+             WHERE run_id = 'rebase-mixed-origin' AND child_index = 1"
+        ),
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    assert!(!rebase_initial_signed_schedule_for_anchor_readiness(
+        &db_path,
+        "rebase-mixed-origin",
+        250,
+    )
+    .unwrap());
+    assert!(!rebase_initial_signed_schedule_for_anchor_readiness(
+        &db_path,
+        "rebase-mixed-origin",
+        300,
+    )
+    .unwrap());
+
+    let (origin, rebased, children) =
+        signed_child_schedule_snapshot(&db_path, "rebase-mixed-origin");
+    assert_eq!(origin, Some(100));
+    assert_eq!(rebased, Some(100));
+    assert_eq!(children, vec![(0, 100, 69_120), (1, 348, 69_120)]);
+
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let projection =
+        migration_timing_projection_for_run(&conn, "rebase-mixed-origin", 500, 2, 3).unwrap();
+    assert_eq!(
+        projection.projected_signed_parts,
+        vec![
+            MigrationTimingProjectedSignedPart {
+                part_index: 0,
+                schedule_start_height: 100,
+                scheduled_height: 250,
+            },
+            MigrationTimingProjectedSignedPart {
+                part_index: 1,
+                schedule_start_height: 300,
+                scheduled_height: 348,
+            },
+        ]
+    );
+    assert_eq!(projection.next_action_height, Some(250));
+    assert_eq!(projection.next_action_part_index, Some(0));
+}
+
+#[test]
+fn initial_schedule_rebase_skips_after_partial_promotion_and_survives_reorg_reset() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    create_signed_children_rebase_fixture(
+        &db_path,
+        "rebase-reorg",
+        100,
+        &[(0, 100, 0), (1, 200, 48)],
+        Some(250),
+    );
+    assert!(
+        rebase_initial_signed_schedule_for_anchor_readiness(&db_path, "rebase-reorg", 250).unwrap()
+    );
+
+    let selected_note = PreparedOrchardNoteRef {
+        txid_hex: format!("{:064x}", 100),
+        output_index: 0,
+        value_zatoshi: 110,
+        note_version: 2,
+        nullifier_hex: Some(format!("{:064x}", 200)),
+    };
+    insert_pending_txs(
+        &db_path,
+        "rebase-reorg",
+        vec![PendingMigrationTxInsert {
+            part_index: 0,
+            txid_hex: format!("{:064x}", 1),
+            raw_tx: vec![1, 0xaa, 0x55],
+            target_height: 101,
+            anchor_boundary_height: Some(90),
+            expiry_height: 69_120,
+            scheduled_height: 250,
+            value_zatoshi: 100,
+            fee_zatoshi: 10,
+            selected_note: selected_note.clone(),
+            metadata: PendingMigrationTxMetadata {
+                tx_kind: "migration".to_string(),
+                funding_account_uuid: "account-1".to_string(),
+                selected_note,
+            },
+        }],
+        TEST_PASSWORD,
+        TEST_SALT_BASE64,
+    )
+    .unwrap();
+
+    assert!(
+        !rebase_initial_signed_schedule_for_anchor_readiness(&db_path, "rebase-reorg", 300)
+            .unwrap()
+    );
+
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    conn.execute(
+        &format!("DELETE FROM {PENDING_TXS_TABLE} WHERE run_id = 'rebase-reorg'"),
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    assert!(
+        !rebase_initial_signed_schedule_for_anchor_readiness(&db_path, "rebase-reorg", 350)
+            .unwrap()
+    );
+    let (origin, rebased, children) = signed_child_schedule_snapshot(&db_path, "rebase-reorg");
+    assert_eq!(origin, Some(250));
+    assert_eq!(rebased, Some(250));
+    assert_eq!(children, vec![(0, 250, 69_120), (1, 298, 69_120)]);
+}
+
+#[test]
+fn genuine_catch_up_still_redraws_after_initial_schedule_rebase() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    create_signed_children_rebase_fixture(
+        &db_path,
+        "rebase-catch-up",
+        100,
+        &[(0, 100, 0), (1, 200, 48)],
+        Some(200),
+    );
+    assert!(
+        rebase_initial_signed_schedule_for_anchor_readiness(&db_path, "rebase-catch-up", 200)
+            .unwrap()
+    );
+
+    let pending = (0..2)
+        .map(|index| {
+            let value_zatoshi = if index == 0 { 100 } else { 200 };
+            let selected_note = PreparedOrchardNoteRef {
+                txid_hex: format!("{:064x}", 100 + index),
+                output_index: 0,
+                value_zatoshi: value_zatoshi + 10,
+                note_version: 2,
+                nullifier_hex: Some(format!("{:064x}", 200 + index)),
+            };
+            PendingMigrationTxInsert {
+                part_index: index,
+                txid_hex: format!("{:064x}", index + 1),
+                raw_tx: vec![index as u8, 0xaa, 0x55],
+                target_height: 101,
+                anchor_boundary_height: Some(90),
+                expiry_height: 69_120,
+                scheduled_height: 200 + if index == 0 { 0 } else { 48 },
+                value_zatoshi,
+                fee_zatoshi: 10,
+                selected_note: selected_note.clone(),
+                metadata: PendingMigrationTxMetadata {
+                    tx_kind: "migration".to_string(),
+                    funding_account_uuid: "account-1".to_string(),
+                    selected_note,
+                },
+            }
+        })
+        .collect();
+    insert_pending_txs(
+        &db_path,
+        "rebase-catch-up",
+        pending,
+        TEST_PASSWORD,
+        TEST_SALT_BASE64,
+    )
+    .unwrap();
+
+    // Tip is past both rebased heights, so overdue catch-up must redraw.
+    reschedule_overdue_pending_txs(&db_path, "rebase-catch-up", WalletNetwork::Main, 300).unwrap();
+
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let mut stmt = conn
+        .prepare(&format!(
+            "SELECT scheduled_height, status
+             FROM {PENDING_TXS_TABLE}
+             WHERE run_id = 'rebase-catch-up'
+             ORDER BY part_index ASC"
+        ))
+        .unwrap();
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+    let still_original = rows
+        .iter()
+        .filter(|(_, status)| status == "scheduled")
+        .map(|(height, _)| *height)
+        .collect::<Vec<_>>();
+    assert_ne!(
+        still_original,
+        vec![200, 248],
+        "catch-up must not keep the entire overdue rebased schedule unchanged: {rows:?}"
     );
 }
 
@@ -2358,7 +3007,7 @@ fn persisting_presigned_children_keeps_ready_phase_and_proof_height() {
 }
 
 #[test]
-fn timing_projection_keeps_unpromoted_parts_after_a_reschedule() {
+fn timing_projection_keeps_later_proof_wave_after_initial_rebase() {
     let schedule = vec![
         MigrationScheduleEntry {
             part_index: Some(0),
@@ -2382,6 +3031,7 @@ fn timing_projection_keeps_unpromoted_parts_after_a_reschedule() {
     let signed_children = vec![MigrationTimingSignedChild {
         part_index: 1,
         target_height: 101,
+        scheduled_height: Some(788),
     }];
 
     let projection = calculate_migration_timing_projection(
@@ -2389,6 +3039,8 @@ fn timing_projection_keeps_unpromoted_parts_after_a_reschedule() {
         &pending,
         &signed_children,
         Some(550),
+        Some(500),
+        550,
         2,
         3,
     )
@@ -2431,9 +3083,10 @@ fn timing_projection_ignores_retained_signed_children_after_promotion() {
             "INSERT INTO {RUNS_TABLE}
              (run_id, account_uuid, network, db_fingerprint, phase,
               created_at_ms, updated_at_ms, target_values_json,
-              schedule_json, proof_retry_height)
+              schedule_json, proof_retry_height,
+              initial_schedule_rebased_origin_height)
              VALUES ('run-timing', 'account-1', 'test', 'db', ?1, 1, 1,
-                     '[100,200]', ?2, 550)"
+                     '[100,200]', ?2, 550, 500)"
         ),
         params![PHASE_BROADCAST_SCHEDULED, schedule_json],
     )
@@ -2457,20 +3110,35 @@ fn timing_projection_ignores_retained_signed_children_after_promotion() {
                 "INSERT INTO {SIGNED_CHILD_PCZTS_TABLE}
                  (run_id, message_id, child_index, encrypted_base_pczt,
                   encrypted_compact_sigs, target_height, expiry_height,
-                  value_zatoshi, fee_zatoshi, selected_note_json, metadata_json)
+                  scheduled_height, value_zatoshi, fee_zatoshi,
+                  selected_note_json, metadata_json)
                  VALUES ('run-timing', ?1, ?2, 'base', 'sigs', 101, 900,
-                         99, 1, '{{}}', '{{}}')"
+                         ?3, 99, 1, '{{}}', '{{}}')"
             ),
-            params![format!("message-{child_index}"), child_index],
+            params![
+                format!("message-{child_index}"),
+                child_index,
+                500 + [144, 288][child_index as usize],
+            ],
         )
         .unwrap();
     }
 
-    let projection = migration_timing_projection_for_run(&conn, "run-timing", 2, 3).unwrap();
+    let projection = migration_timing_projection_for_run(&conn, "run-timing", 550, 2, 3).unwrap();
 
     assert_eq!(projection.next_action_height, Some(550));
     assert_eq!(projection.next_action_part_index, Some(1));
+    assert_eq!(projection.next_proof_window_height, Some(550));
+    assert_eq!(projection.next_proof_window_part_indices, vec![1]);
     assert_eq!(projection.estimated_completion_height, Some(791));
+    assert_eq!(
+        projection.projected_signed_parts,
+        vec![MigrationTimingProjectedSignedPart {
+            part_index: 1,
+            schedule_start_height: 500,
+            scheduled_height: 788,
+        }]
+    );
 }
 
 #[test]
@@ -2490,7 +3158,8 @@ fn timing_projection_counts_the_mined_block_as_confirmation_one() {
     }];
 
     let projection =
-        calculate_migration_timing_projection(&schedule, &pending, &[], None, 1, 3).unwrap();
+        calculate_migration_timing_projection(&schedule, &pending, &[], None, None, 100, 1, 3)
+            .unwrap();
 
     assert_eq!(projection.estimated_completion_height, Some(107));
 }
@@ -2512,6 +3181,7 @@ fn timing_projection_waits_for_multi_part_catch_up_reschedule() {
     let signed_children = vec![MigrationTimingSignedChild {
         part_index: 1,
         target_height: 101,
+        scheduled_height: Some(180),
     }];
     let pending = vec![MigrationTimingPendingPart {
         part_index: Some(0),
@@ -2527,13 +3197,77 @@ fn timing_projection_waits_for_multi_part_catch_up_reschedule() {
         &pending,
         &signed_children,
         Some(200),
+        Some(100),
+        200,
         2,
         3,
     )
     .unwrap();
 
     assert_eq!(projection.next_action_height, Some(150));
+    assert_eq!(projection.next_action_part_index, Some(0));
+    assert_eq!(projection.next_proof_window_height, Some(200));
+    assert_eq!(projection.next_proof_window_part_indices, vec![1]);
     assert_eq!(projection.estimated_completion_height, None);
+    assert_eq!(
+        projection.projected_signed_parts,
+        vec![MigrationTimingProjectedSignedPart {
+            part_index: 1,
+            schedule_start_height: 100,
+            scheduled_height: 200,
+        }]
+    );
+}
+
+#[test]
+fn timing_projection_clamps_persisted_child_to_proof_readiness() {
+    let schedule = vec![
+        MigrationScheduleEntry {
+            part_index: Some(0),
+            value_zatoshi: 100,
+            block_offset: 50,
+        },
+        MigrationScheduleEntry {
+            part_index: Some(1),
+            value_zatoshi: 200,
+            block_offset: 80,
+        },
+    ];
+    let pending = vec![MigrationTimingPendingPart {
+        part_index: Some(0),
+        target_height: 101,
+        schedule_start_height: Some(100),
+        scheduled_height: 150,
+        status: "confirmed".to_string(),
+        mined_height: Some(150),
+    }];
+    let signed_children = vec![MigrationTimingSignedChild {
+        part_index: 1,
+        target_height: 101,
+        scheduled_height: Some(180),
+    }];
+
+    let projection = calculate_migration_timing_projection(
+        &schedule,
+        &pending,
+        &signed_children,
+        Some(200),
+        None,
+        200,
+        2,
+        3,
+    )
+    .unwrap();
+
+    assert_eq!(
+        projection.projected_signed_parts,
+        vec![MigrationTimingProjectedSignedPart {
+            part_index: 1,
+            schedule_start_height: 100,
+            scheduled_height: 200,
+        }]
+    );
+    assert_eq!(projection.estimated_completion_height, Some(203));
 }
 
 #[test]

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -4431,6 +4431,12 @@ fn finalize_presigned_migration_children(
     if super::migration::signed_child_pczt_count(db_path, run_id)? == 0 {
         return Ok(0);
     }
+    // Keystone persists one bounded QR batch at a time while the run remains
+    // ready_to_migrate. Do not promote the first batch and move the run to
+    // broadcast_scheduled before every remaining batch has been signed.
+    if !super::migration::migration_part_assignment_complete(db_path, run_id)? {
+        return Ok(0);
+    }
     if !prepared_note_spend_metadata_is_available(db_path, run_id)? {
         let timing_policy = super::migration::timing_policy_for_run(db_path, run_id, network)?;
         if let Some(retry_height) = super::migration::prepared_notes_proof_ready_height(
@@ -4458,11 +4464,6 @@ fn finalize_presigned_migration_children(
         }
     }
     let current_scanned_height = current_migration_scanned_height(db_path, network)?;
-    let _ = super::migration::rebase_initial_signed_schedule_for_anchor_readiness(
-        db_path,
-        run_id,
-        current_scanned_height,
-    )?;
 
     let signed_children = super::migration::signed_child_pczts_for_run(
         db_path,
@@ -4600,6 +4601,7 @@ fn finalize_presigned_migration_children(
             db_path,
             run_id,
             vec![pending_insert],
+            current_scanned_height,
             remaining_child_retry_height,
             pending_password,
             pending_salt_base64,

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -4444,6 +4444,26 @@ fn finalize_presigned_migration_children(
         return Ok(0);
     }
 
+    let timing_policy = super::migration::timing_policy_for_run(db_path, run_id, network)?;
+    // Persist the first proof-ready height only when unset so later
+    // next-anchor retries are not rewritten before the one-time rebase.
+    if super::migration::proof_retry_height(db_path, run_id)?.is_none() {
+        if let Some(ready_height) = super::migration::prepared_notes_proof_ready_height(
+            db_path,
+            run_id,
+            network,
+            timing_policy,
+        )? {
+            super::migration::set_proof_retry_height(db_path, run_id, ready_height)?;
+        }
+    }
+    let current_scanned_height = current_migration_scanned_height(db_path, network)?;
+    let _ = super::migration::rebase_initial_signed_schedule_for_anchor_readiness(
+        db_path,
+        run_id,
+        current_scanned_height,
+    )?;
+
     let signed_children = super::migration::signed_child_pczts_for_run(
         db_path,
         run_id,
@@ -4454,10 +4474,8 @@ fn finalize_presigned_migration_children(
         return Ok(0);
     }
     let current_prepared = super::migration::prepared_notes_for_run(db_path, run_id)?;
-    let timing_policy = super::migration::timing_policy_for_run(db_path, run_id, network)?;
     let already_pending = super::migration::pending_migration_note_outpoints(db_path, run_id)?;
     let signed_child_count = signed_children.len();
-    let current_scanned_height = current_migration_scanned_height(db_path, network)?;
     let mut durable_retry_height = super::migration::next_anchor_retry_height_after(
         network,
         timing_policy,

--- a/test/features/migration/ironwood_migration_presentation_test.dart
+++ b/test/features/migration/ironwood_migration_presentation_test.dart
@@ -402,6 +402,74 @@ void main() {
     expect(presentation.scheduledHeight, 3_428_143);
   });
 
+  test('presents the rebased height for an unpromoted signed note', () {
+    final status = _status(
+      phase: 'broadcast_scheduled',
+      broadcasts: const [],
+      nextActionHeight: 3_435_409,
+      parts: [
+        _part(
+          index: 0,
+          value: 20_000,
+          state: rust_sync.MigrationPartState.preparing,
+          scheduledHeight: 3_435_409,
+        ),
+      ],
+    );
+
+    final presentation = migrationNextActionPresentation(
+      status: status,
+      currentHeight: 3_435_400,
+    );
+
+    expect(presentation.label, 'Next migration');
+    expect(presentation.amountZatoshi, BigInt.from(20_000));
+    expect(presentation.detail, 'at');
+    expect(presentation.scheduledHeight, 3_435_409);
+  });
+
+  test('presents a scheduled transfer before an internal proof window', () {
+    final status = _status(
+      phase: 'broadcast_scheduled',
+      broadcasts: const [],
+      proofReady: false,
+      nextProofWindowHeight: 1_074,
+      nextProofWindowPartIndices: [2],
+      parts: [
+        _part(
+          index: 0,
+          scheduleOrder: 0,
+          value: 500_000_000,
+          state: rust_sync.MigrationPartState.migrating,
+          scheduledHeight: 1_071,
+        ),
+        _part(
+          index: 1,
+          scheduleOrder: 1,
+          value: 50_000_000_000,
+          state: rust_sync.MigrationPartState.scheduled,
+          scheduledHeight: 1_083,
+        ),
+        _part(
+          index: 2,
+          scheduleOrder: 2,
+          value: 1_000_000_000_000,
+          scheduledHeight: 1_700,
+        ),
+      ],
+    );
+
+    final presentation = migrationNextActionPresentation(
+      status: status,
+      currentHeight: 1_071,
+    );
+
+    expect(presentation.label, 'Next migration');
+    expect(presentation.amountZatoshi, BigInt.from(50_000_000_000));
+    expect(presentation.detail, 'at');
+    expect(presentation.scheduledHeight, 1_083);
+  });
+
   test('keeps a signing part block while the batch needs input', () {
     final status = _status(
       phase: 'ready_to_migrate',


### PR DESCRIPTION
## Summary

- durably rebase the initial unpromoted signed-child schedule when proof finalization first becomes possible
- preserve approved per-child offsets while preventing the anchor-readiness wait from making transfers immediately overdue
- retain existing catch-up and re-sign behavior when rebasing would cross an expiry bucket or cannot safely preserve the approved origin
- project finalized child timing from persisted heights and surface scheduled transfers ahead of later proof windows

## Motivation / Why

Signed migration schedules are created before denomination outputs become provable. By the time proof finalization can run, several approved transfer heights may already be overdue, causing catch-up scheduling to replace the intended tapered spacing. Anchoring the initial schedule to the actual finalization height preserves those approved offsets without changing later recovery behavior.

Observed run:

```
schedule origin:    3435169
denomination mined: 3435172
proof-ready:       ~3435409   (240-block readiness delay)
approved offsets:   0, 23, 81, 183, 311
overdue at ready:   0, 23, 81, 183
```

Starting the approved offsets at the height where finalization actually runs removes the routine trigger. Anchoring to the finalization height rather than the chain-derived proof-ready height also means the origin is not predictable from the denomination transaction, and it stays correct when the app is opened well after readiness.

## Human Context

Rebase migration schedule onto proof finalization height

We observed that there were surprisingly short clusters at the beginning of the schedule in manual testing on mainnet. What happened: the system was defining the schedule relative to the height of schedule creation without accounting for anchor delays.

By the time their anchor became eligible, many notes would become overdue and get rescheduled. Rescheduling deliberately had shorter mean, resulting in visible clusters in the beginning.

This PR "rebases" the schedule from the original height against the heights proofs can be constructed, eliminating the inevitable recreation and clustering.

Tested on both Regtest and Mainnet. Several rounds of AI reviews passed with no outstanding blockers.

## Tests

- `cargo test --lib wallet::sync::migration::tests` — 154 passed
- `fvm flutter test test/features/migration/ironwood_migration_presentation_test.dart` — 36 passed
- `fvm flutter analyze lib/src/features/migration/models/ironwood_migration_presentation.dart test/features/migration/ironwood_migration_presentation_test.dart`
- Rust formatting and `git diff --check`