### PR TITLE
Pack Keystone migration signing rounds by encoded size

### DIFF
--- a/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
@@ -457,6 +457,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
   List<rust_sync.KeystoneSignedMigrationMessage>? _pendingSignedMessages;
   KeystoneQrScannerControls? _scannerControls;
   bool _decoding = false;
+  bool _signingPlanConfirmed = false;
   // Multi-part UR scan progress (0-100) for the mobile scanner chrome. The
   // scanner card reports it; the mobile view renders it under the viewfinder.
   int _scanProgress = 0;
@@ -495,6 +496,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
       _stage = widget.previewStartScanning
           ? _KeystoneDenominationSignStage.scanning
           : _KeystoneDenominationSignStage.showQr;
+      _signingPlanConfirmed = widget.previewStartScanning;
       _requestCompleted = true;
       return;
     }
@@ -550,6 +552,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
       _pendingSignedMessages = null;
       _scannerControls = null;
       _decoding = false;
+      _signingPlanConfirmed = false;
       _scanProgress = 0;
     });
 
@@ -586,10 +589,17 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
       }
       _request = request;
       _accountUuid = accountUuid;
-      final signingRounds = _keystoneSigningRounds(
-        request.messages,
-        request.signingBatchLimit,
-      );
+      final signingRounds = request.messages.isEmpty
+          ? const <List<rust_sync.KeystoneMigrationMessage>>[]
+          : _keystoneSigningRoundsFromCounts(
+              request.messages,
+              await rust_keystone.zcashSignBatchRoundMessageCounts(
+                requestId: request.requestId,
+                messages: _zcashBatchMessageInputs(request.messages),
+                maxMessages: request.signingBatchLimit,
+              ),
+            );
+      if (!mounted) return;
       _signingRounds = signingRounds;
       if (request.messages.isEmpty) {
         if (widget.step != _KeystonePrivateSignStep.denominations) {
@@ -609,14 +619,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
               index,
               signingRounds.length,
             ),
-            messages: signingRounds[index]
-                .map(
-                  (message) => rust_keystone_wallet.ZcashBatchMessageInput(
-                    id: message.id,
-                    pcztBytes: message.redactedPczt,
-                  ),
-                )
-                .toList(),
+            messages: _zcashBatchMessageInputs(signingRounds[index]),
             maxFragmentLen: BigInt.from(_keystoneMigrationQrMaxFragmentLen),
           ),
         );
@@ -666,11 +669,10 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
 
   /// How many transactions the QR currently on screen signs.
   ///
