### PR TITLE
Show full truncated sidebar sync errors on hover

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -184,6 +184,11 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     builder: buildDesktopHomeSidebarCompactBalancesUseCase,
   ),
   FigmaCompareScenario(
+    id: 'desktop-home-sidebar-sync-network-error',
+    description: 'Desktop home sidebar with a network sync failure',
+    builder: buildDesktopHomeSidebarSyncNetworkErrorUseCase,
+  ),
+  FigmaCompareScenario(
     id: 'ironwood-migration-intro',
     description: 'Ironwood migration intro screen',
     builder: buildIronwoodMigrationIntroUseCase,

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -30,6 +30,7 @@ import '../widgets/app_copy_feedback.dart';
 import '../widgets/app_icon.dart';
 import '../widgets/app_profile_picture.dart';
 import '../widgets/app_tappable.dart';
+import '../widgets/app_tooltip.dart';
 import '../widgets/app_toast.dart';
 import 'app_desktop_shell.dart';
 import 'desktop_sidebar_spacing.dart';
@@ -1547,11 +1548,10 @@ class _SidebarSyncStatusState extends State<_SidebarSyncStatus>
             indicatorColor: indicatorColor,
             glow: _SidebarSyncMotion.staticGlow,
             syncedHeight: syncedHeight,
-            text: Text(
-              label,
-              key: const ValueKey('sidebar_sync_text'),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
+            text: _SidebarSyncStaticLabel(
+              label: label,
+              tooltipMessage: status.semanticsLabel,
+              showTooltipOnOverflow: status.kind == SyncStatusKind.failed,
               style: AppTypography.labelLarge.copyWith(color: textColor),
             ),
           );
@@ -1630,6 +1630,52 @@ class _SidebarSyncStatusState extends State<_SidebarSyncStatus>
           ),
         ),
       ],
+    );
+  }
+}
+
+class _SidebarSyncStaticLabel extends StatelessWidget {
+  const _SidebarSyncStaticLabel({
+    required this.label,
+    required this.tooltipMessage,
+    required this.showTooltipOnOverflow,
+    required this.style,
+  });
+
+  final String label;
+  final String tooltipMessage;
+  final bool showTooltipOnOverflow;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget labelText() => Text(
+      label,
+      key: const ValueKey('sidebar_sync_text'),
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: style,
+    );
+
+    if (!showTooltipOnOverflow) return labelText();
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (!constraints.maxWidth.isFinite) return labelText();
+
+        final painter = TextPainter(
+          text: TextSpan(text: label, style: style),
+          textDirection: Directionality.of(context),
+          textScaler: MediaQuery.textScalerOf(context),
+          ellipsis: '...',
+          maxLines: 1,
+        )..layout(maxWidth: constraints.maxWidth);
+
+        final text = labelText();
+        if (!painter.didExceedMaxLines) return text;
+
+        return AppTooltip(message: tooltipMessage, child: text);
+      },
     );
   }
 }

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -1674,7 +1674,11 @@ class _SidebarSyncStaticLabel extends StatelessWidget {
         final text = labelText();
         if (!painter.didExceedMaxLines) return text;
 
-        return AppTooltip(message: tooltipMessage, child: text);
+        return AppTooltip(
+          message: tooltipMessage,
+          excludeFromSemantics: true,
+          child: text,
+        );
       },
     );
   }

