### PR TITLE
Use device-bound Keychain accessibility for iOS secure storage

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		42257B77B623F2ABAD2A1912 /* DynamicIslandManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4D4F9C0A149C751B796E19 /* DynamicIslandManager.swift */; };
 		5736417E0A4E184E8572693A /* WalletPathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5736417D0A4E184E8572693A /* WalletPathResolver.swift */; };
+		KEYMIG010000000000000001 /* KeychainAccessibilityMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = KEYMIG000000000000000001 /* KeychainAccessibilityMigrator.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		8108A5A50BC98B3D741F1711 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FED55156EBDEE425125AD2C /* Pods_Runner.framework */; };
@@ -98,6 +99,7 @@
 		363BC99CD33184F9C3C7E797 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		5736417D0A4E184E8572693A /* WalletPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletPathResolver.swift; sourceTree = "<group>"; };
+		KEYMIG000000000000000001 /* KeychainAccessibilityMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAccessibilityMigrator.swift; sourceTree = "<group>"; };
 		603F096B051231C6A1C6A5B1 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		64501DB95B6D078121FE7DE1 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		6A4D4F9C0A149C751B796E19 /* DynamicIslandManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DynamicIslandManager.swift; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 				BIOUNLK00ED2DC5600515810 /* BiometricUnlockHandler.swift */,
 				DATEPCK00ED2DC5600515810 /* DatePickerHandler.swift */,
 				5736417D0A4E184E8572693A /* WalletPathResolver.swift */,
+				KEYMIG000000000000000001 /* KeychainAccessibilityMigrator.swift */,
 				ZSYNC000ED2DC5600515810 /* zcash_sync.h */,
 				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
@@ -549,6 +552,7 @@
 				BIOUNLK01ED2DC5600515810 /* BiometricUnlockHandler.swift in Sources */,
 				DATEPCK01ED2DC5600515810 /* DatePickerHandler.swift in Sources */,
 				5736417E0A4E184E8572693A /* WalletPathResolver.swift in Sources */,
+				KEYMIG010000000000000001 /* KeychainAccessibilityMigrator.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
 				42257B77B623F2ABAD2A1912 /* DynamicIslandManager.swift in Sources */,

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -52,6 +52,16 @@ import UIKit
 
     let messenger = engineBridge.applicationRegistrar.messenger()
 