-  /// `_signingRounds` is the exact partition of `request.messages` that the
-  /// QR encoder consumes (`_keystoneSigningRounds`, capped by
-  /// `signingBatchLimit` and the Keystone byte budget), so the current round's
-  /// length is the real message count for this QR and the flattened total is
-  /// the request's message count.
+  /// `_signingRounds` is the ordered partition returned by Rust's exact
+  /// compact and resolved request sizing and consumed by the QR encoder, so
+  /// the current round's length is the real message count for this QR and the
+  /// flattened total is the request's message count.
   String? get _signingMessageCountLabel {
     final round = _currentSigningRound;
     if (round == null || round.isEmpty) return null;
@@ -683,6 +685,22 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
 
   String _transactionCountText(int count) =>
       count == 1 ? '1 transaction' : '$count transactions';
+
+  bool get _requiresSigningPlanConfirmation =>
+      !widget.mobileLayout && widget.step == _KeystonePrivateSignStep.combined;
+
+  bool get _showsSigningPlanConfirmation =>
+      _requiresSigningPlanConfirmation && !_signingPlanConfirmed;
+
+  void _beginSigning() {
+    if (_urParts.isEmpty ||
+        ironwoodMigrationKeystoneProofFailed(_proofStatus)) {
+      return;
+    }
+    setState(() {
+      _signingPlanConfirmed = true;
+    });
+  }
 
   Future<void> _handleScanComplete(ScanResult result) async {
     if (_decoding ||
@@ -1117,7 +1135,10 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
             height: 560,
             child: Center(child: CircularProgressIndicator()),
           ),
-          _KeystoneDenominationSignStage.showQr => _buildQrContent(context),
+          _KeystoneDenominationSignStage.showQr =>
+            _showsSigningPlanConfirmation
+                ? _buildSigningPlanConfirmation(context)
+                : _buildQrContent(context),
           _KeystoneDenominationSignStage.scanning ||
           _KeystoneDenominationSignStage.waitingForProofs ||
           _KeystoneDenominationSignStage.completing => _buildScannerContent(
@@ -1454,6 +1475,134 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
             expand: true,
             variant: AppButtonVariant.ghost,
             onPressed: () => unawaited(_returnToReview()),
+            child: Text(widget.step.previousButtonLabel),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSigningPlanConfirmation(BuildContext context) {
+    final colors = context.colors;
+    final signingRoundCount = _signingRounds.length;
+    final transactionCount = _request?.messages.length ?? 0;
+    final proofStatusText = _proofStatusText;
+    final proofFailed = ironwoodMigrationKeystoneProofFailed(_proofStatus);
+    final qrPayloadsReady = _urParts.isNotEmpty;
+    final roundLabel = signingRoundCount == 1
+        ? '1 QR signing round'
+        : '$signingRoundCount QR signing rounds';
+    final transactionLabel = transactionCount == 1
+        ? '1 transaction total'
+        : '$transactionCount transactions total';
+
+    return Padding(
+      key: const ValueKey('keystone_migration_signing_plan_confirmation'),
+      padding: const EdgeInsets.only(top: AppSpacing.xl),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              color: colors.background.raised,
+              border: Border.all(color: colors.border.subtle),
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Center(
+              child: AppIcon(AppIcons.qr, size: 28, color: colors.icon.accent),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.base),
+          Text(
+            'Keystone signing plan',
+            textAlign: TextAlign.center,
+            style: AppTypography.headlineLarge.copyWith(
+              color: colors.text.accent,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          Container(
+            width: 360,
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.base,
+              vertical: AppSpacing.base,
+            ),
+            decoration: BoxDecoration(
+              color: colors.background.raised,
+              border: Border.all(color: colors.border.subtle),
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Column(
+              children: [
+                Text(
+                  roundLabel,
+                  key: const ValueKey(
+                    'keystone_migration_exact_signing_round_count',
+                  ),
+                  textAlign: TextAlign.center,
+                  style: AppTypography.headlineSmall.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xxs),
+                Text(
+                  transactionLabel,
+                  textAlign: TextAlign.center,
+                  style: AppTypography.bodyMedium.copyWith(
+                    color: colors.text.secondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.base),
+          SizedBox(
+            width: 360,
+            child: Text(
+              'Each round uses one animated request QR and one signed '
+              'response QR.',
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMedium.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+          ),
+          if (proofStatusText != null) ...[
+            const SizedBox(height: AppSpacing.xs),
+            SizedBox(
+              width: 360,
+              child: Text(
+                proofStatusText,
+                textAlign: TextAlign.center,
+                style: AppTypography.bodySmall.copyWith(
+                  color: proofFailed
+                      ? colors.text.destructive
+                      : colors.text.secondary,
+                ),
+              ),
+            ),
+          ],
+          const SizedBox(height: AppSpacing.lg),
+          AppButton(
+            key: const ValueKey('keystone_migration_begin_signing'),
+            onPressed: qrPayloadsReady && !proofFailed ? _beginSigning : null,
+            height: 44,
+            minWidth: 230,
+            trailing: qrPayloadsReady
+                ? const AppIcon(AppIcons.chevronForward, size: 20)
+                : null,
+            child: Text(
+              qrPayloadsReady ? 'Begin signing' : 'Preparing QR codes...',
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          AppButton(
+            onPressed: () => unawaited(_returnToReview()),
+            variant: AppButtonVariant.ghost,
+            height: 44,
+            minWidth: 230,
             child: Text(widget.step.previousButtonLabel),
           ),
         ],
@@ -1807,15 +1956,12 @@ List<rust_sync.KeystoneSignedMigrationMessage> _signedMigrationMessagesFor(
   ];
 }
 
-// The Keystone firmware enforces two independent caps on one signing round:
-// the message count (`signingBatchLimit`) and a 512 KiB ceiling that covers
-// both the canonical PCZT byte total and the request-id + Postcard envelope
-// (`ZCASH_SIGN_BATCH_MAX_TOTAL_BYTES` in rust/src/wallet/keystone.rs). Rounds
-// must stay under both, or QR encoding rejects the round after the user has
-// already approved the migration.
-const _keystoneSigningRoundMaxTotalBytes = 512 * 1024;
-// Headroom for the request id and per-message Postcard framing, which the
-// firmware counts against the same ceiling as the raw PCZT payloads.
+// This local partitioner is used by deterministic previews and helper tests.
+// Production requests use Rust's post-resolution size-aware partitioner.
+const _keystoneSigningRoundMaxMessages = 40;
+const _keystoneSigningRoundMaxTotalBytes = 80 * 1024;
+// Reserve 16 KiB for the request id, per-message Postcard framing, and the
+// outer CBOR envelope.
 const _keystoneSigningRoundByteBudget =
     _keystoneSigningRoundMaxTotalBytes - 16 * 1024;
 
@@ -1833,6 +1979,7 @@ List<List<rust_sync.KeystoneMigrationMessage>> _keystoneSigningRounds(
   if (limit <= 0) {
     throw StateError('Keystone signing batch limit must be positive.');
   }
+  final roundLimit = math.min(limit, _keystoneSigningRoundMaxMessages);
   final rounds = <List<rust_sync.KeystoneMigrationMessage>>[];
   var round = <rust_sync.KeystoneMigrationMessage>[];
   var roundBytes = 0;
@@ -1850,7 +1997,7 @@ List<List<rust_sync.KeystoneMigrationMessage>> _keystoneSigningRounds(
     final overflowsByteBudget =
         round.isNotEmpty &&
         roundBytes + messageBytes > _keystoneSigningRoundByteBudget;
-    if (round.length >= limit || overflowsByteBudget) {
+    if (round.length >= roundLimit || overflowsByteBudget) {
       rounds.add(round);
       round = <rust_sync.KeystoneMigrationMessage>[];
       roundBytes = 0;
@@ -1859,6 +2006,44 @@ List<List<rust_sync.KeystoneMigrationMessage>> _keystoneSigningRounds(
     roundBytes += messageBytes;
   }
   if (round.isNotEmpty) rounds.add(round);
+  return rounds;
+}
+
+List<rust_keystone_wallet.ZcashBatchMessageInput> _zcashBatchMessageInputs(
+  List<rust_sync.KeystoneMigrationMessage> messages,
+) => [
+  for (final message in messages)
+    rust_keystone_wallet.ZcashBatchMessageInput(
+      id: message.id,
+      pcztBytes: message.redactedPczt,
+      expectedSignatureCount: message.expectedSignatureCount,
+    ),
+];
+
+@visibleForTesting
+List<List<rust_sync.KeystoneMigrationMessage>>
+keystoneSigningRoundsFromCountsForTest(
+  List<rust_sync.KeystoneMigrationMessage> messages,
+  List<int> counts,
+) => _keystoneSigningRoundsFromCounts(messages, counts);
+
+List<List<rust_sync.KeystoneMigrationMessage>> _keystoneSigningRoundsFromCounts(
+  List<rust_sync.KeystoneMigrationMessage> messages,
+  List<int> counts,
+) {
+  if (messages.isEmpty && counts.isEmpty) return const [];
+  final rounds = <List<rust_sync.KeystoneMigrationMessage>>[];
+  var offset = 0;
+  for (final count in counts) {
+    if (count <= 0 || offset + count > messages.length) {
+      throw StateError('Keystone signing round partition is invalid.');
+    }
+    rounds.add(messages.sublist(offset, offset + count));
+    offset += count;
+  }
+  if (offset != messages.length) {
+    throw StateError('Keystone signing round partition is incomplete.');
+  }
   return rounds;
 }
 

--- a/lib/src/rust/api/keystone.dart
+++ b/lib/src/rust/api/keystone.dart
@@ -49,6 +49,18 @@ Future<List<String>> encodeZcashSignBatchUrParts({
   maxFragmentLen: maxFragmentLen,
 );
 
+/// Return the ordered message count for each Keystone signing round after
+/// accounting for compact fields that expand inside the firmware.
+Future<Uint32List> zcashSignBatchRoundMessageCounts({
+  required String requestId,
+  required List<ZcashBatchMessageInput> messages,
+  required int maxMessages,
+}) => RustLib.instance.api.crateApiKeystoneZcashSignBatchRoundMessageCounts(
+  requestId: requestId,
+  messages: messages,
+  maxMessages: maxMessages,
+);
+
 /// Decode the CBOR payload returned from a `zcash-sign-result` UR.
 Future<ZcashBatchSignResult> decodeZcashSignResultCbor({
   required List<int> cbor,

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -1229,13 +1229,18 @@ class KeystoneMigrationMessage {
   final String id;
   final Uint8List redactedPczt;
 
+  /// Number of spend authorization signatures expected from Keystone.
+  final int expectedSignatureCount;
+
   const KeystoneMigrationMessage({
     required this.id,
     required this.redactedPczt,
+    required this.expectedSignatureCount,
   });
 
   @override
-  int get hashCode => id.hashCode ^ redactedPczt.hashCode;
+  int get hashCode =>
+      id.hashCode ^ redactedPczt.hashCode ^ expectedSignatureCount.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1243,7 +1248,8 @@ class KeystoneMigrationMessage {
       other is KeystoneMigrationMessage &&
           runtimeType == other.runtimeType &&
           id == other.id &&
-          redactedPczt == other.redactedPczt;
+          redactedPczt == other.redactedPczt &&
+          expectedSignatureCount == other.expectedSignatureCount;
 }
 
 class KeystoneMigrationProofStatus {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -521113960;
+  int get rustContentHash => -1527177591;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -1121,6 +1121,12 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiSyncWriteBlockMetadata({
     required String cachePath,
     required List<BlockMetaInfo> blocks,
+  });
+
+  Future<Uint32List> crateApiKeystoneZcashSignBatchRoundMessageCounts({
+    required String requestId,
+    required List<ZcashBatchMessageInput> messages,
+    required int maxMessages,
   });
 }
 
@@ -7860,6 +7866,44 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: ["cachePath", "blocks"],
       );
 
+  @override
+  Future<Uint32List> crateApiKeystoneZcashSignBatchRoundMessageCounts({
+    required String requestId,
+    required List<ZcashBatchMessageInput> messages,
+    required int maxMessages,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(requestId, serializer);
+          sse_encode_list_zcash_batch_message_input(messages, serializer);
+          sse_encode_u_32(maxMessages, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 158,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_prim_u_32_strict,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiKeystoneZcashSignBatchRoundMessageCountsConstMeta,
+        argValues: [requestId, messages, maxMessages],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiKeystoneZcashSignBatchRoundMessageCountsConstMeta =>
+      const TaskConstMeta(
+        debugName: "zcash_sign_batch_round_message_counts",
+        argNames: ["requestId", "messages", "maxMessages"],
+      );
+
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -8495,11 +8539,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   KeystoneMigrationMessage dco_decode_keystone_migration_message(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return KeystoneMigrationMessage(
       id: dco_decode_String(arr[0]),
       redactedPczt: dco_decode_list_prim_u_8_strict(arr[1]),
+      expectedSignatureCount: dco_decode_u_32(arr[2]),
     );
   }
 
@@ -10124,11 +10169,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ZcashBatchMessageInput dco_decode_zcash_batch_message_input(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return ZcashBatchMessageInput(
       id: dco_decode_String(arr[0]),
       pcztBytes: dco_decode_list_prim_u_8_strict(arr[1]),
+      expectedSignatureCount: dco_decode_u_32(arr[2]),
     );
   }
 
@@ -10903,7 +10949,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_id = sse_decode_String(deserializer);
     var var_redactedPczt = sse_decode_list_prim_u_8_strict(deserializer);
-    return KeystoneMigrationMessage(id: var_id, redactedPczt: var_redactedPczt);
+    var var_expectedSignatureCount = sse_decode_u_32(deserializer);
+    return KeystoneMigrationMessage(
+      id: var_id,
+      redactedPczt: var_redactedPczt,
+      expectedSignatureCount: var_expectedSignatureCount,
+    );
   }
 
   @protected
@@ -13160,7 +13211,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_id = sse_decode_String(deserializer);
     var var_pcztBytes = sse_decode_list_prim_u_8_strict(deserializer);
-    return ZcashBatchMessageInput(id: var_id, pcztBytes: var_pcztBytes);
+    var var_expectedSignatureCount = sse_decode_u_32(deserializer);
+    return ZcashBatchMessageInput(
+      id: var_id,
+      pcztBytes: var_pcztBytes,
+      expectedSignatureCount: var_expectedSignatureCount,
+    );
   }
 
   @protected
@@ -13836,6 +13892,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.id, serializer);
     sse_encode_list_prim_u_8_strict(self.redactedPczt, serializer);
+    sse_encode_u_32(self.expectedSignatureCount, serializer);
   }
 
   @protected
@@ -15594,6 +15651,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.id, serializer);
     sse_encode_list_prim_u_8_strict(self.pcztBytes, serializer);
+    sse_encode_u_32(self.expectedSignatureCount, serializer);
   }
 
   @protected

--- a/lib/src/rust/wallet/keystone.dart
+++ b/lib/src/rust/wallet/keystone.dart
@@ -66,10 +66,19 @@ class ZcashBatchMessageInput {
   final String id;
   final Uint8List pcztBytes;
 
-  const ZcashBatchMessageInput({required this.id, required this.pcztBytes});
+  /// Number of spend authorization signatures the wallet expects the signer
+  /// to return for this PCZT.
+  final int expectedSignatureCount;
+
+  const ZcashBatchMessageInput({
+    required this.id,
+    required this.pcztBytes,
+    required this.expectedSignatureCount,
+  });
 
   @override
-  int get hashCode => id.hashCode ^ pcztBytes.hashCode;
+  int get hashCode =>
+      id.hashCode ^ pcztBytes.hashCode ^ expectedSignatureCount.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -77,7 +86,8 @@ class ZcashBatchMessageInput {
       other is ZcashBatchMessageInput &&
           runtimeType == other.runtimeType &&
           id == other.id &&
-          pcztBytes == other.pcztBytes;
+          pcztBytes == other.pcztBytes &&
+          expectedSignatureCount == other.expectedSignatureCount;
 }
 
 class ZcashBatchSignResult {

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -2547,6 +2547,7 @@ class _IronwoodMigrationHarnessState extends State<_IronwoodMigrationHarness> {
                   rust_sync.KeystoneMigrationMessage(
                     id: 'preview-immediate-transaction',
                     redactedPczt: Uint8List.fromList(const [1, 2, 3]),
+                    expectedSignatureCount: 0,
                   ),
                 ],
                 signingBatchLimit: 1,
@@ -2568,10 +2569,12 @@ class _IronwoodMigrationHarnessState extends State<_IronwoodMigrationHarness> {
                 rust_sync.KeystoneMigrationMessage(
                   id: 'preview-private-split-1',
                   redactedPczt: Uint8List.fromList(const [1, 2, 3]),
+                  expectedSignatureCount: 0,
                 ),
                 rust_sync.KeystoneMigrationMessage(
                   id: 'preview-private-split-2',
                   redactedPczt: Uint8List.fromList(const [4, 5, 6]),
+                  expectedSignatureCount: 0,
                 ),
               ],
               signingBatchLimit: 1,

--- a/rust/src/api/keystone.rs
+++ b/rust/src/api/keystone.rs
@@ -44,6 +44,21 @@ pub fn encode_zcash_sign_batch_ur_parts(
     keystone::encode_zcash_sign_batch_ur_parts(&request_id, &messages, max_fragment_len)
 }
 
+/// Return the ordered message count for each Keystone signing round after
+/// accounting for compact fields that expand inside the firmware.
+pub fn zcash_sign_batch_round_message_counts(
+    request_id: String,
+    messages: Vec<ZcashBatchMessageInput>,
+    max_messages: u32,
+) -> Result<Vec<u32>, String> {
+    keystone::zcash_sign_batch_round_message_counts(
+        &request_id,
+        &messages,
+        usize::try_from(max_messages)
+            .map_err(|_| "Zcash signing round message limit exceeds usize".to_string())?,
+    )
+}
+
 /// Decode the CBOR payload returned from a `zcash-sign-result` UR.
 pub fn decode_zcash_sign_result_cbor(cbor: Vec<u8>) -> Result<ZcashBatchSignResult, String> {
     keystone::decode_zcash_sign_result_cbor(&cbor)

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -688,6 +688,8 @@ pub struct IronwoodMigrationResult {
 pub struct KeystoneMigrationMessage {
     pub id: String,
     pub redacted_pczt: Vec<u8>,
+    /// Number of spend authorization signatures expected from Keystone.
+    pub expected_signature_count: u32,
 }
 
 pub struct KeystoneMigrationSigningRequest {
@@ -1227,6 +1229,7 @@ pub fn prepare_orchard_migration_immediate_pczt(
                 .map(|message| KeystoneMigrationMessage {
                     id: message.id,
                     redacted_pczt: message.redacted_pczt,
+                    expected_signature_count: message.expected_signature_count,
                 })
                 .collect(),
         })
@@ -1799,6 +1802,7 @@ pub fn prepare_orchard_migration_denominations_pczt(
                 .map(|message| KeystoneMigrationMessage {
                     id: message.id,
                     redacted_pczt: message.redacted_pczt,
+                    expected_signature_count: message.expected_signature_count,
                 })
                 .collect(),
         })
@@ -1946,6 +1950,7 @@ pub fn prepare_orchard_migration_single_qr_pczt(
                 .map(|message| KeystoneMigrationMessage {
                     id: message.id,
                     redacted_pczt: message.redacted_pczt,
+                    expected_signature_count: message.expected_signature_count,
                 })
                 .collect(),
         })
@@ -2005,6 +2010,7 @@ pub fn prepare_orchard_migration_batch_pczt(
                 .map(|message| KeystoneMigrationMessage {
                     id: message.id,
                     redacted_pczt: message.redacted_pczt,
+                    expected_signature_count: message.expected_signature_count,
                 })
                 .collect(),
         })

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -521113960;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1527177591;
 
 // Section: executor
 
@@ -6293,6 +6293,47 @@ fn wire__crate__api__sync__write_block_metadata_impl(
         },
     )
 }
+fn wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "zcash_sign_batch_round_message_counts",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_request_id = <String>::sse_decode(&mut deserializer);
+            let api_messages = <Vec<crate::wallet::keystone::ZcashBatchMessageInput>>::sse_decode(
+                &mut deserializer,
+            );
+            let api_max_messages = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::keystone::zcash_sign_batch_round_message_counts(
+                        api_request_id,
+                        api_messages,
+                        api_max_messages,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 
 // Section: static_checks
 
@@ -7237,9 +7278,11 @@ impl SseDecode for crate::api::sync::KeystoneMigrationMessage {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_id = <String>::sse_decode(deserializer);
         let mut var_redactedPczt = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_expectedSignatureCount = <u32>::sse_decode(deserializer);
         return crate::api::sync::KeystoneMigrationMessage {
             id: var_id,
             redacted_pczt: var_redactedPczt,
+            expected_signature_count: var_expectedSignatureCount,
         };
     }
 }
@@ -9441,9 +9484,11 @@ impl SseDecode for crate::wallet::keystone::ZcashBatchMessageInput {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_id = <String>::sse_decode(deserializer);
         let mut var_pcztBytes = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_expectedSignatureCount = <u32>::sse_decode(deserializer);
         return crate::wallet::keystone::ZcashBatchMessageInput {
             id: var_id,
             pczt_bytes: var_pcztBytes,
+            expected_signature_count: var_expectedSignatureCount,
         };
     }
 }
@@ -9631,6 +9676,7 @@ fn pde_ffi_dispatcher_primary_impl(
 154 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
 155 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
 157 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10431,6 +10477,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::sync::KeystoneMigrationMessag
         [
             self.id.into_into_dart().into_dart(),
             self.redacted_pczt.into_into_dart().into_dart(),
+            self.expected_signature_count.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -12158,6 +12205,7 @@ impl flutter_rust_bridge::IntoDart for crate::wallet::keystone::ZcashBatchMessag
         [
             self.id.into_into_dart().into_dart(),
             self.pczt_bytes.into_into_dart().into_dart(),
+            self.expected_signature_count.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -12667,6 +12715,7 @@ impl SseEncode for crate::api::sync::KeystoneMigrationMessage {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.id, serializer);
         <Vec<u8>>::sse_encode(self.redacted_pczt, serializer);
+        <u32>::sse_encode(self.expected_signature_count, serializer);
     }
 }
 
@@ -14223,6 +14272,7 @@ impl SseEncode for crate::wallet::keystone::ZcashBatchMessageInput {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.id, serializer);
         <Vec<u8>>::sse_encode(self.pczt_bytes, serializer);
+        <u32>::sse_encode(self.expected_signature_count, serializer);
     }
 }
 

--- a/rust/src/wallet/keystone.rs
+++ b/rust/src/wallet/keystone.rs
@@ -28,6 +28,9 @@ pub struct KeystoneAccountInfo {
 pub struct ZcashBatchMessageInput {
     pub id: String,
     pub pczt_bytes: Vec<u8>,
+    /// Number of spend authorization signatures the wallet expects the signer
+    /// to return for this PCZT.
+    pub expected_signature_count: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -119,12 +122,20 @@ const ZCASH_SIGN_BATCH_TYPE: &str = "zcash-sign-batch";
 const ZCASH_SIGN_BATCH_VERSION: u32 = 1;
 pub(crate) const ZCASH_SIGN_MESSAGE_KIND_PCZT_V1: u32 = 1;
 const ZCASH_SIGN_STATUS_SIGNED: u32 = 0;
-// Must match the signer's `ZCASH_BATCH_MAX_PCZTS`; the device rejects any larger
-// batch before checking or signing it.
+// The firmware supports at most 40 PCZTs per signing request.
 pub(crate) const ZCASH_SIGN_BATCH_MAX_MESSAGES: usize = 40;
-// Must match the signer's `ZCASH_BATCH_MAX_TOTAL_BYTES`. The firmware applies
-// this to both the canonical PCZT byte total and request-id + Postcard envelope.
-const ZCASH_SIGN_BATCH_MAX_TOTAL_BYTES: usize = 512 * 1024;
+// Keep the displayed QR short enough to scan comfortably in both directions.
+pub(crate) const ZCASH_SIGN_BATCH_MAX_COMPACT_CBOR_BYTES: usize = 80 * 1024;
+// Keep the signature-only response small enough to scan comfortably.
+pub(crate) const ZCASH_SIGN_BATCH_MAX_SIGNATURES: usize = 96;
+// Keep the resolved firmware representation 46 KiB below the signer's
+// 512-KiB limit.
+const ZCASH_SIGN_BATCH_MAX_TOTAL_BYTES: usize = 466 * 1024;
+// Keystone retains a normalized batch after resolving compact PCZT fields and
+// applies its request limit to that larger representation. Calculate that size
+// before displaying a round instead of reserving a fixed expansion estimate.
+pub(crate) const ZCASH_SIGN_BATCH_MAX_RESOLVED_TOTAL_BYTES: usize =
+    ZCASH_SIGN_BATCH_MAX_TOTAL_BYTES;
 
 const ZCASH_SIG_POOL_ORCHARD: u32 = 0;
 const ZCASH_SIG_POOL_IRONWOOD: u32 = 1;
@@ -456,6 +467,7 @@ pub(crate) fn encode_zcash_sign_batch_postcard(
     let mut payloads = std::collections::HashSet::new();
     let mut pczts = Vec::with_capacity(messages.len());
     let mut total_payload_bytes = 0usize;
+    let mut total_signature_count = 0usize;
     for message in messages {
         if message.id.is_empty() {
             return Err("Zcash batch message id must not be empty".to_string());
@@ -480,15 +492,231 @@ pub(crate) fn encode_zcash_sign_batch_postcard(
                 "Zcash batch PCZTs exceed {ZCASH_SIGN_BATCH_MAX_TOTAL_BYTES} bytes"
             ));
         }
-        pczts.push(
-            pczt::Pczt::parse(&message.pczt_bytes)
-                .map_err(|e| format!("Invalid PCZT for batch message {}: {e:?}", message.id))?,
-        );
+        let pczt = pczt::Pczt::parse(&message.pczt_bytes)
+            .map_err(|e| format!("Invalid PCZT for batch message {}: {e:?}", message.id))?;
+        total_signature_count = total_signature_count
+            .checked_add(
+                usize::try_from(message.expected_signature_count)
+                    .map_err(|_| "Zcash batch signature count exceeds usize")?,
+            )
+            .ok_or("Zcash batch signature count overflow")?;
+        if total_signature_count > ZCASH_SIGN_BATCH_MAX_SIGNATURES {
+            return Err(format!(
+                "Zcash batch expects more than {ZCASH_SIGN_BATCH_MAX_SIGNATURES} spend signatures"
+            ));
+        }
+        pczts.push(pczt);
     }
 
     BatchSignRequest::new(pczts)
         .serialize()
         .map_err(|e| format!("Encode PCZT batch signing request: {e:?}"))
+}
+
+#[derive(Clone)]
+struct PreparedZcashBatchMessage {
+    compact_pczt: pczt::Pczt,
+    resolved_pczt: pczt::Pczt,
+    compact_payload_len: usize,
+    expected_signature_count: usize,
+}
+
+struct ZcashSignBatchRoundSize {
+    compact_payload_bytes: usize,
+    compact_request_bytes: usize,
+    compact_cbor_bytes: usize,
+    resolved_request_bytes: usize,
+    expected_signature_count: usize,
+}
+
+impl ZcashSignBatchRoundSize {
+    fn fits(&self, request_id_len: usize) -> bool {
+        self.compact_payload_bytes <= ZCASH_SIGN_BATCH_MAX_TOTAL_BYTES
+            && request_id_len.saturating_add(self.compact_request_bytes)
+                <= ZCASH_SIGN_BATCH_MAX_TOTAL_BYTES
+            && self.compact_cbor_bytes <= ZCASH_SIGN_BATCH_MAX_COMPACT_CBOR_BYTES
+            && request_id_len.saturating_add(self.resolved_request_bytes)
+                <= ZCASH_SIGN_BATCH_MAX_RESOLVED_TOTAL_BYTES
+            && self.expected_signature_count <= ZCASH_SIGN_BATCH_MAX_SIGNATURES
+    }
+}
+
+fn prepare_zcash_batch_messages(
+    messages: &[ZcashBatchMessageInput],
+) -> Result<Vec<PreparedZcashBatchMessage>, String> {
+    let mut ids = std::collections::HashSet::with_capacity(messages.len());
+    let mut payloads = std::collections::HashSet::with_capacity(messages.len());
+    let mut prepared = Vec::with_capacity(messages.len());
+    for message in messages {
+        if message.id.is_empty() {
+            return Err("Zcash batch message id must not be empty".to_string());
+        }
+        if !ids.insert(message.id.as_str()) {
+            return Err(format!("Duplicate Zcash batch message id {}", message.id));
+        }
+        if message.pczt_bytes.is_empty() {
+            return Err(format!(
+                "Zcash batch message {} has an empty payload",
+                message.id
+            ));
+        }
+        if !payloads.insert(message.pczt_bytes.as_slice()) {
+            return Err("Duplicate Zcash batch payload".to_string());
+        }
+
+        let compact_pczt = pczt::Pczt::parse(&message.pczt_bytes)
+            .map_err(|e| format!("Invalid PCZT for batch message {}: {e:?}", message.id))?;
+        let mut resolved_pczt = compact_pczt.clone();
+        resolved_pczt.resolve_fields().map_err(|e| {
+            format!(
+                "Resolve PCZT fields for batch message {}: {e:?}",
+                message.id
+            )
+        })?;
+        prepared.push(PreparedZcashBatchMessage {
+            expected_signature_count: usize::try_from(message.expected_signature_count)
+                .map_err(|_| "Zcash batch signature count exceeds usize")?,
+            compact_pczt,
+            resolved_pczt,
+            compact_payload_len: message.pczt_bytes.len(),
+        });
+    }
+    Ok(prepared)
+}
+
+fn zcash_sign_batch_round_size(
+    messages: &[PreparedZcashBatchMessage],
+    request_id_len: usize,
+) -> Result<ZcashSignBatchRoundSize, String> {
+    let compact_payload_bytes = messages.iter().try_fold(0usize, |total, message| {
+        total
+            .checked_add(message.compact_payload_len)
+            .ok_or("Zcash batch payload byte count overflow")
+    })?;
+    let expected_signature_count = messages.iter().try_fold(0usize, |total, message| {
+        total
+            .checked_add(message.expected_signature_count)
+            .ok_or("Zcash batch signature count overflow")
+    })?;
+    let compact_request = BatchSignRequest::new(
+        messages
+            .iter()
+            .map(|message| message.compact_pczt.clone())
+            .collect(),
+    )
+    .serialize()
+    .map_err(|e| format!("Encode compact PCZT batch signing request: {e:?}"))?;
+    let compact_request_bytes = compact_request.len();
+    let compact_cbor: Vec<u8> = ZcashSignBatch::new(vec![b'r'; request_id_len], compact_request)
+        .try_into()
+        .map_err(|e: ur_registry::error::URError| {
+            format!("Encode compact zcash-sign-batch envelope: {e:?}")
+        })?;
+    let resolved_request_bytes = BatchSignRequest::new(
+        messages
+            .iter()
+            .map(|message| message.resolved_pczt.clone())
+            .collect(),
+    )
+    .serialize()
+    .map_err(|e| format!("Encode resolved PCZT batch signing request: {e:?}"))?
+    .len();
+
+    Ok(ZcashSignBatchRoundSize {
+        compact_payload_bytes,
+        compact_request_bytes,
+        compact_cbor_bytes: compact_cbor.len(),
+        resolved_request_bytes,
+        expected_signature_count,
+    })
+}
+
+/// Partitions ordered PCZTs into signing rounds that fit both the compact QR
+/// request and Keystone's larger post-`resolve_fields` retained request.
+pub fn zcash_sign_batch_round_message_counts(
+    request_id: &str,
+    messages: &[ZcashBatchMessageInput],
+    max_messages: usize,
+) -> Result<Vec<u32>, String> {
+    if request_id.is_empty() {
+        return Err("Zcash batch request id must not be empty".to_string());
+    }
+    if messages.is_empty() {
+        return Ok(Vec::new());
+    }
+    if max_messages == 0 {
+        return Err("Zcash signing round message limit must be positive".to_string());
+    }
+
+    let prepared = prepare_zcash_batch_messages(messages)?;
+    let round_limit = max_messages.min(ZCASH_SIGN_BATCH_MAX_MESSAGES);
+    // This is an upper bound for every actual `round-X-of-Y` request id because
+    // a request cannot have more rounds than messages.
+    let max_round_request_id_len = format!(
+        "{request_id}-round-{}-of-{}",
+        messages.len(),
+        messages.len()
+    )
+    .len();
+    let mut counts = Vec::new();
+    let mut start = 0usize;
+    let mut largest_compact_cbor = 0usize;
+    let mut largest_resolved_request = 0usize;
+    let mut largest_signature_count = 0usize;
+
+    while start < prepared.len() {
+        let remaining = prepared.len() - start;
+        let max_count = remaining.min(round_limit);
+        let mut low = 1usize;
+        let mut high = max_count;
+        let mut best: Option<(usize, ZcashSignBatchRoundSize)> = None;
+        while low <= high {
+            let candidate_count = low + (high - low) / 2;
+            let size = zcash_sign_batch_round_size(
+                &prepared[start..start + candidate_count],
+                max_round_request_id_len,
+            )?;
+            if size.fits(max_round_request_id_len) {
+                best = Some((candidate_count, size));
+                low = candidate_count + 1;
+            } else {
+                high = candidate_count - 1;
+            }
+        }
+
+        let Some((count, size)) = best else {
+            return Err(format!(
+                "Zcash batch message {} exceeds Keystone's signing round limits",
+                messages[start].id
+            ));
+        };
+        largest_compact_cbor = largest_compact_cbor.max(size.compact_cbor_bytes);
+        largest_resolved_request = largest_resolved_request.max(size.resolved_request_bytes);
+        largest_signature_count = largest_signature_count.max(size.expected_signature_count);
+        counts.push(
+            u32::try_from(count)
+                .map_err(|_| "Zcash signing round message count exceeds u32".to_string())?,
+        );
+        start += count;
+    }
+
+    log::info!(
+        "keystone: partitioned Zcash sign batch: messages={} rounds={} largest_compact_cbor_bytes={} largest_resolved_request_bytes={} largest_expected_signatures={}",
+        messages.len(),
+        counts.len(),
+        largest_compact_cbor,
+        largest_resolved_request,
+        largest_signature_count,
+    );
+    Ok(counts)
+}
+
+#[cfg(test)]
+pub(crate) fn resolved_zcash_sign_batch_request_len(
+    messages: &[ZcashBatchMessageInput],
+) -> Result<usize, String> {
+    let prepared = prepare_zcash_batch_messages(messages)?;
+    Ok(zcash_sign_batch_round_size(&prepared, 1)?.resolved_request_bytes)
 }
 
 /// Encode several redacted PCZTs into the `zcash-sign-batch` outer CBOR
@@ -518,6 +746,11 @@ pub fn encode_zcash_sign_batch_ur_parts(
             format!("Encode zcash-sign-batch CBOR envelope: {e:?}")
         })?;
     let cbor_len = cbor.len();
+    if cbor_len > ZCASH_SIGN_BATCH_MAX_COMPACT_CBOR_BYTES {
+        return Err(format!(
+            "Zcash batch QR request exceeds {ZCASH_SIGN_BATCH_MAX_COMPACT_CBOR_BYTES} bytes"
+        ));
+    }
     let mut ur_encoder = ur::Encoder::new(&cbor, max_fragment_len, ZCASH_SIGN_BATCH_TYPE)
         .map_err(|e| format!("UR encoder: {e}"))?;
     let count = ur_part_count(ur_encoder.fragment_count());
@@ -809,10 +1042,12 @@ mod tests {
                 ZcashBatchMessageInput {
                     id: "tx-1".to_string(),
                     pczt_bytes: test_pczt_bytes(1),
+                    expected_signature_count: 0,
                 },
                 ZcashBatchMessageInput {
                     id: "tx-2".to_string(),
                     pczt_bytes: test_pczt_bytes(2),
+                    expected_signature_count: 0,
                 },
             ],
             10_000,
@@ -839,18 +1074,19 @@ mod tests {
     }
 
     #[test]
-    fn encodes_forty_zcash_sign_batch_messages() {
+    fn encodes_maximum_supported_zcash_sign_batch_messages() {
         let messages = (1..=ZCASH_SIGN_BATCH_MAX_MESSAGES)
             .map(|index| ZcashBatchMessageInput {
                 id: format!("tx-{index}"),
                 pczt_bytes: test_pczt_bytes(index as u32),
+                expected_signature_count: 0,
             })
             .collect::<Vec<_>>();
 
-        let parts = encode_zcash_sign_batch_ur_parts("request-40", &messages, 1_000_000)
-            .expect("40-message batch should encode");
+        let parts = encode_zcash_sign_batch_ur_parts("request-max", &messages, 1_000_000)
+            .expect("maximum supported message batch should encode");
         let envelope = ZcashSignBatch::try_from(decode_test_ur_parts(&parts))
-            .expect("40-message zcash-sign-batch CBOR should decode");
+            .expect("maximum supported zcash-sign-batch CBOR should decode");
         let request =
             BatchSignRequest::parse(envelope.get_data()).expect("Postcard request should decode");
 
@@ -858,11 +1094,72 @@ mod tests {
     }
 
     #[test]
-    fn rejects_maximum_valid_pczts_above_firmware_byte_limit() {
+    fn partitions_zcash_sign_batch_by_requested_message_limit() {
+        let messages = (1..=5)
+            .map(|index| ZcashBatchMessageInput {
+                id: format!("tx-{index}"),
+                pczt_bytes: test_pczt_bytes(index),
+                expected_signature_count: 0,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            zcash_sign_batch_round_message_counts("request-rounds", &messages, 2).unwrap(),
+            vec![2, 2, 1]
+        );
+    }
+
+    #[test]
+    fn partitions_zcash_sign_batch_by_expected_returned_signatures() {
+        let messages = [
+            ZcashBatchMessageInput {
+                id: "tx-1".to_string(),
+                pczt_bytes: test_pczt_bytes(1),
+                expected_signature_count: 64,
+            },
+            ZcashBatchMessageInput {
+                id: "tx-2".to_string(),
+                pczt_bytes: test_pczt_bytes(2),
+                expected_signature_count: 64,
+            },
+            ZcashBatchMessageInput {
+                id: "tx-3".to_string(),
+                pczt_bytes: test_pczt_bytes(3),
+                expected_signature_count: 1,
+            },
+        ];
+
+        assert_eq!(
+            zcash_sign_batch_round_message_counts("request-signatures", &messages, 40).unwrap(),
+            vec![1, 2]
+        );
+        assert_eq!(
+            encode_zcash_sign_batch_postcard(&messages).unwrap_err(),
+            "Zcash batch expects more than 96 spend signatures"
+        );
+    }
+
+    #[test]
+    fn rejects_zero_zcash_sign_batch_round_limit() {
+        let messages = [ZcashBatchMessageInput {
+            id: "tx-1".to_string(),
+            pczt_bytes: test_pczt_bytes(1),
+            expected_signature_count: 0,
+        }];
+
+        assert_eq!(
+            zcash_sign_batch_round_message_counts("request-rounds", &messages, 0).unwrap_err(),
+            "Zcash signing round message limit must be positive"
+        );
+    }
+
+    #[test]
+    fn rejects_maximum_valid_pczts_above_supported_byte_limit() {
         let messages = (1..=ZCASH_SIGN_BATCH_MAX_MESSAGES)
             .map(|index| ZcashBatchMessageInput {
                 id: format!("tx-{index}"),
                 pczt_bytes: test_pczt_bytes_with_padding(index as u32, 15 * 1024),
+                expected_signature_count: 0,
             })
             .collect::<Vec<_>>();
 
@@ -882,6 +1179,7 @@ mod tests {
             &[ZcashBatchMessageInput {
                 id: "tx-1".to_string(),
                 pczt_bytes: test_pczt_bytes(1),
+                expected_signature_count: 0,
             }],
             20,
         )
@@ -902,6 +1200,25 @@ mod tests {
     }
 
     #[test]
+    fn rejects_zcash_sign_batch_above_compact_qr_limit() {
+        let messages = [ZcashBatchMessageInput {
+            id: "tx-1".to_string(),
+            pczt_bytes: test_pczt_bytes_with_padding(1, ZCASH_SIGN_BATCH_MAX_COMPACT_CBOR_BYTES),
+            expected_signature_count: 0,
+        }];
+
+        let err = encode_zcash_sign_batch_ur_parts("request-large-qr", &messages, 10_000)
+            .expect_err("oversized compact QR request should fail");
+
+        assert_eq!(
+            err,
+            format!(
+                "Zcash batch QR request exceeds {ZCASH_SIGN_BATCH_MAX_COMPACT_CBOR_BYTES} bytes"
+            )
+        );
+    }
+
+    #[test]
     fn ur_part_count_adds_small_redundancy_tail() {
         assert_eq!(ur_part_count(0), 0);
         assert_eq!(ur_part_count(1), 1);
@@ -918,10 +1235,12 @@ mod tests {
                 ZcashBatchMessageInput {
                     id: "tx-1".to_string(),
                     pczt_bytes: test_pczt_bytes(1),
+                    expected_signature_count: 0,
                 },
                 ZcashBatchMessageInput {
                     id: "tx-1".to_string(),
                     pczt_bytes: test_pczt_bytes(2),
+                    expected_signature_count: 0,
                 },
             ],
             10_000,
@@ -938,6 +1257,7 @@ mod tests {
             &[ZcashBatchMessageInput {
                 id: "tx-1".to_string(),
                 pczt_bytes: test_pczt_bytes(1),
+                expected_signature_count: 0,
             }],
             10_000,
         )
@@ -947,13 +1267,14 @@ mod tests {
     }
 
     #[test]
-    fn rejects_zcash_batch_envelope_above_firmware_limit() {
+    fn rejects_zcash_batch_envelope_above_supported_limit() {
         let request_id = "r".repeat(ZCASH_SIGN_BATCH_MAX_TOTAL_BYTES);
         let err = encode_zcash_sign_batch_ur_parts(
             &request_id,
             &[ZcashBatchMessageInput {
                 id: "tx-1".to_string(),
                 pczt_bytes: test_pczt_bytes(1),
+                expected_signature_count: 0,
             }],
             10_000,
         )
@@ -962,6 +1283,28 @@ mod tests {
         assert_eq!(
             err,
             format!("Zcash batch request exceeds {ZCASH_SIGN_BATCH_MAX_TOTAL_BYTES} bytes")
+        );
+    }
+
+    #[test]
+    fn rejects_final_cbor_envelope_above_compact_limit() {
+        let messages = [ZcashBatchMessageInput {
+            id: "tx-1".to_string(),
+            pczt_bytes: test_pczt_bytes(1),
+            expected_signature_count: 0,
+        }];
+        let postcard = encode_zcash_sign_batch_postcard(&messages)
+            .expect("test signing request should serialize");
+        let request_id = "r".repeat(ZCASH_SIGN_BATCH_MAX_COMPACT_CBOR_BYTES - postcard.len());
+
+        let err = encode_zcash_sign_batch_ur_parts(&request_id, &messages, 10_000)
+            .expect_err("outer CBOR framing should push the request over the limit");
+
+        assert_eq!(
+            err,
+            format!(
+                "Zcash batch QR request exceeds {ZCASH_SIGN_BATCH_MAX_COMPACT_CBOR_BYTES} bytes"
+            )
         );
     }
 

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -524,6 +524,22 @@ pub(crate) struct OrchardMigrationPrivatePlan {
 pub(crate) struct KeystoneMigrationMessage {
     pub id: String,
     pub redacted_pczt: Vec<u8>,
+    /// Wallet-owned actions that still require external authorization.
+    pub expected_signature_count: u32,
+}
+
+fn keystone_migration_message(
+    id: &str,
+    redacted_pczt: &[u8],
+    expected_signature_count: usize,
+) -> KeystoneMigrationMessage {
+    KeystoneMigrationMessage {
+        id: id.to_string(),
+        redacted_pczt: redacted_pczt.to_vec(),
+        // Any value that cannot fit in u32 is already far above the per-round
+        // limit and will be rejected by the partitioner.
+        expected_signature_count: u32::try_from(expected_signature_count).unwrap_or(u32::MAX),
+    }
 }
 
 pub(crate) struct KeystoneMigrationSigningRequest {

--- a/rust/src/wallet/sync/send/ironwood_migration.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration.rs
@@ -107,9 +107,12 @@ pub(crate) fn prepare_orchard_migration_denominations_pczt(
     let messages = split
         .stages
         .iter()
-        .map(|stage| KeystoneMigrationMessage {
-            id: stage.id.clone(),
-            redacted_pczt: stage.redacted_pczt.clone(),
+        .map(|stage| {
+            keystone_migration_message(
+                &stage.id,
+                &stage.redacted_pczt,
+                stage.orchard_spend_action_indices.len(),
+            )
         })
         .collect::<Vec<_>>();
     if !messages.is_empty() {
@@ -416,18 +419,20 @@ pub(crate) fn prepare_orchard_migration_single_qr_pczt(
 
     let request_id = new_keystone_migration_request_id("single");
     let mut messages = Vec::with_capacity(total_messages);
-    messages.extend(split.stages.iter().map(|stage| KeystoneMigrationMessage {
-        id: stage.id.clone(),
-        redacted_pczt: stage.redacted_pczt.clone(),
+    messages.extend(split.stages.iter().map(|stage| {
+        keystone_migration_message(
+            &stage.id,
+            &stage.redacted_pczt,
+            stage.orchard_spend_action_indices.len(),
+        )
     }));
-    messages.extend(
-        child_messages
-            .iter()
-            .map(|message| KeystoneMigrationMessage {
-                id: message.id.clone(),
-                redacted_pczt: message.redacted_pczt.clone(),
-            }),
-    );
+    messages.extend(child_messages.iter().map(|message| {
+        keystone_migration_message(
+            &message.id,
+            &message.redacted_pczt,
+            message.orchard_spend_action_indices.len(),
+        )
+    }));
     validate_keystone_migration_messages(&messages)?;
 
     let root_proofs = split
@@ -708,10 +713,11 @@ pub(crate) fn prepare_orchard_migration_immediate_pczt(
     let redacted_pczt = super::pczt::redact_pczt_for_batch_signer(&built.base_pczt)?;
     let request_id = new_keystone_migration_request_id("immediate");
     let message_id = format!("{request_id}-transaction");
-    let messages = vec![KeystoneMigrationMessage {
-        id: message_id.clone(),
-        redacted_pczt,
-    }];
+    let messages = vec![keystone_migration_message(
+        &message_id,
+        &redacted_pczt,
+        built.orchard_spend_action_indices.len(),
+    )];
     validate_keystone_migration_messages(&messages)?;
     let base_pczt = built.base_pczt.clone();
     let mut store = keystone_immediate_migration_requests()
@@ -1094,9 +1100,12 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
     let request_id = new_keystone_migration_request_id("batch");
     let messages = created
         .iter()
-        .map(|message| KeystoneMigrationMessage {
-            id: message.id.clone(),
-            redacted_pczt: message.redacted_pczt.clone(),
+        .map(|message| {
+            keystone_migration_message(
+                &message.id,
+                &message.redacted_pczt,
+                message.orchard_spend_action_indices.len(),
+            )
         })
         .collect::<Vec<_>>();
     validate_keystone_migration_messages(&messages)?;

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -467,6 +467,7 @@ fn keystone_migration_signing_accepts_multiple_firmware_rounds() {
         .map(|index| KeystoneMigrationMessage {
             id: format!("message-{index}"),
             redacted_pczt: vec![index as u8, 1],
+            expected_signature_count: 0,
         })
         .collect::<Vec<_>>();
 
@@ -2365,8 +2366,7 @@ fn orchard_denomination_split_pczt_uses_v6_for_change_outputs() {
     crate::wallet::sync::pczt::redact_pczt_for_signer(&built_pczt.bytes).unwrap();
 }
 
-#[test]
-fn padded_denomination_split_builds_exactly_sixteen_actions() {
+fn built_padded_v6_split_pczt() -> (BuiltPczt, UnifiedSpendingKey) {
     crate::wallet::network::configure_regtest_nu6_3_activation_height(2).unwrap();
     let network = WalletNetwork::Regtest;
     let target_height = 120;
@@ -2440,6 +2440,12 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
         16
     );
     let built = pczt_from_build_result(build_result, network, None, 1, outputs.len()).unwrap();
+    (built, usk)
+}
+
+#[test]
+fn padded_denomination_split_builds_exactly_sixteen_actions() {
+    let (built, usk) = built_padded_v6_split_pczt();
     assert_eq!(
         pczt::Pczt::parse(&built.bytes)
             .unwrap()
@@ -2464,6 +2470,64 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
     assert_eq!(sigs.len(), 11);
     crate::wallet::sync::pczt::preflight_orchard_spend_auth_signatures(&built.bytes, &sigs)
         .unwrap();
+}
+
+#[test]
+fn keystone_round_partition_bounds_resolved_padded_splits() {
+    let messages = (0..40)
+        .map(|index| {
+            let (built, _) = built_padded_v6_split_pczt();
+            crate::wallet::keystone::ZcashBatchMessageInput {
+                id: format!("split-{index}"),
+                pczt_bytes: built.redacted_bytes,
+                expected_signature_count: built.orchard_spend_action_indices.len() as u32,
+            }
+        })
+        .collect::<Vec<_>>();
+    let request_id = "migration-request";
+    let unsplit_resolved =
+        crate::wallet::keystone::resolved_zcash_sign_batch_request_len(&messages).unwrap();
+    assert!(
+        request_id.len() + unsplit_resolved > 512 * 1024,
+        "fixture must reproduce the firmware's post-resolution overflow"
+    );
+
+    let counts =
+        crate::wallet::keystone::zcash_sign_batch_round_message_counts(request_id, &messages, 40)
+            .unwrap();
+    assert!(counts.len() > 1);
+    assert_eq!(
+        counts.iter().map(|count| *count as usize).sum::<usize>(),
+        messages.len()
+    );
+
+    let mut offset = 0usize;
+    for (round_index, count) in counts.iter().enumerate() {
+        let count = *count as usize;
+        let round_request_id =
+            format!("{request_id}-round-{}-of-{}", round_index + 1, counts.len());
+        let resolved = crate::wallet::keystone::resolved_zcash_sign_batch_request_len(
+            &messages[offset..offset + count],
+        )
+        .unwrap();
+        assert!(
+            round_request_id.len() + resolved
+                <= crate::wallet::keystone::ZCASH_SIGN_BATCH_MAX_RESOLVED_TOTAL_BYTES
+        );
+        let round = &messages[offset..offset + count];
+        let expected_signatures = round
+            .iter()
+            .map(|message| message.expected_signature_count as usize)
+            .sum::<usize>();
+        assert!(expected_signatures <= crate::wallet::keystone::ZCASH_SIGN_BATCH_MAX_SIGNATURES);
+        crate::wallet::keystone::encode_zcash_sign_batch_ur_parts(
+            &round_request_id,
+            round,
+            1_000_000,
+        )
+        .unwrap();
+        offset += count;
+    }
 }
 
 #[test]

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -1042,10 +1042,12 @@ void main() {
           rust_sync.KeystoneMigrationMessage(
             id: 'split-1',
             redactedPczt: Uint8List.fromList([1]),
+            expectedSignatureCount: 0,
           ),
           rust_sync.KeystoneMigrationMessage(
             id: 'split-2',
             redactedPczt: Uint8List.fromList([2]),
+            expectedSignatureCount: 0,
           ),
         ],
         signingBatchLimit: 1,
@@ -1059,6 +1061,25 @@ void main() {
         ),
       );
       await tester.pump();
+
+      expect(
+        find.byKey(
+          const ValueKey('keystone_migration_signing_plan_confirmation'),
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('2 QR signing rounds'), findsOneWidget);
+      expect(find.text('2 transactions total'), findsOneWidget);
+      expect(
+        find.text(
+          'Each round uses one animated request QR and one signed response QR.',
+        ),
+        findsOneWidget,
+      );
+      await tester.tap(
+        find.byKey(const ValueKey('keystone_migration_begin_signing')),
+      );
+      await tester.pumpAndSettle();
 
       expect(find.text('Step 1 of 2'), findsNothing);
       expect(find.text('Round 1 of 2'), findsOneWidget);
@@ -1177,6 +1198,7 @@ void main() {
         rust_sync.KeystoneMigrationMessage(
           id: id,
           redactedPczt: Uint8List(bytes),
+          expectedSignatureCount: 0,
         );
 
     test('chunks by the signing batch limit', () {
@@ -1186,7 +1208,33 @@ void main() {
       expect(rounds.map((round) => round.length), [2, 2, 1]);
     });
 
-    test('splits the first message beyond the 40-message firmware cap', () {
+    test('applies Rust post-resolution round counts without reordering', () {
+      final rounds = keystoneSigningRoundsFromCountsForTest(
+        [for (var i = 0; i < 5; i++) message('m$i', 10)],
+        [2, 1, 2],
+      );
+
+      expect(rounds.map((round) => round.length), [2, 1, 2]);
+      expect(rounds.expand((round) => round).map((item) => item.id), [
+        'm0',
+        'm1',
+        'm2',
+        'm3',
+        'm4',
+      ]);
+    });
+
+    test('rejects an incomplete Rust round partition', () {
+      expect(
+        () => keystoneSigningRoundsFromCountsForTest(
+          [for (var i = 0; i < 3; i++) message('m$i', 10)],
+          [2],
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('splits the first message beyond the 40-message supported cap', () {
       final messages = [for (var i = 0; i < 41; i++) message('m$i', 10)];
       expect(
         keystoneSigningRoundsForTest(
@@ -1196,16 +1244,16 @@ void main() {
         [40],
       );
       expect(
-        keystoneSigningRoundsForTest(messages, 40).map((round) => round.length),
+        keystoneSigningRoundsForTest(messages, 50).map((round) => round.length),
         [40, 1],
       );
     });
 
-    test('splits a round that would exceed the firmware byte ceiling', () {
-      // 40 messages of 26 KiB total over 1 MiB — the count fits in one round
-      // but the firmware rejects anything over 512 KiB per round.
+    test('moves a transaction when a preview round would exceed 64 KiB', () {
+      // The preview partitioner reserves 16 KiB of the 80-KiB QR ceiling for
+      // request framing. Production uses Rust's exact encoded size.
       final rounds = keystoneSigningRoundsForTest([
-        for (var i = 0; i < 40; i++) message('m$i', 26 * 1024),
+        for (var i = 0; i < 40; i++) message('m$i', 4 * 1024),
       ], 40);
       expect(rounds.length, greaterThan(1));
       for (final round in rounds) {
@@ -1213,11 +1261,21 @@ void main() {
           0,
           (total, item) => total + item.redactedPczt.length + item.id.length,
         );
-        expect(bytes, lessThanOrEqualTo(512 * 1024 - 16 * 1024));
+        expect(bytes, lessThanOrEqualTo(64 * 1024));
       }
       expect(rounds.expand((round) => round).map((item) => item.id).toList(), [
         for (var i = 0; i < 40; i++) 'm$i',
       ]);
+    });
+
+    test('splits large synthetic PCZTs at the byte budget', () {
+      // Use 14-KiB payloads to make the preview byte ceiling override the
+      // 40-message count limit.
+      final rounds = keystoneSigningRoundsForTest([
+        for (var i = 0; i < 11; i++) message('m$i', 14 * 1024),
+      ], 40);
+
+      expect(rounds.map((round) => round.length), [4, 4, 3]);
     });
 
     test('rejects a message no round could ever carry', () {
@@ -1234,7 +1292,7 @@ void main() {
     });
 
     test('still packs a message that only just fits', () {
-      const budget = 512 * 1024 - 16 * 1024;
+      const budget = 64 * 1024;
       final rounds = keystoneSigningRoundsForTest([
         message('big', budget - 'big'.length),
         message('small', 10),

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -5448,6 +5448,7 @@ rust_sync.KeystoneMigrationSigningRequest _keystoneSigningRequest() {
       rust_sync.KeystoneMigrationMessage(
         id: 'message-1',
         redactedPczt: Uint8List.fromList([1, 2, 3]),
+        expectedSignatureCount: 0,
       ),
     ],
     signingBatchLimit: 35,

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -75,6 +75,19 @@ class _RustApiFake implements RustLibApi {
   }
 
   @override
+  Future<Uint32List> crateApiKeystoneZcashSignBatchRoundMessageCounts({
+    required String requestId,
+    required List<rust_keystone_wallet.ZcashBatchMessageInput> messages,
+    required int maxMessages,
+  }) async {
+    final limit = math.min(maxMessages, 40);
+    return Uint32List.fromList([
+      for (var remaining = messages.length; remaining > 0; remaining -= limit)
+        math.min(remaining, limit),
+    ]);
+  }
+
+  @override
   Future<rust_keystone.KeystoneSigResult>
   crateApiKeystoneDecodeZcashBatchSignResponse({
     required List<int> cbor,
@@ -1231,6 +1244,7 @@ rust_sync.KeystoneMigrationSigningRequest _keystoneDenominationRequest() {
       rust_sync.KeystoneMigrationMessage(
         id: 'split-1',
         redactedPczt: Uint8List.fromList([1, 2, 3]),
+        expectedSignatureCount: 0,
       ),
     ],
     signingBatchLimit: 50,
@@ -3429,10 +3443,12 @@ void main() {
         rust_sync.KeystoneMigrationMessage(
           id: 'split-1',
           redactedPczt: Uint8List.fromList([1]),
+          expectedSignatureCount: 0,
         ),
         rust_sync.KeystoneMigrationMessage(
           id: 'split-2',
           redactedPczt: Uint8List.fromList([2]),
+          expectedSignatureCount: 0,
         ),
       ],
       signingBatchLimit: 1,
@@ -3514,6 +3530,7 @@ void main() {
         rust_sync.KeystoneMigrationMessage(
           id: 'immediate-transaction',
           redactedPczt: Uint8List.fromList([1]),
+          expectedSignatureCount: 0,
         ),
       ],
       signingBatchLimit: 1,
@@ -3604,6 +3621,7 @@ void main() {
                 rust_sync.KeystoneMigrationMessage(
                   id: 'split-1',
                   redactedPczt: Uint8List.fromList([1]),
+                  expectedSignatureCount: 0,
                 ),
               ],
               signingBatchLimit: 40,
@@ -3728,6 +3746,7 @@ void main() {
                     rust_sync.KeystoneMigrationMessage(
                       id: 'child-1',
                       redactedPczt: Uint8List.fromList([1]),
+                      expectedSignatureCount: 0,
                     ),
                   ],
                   signingBatchLimit: 40,
@@ -3971,6 +3990,7 @@ void main() {
                   rust_sync.KeystoneMigrationMessage(
                     id: 'message-$prepareCount',
                     redactedPczt: Uint8List.fromList([prepareCount]),
+                    expectedSignatureCount: 0,
                   ),
                 ],
                 signingBatchLimit: 50,


### PR DESCRIPTION
Keystone resolves compact PCZT fields before enforcing its retained-request size limit, so a batch that looks safe to Vizor can still overflow on the device. This partitions migration signing rounds in Rust from both compact and resolved serialization sizes while preserving message order and the 40-transaction protocol maximum.

Resolved requests retain a conservative 46 KiB margin below Keystone's 512 KiB firmware limit. The change also caps outbound QR payloads at 80 KiB and expected returned signatures at 96 per round, carries exact signature counts through the Rust/Dart boundary, and shows desktop users the exact signing-round and transaction counts before scanning.