--- a/lib/src/core/widgets/app_tooltip.dart
+++ b/lib/src/core/widgets/app_tooltip.dart
@@ -10,6 +10,7 @@ class AppTooltip extends StatelessWidget {
     this.richMessage,
     this.preferBelow = false,
     this.tapToShow = false,
+    this.excludeFromSemantics = false,
     super.key,
   }) : assert(
          (message == null) != (richMessage == null),
@@ -20,6 +21,7 @@ class AppTooltip extends StatelessWidget {
   final InlineSpan? richMessage;
   final bool preferBelow;
   final bool tapToShow;
+  final bool excludeFromSemantics;
   final Widget child;
 
   @override
@@ -41,6 +43,7 @@ class AppTooltip extends StatelessWidget {
       showDuration: const Duration(seconds: 8),
       triggerMode: tapToShow ? TooltipTriggerMode.tap : null,
       preferBelow: preferBelow,
+      excludeFromSemantics: excludeFromSemantics,
       constraints: const BoxConstraints(maxWidth: 340),
       padding: const EdgeInsets.symmetric(
         horizontal: AppSpacing.s,

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -66,6 +66,7 @@ import '../src/providers/account_provider.dart';
 import '../src/providers/biometric_unlock_provider.dart';
 import '../src/providers/privacy_mode_provider.dart';
 import '../src/providers/receive_address_provider.dart';
+import '../src/providers/sync_failure.dart';
 import '../src/providers/sync_provider.dart';
 import '../src/providers/zec_price_change_provider.dart';
 import '../src/rust/api/sync.dart' as rust_sync;
@@ -917,6 +918,23 @@ Widget buildDesktopHomeSidebarCompactBalancesUseCase(BuildContext context) {
       accountUuid: _accountsDesignState.activeAccountUuid!,
       status: status,
     ),
+  );
+}
+
+Widget buildDesktopHomeSidebarSyncNetworkErrorUseCase(BuildContext context) {
+  return _buildDesktopHomeUseCase(
+    accountState: _accountsDesignState,
+    syncState: SyncState(
+      accountUuid: _accountsDesignState.activeAccountUuid,
+      hasAccountScopedData: true,
+      failure: const SyncFailure(
+        kind: SyncFailureKind.network,
+        rawMessage: 'network failed',
+        userMessage: 'Network connection lost.',
+        showSettingsAction: false,
+      ),
+    ),
+    migrationCta: const IronwoodHomeMigrationCtaState.hidden(),
   );
 }
 

--- a/test/app_main_sidebar_test.dart
+++ b/test/app_main_sidebar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show PointerDeviceKind;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -920,6 +922,60 @@ void main() {
     _expectSyncIndicatorGlow(tester, blurRadius: 12);
   });
 
+  testWidgets('sidebar omits the error tooltip when the label fits', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_sidebarHarness(_networkFailureSyncState()));
+    await tester.pump();
+
+    expect(_syncTextTooltip(), findsNothing);
+  });
+
+  testWidgets('sidebar adds the error tooltip only after actual overflow', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _sidebarHarness(_networkFailureSyncState(), sidebarWidth: 180),
+    );
+    await tester.pump();
+
+    final tooltip = tester.widget<Tooltip>(_syncTextTooltip());
+    expect(tooltip.message, 'Syncing failed. Network error');
+  });
+
+  testWidgets('sidebar shows the full overflowed error label on hover', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _sidebarHarness(_networkFailureSyncState(), sidebarWidth: 180),
+    );
+    await tester.pump();
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.addPointer();
+    await gesture.moveTo(
+      tester.getCenter(find.byKey(const ValueKey('sidebar_sync_text'))),
+    );
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('Syncing failed. Network error'), findsOneWidget);
+  });
+
+  testWidgets('sidebar does not add an overflow tooltip for syncing status', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _sidebarHarness(
+        SyncState(isSyncing: true, displayPercentage: 0.34),
+        sidebarWidth: 180,
+      ),
+    );
+    await tester.pump();
+
+    expect(_syncTextTooltip(), findsNothing);
+  });
+
   testWidgets('sidebar uses dark success sync indicator color from Figma', (
     tester,
   ) async {
@@ -1047,6 +1103,7 @@ Widget _sidebarHarness(
   AccountState? accountState,
   String initialLocation = '/home',
   bool disableAnimations = true,
+  double sidebarWidth = 256,
   IronwoodHomeMigrationCtaState ironwoodHomeMigrationCtaState =
       const IronwoodHomeMigrationCtaState.hidden(),
   IronwoodPostMigrationState ironwoodPostMigrationState =
@@ -1060,9 +1117,10 @@ Widget _sidebarHarness(
     routes: [
       GoRoute(
         path: '/home',
-        builder: (_, _) => const AppDesktopShell(
-          sidebar: AppMainSidebar(),
-          pane: AppDesktopPane(child: Text('home route')),
+        builder: (_, _) => AppDesktopShell(
+          sidebarWidth: sidebarWidth,
+          sidebar: const AppMainSidebar(),
+          pane: const AppDesktopPane(child: Text('home route')),
         ),
       ),
       GoRoute(path: '/accounts', builder: (_, _) => const Text('accounts')),
@@ -1164,6 +1222,24 @@ Widget _sidebarHarness(
         child: AppTheme(data: themeData, child: child!),
       ),
     ),
+  );
+}
+
+SyncState _networkFailureSyncState() {
+  return SyncState(
+    failure: const SyncFailure(
+      kind: SyncFailureKind.network,
+      rawMessage: 'network failed',
+      userMessage: 'Network connection lost.',
+      showSettingsAction: false,
+    ),
+  );
+}
+
+Finder _syncTextTooltip() {
+  return find.ancestor(
+    of: find.byKey(const ValueKey('sidebar_sync_text')),
+    matching: find.byType(Tooltip),
   );
 }
 

--- a/test/app_main_sidebar_test.dart
+++ b/test/app_main_sidebar_test.dart
@@ -941,6 +941,24 @@ void main() {
 
     final tooltip = tester.widget<Tooltip>(_syncTextTooltip());
     expect(tooltip.message, 'Syncing failed. Network error');
+    expect(tooltip.excludeFromSemantics, isTrue);
+  });
+
+  testWidgets('overflow error tooltip is excluded from row semantics', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      _sidebarHarness(_networkFailureSyncState(), sidebarWidth: 180),
+    );
+    await tester.pump();
+
+    final syncSemantics = tester.getSemantics(
+      find.byKey(const ValueKey('sidebar_sync_text')),
+    );
+    expect(syncSemantics.label, contains('Syncing failed. Network error'));
+    expect(syncSemantics.tooltip, isEmpty);
+    semantics.dispose();
   });
 
   testWidgets('sidebar shows the full overflowed error label on hover', (


### PR DESCRIPTION
## Summary

- detect whether the desktop sidebar sync error label actually overflows its available width
- show the full user-facing error label in the shared app tooltip only when truncation occurs
- add deterministic desktop sync-error capture coverage and widget tests for fitting, overflowing, hover, and non-error states

## Why

Sidebar sync failures use a single-line label. Longer failure labels can be truncated, leaving users unable to read the complete status. The label now measures the rendered text with the same typography and text scaling as the UI, so a tooltip is added only when the rendered line genuinely overflows.

## Impact

Desktop users can hover a truncated sync failure to read the full status. Labels that fit, syncing states, and synced states keep their existing behavior and layout.

## Validation

- `fvm flutter test --no-pub test/app_main_sidebar_test.dart` (45 tests passed)
- desktop dark-theme widget capture at 1080×720 passed
- targeted analysis passed for the changed sidebar source and tests
- `git diff --check` passed

Full-project analysis still reports 23 pre-existing unused-declaration warnings in Ironwood migration files; this change introduces no new analyzer findings.