+    let keychainAccessibilityMigrationHandler =
+      KeychainAccessibilityMigrationChannel()
+    let keychainAccessibilityMigrationChannel = FlutterMethodChannel(
+      name: keychainAccessibilityMigrationChannelName,
+      binaryMessenger: messenger
+    )
+    keychainAccessibilityMigrationChannel.setMethodCallHandler { call, result in
+      keychainAccessibilityMigrationHandler.handle(call, result: result)
+    }
+
     let backgroundMigrationChannel = FlutterMethodChannel(
       name: "com.zcash.wallet/background_migration",
       binaryMessenger: messenger

--- a/ios/Runner/KeychainAccessibilityMigrator.swift
+++ b/ios/Runner/KeychainAccessibilityMigrator.swift
@@ -1,0 +1,387 @@
+import Flutter
+import Foundation
+import Security
+
+let keychainAccessibilityMigrationChannelName =
+  "com.zcash.wallet/keychain_accessibility_migration"
+let keychainAccessibilityMigrationStagingSuffix =
+  ".accessibility-migration-v1"
+let keychainAccessibilityMigrationAllowedServices = [
+  "com.keplr.vizor.secure_store",
+  "com.keplr.vizor.ironwood.secure_store",
+  "com.keplr.vizor.test.secure_store",
+  "com.keplr.vizor.regtest.secure_store",
+]
+
+private let keychainAccessibilityTarget =
+  kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String
+private let keychainAccessibilityLegacy =
+  kSecAttrAccessibleAfterFirstUnlock as String
+
+struct KeychainAccessibilityMigrationItem: Equatable {
+  let account: String
+  let data: Data
+  let accessibility: String
+  let attributes: [String: AnyHashable]
+
+  static func == (
+    lhs: KeychainAccessibilityMigrationItem,
+    rhs: KeychainAccessibilityMigrationItem
+  ) -> Bool {
+    lhs.account == rhs.account
+      && lhs.data == rhs.data
+      && lhs.accessibility == rhs.accessibility
+      && lhs.attributes == rhs.attributes
+  }
+}
+
+protocol KeychainAccessibilityMigrationStore {
+  func items(service: String) throws -> [KeychainAccessibilityMigrationItem]
+  func add(
+    _ item: KeychainAccessibilityMigrationItem,
+    service: String
+  ) throws
+  func delete(service: String, account: String) throws
+}
+
+enum KeychainAccessibilityMigrationError: Error, Equatable {
+  case invalidService
+  case duplicateAccount(String)
+  case conflictingCopies(String)
+  case unexpectedAccessibility(account: String, accessibility: String)
+  case protectedDataUnavailable
+  case keychain(operation: String, status: OSStatus)
+}
+
+final class KeychainAccessibilityMigrator {
+  static let shared = KeychainAccessibilityMigrator()
+
+  private static let allowedServices = Set(
+    keychainAccessibilityMigrationAllowedServices
+  )
+
+  private let store: KeychainAccessibilityMigrationStore
+
+  init(store: KeychainAccessibilityMigrationStore = SecurityKeychainMigrationStore()) {
+    self.store = store
+  }
+
+  @discardableResult
+  func ensureFirstUnlockThisDeviceOnly(service: String) throws -> Int {
+    guard Self.allowedServices.contains(service) else {
+      throw KeychainAccessibilityMigrationError.invalidService
+    }
+
+    let stagingService = service + keychainAccessibilityMigrationStagingSuffix
+    let canonical = try indexedItems(try store.items(service: service))
+    let staged = try indexedItems(try store.items(service: stagingService))
+    let accounts = Set(canonical.keys).union(staged.keys).sorted()
+    var migratedCount = 0
+
+    for account in accounts {
+      let didMigrate = try migrate(
+        account: account,
+        canonical: canonical[account],
+        staged: staged[account],
+        service: service,
+        stagingService: stagingService
+      )
+      if didMigrate {
+        migratedCount += 1
+      }
+    }
+    return migratedCount
+  }
+
+  private func indexedItems(
+    _ items: [KeychainAccessibilityMigrationItem]
+  ) throws -> [String: KeychainAccessibilityMigrationItem] {
+    var result: [String: KeychainAccessibilityMigrationItem] = [:]
+    for item in items {
+      if result.updateValue(item, forKey: item.account) != nil {
+        throw KeychainAccessibilityMigrationError.duplicateAccount(item.account)
+      }
+    }
+    return result
+  }
+
+  private func migrate(
+    account: String,
+    canonical: KeychainAccessibilityMigrationItem?,
+    staged: KeychainAccessibilityMigrationItem?,
+    service: String,
+    stagingService: String
+  ) throws -> Bool {
+    if let staged {
+      try requireTarget(staged)
+    }
+
+    guard let canonical else {
+      guard let staged else { return false }
+      try store.add(staged, service: service)
+      try verify(staged, service: service)
+      try store.delete(service: stagingService, account: account)
+      return true
+    }
+
+    if canonical.accessibility == keychainAccessibilityTarget {
+      guard let staged else { return false }
+      try requireMatchingData(canonical, staged)
+      try store.delete(service: stagingService, account: account)
+      return false
+    }
+
+    guard canonical.accessibility == keychainAccessibilityLegacy else {
+      throw KeychainAccessibilityMigrationError.unexpectedAccessibility(
+        account: account,
+        accessibility: canonical.accessibility
+      )
+    }
+
+    if let staged {
+      try requireMatchingData(canonical, staged)
+    } else {
+      try store.add(canonical, service: stagingService)
+      try verify(canonical, service: stagingService)
+    }
+
+    try store.delete(service: service, account: account)
+    try store.add(canonical, service: service)
+    try verify(canonical, service: service)
+    try store.delete(service: stagingService, account: account)
+    return true
+  }
+
+  private func requireTarget(
+    _ item: KeychainAccessibilityMigrationItem
+  ) throws {
+    guard item.accessibility == keychainAccessibilityTarget else {
+      throw KeychainAccessibilityMigrationError.unexpectedAccessibility(
+        account: item.account,
+        accessibility: item.accessibility
+      )
+    }
+  }
+
+  private func requireMatchingData(
+    _ lhs: KeychainAccessibilityMigrationItem,
+    _ rhs: KeychainAccessibilityMigrationItem
+  ) throws {
+    guard lhs.data == rhs.data else {
+      throw KeychainAccessibilityMigrationError.conflictingCopies(lhs.account)
+    }
+  }
+
+  private func verify(
+    _ expected: KeychainAccessibilityMigrationItem,
+    service: String
+  ) throws {
+    let matches = try store.items(service: service).filter {
+      $0.account == expected.account
+    }
+    guard matches.count == 1 else {
+      throw KeychainAccessibilityMigrationError.conflictingCopies(expected.account)
+    }
+    let actual = matches[0]
+    try requireTarget(actual)
+    try requireMatchingData(expected, actual)
+  }
+}
+
+final class SecurityKeychainMigrationStore: KeychainAccessibilityMigrationStore {
+  func items(service: String) throws -> [KeychainAccessibilityMigrationItem] {
+    let query: [CFString: Any] = [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrService: service,
+      kSecReturnAttributes: true,
+      kSecReturnData: true,
+      kSecMatchLimit: kSecMatchLimitAll,
+    ]
+
+    var result: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    if status == errSecItemNotFound {
+      return []
+    }
+    try check(status, operation: "read")
+
+    guard let dictionaries = result as? [[CFString: Any]] else {
+      throw KeychainAccessibilityMigrationError.keychain(
+        operation: "decode",
+        status: errSecDecode
+      )
+    }
+
+    return try dictionaries.map { attributes in
+      guard
+        let account = attributes[kSecAttrAccount] as? String,
+        let data = attributes[kSecValueData] as? Data,
+        let accessibility = attributes[kSecAttrAccessible] as? String
+      else {
+        throw KeychainAccessibilityMigrationError.keychain(
+          operation: "decode",
+          status: errSecDecode
+        )
+      }
+
+      var preserved: [String: AnyHashable] = [:]
+      for key in [
+        kSecAttrLabel,
+        kSecAttrDescription,
+        kSecAttrComment,
+        kSecAttrGeneric,
+        kSecAttrIsInvisible,
+        kSecAttrIsNegative,
+        kSecAttrAccessGroup,
+      ] {
+        if let value = attributes[key] as? AnyHashable {
+          preserved[key as String] = value
+        }
+      }
+      return KeychainAccessibilityMigrationItem(
+        account: account,
+        data: data,
+        accessibility: accessibility,
+        attributes: preserved
+      )
+    }
+  }
+
+  func add(
+    _ item: KeychainAccessibilityMigrationItem,
+    service: String
+  ) throws {
+    var error: Unmanaged<CFError>?
+    guard
+      let accessControl = SecAccessControlCreateWithFlags(
+        nil,
+        kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        [],
+        &error
+      )
+    else {
+      _ = error?.takeRetainedValue()
+      throw KeychainAccessibilityMigrationError.keychain(
+        operation: "create_access_control",
+        status: errSecParam
+      )
+    }
+
+    var query: [CFString: Any] = [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrAccount: item.account,
+      kSecAttrService: service,
+      kSecAttrAccessControl: accessControl,
+      kSecValueData: item.data,
+    ]
+    for (key, value) in item.attributes {
+      query[key as CFString] = value
+    }
+    try check(SecItemAdd(query as CFDictionary, nil), operation: "add")
+  }
+
+  func delete(service: String, account: String) throws {
+    let query: [CFString: Any] = [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrService: service,
+      kSecAttrAccount: account,
+    ]
+    let status = SecItemDelete(query as CFDictionary)
+    if status == errSecItemNotFound { return }
+    try check(status, operation: "delete")
+  }
+
+  private func check(_ status: OSStatus, operation: String) throws {
+    if status == errSecSuccess { return }
+    if status == errSecInteractionNotAllowed {
+      throw KeychainAccessibilityMigrationError.protectedDataUnavailable
+    }
+    throw KeychainAccessibilityMigrationError.keychain(
+      operation: operation,
+      status: status
+    )
+  }
+}
+
+final class KeychainAccessibilityMigrationChannel {
+  private let queue = DispatchQueue(
+    label: "com.zcash.wallet.keychain-accessibility-migration",
+    qos: .userInitiated
+  )
+
+  func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard call.method == "ensureFirstUnlockThisDeviceOnly" else {
+      result(FlutterMethodNotImplemented)
+      return
+    }
+    guard
+      let arguments = call.arguments as? [String: Any],
+      let service = arguments["service"] as? String
+    else {
+      result(
+        FlutterError(
+          code: "invalid_arguments",
+          message: "Missing secure-store service.",
+          details: nil
+        )
+      )
+      return
+    }
+
+    queue.async {
+      do {
+        let migrated = try KeychainAccessibilityMigrator.shared
+          .ensureFirstUnlockThisDeviceOnly(service: service)
+        DispatchQueue.main.async {
+          result(["status": "complete", "migrated": migrated])
+        }
+      } catch {
+        let flutterError = Self.flutterError(error)
+        DispatchQueue.main.async { result(flutterError) }
+      }
+    }
+  }
+
+  private static func flutterError(_ error: Error) -> FlutterError {
+    guard let migrationError = error as? KeychainAccessibilityMigrationError else {
+      return FlutterError(
+        code: "migration_failed",
+        message: "The iOS secure-store migration failed.",
+        details: String(describing: error)
+      )
+    }
+    switch migrationError {
+    case .protectedDataUnavailable:
+      return FlutterError(
+        code: "protected_data_unavailable",
+        message: "Unlock the device once after restart to access secure storage.",
+        details: nil
+      )
+    case .keychain(let operation, let status):
+      return FlutterError(
+        code: "keychain_error",
+        message: "The iOS secure-store migration failed.",
+        details: ["operation": operation, "status": status]
+      )
+    case .invalidService:
+      return FlutterError(
+        code: "invalid_service",
+        message: "The secure-store service is not allowed.",
+        details: nil
+      )
+    case .duplicateAccount(let account),
+      .conflictingCopies(let account):
+      return FlutterError(
+        code: "migration_conflict",
+        message: "Conflicting secure-store copies were found.",
+        details: ["account": account]
+      )
+    case .unexpectedAccessibility(let account, let accessibility):
+      return FlutterError(
+        code: "unexpected_accessibility",
+        message: "An unexpected secure-store protection class was found.",
+        details: ["account": account, "accessibility": accessibility]
+      )
+    }
+  }
+}

--- a/ios/Runner/KeychainAccessibilityMigrator.swift
+++ b/ios/Runner/KeychainAccessibilityMigrator.swift
@@ -6,6 +6,7 @@ let keychainAccessibilityMigrationChannelName =
   "com.zcash.wallet/keychain_accessibility_migration"
 let keychainAccessibilityMigrationStagingSuffix =
   ".accessibility-migration-v1"
+let keychainAccessibilityMigrationVersion = 1
 let keychainAccessibilityMigrationAllowedServices = [
   "com.keplr.vizor.secure_store",
   "com.keplr.vizor.ironwood.secure_store",
@@ -44,6 +45,11 @@ protocol KeychainAccessibilityMigrationStore {
   func delete(service: String, account: String) throws
 }
 
+protocol KeychainAccessibilityMigrationCompletionStore {
+  func isComplete(service: String, version: Int) -> Bool
+  func markComplete(service: String, version: Int)
+}
+
 enum KeychainAccessibilityMigrationError: Error, Equatable {
   case invalidService
   case duplicateAccount(String)
@@ -61,15 +67,27 @@ final class KeychainAccessibilityMigrator {
   )
 
   private let store: KeychainAccessibilityMigrationStore
+  private let completionStore: KeychainAccessibilityMigrationCompletionStore
 
-  init(store: KeychainAccessibilityMigrationStore = SecurityKeychainMigrationStore()) {
+  init(
+    store: KeychainAccessibilityMigrationStore = SecurityKeychainMigrationStore(),
+    completionStore: KeychainAccessibilityMigrationCompletionStore =
+      UserDefaultsKeychainAccessibilityMigrationCompletionStore()
+  ) {
     self.store = store
+    self.completionStore = completionStore
   }
 
   @discardableResult
   func ensureFirstUnlockThisDeviceOnly(service: String) throws -> Int {
     guard Self.allowedServices.contains(service) else {
       throw KeychainAccessibilityMigrationError.invalidService
+    }
+    if completionStore.isComplete(
+      service: service,
+      version: keychainAccessibilityMigrationVersion
+    ) {
+      return 0
     }
 
     let stagingService = service + keychainAccessibilityMigrationStagingSuffix
@@ -90,6 +108,10 @@ final class KeychainAccessibilityMigrator {
         migratedCount += 1
       }
     }
+    completionStore.markComplete(
+      service: service,
+      version: keychainAccessibilityMigrationVersion
+    )
     return migratedCount
   }
 
@@ -185,6 +207,28 @@ final class KeychainAccessibilityMigrator {
     let actual = matches[0]
     try requireTarget(actual)
     try requireMatchingData(expected, actual)
+  }
+}
+
+final class UserDefaultsKeychainAccessibilityMigrationCompletionStore:
+  KeychainAccessibilityMigrationCompletionStore
+{
+  private let userDefaults: UserDefaults
+
+  init(userDefaults: UserDefaults = .standard) {
+    self.userDefaults = userDefaults
+  }
+
+  func isComplete(service: String, version: Int) -> Bool {
+    userDefaults.bool(forKey: key(service: service, version: version))
+  }
+
+  func markComplete(service: String, version: Int) {
+    userDefaults.set(true, forKey: key(service: service, version: version))
+  }
+
+  private func key(service: String, version: Int) -> String {
+    "vizor_keychain_accessibility_migration_v\(version)_complete.\(service)"
   }
 }
 

--- a/ios/Runner/WalletPathResolver.swift
+++ b/ios/Runner/WalletPathResolver.swift
@@ -83,7 +83,7 @@ struct FreshInstallKeychainCleaner {
         var hasCleanupPending: () -> Bool
         var markCleanupPending: () -> Void
         var clearCleanupPending: () -> Void
-        var readWalletDbName: () -> KeychainDbNameLookup
+        var readWalletDbNames: () -> [KeychainDbNameLookup]
         var walletDbExists: (String) -> Bool
         var deleteKeychainService: (String) -> OSStatus
         var log: (String) -> Void
@@ -104,8 +104,12 @@ struct FreshInstallKeychainCleaner {
             clearCleanupPending: {
                 UserDefaults.standard.removeObject(forKey: cleanupPendingKey)
             },
-            readWalletDbName: {
-                FreshInstallKeychainCleaner.readWalletDbNameFromKeychain()
+            readWalletDbNames: {
+                FreshInstallKeychainCleaner.secureStoreServicesToClear.map { service in
+                    FreshInstallKeychainCleaner.readWalletDbNameFromKeychain(
+                        service: service
+                    )
+                }
             },
             walletDbExists: { dbName in
                 FreshInstallKeychainCleaner.walletDbExists(dbName)
@@ -119,13 +123,16 @@ struct FreshInstallKeychainCleaner {
         )
     }
 
+    static let secureStoreServicesToClear =
+        keychainAccessibilityMigrationAllowedServices.flatMap { service in
+            [service + keychainAccessibilityMigrationStagingSuffix, service]
+        }
+
     static let servicesToClear = [
         biometricUnlockService,
         ironwoodMigrationBackgroundCredentialService,
         ironwoodMigrationOutboxKeyService,
-        // Keep this last: it holds zcash_wallet_db_name, the stale-install anchor.
-        secureStoreService,
-    ]
+    ] + secureStoreServicesToClear
 
     static func runIfNeeded(dependencies: Dependencies = .live) {
         if dependencies.hasInstallSentinel() {
@@ -161,43 +168,52 @@ struct FreshInstallKeychainCleaner {
             return .sentinelPresent
         }
 
-        switch dependencies.readWalletDbName() {
-        case .missing:
-            return .markInstalled
-        case .invalid:
-            return .deferCleanupAfterInvalidWalletDbName
-        case .failed(let status):
-            return .deferCleanupAfterReadFailure(status)
-        case .found(let dbName):
-            // Existing users from before this install sentinel existed can have a
-            // Keychain wallet DB name without the sentinel. If the app-private DB
-            // still exists, preserve their Keychain values and write the sentinel.
-            return dependencies.walletDbExists(dbName)
-                ? .preserveExistingInstall
-                : .clearStaleKeychain
+        var dbNames: [String] = []
+        for lookup in dependencies.readWalletDbNames() {
+            switch lookup {
+            case .missing:
+                continue
+            case .invalid:
+                return .deferCleanupAfterInvalidWalletDbName
+            case .failed(let status):
+                return .deferCleanupAfterReadFailure(status)
+            case .found(let dbName):
+                dbNames.append(dbName)
+            }
         }
+
+        guard !dbNames.isEmpty else {
+            return .markInstalled
+        }
+
+        // Existing users from before this install sentinel existed can have a
+        // Keychain wallet DB name without the sentinel. Preserve every service
+        // when any referenced app-private DB still exists; only a true reinstall
+        // may clear all network-scoped Keychain values.
+        return dbNames.contains(where: dependencies.walletDbExists)
+            ? .preserveExistingInstall
+            : .clearStaleKeychain
     }
 
     private static func clearStaleKeychain(dependencies: Dependencies) {
         var nonAnchorFailure: OSStatus?
-        var anchorStatus: OSStatus?
+        var secureStoreFailure: OSStatus?
 
         for service in servicesToClear {
             let status = dependencies.deleteKeychainService(service)
-            if service == secureStoreService {
-                anchorStatus = status
+            if secureStoreServicesToClear.contains(service) {
+                if !isKeychainDeleteSuccess(status), secureStoreFailure == nil {
+                    secureStoreFailure = status
+                }
             } else if !isKeychainDeleteSuccess(status), nonAnchorFailure == nil {
                 nonAnchorFailure = status
             }
         }
 
-        guard let anchorStatus else {
-            dependencies.log("fresh install: deferred keychain cleanup; secure store was not attempted")
-            return
-        }
-
-        guard isKeychainDeleteSuccess(anchorStatus) else {
-            dependencies.log("fresh install: deferred keychain cleanup after delete status \(anchorStatus)")
+        if let secureStoreFailure {
+            dependencies.log(
+                "fresh install: deferred keychain cleanup after delete status \(secureStoreFailure)"
+            )
             return
         }
 
@@ -213,11 +229,13 @@ struct FreshInstallKeychainCleaner {
         }
     }
 
-    private static func readWalletDbNameFromKeychain() -> KeychainDbNameLookup {
+    private static func readWalletDbNameFromKeychain(
+        service: String = secureStoreService
+    ) -> KeychainDbNameLookup {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: walletDbNameKey,
-            kSecAttrService: secureStoreService,
+            kSecAttrService: service,
             kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne,
         ]

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -2236,6 +2236,19 @@ class RunnerTests: XCTestCase {
     XCTAssertTrue(harness.deletedServices.isEmpty)
   }
 
+  func testFreshInstallCleanerPreservesStagingOnlyInterruptedMigration() {
+    let harness = FreshInstallCleanerHarness()
+    harness.lookup = .missing
+    harness.stagedLookup = .found("zcash_wallet_existing.db")
+    harness.walletDbExists = true
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertTrue(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
+    XCTAssertTrue(harness.deletedServices.isEmpty)
+  }
+
   func testFreshInstallCleanerClearsStaleKeychainWhenWalletDbIsGone() {
     let harness = FreshInstallCleanerHarness()
     harness.lookup = .found("zcash_wallet_deleted.db")
@@ -2249,6 +2262,57 @@ class RunnerTests: XCTestCase {
       harness.deletedServices,
       FreshInstallKeychainCleaner.servicesToClear
     )
+  }
+
+  func testFreshInstallCleanerClearsStagingOnlyStateAfterReinstall() {
+    let harness = FreshInstallCleanerHarness()
+    harness.lookup = .missing
+    harness.stagedLookup = .found("zcash_wallet_deleted.db")
+    harness.walletDbExists = false
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertTrue(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
+    XCTAssertEqual(
+      harness.deletedServices,
+      FreshInstallKeychainCleaner.servicesToClear
+    )
+  }
+
+  func testFreshInstallCleanerClearsNonMainStagingOnlyStateAfterReinstall() {
+    let harness = FreshInstallCleanerHarness()
+    harness.lookups = [
+      .missing,
+      .missing,
+      .missing,
+      .found("zcash_wallet_deleted.db"),
+    ]
+    harness.walletDbExists = false
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertTrue(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
+    XCTAssertEqual(
+      harness.deletedServices,
+      FreshInstallKeychainCleaner.servicesToClear
+    )
+  }
+
+  func testFreshInstallCleanerPreservesAnyExistingNetworkDatabase() {
+    let harness = FreshInstallCleanerHarness()
+    harness.lookups = [
+      .found("zcash_wallet_deleted.db"),
+      .found("zcash_wallet_existing.db"),
+    ]
+    harness.existingDbNames = ["zcash_wallet_existing.db"]
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertTrue(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
+    XCTAssertTrue(harness.deletedServices.isEmpty)
   }
 
   func testFreshInstallCleanerDefersSentinelWhenKeychainReadFails() {
@@ -2382,6 +2446,158 @@ class RunnerTests: XCTestCase {
     XCTAssertFalse(harness.markedInstalled)
     XCTAssertTrue(harness.cleanupPending)
     XCTAssertTrue(harness.deletedServices.isEmpty)
+  }
+
+  func testKeychainAccessibilityMigrationMovesLegacyItemThroughStaging() throws {
+    let service = "com.keplr.vizor.secure_store"
+    let store = KeychainAccessibilityMigrationStoreHarness()
+    store.put(
+      service: service,
+      account: "zcash_account_mnemonic_test",
+      data: Data("ciphertext".utf8),
+      accessibility: kSecAttrAccessibleAfterFirstUnlock as String
+    )
+
+    let migrated = try KeychainAccessibilityMigrator(store: store)
+      .ensureFirstUnlockThisDeviceOnly(service: service)
+
+    XCTAssertEqual(migrated, 1)
+    XCTAssertEqual(store.itemsByService[service]?.count, 1)
+    XCTAssertEqual(
+      store.itemsByService[service]?.first?.accessibility,
+      kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String
+    )
+    XCTAssertEqual(
+      store.itemsByService[service]?.first?.data,
+      Data("ciphertext".utf8)
+    )
+    XCTAssertNil(
+      store.itemsByService[
+        service + keychainAccessibilityMigrationStagingSuffix
+      ]
+    )
+  }
+
+  func testKeychainAccessibilityMigrationRecoversFromStagingOnly() throws {
+    let service = "com.keplr.vizor.secure_store"
+    let staging = service + keychainAccessibilityMigrationStagingSuffix
+    let store = KeychainAccessibilityMigrationStoreHarness()
+    store.put(
+      service: staging,
+      account: "zcash_wallet_db_name",
+      data: Data("wallet.db".utf8),
+      accessibility: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String
+    )
+
+    let migrated = try KeychainAccessibilityMigrator(store: store)
+      .ensureFirstUnlockThisDeviceOnly(service: service)
+
+    XCTAssertEqual(migrated, 1)
+    XCTAssertEqual(
+      store.itemsByService[service]?.first?.data,
+      Data("wallet.db".utf8)
+    )
+    XCTAssertNil(store.itemsByService[staging])
+  }
+
+  func testKeychainAccessibilityMigrationPreservesConflictingCopies() {
+    let service = "com.keplr.vizor.secure_store"
+    let staging = service + keychainAccessibilityMigrationStagingSuffix
+    let store = KeychainAccessibilityMigrationStoreHarness()
+    store.put(
+      service: service,
+      account: "zcash_accounts",
+      data: Data("canonical".utf8),
+      accessibility: kSecAttrAccessibleAfterFirstUnlock as String
+    )
+    store.put(
+      service: staging,
+      account: "zcash_accounts",
+      data: Data("staged".utf8),
+      accessibility: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String
+    )
+
+    XCTAssertThrowsError(
+      try KeychainAccessibilityMigrator(store: store)
+        .ensureFirstUnlockThisDeviceOnly(service: service)
+    ) { error in
+      XCTAssertEqual(
+        error as? KeychainAccessibilityMigrationError,
+        .conflictingCopies("zcash_accounts")
+      )
+    }
+    XCTAssertEqual(
+      store.itemsByService[service]?.first?.data,
+      Data("canonical".utf8)
+    )
+    XCTAssertEqual(
+      store.itemsByService[staging]?.first?.data,
+      Data("staged".utf8)
+    )
+  }
+
+  func testFreshInstallCleanerIncludesAccessibilityMigrationStagingService() {
+    XCTAssertTrue(
+      FreshInstallKeychainCleaner.servicesToClear.contains(
+        "com.keplr.vizor.secure_store"
+          + keychainAccessibilityMigrationStagingSuffix
+      )
+    )
+  }
+
+  func testSecurityKeychainMigrationStoreWritesPluginCompatibleTargetClass() throws {
+    let service = "com.zcash.wallet.tests.keychain-migration.\(UUID().uuidString)"
+    let staging = service + keychainAccessibilityMigrationStagingSuffix
+    let account = "test-item"
+    defer {
+      for candidate in [service, staging] {
+        SecItemDelete(
+          [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: candidate,
+          ] as CFDictionary
+        )
+      }
+    }
+
+    var accessControlError: Unmanaged<CFError>?
+    let legacyAccessControl = try XCTUnwrap(
+      SecAccessControlCreateWithFlags(
+        nil,
+        kSecAttrAccessibleAfterFirstUnlock,
+        [],
+        &accessControlError
+      )
+    )
+    XCTAssertNil(accessControlError)
+    XCTAssertEqual(
+      SecItemAdd(
+        [
+          kSecClass: kSecClassGenericPassword,
+          kSecAttrService: service,
+          kSecAttrAccount: account,
+          kSecAttrAccessControl: legacyAccessControl,
+          kSecValueData: Data("secret".utf8),
+        ] as CFDictionary,
+        nil
+      ),
+      errSecSuccess
+    )
+
+    let store = SecurityKeychainMigrationStore()
+    let legacy = try XCTUnwrap(store.items(service: service).first)
+    XCTAssertEqual(
+      legacy.accessibility,
+      kSecAttrAccessibleAfterFirstUnlock as String
+    )
+
+    try store.add(legacy, service: staging)
+    let target = try XCTUnwrap(store.items(service: staging).first)
+    XCTAssertEqual(target.data, Data("secret".utf8))
+    XCTAssertEqual(
+      target.accessibility,
+      kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String
+    )
   }
 
 }
@@ -2577,7 +2793,10 @@ private final class FreshInstallCleanerHarness {
   var markedInstalled = false
   var cleanupPending = false
   var lookup: KeychainDbNameLookup = .missing
+  var stagedLookup: KeychainDbNameLookup = .missing
+  var lookups: [KeychainDbNameLookup]?
   var walletDbExists = false
+  var existingDbNames: Set<String>?
   var deleteStatuses: [String: OSStatus] = [:]
   var deletedServices: [String] = []
   var logs: [String] = []
@@ -2600,11 +2819,11 @@ private final class FreshInstallCleanerHarness {
       clearCleanupPending: {
         self.cleanupPending = false
       },
-      readWalletDbName: {
-        self.lookup
+      readWalletDbNames: {
+        self.lookups ?? [self.lookup, self.stagedLookup]
       },
-      walletDbExists: { _ in
-        self.walletDbExists
+      walletDbExists: { dbName in
+        self.existingDbNames?.contains(dbName) ?? self.walletDbExists
       },
       deleteKeychainService: { service in
         self.deletedServices.append(service)
@@ -2614,5 +2833,56 @@ private final class FreshInstallCleanerHarness {
         self.logs.append(message)
       }
     )
+  }
+}
+
+private final class KeychainAccessibilityMigrationStoreHarness:
+  KeychainAccessibilityMigrationStore
+{
+  var itemsByService: [String: [KeychainAccessibilityMigrationItem]] = [:]
+
+  func put(
+    service: String,
+    account: String,
+    data: Data,
+    accessibility: String
+  ) {
+    itemsByService[service, default: []].append(
+      KeychainAccessibilityMigrationItem(
+        account: account,
+        data: data,
+        accessibility: accessibility,
+        attributes: [:]
+      )
+    )
+  }
+
+  func items(service: String) throws -> [KeychainAccessibilityMigrationItem] {
+    itemsByService[service] ?? []
+  }
+
+  func add(
+    _ item: KeychainAccessibilityMigrationItem,
+    service: String
+  ) throws {
+    if itemsByService[service]?.contains(where: { $0.account == item.account }) == true {
+      throw KeychainAccessibilityMigrationError.keychain(
+        operation: "add",
+        status: errSecDuplicateItem
+      )
+    }
+    put(
+      service: service,
+      account: item.account,
+      data: item.data,
+      accessibility: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String
+    )
+  }
+
+  func delete(service: String, account: String) throws {
+    itemsByService[service]?.removeAll { $0.account == account }
+    if itemsByService[service]?.isEmpty == true {
+      itemsByService.removeValue(forKey: service)
+    }
   }
 }

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -2451,6 +2451,7 @@ class RunnerTests: XCTestCase {
   func testKeychainAccessibilityMigrationMovesLegacyItemThroughStaging() throws {
     let service = "com.keplr.vizor.secure_store"
     let store = KeychainAccessibilityMigrationStoreHarness()
+    let completionStore = KeychainAccessibilityMigrationCompletionStoreHarness()
     store.put(
       service: service,
       account: "zcash_account_mnemonic_test",
@@ -2458,7 +2459,10 @@ class RunnerTests: XCTestCase {
       accessibility: kSecAttrAccessibleAfterFirstUnlock as String
     )
 
-    let migrated = try KeychainAccessibilityMigrator(store: store)
+    let migrated = try KeychainAccessibilityMigrator(
+      store: store,
+      completionStore: completionStore
+    )
       .ensureFirstUnlockThisDeviceOnly(service: service)
 
     XCTAssertEqual(migrated, 1)
@@ -2476,12 +2480,19 @@ class RunnerTests: XCTestCase {
         service + keychainAccessibilityMigrationStagingSuffix
       ]
     )
+    XCTAssertTrue(
+      completionStore.isComplete(
+        service: service,
+        version: keychainAccessibilityMigrationVersion
+      )
+    )
   }
 
   func testKeychainAccessibilityMigrationRecoversFromStagingOnly() throws {
     let service = "com.keplr.vizor.secure_store"
     let staging = service + keychainAccessibilityMigrationStagingSuffix
     let store = KeychainAccessibilityMigrationStoreHarness()
+    let completionStore = KeychainAccessibilityMigrationCompletionStoreHarness()
     store.put(
       service: staging,
       account: "zcash_wallet_db_name",
@@ -2489,7 +2500,10 @@ class RunnerTests: XCTestCase {
       accessibility: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String
     )
 
-    let migrated = try KeychainAccessibilityMigrator(store: store)
+    let migrated = try KeychainAccessibilityMigrator(
+      store: store,
+      completionStore: completionStore
+    )
       .ensureFirstUnlockThisDeviceOnly(service: service)
 
     XCTAssertEqual(migrated, 1)
@@ -2504,6 +2518,7 @@ class RunnerTests: XCTestCase {
     let service = "com.keplr.vizor.secure_store"
     let staging = service + keychainAccessibilityMigrationStagingSuffix
     let store = KeychainAccessibilityMigrationStoreHarness()
+    let completionStore = KeychainAccessibilityMigrationCompletionStoreHarness()
     store.put(
       service: service,
       account: "zcash_accounts",
@@ -2518,7 +2533,10 @@ class RunnerTests: XCTestCase {
     )
 
     XCTAssertThrowsError(
-      try KeychainAccessibilityMigrator(store: store)
+      try KeychainAccessibilityMigrator(
+        store: store,
+        completionStore: completionStore
+      )
         .ensureFirstUnlockThisDeviceOnly(service: service)
     ) { error in
       XCTAssertEqual(
@@ -2534,6 +2552,114 @@ class RunnerTests: XCTestCase {
       store.itemsByService[staging]?.first?.data,
       Data("staged".utf8)
     )
+    XCTAssertFalse(
+      completionStore.isComplete(
+        service: service,
+        version: keychainAccessibilityMigrationVersion
+      )
+    )
+  }
+
+  func testKeychainAccessibilityMigrationSkipsKeychainAfterCompletion() throws {
+    let service = "com.keplr.vizor.secure_store"
+    let store = KeychainAccessibilityMigrationStoreHarness()
+    let completionStore = KeychainAccessibilityMigrationCompletionStoreHarness()
+    completionStore.markComplete(
+      service: service,
+      version: keychainAccessibilityMigrationVersion
+    )
+
+    let migrated = try KeychainAccessibilityMigrator(
+      store: store,
+      completionStore: completionStore
+    ).ensureFirstUnlockThisDeviceOnly(service: service)
+
+    XCTAssertEqual(migrated, 0)
+    XCTAssertTrue(store.readServices.isEmpty)
+  }
+
+  func testKeychainAccessibilityMigrationCompletionIsServiceScoped() throws {
+    let completedService = "com.keplr.vizor.secure_store"
+    let pendingService = "com.keplr.vizor.test.secure_store"
+    let store = KeychainAccessibilityMigrationStoreHarness()
+    let completionStore = KeychainAccessibilityMigrationCompletionStoreHarness()
+    completionStore.markComplete(
+      service: completedService,
+      version: keychainAccessibilityMigrationVersion
+    )
+
+    let migrator = KeychainAccessibilityMigrator(
+      store: store,
+      completionStore: completionStore
+    )
+    XCTAssertEqual(
+      try migrator.ensureFirstUnlockThisDeviceOnly(service: completedService),
+      0
+    )
+    XCTAssertEqual(
+      try migrator.ensureFirstUnlockThisDeviceOnly(service: pendingService),
+      0
+    )
+
+    XCTAssertEqual(
+      store.readServices,
+      [
+        pendingService,
+        pendingService + keychainAccessibilityMigrationStagingSuffix,
+      ]
+    )
+    XCTAssertTrue(
+      completionStore.isComplete(
+        service: pendingService,
+        version: keychainAccessibilityMigrationVersion
+      )
+    )
+  }
+
+  func testKeychainAccessibilityMigrationCompletionIsVersionScoped() throws {
+    let suiteName = "KeychainAccessibilityMigration.\(UUID().uuidString)"
+    let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { userDefaults.removePersistentDomain(forName: suiteName) }
+    let completionStore =
+      UserDefaultsKeychainAccessibilityMigrationCompletionStore(
+        userDefaults: userDefaults
+      )
+    let service = "com.keplr.vizor.secure_store"
+
+    completionStore.markComplete(service: service, version: 1)
+
+    XCTAssertTrue(completionStore.isComplete(service: service, version: 1))
+    XCTAssertFalse(completionStore.isComplete(service: service, version: 2))
+  }
+
+  func testKeychainAccessibilityMigrationDoesNotCompleteAfterStoreFailure() {
+    let service = "com.keplr.vizor.secure_store"
+
+    for operation in ["read", "add", "delete"] {
+      let store = KeychainAccessibilityMigrationStoreHarness()
+      let completionStore = KeychainAccessibilityMigrationCompletionStoreHarness()
+      store.put(
+        service: service,
+        account: "zcash_accounts",
+        data: Data("ciphertext".utf8),
+        accessibility: kSecAttrAccessibleAfterFirstUnlock as String
+      )
+      store.failureOperation = operation
+
+      XCTAssertThrowsError(
+        try KeychainAccessibilityMigrator(
+          store: store,
+          completionStore: completionStore
+        ).ensureFirstUnlockThisDeviceOnly(service: service),
+        "Expected the \(operation) failure to abort migration"
+      )
+      XCTAssertFalse(
+        completionStore.isComplete(
+          service: service,
+          version: keychainAccessibilityMigrationVersion
+        )
+      )
+    }
   }
 
   func testFreshInstallCleanerIncludesAccessibilityMigrationStagingService() {
@@ -2840,6 +2966,8 @@ private final class KeychainAccessibilityMigrationStoreHarness:
   KeychainAccessibilityMigrationStore
 {
   var itemsByService: [String: [KeychainAccessibilityMigrationItem]] = [:]
+  private(set) var readServices: [String] = []
+  var failureOperation: String?
 
   func put(
     service: String,
@@ -2858,13 +2986,26 @@ private final class KeychainAccessibilityMigrationStoreHarness:
   }
 
   func items(service: String) throws -> [KeychainAccessibilityMigrationItem] {
-    itemsByService[service] ?? []
+    readServices.append(service)
+    if failureOperation == "read" {
+      throw KeychainAccessibilityMigrationError.keychain(
+        operation: "read",
+        status: errSecAuthFailed
+      )
+    }
+    return itemsByService[service] ?? []
   }
 
   func add(
     _ item: KeychainAccessibilityMigrationItem,
     service: String
   ) throws {
+    if failureOperation == "add" {
+      throw KeychainAccessibilityMigrationError.keychain(
+        operation: "add",
+        status: errSecAuthFailed
+      )
+    }
     if itemsByService[service]?.contains(where: { $0.account == item.account }) == true {
       throw KeychainAccessibilityMigrationError.keychain(
         operation: "add",
@@ -2880,9 +3021,33 @@ private final class KeychainAccessibilityMigrationStoreHarness:
   }
 
   func delete(service: String, account: String) throws {
+    if failureOperation == "delete" {
+      throw KeychainAccessibilityMigrationError.keychain(
+        operation: "delete",
+        status: errSecAuthFailed
+      )
+    }
     itemsByService[service]?.removeAll { $0.account == account }
     if itemsByService[service]?.isEmpty == true {
       itemsByService.removeValue(forKey: service)
     }
+  }
+}
+
+private final class KeychainAccessibilityMigrationCompletionStoreHarness:
+  KeychainAccessibilityMigrationCompletionStore
+{
+  private var completed: Set<String> = []
+
+  func isComplete(service: String, version: Int) -> Bool {
+    completed.contains(key(service: service, version: version))
+  }
+
+  func markComplete(service: String, version: Int) {
+    completed.insert(key(service: service, version: version))
+  }
+
+  private func key(service: String, version: Int) -> String {
+    "\(version):\(service)"
   }
 }

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -215,6 +215,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
 
   try {
     log('bootstrap: loading startup snapshot');
+    await ensureIosSecureStoreAccessibilityMigrated();
     await storage.ensureWalletDbName();
     await _applyE2eBootstrapOverrides(storage);
     var passwordRotationRecoveryFailed = false;

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -11,7 +11,7 @@ import 'package:flutter/foundation.dart'
         kDebugMode,
         kIsWeb,
         visibleForTesting;
-import 'package:flutter/services.dart' show PlatformException;
+import 'package:flutter/services.dart' show MethodChannel, PlatformException;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../config/network_config.dart';
@@ -40,6 +40,27 @@ const _votingHotkeyKeyPrefix = 'zcash_account_voting_hotkey_';
 const _e2eUseFirstUnlockMnemonicKeychain = bool.fromEnvironment(
   'ZCASH_E2E_FIRST_UNLOCK_MNEMONIC_KEYCHAIN',
 );
+const _iosKeychainAccessibilityMigrationChannel = MethodChannel(
+  'com.zcash.wallet/keychain_accessibility_migration',
+);
+
+Future<void> ensureIosSecureStoreAccessibilityMigrated({
+  MethodChannel channel = _iosKeychainAccessibilityMigrationChannel,
+}) async {
+  if (kIsWeb || defaultTargetPlatform != TargetPlatform.iOS) return;
+  final service = secureStoreServiceForNetwork(kZcashDefaultNetworkName);
+  try {
+    await channel.invokeMethod<Object?>(
+      'ensureFirstUnlockThisDeviceOnly',
+      <String, Object?>{'service': service},
+    );
+  } catch (error) {
+    throw SecureStorageUnavailableException(
+      operation: 'iOS Keychain accessibility migration',
+      cause: error,
+    );
+  }
+}
 
 class PasswordRotationRecoveryFailedException implements Exception {
   const PasswordRotationRecoveryFailedException();
@@ -83,7 +104,7 @@ class AppSecureStore {
     return FlutterSecureStorage(
       iOptions: IOSOptions(
         accountName: service,
-        accessibility: KeychainAccessibility.first_unlock,
+        accessibility: KeychainAccessibility.first_unlock_this_device,
       ),
       aOptions: kZcashDefaultNetworkName == 'main'
           ? AndroidOptions.defaultOptions
@@ -104,7 +125,7 @@ class AppSecureStore {
     return FlutterSecureStorage(
       iOptions: IOSOptions(
         accountName: service,
-        accessibility: KeychainAccessibility.first_unlock,
+        accessibility: KeychainAccessibility.first_unlock_this_device,
       ),
       aOptions: kZcashDefaultNetworkName == 'main'
           ? AndroidOptions.defaultOptions

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/core/security/password_policy.dart';
 import 'package:zcash_wallet/src/core/security/software_wallet_secret.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
@@ -45,6 +46,46 @@ void main() {
   tearDown(() async {
     await store.deleteAll();
     debugDefaultTargetPlatformOverride = previousTargetPlatform;
+  });
+
+  test('iOS secure-store migration waits for the native migrator', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    const channel = MethodChannel('test/keychain_accessibility_migration');
+    MethodCall? received;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          received = call;
+          return <String, Object?>{'status': 'complete', 'migrated': 1};
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    await ensureIosSecureStoreAccessibilityMigrated(channel: channel);
+
+    expect(received?.method, 'ensureFirstUnlockThisDeviceOnly');
+    expect(received?.arguments, <String, Object?>{
+      'service': secureStoreServiceForNetwork(kZcashDefaultNetworkName),
+    });
+  });
+
+  test('iOS native migration errors fail closed as unavailable storage', () {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    const channel = MethodChannel('test/keychain_accessibility_failure');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (_) async {
+          throw PlatformException(code: 'migration_conflict');
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    expect(
+      ensureIosSecureStoreAccessibilityMigrated(channel: channel),
+      throwsA(isA<SecureStorageUnavailableException>()),
+    );
   });
 
   test('changePassword rotates mnemonic payloads and verifier', () async {


### PR DESCRIPTION
## Summary

Update iOS secure storage to use the `first_unlock_this_device` Keychain accessibility class.

Existing Keychain items are migrated during app bootstrap before Flutter reads secure storage. macOS storage behavior is unchanged.

## Changes

- Configure the iOS `flutter_secure_storage` instances with `first_unlock_this_device`.
- Add a native Swift migration for existing `first_unlock` Generic Password items.
- Use a staging service and data verification so interrupted migrations can resume safely on the next launch.
- Preserve existing Keychain data when a migration encounters an unexpected or conflicting state.
- Handle fresh installs and reinstalls across the supported network-scoped secure-storage services.
- Record migration completion per service and migration version to avoid repeated Keychain scans after a successful migration.
- Run the migration before the Dart bootstrap accesses secure storage.

## Migration behavior

The migration handles:

- legacy-only items;
- already-migrated items;
- staging-only items left by an interrupted migration;
- matching canonical and staging copies;
- read, write, or delete failures.

A completion marker is written only after the full service has been processed successfully. Incomplete migrations remain retryable on the next launch.

## User impact

There are no UI or wallet-format changes.

Existing iOS users receive a one-time Keychain migration during startup. After completion, later launches perform only a lightweight completion check and do not rescan Keychain items.

The availability behavior remains “after the first device unlock following a restart.” The updated Keychain class keeps the stored items associated with the current device.

macOS behavior is unchanged.

## Validation

- iOS `RunnerTests`
- Simulator Keychain integration coverage
- Flutter secure-storage tests
- Dart static analysis
- Interrupted-migration and reinstall cleanup cases
