### PR TITLE
Route transaction submissions across managed providers

### DIFF
--- a/integration_test/sync_stream_error_test.dart
+++ b/integration_test/sync_stream_error_test.dart
@@ -22,6 +22,7 @@ void main() {
         lightwalletdUrl: 'http://127.0.0.1:1',
         network: 'invalid-test-network',
         mode: 1,
+        managedSubmissionRouting: false,
       );
 
       await expectLater(

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -13,9 +13,15 @@ struct IronwoodMigrationBackgroundManifest: Decodable {
   let accountUuid: String
   let dbPath: String
   let lightwalletdUrl: String
+  // Optional so manifests written before managed routing decode as disabled.
+  let managedSubmissionRouting: Bool?
   let credentialHex: String
   let saltBase64: String
   let expectedRunId: String?
+
+  var usesManagedSubmissionRouting: Bool {
+    managedSubmissionRouting ?? false
+  }
 }
 
 enum IronwoodMigrationBackgroundCredentialStore {

--- a/ios/Runner/BackgroundMigrationOutbox.swift
+++ b/ios/Runner/BackgroundMigrationOutbox.swift
@@ -84,6 +84,8 @@ struct BackgroundMigrationOutboxBatch: Codable, Equatable {
   let accountUuid: String
   let runId: String
   var lightwalletdUrl: String
+  // Optional so persisted batches from older app versions remain readable.
+  var managedSubmissionRouting: Bool? = nil
   var timingMeanBlocks: UInt64
   var timingMaxBlocks: UInt64
   let createdAt: Date
@@ -104,6 +106,10 @@ struct BackgroundMigrationOutboxBatch: Codable, Equatable {
   var items: [BackgroundMigrationOutboxItem]
 
   var scopeKey: String { "\(network):\(accountUuid)" }
+
+  var usesManagedSubmissionRouting: Bool {
+    managedSubmissionRouting ?? false
+  }
 
   /// Whether this batch still owes the user a proof-ready announcement.
   ///
@@ -146,6 +152,7 @@ struct BackgroundMigrationOutboxSelection: Equatable {
   let accountUuid: String
   let scopeKey: String
   let lightwalletdUrl: String
+  let managedSubmissionRouting: Bool
   let item: BackgroundMigrationOutboxItem
 }
 
@@ -244,11 +251,14 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
       else {
         throw BackgroundMigrationOutboxError.conflictingBatch
       }
-      if existing.lightwalletdUrl != batch.lightwalletdUrl {
+      if existing.lightwalletdUrl != batch.lightwalletdUrl
+        || existing.usesManagedSubmissionRouting != batch.usesManagedSubmissionRouting
+      {
         guard !existing.items.contains(where: { $0.status == .submitting }) else {
           throw BackgroundMigrationOutboxError.conflictingBatch
         }
         batches[batchIndex].lightwalletdUrl = batch.lightwalletdUrl
+        batches[batchIndex].managedSubmissionRouting = batch.managedSubmissionRouting
       }
       // The timing cadence is scheduling policy, not batch identity: a newer
       // app build may legitimately recompute it for the same run (e.g. the
@@ -337,6 +347,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
     runId: String,
     expectedTxids: Set<String>,
     lightwalletdUrl: String,
+    managedSubmissionRouting: Bool? = nil,
     at date: Date
   ) throws -> Bool {
     guard !expectedTxids.isEmpty, !lightwalletdUrl.isEmpty else {
@@ -374,6 +385,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
       batches[batchIndex].items[itemIndex] = item
     }
     batches[batchIndex].lightwalletdUrl = lightwalletdUrl
+    batches[batchIndex].managedSubmissionRouting = managedSubmissionRouting
     if batches[batchIndex].items.contains(where: { $0.status == .armed }) {
       batches[batchIndex].armedAt = batches[batchIndex].armedAt ?? date
     }
@@ -833,6 +845,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
       accountUuid: batch.accountUuid,
       scopeKey: batch.scopeKey,
       lightwalletdUrl: batch.lightwalletdUrl,
+      managedSubmissionRouting: batch.usesManagedSubmissionRouting,
       item: item
     )
   }

--- a/ios/Runner/BackgroundMigrationOutboxChannel.swift
+++ b/ios/Runner/BackgroundMigrationOutboxChannel.swift
@@ -53,6 +53,10 @@ enum BackgroundMigrationOutboxChannel {
         runId: string(arguments, "runId"),
         expectedTxids: Set(expectedTxids),
         lightwalletdUrl: string(arguments, "lightwalletdUrl"),
+        managedSubmissionRouting: try optionalBool(
+          arguments,
+          "managedSubmissionRouting"
+        ),
         at: Date()
       )
     }
@@ -243,6 +247,10 @@ enum BackgroundMigrationOutboxChannel {
       accountUuid: try string(arguments, "accountUuid"),
       runId: try string(arguments, "runId"),
       lightwalletdUrl: try string(arguments, "lightwalletdUrl"),
+      managedSubmissionRouting: try optionalBool(
+        arguments,
+        "managedSubmissionRouting"
+      ),
       timingMeanBlocks: try uint64(arguments, "timingMeanBlocks"),
       timingMaxBlocks: try uint64(arguments, "timingMaxBlocks"),
       createdAt: Date(
@@ -294,6 +302,17 @@ enum BackgroundMigrationOutboxChannel {
       throw BackgroundMigrationOutboxChannelError.invalidArguments(key)
     }
     return UInt64(number.int64Value)
+  }
+
+  private static func optionalBool(
+    _ values: [String: Any],
+    _ key: String
+  ) throws -> Bool? {
+    guard let rawValue = values[key], !(rawValue is NSNull) else { return nil }
+    guard let value = rawValue as? Bool else {
+      throw BackgroundMigrationOutboxChannelError.invalidArguments(key)
+    }
+    return value
   }
 
   private static func uint32(_ values: [String: Any], _ key: String) throws -> UInt32 {

--- a/ios/Runner/BackgroundMigrationOutboxRunner.swift
+++ b/ios/Runner/BackgroundMigrationOutboxRunner.swift
@@ -10,6 +10,8 @@ struct BackgroundMigrationOutboxRunnerDependencies {
     (
       String,
       Data,
+      Data,
+      Bool,
       BackgroundMigrationCancellation
     ) -> Result<NativeLightwalletdSendResponse, NativeLightwalletdError>
 
@@ -20,10 +22,13 @@ struct BackgroundMigrationOutboxRunnerDependencies {
         cancellation: cancellation
       )
     },
-    sendTransaction: { endpoint, rawTransaction, cancellation in
+    sendTransaction: {
+      endpoint, transactionId, rawTransaction, managedSubmissionRouting, cancellation in
       NativeLightwalletdClient.sendTransaction(
         endpoint: endpoint,
+        transactionId: transactionId,
         rawTransaction: rawTransaction,
+        managedSubmissionRouting: managedSubmissionRouting,
         cancellation: cancellation
       )
     }
@@ -114,8 +119,10 @@ enum BackgroundMigrationOutboxRunner {
     var proofReady: BackgroundMigrationProofReadyMetadata?
     var attemptedAccountUuid: String?
     let selection: BackgroundMigrationOutboxSelection
+    let transactionId: Data
     do {
       var selected: BackgroundMigrationOutboxSelection?
+      var selectedTransactionId: Data?
       let snapshot = try store.update { snapshot in
         snapshot.expireItems(remoteHeight: remoteHeight, endpoint: endpoint, at: now)
         snapshot.markDueItemsNeedingResign(
@@ -143,6 +150,14 @@ enum BackgroundMigrationOutboxRunner {
         )
         if let selected {
           attemptedAccountUuid = selected.accountUuid
+          guard
+            let byteOrders = NativeLightwalletdClient.transactionIdByteOrders(
+              storedHex: selected.item.txidHex
+            )
+          else {
+            throw BackgroundMigrationOutboxError.invalidBatch
+          }
+          selectedTransactionId = byteOrders.protocolOrder
           try snapshot.validateReschedulingAfterAcceptance(
             itemId: selected.item.itemId,
             remoteHeight: remoteHeight
@@ -193,7 +208,11 @@ enum BackgroundMigrationOutboxRunner {
           }
         )
       }
+      guard let selectedTransactionId else {
+        throw BackgroundMigrationOutboxError.invalidBatch
+      }
       selection = selected
+      transactionId = selectedTransactionId
     } catch BackgroundMigrationOutboxError.invalidSchedule {
       return BackgroundMigrationOutboxRunResult(
         transport: .needsUserAction,
@@ -232,7 +251,9 @@ enum BackgroundMigrationOutboxRunner {
 
     switch dependencies.sendTransaction(
       selection.lightwalletdUrl,
+      transactionId,
       selection.item.rawTransaction,
+      selection.managedSubmissionRouting,
       cancellation
     ) {
     case .failure(let error):
@@ -250,7 +271,9 @@ enum BackgroundMigrationOutboxRunner {
       )
     case .success(let response):
       do {
-        if response.errorCode == 0 || isAcceptedEquivalent(response.errorMessage) {
+        let accepted = response.accepted
+          ?? (response.errorCode == 0 || isAcceptedEquivalent(response.errorMessage))
+        if accepted {
           var random = SystemRandomNumberGenerator()
           let snapshot = try store.update { snapshot in
             try snapshot.recordAccepted(

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -1901,6 +1901,7 @@ final class BackgroundMigrationPreparationManager {
         switch transactionObservation(
           endpoint: manifest.lightwalletdUrl,
           transactionIdHex: transactionId,
+          managedSubmissionRouting: manifest.usesManagedSubmissionRouting,
           cancellation: cancellation
         ) {
         case .success(let observation):
@@ -1991,18 +1992,28 @@ final class BackgroundMigrationPreparationManager {
   private func transactionObservation(
     endpoint: String,
     transactionIdHex: String,
+    managedSubmissionRouting: Bool,
     cancellation: BackgroundMigrationCancellation
   ) -> Result<
     NativeLightwalletdTransactionObservation,
     NativeLightwalletdError
   > {
-    guard let storedOrder = Self.transactionIdData(transactionIdHex) else {
+    guard
+      let byteOrders = NativeLightwalletdClient.transactionIdByteOrders(
+        storedHex: transactionIdHex
+      )
+    else {
       return .failure(.malformedResponse)
     }
-    let protocolOrder = Data(storedOrder.reversed())
+    let storedOrder = byteOrders.stored
+    let protocolOrder = byteOrders.protocolOrder
+    // Both lookup byte orders keep the same endpoint, routing policy, and
+    // canonical routing key. Only the GetTransaction lookup bytes may change.
     let first = NativeLightwalletdClient.transaction(
       endpoint: endpoint,
+      routingTransactionId: protocolOrder,
       transactionId: protocolOrder,
+      managedSubmissionRouting: managedSubmissionRouting,
       cancellation: cancellation
     )
     guard protocolOrder != storedOrder,
@@ -2012,29 +2023,15 @@ final class BackgroundMigrationPreparationManager {
     }
     let second = NativeLightwalletdClient.transaction(
       endpoint: endpoint,
+      routingTransactionId: protocolOrder,
       transactionId: storedOrder,
+      managedSubmissionRouting: managedSubmissionRouting,
       cancellation: cancellation
     )
     return transactionObservationAfterStoredByteOrderFallback(
       first: first,
       second: second
     )
-  }
-
-  private static func transactionIdData(_ hex: String) -> Data? {
-    guard hex.count == 64 else { return nil }
-    var bytes = [UInt8]()
-    bytes.reserveCapacity(32)
-    var index = hex.startIndex
-    while index < hex.endIndex {
-      let next = hex.index(index, offsetBy: 2)
-      guard let byte = UInt8(hex[index..<next], radix: 16) else {
-        return nil
-      }
-      bytes.append(byte)
-      index = next
-    }
-    return Data(bytes)
   }
 
   private func waitForNextConfirmationQuery(

--- a/ios/Runner/NativeLightwalletdClient.swift
+++ b/ios/Runner/NativeLightwalletdClient.swift
@@ -55,6 +55,13 @@ enum NativeLightwalletdError: Error, Equatable {
 struct NativeLightwalletdSendResponse: Equatable {
   let errorCode: Int32
   let errorMessage: String
+  let accepted: Bool?
+
+  init(errorCode: Int32, errorMessage: String, accepted: Bool? = nil) {
+    self.errorCode = errorCode
+    self.errorMessage = errorMessage
+    self.accepted = accepted
+  }
 }
 
 enum NativeLightwalletdTransactionObservation: Equatable {
@@ -189,13 +196,16 @@ enum NativeLightwalletdClient {
 
   static func transaction(
     endpoint: String,
+    routingTransactionId: Data,
     transactionId: Data,
+    managedSubmissionRouting: Bool,
     cancellation: BackgroundMigrationCancellation
   ) -> Result<
     NativeLightwalletdTransactionObservation,
     NativeLightwalletdError
   > {
-    guard transactionId.count == 32,
+    guard routingTransactionId.count == 32,
+      transactionId.count == 32,
       rpcURL(endpoint: endpoint, methodPath: getTransactionPath) != nil
     else {
       return .failure(.invalidEndpoint)
@@ -208,14 +218,19 @@ enum NativeLightwalletdClient {
       mined_height: 0
     )
     let code = endpoint.withCString { endpointPointer in
-      transactionId.withUnsafeBytes { transactionPointer in
-        zcash_lightwalletd_observe_transaction(
-          endpointPointer,
-          transactionPointer.bindMemory(to: UInt8.self).baseAddress,
-          UInt(transactionId.count),
-          &nativeObservation,
-          cancellation.lightwalletdCancellationHandle
-        )
+      routingTransactionId.withUnsafeBytes { routingTransactionPointer in
+        transactionId.withUnsafeBytes { transactionPointer in
+          zcash_lightwalletd_observe_transaction(
+            endpointPointer,
+            routingTransactionPointer.bindMemory(to: UInt8.self).baseAddress,
+            UInt(routingTransactionId.count),
+            transactionPointer.bindMemory(to: UInt8.self).baseAddress,
+            UInt(transactionId.count),
+            &nativeObservation,
+            managedSubmissionRouting,
+            cancellation.lightwalletdCancellationHandle
+          )
+        }
       }
     }
     guard code != ZCASH_LIGHTWALLETD_RESULT_CANCELLED,
@@ -238,6 +253,26 @@ enum NativeLightwalletdClient {
     default:
       return .failure(.malformedResponse)
     }
+  }
+
+  static func transactionIdByteOrders(
+    storedHex: String
+  ) -> (stored: Data, protocolOrder: Data)? {
+    guard storedHex.count == 64 else { return nil }
+    var bytes = [UInt8]()
+    bytes.reserveCapacity(32)
+    var index = storedHex.startIndex
+    while index < storedHex.endIndex {
+      let next = storedHex.index(index, offsetBy: 2)
+      guard let byte = UInt8(storedHex[index..<next], radix: 16) else {
+        return nil
+      }
+      bytes.append(byte)
+      index = next
+    }
+    guard bytes.count == 32 else { return nil }
+    let stored = Data(bytes)
+    return (stored, Data(stored.reversed()))
   }
 
   static func parseTransactionResponse(
@@ -263,10 +298,13 @@ enum NativeLightwalletdClient {
 
   static func sendTransaction(
     endpoint: String,
+    transactionId: Data,
     rawTransaction: Data,
+    managedSubmissionRouting: Bool,
     cancellation: BackgroundMigrationCancellation
   ) -> Result<NativeLightwalletdSendResponse, NativeLightwalletdError> {
-    guard !rawTransaction.isEmpty,
+    guard transactionId.count == 32,
+      !rawTransaction.isEmpty,
       rpcURL(endpoint: endpoint, methodPath: sendTransactionPath) != nil
     else {
       return .failure(.invalidEndpoint)
@@ -276,18 +314,25 @@ enum NativeLightwalletdClient {
     }
     var responseErrorCode: Int32 = 0
     var responseErrorMessage = [CChar](repeating: 0, count: 4096)
+    var responseAccepted = false
     let code = endpoint.withCString { endpointPointer in
-      rawTransaction.withUnsafeBytes { transactionPointer in
-        responseErrorMessage.withUnsafeMutableBufferPointer { messagePointer in
-          zcash_lightwalletd_send_transaction(
-            endpointPointer,
-            transactionPointer.bindMemory(to: UInt8.self).baseAddress,
-            UInt(rawTransaction.count),
-            &responseErrorCode,
-            messagePointer.baseAddress,
-            UInt(messagePointer.count),
-            cancellation.lightwalletdCancellationHandle
-          )
+      transactionId.withUnsafeBytes { transactionIdPointer in
+        rawTransaction.withUnsafeBytes { transactionPointer in
+          responseErrorMessage.withUnsafeMutableBufferPointer { messagePointer in
+            zcash_lightwalletd_send_transaction(
+              endpointPointer,
+              transactionIdPointer.bindMemory(to: UInt8.self).baseAddress,
+              UInt(transactionId.count),
+              transactionPointer.bindMemory(to: UInt8.self).baseAddress,
+              UInt(rawTransaction.count),
+              &responseErrorCode,
+              messagePointer.baseAddress,
+              UInt(messagePointer.count),
+              &responseAccepted,
+              managedSubmissionRouting,
+              cancellation.lightwalletdCancellationHandle
+            )
+          }
         }
       }
     }
@@ -302,7 +347,8 @@ enum NativeLightwalletdClient {
     return .success(
       NativeLightwalletdSendResponse(
         errorCode: responseErrorCode,
-        errorMessage: String(cString: responseErrorMessage)
+        errorMessage: String(cString: responseErrorMessage),
+        accepted: responseAccepted
       )
     )
   }

--- a/ios/Runner/zcash_sync.h
+++ b/ios/Runner/zcash_sync.h
@@ -32,19 +32,26 @@ int32_t zcash_lightwalletd_latest_block_height(
 
 int32_t zcash_lightwalletd_observe_transaction(
     const char* lightwalletd_url,
+    const uint8_t* routing_transaction_id,
+    uintptr_t routing_transaction_id_len,
     const uint8_t* transaction_id,
     uintptr_t transaction_id_len,
     CLightwalletdTransactionObservation* output,
+    bool managed_submission_routing,
     void* cancellation
 );
 
 int32_t zcash_lightwalletd_send_transaction(
     const char* lightwalletd_url,
+    const uint8_t* transaction_id,
+    uintptr_t transaction_id_len,
     const uint8_t* raw_transaction,
     uintptr_t raw_transaction_len,
     int32_t* response_error_code,
     char* response_error_message,
     uintptr_t response_error_message_capacity,
+    bool* response_accepted,
+    bool managed_submission_routing,
     void* cancellation
 );
 

--- a/ios/RunnerTests/BackgroundMigrationOutboxTests.swift
+++ b/ios/RunnerTests/BackgroundMigrationOutboxTests.swift
@@ -88,6 +88,38 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     XCTAssertNil(snapshot.announcedBroadcastCompleteBatchIds)
   }
 
+  func testSnapshotPersistsManagedRoutingAndLegacyBatchDefaultsToFalse() throws {
+    var snapshot = BackgroundMigrationOutboxSnapshot()
+    snapshot.batches = [
+      makeBatch(
+        batchId: "batch-a",
+        account: "account-a",
+        managedSubmissionRouting: true
+      )
+    ]
+    let encoded = try JSONEncoder().encode(snapshot)
+    let decoded = try JSONDecoder().decode(
+      BackgroundMigrationOutboxSnapshot.self,
+      from: encoded
+    )
+
+    XCTAssertTrue(try XCTUnwrap(decoded.batches.first).usesManagedSubmissionRouting)
+
+    var legacyObject = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+    )
+    var legacyBatches = try XCTUnwrap(legacyObject["batches"] as? [[String: Any]])
+    legacyBatches[0].removeValue(forKey: "managedSubmissionRouting")
+    legacyObject["batches"] = legacyBatches
+    let legacyData = try JSONSerialization.data(withJSONObject: legacyObject)
+    let legacy = try JSONDecoder().decode(
+      BackgroundMigrationOutboxSnapshot.self,
+      from: legacyData
+    )
+
+    XCTAssertFalse(try XCTUnwrap(legacy.batches.first).usesManagedSubmissionRouting)
+  }
+
   func testDiscardBatchRemovesAnIdleRecordButKeepsTheAccountScope() throws {
     var snapshot = BackgroundMigrationOutboxSnapshot()
     let batch = makeBatch(batchId: "batch-a", account: "account-a")
@@ -193,11 +225,13 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       runId: batch.runId,
       expectedTxids: Set(batch.items.map(\.txidHex)),
       lightwalletdUrl: "https://updated.example:443",
+      managedSubmissionRouting: true,
       at: now
     )
 
     XCTAssertTrue(recovered)
     XCTAssertEqual(snapshot.batches[0].lightwalletdUrl, "https://updated.example:443")
+    XCTAssertTrue(snapshot.batches[0].usesManagedSubmissionRouting)
     XCTAssertEqual(snapshot.batches[0].armedAt, now)
     XCTAssertTrue(snapshot.batches[0].items.allSatisfy { $0.status == .armed })
   }
@@ -250,7 +284,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     )
   }
 
-  func testRestagingMovesAnIdleBatchToTheCurrentEndpoint() throws {
+  func testRestagingMovesAnIdleBatchToTheCurrentSubmissionRoute() throws {
     let original = makeBatch(
       batchId: "batch-a",
       account: "account-a",
@@ -258,6 +292,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     )
     var replacement = original
     replacement.lightwalletdUrl = "https://replacement.example:443"
+    replacement.managedSubmissionRouting = true
     var snapshot = BackgroundMigrationOutboxSnapshot()
 
     try snapshot.stage(original)
@@ -272,6 +307,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       snapshot.batches.first?.lightwalletdUrl,
       replacement.lightwalletdUrl
     )
+    XCTAssertTrue(try XCTUnwrap(snapshot.batches.first).usesManagedSubmissionRouting)
   }
 
   func testRestagingUpdatesTimingCadenceOnAnIdleBatch() throws {
@@ -705,20 +741,32 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     )
   }
 
-  func testRunnerQueriesTipAndSubmitsOnlyOneDueTransaction() throws {
+  func testRunnerKeepsTipOnOriginalEndpointAndRoutesOneDueTransaction() throws {
     let harness = try makeStoreHarness()
     defer { harness.cleanup() }
     let batch = makeBatch(
       batchId: "batch-a",
       account: "account-a",
-      heights: [100, 101]
+      heights: [100, 101],
+      managedSubmissionRouting: true
     )
     try stageAndArm(batch, in: harness.store)
+    var heightEndpoints: [String] = []
+    var sendEndpoints: [String] = []
+    var sentTransactionIds: [Data] = []
     var sentPayloads: [Data] = []
+    var managedRoutingValues: [Bool] = []
     let dependencies = BackgroundMigrationOutboxRunnerDependencies(
-      latestBlockHeight: { _, _ in .success(200) },
-      sendTransaction: { _, payload, _ in
+      latestBlockHeight: { endpoint, _ in
+        heightEndpoints.append(endpoint)
+        return .success(200)
+      },
+      sendTransaction: {
+        endpoint, transactionId, payload, managedSubmissionRouting, _ in
+        sendEndpoints.append(endpoint)
+        sentTransactionIds.append(transactionId)
         sentPayloads.append(payload)
+        managedRoutingValues.append(managedSubmissionRouting)
         return .success(
           NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
         )
@@ -732,7 +780,14 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       dependencies: dependencies
     )
 
+    XCTAssertEqual(heightEndpoints, [batch.lightwalletdUrl])
+    XCTAssertEqual(sendEndpoints, [batch.lightwalletdUrl])
+    XCTAssertEqual(
+      sentTransactionIds,
+      [Data([0x01] + [UInt8](repeating: 0, count: 31))]
+    )
     XCTAssertEqual(sentPayloads, [batch.items[0].rawTransaction])
+    XCTAssertEqual(managedRoutingValues, [true])
     guard case .accepted(_, let observedHeight, _) = outcome.transport else {
       return XCTFail("Expected an accepted background submission, got \(outcome)")
     }
@@ -824,7 +879,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     try stageAndArm(batch, in: harness.store)
     let dependencies = BackgroundMigrationOutboxRunnerDependencies(
       latestBlockHeight: { _, _ in .success(200) },
-      sendTransaction: { _, _, _ in
+      sendTransaction: { _, _, _, _, _ in
         .success(
           NativeLightwalletdSendResponse(
             errorCode: 1,
@@ -845,7 +900,84 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       result.broadcastComplete,
       BackgroundMigrationBroadcastCompleteMetadata(batchId: batch.batchId)
     )
-    XCTAssertEqual(try harness.store.read().receipts.first?.outcome, .acceptedEquivalent)
+    let receipt = try XCTUnwrap(harness.store.read().receipts.first)
+    XCTAssertEqual(receipt.outcome, .acceptedEquivalent)
+    XCTAssertEqual(receipt.responseCode, 1)
+    XCTAssertEqual(receipt.responseMessage, "already in mempool")
+  }
+
+  func testRunnerUsesNativeAcceptedClassification() throws {
+    let harness = try makeStoreHarness()
+    defer { harness.cleanup() }
+    let batch = makeBatch(
+      batchId: "batch-a",
+      account: "account-a",
+      heights: [100]
+    )
+    try stageAndArm(batch, in: harness.store)
+    let dependencies = BackgroundMigrationOutboxRunnerDependencies(
+      latestBlockHeight: { _, _ in .success(200) },
+      sendTransaction: { _, _, _, _, _ in
+        .success(
+          NativeLightwalletdSendResponse(
+            errorCode: 1,
+            errorMessage: "classified as accepted by Rust",
+            accepted: true
+          )
+        )
+      }
+    )
+
+    let result = BackgroundMigrationOutboxRunner.runOnce(
+      store: harness.store,
+      cancellation: BackgroundMigrationCancellation(),
+      now: now,
+      dependencies: dependencies
+    )
+
+    guard case .accepted = result.transport else {
+      return XCTFail("Expected the native classification to be accepted")
+    }
+    let receipt = try XCTUnwrap(harness.store.read().receipts.first)
+    XCTAssertEqual(receipt.outcome, .acceptedEquivalent)
+    XCTAssertEqual(receipt.responseCode, 1)
+    XCTAssertEqual(receipt.responseMessage, "classified as accepted by Rust")
+  }
+
+  func testRunnerUsesNativeRejectedClassification() throws {
+    let harness = try makeStoreHarness()
+    defer { harness.cleanup() }
+    let batch = makeBatch(
+      batchId: "batch-a",
+      account: "account-a",
+      heights: [100]
+    )
+    try stageAndArm(batch, in: harness.store)
+    let dependencies = BackgroundMigrationOutboxRunnerDependencies(
+      latestBlockHeight: { _, _ in .success(200) },
+      sendTransaction: { _, _, _, _, _ in
+        .success(
+          NativeLightwalletdSendResponse(
+            errorCode: 1,
+            errorMessage: "already in mempool",
+            accepted: false
+          )
+        )
+      }
+    )
+
+    let result = BackgroundMigrationOutboxRunner.runOnce(
+      store: harness.store,
+      cancellation: BackgroundMigrationCancellation(),
+      now: now,
+      dependencies: dependencies
+    )
+
+    XCTAssertEqual(result.transport, .needsUserAction)
+    let receipt = try XCTUnwrap(harness.store.read().receipts.first)
+    XCTAssertEqual(receipt.outcome, .rejected)
+    XCTAssertEqual(receipt.responseCode, 1)
+    XCTAssertEqual(receipt.responseMessage, "already in mempool")
   }
 
   func testRunnerDoesNotReportBroadcastCompleteWhileBatchHasMoreWork() throws {
@@ -859,7 +991,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     try stageAndArm(batch, in: harness.store)
     let dependencies = BackgroundMigrationOutboxRunnerDependencies(
       latestBlockHeight: { _, _ in .success(200) },
-      sendTransaction: { _, _, _ in
+      sendTransaction: { _, _, _, _, _ in
         .success(
           NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
         )
@@ -887,7 +1019,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     try stageAndArm(batch, in: harness.store)
     let dependencies = BackgroundMigrationOutboxRunnerDependencies(
       latestBlockHeight: { _, _ in .success(200) },
-      sendTransaction: { _, _, _ in
+      sendTransaction: { _, _, _, _, _ in
         .success(
           NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
         )
@@ -948,7 +1080,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
         tipQueryCount += 1
         return .success(200)
       },
-      sendTransaction: { _, payload, _ in
+      sendTransaction: { _, _, payload, _, _ in
         sendCount += 1
         XCTAssertEqual(payload, batch.items[0].rawTransaction)
         return .success(
@@ -992,7 +1124,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     var sendCount = 0
     let dependencies = BackgroundMigrationOutboxRunnerDependencies(
       latestBlockHeight: { _, _ in .success(200) },
-      sendTransaction: { _, _, _ in
+      sendTransaction: { _, _, _, _, _ in
         sendCount += 1
         return .success(
           NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
@@ -1040,7 +1172,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     var sendCount = 0
     let dependencies = BackgroundMigrationOutboxRunnerDependencies(
       latestBlockHeight: { _, _ in .success(34_560) },
-      sendTransaction: { _, _, _ in
+      sendTransaction: { _, _, _, _, _ in
         sendCount += 1
         return .success(
           NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
@@ -1081,7 +1213,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     var sendCount = 0
     let dependencies = BackgroundMigrationOutboxRunnerDependencies(
       latestBlockHeight: { _, _ in .success(288) },
-      sendTransaction: { _, _, _ in
+      sendTransaction: { _, _, _, _, _ in
         sendCount += 1
         return .success(
           NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
@@ -1154,7 +1286,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     try stageAndArm(batch, in: harness.store)
     let dependencies = BackgroundMigrationOutboxRunnerDependencies(
       latestBlockHeight: { _, _ in .success(288) },
-      sendTransaction: { _, _, _ in
+      sendTransaction: { _, _, _, _, _ in
         XCTFail("A proof watch must not submit a transaction")
         return .success(
           NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
@@ -1219,7 +1351,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       store: harness.store,
       dependencies: BackgroundMigrationOutboxRunnerDependencies(
         latestBlockHeight: { _, _ in .success(288) },
-        sendTransaction: { _, _, _ in
+        sendTransaction: { _, _, _, _, _ in
           XCTFail("A proof watch must not submit a transaction")
           return .success(
             NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
@@ -1276,7 +1408,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     try stageAndArm(batch, in: harness.store)
     let dependencies = BackgroundMigrationOutboxRunnerDependencies(
       latestBlockHeight: { _, _ in .success(200) },
-      sendTransaction: { _, _, _ in
+      sendTransaction: { _, _, _, _, _ in
         XCTFail("A proof watch must not submit a transaction")
         return .success(
           NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
@@ -1352,7 +1484,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     try stageAndArm(batch, in: harness.store)
     let dependencies = BackgroundMigrationOutboxRunnerDependencies(
       latestBlockHeight: { _, _ in .success(200) },
-      sendTransaction: { _, _, _ in .failure(.timedOut) }
+      sendTransaction: { _, _, _, _, _ in .failure(.timedOut) }
     )
 
     let outcome = BackgroundMigrationOutboxRunner.runOnce(
@@ -1583,7 +1715,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       requiresPreparationProofVerification: true,
       dependencies: BackgroundMigrationOutboxRunnerDependencies(
         latestBlockHeight: { _, _ in .success(288) },
-        sendTransaction: { _, _, _ in
+        sendTransaction: { _, _, _, _, _ in
           XCTFail("a proof watch must not submit a transaction")
           return .success(
             NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
@@ -1638,7 +1770,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       requiresPreparationProofVerification: true,
       dependencies: BackgroundMigrationOutboxRunnerDependencies(
         latestBlockHeight: { _, _ in .success(288) },
-        sendTransaction: { _, _, _ in
+        sendTransaction: { _, _, _, _, _ in
           XCTFail("a proof watch must not submit a transaction")
           return .success(
             NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
@@ -1660,7 +1792,8 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     batchId: String,
     account: String,
     heights: [UInt64] = [100, 101, 102],
-    nextProofHeight: UInt64? = nil
+    nextProofHeight: UInt64? = nil,
+    managedSubmissionRouting: Bool? = nil
   ) -> BackgroundMigrationOutboxBatch {
     BackgroundMigrationOutboxBatch(
       batchId: batchId,
@@ -1668,6 +1801,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       accountUuid: account,
       runId: "run-\(account)",
       lightwalletdUrl: "https://testnet.zec.rocks:443",
+      managedSubmissionRouting: managedSubmissionRouting,
       timingMeanBlocks: 144,
       timingMaxBlocks: 576,
       createdAt: now,

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -2728,7 +2728,61 @@ class RunnerTests: XCTestCase {
 
 }
 
+final class IronwoodMigrationBackgroundManifestTests: XCTestCase {
+  func testManagedSubmissionRoutingIsOptionalAndDefaultsToFalse() throws {
+    var values: [String: Any] = [
+      "version": 1,
+      "network": "test",
+      "accountUuid": "account-a",
+      "dbPath": "/tmp/wallet.db",
+      "lightwalletdUrl": "https://testnet.zec.rocks:443",
+      "credentialHex": "00",
+      "saltBase64": "AA==",
+    ]
+    let legacy = try JSONDecoder().decode(
+      IronwoodMigrationBackgroundManifest.self,
+      from: JSONSerialization.data(withJSONObject: values)
+    )
+
+    XCTAssertFalse(legacy.usesManagedSubmissionRouting)
+
+    values["managedSubmissionRouting"] = true
+    let managed = try JSONDecoder().decode(
+      IronwoodMigrationBackgroundManifest.self,
+      from: JSONSerialization.data(withJSONObject: values)
+    )
+
+    XCTAssertTrue(managed.usesManagedSubmissionRouting)
+  }
+}
+
 final class NativeLightwalletdClientTests: XCTestCase {
+  func testTransactionIdByteOrdersRequireAndReverseExactly32Bytes() throws {
+    let storedHex = String(repeating: "00", count: 31) + "01"
+    let byteOrders = try XCTUnwrap(
+      NativeLightwalletdClient.transactionIdByteOrders(storedHex: storedHex)
+    )
+
+    XCTAssertEqual(
+      byteOrders.stored,
+      Data([UInt8](repeating: 0, count: 31) + [0x01])
+    )
+    XCTAssertEqual(
+      byteOrders.protocolOrder,
+      Data([0x01] + [UInt8](repeating: 0, count: 31))
+    )
+    XCTAssertNil(
+      NativeLightwalletdClient.transactionIdByteOrders(
+        storedHex: String(repeating: "00", count: 31)
+      )
+    )
+    XCTAssertNil(
+      NativeLightwalletdClient.transactionIdByteOrders(
+        storedHex: String(repeating: "zz", count: 32)
+      )
+    )
+  }
+
   func testBackgroundMigrationCancellationSignalsWaitingWork() {
     let cancellation = BackgroundMigrationCancellation()
     let cancelled = expectation(description: "cancelled")

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -9,9 +9,6 @@ const kIronwoodMasqueradeRpcEndpointPresetId = 'ironwood-masquerade';
 const kRegtestSlowRpcEndpointPresetId = 'slow-regtest';
 const kRegtestUnavailableRpcEndpointPresetId = 'unavailable-regtest';
 
-/// How a transaction submission endpoint is chosen.
-enum TransactionSubmissionRouting { currentEndpointOnly, managedProviders }
-
 class RpcEndpointConfig {
   const RpcEndpointConfig({
     required this.networkName,
@@ -24,6 +21,15 @@ class RpcEndpointConfig {
   final String? presetId;
 
   ZcashNetwork get network => zcashNetworkFromName(networkName);
+
+  /// Whether transaction submission may use providers managed by Vizor.
+  ///
+  /// Custom endpoints, legacy endpoint records, non-mainnet networks, and
+  /// masquerade builds remain pinned to the configured endpoint.
+  bool get usesManagedSubmissionRouting =>
+      !kZcashIronwoodMasquerade &&
+      network == ZcashNetwork.mainnet &&
+      explicitRpcEndpointPresetFor(this) != null;
 
   String get normalizedLightwalletdUrl =>
       normalizeRpcEndpointUrl(lightwalletdUrl, allowDefaultPort: true);
@@ -237,23 +243,6 @@ RpcEndpointPreset? explicitRpcEndpointPresetFor(RpcEndpointConfig config) {
   }
 
   return findRpcEndpointPresetById(config.networkName, presetId);
-}
-
-/// Selects whether transaction submission may use providers managed by Vizor.
-///
-/// Explicit mainnet presets use managed routing, including community presets.
-/// Custom endpoints, legacy endpoint records without a preset ID, testnet,
-/// regtest, and masquerade builds stay pinned to the configured endpoint.
-TransactionSubmissionRouting transactionSubmissionRoutingFor(
-  RpcEndpointConfig config,
-) {
-  if (kZcashIronwoodMasquerade ||
-      config.network != ZcashNetwork.mainnet ||
-      explicitRpcEndpointPresetFor(config) == null) {
-    return TransactionSubmissionRouting.currentEndpointOnly;
-  }
-
-  return TransactionSubmissionRouting.managedProviders;
 }
 
 List<RpcEndpointConfig> fallbackRpcEndpointCandidatesFor(

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -9,6 +9,9 @@ const kIronwoodMasqueradeRpcEndpointPresetId = 'ironwood-masquerade';
 const kRegtestSlowRpcEndpointPresetId = 'slow-regtest';
 const kRegtestUnavailableRpcEndpointPresetId = 'unavailable-regtest';
 
+/// How a transaction submission endpoint is chosen.
+enum TransactionSubmissionRouting { currentEndpointOnly, managedProviders }
+
 class RpcEndpointConfig {
   const RpcEndpointConfig({
     required this.networkName,
@@ -63,6 +66,7 @@ class RpcEndpointPreset {
 
 // Public lightwalletd presets. Keep the mainnet default aligned with Zodl's
 // default endpoint while preserving zec.rocks as a selectable fallback.
+// Keep managed provider URLs aligned with Rust's submission provider catalog.
 const kIronwoodMasqueradeRpcEndpointPreset = RpcEndpointPreset(
   id: kIronwoodMasqueradeRpcEndpointPresetId,
   region: 'Ironwood',
@@ -233,6 +237,23 @@ RpcEndpointPreset? explicitRpcEndpointPresetFor(RpcEndpointConfig config) {
   }
 
   return findRpcEndpointPresetById(config.networkName, presetId);
+}
+
+/// Selects whether transaction submission may use providers managed by Vizor.
+///
+/// Explicit mainnet presets use managed routing, including community presets.
+/// Custom endpoints, legacy endpoint records without a preset ID, testnet,
+/// regtest, and masquerade builds stay pinned to the configured endpoint.
+TransactionSubmissionRouting transactionSubmissionRoutingFor(
+  RpcEndpointConfig config,
+) {
+  if (kZcashIronwoodMasquerade ||
+      config.network != ZcashNetwork.mainnet ||
+      explicitRpcEndpointPresetFor(config) == null) {
+    return TransactionSubmissionRouting.currentEndpointOnly;
+  }
+
+  return TransactionSubmissionRouting.managedProviders;
 }
 
 List<RpcEndpointConfig> fallbackRpcEndpointCandidatesFor(

--- a/lib/src/features/home/screens/mobile/mobile_keystone_shield_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_keystone_shield_screen.dart
@@ -298,9 +298,7 @@ class _MobileKeystoneShieldScreenState
     try {
       final dbPath = await getWalletDbPath();
       final endpoint = ref.read(rpcEndpointFailoverProvider).current;
-      final managedSubmissionRouting =
-          transactionSubmissionRoutingFor(endpoint) ==
-          TransactionSubmissionRouting.managedProviders;
+      final managedSubmissionRouting = endpoint.usesManagedSubmissionRouting;
       attemptedEndpoint = endpoint;
       final result = await rust_sync.extractAndBroadcastPczt(
         dbPath: dbPath,

--- a/lib/src/features/home/screens/mobile/mobile_keystone_shield_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_keystone_shield_screen.dart
@@ -298,11 +298,15 @@ class _MobileKeystoneShieldScreenState
     try {
       final dbPath = await getWalletDbPath();
       final endpoint = ref.read(rpcEndpointFailoverProvider).current;
+      final managedSubmissionRouting =
+          transactionSubmissionRoutingFor(endpoint) ==
+          TransactionSubmissionRouting.managedProviders;
       attemptedEndpoint = endpoint;
       final result = await rust_sync.extractAndBroadcastPczt(
         dbPath: dbPath,
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
         network: endpoint.networkName,
+        managedSubmissionRouting: managedSubmissionRouting,
         pcztWithProofsBytes: pcztWithProofs,
         pcztWithSignaturesBytes: signatures,
         spendParamsPath: _needsSaplingParams ? saplingParams.spendPath : null,

--- a/lib/src/features/home/services/transparent_shielding_service.dart
+++ b/lib/src/features/home/services/transparent_shielding_service.dart
@@ -69,6 +69,9 @@ Future<rust_sync.ShieldTransparentResult> shieldTransparentSoftwareBalance({
 
     final dbPath = await getWalletDbPath();
     final endpoint = ref.read(rpcEndpointFailoverProvider).current;
+    final managedSubmissionRouting =
+        transactionSubmissionRoutingFor(endpoint) ==
+        TransactionSubmissionRouting.managedProviders;
     attemptedEndpoint = endpoint;
 
     late final rust_sync.ShieldTransparentResult result;
@@ -84,6 +87,7 @@ Future<rust_sync.ShieldTransparentResult> shieldTransparentSoftwareBalance({
         network: endpoint.networkName,
         accountUuid: accountUuid,
         password: password,
+        managedSubmissionRouting: managedSubmissionRouting,
       );
     } else {
       final accountNotifier = ref.read(accountProvider.notifier);
@@ -101,6 +105,7 @@ Future<rust_sync.ShieldTransparentResult> shieldTransparentSoftwareBalance({
           network: endpoint.networkName,
           accountUuid: accountUuid,
           mnemonicBytes: mnemonicBytes,
+          managedSubmissionRouting: managedSubmissionRouting,
         );
       } finally {
         mnemonicBytes.fillRange(0, mnemonicBytes.length, 0);

--- a/lib/src/features/home/services/transparent_shielding_service.dart
+++ b/lib/src/features/home/services/transparent_shielding_service.dart
@@ -69,9 +69,7 @@ Future<rust_sync.ShieldTransparentResult> shieldTransparentSoftwareBalance({
 
     final dbPath = await getWalletDbPath();
     final endpoint = ref.read(rpcEndpointFailoverProvider).current;
-    final managedSubmissionRouting =
-        transactionSubmissionRoutingFor(endpoint) ==
-        TransactionSubmissionRouting.managedProviders;
+    final managedSubmissionRouting = endpoint.usesManagedSubmissionRouting;
     attemptedEndpoint = endpoint;
 
     late final rust_sync.ShieldTransparentResult result;

--- a/lib/src/features/home/widgets/keystone_shield_signing_overlay.dart
+++ b/lib/src/features/home/widgets/keystone_shield_signing_overlay.dart
@@ -200,11 +200,15 @@ class _KeystoneShieldSigningOverlayState
     try {
       final dbPath = await getWalletDbPath();
       final endpoint = ref.read(rpcEndpointFailoverProvider).current;
+      final managedSubmissionRouting =
+          transactionSubmissionRoutingFor(endpoint) ==
+          TransactionSubmissionRouting.managedProviders;
       attemptedEndpoint = endpoint;
       final result = await rust_sync.extractAndBroadcastPczt(
         dbPath: dbPath,
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
         network: endpoint.networkName,
+        managedSubmissionRouting: managedSubmissionRouting,
         pcztWithProofsBytes: pcztWithProofs,
         pcztWithSignaturesBytes: signatures,
         spendParamsPath: _needsSaplingParams ? saplingParams.spendPath : null,

--- a/lib/src/features/home/widgets/keystone_shield_signing_overlay.dart
+++ b/lib/src/features/home/widgets/keystone_shield_signing_overlay.dart
@@ -200,9 +200,7 @@ class _KeystoneShieldSigningOverlayState
     try {
       final dbPath = await getWalletDbPath();
       final endpoint = ref.read(rpcEndpointFailoverProvider).current;
-      final managedSubmissionRouting =
-          transactionSubmissionRoutingFor(endpoint) ==
-          TransactionSubmissionRouting.managedProviders;
+      final managedSubmissionRouting = endpoint.usesManagedSubmissionRouting;
       attemptedEndpoint = endpoint;
       final result = await rust_sync.extractAndBroadcastPczt(
         dbPath: dbPath,

--- a/lib/src/features/migration/services/ironwood_migration_background_credential_store.dart
+++ b/lib/src/features/migration/services/ironwood_migration_background_credential_store.dart
@@ -35,6 +35,7 @@ class IronwoodMigrationBackgroundCredentialManifest {
     required String accountUuid,
     required String dbPath,
     required String lightwalletdUrl,
+    bool managedSubmissionRouting = false,
     required String credentialHex,
     required String saltBase64,
     required String? expectedRunId,
@@ -55,6 +56,7 @@ class IronwoodMigrationBackgroundCredentialManifest {
       accountUuid: accountUuid,
       dbPath: dbPath,
       lightwalletdUrl: lightwalletdUrl,
+      managedSubmissionRouting: managedSubmissionRouting,
       credentialHex: credentialHex,
       saltBase64: saltBase64,
       expectedRunId: expectedRunId,
@@ -67,6 +69,7 @@ class IronwoodMigrationBackgroundCredentialManifest {
     required this.accountUuid,
     required this.dbPath,
     required this.lightwalletdUrl,
+    required this.managedSubmissionRouting,
     required this.credentialHex,
     required this.saltBase64,
     required this.expectedRunId,
@@ -84,8 +87,14 @@ class IronwoodMigrationBackgroundCredentialManifest {
         'Ironwood migration manifest must be a JSON object.',
       );
     }
-    if (decoded.length != _manifestKeys.length ||
-        !_manifestKeys.every(decoded.containsKey)) {
+    final hasManagedSubmissionRouting = decoded.containsKey(
+      'managedSubmissionRouting',
+    );
+    final expectedKeys = hasManagedSubmissionRouting
+        ? _manifestKeys
+        : _legacyManifestKeys;
+    if (decoded.length != expectedKeys.length ||
+        !expectedKeys.every(decoded.containsKey)) {
       throw const FormatException(
         'Ironwood migration manifest fields do not match version 1.',
       );
@@ -96,6 +105,9 @@ class IronwoodMigrationBackgroundCredentialManifest {
     final accountUuid = decoded['accountUuid'];
     final dbPath = decoded['dbPath'];
     final lightwalletdUrl = decoded['lightwalletdUrl'];
+    final managedSubmissionRouting = hasManagedSubmissionRouting
+        ? decoded['managedSubmissionRouting']
+        : false;
     final credentialHex = decoded['credentialHex'];
     final saltBase64 = decoded['saltBase64'];
     final expectedRunId = decoded['expectedRunId'];
@@ -104,6 +116,7 @@ class IronwoodMigrationBackgroundCredentialManifest {
         accountUuid is! String ||
         dbPath is! String ||
         lightwalletdUrl is! String ||
+        managedSubmissionRouting is! bool ||
         credentialHex is! String ||
         saltBase64 is! String ||
         (expectedRunId != null && expectedRunId is! String)) {
@@ -119,6 +132,7 @@ class IronwoodMigrationBackgroundCredentialManifest {
         accountUuid: accountUuid,
         dbPath: dbPath,
         lightwalletdUrl: lightwalletdUrl,
+        managedSubmissionRouting: managedSubmissionRouting,
         credentialHex: credentialHex,
         saltBase64: saltBase64,
         expectedRunId: expectedRunId as String?,
@@ -133,6 +147,7 @@ class IronwoodMigrationBackgroundCredentialManifest {
   final String accountUuid;
   final String dbPath;
   final String lightwalletdUrl;
+  final bool managedSubmissionRouting;
   final String credentialHex;
   final String saltBase64;
   final String? expectedRunId;
@@ -143,6 +158,7 @@ class IronwoodMigrationBackgroundCredentialManifest {
     'accountUuid': accountUuid,
     'dbPath': dbPath,
     'lightwalletdUrl': lightwalletdUrl,
+    'managedSubmissionRouting': managedSubmissionRouting,
     'credentialHex': credentialHex,
     'saltBase64': saltBase64,
     'expectedRunId': expectedRunId,
@@ -161,6 +177,7 @@ class IronwoodMigrationBackgroundCredentialManifest {
       accountUuid: accountUuid,
       dbPath: dbPath,
       lightwalletdUrl: lightwalletdUrl,
+      managedSubmissionRouting: managedSubmissionRouting,
       credentialHex: credentialHex,
       saltBase64: saltBase64,
       expectedRunId: runId,
@@ -174,6 +191,7 @@ class IronwoodMigrationBackgroundCredentialManifest {
       accountUuid: accountUuid,
       dbPath: value,
       lightwalletdUrl: lightwalletdUrl,
+      managedSubmissionRouting: managedSubmissionRouting,
       credentialHex: credentialHex,
       saltBase64: saltBase64,
       expectedRunId: expectedRunId,
@@ -189,6 +207,7 @@ class IronwoodMigrationBackgroundCredentialManifest {
           accountUuid == other.accountUuid &&
           dbPath == other.dbPath &&
           lightwalletdUrl == other.lightwalletdUrl &&
+          managedSubmissionRouting == other.managedSubmissionRouting &&
           credentialHex == other.credentialHex &&
           saltBase64 == other.saltBase64 &&
           expectedRunId == other.expectedRunId;
@@ -200,6 +219,7 @@ class IronwoodMigrationBackgroundCredentialManifest {
     accountUuid,
     dbPath,
     lightwalletdUrl,
+    managedSubmissionRouting,
     credentialHex,
     saltBase64,
     expectedRunId,
@@ -287,6 +307,7 @@ class IronwoodMigrationBackgroundCredentialStore {
     required String accountUuid,
     required String dbPath,
     required String lightwalletdUrl,
+    bool managedSubmissionRouting = false,
   }) async {
     final credentialBytes = _randomBytes(32);
     final saltBytes = _randomBytes(16);
@@ -301,6 +322,7 @@ class IronwoodMigrationBackgroundCredentialStore {
       accountUuid: accountUuid,
       dbPath: dbPath,
       lightwalletdUrl: lightwalletdUrl,
+      managedSubmissionRouting: managedSubmissionRouting,
       credentialHex: credentialBytes
           .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
           .join(),
@@ -609,6 +631,17 @@ class IronwoodMigrationBackgroundLifecycle {
 }
 
 const _manifestKeys = <String>{
+  'version',
+  'network',
+  'accountUuid',
+  'dbPath',
+  'lightwalletdUrl',
+  'managedSubmissionRouting',
+  'credentialHex',
+  'saltBase64',
+  'expectedRunId',
+};
+const _legacyManifestKeys = <String>{
   'version',
   'network',
   'accountUuid',

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -217,6 +217,7 @@ typedef IronwoodMigrationSoftwareStarter =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
       required String lightwalletdUrl,
+      required bool managedSubmissionRouting,
       required String network,
       required String accountUuid,
       required List<int> mnemonicBytes,
@@ -228,6 +229,7 @@ typedef IronwoodMigrationImmediateStarter =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
       required String lightwalletdUrl,
+      required bool managedSubmissionRouting,
       required String network,
       required String accountUuid,
       required List<int> mnemonicBytes,
@@ -257,6 +259,7 @@ typedef IronwoodMigrationMacosSoftwareStarter =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
       required String lightwalletdUrl,
+      required bool managedSubmissionRouting,
       required String network,
       required String accountUuid,
       required String password,
@@ -267,6 +270,7 @@ typedef IronwoodMigrationDueBroadcaster =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
       required String lightwalletdUrl,
+      required bool managedSubmissionRouting,
       required String network,
       required String accountUuid,
       required String password,
@@ -308,6 +312,7 @@ typedef IronwoodMigrationOutboxBatchRecoverer =
       required String accountUuid,
       required String runId,
       required String lightwalletdUrl,
+      required bool managedSubmissionRouting,
       required List<String> expectedTxids,
     });
 typedef IronwoodMigrationOutboxBatchChecker =
@@ -426,6 +431,7 @@ typedef IronwoodMigrationKeystoneImmediateCompleter =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
       required String lightwalletdUrl,
+      required bool managedSubmissionRouting,
       required String network,
       required String accountUuid,
       required String requestId,
@@ -442,6 +448,7 @@ typedef IronwoodMigrationKeystoneDenominationCompleter =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
       required String lightwalletdUrl,
+      required bool managedSubmissionRouting,
       required String network,
       required String accountUuid,
       required String requestId,
@@ -454,6 +461,7 @@ typedef IronwoodMigrationKeystoneSingleQrCompleter =
     Future<rust_sync.IronwoodMigrationResult> Function({
       required String dbPath,
       required String lightwalletdUrl,
+      required bool managedSubmissionRouting,
       required String network,
       required String accountUuid,
       required String requestId,
@@ -515,6 +523,7 @@ _defaultPrepareKeystoneSingleQrMigration({
 Future<rust_sync.IronwoodMigrationResult> _defaultStartSoftwareMigration({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required List<int> mnemonicBytes,
@@ -524,6 +533,7 @@ Future<rust_sync.IronwoodMigrationResult> _defaultStartSoftwareMigration({
 }) => rust_sync.migrateOrchardToIronwood(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   accountUuid: accountUuid,
   mnemonicBytes: mnemonicBytes,
@@ -536,6 +546,7 @@ Future<rust_sync.IronwoodMigrationResult> _defaultStartSoftwareMigration({
 Future<rust_sync.IronwoodMigrationResult> _defaultStartMacosSoftwareMigration({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required String password,
@@ -544,6 +555,7 @@ Future<rust_sync.IronwoodMigrationResult> _defaultStartMacosSoftwareMigration({
 }) => rust_sync.migrateOrchardToIronwoodWithMacosStoredMnemonic(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   accountUuid: accountUuid,
   password: password,
@@ -556,6 +568,7 @@ Future<rust_sync.IronwoodMigrationResult>
 _defaultCompleteKeystoneDenominationMigration({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required String requestId,
@@ -566,6 +579,7 @@ _defaultCompleteKeystoneDenominationMigration({
 }) => rust_sync.completeOrchardMigrationDenominationsPczt(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   accountUuid: accountUuid,
   requestId: requestId,
@@ -579,6 +593,7 @@ Future<rust_sync.IronwoodMigrationResult>
 _defaultCompleteKeystoneSingleQrMigration({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required String requestId,
@@ -588,6 +603,7 @@ _defaultCompleteKeystoneSingleQrMigration({
 }) => rust_sync.completeOrchardMigrationSingleQrPczt(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   accountUuid: accountUuid,
   requestId: requestId,
@@ -1134,6 +1150,7 @@ class IronwoodMigrationService {
           network: endpoint.networkName,
           accountUuid: accountUuid,
           lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+          managedSubmissionRouting: _managedSubmissionRoutingFor(endpoint),
         );
         await _serializeCredentialState(context, () async {
           var quiesceAttempted = false;
@@ -1333,9 +1350,14 @@ class IronwoodMigrationService {
                 password: resolvedManifest.credentialHex,
                 saltBase64: resolvedManifest.saltBase64,
               );
+              final outboxContext = _contextWithSubmissionRoute(
+                context,
+                resolvedManifest.lightwalletdUrl,
+                resolvedManifest.managedSubmissionRouting,
+              );
               final requiredTxids = _scheduledBroadcastTxids(status);
               final restored = await _stagePersistedMigrationOutbox(
-                context: context,
+                context: outboxContext,
                 credential: credential,
                 expectedRunId: status.activeRunId,
                 requiredTxids: requiredTxids,
@@ -1497,21 +1519,25 @@ class IronwoodMigrationService {
       network: endpoint.networkName,
       accountUuid: accountUuid,
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      managedSubmissionRouting: _managedSubmissionRoutingFor(endpoint),
     );
 
     if (isMacOS()) {
       return _runCredentialOperation(
         context: context,
         mayCreateRun: true,
-        operation: (credential) => startMacosSoftwareMigration(
-          dbPath: dbPath,
-          lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-          network: endpoint.networkName,
-          accountUuid: accountUuid,
-          password: credential.password,
-          saltBase64: credential.saltBase64,
-          approvedSchedule: approvedSchedule,
-        ),
+        operation: (credential, submissionContext) =>
+            startMacosSoftwareMigration(
+              dbPath: dbPath,
+              lightwalletdUrl: submissionContext.lightwalletdUrl!,
+              managedSubmissionRouting:
+                  submissionContext.managedSubmissionRouting,
+              network: endpoint.networkName,
+              accountUuid: accountUuid,
+              password: credential.password,
+              saltBase64: credential.saltBase64,
+              approvedSchedule: approvedSchedule,
+            ),
       );
     }
 
@@ -1519,7 +1545,7 @@ class IronwoodMigrationService {
       context: context,
       mayCreateRun: true,
       onCurrentStatus: _reconcileBackgroundPreparationBestEffort,
-      operation: (credential) async {
+      operation: (credential, submissionContext) async {
         final mnemonicBytes = await getMnemonicBytesForAccount(accountUuid);
         if (mnemonicBytes == null || mnemonicBytes.isEmpty) {
           throw Exception('Mnemonic not found for the migration account.');
@@ -1529,7 +1555,9 @@ class IronwoodMigrationService {
         try {
           resultFuture = startSoftwareMigration(
             dbPath: dbPath,
-            lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+            lightwalletdUrl: submissionContext.lightwalletdUrl!,
+            managedSubmissionRouting:
+                submissionContext.managedSubmissionRouting,
             network: endpoint.networkName,
             accountUuid: accountUuid,
             mnemonicBytes: mnemonicBytes,
@@ -1560,6 +1588,7 @@ class IronwoodMigrationService {
       network: endpoint.networkName,
       accountUuid: accountUuid,
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      managedSubmissionRouting: _managedSubmissionRoutingFor(endpoint),
     );
 
     try {
@@ -1575,6 +1604,7 @@ class IronwoodMigrationService {
             return await startImmediateMigration(
               dbPath: dbPath,
               lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+              managedSubmissionRouting: context.managedSubmissionRouting,
               network: endpoint.networkName,
               accountUuid: accountUuid,
               mnemonicBytes: mnemonicBytes,
@@ -1604,6 +1634,7 @@ class IronwoodMigrationService {
       network: endpoint.networkName,
       accountUuid: accountUuid,
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      managedSubmissionRouting: _managedSubmissionRoutingFor(endpoint),
     );
 
     final rust_sync.IronwoodMigrationResult broadcastResult;
@@ -1615,9 +1646,10 @@ class IronwoodMigrationService {
         onCurrentStatus: isHardwareAccount(accountUuid)
             ? null
             : _reconcileBackgroundPreparationBestEffort,
-        operation: (credential) => prepareMigrationOutbox(
+        operation: (credential, submissionContext) => prepareMigrationOutbox(
           dbPath: dbPath,
-          lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+          lightwalletdUrl: submissionContext.lightwalletdUrl!,
+          managedSubmissionRouting: submissionContext.managedSubmissionRouting,
           network: endpoint.networkName,
           accountUuid: accountUuid,
           password: credential.password,
@@ -1628,9 +1660,10 @@ class IronwoodMigrationService {
       broadcastResult = await _runCredentialOperation(
         context: context,
         mayCreateRun: false,
-        operation: (credential) => broadcastDueMigration(
+        operation: (credential, submissionContext) => broadcastDueMigration(
           dbPath: dbPath,
-          lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+          lightwalletdUrl: submissionContext.lightwalletdUrl!,
+          managedSubmissionRouting: submissionContext.managedSubmissionRouting,
           network: endpoint.networkName,
           accountUuid: accountUuid,
           password: credential.password,
@@ -1662,22 +1695,25 @@ class IronwoodMigrationService {
       return _runCredentialOperation(
         context: context,
         mayCreateRun: true,
-        operation: (credential) => startMacosSoftwareMigration(
-          dbPath: dbPath,
-          lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-          network: endpoint.networkName,
-          accountUuid: accountUuid,
-          password: credential.password,
-          saltBase64: credential.saltBase64,
-          approvedSchedule: const [],
-        ),
+        operation: (credential, submissionContext) =>
+            startMacosSoftwareMigration(
+              dbPath: dbPath,
+              lightwalletdUrl: submissionContext.lightwalletdUrl!,
+              managedSubmissionRouting:
+                  submissionContext.managedSubmissionRouting,
+              network: endpoint.networkName,
+              accountUuid: accountUuid,
+              password: credential.password,
+              saltBase64: credential.saltBase64,
+              approvedSchedule: const [],
+            ),
       );
     }
 
     return _runCredentialOperation(
       context: context,
       mayCreateRun: true,
-      operation: (credential) async {
+      operation: (credential, submissionContext) async {
         final mnemonicBytes = await getMnemonicBytesForAccount(accountUuid);
         if (mnemonicBytes == null || mnemonicBytes.isEmpty) {
           throw Exception('Mnemonic not found for the migration account.');
@@ -1685,7 +1721,9 @@ class IronwoodMigrationService {
         try {
           return startSoftwareMigration(
             dbPath: dbPath,
-            lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+            lightwalletdUrl: submissionContext.lightwalletdUrl!,
+            managedSubmissionRouting:
+                submissionContext.managedSubmissionRouting,
             network: endpoint.networkName,
             accountUuid: accountUuid,
             mnemonicBytes: mnemonicBytes,
@@ -1712,6 +1750,7 @@ class IronwoodMigrationService {
       network: endpoint.networkName,
       accountUuid: accountUuid,
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      managedSubmissionRouting: _managedSubmissionRoutingFor(endpoint),
     );
     return operationRegistry.run(
       network: context.network,
@@ -1779,6 +1818,7 @@ class IronwoodMigrationService {
       network: endpoint.networkName,
       accountUuid: accountUuid,
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      managedSubmissionRouting: _managedSubmissionRoutingFor(endpoint),
     );
 
     await operationRegistry.run(
@@ -1798,6 +1838,7 @@ class IronwoodMigrationService {
         // inside the classifying `try`: the side effects below must never be
         // reinterpreted as a credential fault.
         _MigrationCredential? usableCredential;
+        bool? usableManagedSubmissionRouting;
         try {
           existingManifest = await backgroundCredentialStore.read(
             network: context.network,
@@ -1844,6 +1885,8 @@ class IronwoodMigrationService {
                 password: resolvedManifest.credentialHex,
                 saltBase64: resolvedManifest.saltBase64,
               );
+              usableManagedSubmissionRouting =
+                  resolvedManifest.managedSubmissionRouting;
             }
           }
         } catch (error) {
@@ -1866,8 +1909,13 @@ class IronwoodMigrationService {
           // revoking the account scope, which would delete the very credential
           // this restage depends on. A failed restage leaves the DB run intact
           // for the rebuild below.
+          final outboxContext = _contextWithSubmissionRoute(
+            context,
+            existingManifest!.lightwalletdUrl,
+            usableManagedSubmissionRouting!,
+          );
           final restored = await _stagePersistedMigrationOutbox(
-            context: context,
+            context: outboxContext,
             credential: usableCredential,
             expectedRunId: oldRunId,
             requiredTxids: requiredTxids,
@@ -1923,6 +1971,7 @@ class IronwoodMigrationService {
             accountUuid: context.accountUuid,
             dbPath: context.dbPath,
             lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+            managedSubmissionRouting: context.managedSubmissionRouting,
           );
           final credential = _MigrationCredential(
             password: manifest.credentialHex,
@@ -1935,6 +1984,7 @@ class IronwoodMigrationService {
             await startSoftwareMigration(
               dbPath: context.dbPath,
               lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+              managedSubmissionRouting: context.managedSubmissionRouting,
               network: context.network,
               accountUuid: context.accountUuid,
               mnemonicBytes: mnemonicBytes,
@@ -2043,12 +2093,14 @@ class IronwoodMigrationService {
   }) async {
     final dbPath = await getWalletDbPath();
     final endpoint = getEndpoint();
+    final managedSubmissionRouting = _managedSubmissionRoutingFor(endpoint);
     return operationRegistry.run(
       network: endpoint.networkName,
       accountUuid: accountUuid,
       operation: () => completeKeystoneImmediateMigration(
         dbPath: dbPath,
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        managedSubmissionRouting: managedSubmissionRouting,
         network: endpoint.networkName,
         accountUuid: accountUuid,
         requestId: requestId,
@@ -2068,12 +2120,13 @@ class IronwoodMigrationService {
       network: endpoint.networkName,
       accountUuid: accountUuid,
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      managedSubmissionRouting: _managedSubmissionRoutingFor(endpoint),
     );
     return _runCredentialOperation(
       context: context,
       mayCreateRun: true,
       prepareOutboxAfterOperation: false,
-      operation: (_) => createPrivateMigrationDraft(
+      operation: (_, _) => createPrivateMigrationDraft(
         dbPath: dbPath,
         network: endpoint.networkName,
         accountUuid: accountUuid,
@@ -2095,22 +2148,26 @@ class IronwoodMigrationService {
       network: endpoint.networkName,
       accountUuid: accountUuid,
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      managedSubmissionRouting: _managedSubmissionRoutingFor(endpoint),
     );
 
     return _runCredentialOperation(
       context: context,
       mayCreateRun: true,
       onCurrentStatus: _reconcileBackgroundPreparationBestEffort,
-      operation: (credential) => completeKeystoneSingleQrMigration(
-        dbPath: dbPath,
-        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-        network: endpoint.networkName,
-        accountUuid: accountUuid,
-        requestId: requestId,
-        signedMessages: signedMessages,
-        password: credential.password,
-        saltBase64: credential.saltBase64,
-      ),
+      operation: (credential, submissionContext) =>
+          completeKeystoneSingleQrMigration(
+            dbPath: dbPath,
+            lightwalletdUrl: submissionContext.lightwalletdUrl!,
+            managedSubmissionRouting:
+                submissionContext.managedSubmissionRouting,
+            network: endpoint.networkName,
+            accountUuid: accountUuid,
+            requestId: requestId,
+            signedMessages: signedMessages,
+            password: credential.password,
+            saltBase64: credential.saltBase64,
+          ),
     );
   }
 
@@ -2128,23 +2185,27 @@ class IronwoodMigrationService {
       network: endpoint.networkName,
       accountUuid: accountUuid,
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      managedSubmissionRouting: _managedSubmissionRoutingFor(endpoint),
     );
 
     return _runCredentialOperation(
       context: context,
       mayCreateRun: true,
       onCurrentStatus: _reconcileBackgroundPreparationBestEffort,
-      operation: (credential) => completeKeystoneDenominationMigration(
-        dbPath: dbPath,
-        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-        network: endpoint.networkName,
-        accountUuid: accountUuid,
-        requestId: requestId,
-        signedMessages: signedMessages,
-        password: credential.password,
-        saltBase64: credential.saltBase64,
-        approvedSchedule: approvedSchedule,
-      ),
+      operation: (credential, submissionContext) =>
+          completeKeystoneDenominationMigration(
+            dbPath: dbPath,
+            lightwalletdUrl: submissionContext.lightwalletdUrl!,
+            managedSubmissionRouting:
+                submissionContext.managedSubmissionRouting,
+            network: endpoint.networkName,
+            accountUuid: accountUuid,
+            requestId: requestId,
+            signedMessages: signedMessages,
+            password: credential.password,
+            saltBase64: credential.saltBase64,
+            approvedSchedule: approvedSchedule,
+          ),
     );
   }
 
@@ -2176,12 +2237,13 @@ class IronwoodMigrationService {
       network: endpoint.networkName,
       accountUuid: accountUuid,
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      managedSubmissionRouting: _managedSubmissionRoutingFor(endpoint),
     );
 
     return _runCredentialOperation(
       context: context,
       mayCreateRun: true,
-      operation: (credential) => completeKeystoneBatchMigration(
+      operation: (credential, _) => completeKeystoneBatchMigration(
         dbPath: dbPath,
         network: endpoint.networkName,
         accountUuid: accountUuid,
@@ -2196,7 +2258,11 @@ class IronwoodMigrationService {
   Future<T> _runCredentialOperation<T>({
     required _MigrationCredentialContext context,
     required bool mayCreateRun,
-    required Future<T> Function(_MigrationCredential credential) operation,
+    required Future<T> Function(
+      _MigrationCredential credential,
+      _MigrationCredentialContext submissionContext,
+    )
+    operation,
     bool prepareOutboxAfterOperation = true,
     Future<void> Function(rust_sync.MigrationStatus status)? onCurrentStatus,
   }) async {
@@ -2205,16 +2271,18 @@ class IronwoodMigrationService {
       accountUuid: context.accountUuid,
       operation: () async {
         if (!isMobile()) {
-          return operation(await _legacyCredential(context));
+          return operation(await _legacyCredential(context), context);
         }
 
         return _serializeCredentialState(context, () async {
           final initialStatus = await _getStatusForContext(context);
-          final credential = await _selectMobileCredential(
+          final selection = await _selectMobileCredential(
             context: context,
             status: initialStatus,
             mayCreateRun: mayCreateRun,
           );
+          final credential = selection.credential;
+          final submissionContext = selection.submissionContext;
           if (_usesNativeMigrationOutbox) {
             await _reconcileMigrationOutboxReceipts(context: context);
           }
@@ -2223,7 +2291,7 @@ class IronwoodMigrationService {
           Object? operationError;
           StackTrace? operationStackTrace;
           try {
-            result = await operation(credential);
+            result = await operation(credential, submissionContext);
           } catch (error, stackTrace) {
             operationError = error;
             operationStackTrace = stackTrace;
@@ -2274,7 +2342,7 @@ class IronwoodMigrationService {
               !waitingForDenominationConfirmations) {
             try {
               final outboxRefresh = await _refreshMigrationOutbox(
-                context: context,
+                context: submissionContext,
                 credential: credential,
                 prepare: prepareOutboxAfterOperation,
                 statusForStaleBatchDiscard: currentStatus,
@@ -2304,7 +2372,7 @@ class IronwoodMigrationService {
     );
   }
 
-  Future<_MigrationCredential> _selectMobileCredential({
+  Future<_MigrationCredentialSelection> _selectMobileCredential({
     required _MigrationCredentialContext context,
     required rust_sync.MigrationStatus status,
     required bool mayCreateRun,
@@ -2324,6 +2392,7 @@ class IronwoodMigrationService {
           accountUuid: context.accountUuid,
           dbPath: context.dbPath,
           lightwalletdUrl: context.lightwalletdUrl!,
+          managedSubmissionRouting: context.managedSubmissionRouting,
         );
       }
       if (manifest == null) {
@@ -2345,23 +2414,43 @@ class IronwoodMigrationService {
         accountUuid: context.accountUuid,
         expectedRunId: activeRunId,
       );
-      return _MigrationCredential(
-        password: resolvedManifest.credentialHex,
-        saltBase64: resolvedManifest.saltBase64,
+      return _MigrationCredentialSelection(
+        credential: _MigrationCredential(
+          password: resolvedManifest.credentialHex,
+          saltBase64: resolvedManifest.saltBase64,
+        ),
+        submissionContext: _contextWithSubmissionRoute(
+          context,
+          resolvedManifest.lightwalletdUrl,
+          resolvedManifest.managedSubmissionRouting,
+        ),
       );
     }
 
     await _reconcileBackgroundCredential(context: context, status: status);
-    if (!mayCreateRun) return _legacyCredential(context);
+    if (!mayCreateRun) {
+      return _MigrationCredentialSelection(
+        credential: await _legacyCredential(context),
+        submissionContext: context,
+      );
+    }
     final manifest = await backgroundCredentialStore.prepare(
       network: context.network,
       accountUuid: context.accountUuid,
       dbPath: context.dbPath,
       lightwalletdUrl: context.lightwalletdUrl!,
+      managedSubmissionRouting: context.managedSubmissionRouting,
     );
-    return _MigrationCredential(
-      password: manifest.credentialHex,
-      saltBase64: manifest.saltBase64,
+    return _MigrationCredentialSelection(
+      credential: _MigrationCredential(
+        password: manifest.credentialHex,
+        saltBase64: manifest.saltBase64,
+      ),
+      submissionContext: _contextWithSubmissionRoute(
+        context,
+        manifest.lightwalletdUrl,
+        manifest.managedSubmissionRouting,
+      ),
     );
   }
 
@@ -2385,8 +2474,11 @@ class IronwoodMigrationService {
     required _MigrationCredentialContext context,
     required rust_sync.MigrationStatus status,
   }) async {
+    final outboxContext = await _contextWithBackgroundSubmissionRouting(
+      context,
+    );
     final runId = status.activeRunId;
-    final lightwalletdUrl = context.lightwalletdUrl;
+    final lightwalletdUrl = outboxContext.lightwalletdUrl;
     if (!_usesNativeMigrationOutbox ||
         runId == null ||
         lightwalletdUrl == null) {
@@ -2399,11 +2491,12 @@ class IronwoodMigrationService {
     bool recovered;
     try {
       recovered = await recoverMigrationOutboxBatch(
-        batchId: _migrationOutboxBatchId(context, runId),
-        network: context.network,
-        accountUuid: context.accountUuid,
+        batchId: _migrationOutboxBatchId(outboxContext, runId),
+        network: outboxContext.network,
+        accountUuid: outboxContext.accountUuid,
         runId: runId,
         lightwalletdUrl: lightwalletdUrl,
+        managedSubmissionRouting: outboxContext.managedSubmissionRouting,
         expectedTxids: expectedTxids,
       );
     } catch (error) {
@@ -2524,6 +2617,7 @@ class IronwoodMigrationService {
         network: context.network,
         accountUuid: context.accountUuid,
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        managedSubmissionRouting: _managedSubmissionRoutingFor(endpoint),
       );
     } catch (_) {
       return context;
@@ -2635,24 +2729,28 @@ class IronwoodMigrationService {
     required bool prepare,
     rust_sync.MigrationStatus? statusForStaleBatchDiscard,
   }) async {
-    final lightwalletdUrl = context.lightwalletdUrl;
+    final outboxContext = await _contextWithBackgroundSubmissionRouting(
+      context,
+    );
+    final lightwalletdUrl = outboxContext.lightwalletdUrl;
     if (lightwalletdUrl == null) {
       return const _MigrationOutboxRefreshResult();
     }
 
     if (prepare) {
       await prepareMigrationOutbox(
-        dbPath: context.dbPath,
+        dbPath: outboxContext.dbPath,
         lightwalletdUrl: lightwalletdUrl,
-        network: context.network,
-        accountUuid: context.accountUuid,
+        managedSubmissionRouting: outboxContext.managedSubmissionRouting,
+        network: outboxContext.network,
+        accountUuid: outboxContext.accountUuid,
         password: credential.password,
         saltBase64: credential.saltBase64,
       );
     }
 
     final batch = await _stagePersistedMigrationOutbox(
-      context: context,
+      context: outboxContext,
       credential: credential,
       statusForStaleBatchDiscard: statusForStaleBatchDiscard,
     );
@@ -2670,6 +2768,41 @@ class IronwoodMigrationService {
     return _MigrationOutboxRefreshResult(
       staged: true,
       reconciledReceipt: reconciledTxids.isNotEmpty,
+    );
+  }
+
+  Future<_MigrationCredentialContext> _contextWithBackgroundSubmissionRouting(
+    _MigrationCredentialContext context,
+  ) async {
+    final manifest = await backgroundCredentialStore.read(
+      network: context.network,
+      accountUuid: context.accountUuid,
+    );
+    if (manifest == null) return context;
+
+    final resolvedManifest = await _resolveManifestContext(manifest, context);
+    return _contextWithSubmissionRoute(
+      context,
+      resolvedManifest.lightwalletdUrl,
+      resolvedManifest.managedSubmissionRouting,
+    );
+  }
+
+  _MigrationCredentialContext _contextWithSubmissionRoute(
+    _MigrationCredentialContext context,
+    String lightwalletdUrl,
+    bool managedSubmissionRouting,
+  ) {
+    if (context.lightwalletdUrl == lightwalletdUrl &&
+        context.managedSubmissionRouting == managedSubmissionRouting) {
+      return context;
+    }
+    return _MigrationCredentialContext(
+      dbPath: context.dbPath,
+      network: context.network,
+      accountUuid: context.accountUuid,
+      lightwalletdUrl: lightwalletdUrl,
+      managedSubmissionRouting: managedSubmissionRouting,
     );
   }
 
@@ -2721,6 +2854,7 @@ class IronwoodMigrationService {
       'accountUuid': context.accountUuid,
       'runId': batch.runId,
       'lightwalletdUrl': lightwalletdUrl,
+      'managedSubmissionRouting': context.managedSubmissionRouting,
       'timingMeanBlocks': batch.timingMeanBlocks,
       'timingMaxBlocks': batch.timingMaxBlocks,
       'createdAtMs': DateTime.now().millisecondsSinceEpoch,
@@ -2996,6 +3130,10 @@ RpcEndpointConfig _missingEndpoint() {
   throw StateError('Ironwood migration endpoint getter is not configured.');
 }
 
+bool _managedSubmissionRoutingFor(RpcEndpointConfig endpoint) =>
+    transactionSubmissionRoutingFor(endpoint) ==
+    TransactionSubmissionRouting.managedProviders;
+
 String _missingSessionPassword() {
   throw StateError('Ironwood migration password getter is not configured.');
 }
@@ -3134,6 +3272,7 @@ Future<bool> _defaultRecoverMigrationOutboxBatch({
   required String accountUuid,
   required String runId,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required List<String> expectedTxids,
 }) async {
   return await _backgroundMigrationChannel
@@ -3143,6 +3282,7 @@ Future<bool> _defaultRecoverMigrationOutboxBatch({
             'accountUuid': accountUuid,
             'runId': runId,
             'lightwalletdUrl': lightwalletdUrl,
+            'managedSubmissionRouting': managedSubmissionRouting,
             'expectedTxids': expectedTxids,
           }) ??
       false;
@@ -3247,12 +3387,14 @@ class _MigrationCredentialContext {
     required this.network,
     required this.accountUuid,
     this.lightwalletdUrl,
+    this.managedSubmissionRouting = false,
   });
 
   final String dbPath;
   final String network;
   final String accountUuid;
   final String? lightwalletdUrl;
+  final bool managedSubmissionRouting;
 }
 
 String? _fileName(String path) {
@@ -3270,6 +3412,16 @@ class _MigrationCredential {
 
   final String password;
   final String saltBase64;
+}
+
+class _MigrationCredentialSelection {
+  const _MigrationCredentialSelection({
+    required this.credential,
+    required this.submissionContext,
+  });
+
+  final _MigrationCredential credential;
+  final _MigrationCredentialContext submissionContext;
 }
 
 class _MigrationOutboxRefreshResult {

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -3131,8 +3131,7 @@ RpcEndpointConfig _missingEndpoint() {
 }
 
 bool _managedSubmissionRoutingFor(RpcEndpointConfig endpoint) =>
-    transactionSubmissionRoutingFor(endpoint) ==
-    TransactionSubmissionRouting.managedProviders;
+    endpoint.usesManagedSubmissionRouting;
 
 String _missingSessionPassword() {
   throw StateError('Ironwood migration password getter is not configured.');

--- a/lib/src/features/send/services/send_flow.dart
+++ b/lib/src/features/send/services/send_flow.dart
@@ -13,7 +13,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
-import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
@@ -405,9 +404,7 @@ Future<SendBroadcastOutcome> runSendBroadcast({
   try {
     final dbPath = await getWalletDbPath();
     final endpoint = ref.read(rpcEndpointFailoverProvider).current;
-    final managedSubmissionRouting =
-        transactionSubmissionRoutingFor(endpoint) ==
-        TransactionSubmissionRouting.managedProviders;
+    final managedSubmissionRouting = endpoint.usesManagedSubmissionRouting;
     var saplingParams = await loadSaplingParamsStatus();
 
     if (args.needsSaplingParams) {

--- a/lib/src/features/send/services/send_flow.dart
+++ b/lib/src/features/send/services/send_flow.dart
@@ -13,6 +13,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
@@ -404,6 +405,9 @@ Future<SendBroadcastOutcome> runSendBroadcast({
   try {
     final dbPath = await getWalletDbPath();
     final endpoint = ref.read(rpcEndpointFailoverProvider).current;
+    final managedSubmissionRouting =
+        transactionSubmissionRoutingFor(endpoint) ==
+        TransactionSubmissionRouting.managedProviders;
     var saplingParams = await loadSaplingParamsStatus();
 
     if (args.needsSaplingParams) {
@@ -459,6 +463,7 @@ Future<SendBroadcastOutcome> runSendBroadcast({
           dbPath: dbPath,
           lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
           network: endpoint.networkName,
+          managedSubmissionRouting: managedSubmissionRouting,
           pcztWithProofsBytes: keystone.pcztWithProofsBytes,
           pcztWithSignaturesBytes: keystone.pcztWithSignaturesBytes,
           spendParamsPath: args.needsSaplingParams
@@ -510,6 +515,7 @@ Future<SendBroadcastOutcome> runSendBroadcast({
           proposalId: args.proposalId,
           sendFlowId: args.sendFlowId,
           password: password,
+          managedSubmissionRouting: managedSubmissionRouting,
           spendParamsPath: args.needsSaplingParams
               ? saplingParams.spendPath
               : null,
@@ -538,6 +544,7 @@ Future<SendBroadcastOutcome> runSendBroadcast({
             proposalId: args.proposalId,
             sendFlowId: args.sendFlowId,
             mnemonicBytes: mnemonicBytes,
+            managedSubmissionRouting: managedSubmissionRouting,
             spendParamsPath: args.needsSaplingParams
                 ? saplingParams.spendPath
                 : null,

--- a/lib/src/features/swap/providers/swap_deposit_sender.dart
+++ b/lib/src/features/swap/providers/swap_deposit_sender.dart
@@ -3,7 +3,6 @@ import 'dart:io' show Platform;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
-import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
@@ -110,9 +109,7 @@ class RustSwapDepositSender implements SwapDepositSender {
       final proposal = proposalContext.proposal;
       final dbPath = proposalContext.dbPath;
       final endpoint = proposalContext.endpoint;
-      final managedSubmissionRouting =
-          transactionSubmissionRoutingFor(endpoint) ==
-          TransactionSubmissionRouting.managedProviders;
+      final managedSubmissionRouting = endpoint.usesManagedSubmissionRouting;
       proposalId = proposal.proposalId;
       log(
         'SwapDepositSender: proposal ready flow=$sendFlowId '

--- a/lib/src/features/swap/providers/swap_deposit_sender.dart
+++ b/lib/src/features/swap/providers/swap_deposit_sender.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Platform;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
@@ -109,6 +110,9 @@ class RustSwapDepositSender implements SwapDepositSender {
       final proposal = proposalContext.proposal;
       final dbPath = proposalContext.dbPath;
       final endpoint = proposalContext.endpoint;
+      final managedSubmissionRouting =
+          transactionSubmissionRoutingFor(endpoint) ==
+          TransactionSubmissionRouting.managedProviders;
       proposalId = proposal.proposalId;
       log(
         'SwapDepositSender: proposal ready flow=$sendFlowId '
@@ -138,6 +142,7 @@ class RustSwapDepositSender implements SwapDepositSender {
           proposalId: proposal.proposalId,
           sendFlowId: sendFlowId,
           password: password,
+          managedSubmissionRouting: managedSubmissionRouting,
         );
       } else {
         final mnemonicBytes = await _ref
@@ -155,6 +160,7 @@ class RustSwapDepositSender implements SwapDepositSender {
             proposalId: proposal.proposalId,
             sendFlowId: sendFlowId,
             mnemonicBytes: mnemonicBytes,
+            managedSubmissionRouting: managedSubmissionRouting,
           );
         } finally {
           mnemonicBytes.fillRange(0, mnemonicBytes.length, 0);

--- a/lib/src/features/swap/providers/swap_hardware_signing_service.dart
+++ b/lib/src/features/swap/providers/swap_hardware_signing_service.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
-import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
@@ -240,9 +239,7 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
     try {
       final dbPath = await getWalletDbPath();
       final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
-      final managedSubmissionRouting =
-          transactionSubmissionRoutingFor(endpoint) ==
-          TransactionSubmissionRouting.managedProviders;
+      final managedSubmissionRouting = endpoint.usesManagedSubmissionRouting;
       result = await rust_sync.extractAndBroadcastPczt(
         dbPath: dbPath,
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,

--- a/lib/src/features/swap/providers/swap_hardware_signing_service.dart
+++ b/lib/src/features/swap/providers/swap_hardware_signing_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
@@ -239,10 +240,14 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
     try {
       final dbPath = await getWalletDbPath();
       final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+      final managedSubmissionRouting =
+          transactionSubmissionRoutingFor(endpoint) ==
+          TransactionSubmissionRouting.managedProviders;
       result = await rust_sync.extractAndBroadcastPczt(
         dbPath: dbPath,
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
         network: endpoint.networkName,
+        managedSubmissionRouting: managedSubmissionRouting,
         pcztWithProofsBytes: pcztWithProofsBytes,
         pcztWithSignaturesBytes: pcztWithSignaturesBytes,
         spendParamsPath: spendParamsPath,

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -1115,8 +1115,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
           final endpoint = _endpointConfig;
           final managedSubmissionRouting =
-              transactionSubmissionRoutingFor(endpoint) ==
-              TransactionSubmissionRouting.managedProviders;
+              endpoint.usesManagedSubmissionRouting;
           log('Sync: starting foreground sync via ${endpoint.hostPort}');
           // Fire up the mempool observer alongside the scan loop.
           // It has its own Rust cancel flag (MEMPOOL_CANCEL) and runs

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -1114,6 +1114,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
           }
 
           final endpoint = _endpointConfig;
+          final managedSubmissionRouting =
+              transactionSubmissionRoutingFor(endpoint) ==
+              TransactionSubmissionRouting.managedProviders;
           log('Sync: starting foreground sync via ${endpoint.hostPort}');
           // Fire up the mempool observer alongside the scan loop.
           // It has its own Rust cancel flag (MEMPOOL_CANCEL) and runs
@@ -1125,6 +1128,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
             lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
             network: endpoint.networkName,
             mode: 1,
+            managedSubmissionRouting: managedSubmissionRouting,
           );
           _syncSub = stream.listen(
             (event) {

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -7,7 +7,7 @@ import '../frb_generated.dart';
 import 'keystone.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `catch`, `fetch_block_time`, `migration_status_from_balance`, `parse_network_and_migrate`, `run_full_sync_internal`, `submission_mode`, `to_wallet_migration_schedule`, `to_wallet_signed_messages`
+// These functions are ignored because they are not marked as `pub`: `catch`, `fetch_block_time`, `migration_status_from_balance`, `parse_network_and_migrate`, `run_full_sync_internal`, `to_wallet_migration_schedule`, `to_wallet_signed_messages`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `MempoolObserverState`
 
 /// Set the desired sync mode. 0=none, 1=foreground, 2=background.

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -7,7 +7,7 @@ import '../frb_generated.dart';
 import 'keystone.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `catch`, `fetch_block_time`, `migration_status_from_balance`, `parse_network_and_migrate`, `run_full_sync_internal`, `to_wallet_migration_schedule`, `to_wallet_signed_messages`
+// These functions are ignored because they are not marked as `pub`: `catch`, `fetch_block_time`, `migration_status_from_balance`, `parse_network_and_migrate`, `run_full_sync_internal`, `submission_mode`, `to_wallet_migration_schedule`, `to_wallet_signed_messages`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `MempoolObserverState`
 
 /// Set the desired sync mode. 0=none, 1=foreground, 2=background.
@@ -23,11 +23,13 @@ int getSyncMode() => RustLib.instance.api.crateApiSyncGetSyncMode();
 Stream<ApiSyncProgressEvent> startFullSync({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required int mode,
 }) => RustLib.instance.api.crateApiSyncStartFullSync(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   mode: mode,
 );
@@ -39,11 +41,13 @@ Stream<ApiSyncProgressEvent> startFullSync({
 Future<void> runFullSyncBlocking({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required int mode,
 }) => RustLib.instance.api.crateApiSyncRunFullSyncBlocking(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   mode: mode,
 );
@@ -263,6 +267,7 @@ Future<SendMaxEstimateResult> estimateSendMax({
 Future<ExecuteProposalResult> executeProposal({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required BigInt proposalId,
   required String sendFlowId,
   required List<int> mnemonicBytes,
@@ -271,6 +276,7 @@ Future<ExecuteProposalResult> executeProposal({
 }) => RustLib.instance.api.crateApiSyncExecuteProposal(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   proposalId: proposalId,
   sendFlowId: sendFlowId,
   mnemonicBytes: mnemonicBytes,
@@ -284,6 +290,7 @@ Future<ExecuteProposalResult> executeProposal({
 Future<ExecuteProposalResult> executeProposalWithMacosStoredMnemonic({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required BigInt proposalId,
   required String sendFlowId,
   required String password,
@@ -292,6 +299,7 @@ Future<ExecuteProposalResult> executeProposalWithMacosStoredMnemonic({
 }) => RustLib.instance.api.crateApiSyncExecuteProposalWithMacosStoredMnemonic(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   proposalId: proposalId,
   sendFlowId: sendFlowId,
   password: password,
@@ -302,6 +310,7 @@ Future<ExecuteProposalResult> executeProposalWithMacosStoredMnemonic({
 Future<IronwoodMigrationResult> migrateOrchardToIronwood({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required List<int> mnemonicBytes,
@@ -312,6 +321,7 @@ Future<IronwoodMigrationResult> migrateOrchardToIronwood({
 }) => RustLib.instance.api.crateApiSyncMigrateOrchardToIronwood(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   accountUuid: accountUuid,
   mnemonicBytes: mnemonicBytes,
@@ -326,6 +336,7 @@ Future<IronwoodMigrationResult> migrateOrchardToIronwood({
 Future<IronwoodMigrationResult> migrateOrchardToIronwoodImmediately({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required List<int> mnemonicBytes,
@@ -336,6 +347,7 @@ Future<IronwoodMigrationResult> migrateOrchardToIronwoodImmediately({
 }) => RustLib.instance.api.crateApiSyncMigrateOrchardToIronwoodImmediately(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   accountUuid: accountUuid,
   mnemonicBytes: mnemonicBytes,
@@ -366,6 +378,7 @@ Future<KeystoneMigrationSigningRequest> prepareOrchardMigrationImmediatePczt({
 Future<IronwoodMigrationResult> completeOrchardMigrationImmediatePczt({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required String requestId,
@@ -373,6 +386,7 @@ Future<IronwoodMigrationResult> completeOrchardMigrationImmediatePczt({
 }) => RustLib.instance.api.crateApiSyncCompleteOrchardMigrationImmediatePczt(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   accountUuid: accountUuid,
   requestId: requestId,
@@ -473,6 +487,7 @@ Future<OrchardMigrationPrivatePlan?> getOrchardMigrationPrivatePlan({
 Future<IronwoodMigrationResult> prepareOrchardMigrationOutbox({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required String password,
@@ -480,6 +495,7 @@ Future<IronwoodMigrationResult> prepareOrchardMigrationOutbox({
 }) => RustLib.instance.api.crateApiSyncPrepareOrchardMigrationOutbox(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   accountUuid: accountUuid,
   password: password,
@@ -527,6 +543,7 @@ Future<void> reconcileOrchardMigrationOutboxReceipt({
 Future<IronwoodMigrationResult> broadcastDueOrchardMigrationTransactions({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required String password,
@@ -534,6 +551,7 @@ Future<IronwoodMigrationResult> broadcastDueOrchardMigrationTransactions({
 }) => RustLib.instance.api.crateApiSyncBroadcastDueOrchardMigrationTransactions(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   accountUuid: accountUuid,
   password: password,
@@ -543,6 +561,7 @@ Future<IronwoodMigrationResult> broadcastDueOrchardMigrationTransactions({
 Future<IronwoodMigrationResult> broadcastOneDueOrchardMigrationTransaction({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required String password,
@@ -551,6 +570,7 @@ Future<IronwoodMigrationResult> broadcastOneDueOrchardMigrationTransaction({
     RustLib.instance.api.crateApiSyncBroadcastOneDueOrchardMigrationTransaction(
       dbPath: dbPath,
       lightwalletdUrl: lightwalletdUrl,
+      managedSubmissionRouting: managedSubmissionRouting,
       network: network,
       accountUuid: accountUuid,
       password: password,
@@ -591,6 +611,7 @@ Future<String> createOrResumePrivateMigrationDraft({
 Future<IronwoodMigrationResult> completeOrchardMigrationDenominationsPczt({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required String requestId,
@@ -602,6 +623,7 @@ Future<IronwoodMigrationResult> completeOrchardMigrationDenominationsPczt({
     RustLib.instance.api.crateApiSyncCompleteOrchardMigrationDenominationsPczt(
       dbPath: dbPath,
       lightwalletdUrl: lightwalletdUrl,
+      managedSubmissionRouting: managedSubmissionRouting,
       network: network,
       accountUuid: accountUuid,
       requestId: requestId,
@@ -632,6 +654,7 @@ Future<KeystoneMigrationSigningRequest> prepareOrchardMigrationSingleQrPczt({
 Future<IronwoodMigrationResult> completeOrchardMigrationSingleQrPczt({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required String requestId,
@@ -641,6 +664,7 @@ Future<IronwoodMigrationResult> completeOrchardMigrationSingleQrPczt({
 }) => RustLib.instance.api.crateApiSyncCompleteOrchardMigrationSingleQrPczt(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   accountUuid: accountUuid,
   requestId: requestId,
@@ -695,6 +719,7 @@ Future<IronwoodMigrationResult>
 migrateOrchardToIronwoodWithMacosStoredMnemonic({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required String password,
@@ -705,6 +730,7 @@ migrateOrchardToIronwoodWithMacosStoredMnemonic({
     .crateApiSyncMigrateOrchardToIronwoodWithMacosStoredMnemonic(
       dbPath: dbPath,
       lightwalletdUrl: lightwalletdUrl,
+      managedSubmissionRouting: managedSubmissionRouting,
       network: network,
       accountUuid: accountUuid,
       password: password,
@@ -742,12 +768,14 @@ Future<ShieldTransparentPcztResult> createShieldTransparentPczt({
 Future<ShieldTransparentResult> shieldTransparentBalance({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required List<int> mnemonicBytes,
 }) => RustLib.instance.api.crateApiSyncShieldTransparentBalance(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   accountUuid: accountUuid,
   mnemonicBytes: mnemonicBytes,
@@ -760,6 +788,7 @@ Future<ShieldTransparentResult>
 shieldTransparentBalanceWithMacosStoredMnemonic({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required String accountUuid,
   required String password,
@@ -767,6 +796,7 @@ shieldTransparentBalanceWithMacosStoredMnemonic({
     .crateApiSyncShieldTransparentBalanceWithMacosStoredMnemonic(
       dbPath: dbPath,
       lightwalletdUrl: lightwalletdUrl,
+      managedSubmissionRouting: managedSubmissionRouting,
       network: network,
       accountUuid: accountUuid,
       password: password,
@@ -953,6 +983,7 @@ Future<Uint8List> redactPcztForSigner({required List<int> pcztBytes}) =>
 Future<ExtractAndBroadcastPcztResult> extractAndBroadcastPczt({
   required String dbPath,
   required String lightwalletdUrl,
+  required bool managedSubmissionRouting,
   required String network,
   required List<int> pcztWithProofsBytes,
   required List<int> pcztWithSignaturesBytes,
@@ -961,6 +992,7 @@ Future<ExtractAndBroadcastPcztResult> extractAndBroadcastPczt({
 }) => RustLib.instance.api.crateApiSyncExtractAndBroadcastPczt(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
+  managedSubmissionRouting: managedSubmissionRouting,
   network: network,
   pcztWithProofsBytes: pcztWithProofsBytes,
   pcztWithSignaturesBytes: pcztWithSignaturesBytes,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -128,6 +128,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncBroadcastDueOrchardMigrationTransactions({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String password,
@@ -138,6 +139,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncBroadcastOneDueOrchardMigrationTransaction({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String password,
@@ -207,6 +209,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncCompleteOrchardMigrationDenominationsPczt({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String requestId,
@@ -220,6 +223,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncCompleteOrchardMigrationImmediatePczt({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String requestId,
@@ -230,6 +234,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncCompleteOrchardMigrationSingleQrPczt({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String requestId,
@@ -437,6 +442,7 @@ abstract class RustLibApi extends BaseApi {
   Future<ExecuteProposalResult> crateApiSyncExecuteProposal({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required BigInt proposalId,
     required String sendFlowId,
     required List<int> mnemonicBytes,
@@ -448,6 +454,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncExecuteProposalWithMacosStoredMnemonic({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required BigInt proposalId,
     required String sendFlowId,
     required String password,
@@ -466,6 +473,7 @@ abstract class RustLibApi extends BaseApi {
   Future<ExtractAndBroadcastPcztResult> crateApiSyncExtractAndBroadcastPczt({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required List<int> pcztWithProofsBytes,
     required List<int> pcztWithSignaturesBytes,
@@ -758,6 +766,7 @@ abstract class RustLibApi extends BaseApi {
   Future<IronwoodMigrationResult> crateApiSyncMigrateOrchardToIronwood({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required List<int> mnemonicBytes,
@@ -771,6 +780,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncMigrateOrchardToIronwoodImmediately({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required List<int> mnemonicBytes,
@@ -784,6 +794,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncMigrateOrchardToIronwoodWithMacosStoredMnemonic({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String password,
@@ -855,6 +866,7 @@ abstract class RustLibApi extends BaseApi {
   Future<IronwoodMigrationResult> crateApiSyncPrepareOrchardMigrationOutbox({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String password,
@@ -991,6 +1003,7 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiSyncRunFullSyncBlocking({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required int mode,
   });
@@ -1042,6 +1055,7 @@ abstract class RustLibApi extends BaseApi {
   Future<ShieldTransparentResult> crateApiSyncShieldTransparentBalance({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required List<int> mnemonicBytes,
@@ -1051,6 +1065,7 @@ abstract class RustLibApi extends BaseApi {
   crateApiSyncShieldTransparentBalanceWithMacosStoredMnemonic({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String password,
@@ -1059,6 +1074,7 @@ abstract class RustLibApi extends BaseApi {
   Stream<ApiSyncProgressEvent> crateApiSyncStartFullSync({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required int mode,
   });
@@ -1361,6 +1377,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncBroadcastDueOrchardMigrationTransactions({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String password,
@@ -1372,6 +1389,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(password, serializer);
@@ -1392,6 +1410,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           network,
           accountUuid,
           password,
@@ -1409,6 +1428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "accountUuid",
           "password",
@@ -1421,6 +1441,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncBroadcastOneDueOrchardMigrationTransaction({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String password,
@@ -1432,6 +1453,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(password, serializer);
@@ -1452,6 +1474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           network,
           accountUuid,
           password,
@@ -1469,6 +1492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "accountUuid",
           "password",
@@ -1884,6 +1908,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncCompleteOrchardMigrationDenominationsPczt({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String requestId,
@@ -1898,6 +1923,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(requestId, serializer);
@@ -1927,6 +1953,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           network,
           accountUuid,
           requestId,
@@ -1947,6 +1974,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "accountUuid",
           "requestId",
@@ -1962,6 +1990,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncCompleteOrchardMigrationImmediatePczt({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String requestId,
@@ -1973,6 +2002,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(requestId, serializer);
@@ -1995,6 +2025,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           network,
           accountUuid,
           requestId,
@@ -2012,6 +2043,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "accountUuid",
           "requestId",
@@ -2024,6 +2056,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncCompleteOrchardMigrationSingleQrPczt({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String requestId,
@@ -2037,6 +2070,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(requestId, serializer);
@@ -2061,6 +2095,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           network,
           accountUuid,
           requestId,
@@ -2080,6 +2115,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "accountUuid",
           "requestId",
@@ -3454,6 +3490,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<ExecuteProposalResult> crateApiSyncExecuteProposal({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required BigInt proposalId,
     required String sendFlowId,
     required List<int> mnemonicBytes,
@@ -3466,6 +3503,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_u_64(proposalId, serializer);
           sse_encode_String(sendFlowId, serializer);
           sse_encode_list_prim_u_8_loose(mnemonicBytes, serializer);
@@ -3486,6 +3524,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           proposalId,
           sendFlowId,
           mnemonicBytes,
@@ -3503,6 +3542,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "proposalId",
           "sendFlowId",
           "mnemonicBytes",
@@ -3516,6 +3556,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncExecuteProposalWithMacosStoredMnemonic({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required BigInt proposalId,
     required String sendFlowId,
     required String password,
@@ -3528,6 +3569,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_u_64(proposalId, serializer);
           sse_encode_String(sendFlowId, serializer);
           sse_encode_String(password, serializer);
@@ -3548,6 +3590,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           proposalId,
           sendFlowId,
           password,
@@ -3566,6 +3609,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "proposalId",
           "sendFlowId",
           "password",
@@ -3625,6 +3669,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<ExtractAndBroadcastPcztResult> crateApiSyncExtractAndBroadcastPczt({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required List<int> pcztWithProofsBytes,
     required List<int> pcztWithSignaturesBytes,
@@ -3637,6 +3682,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_list_prim_u_8_loose(pcztWithProofsBytes, serializer);
           sse_encode_list_prim_u_8_loose(pcztWithSignaturesBytes, serializer);
@@ -3657,6 +3703,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           network,
           pcztWithProofsBytes,
           pcztWithSignaturesBytes,
@@ -3674,6 +3721,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "pcztWithProofsBytes",
           "pcztWithSignaturesBytes",
@@ -5514,6 +5562,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<IronwoodMigrationResult> crateApiSyncMigrateOrchardToIronwood({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required List<int> mnemonicBytes,
@@ -5528,6 +5577,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_list_prim_u_8_loose(mnemonicBytes, serializer);
@@ -5553,6 +5603,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           network,
           accountUuid,
           mnemonicBytes,
@@ -5572,6 +5623,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "accountUuid",
           "mnemonicBytes",
@@ -5587,6 +5639,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncMigrateOrchardToIronwoodImmediately({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required List<int> mnemonicBytes,
@@ -5601,6 +5654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_list_prim_u_8_loose(mnemonicBytes, serializer);
@@ -5623,6 +5677,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           network,
           accountUuid,
           mnemonicBytes,
@@ -5642,6 +5697,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "accountUuid",
           "mnemonicBytes",
@@ -5657,6 +5713,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncMigrateOrchardToIronwoodWithMacosStoredMnemonic({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String password,
@@ -5670,6 +5727,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(password, serializer);
@@ -5695,6 +5753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           network,
           accountUuid,
           password,
@@ -5714,6 +5773,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "accountUuid",
           "password",
@@ -6113,6 +6173,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<IronwoodMigrationResult> crateApiSyncPrepareOrchardMigrationOutbox({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String password,
@@ -6124,6 +6185,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(password, serializer);
@@ -6143,6 +6205,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           network,
           accountUuid,
           password,
@@ -6159,6 +6222,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "accountUuid",
           "password",
@@ -6986,6 +7050,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<void> crateApiSyncRunFullSyncBlocking({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required int mode,
   }) {
@@ -6995,6 +7060,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_u_8(mode, serializer);
           pdeCallFfi(
@@ -7009,7 +7075,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncRunFullSyncBlockingConstMeta,
-        argValues: [dbPath, lightwalletdUrl, network, mode],
+        argValues: [
+          dbPath,
+          lightwalletdUrl,
+          managedSubmissionRouting,
+          network,
+          mode,
+        ],
         apiImpl: this,
       ),
     );
@@ -7018,7 +7090,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiSyncRunFullSyncBlockingConstMeta =>
       const TaskConstMeta(
         debugName: "run_full_sync_blocking",
-        argNames: ["dbPath", "lightwalletdUrl", "network", "mode"],
+        argNames: [
+          "dbPath",
+          "lightwalletdUrl",
+          "managedSubmissionRouting",
+          "network",
+          "mode",
+        ],
       );
 
   @override
@@ -7305,6 +7383,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<ShieldTransparentResult> crateApiSyncShieldTransparentBalance({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required List<int> mnemonicBytes,
@@ -7315,6 +7394,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_list_prim_u_8_loose(mnemonicBytes, serializer);
@@ -7333,6 +7413,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           dbPath,
           lightwalletdUrl,
+          managedSubmissionRouting,
           network,
           accountUuid,
           mnemonicBytes,
@@ -7348,6 +7429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "accountUuid",
           "mnemonicBytes",
@@ -7359,6 +7441,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   crateApiSyncShieldTransparentBalanceWithMacosStoredMnemonic({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required String accountUuid,
     required String password,
@@ -7369,6 +7452,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(managedSubmissionRouting, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(password, serializer);
@@ -7385,7 +7469,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         ),
         constMeta:
             kCrateApiSyncShieldTransparentBalanceWithMacosStoredMnemonicConstMeta,
-        argValues: [dbPath, lightwalletdUrl, network, accountUuid, password],
+        argValues: [
+          dbPath,
+          lightwalletdUrl,
+          managedSubmissionRouting,
+          network,
+          accountUuid,
+          password,
+        ],
         apiImpl: this,
       ),
     );
@@ -7398,6 +7489,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "dbPath",
           "lightwalletdUrl",
+          "managedSubmissionRouting",
           "network",
           "accountUuid",
           "password",
@@ -7408,6 +7500,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Stream<ApiSyncProgressEvent> crateApiSyncStartFullSync({
     required String dbPath,
     required String lightwalletdUrl,
+    required bool managedSubmissionRouting,
     required String network,
     required int mode,
   }) {
@@ -7419,6 +7512,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_String(dbPath, serializer);
             sse_encode_String(lightwalletdUrl, serializer);
+            sse_encode_bool(managedSubmissionRouting, serializer);
             sse_encode_String(network, serializer);
             sse_encode_u_8(mode, serializer);
             sse_encode_StreamSink_api_sync_progress_event_Sse(sink, serializer);
@@ -7434,7 +7528,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             decodeErrorData: sse_decode_String,
           ),
           constMeta: kCrateApiSyncStartFullSyncConstMeta,
-          argValues: [dbPath, lightwalletdUrl, network, mode, sink],
+          argValues: [
+            dbPath,
+            lightwalletdUrl,
+            managedSubmissionRouting,
+            network,
+            mode,
+            sink,
+          ],
           apiImpl: this,
         ),
       ),
@@ -7444,7 +7545,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiSyncStartFullSyncConstMeta => const TaskConstMeta(
     debugName: "start_full_sync",
-    argNames: ["dbPath", "lightwalletdUrl", "network", "mode", "sink"],
+    argNames: [
+      "dbPath",
+      "lightwalletdUrl",
+      "managedSubmissionRouting",
+      "network",
+      "mode",
+      "sink",
+    ],
   );
 
   @override

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -44,9 +44,20 @@ pub struct ApiSyncProgressEvent {
     pub phase: String,
 }
 
+fn submission_mode(managed_submission_routing: bool) -> wallet_sync::SubmissionMode {
+    // Dart may enable this only for an explicit managed mainnet preset; URL
+    // matching cannot distinguish a custom endpoint that reuses a built-in URL.
+    if managed_submission_routing {
+        wallet_sync::SubmissionMode::ProviderAware
+    } else {
+        wallet_sync::SubmissionMode::CurrentOnly
+    }
+}
+
 fn run_full_sync_internal<F>(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     mode: u8,
     on_progress: F,
@@ -73,6 +84,7 @@ where
             sync_engine::run_sync_inner(
                 &db_path,
                 &lightwalletd_url,
+                submission_mode(managed_submission_routing),
                 network,
                 cancel,
                 mode,
@@ -93,31 +105,39 @@ where
 pub fn start_full_sync(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     mode: u8,
     sink: StreamSink<ApiSyncProgressEvent>,
 ) -> Result<(), String> {
-    let result = run_full_sync_internal(db_path, lightwalletd_url, network, mode, |progress| {
-        if sink
-            .add(ApiSyncProgressEvent {
-                scanned_height: progress.scanned_height,
-                chain_tip_height: progress.chain_tip_height,
-                percentage: progress.percentage,
-                display_target_percentage: progress.display_target_percentage,
-                display_target_blocks: progress.display_target_blocks,
-                is_syncing: progress.is_syncing,
-                is_complete: progress.is_complete,
-                has_new_tx: progress.has_new_tx,
-                phase: progress.phase.clone(),
-            })
-            .is_err()
-        {
-            log::warn!(
-                "[{}] sync: StreamSink closed, progress not delivered",
-                sync_engine::elapsed(),
-            );
-        }
-    });
+    let result = run_full_sync_internal(
+        db_path,
+        lightwalletd_url,
+        managed_submission_routing,
+        network,
+        mode,
+        |progress| {
+            if sink
+                .add(ApiSyncProgressEvent {
+                    scanned_height: progress.scanned_height,
+                    chain_tip_height: progress.chain_tip_height,
+                    percentage: progress.percentage,
+                    display_target_percentage: progress.display_target_percentage,
+                    display_target_blocks: progress.display_target_blocks,
+                    is_syncing: progress.is_syncing,
+                    is_complete: progress.is_complete,
+                    has_new_tx: progress.has_new_tx,
+                    phase: progress.phase.clone(),
+                })
+                .is_err()
+            {
+                log::warn!(
+                    "[{}] sync: StreamSink closed, progress not delivered",
+                    sync_engine::elapsed(),
+                );
+            }
+        },
+    );
 
     // Generated Dart exposes the sink stream, while the FRB task future is
     // detached. Forward terminal errors through the stream it actually reads.
@@ -140,10 +160,18 @@ pub fn start_full_sync(
 pub fn run_full_sync_blocking(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     mode: u8,
 ) -> Result<(), String> {
-    run_full_sync_internal(db_path, lightwalletd_url, network, mode, |_| {})
+    run_full_sync_internal(
+        db_path,
+        lightwalletd_url,
+        managed_submission_routing,
+        network,
+        mode,
+        |_| {},
+    )
 }
 
 /// Cancel a running full sync.
@@ -1039,6 +1067,7 @@ pub fn estimate_send_max(
 pub fn execute_proposal(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     proposal_id: u64,
     send_flow_id: String,
     mnemonic_bytes: Vec<u8>,
@@ -1054,6 +1083,7 @@ pub fn execute_proposal(
         let r = rt.block_on(wallet_sync::execute_proposal(
             &db_path,
             &lightwalletd_url,
+            submission_mode(managed_submission_routing),
             proposal_id,
             &send_flow_id,
             seed,
@@ -1076,6 +1106,7 @@ pub fn execute_proposal(
 pub fn execute_proposal_with_macos_stored_mnemonic(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     proposal_id: u64,
     send_flow_id: String,
     password: String,
@@ -1088,6 +1119,7 @@ pub fn execute_proposal_with_macos_stored_mnemonic(
         let r = rt.block_on(wallet_sync::execute_proposal_with_seed_loader(
             &db_path,
             &lightwalletd_url,
+            submission_mode(managed_submission_routing),
             proposal_id,
             &send_flow_id,
             move |network, account_id| {
@@ -1113,6 +1145,7 @@ pub fn execute_proposal_with_macos_stored_mnemonic(
 pub fn migrate_orchard_to_ironwood(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     account_uuid: String,
     mnemonic_bytes: Vec<u8>,
@@ -1132,6 +1165,7 @@ pub fn migrate_orchard_to_ironwood(
         let r = rt.block_on(wallet_sync::migrate_orchard_to_ironwood(
             &db_path,
             &lightwalletd_url,
+            submission_mode(managed_submission_routing),
             network,
             &account_uuid,
             seed,
@@ -1159,6 +1193,7 @@ pub fn migrate_orchard_to_ironwood(
 pub fn migrate_orchard_to_ironwood_immediately(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     account_uuid: String,
     mnemonic_bytes: Vec<u8>,
@@ -1176,6 +1211,7 @@ pub fn migrate_orchard_to_ironwood_immediately(
         let r = rt.block_on(wallet_sync::migrate_orchard_to_ironwood_immediately(
             &db_path,
             &lightwalletd_url,
+            submission_mode(managed_submission_routing),
             network,
             &account_uuid,
             seed,
@@ -1239,6 +1275,7 @@ pub fn prepare_orchard_migration_immediate_pczt(
 pub async fn complete_orchard_migration_immediate_pczt(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     account_uuid: String,
     request_id: String,
@@ -1248,6 +1285,7 @@ pub async fn complete_orchard_migration_immediate_pczt(
     let r = wallet_sync::complete_orchard_migration_immediate_pczt(
         &db_path,
         &lightwalletd_url,
+        submission_mode(managed_submission_routing),
         network,
         &account_uuid,
         &request_id,
@@ -1595,6 +1633,7 @@ pub fn get_orchard_migration_private_plan(
 pub fn prepare_orchard_migration_outbox(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     account_uuid: String,
     password: String,
@@ -1607,6 +1646,7 @@ pub fn prepare_orchard_migration_outbox(
         let result = rt.block_on(wallet_sync::IronwoodMigrationResult::prepare_outbox(
             &db_path,
             &lightwalletd_url,
+            submission_mode(managed_submission_routing),
             network,
             &account_uuid,
             password.as_slice(),
@@ -1709,6 +1749,7 @@ pub fn reconcile_orchard_migration_outbox_receipt(
 pub fn broadcast_due_orchard_migration_transactions(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     account_uuid: String,
     password: String,
@@ -1721,6 +1762,7 @@ pub fn broadcast_due_orchard_migration_transactions(
         let r = rt.block_on(wallet_sync::broadcast_due_orchard_migration_transactions(
             &db_path,
             &lightwalletd_url,
+            submission_mode(managed_submission_routing),
             network,
             &account_uuid,
             password,
@@ -1741,6 +1783,7 @@ pub fn broadcast_due_orchard_migration_transactions(
 pub fn broadcast_one_due_orchard_migration_transaction(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     account_uuid: String,
     password: String,
@@ -1754,6 +1797,7 @@ pub fn broadcast_one_due_orchard_migration_transaction(
             wallet_sync::broadcast_one_due_orchard_migration_transaction(
                 &db_path,
                 &lightwalletd_url,
+                submission_mode(managed_submission_routing),
                 network,
                 &account_uuid,
                 password,
@@ -1885,6 +1929,7 @@ fn to_wallet_signed_messages(
 pub async fn complete_orchard_migration_denominations_pczt(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     account_uuid: String,
     request_id: String,
@@ -1899,6 +1944,7 @@ pub async fn complete_orchard_migration_denominations_pczt(
     let r = wallet_sync::complete_orchard_migration_denominations_pczt(
         &db_path,
         &lightwalletd_url,
+        submission_mode(managed_submission_routing),
         network,
         &account_uuid,
         &request_id,
@@ -1960,6 +2006,7 @@ pub fn prepare_orchard_migration_single_qr_pczt(
 pub async fn complete_orchard_migration_single_qr_pczt(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     account_uuid: String,
     request_id: String,
@@ -1973,6 +2020,7 @@ pub async fn complete_orchard_migration_single_qr_pczt(
     let r = wallet_sync::complete_orchard_migration_single_qr_pczt(
         &db_path,
         &lightwalletd_url,
+        submission_mode(managed_submission_routing),
         network,
         &account_uuid,
         &request_id,
@@ -2077,6 +2125,7 @@ pub fn complete_orchard_migration_batch_pczt(
 pub fn migrate_orchard_to_ironwood_with_macos_stored_mnemonic(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     account_uuid: String,
     password: String,
@@ -2097,6 +2146,7 @@ pub fn migrate_orchard_to_ironwood_with_macos_stored_mnemonic(
         let r = rt.block_on(wallet_sync::migrate_orchard_to_ironwood(
             &db_path,
             &lightwalletd_url,
+            submission_mode(managed_submission_routing),
             network,
             &account_uuid,
             seed,
@@ -2167,6 +2217,7 @@ pub fn create_shield_transparent_pczt(
 pub fn shield_transparent_balance(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     account_uuid: String,
     mnemonic_bytes: Vec<u8>,
@@ -2181,6 +2232,7 @@ pub fn shield_transparent_balance(
         let r = rt.block_on(wallet_sync::shield_transparent_balance(
             &db_path,
             &lightwalletd_url,
+            submission_mode(managed_submission_routing),
             network,
             &account_uuid,
             seed,
@@ -2203,6 +2255,7 @@ pub fn shield_transparent_balance(
 pub fn shield_transparent_balance_with_macos_stored_mnemonic(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     account_uuid: String,
     password: String,
@@ -2216,6 +2269,7 @@ pub fn shield_transparent_balance_with_macos_stored_mnemonic(
         let r = rt.block_on(wallet_sync::shield_transparent_balance(
             &db_path,
             &lightwalletd_url,
+            submission_mode(managed_submission_routing),
             network,
             &account_uuid,
             seed,
@@ -2545,6 +2599,7 @@ pub fn redact_pczt_for_signer(pczt_bytes: Vec<u8>) -> Result<Vec<u8>, String> {
 pub async fn extract_and_broadcast_pczt(
     db_path: String,
     lightwalletd_url: String,
+    managed_submission_routing: bool,
     network: String,
     pczt_with_proofs_bytes: Vec<u8>,
     pczt_with_signatures_bytes: Vec<u8>,
@@ -2555,6 +2610,7 @@ pub async fn extract_and_broadcast_pczt(
     let result = wallet_sync::extract_and_broadcast_pczt(
         &db_path,
         &lightwalletd_url,
+        submission_mode(managed_submission_routing),
         network,
         &pczt_with_proofs_bytes,
         &pczt_with_signatures_bytes,

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -6,6 +6,7 @@ use flutter_rust_bridge::frb;
 use zeroize::Zeroizing;
 
 use crate::frb_generated::StreamSink;
+use crate::wallet::sync::submission_mode;
 use crate::wallet::{keys, network::WalletNetwork, secret_store, sync as wallet_sync, sync_engine};
 
 // ======================== Sync Mode ========================
@@ -42,16 +43,6 @@ pub struct ApiSyncProgressEvent {
     /// Current sync phase: `"download"`, `"scan"`, `"enhance"`, or
     /// `""` (completion / unspecified).
     pub phase: String,
-}
-
-fn submission_mode(managed_submission_routing: bool) -> wallet_sync::SubmissionMode {
-    // Dart may enable this only for an explicit managed mainnet preset; URL
-    // matching cannot distinguish a custom endpoint that reuses a built-in URL.
-    if managed_submission_routing {
-        wallet_sync::SubmissionMode::ProviderAware
-    } else {
-        wallet_sync::SubmissionMode::CurrentOnly
-    }
 }
 
 fn run_full_sync_internal<F>(

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use crate::migration_preparation::{self, MigrationPreparationProgress};
 use crate::wallet::keys;
+use crate::wallet::sync::submission_mode;
 use futures::{stream::FuturesUnordered, StreamExt};
 use tonic::Code;
 
@@ -72,14 +73,6 @@ fn transaction_observation_from_height(height: u64) -> CLightwalletdTransactionO
             state: 2,
             mined_height,
         },
-    }
-}
-
-fn submission_mode(managed_submission_routing: bool) -> crate::wallet::sync::SubmissionMode {
-    if managed_submission_routing {
-        crate::wallet::sync::SubmissionMode::ProviderAware
-    } else {
-        crate::wallet::sync::SubmissionMode::CurrentOnly
     }
 }
 

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use crate::migration_preparation::{self, MigrationPreparationProgress};
 use crate::wallet::keys;
+use futures::{stream::FuturesUnordered, StreamExt};
 use tonic::Code;
 
 #[repr(C)]
@@ -74,6 +75,58 @@ fn transaction_observation_from_height(height: u64) -> CLightwalletdTransactionO
     }
 }
 
+fn submission_mode(managed_submission_routing: bool) -> crate::wallet::sync::SubmissionMode {
+    if managed_submission_routing {
+        crate::wallet::sync::SubmissionMode::ProviderAware
+    } else {
+        crate::wallet::sync::SubmissionMode::CurrentOnly
+    }
+}
+
+async fn observe_transaction(
+    configured_url: &str,
+    mode: crate::wallet::sync::SubmissionMode,
+    routing_transaction_id: [u8; 32],
+    transaction_id: [u8; 32],
+) -> Result<Option<CLightwalletdTransactionObservation>, tonic::Status> {
+    let groups = crate::wallet::sync::resolve_submission_endpoint_groups(
+        configured_url,
+        mode,
+        routing_transaction_id,
+    );
+    let mut last_error = None;
+
+    for group in groups {
+        let mut attempts = FuturesUnordered::new();
+        for endpoint in group {
+            attempts.push(async move {
+                let mut client = crate::wallet::sync_engine::open_lwd_channel(&endpoint)
+                    .await
+                    .map_err(|error| tonic::Status::unavailable(error.to_string()))?;
+                crate::wallet::sync_engine::get_transaction(&mut client, transaction_id.to_vec())
+                    .await
+            });
+        }
+
+        while let Some(result) = attempts.next().await {
+            match result {
+                Ok(transaction) => {
+                    return Ok(Some(transaction_observation_from_height(
+                        transaction.height,
+                    )));
+                }
+                Err(error) if error.code() == Code::NotFound => {}
+                Err(error) => last_error = Some(error),
+            }
+        }
+    }
+
+    match last_error {
+        Some(error) => Err(error),
+        None => Ok(None),
+    }
+}
+
 /// Safely convert a C string pointer to a `&str`. Returns `None` if
 /// the pointer is null, not valid UTF-8, or empty.
 unsafe fn c_str_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
@@ -84,6 +137,13 @@ unsafe fn c_str_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
         Ok(value) if !value.is_empty() => Some(value),
         _ => None,
     }
+}
+
+unsafe fn copy_c_string(value: &str, output: *mut c_char, capacity: usize) {
+    let bytes = value.as_bytes();
+    let copied_len = bytes.len().min(capacity.saturating_sub(1));
+    std::ptr::copy_nonoverlapping(bytes.as_ptr().cast::<c_char>(), output, copied_len);
+    *output.add(copied_len) = 0;
 }
 
 fn log_panic(context: &str, panic: Box<dyn std::any::Any + Send>) {
@@ -227,23 +287,37 @@ pub extern "C" fn zcash_lightwalletd_latest_block_height(
 #[no_mangle]
 pub extern "C" fn zcash_lightwalletd_observe_transaction(
     lightwalletd_url: *const c_char,
+    routing_transaction_id: *const u8,
+    routing_transaction_id_len: usize,
     transaction_id: *const u8,
     transaction_id_len: usize,
     output: *mut CLightwalletdTransactionObservation,
+    managed_submission_routing: bool,
     cancellation: *const CLightwalletdCancellation,
 ) -> i32 {
     let result = std::panic::catch_unwind(|| {
         let Some(lightwalletd_url) = (unsafe { c_str_to_str(lightwalletd_url) }) else {
             return 1;
         };
+        if routing_transaction_id.is_null() || routing_transaction_id_len != 32 {
+            return 1;
+        }
         if transaction_id.is_null() || transaction_id_len != 32 {
             return 1;
         }
         let Some(output) = (unsafe { output.as_mut() }) else {
             return 1;
         };
-        let transaction_id =
-            unsafe { std::slice::from_raw_parts(transaction_id, transaction_id_len) }.to_vec();
+        let routing_transaction_id: [u8; 32] = unsafe {
+            std::slice::from_raw_parts(routing_transaction_id, routing_transaction_id_len)
+                .try_into()
+                .expect("routing transaction ID length was checked")
+        };
+        let transaction_id: [u8; 32] = unsafe {
+            std::slice::from_raw_parts(transaction_id, transaction_id_len)
+                .try_into()
+                .expect("transaction ID length was checked")
+        };
         let runtime = match lightwalletd_runtime() {
             Ok(runtime) => runtime,
             Err(error) => {
@@ -254,19 +328,19 @@ pub extern "C" fn zcash_lightwalletd_observe_transaction(
         let cancellation = unsafe { cancellation.as_ref() };
         match runtime.block_on(await_lightwalletd_request_or_cancellation(
             cancellation,
-            async {
-                let mut client = crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url)
-                    .await
-                    .map_err(|error| tonic::Status::unavailable(error.to_string()))?;
-                crate::wallet::sync_engine::get_transaction(&mut client, transaction_id).await
-            },
+            observe_transaction(
+                lightwalletd_url,
+                submission_mode(managed_submission_routing),
+                routing_transaction_id,
+                transaction_id,
+            ),
         )) {
             Err(()) => LIGHTWALLETD_RESULT_CANCELLED,
-            Ok(Ok(transaction)) => {
-                *output = transaction_observation_from_height(transaction.height);
+            Ok(Ok(Some(observation))) => {
+                *output = observation;
                 0
             }
-            Ok(Err(error)) if error.code() == Code::NotFound => {
+            Ok(Ok(None)) => {
                 *output = CLightwalletdTransactionObservation::not_found();
                 0
             }
@@ -291,17 +365,24 @@ pub extern "C" fn zcash_lightwalletd_observe_transaction(
 #[no_mangle]
 pub extern "C" fn zcash_lightwalletd_send_transaction(
     lightwalletd_url: *const c_char,
+    transaction_id: *const u8,
+    transaction_id_len: usize,
     raw_transaction: *const u8,
     raw_transaction_len: usize,
     response_error_code: *mut i32,
     response_error_message: *mut c_char,
     response_error_message_capacity: usize,
+    response_accepted: *mut bool,
+    managed_submission_routing: bool,
     cancellation: *const CLightwalletdCancellation,
 ) -> i32 {
     let result = std::panic::catch_unwind(|| {
         let Some(lightwalletd_url) = (unsafe { c_str_to_str(lightwalletd_url) }) else {
             return 1;
         };
+        if transaction_id.is_null() || transaction_id_len != 32 {
+            return 1;
+        }
         if raw_transaction.is_null() || raw_transaction_len == 0 {
             return 1;
         }
@@ -311,6 +392,14 @@ pub extern "C" fn zcash_lightwalletd_send_transaction(
         if response_error_message.is_null() || response_error_message_capacity == 0 {
             return 1;
         }
+        let Some(response_accepted) = (unsafe { response_accepted.as_mut() }) else {
+            return 1;
+        };
+        let transaction_id: [u8; 32] = unsafe {
+            std::slice::from_raw_parts(transaction_id, transaction_id_len)
+                .try_into()
+                .expect("transaction ID length was checked")
+        };
         let raw_transaction =
             unsafe { std::slice::from_raw_parts(raw_transaction, raw_transaction_len) }.to_vec();
         let runtime = match lightwalletd_runtime() {
@@ -323,37 +412,44 @@ pub extern "C" fn zcash_lightwalletd_send_transaction(
         let cancellation = unsafe { cancellation.as_ref() };
         match runtime.block_on(await_lightwalletd_request_or_cancellation(
             cancellation,
-            async {
-                let mut client = crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url)
-                    .await
-                    .map_err(|error| error.to_string())?;
-                crate::wallet::sync_engine::send_transaction_with_status(
-                    &mut client,
-                    &raw_transaction,
-                )
-                .await
-                .map_err(|error| error.to_string())
-            },
+            crate::wallet::sync::submit_transaction(
+                lightwalletd_url,
+                submission_mode(managed_submission_routing),
+                transaction_id,
+                &raw_transaction,
+            ),
         )) {
             Err(()) => LIGHTWALLETD_RESULT_CANCELLED,
-            Ok(Ok(response)) => {
-                *response_error_code = response.error_code;
-                let bytes = response.error_message.as_bytes();
-                let copied_len = bytes
-                    .len()
-                    .min(response_error_message_capacity.saturating_sub(1));
+            Ok(crate::wallet::sync::SubmissionOutcome::Accepted { code, message, .. }) => {
+                *response_error_code = code;
+                *response_accepted = true;
                 unsafe {
-                    std::ptr::copy_nonoverlapping(
-                        bytes.as_ptr().cast::<c_char>(),
+                    copy_c_string(
+                        &message,
                         response_error_message,
-                        copied_len,
-                    );
-                    *response_error_message.add(copied_len) = 0;
-                }
+                        response_error_message_capacity,
+                    )
+                };
                 0
             }
-            Ok(Err(error)) => {
-                log::error!("ffi: send lightwalletd transaction: {error}");
+            Ok(crate::wallet::sync::SubmissionOutcome::Rejected { code, message, .. }) => {
+                *response_error_code = code;
+                *response_accepted = false;
+                unsafe {
+                    copy_c_string(
+                        &message,
+                        response_error_message,
+                        response_error_message_capacity,
+                    )
+                };
+                0
+            }
+            Ok(crate::wallet::sync::SubmissionOutcome::NotSubmitted { failures })
+            | Ok(crate::wallet::sync::SubmissionOutcome::Indeterminate { failures }) => {
+                log::error!(
+                    "ffi: send lightwalletd transaction: {}",
+                    crate::wallet::sync::submission_failures_message(&failures)
+                );
                 1
             }
         }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -245,6 +245,7 @@ fn wire__crate__api__sync__broadcast_due_orchard_migration_transactions_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_password = <String>::sse_decode(&mut deserializer);
@@ -255,6 +256,7 @@ fn wire__crate__api__sync__broadcast_due_orchard_migration_transactions_impl(
                     let output_ok = crate::api::sync::broadcast_due_orchard_migration_transactions(
                         api_db_path,
                         api_lightwalletd_url,
+                        api_managed_submission_routing,
                         api_network,
                         api_account_uuid,
                         api_password,
@@ -290,6 +292,7 @@ fn wire__crate__api__sync__broadcast_one_due_orchard_migration_transaction_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_password = <String>::sse_decode(&mut deserializer);
@@ -301,6 +304,7 @@ fn wire__crate__api__sync__broadcast_one_due_orchard_migration_transaction_impl(
                         crate::api::sync::broadcast_one_due_orchard_migration_transaction(
                             api_db_path,
                             api_lightwalletd_url,
+                            api_managed_submission_routing,
                             api_network,
                             api_account_uuid,
                             api_password,
@@ -638,6 +642,7 @@ fn wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_request_id = <String>::sse_decode(&mut deserializer);
@@ -657,6 +662,7 @@ fn wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(
                             crate::api::sync::complete_orchard_migration_denominations_pczt(
                                 api_db_path,
                                 api_lightwalletd_url,
+                                api_managed_submission_routing,
                                 api_network,
                                 api_account_uuid,
                                 api_request_id,
@@ -698,6 +704,7 @@ fn wire__crate__api__sync__complete_orchard_migration_immediate_pczt_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_request_id = <String>::sse_decode(&mut deserializer);
@@ -713,6 +720,7 @@ fn wire__crate__api__sync__complete_orchard_migration_immediate_pczt_impl(
                             crate::api::sync::complete_orchard_migration_immediate_pczt(
                                 api_db_path,
                                 api_lightwalletd_url,
+                                api_managed_submission_routing,
                                 api_network,
                                 api_account_uuid,
                                 api_request_id,
@@ -751,6 +759,7 @@ fn wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_request_id = <String>::sse_decode(&mut deserializer);
@@ -768,6 +777,7 @@ fn wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(
                             crate::api::sync::complete_orchard_migration_single_qr_pczt(
                                 api_db_path,
                                 api_lightwalletd_url,
+                                api_managed_submission_routing,
                                 api_network,
                                 api_account_uuid,
                                 api_request_id,
@@ -2140,6 +2150,7 @@ fn wire__crate__api__sync__execute_proposal_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_proposal_id = <u64>::sse_decode(&mut deserializer);
             let api_send_flow_id = <String>::sse_decode(&mut deserializer);
             let api_mnemonic_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
@@ -2151,6 +2162,7 @@ fn wire__crate__api__sync__execute_proposal_impl(
                     let output_ok = crate::api::sync::execute_proposal(
                         api_db_path,
                         api_lightwalletd_url,
+                        api_managed_submission_routing,
                         api_proposal_id,
                         api_send_flow_id,
                         api_mnemonic_bytes,
@@ -2187,6 +2199,7 @@ fn wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_proposal_id = <u64>::sse_decode(&mut deserializer);
             let api_send_flow_id = <String>::sse_decode(&mut deserializer);
             let api_password = <String>::sse_decode(&mut deserializer);
@@ -2198,6 +2211,7 @@ fn wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(
                     let output_ok = crate::api::sync::execute_proposal_with_macos_stored_mnemonic(
                         api_db_path,
                         api_lightwalletd_url,
+                        api_managed_submission_routing,
                         api_proposal_id,
                         api_send_flow_id,
                         api_password,
@@ -2277,6 +2291,7 @@ fn wire__crate__api__sync__extract_and_broadcast_pczt_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_pczt_with_proofs_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
             let api_pczt_with_signatures_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
@@ -2289,6 +2304,7 @@ fn wire__crate__api__sync__extract_and_broadcast_pczt_impl(
                         let output_ok = crate::api::sync::extract_and_broadcast_pczt(
                             api_db_path,
                             api_lightwalletd_url,
+                            api_managed_submission_routing,
                             api_network,
                             api_pczt_with_proofs_bytes,
                             api_pczt_with_signatures_bytes,
@@ -4149,6 +4165,7 @@ fn wire__crate__api__sync__migrate_orchard_to_ironwood_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_mnemonic_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
@@ -4163,6 +4180,7 @@ fn wire__crate__api__sync__migrate_orchard_to_ironwood_impl(
                     let output_ok = crate::api::sync::migrate_orchard_to_ironwood(
                         api_db_path,
                         api_lightwalletd_url,
+                        api_managed_submission_routing,
                         api_network,
                         api_account_uuid,
                         api_mnemonic_bytes,
@@ -4201,6 +4219,7 @@ fn wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_mnemonic_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
@@ -4214,6 +4233,7 @@ fn wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(
                     let output_ok = crate::api::sync::migrate_orchard_to_ironwood_immediately(
                         api_db_path,
                         api_lightwalletd_url,
+                        api_managed_submission_routing,
                         api_network,
                         api_account_uuid,
                         api_mnemonic_bytes,
@@ -4252,6 +4272,7 @@ fn wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemoni
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_password = <String>::sse_decode(&mut deserializer);
@@ -4266,6 +4287,7 @@ fn wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemoni
                         crate::api::sync::migrate_orchard_to_ironwood_with_macos_stored_mnemonic(
                             api_db_path,
                             api_lightwalletd_url,
+                            api_managed_submission_routing,
                             api_network,
                             api_account_uuid,
                             api_password,
@@ -4661,6 +4683,7 @@ fn wire__crate__api__sync__prepare_orchard_migration_outbox_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_password = <String>::sse_decode(&mut deserializer);
@@ -4671,6 +4694,7 @@ fn wire__crate__api__sync__prepare_orchard_migration_outbox_impl(
                     let output_ok = crate::api::sync::prepare_orchard_migration_outbox(
                         api_db_path,
                         api_lightwalletd_url,
+                        api_managed_submission_routing,
                         api_network,
                         api_account_uuid,
                         api_password,
@@ -5421,6 +5445,7 @@ fn wire__crate__api__sync__run_full_sync_blocking_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_mode = <u8>::sse_decode(&mut deserializer);
             deserializer.end();
@@ -5429,6 +5454,7 @@ fn wire__crate__api__sync__run_full_sync_blocking_impl(
                     let output_ok = crate::api::sync::run_full_sync_blocking(
                         api_db_path,
                         api_lightwalletd_url,
+                        api_managed_submission_routing,
                         api_network,
                         api_mode,
                     )?;
@@ -5717,6 +5743,7 @@ fn wire__crate__api__sync__shield_transparent_balance_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_mnemonic_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
@@ -5726,6 +5753,7 @@ fn wire__crate__api__sync__shield_transparent_balance_impl(
                     let output_ok = crate::api::sync::shield_transparent_balance(
                         api_db_path,
                         api_lightwalletd_url,
+                        api_managed_submission_routing,
                         api_network,
                         api_account_uuid,
                         api_mnemonic_bytes,
@@ -5760,6 +5788,7 @@ fn wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_password = <String>::sse_decode(&mut deserializer);
@@ -5770,6 +5799,7 @@ fn wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic
                         crate::api::sync::shield_transparent_balance_with_macos_stored_mnemonic(
                             api_db_path,
                             api_lightwalletd_url,
+                            api_managed_submission_routing,
                             api_network,
                             api_account_uuid,
                             api_password,
@@ -5804,6 +5834,7 @@ fn wire__crate__api__sync__start_full_sync_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_managed_submission_routing = <bool>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_mode = <u8>::sse_decode(&mut deserializer);
             let api_sink = <StreamSink<
@@ -5816,6 +5847,7 @@ fn wire__crate__api__sync__start_full_sync_impl(
                     let output_ok = crate::api::sync::start_full_sync(
                         api_db_path,
                         api_lightwalletd_url,
+                        api_managed_submission_routing,
                         api_network,
                         api_mode,
                         api_sink,

--- a/rust/src/migration_preparation.rs
+++ b/rust/src/migration_preparation.rs
@@ -194,7 +194,6 @@ pub fn is_sync_running() -> bool {
 pub fn run_sync(
     db_path: &str,
     lightwalletd_url: &str,
-    submission_mode: sync::SubmissionMode,
     network: WalletNetwork,
     progress_callback: impl Fn(SyncProgressEvent) + Send + Sync,
 ) -> Result<(), MigrationPreparationError> {
@@ -208,7 +207,7 @@ pub fn run_sync(
         .block_on(sync_engine::run_sync_inner(
             db_path,
             lightwalletd_url,
-            submission_mode,
+            sync::SubmissionMode::CurrentOnly,
             network,
             control.cancel.clone(),
             MIGRATION_PREPARATION_SYNC_MODE,

--- a/rust/src/migration_preparation.rs
+++ b/rust/src/migration_preparation.rs
@@ -194,6 +194,7 @@ pub fn is_sync_running() -> bool {
 pub fn run_sync(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: sync::SubmissionMode,
     network: WalletNetwork,
     progress_callback: impl Fn(SyncProgressEvent) + Send + Sync,
 ) -> Result<(), MigrationPreparationError> {
@@ -207,6 +208,7 @@ pub fn run_sync(
         .block_on(sync_engine::run_sync_inner(
             db_path,
             lightwalletd_url,
+            submission_mode,
             network,
             control.cancel.clone(),
             MIGRATION_PREPARATION_SYNC_MODE,
@@ -294,6 +296,7 @@ pub fn inspect_proof_readiness(
 pub fn advance(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: sync::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     expected_run_id: &str,
@@ -311,6 +314,7 @@ pub fn advance(
         .block_on(sync::advance_orchard_migration_preparation_for_run(
             db_path,
             lightwalletd_url,
+            submission_mode,
             network,
             account_uuid,
             expected_run_id,

--- a/rust/src/wallet/sync/broadcast.rs
+++ b/rust/src/wallet/sync/broadcast.rs
@@ -1,17 +1,4 @@
-use zcash_client_backend::proto::service::SendResponse;
-
-pub(super) fn send_response_rejection_error(resp: &SendResponse) -> Option<String> {
-    if resp.error_code == 0 || send_rejection_is_already_accepted(&resp.error_message) {
-        return None;
-    }
-
-    Some(format!(
-        "Broadcast rejected: {} (code {})",
-        resp.error_message, resp.error_code
-    ))
-}
-
-pub(super) fn send_rejection_is_already_accepted(message: &str) -> bool {
+pub(crate) fn send_rejection_is_already_accepted(message: &str) -> bool {
     let message = message.to_ascii_lowercase();
     message.contains("transaction was committed to the best chain")
         || message.contains("already in mempool")
@@ -28,25 +15,8 @@ pub(super) fn send_rejection_is_already_accepted(message: &str) -> bool {
 mod tests {
     use super::*;
 
-    fn send_response(error_code: i32, error_message: &str) -> SendResponse {
-        SendResponse {
-            error_code,
-            error_message: error_message.to_string(),
-        }
-    }
-
     #[test]
-    fn send_response_success_is_accepted_even_when_message_contains_txid() {
-        let resp = send_response(
-            0,
-            "838813428b78712263511ed5c6fb9a108c939038a440b74f72bee6caedf602fd",
-        );
-
-        assert_eq!(send_response_rejection_error(&resp), None);
-    }
-
-    #[test]
-    fn duplicate_send_responses_are_accepted() {
+    fn duplicate_send_messages_are_accepted() {
         for message in [
             "transaction was committed to the best chain",
             "already in mempool",
@@ -59,26 +29,18 @@ mod tests {
             "already known",
             "Error: TXN-ALREADY-IN-MEMPOOL from node",
         ] {
-            let resp = send_response(-25, message);
-
-            assert_eq!(send_response_rejection_error(&resp), None, "{message}");
+            assert!(send_rejection_is_already_accepted(message), "{message}");
         }
     }
 
     #[test]
-    fn unrelated_send_rejections_remain_fatal() {
+    fn unrelated_send_messages_are_not_accepted() {
         for message in [
             "bad-txns-inputs-spent",
             "",
             "mandatory-script-verify-flag-failed",
         ] {
-            let resp = send_response(18, message);
-
-            assert_eq!(
-                send_response_rejection_error(&resp),
-                Some(format!("Broadcast rejected: {message} (code 18)")),
-                "{message}"
-            );
+            assert!(!send_rejection_is_already_accepted(message), "{message}");
         }
     }
 }

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -3533,6 +3533,25 @@ pub(crate) fn mark_pending_broadcast_attempted(
     }
 }
 
+pub(crate) fn clear_pending_broadcast_attempted(
+    db_path: &str,
+    run_id: &str,
+    txid_hex: &str,
+) -> Result<(), String> {
+    let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+    ensure_schema(&conn)?;
+    conn.execute(
+        &format!(
+            "UPDATE {PENDING_TXS_TABLE}
+             SET broadcast_attempted = 0
+             WHERE run_id = ?1 AND txid_hex = ?2 AND status = 'scheduled'"
+        ),
+        params![run_id, txid_hex],
+    )
+    .map_err(|e| format!("Clear migration broadcast attempt: {e}"))?;
+    Ok(())
+}
+
 pub(crate) fn mark_denomination_broadcast_attempted(
     db_path: &str,
     run_id: &str,
@@ -3576,7 +3595,7 @@ pub(crate) fn clear_denomination_broadcast_attempted(
         ),
         params![run_id, txid_hex],
     )
-    .map_err(|e| format!("Clear rejected denomination broadcast attempt: {e}"))?;
+    .map_err(|e| format!("Clear denomination broadcast attempt: {e}"))?;
     Ok(())
 }
 

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -276,6 +276,20 @@ fn stop_candidates_track_attempts_for_children_and_denomination_stages() {
         candidate.kind == MigrationStopCandidateKind::DenominationStage
             && candidate.txid_hex == stage_txid
     }));
+
+    clear_pending_broadcast_attempted(&db_path, "run-attempts", &child_txids[0]).unwrap();
+    clear_denomination_broadcast_attempted(&db_path, "run-attempts", &stage_txid).unwrap();
+
+    let reset = scheduled_migration_stop_candidates(
+        &db_path,
+        "account-1",
+        WalletNetwork::Regtest,
+        "run-attempts",
+    )
+    .unwrap();
+    assert!(reset
+        .iter()
+        .all(|candidate| candidate.attempt_state == MigrationBroadcastAttemptState::NotAttempted));
 }
 
 #[test]

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -30,6 +30,13 @@ mod proposal_locks;
 mod send;
 mod transactions;
 
+pub use crate::wallet::sync_engine::submission::SubmissionMode;
+pub(crate) use crate::wallet::sync_engine::submission::{
+    resolve_submission_endpoint_groups, submission_failures_message, submit_transaction,
+    submit_transaction_while, SubmissionFailure, SubmissionOutcome,
+};
+pub(crate) use broadcast::send_rejection_is_already_accepted;
+
 // Re-export the split submodules at the `wallet::sync` path so every
 // `crate::wallet::sync::propose_send` / `::get_wallet_balance` /
 // `::extract_and_broadcast_pczt` etc. call path keeps resolving with

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -32,8 +32,8 @@ mod transactions;
 
 pub use crate::wallet::sync_engine::submission::SubmissionMode;
 pub(crate) use crate::wallet::sync_engine::submission::{
-    resolve_submission_endpoint_groups, submission_failures_message, submit_transaction,
-    submit_transaction_while, SubmissionFailure, SubmissionOutcome,
+    resolve_submission_endpoint_groups, submission_failures_message, submission_mode,
+    submit_transaction, submit_transaction_while, SubmissionOutcome,
 };
 pub(crate) use broadcast::send_rejection_is_already_accepted;
 

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -912,6 +912,7 @@ pub(crate) fn extract_compact_sigs_from_pczt(
 pub async fn extract_and_broadcast_pczt(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     pczt_with_proofs_bytes: &[u8],
     pczt_with_signatures_bytes: &[u8],
@@ -1014,28 +1015,27 @@ pub async fn extract_and_broadcast_pczt(
         return Err(error);
     }
 
-    let resp = match crate::wallet::sync_engine::send_transaction_with_status(
-        &mut client,
-        &tx_bytes,
-    )
-    .await
+    let mut transaction_id = [0; 32];
+    transaction_id.copy_from_slice(txid.as_ref());
+    match super::submit_transaction(lightwalletd_url, submission_mode, transaction_id, &tx_bytes)
+        .await
     {
-        Ok(resp) => resp,
-        // Once SendTransaction has started, a gRPC status is not proof that
-        // the server rejected the transaction. The server may have accepted
-        // and relayed it before the response or connection was lost. Treat
-        // every transport status conservatively; explicit SendResponse
-        // rejection below remains the only definite rejection path.
-        Err(status) => {
-            return Ok(handle_pczt_transport_failure(
-                &txid.to_string(),
-                &status,
-                store_locally,
-            ));
+        super::SubmissionOutcome::Accepted { .. } => {
+            handle_pczt_accepted(&txid.to_string(), store_locally)
         }
-    };
-
-    handle_pczt_send_response(&txid.to_string(), &resp, store_locally)
+        super::SubmissionOutcome::Rejected { code, message, .. } => {
+            Err(format!("Broadcast rejected: {message} (code {code})"))
+        }
+        super::SubmissionOutcome::NotSubmitted { failures } => Err(format!(
+            "Broadcast could not start: {}",
+            super::submission_failures_message(&failures)
+        )),
+        super::SubmissionOutcome::Indeterminate { failures } => Ok(handle_pczt_transport_failure(
+            &txid.to_string(),
+            &super::submission_failures_message(&failures),
+            store_locally,
+        )),
+    }
 }
 
 fn pczt_broadcast_expiry_error(
@@ -1054,22 +1054,13 @@ fn pczt_broadcast_expiry_error(
     }
 }
 
-fn handle_pczt_send_response<F>(
+fn handle_pczt_accepted<F>(
     txid: &str,
-    resp: &zcash_client_backend::proto::service::SendResponse,
     store_locally: F,
 ) -> Result<ExtractAndBroadcastPcztResult, String>
 where
     F: FnOnce() -> Result<(), String>,
 {
-    // zebra-lightwalletd returns the txid in `error_message` on
-    // success, so the only reliable clean-success signal is
-    // `error_code`. Duplicate/already-known responses are also
-    // definite acceptance because the network already has the tx.
-    if let Some(error) = super::broadcast::send_response_rejection_error(resp) {
-        return Err(error);
-    }
-
     // Broadcast was accepted. Persist locally so the UI sees the tx
     // immediately and the spent notes stop showing up as spendable.
     if let Err(storage_err) = store_locally() {
@@ -1092,14 +1083,14 @@ where
 
 fn handle_pczt_transport_failure<F>(
     txid: &str,
-    status: &tonic::Status,
+    detail: &str,
     store_locally: F,
 ) -> ExtractAndBroadcastPcztResult
 where
     F: FnOnce() -> Result<(), String>,
 {
     let mut message = format!(
-        "Broadcast response was unavailable for txid={txid} ({status}). The transaction may \
+        "Broadcast response was unavailable for txid={txid} ({detail}). The transaction may \
          already be on the network. Do not send again until sync or an explorer confirms \
          whether this transaction was accepted."
     );
@@ -1129,20 +1120,12 @@ mod tests {
     use std::cell::Cell;
 
     use super::*;
-    use zcash_client_backend::proto::service::SendResponse;
-
-    fn send_response(error_code: i32, error_message: &str) -> SendResponse {
-        SendResponse {
-            error_code,
-            error_message: error_message.to_string(),
-        }
-    }
 
     #[test]
-    fn pczt_success_response_stores_locally_and_returns_broadcasted() {
+    fn pczt_accepted_submission_stores_locally_and_returns_broadcasted() {
         let store_calls = Cell::new(0);
 
-        let result = handle_pczt_send_response("txid", &send_response(0, "txid"), || {
+        let result = handle_pczt_accepted("txid", || {
             store_calls.set(store_calls.get() + 1);
             Ok(())
         })
@@ -1154,27 +1137,8 @@ mod tests {
     }
 
     #[test]
-    fn pczt_duplicate_response_stores_locally_and_returns_broadcasted() {
-        let store_calls = Cell::new(0);
-
-        let result =
-            handle_pczt_send_response("txid", &send_response(18, "txn-already-in-mempool"), || {
-                store_calls.set(store_calls.get() + 1);
-                Ok(())
-            })
-            .unwrap();
-
-        assert_eq!(result.status, ExtractAndBroadcastPcztResult::BROADCASTED);
-        assert_eq!(result.message, None);
-        assert_eq!(store_calls.get(), 1);
-    }
-
-    #[test]
-    fn pczt_duplicate_response_with_storage_failure_is_network_success() {
-        let result = handle_pczt_send_response("txid", &send_response(18, "already known"), || {
-            Err("database is busy".to_string())
-        })
-        .unwrap();
+    fn pczt_accepted_submission_with_storage_failure_is_network_success() {
+        let result = handle_pczt_accepted("txid", || Err("database is busy".to_string())).unwrap();
 
         assert_eq!(
             result.status,
@@ -1190,14 +1154,11 @@ mod tests {
     #[test]
     fn pczt_non_deadline_transport_failure_remains_ambiguous() {
         let store_calls = Cell::new(0);
-        let result = handle_pczt_transport_failure(
-            "txid",
-            &tonic::Status::unavailable("connection reset after request"),
-            || {
+        let result =
+            handle_pczt_transport_failure("txid", "connection reset after request", || {
                 store_calls.set(store_calls.get() + 1);
                 Ok(())
-            },
-        );
+            });
 
         assert_eq!(
             result.status,
@@ -1209,22 +1170,6 @@ mod tests {
             .unwrap_or_default()
             .contains("stored locally"));
         assert_eq!(store_calls.get(), 1);
-    }
-
-    #[test]
-    fn pczt_fatal_rejection_does_not_store_locally() {
-        let store_calls = Cell::new(0);
-
-        let err =
-            handle_pczt_send_response("txid", &send_response(18, "bad-txns-inputs-spent"), || {
-                store_calls.set(store_calls.get() + 1);
-                Ok(())
-            })
-            .err()
-            .unwrap();
-
-        assert_eq!(err, "Broadcast rejected: bad-txns-inputs-spent (code 18)");
-        assert_eq!(store_calls.get(), 0);
     }
 
     #[test]

--- a/rust/src/wallet/sync/proposal_locks.rs
+++ b/rust/src/wallet/sync/proposal_locks.rs
@@ -114,23 +114,35 @@ pub(super) fn remove(db_path: &str, owner: LockOwner) -> Result<(), String> {
     Ok(())
 }
 
-pub(super) fn mark_retain_until_expiry(db_path: &str, owner: LockOwner) -> Result<(), String> {
+fn set_retain_until_expiry(
+    db_path: &str,
+    owner: LockOwner,
+    retain_until_expiry: bool,
+) -> Result<(), String> {
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
     let updated = conn
         .execute(
             &format!(
                 "UPDATE {TABLE}
-             SET retain_until_expiry = 1
-             WHERE owner = ?1"
+                 SET retain_until_expiry = ?2
+                 WHERE owner = ?1"
             ),
-            params![owner.as_bytes().as_slice()],
+            params![owner.as_bytes().as_slice(), retain_until_expiry],
         )
-        .map_err(|e| format!("Retain send proposal lock until expiry: {e}"))?;
+        .map_err(|e| format!("Update send proposal lock restart policy: {e}"))?;
     if updated == 0 {
         return Err("Send proposal lock recovery row no longer exists".to_string());
     }
     Ok(())
+}
+
+pub(super) fn mark_retain_until_expiry(db_path: &str, owner: LockOwner) -> Result<(), String> {
+    set_retain_until_expiry(db_path, owner, true)
+}
+
+pub(super) fn clear_retain_until_expiry(db_path: &str, owner: LockOwner) -> Result<(), String> {
+    set_retain_until_expiry(db_path, owner, false)
 }
 
 pub(super) fn update_expiry(

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -108,8 +108,8 @@ use super::migration_wallet_ops::{
 };
 use super::{
     consume_stored_proposal, finish_stored_proposal, open_readonly_conn, open_wallet_db,
-    open_wallet_db_for_read, stored_proposal_lock, StoredProposal, StoredProposalLock,
-    WalletDatabase, PROPOSAL_STORE,
+    open_wallet_db_for_read, stored_proposal_lock, submission_failures_message, StoredProposal,
+    StoredProposalLock, WalletDatabase, PROPOSAL_STORE,
 };
 
 const UNBROADCAST_MIGRATION_RECOVERY_SAFETY_BLOCKS: u32 = 10;
@@ -5877,10 +5877,6 @@ fn txid_bytes(txid: &TxId) -> [u8; 32] {
     let mut bytes = [0; 32];
     bytes.copy_from_slice(txid.as_ref());
     bytes
-}
-
-fn submission_failures_message(failures: &[super::SubmissionFailure]) -> String {
-    super::submission_failures_message(failures)
 }
 
 #[derive(Debug)]

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -198,6 +198,12 @@ impl ImmediateMigrationInputLock {
         Ok(())
     }
 
+    fn reset_after_not_submitted(&mut self) -> Result<(), String> {
+        super::proposal_locks::clear_retain_until_expiry(&self.db_path, self.owner)?;
+        self.retain_on_drop = false;
+        Ok(())
+    }
+
     fn release(&mut self) -> Result<(), String> {
         if !self.active {
             return Ok(());
@@ -408,6 +414,7 @@ impl IronwoodMigrationResult {
     pub(crate) async fn prepare_outbox(
         db_path: &str,
         lightwalletd_url: &str,
+        submission_mode: super::SubmissionMode,
         network: WalletNetwork,
         account_uuid: &str,
         pending_password: &[u8],
@@ -416,6 +423,7 @@ impl IronwoodMigrationResult {
         prepare_orchard_migration_outbox(
             db_path,
             lightwalletd_url,
+            submission_mode,
             network,
             account_uuid,
             pending_password,
@@ -1081,6 +1089,7 @@ fn create_shield_transparent_pczt_with_expiry(
 pub(crate) async fn shield_transparent_balance(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     seed: SecretVec<u8>,
@@ -1146,9 +1155,15 @@ pub(crate) async fn shield_transparent_balance(
 
     let txids: Vec<TxId> = txids.iter().cloned().collect();
     Ok(
-        broadcast_created_transactions(db_path, lightwalletd_url, &txids, "shield")
-            .await
-            .into_shield_transparent_result(fee_zatoshi, shielded_zatoshi),
+        broadcast_created_transactions(
+            db_path,
+            lightwalletd_url,
+            submission_mode,
+            &txids,
+            "shield",
+        )
+        .await
+        .into_shield_transparent_result(fee_zatoshi, shielded_zatoshi),
     )
 }
 
@@ -1162,6 +1177,7 @@ pub(crate) async fn shield_transparent_balance(
 pub async fn execute_proposal(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     proposal_id: u64,
     send_flow_id: &str,
     seed: SecretVec<u8>,
@@ -1176,6 +1192,7 @@ pub async fn execute_proposal(
     execute_stored_proposal(
         db_path,
         lightwalletd_url,
+        submission_mode,
         stored,
         seed,
         spend_params_path,
@@ -1187,6 +1204,7 @@ pub async fn execute_proposal(
 pub async fn execute_proposal_with_seed_loader<F>(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     proposal_id: u64,
     send_flow_id: &str,
     load_seed: F,
@@ -1215,6 +1233,7 @@ where
     execute_stored_proposal(
         db_path,
         lightwalletd_url,
+        submission_mode,
         stored,
         seed,
         spend_params_path,
@@ -1226,6 +1245,7 @@ where
 async fn execute_stored_proposal(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     stored: StoredProposal,
     seed: SecretVec<u8>,
     spend_params_path: Option<&str>,
@@ -1383,7 +1403,7 @@ async fn execute_stored_proposal(
 
     let txids: Vec<TxId> = txids.iter().cloned().collect();
     Ok(
-        broadcast_created_transactions(db_path, lightwalletd_url, &txids, "send")
+        broadcast_created_transactions(db_path, lightwalletd_url, submission_mode, &txids, "send")
             .await
             .into_execute_result(),
     )
@@ -1392,6 +1412,7 @@ async fn execute_stored_proposal(
 pub(crate) async fn migrate_orchard_to_ironwood(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     seed: SecretVec<u8>,
@@ -1417,6 +1438,7 @@ pub(crate) async fn migrate_orchard_to_ironwood(
             match advance_staged_denomination_run(
                 db_path,
                 lightwalletd_url,
+                submission_mode,
                 network,
                 account_uuid,
                 &run,
@@ -1509,6 +1531,7 @@ pub(crate) async fn migrate_orchard_to_ironwood(
                     let result = broadcast_due_scheduled_migration_txs(
                         db_path,
                         lightwalletd_url,
+                        submission_mode,
                         network,
                         &run.run_id,
                         pending_password.as_slice(),
@@ -1624,6 +1647,7 @@ pub(crate) async fn migrate_orchard_to_ironwood(
         let result = broadcast_due_scheduled_migration_txs(
             db_path,
             lightwalletd_url,
+            submission_mode,
             network,
             &run_id,
             pending_password.as_slice(),
@@ -1640,6 +1664,7 @@ pub(crate) async fn migrate_orchard_to_ironwood(
     let Some(broadcast) = broadcast_pending_denomination_stages(
         db_path,
         lightwalletd_url,
+        submission_mode,
         network,
         &run_id,
         pending_password.as_slice(),
@@ -1859,6 +1884,7 @@ fn build_orchard_migration_immediate_pczt(
 pub(crate) async fn migrate_orchard_to_ironwood_immediately(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     seed: SecretVec<u8>,
@@ -1882,26 +1908,44 @@ pub(crate) async fn migrate_orchard_to_ironwood_immediately(
     super::pczt::preflight_orchard_spend_auth_signatures(&base_pczt, &sigs)?;
     let proofed = super::pczt::add_proofs_to_pczt(&base_pczt, None, None)?;
     let extracted = super::pczt::apply_sigs_and_extract(&proofed, &sigs, None, None)?;
-    let mut client = crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url)
-        .await
-        .map_err(|e| format!("Connect to lightwalletd for Immediate migration failed: {e}"))?;
     // From this point a cancelled future or terminated process cannot prove
     // that lightwalletd rejected the transaction. Persist the conservative
     // restart policy before starting SendTransaction.
     input_lock.mark_broadcast_started()?;
-    let response = match crate::wallet::sync_engine::send_transaction_with_status(
-        &mut client,
+    let outcome = super::submit_transaction(
+        lightwalletd_url,
+        submission_mode,
+        txid_bytes(&extracted.txid),
         &extracted.raw_tx,
     )
-    .await
-    {
-        Ok(response) => response,
-        // A gRPC status after SendTransaction starts is ambiguous: the server
-        // may have accepted and relayed the transaction before the response
-        // was lost. Preserve the transaction locally, or retain the generic
-        // input lock when local storage also fails. Only an explicit
-        // SendResponse rejection below is a definite failure.
-        Err(status) => {
+    .await;
+    match outcome {
+        super::SubmissionOutcome::Rejected { code, message, .. } => {
+            let error = format!("Broadcast rejected: {message} (code {code})");
+            return match input_lock.release() {
+                Ok(()) => Err(error),
+                Err(release_error) => Err(format!(
+                    "{error}; additionally failed to release Immediate migration inputs: \
+                     {release_error}"
+                )),
+            };
+        }
+        super::SubmissionOutcome::NotSubmitted { failures } => {
+            let error = format!(
+                "Immediate migration broadcast could not start: {}",
+                submission_failures_message(&failures)
+            );
+            return match input_lock.release() {
+                Ok(()) => Err(error),
+                Err(release_error) => Err(format!(
+                    "{error}; additionally failed to release Immediate migration inputs: \
+                     {release_error}"
+                )),
+            };
+        }
+        // A transport failure after SendTransaction starts is ambiguous: a
+        // server may have accepted and relayed it before the response was lost.
+        super::SubmissionOutcome::Indeterminate { failures } => {
             let storage_message = match decrypt_and_store_migration_tx(
                 db_path,
                 network,
@@ -1928,22 +1972,15 @@ pub(crate) async fn migrate_orchard_to_ironwood_immediately(
                 broadcasted_count: 0,
                 total_count: 1,
                 message: Some(format!(
-                    "The Immediate migration broadcast response was unavailable ({status}) and \
-                     may already be on the network. {storage_message}"
+                    "The Immediate migration broadcast response was unavailable ({}) and may \
+                     already be on the network. {storage_message}",
+                    submission_failures_message(&failures)
                 )),
                 fee_zatoshi,
                 migrated_zatoshi,
             });
         }
-    };
-    if let Some(error) = super::broadcast::send_response_rejection_error(&response) {
-        return match input_lock.release() {
-            Ok(()) => Err(error),
-            Err(release_error) => Err(format!(
-                "{error}; additionally failed to release Immediate migration inputs: \
-                 {release_error}"
-            )),
-        };
+        super::SubmissionOutcome::Accepted { .. } => {}
     }
     let storage_error = decrypt_and_store_migration_tx(db_path, network, &extracted.raw_tx).err();
     if storage_error.is_some() {
@@ -2190,6 +2227,7 @@ pub(crate) async fn abandon_orchard_migration(
 async fn prepare_orchard_migration_outbox(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     pending_password: &[u8],
@@ -2211,6 +2249,7 @@ async fn prepare_orchard_migration_outbox(
     match advance_staged_denomination_run(
         db_path,
         lightwalletd_url,
+        submission_mode,
         network,
         account_uuid,
         &run,
@@ -2441,6 +2480,7 @@ fn any_migration_proof_candidate_ready<T>(
 pub(crate) async fn advance_orchard_migration_preparation_for_run(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     expected_run_id: &str,
@@ -2471,6 +2511,7 @@ pub(crate) async fn advance_orchard_migration_preparation_for_run(
     match advance_staged_denomination_run(
         db_path,
         lightwalletd_url,
+        submission_mode,
         network,
         account_uuid,
         &run,
@@ -2508,6 +2549,7 @@ pub(crate) async fn advance_orchard_migration_preparation_for_run(
 pub async fn broadcast_due_orchard_migration_transactions(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     pending_password: zeroize::Zeroizing<Vec<u8>>,
@@ -2516,6 +2558,7 @@ pub async fn broadcast_due_orchard_migration_transactions(
     broadcast_due_orchard_migration_transactions_inner(
         db_path,
         lightwalletd_url,
+        submission_mode,
         network,
         account_uuid,
         pending_password,
@@ -2529,6 +2572,7 @@ pub async fn broadcast_due_orchard_migration_transactions(
 pub async fn broadcast_one_due_orchard_migration_transaction(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     pending_password: zeroize::Zeroizing<Vec<u8>>,
@@ -2537,6 +2581,7 @@ pub async fn broadcast_one_due_orchard_migration_transaction(
     let advance = broadcast_due_orchard_migration_transactions_inner(
         db_path,
         lightwalletd_url,
+        submission_mode,
         network,
         account_uuid,
         pending_password,
@@ -2550,6 +2595,7 @@ pub async fn broadcast_one_due_orchard_migration_transaction(
 async fn broadcast_due_orchard_migration_transactions_inner(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     pending_password: zeroize::Zeroizing<Vec<u8>>,
@@ -2589,6 +2635,7 @@ async fn broadcast_due_orchard_migration_transactions_inner(
         return broadcast_due_scheduled_migration_txs(
             db_path,
             lightwalletd_url,
+            submission_mode,
             network,
             &run.run_id,
             pending_password.as_slice(),
@@ -2603,6 +2650,7 @@ async fn broadcast_due_orchard_migration_transactions_inner(
     match advance_staged_denomination_run(
         db_path,
         lightwalletd_url,
+        submission_mode,
         network,
         account_uuid,
         &run,
@@ -2650,6 +2698,7 @@ async fn broadcast_due_orchard_migration_transactions_inner(
     broadcast_due_scheduled_migration_txs(
         db_path,
         lightwalletd_url,
+        submission_mode,
         network,
         &run.run_id,
         pending_password.as_slice(),
@@ -4828,6 +4877,7 @@ fn denomination_expiry_scan_wait_result(txids: &str, total_count: u32) -> Create
 async fn broadcast_pending_denomination_stages(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     run_id: &str,
     pending_password: &[u8],
@@ -4961,8 +5011,12 @@ async fn broadcast_pending_denomination_stages(
             run_id,
             &stage.expected_txid_hex,
         )?;
-        if let Err(e) = broadcast_raw_transaction(&mut client, &stage.raw_tx).await {
-            if migration_broadcast_failure_requires_rebuild(&e) {
+        let stage_txid = txid_bytes(&parse_txid_hex(&stage.expected_txid_hex)?);
+        if let Err(e) =
+            broadcast_raw_transaction(lightwalletd_url, submission_mode, stage_txid, &stage.raw_tx)
+                .await
+        {
+            if e.is_definitely_not_accepted() {
                 super::migration::clear_denomination_broadcast_attempted(
                     db_path,
                     run_id,
@@ -5065,6 +5119,7 @@ async fn broadcast_pending_denomination_stages(
 async fn broadcast_due_scheduled_migration_txs(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     run_id: &str,
     pending_password: &[u8],
@@ -5189,30 +5244,6 @@ async fn broadcast_due_scheduled_migration_txs(
         ));
     }
 
-    let mut client = match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await {
-        Ok(client) => client,
-        Err(e) => {
-            let message = format!("Migration broadcast could not start: {e}");
-            super::migration::mark_run_phase(
-                db_path,
-                run_id,
-                super::migration::PHASE_FAILED_RECOVERABLE,
-                Some(&message),
-            )?;
-            return Ok(MigrationBroadcastAdvance::without_acceptance(
-                IronwoodMigrationResult {
-                    txids: String::new(),
-                    status: super::migration::PHASE_FAILED_RECOVERABLE.to_string(),
-                    broadcasted_count: 0,
-                    total_count: fallback_total_count,
-                    message: Some(message),
-                    fee_zatoshi: 0,
-                    migrated_zatoshi: fallback_migrated_zatoshi,
-                },
-            ));
-        }
-    };
-
     super::migration::mark_run_phase(db_path, run_id, super::migration::PHASE_BROADCASTING, None)?;
     let mut accepted_txids = Vec::new();
     for pending in due.into_iter().take(policy.limit(usize::MAX)) {
@@ -5226,7 +5257,22 @@ async fn broadcast_due_scheduled_migration_txs(
             break;
         }
         super::migration::mark_pending_broadcast_attempted(db_path, run_id, &pending.txid_hex)?;
-        if let Err(e) = broadcast_raw_transaction(&mut client, &pending.raw_tx).await {
+        let pending_txid = txid_bytes(&parse_txid_hex(&pending.txid_hex)?);
+        if let Err(e) = broadcast_raw_transaction(
+            lightwalletd_url,
+            submission_mode,
+            pending_txid,
+            &pending.raw_tx,
+        )
+        .await
+        {
+            if e.is_definitely_not_accepted() {
+                super::migration::clear_pending_broadcast_attempted(
+                    db_path,
+                    run_id,
+                    &pending.txid_hex,
+                )?;
+            }
             log::error!(
                 "migration: broadcast rejected for {}: {}",
                 pending.txid_hex,
@@ -5386,8 +5432,8 @@ async fn broadcast_due_scheduled_migration_txs(
     })
 }
 
-fn migration_broadcast_failure_requires_rebuild(error: &str) -> bool {
-    error.starts_with("Broadcast rejected:")
+fn migration_broadcast_failure_requires_rebuild(error: &BroadcastFailure) -> bool {
+    matches!(error, BroadcastFailure::Rejected { .. })
 }
 
 fn decrypt_and_store_migration_tx(
@@ -5732,29 +5778,13 @@ impl CreatedBroadcastResult {
 async fn broadcast_created_transactions(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     txids: &[TxId],
     log_label: &str,
 ) -> CreatedBroadcastResult {
     let txid_strings: Vec<String> = txids.iter().map(|id| format!("{id}")).collect();
     let txids_joined = txid_strings.join(",");
     let total_count = txids.len() as u32;
-
-    // Connect to lightwalletd once for all broadcasts.
-    let mut client = match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await {
-        Ok(client) => client,
-        Err(e) => {
-            let message =
-                format!("Broadcast could not start after local transaction creation. Error: {e}");
-            log::warn!("{log_label}: {message}");
-            return CreatedBroadcastResult {
-                txids: txids_joined,
-                status: CreatedBroadcastResult::PENDING_BROADCAST,
-                broadcasted_count: 0,
-                total_count,
-                message: Some(message),
-            };
-        }
-    };
 
     let read_conn = match open_readonly_conn(db_path) {
         Ok(conn) => conn,
@@ -5799,7 +5829,14 @@ async fn broadcast_created_transactions(
             }
         };
 
-        match broadcast_raw_transaction(&mut client, &raw_tx).await {
+        match broadcast_raw_transaction(
+            lightwalletd_url,
+            submission_mode,
+            txid_bytes(txid),
+            &raw_tx,
+        )
+        .await
+        {
             Ok(()) => {
                 broadcast_ok.push(format!("{txid}"));
                 log::info!("{log_label}: broadcast {txid} ({} bytes)", raw_tx.len());
@@ -5836,20 +5873,96 @@ async fn broadcast_created_transactions(
     }
 }
 
-/// Broadcast a raw transaction using an existing gRPC client.
-async fn broadcast_raw_transaction(
-    client: &mut zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient<tonic::transport::Channel>,
-    raw_tx: &[u8],
-) -> Result<(), String> {
-    let resp = crate::wallet::sync_engine::send_transaction(client, raw_tx)
-        .await
-        .map_err(|e| format!("SendTransaction gRPC failed: {e}"))?;
+fn txid_bytes(txid: &TxId) -> [u8; 32] {
+    let mut bytes = [0; 32];
+    bytes.copy_from_slice(txid.as_ref());
+    bytes
+}
 
-    if let Some(error) = super::broadcast::send_response_rejection_error(&resp) {
-        return Err(error);
+fn submission_failures_message(failures: &[super::SubmissionFailure]) -> String {
+    super::submission_failures_message(failures)
+}
+
+#[derive(Debug)]
+enum BroadcastFailure {
+    Rejected { code: i32, message: String },
+    NotSubmitted { message: String },
+    Indeterminate { message: String },
+}
+
+impl BroadcastFailure {
+    fn is_definitely_not_accepted(&self) -> bool {
+        !matches!(self, Self::Indeterminate { .. })
     }
+}
 
-    Ok(())
+impl std::fmt::Display for BroadcastFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rejected { code, message } => {
+                write!(formatter, "Broadcast rejected: {message} (code {code})")
+            }
+            Self::NotSubmitted { message } => {
+                write!(formatter, "Broadcast could not start: {message}")
+            }
+            Self::Indeterminate { message } => {
+                write!(formatter, "Broadcast response was unavailable: {message}")
+            }
+        }
+    }
+}
+
+/// Broadcast a raw transaction through the configured submission policy.
+async fn broadcast_raw_transaction(
+    lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
+    transaction_id: [u8; 32],
+    raw_tx: &[u8],
+) -> Result<(), BroadcastFailure> {
+    broadcast_raw_transaction_while(
+        lightwalletd_url,
+        submission_mode,
+        transaction_id,
+        raw_tx,
+        || true,
+    )
+    .await
+}
+
+async fn broadcast_raw_transaction_while<ShouldContinue>(
+    lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
+    transaction_id: [u8; 32],
+    raw_tx: &[u8],
+    should_continue: ShouldContinue,
+) -> Result<(), BroadcastFailure>
+where
+    ShouldContinue: Fn() -> bool,
+{
+    match super::submit_transaction_while(
+        lightwalletd_url,
+        submission_mode,
+        transaction_id,
+        raw_tx,
+        should_continue,
+    )
+    .await
+    {
+        super::SubmissionOutcome::Accepted { .. } => Ok(()),
+        super::SubmissionOutcome::Rejected { code, message, .. } => {
+            Err(BroadcastFailure::Rejected { code, message })
+        }
+        super::SubmissionOutcome::NotSubmitted { failures } => {
+            Err(BroadcastFailure::NotSubmitted {
+                message: submission_failures_message(&failures),
+            })
+        }
+        super::SubmissionOutcome::Indeterminate { failures } => {
+            Err(BroadcastFailure::Indeterminate {
+                message: submission_failures_message(&failures),
+            })
+        }
+    }
 }
 
 // ======================== Auto-Resubmit ========================
@@ -5910,9 +6023,6 @@ pub(crate) struct ResubmitStats {
 /// without introducing an extra await point between the RPC
 /// response and the stats bump.
 ///
-/// The caller owns the gRPC client. In the sync loop the same
-/// client that downloaded the compact blocks is threaded straight
-/// through, so auto-resubmit reuses the same connection.
 /// `excluded_txids` are filtered before their raw bytes are loaded.
 /// Recovery uses this to avoid rebroadcasting transactions that
 /// compact scanning can restore as mined.
@@ -5923,7 +6033,8 @@ pub(crate) struct ResubmitStats {
 /// wallet is doing without enabling DEBUG everywhere.
 pub(crate) async fn resubmit_pending_transactions<ShouldExit>(
     db_path: &str,
-    client: &mut zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient<tonic::transport::Channel>,
+    lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     current_height: u32,
     excluded_txids: &HashSet<Vec<u8>>,
     should_exit: ShouldExit,
@@ -5981,7 +6092,23 @@ where
         }
 
         let txid_hex = hex::encode(&tx.txid_bytes);
-        match broadcast_raw_transaction(client, &tx.raw_tx).await {
+        let transaction_id: [u8; 32] = match tx.txid_bytes.as_slice().try_into() {
+            Ok(transaction_id) => transaction_id,
+            Err(_) => {
+                log::warn!("resubmit: {txid_hex} has an invalid transaction ID length");
+                stats.failed += 1;
+                continue;
+            }
+        };
+        match broadcast_raw_transaction_while(
+            lightwalletd_url,
+            submission_mode,
+            transaction_id,
+            &tx.raw_tx,
+            || !should_exit(),
+        )
+        .await
+        {
             Ok(()) => {
                 log::info!(
                     "resubmit: {txid_hex} ok (expiry={}, bytes={})",
@@ -6006,7 +6133,15 @@ where
                     stats.failed += 1;
                     break;
                 }
-                match broadcast_raw_transaction(client, &tx.raw_tx).await {
+                match broadcast_raw_transaction_while(
+                    lightwalletd_url,
+                    submission_mode,
+                    transaction_id,
+                    &tx.raw_tx,
+                    || !should_exit(),
+                )
+                .await
+                {
                     Ok(()) => {
                         log::info!("resubmit: {txid_hex} ok on retry");
                         stats.succeeded += 1;

--- a/rust/src/wallet/sync/send/ironwood_migration.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration.rs
@@ -42,11 +42,7 @@ pub(crate) fn prepare_orchard_migration_denominations_pczt(
     let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
     let draft_run = super::migration::active_migration_run(db_path, account_uuid, network)?;
     if draft_run.is_none()
-        && super::migration::migration_reserves_orchard_inputs(
-            db_path,
-            account_uuid,
-            network,
-        )?
+        && super::migration::migration_reserves_orchard_inputs(db_path, account_uuid, network)?
     {
         return Err("Migration recovery must complete before preparing a new run".to_string());
     }
@@ -179,6 +175,7 @@ fn migration_target_values_for_request(
 pub(crate) async fn complete_orchard_migration_denominations_pczt(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     request_id: &str,
@@ -252,10 +249,8 @@ pub(crate) async fn complete_orchard_migration_denominations_pczt(
             return Err(format!("Keystone result missing {}", stage.id));
         }
     }
-    let prepared_refs = prepared_refs_from_denomination_split(
-        &stored.direct_prepared_refs,
-        &stored.split_stages,
-    );
+    let prepared_refs =
+        prepared_refs_from_denomination_split(&stored.direct_prepared_refs, &stored.split_stages);
     let finalize_result = (|| -> Result<String, String> {
         let denomination_stages =
             signed_denomination_stage_inserts(&stored.split_stages, &signed_by_id)?;
@@ -317,6 +312,7 @@ pub(crate) async fn complete_orchard_migration_denominations_pczt(
     let Some(broadcast) = broadcast_pending_denomination_stages(
         db_path,
         lightwalletd_url,
+        submission_mode,
         network,
         &run_id,
         pending_password,
@@ -483,6 +479,7 @@ pub(crate) fn prepare_orchard_migration_single_qr_pczt(
 pub(crate) async fn complete_orchard_migration_single_qr_pczt(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     request_id: &str,
@@ -567,10 +564,8 @@ pub(crate) async fn complete_orchard_migration_single_qr_pczt(
         }
     }
 
-    let prepared_refs = prepared_refs_from_denomination_split(
-        &stored.direct_prepared_refs,
-        &stored.split_stages,
-    );
+    let prepared_refs =
+        prepared_refs_from_denomination_split(&stored.direct_prepared_refs, &stored.split_stages);
 
     let finalize_result = (|| -> Result<String, String> {
         let denomination_stages =
@@ -651,6 +646,7 @@ pub(crate) async fn complete_orchard_migration_single_qr_pczt(
         return broadcast_due_scheduled_migration_txs(
             db_path,
             lightwalletd_url,
+            submission_mode,
             network,
             &run_id,
             pending_password,
@@ -666,6 +662,7 @@ pub(crate) async fn complete_orchard_migration_single_qr_pczt(
     let Some(broadcast) = broadcast_pending_denomination_stages(
         db_path,
         lightwalletd_url,
+        submission_mode,
         network,
         &run_id,
         pending_password,
@@ -752,6 +749,7 @@ pub(crate) fn prepare_orchard_migration_immediate_pczt(
 pub(crate) async fn complete_orchard_migration_immediate_pczt(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     request_id: &str,
@@ -789,7 +787,7 @@ pub(crate) async fn complete_orchard_migration_immediate_pczt(
             }
             KeystoneMigrationRequestState::Completing => {
                 return Err(
-                    "Keystone Immediate migration request is already completing".to_string(),
+                    "Keystone Immediate migration request is already completing".to_string()
                 );
             }
             KeystoneMigrationRequestState::ProofReady => {}
@@ -805,12 +803,9 @@ pub(crate) async fn complete_orchard_migration_immediate_pczt(
         .remove(&stored.message_id)
         .ok_or("Keystone Immediate migration signature is missing")?;
     let extraction_result = (|| {
-        super::pczt::preflight_orchard_spend_auth_signatures(
-            &stored.base_pczt,
-            &signatures,
-        )?;
+        super::pczt::preflight_orchard_spend_auth_signatures(&stored.base_pczt, &signatures)?;
         let proofed = stored
-        .pczt_with_proofs
+            .pczt_with_proofs
             .as_ref()
             .ok_or("Keystone Immediate migration proofs are not ready")?;
         super::pczt::apply_sigs_and_extract(proofed, &signatures, None, None)
@@ -824,17 +819,6 @@ pub(crate) async fn complete_orchard_migration_immediate_pczt(
             return Err(error);
         }
     };
-    let mut client = match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await {
-        Ok(client) => client,
-        Err(error) => {
-            if let Ok(mut store) = keystone_immediate_migration_requests().lock() {
-                store.insert(request_id.to_string(), stored);
-            }
-            return Err(format!(
-                "Connect to lightwalletd for Immediate migration failed: {error}"
-            ));
-        }
-    };
     let mut input_lock = stored
         .input_lock
         .take()
@@ -844,51 +828,77 @@ pub(crate) async fn complete_orchard_migration_immediate_pczt(
     // starting the RPC so restart recovery cannot release a possibly-spent
     // input.
     input_lock.mark_broadcast_started()?;
-    let response = match crate::wallet::sync_engine::send_transaction_with_status(
-        &mut client,
+    let outcome = super::submit_transaction(
+        lightwalletd_url,
+        submission_mode,
+        txid_bytes(&extracted.txid),
         &extracted.raw_tx,
     )
-    .await
-    {
-        Ok(response) => response,
-        Err(status) => {
-            let storage_message =
-                match decrypt_and_store_migration_tx(db_path, network, &extracted.raw_tx) {
-                    Ok(()) => {
-                        if let Err(error) = input_lock.release() {
-                            log::warn!(
+    .await;
+    match outcome {
+        super::SubmissionOutcome::Rejected { code, message, .. } => {
+            let error = format!("Broadcast rejected: {message} (code {code})");
+            return match input_lock.release() {
+                Ok(()) => Err(error),
+                Err(release_error) => Err(format!(
+                    "{error}; additionally failed to release Keystone Immediate migration \
+                     inputs: {release_error}"
+                )),
+            };
+        }
+        super::SubmissionOutcome::NotSubmitted { failures } => {
+            let reset_result = input_lock.reset_after_not_submitted();
+            stored.input_lock = Some(input_lock);
+            if let Ok(mut store) = keystone_immediate_migration_requests().lock() {
+                store.insert(request_id.to_string(), stored);
+            }
+            let error = format!(
+                "Immediate migration broadcast could not start: {}",
+                submission_failures_message(&failures)
+            );
+            return match reset_result {
+                Ok(()) => Err(error),
+                Err(reset_error) => Err(format!(
+                    "{error}; additionally failed to restore restart recovery for Keystone \
+                     Immediate migration inputs: {reset_error}"
+                )),
+            };
+        }
+        super::SubmissionOutcome::Indeterminate { failures } => {
+            let storage_message = match decrypt_and_store_migration_tx(
+                db_path,
+                network,
+                &extracted.raw_tx,
+            ) {
+                Ok(()) => {
+                    if let Err(error) = input_lock.release() {
+                        log::warn!(
                                 "Keystone Immediate migration stored after ambiguous broadcast but input unlock failed: {error}"
                             );
-                        }
-                        "The transaction was stored locally and will retry automatically during sync."
-                            .to_string()
                     }
-                    Err(error) => {
-                        input_lock.retain_until_expiry();
-                        format!("Local tracking also failed: {error}")
-                    }
-                };
+                    "The transaction was stored locally and will retry automatically during sync."
+                        .to_string()
+                }
+                Err(error) => {
+                    input_lock.retain_until_expiry();
+                    format!("Local tracking also failed: {error}")
+                }
+            };
             return Ok(IronwoodMigrationResult {
                 txids: extracted.txid.to_string(),
                 status: CreatedBroadcastResult::PENDING_BROADCAST.to_string(),
                 broadcasted_count: 0,
                 total_count: 1,
                 message: Some(format!(
-                    "The Immediate migration broadcast response was unavailable ({status}) and may already be on the network. {storage_message}"
+                    "The Immediate migration broadcast response was unavailable ({}) and may \
+                     already be on the network. {storage_message}",
+                    submission_failures_message(&failures)
                 )),
                 fee_zatoshi: stored.fee_zatoshi,
                 migrated_zatoshi: stored.migrated_zatoshi,
             });
         }
-    };
-    if let Some(error) = super::broadcast::send_response_rejection_error(&response) {
-        return match input_lock.release() {
-            Ok(()) => Err(error),
-            Err(release_error) => Err(format!(
-                "{error}; additionally failed to release Keystone Immediate migration inputs: \
-                 {release_error}"
-            )),
-        };
+        super::SubmissionOutcome::Accepted { .. } => {}
     }
     let storage_error = decrypt_and_store_migration_tx(db_path, network, &extracted.raw_tx).err();
     if storage_error.is_some() {
@@ -938,8 +948,7 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
     let initial_signing = recoveries.is_empty();
     let all_prepared_notes = super::migration::prepared_notes_for_run(db_path, &run.run_id)?;
     let pending_totals = super::migration::pending_totals_for_run(db_path, &run.run_id)?;
-    let signed_child_pczt_count =
-        super::migration::signed_child_pczt_count(db_path, &run.run_id)?;
+    let signed_child_pczt_count = super::migration::signed_child_pczt_count(db_path, &run.run_id)?;
     let recovery_part_indices = recoveries
         .iter()
         .map(|recovery| recovery.part_index)
@@ -982,8 +991,7 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
 
     let mut created = Vec::with_capacity(prepared_notes.len());
     let timing_policy = super::migration::timing_policy_for_run(db_path, &run.run_id, network)?;
-    let approved_schedule =
-        super::migration::approved_schedule_for_run(db_path, &run.run_id)?;
+    let approved_schedule = super::migration::approved_schedule_for_run(db_path, &run.run_id)?;
     let signed_schedule_origin =
         super::migration::signed_schedule_origin_for_run(db_path, &run.run_id)?;
     // Recovery batches consume the run's persisted recovery-schedule

--- a/rust/src/wallet/sync/send/ironwood_migration/status_advance.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/status_advance.rs
@@ -138,6 +138,7 @@ fn reconcile_mined_denomination_stages(
 async fn advance_staged_denomination_run(
     db_path: &str,
     lightwalletd_url: &str,
+    submission_mode: super::SubmissionMode,
     network: WalletNetwork,
     account_uuid: &str,
     run: &super::migration::ActiveRun,
@@ -167,6 +168,7 @@ async fn advance_staged_denomination_run(
     if let Some(broadcast) = broadcast_pending_denomination_stages(
         db_path,
         lightwalletd_url,
+        submission_mode,
         network,
         &run.run_id,
         pending_password,
@@ -215,6 +217,7 @@ async fn advance_staged_denomination_run(
             let broadcast = broadcast_pending_denomination_stages(
                 db_path,
                 lightwalletd_url,
+                submission_mode,
                 network,
                 &run.run_id,
                 pending_password,

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -162,6 +162,44 @@ fn immediate_migration_marks_restart_retention_before_broadcast() {
 }
 
 #[test]
+fn immediate_migration_not_submitted_restores_restart_recovery() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_str().unwrap();
+    let owner = LockOwner::new([7; 32]);
+    let output = OutputRef::new(TxId::from_bytes([9; 32]), PoolType::ORCHARD, 0);
+    super::super::proposal_locks::persist(
+        db_path,
+        owner,
+        std::slice::from_ref(&output),
+        BlockHeight::from_u32(100),
+    )
+    .unwrap();
+
+    let mut input_lock =
+        ImmediateMigrationInputLock::new(db_path, WalletNetwork::Regtest, owner, vec![output]);
+    input_lock.mark_broadcast_started().unwrap();
+    input_lock.reset_after_not_submitted().unwrap();
+
+    assert!(!input_lock.retain_on_drop);
+    let conn = Connection::open(db_path).unwrap();
+    let retained: bool = conn
+        .query_row(
+            "SELECT retain_until_expiry
+             FROM vizor_send_proposal_locks
+             WHERE owner = ?1",
+            params![owner.as_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(!retained);
+
+    // The test database only contains the recovery side table, not a complete
+    // wallet schema. Disable Drop cleanup after checking the state Drop uses.
+    input_lock.active = false;
+}
+
+#[test]
 fn immediate_migration_plan_ignores_zero_value_orchard_notes() {
     let target_height = BlockHeight::from_u32(500);
     let with_padding = immediate_migration_plan_for_values(
@@ -981,12 +1019,27 @@ fn shield_result_preserves_pending_broadcast_status() {
 
 #[test]
 fn migration_rebuilds_only_after_explicit_server_rejection() {
-    assert!(migration_broadcast_failure_requires_rebuild(
-        "Broadcast rejected: bad-txns-inputs-spent (code 18)"
+    let rejected = BroadcastFailure::Rejected {
+        code: 18,
+        message: "bad-txns-inputs-spent".to_string(),
+    };
+    let not_submitted = BroadcastFailure::NotSubmitted {
+        message: "connection unavailable".to_string(),
+    };
+    let indeterminate = BroadcastFailure::Indeterminate {
+        message: "response timeout".to_string(),
+    };
+
+    assert!(migration_broadcast_failure_requires_rebuild(&rejected));
+    assert!(!migration_broadcast_failure_requires_rebuild(
+        &not_submitted
     ));
     assert!(!migration_broadcast_failure_requires_rebuild(
-        "SendTransaction gRPC failed: connection unavailable"
+        &indeterminate
     ));
+    assert!(rejected.is_definitely_not_accepted());
+    assert!(not_submitted.is_definitely_not_accepted());
+    assert!(!indeterminate.is_definitely_not_accepted());
 }
 
 #[test]

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -211,7 +211,7 @@ pub(crate) async fn get_transaction(
 }
 
 /// Submit a raw transaction with a bounded response wait.
-pub(crate) async fn send_transaction_with_status(
+pub(super) async fn send_transaction_with_status(
     client: &mut CompactTxStreamerClient<Channel>,
     data: &[u8],
 ) -> Result<SendResponse, Status> {
@@ -227,17 +227,6 @@ pub(crate) async fn send_transaction_with_status(
         )),
     )
     .await
-}
-
-/// Submit a raw transaction with a bounded response wait and map tonic
-/// errors into the sync error taxonomy.
-pub(crate) async fn send_transaction(
-    client: &mut CompactTxStreamerClient<Channel>,
-    data: &[u8],
-) -> Result<SendResponse, SyncError> {
-    send_transaction_with_status(client, data)
-        .await
-        .map_err(|e| status_to_network_error("send_transaction", e))
 }
 
 /// Open the deprecated transparent-address transaction stream with a

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -47,6 +47,7 @@ mod enhance;
 mod error;
 mod lwd;
 pub(crate) mod mempool;
+pub(crate) mod submission;
 
 use enhance::run_enhancement;
 pub(crate) use error::SyncError;
@@ -54,7 +55,6 @@ use error::{RecoveryStrategy, MAX_REWINDS_PER_RUN};
 use lwd::{download_blocks, download_subtree_roots, get_address_utxos_stream, get_tree_state};
 pub(crate) use lwd::{
     get_latest_block, get_taddress_txids, get_transaction, next_stream_message, open_lwd_channel,
-    send_transaction, send_transaction_with_status,
 };
 
 /// Progress event sent to caller (Dart or Swift).
@@ -1424,6 +1424,7 @@ async fn watch_for_exit(should_exit: &impl Fn() -> bool) {
 pub async fn run_sync_inner(
     db_data_path: &str,
     lightwalletd_url: &str,
+    submission_mode: crate::wallet::sync::SubmissionMode,
     network: WalletNetwork,
     cancel: Arc<AtomicBool>,
     running_mode: u8,
@@ -1464,6 +1465,7 @@ pub async fn run_sync_inner(
         match run_sync_impl(
             db_data_path,
             lightwalletd_url,
+            submission_mode,
             network,
             cancel.clone(),
             running_mode,
@@ -1521,6 +1523,7 @@ pub async fn run_sync_inner(
 async fn run_sync_impl(
     db_data_path: &str,
     lightwalletd_url: &str,
+    submission_mode: crate::wallet::sync::SubmissionMode,
     network: WalletNetwork,
     cancel: Arc<AtomicBool>,
     running_mode: u8,
@@ -1621,8 +1624,6 @@ async fn run_sync_impl(
     // `processNewBlocks` (line 551). Best-effort: failures are
     // logged inside the helper and must not abort the sync.
     //
-    // We reuse the same `client` instead of opening a fresh channel.
-    //
     // Pre-flight cancel/mode check: `update_chain_tip` and
     // `open_lwd_channel` can take a couple of seconds under a
     // slow connection, which is long enough for the user to hit
@@ -1644,7 +1645,8 @@ async fn run_sync_impl(
             recovery_resubmit_exclusions(db_data_path, &startup_ranges)?;
         let _ = crate::wallet::sync::resubmit_pending_transactions(
             db_data_path,
-            &mut client,
+            lightwalletd_url,
+            submission_mode,
             tip.height as u32,
             &startup_resubmit_exclusions,
             || {
@@ -2430,7 +2432,8 @@ async fn run_sync_impl(
                 if allow_resubmit {
                     let _ = crate::wallet::sync::resubmit_pending_transactions(
                         db_data_path,
-                        &mut client,
+                        lightwalletd_url,
+                        submission_mode,
                         fresh_tip_height,
                         &resubmit_exclusions,
                         || {

--- a/rust/src/wallet/sync_engine/submission.rs
+++ b/rust/src/wallet/sync_engine/submission.rs
@@ -70,6 +70,16 @@ pub enum SubmissionMode {
     CurrentOnly,
 }
 
+pub(crate) fn submission_mode(managed_submission_routing: bool) -> SubmissionMode {
+    // Routing intent cannot be inferred from the URL because a custom endpoint
+    // may reuse a built-in provider URL.
+    if managed_submission_routing {
+        SubmissionMode::ProviderAware
+    } else {
+        SubmissionMode::CurrentOnly
+    }
+}
+
 /// One endpoint failure that contributed to an inconclusive submission.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct SubmissionFailure {

--- a/rust/src/wallet/sync_engine/submission.rs
+++ b/rust/src/wallet/sync_engine/submission.rs
@@ -1,0 +1,1012 @@
+//! Stateless transaction submission routing.
+//!
+//! Managed mainnet providers are attempted one provider at a time. All of a
+//! provider's regional endpoints receive the same transaction concurrently,
+//! and the first accepted response completes the submission. The configured
+//! sync provider is always the final provider fallback.
+
+use std::{
+    future::Future,
+    sync::{Arc, LazyLock},
+};
+
+use futures::{stream::FuturesUnordered, StreamExt};
+use sha2::{Digest, Sha256};
+use zcash_client_backend::proto::service::SendResponse;
+
+use crate::wallet::sync::send_rejection_is_already_accepted;
+
+use super::lwd::{open_lwd_channel, send_transaction_with_status};
+
+const ROUTE_DOMAIN: &[u8] = b"vizor-lightwalletd-submission-v1";
+
+// Managed regional tasks outlive the short-lived runtimes used by several FFI
+// and FRB entrypoints. This lets every region finish after the first accepted
+// response is returned to the caller.
+static SUBMISSION_RUNTIME: LazyLock<Result<tokio::runtime::Runtime, String>> =
+    LazyLock::new(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("vizor-tx-submission")
+            .enable_all()
+            .build()
+            .map_err(|error| format!("transaction submission runtime unavailable: {error}"))
+    });
+
+// Keep these URLs aligned with the managed presets in rpc_endpoint_config.dart.
+const STARDUST_ENDPOINTS: &[&str] = &[
+    "https://us.zec.stardust.rest:443",
+    "https://eu.zec.stardust.rest:443",
+    "https://eu2.zec.stardust.rest:443",
+    "https://jp.zec.stardust.rest:443",
+];
+
+const ZEC_ROCKS_ENDPOINTS: &[&str] = &[
+    "https://zec.rocks:443",
+    "https://na.zec.rocks:443",
+    "https://sa.zec.rocks:443",
+    "https://eu.zec.rocks:443",
+    "https://ap.zec.rocks:443",
+];
+
+const MANAGED_PROVIDERS: &[Provider] = &[
+    Provider {
+        id: "stardust",
+        endpoints: STARDUST_ENDPOINTS,
+    },
+    Provider {
+        id: "zec-rocks",
+        endpoints: ZEC_ROCKS_ENDPOINTS,
+    },
+];
+
+/// Selects whether submission may use Vizor's managed provider catalog.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SubmissionMode {
+    /// Rank managed providers by transaction ID and keep the configured
+    /// endpoint or provider as the final fallback.
+    ProviderAware,
+    /// Submit only to the configured endpoint. Custom endpoints use this mode.
+    CurrentOnly,
+}
+
+/// One endpoint failure that contributed to an inconclusive submission.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SubmissionFailure {
+    pub(crate) endpoint: String,
+    pub(crate) message: String,
+}
+
+pub(crate) fn submission_failures_message(failures: &[SubmissionFailure]) -> String {
+    failures
+        .iter()
+        .map(|failure| format!("{}: {}", failure.endpoint, failure.message))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// The caller-relevant result of submitting a transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SubmissionOutcome {
+    /// A server accepted the transaction, or reported that it already had it.
+    Accepted {
+        endpoint: String,
+        code: i32,
+        message: String,
+    },
+    /// A server definitively rejected the transaction and no earlier attempt
+    /// had an ambiguous transport result.
+    Rejected {
+        endpoint: String,
+        code: i32,
+        message: String,
+    },
+    /// No `SendTransaction` RPC was started successfully.
+    NotSubmitted { failures: Vec<SubmissionFailure> },
+    /// At least one `SendTransaction` RPC may have reached a server, but no
+    /// accepted response was observed.
+    Indeterminate { failures: Vec<SubmissionFailure> },
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Provider {
+    id: &'static str,
+    endpoints: &'static [&'static str],
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TargetGroup {
+    provider_id: Option<&'static str>,
+    endpoints: Vec<String>,
+}
+
+#[derive(Debug)]
+enum EndpointAttempt {
+    Accepted { code: i32, message: String },
+    Rejected { code: i32, message: String },
+    NotSubmitted { message: String },
+    Indeterminate { message: String },
+}
+
+#[derive(Debug)]
+enum GroupOutcome {
+    Accepted {
+        endpoint: String,
+        code: i32,
+        message: String,
+    },
+    Rejected {
+        endpoint: String,
+        code: i32,
+        message: String,
+    },
+    NotSubmitted {
+        failures: Vec<SubmissionFailure>,
+    },
+    Indeterminate {
+        failures: Vec<SubmissionFailure>,
+    },
+}
+
+/// Submits exactly `raw_transaction`; routing uses the protocol-order
+/// `transaction_id` bytes only as a deterministic provider-order key.
+pub(crate) async fn submit_transaction(
+    configured_url: &str,
+    mode: SubmissionMode,
+    transaction_id: [u8; 32],
+    raw_transaction: &[u8],
+) -> SubmissionOutcome {
+    submit_transaction_while(
+        configured_url,
+        mode,
+        transaction_id,
+        raw_transaction,
+        || true,
+    )
+    .await
+}
+
+/// As [`submit_transaction`], but does not start another provider group after
+/// `should_continue` returns false. Requests already started within a group
+/// are not cancelled.
+pub(crate) async fn submit_transaction_while<ShouldContinue>(
+    configured_url: &str,
+    mode: SubmissionMode,
+    transaction_id: [u8; 32],
+    raw_transaction: &[u8],
+    should_continue: ShouldContinue,
+) -> SubmissionOutcome
+where
+    ShouldContinue: Fn() -> bool,
+{
+    if mode == SubmissionMode::CurrentOnly {
+        return submit_current_with(configured_url.to_string(), |endpoint| async move {
+            submit_to_endpoint(&endpoint, raw_transaction).await
+        })
+        .await;
+    }
+
+    let plan = submission_plan(configured_url, mode, &transaction_id, MANAGED_PROVIDERS);
+    let raw_transaction: Arc<[u8]> = Arc::from(raw_transaction.to_vec());
+
+    dispatch_while_with(
+        &plan,
+        raw_transaction,
+        should_continue,
+        |endpoint, raw_transaction| async move {
+            submit_to_endpoint(&endpoint, &raw_transaction).await
+        },
+    )
+    .await
+}
+
+/// Resolves the same provider and regional endpoint order used for submission
+/// from the protocol-order transaction ID bytes.
+/// Each inner vector is one provider group whose endpoints may be queried
+/// concurrently; outer groups must be attempted sequentially.
+pub(crate) fn resolve_submission_endpoint_groups(
+    configured_url: &str,
+    mode: SubmissionMode,
+    transaction_id: [u8; 32],
+) -> Vec<Vec<String>> {
+    submission_plan(configured_url, mode, &transaction_id, MANAGED_PROVIDERS)
+        .into_iter()
+        .map(|group| group.endpoints)
+        .collect()
+}
+
+fn submission_plan(
+    configured_url: &str,
+    mode: SubmissionMode,
+    transaction_id: &[u8; 32],
+    providers: &'static [Provider],
+) -> Vec<TargetGroup> {
+    if mode == SubmissionMode::CurrentOnly {
+        return vec![configured_target(configured_url)];
+    }
+
+    let configured_provider = providers
+        .iter()
+        .position(|provider| provider.endpoints.contains(&configured_url));
+    let mut ordered: Vec<(usize, Provider)> = providers.iter().copied().enumerate().collect();
+    ordered.sort_by(|(left_index, left), (right_index, right)| {
+        provider_score(transaction_id, right.id)
+            .cmp(&provider_score(transaction_id, left.id))
+            .then_with(|| left.id.cmp(right.id))
+            .then_with(|| left_index.cmp(right_index))
+    });
+
+    if let Some(configured_index) = configured_provider {
+        ordered.sort_by_key(|(index, _)| *index == configured_index);
+    }
+
+    let mut plan: Vec<_> = ordered
+        .into_iter()
+        .map(|(_, provider)| TargetGroup {
+            provider_id: Some(provider.id),
+            endpoints: provider
+                .endpoints
+                .iter()
+                .map(|endpoint| (*endpoint).to_string())
+                .collect(),
+        })
+        .collect();
+
+    // A recognized managed provider is already represented by its full group.
+    // Community presets are not automatic targets, but the user's configured
+    // community URL remains the final one-endpoint fallback.
+    if configured_provider.is_none() {
+        plan.push(configured_target(configured_url));
+    }
+
+    plan
+}
+
+fn configured_target(configured_url: &str) -> TargetGroup {
+    TargetGroup {
+        provider_id: None,
+        endpoints: vec![configured_url.to_string()],
+    }
+}
+
+fn provider_score(transaction_id: &[u8; 32], provider_id: &str) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(ROUTE_DOMAIN);
+    hasher.update(transaction_id);
+    hasher.update([0]);
+    hasher.update(provider_id.as_bytes());
+    hasher.finalize().into()
+}
+
+async fn submit_to_endpoint(endpoint: &str, raw_transaction: &[u8]) -> EndpointAttempt {
+    let mut client = match open_lwd_channel(endpoint).await {
+        Ok(client) => client,
+        Err(error) => {
+            let message = error.to_string();
+            log::warn!("transaction submission did not connect to {endpoint}: {message}");
+            return EndpointAttempt::NotSubmitted { message };
+        }
+    };
+
+    match send_transaction_with_status(&mut client, raw_transaction).await {
+        Ok(response) => classify_send_response(response),
+        Err(error) => {
+            let message = error.to_string();
+            log::warn!("transaction submission to {endpoint} was indeterminate: {message}");
+            EndpointAttempt::Indeterminate { message }
+        }
+    }
+}
+
+fn classify_send_response(response: SendResponse) -> EndpointAttempt {
+    if response.error_code == 0 {
+        EndpointAttempt::Accepted {
+            code: response.error_code,
+            message: response.error_message,
+        }
+    } else if send_rejection_is_already_accepted(&response.error_message) {
+        EndpointAttempt::Accepted {
+            code: response.error_code,
+            message: response.error_message,
+        }
+    } else {
+        EndpointAttempt::Rejected {
+            code: response.error_code,
+            message: response.error_message,
+        }
+    }
+}
+
+async fn submit_current_with<F, Fut>(endpoint: String, attempt: F) -> SubmissionOutcome
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = EndpointAttempt>,
+{
+    let result = attempt(endpoint.clone()).await;
+    match result {
+        EndpointAttempt::Accepted { code, message } => SubmissionOutcome::Accepted {
+            endpoint,
+            code,
+            message,
+        },
+        EndpointAttempt::Rejected { code, message } => SubmissionOutcome::Rejected {
+            endpoint,
+            code,
+            message,
+        },
+        EndpointAttempt::NotSubmitted { message } => SubmissionOutcome::NotSubmitted {
+            failures: vec![SubmissionFailure { endpoint, message }],
+        },
+        EndpointAttempt::Indeterminate { message } => SubmissionOutcome::Indeterminate {
+            failures: vec![SubmissionFailure { endpoint, message }],
+        },
+    }
+}
+
+#[cfg(test)]
+async fn dispatch_with<F, Fut>(
+    plan: &[TargetGroup],
+    raw_transaction: Arc<[u8]>,
+    attempt: F,
+) -> SubmissionOutcome
+where
+    F: Fn(String, Arc<[u8]>) -> Fut,
+    Fut: Future<Output = EndpointAttempt> + Send + 'static,
+{
+    dispatch_while_with(plan, raw_transaction, || true, attempt).await
+}
+
+async fn dispatch_while_with<ShouldContinue, F, Fut>(
+    plan: &[TargetGroup],
+    raw_transaction: Arc<[u8]>,
+    should_continue: ShouldContinue,
+    attempt: F,
+) -> SubmissionOutcome
+where
+    ShouldContinue: Fn() -> bool,
+    F: Fn(String, Arc<[u8]>) -> Fut,
+    Fut: Future<Output = EndpointAttempt> + Send + 'static,
+{
+    let mut failures = Vec::new();
+    let mut ambiguity_seen = false;
+
+    for group in plan {
+        if !should_continue() {
+            break;
+        }
+        log::info!(
+            "transaction submission trying {} endpoint(s) for {}",
+            group.endpoints.len(),
+            group.provider_id.unwrap_or("configured endpoint")
+        );
+
+        match submit_to_group(group, Arc::clone(&raw_transaction), &attempt).await {
+            GroupOutcome::Accepted {
+                endpoint,
+                code,
+                message,
+            } => {
+                return SubmissionOutcome::Accepted {
+                    endpoint,
+                    code,
+                    message,
+                };
+            }
+            GroupOutcome::Rejected {
+                endpoint,
+                code,
+                message,
+            } => {
+                if !ambiguity_seen {
+                    return SubmissionOutcome::Rejected {
+                        endpoint,
+                        code,
+                        message,
+                    };
+                }
+
+                failures.push(SubmissionFailure {
+                    endpoint,
+                    message: format!("rejected with code {code}: {message}"),
+                });
+                return SubmissionOutcome::Indeterminate { failures };
+            }
+            GroupOutcome::NotSubmitted {
+                failures: group_failures,
+            } => failures.extend(group_failures),
+            GroupOutcome::Indeterminate {
+                failures: group_failures,
+            } => {
+                ambiguity_seen = true;
+                failures.extend(group_failures);
+            }
+        }
+    }
+
+    if ambiguity_seen {
+        SubmissionOutcome::Indeterminate { failures }
+    } else {
+        SubmissionOutcome::NotSubmitted { failures }
+    }
+}
+
+async fn submit_to_group<F, Fut>(
+    group: &TargetGroup,
+    raw_transaction: Arc<[u8]>,
+    attempt: &F,
+) -> GroupOutcome
+where
+    F: Fn(String, Arc<[u8]>) -> Fut,
+    Fut: Future<Output = EndpointAttempt> + Send + 'static,
+{
+    let runtime = match &*SUBMISSION_RUNTIME {
+        Ok(runtime) => runtime,
+        Err(message) => {
+            return GroupOutcome::NotSubmitted {
+                failures: group
+                    .endpoints
+                    .iter()
+                    .map(|endpoint| SubmissionFailure {
+                        endpoint: endpoint.clone(),
+                        message: message.clone(),
+                    })
+                    .collect(),
+            };
+        }
+    };
+    let mut attempts = FuturesUnordered::new();
+    for (index, endpoint) in group.endpoints.iter().cloned().enumerate() {
+        let attempt_future = attempt(endpoint.clone(), Arc::clone(&raw_transaction));
+        let task = runtime.spawn(attempt_future);
+        attempts.push(async move {
+            let result = match task.await {
+                Ok(result) => result,
+                Err(error) => EndpointAttempt::Indeterminate {
+                    message: format!("submission task failed: {error}"),
+                },
+            };
+            (index, endpoint, result)
+        });
+    }
+
+    let mut rejections = Vec::new();
+    let mut not_submitted = Vec::new();
+    let mut indeterminate = Vec::new();
+
+    while let Some((index, endpoint, result)) = attempts.next().await {
+        match result {
+            EndpointAttempt::Accepted { code, message } => {
+                // The remaining tasks stay on the process-wide submission
+                // runtime and finish independently of the caller's runtime.
+                return GroupOutcome::Accepted {
+                    endpoint,
+                    code,
+                    message,
+                };
+            }
+            EndpointAttempt::Rejected { code, message } => {
+                rejections.push((index, endpoint, code, message));
+            }
+            EndpointAttempt::NotSubmitted { message } => {
+                not_submitted.push((index, SubmissionFailure { endpoint, message }));
+            }
+            EndpointAttempt::Indeterminate { message } => {
+                indeterminate.push((index, SubmissionFailure { endpoint, message }));
+            }
+        }
+    }
+
+    if !indeterminate.is_empty() {
+        for (index, endpoint, code, message) in rejections {
+            indeterminate.push((
+                index,
+                SubmissionFailure {
+                    endpoint,
+                    message: format!("rejected with code {code}: {message}"),
+                },
+            ));
+        }
+        indeterminate.extend(not_submitted);
+        indeterminate.sort_by_key(|(index, _)| *index);
+        return GroupOutcome::Indeterminate {
+            failures: indeterminate
+                .into_iter()
+                .map(|(_, failure)| failure)
+                .collect(),
+        };
+    }
+
+    if !rejections.is_empty() {
+        rejections.sort_by_key(|(index, _, _, _)| *index);
+        let (_, endpoint, code, message) = rejections.remove(0);
+        return GroupOutcome::Rejected {
+            endpoint,
+            code,
+            message,
+        };
+    }
+
+    not_submitted.sort_by_key(|(index, _)| *index);
+    GroupOutcome::NotSubmitted {
+        failures: not_submitted
+            .into_iter()
+            .map(|(_, failure)| failure)
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        cell::Cell,
+        collections::{HashMap, HashSet},
+        rc::Rc,
+        sync::{mpsc, Arc, Mutex},
+        time::Duration,
+    };
+
+    use tokio::sync::{Barrier, Semaphore};
+
+    use super::*;
+
+    const COMMUNITY_ENDPOINT: &str = "https://z3.deepikaw.xyz:443";
+
+    fn test_plan(configured_url: &str, mode: SubmissionMode, txid_byte: u8) -> Vec<TargetGroup> {
+        submission_plan(configured_url, mode, &[txid_byte; 32], MANAGED_PROVIDERS)
+    }
+
+    fn provider_ids(plan: &[TargetGroup]) -> Vec<Option<&'static str>> {
+        plan.iter().map(|target| target.provider_id).collect()
+    }
+
+    #[test]
+    fn managed_endpoints_are_unique() {
+        let mut endpoints = HashSet::new();
+        for provider in MANAGED_PROVIDERS {
+            assert!(
+                !provider.endpoints.is_empty(),
+                "{} has no endpoints",
+                provider.id
+            );
+            for endpoint in provider.endpoints {
+                assert!(
+                    endpoints.insert(*endpoint),
+                    "managed endpoint appears more than once: {endpoint}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn current_only_uses_exact_configured_url() {
+        let configured_url = STARDUST_ENDPOINTS[0];
+        let plan = test_plan(configured_url, SubmissionMode::CurrentOnly, 1);
+
+        assert_eq!(plan, vec![configured_target(configured_url)]);
+    }
+
+    #[test]
+    fn configured_managed_provider_is_last() {
+        let stardust_plan = test_plan(STARDUST_ENDPOINTS[0], SubmissionMode::ProviderAware, 2);
+        assert_eq!(
+            provider_ids(&stardust_plan),
+            vec![Some("zec-rocks"), Some("stardust")]
+        );
+
+        let rocks_plan = test_plan(ZEC_ROCKS_ENDPOINTS[2], SubmissionMode::ProviderAware, 3);
+        assert_eq!(
+            provider_ids(&rocks_plan),
+            vec![Some("stardust"), Some("zec-rocks")]
+        );
+    }
+
+    #[test]
+    fn community_endpoint_is_only_the_final_fallback() {
+        let plan = test_plan(COMMUNITY_ENDPOINT, SubmissionMode::ProviderAware, 4);
+
+        assert_eq!(plan.len(), 3);
+        assert!(plan[0].provider_id.is_some());
+        assert!(plan[1].provider_id.is_some());
+        assert_eq!(plan[2], configured_target(COMMUNITY_ENDPOINT));
+        assert!(plan[..2]
+            .iter()
+            .flat_map(|target| target.endpoints.iter())
+            .all(|endpoint| endpoint != COMMUNITY_ENDPOINT));
+    }
+
+    #[test]
+    fn provider_order_is_stable_and_txid_dependent() {
+        const THIRD_ENDPOINTS: &[&str] = &["https://third.example:443"];
+        const PROVIDERS: &[Provider] = &[
+            Provider {
+                id: "stardust",
+                endpoints: STARDUST_ENDPOINTS,
+            },
+            Provider {
+                id: "zec-rocks",
+                endpoints: ZEC_ROCKS_ENDPOINTS,
+            },
+            Provider {
+                id: "third",
+                endpoints: THIRD_ENDPOINTS,
+            },
+        ];
+
+        let first = submission_plan(
+            COMMUNITY_ENDPOINT,
+            SubmissionMode::ProviderAware,
+            &[0; 32],
+            PROVIDERS,
+        );
+        let repeated = submission_plan(
+            COMMUNITY_ENDPOINT,
+            SubmissionMode::ProviderAware,
+            &[0; 32],
+            PROVIDERS,
+        );
+        assert_eq!(first, repeated);
+
+        let first_ids = provider_ids(&first[..3]);
+        assert!((1..=u8::MAX).any(|byte| {
+            let candidate = submission_plan(
+                COMMUNITY_ENDPOINT,
+                SubmissionMode::ProviderAware,
+                &[byte; 32],
+                PROVIDERS,
+            );
+            provider_ids(&candidate[..3]) != first_ids
+        }));
+    }
+
+    #[test]
+    fn classifies_success_duplicate_and_rejection() {
+        assert!(matches!(
+            classify_send_response(SendResponse {
+                error_code: 0,
+                error_message: "txid".to_string(),
+            }),
+            EndpointAttempt::Accepted {
+                code: 0,
+                message
+            } if message == "txid"
+        ));
+        assert!(matches!(
+            classify_send_response(SendResponse {
+                error_code: -25,
+                error_message: "TXN-ALREADY-IN-MEMPOOL".to_string(),
+            }),
+            EndpointAttempt::Accepted {
+                code: -25,
+                message
+            } if message == "TXN-ALREADY-IN-MEMPOOL"
+        ));
+        assert!(matches!(
+            classify_send_response(SendResponse {
+                error_code: 18,
+                error_message: "bad-txns-inputs-spent".to_string(),
+            }),
+            EndpointAttempt::Rejected { code: 18, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn all_regions_start_concurrently_with_identical_bytes() {
+        let group = TargetGroup {
+            provider_id: Some("test"),
+            endpoints: vec!["one".to_string(), "two".to_string(), "three".to_string()],
+        };
+        let barrier = Arc::new(Barrier::new(group.endpoints.len()));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let expected = Arc::<[u8]>::from(vec![1, 2, 3, 4]);
+        let result = dispatch_with(&[group], Arc::clone(&expected), {
+            let barrier = Arc::clone(&barrier);
+            let seen = Arc::clone(&seen);
+            move |endpoint, raw_transaction| {
+                let barrier = Arc::clone(&barrier);
+                let seen = Arc::clone(&seen);
+                async move {
+                    seen.lock()
+                        .expect("seen lock")
+                        .push((endpoint.clone(), raw_transaction.to_vec()));
+                    barrier.wait().await;
+                    if endpoint == "two" {
+                        EndpointAttempt::Accepted {
+                            code: 0,
+                            message: String::new(),
+                        }
+                    } else {
+                        EndpointAttempt::NotSubmitted {
+                            message: "offline".to_string(),
+                        }
+                    }
+                }
+            }
+        })
+        .await;
+
+        assert!(matches!(result, SubmissionOutcome::Accepted { .. }));
+        let seen = seen.lock().expect("seen lock");
+        assert_eq!(seen.len(), 3);
+        assert!(seen.iter().all(|(_, bytes)| bytes == expected.as_ref()));
+    }
+
+    #[test]
+    fn regional_attempts_finish_after_callers_runtime_drops() {
+        let group = TargetGroup {
+            provider_id: Some("test"),
+            endpoints: vec![
+                "accepted".to_string(),
+                "remaining-one".to_string(),
+                "remaining-two".to_string(),
+            ],
+        };
+        let barrier = Arc::new(Barrier::new(group.endpoints.len()));
+        let permits = Arc::new(Semaphore::new(0));
+        let (completed_tx, completed_rx) = mpsc::channel();
+
+        let result = {
+            let caller_runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build caller runtime");
+            caller_runtime.block_on(dispatch_with(&[group], Arc::from(vec![1]), {
+                let barrier = Arc::clone(&barrier);
+                let permits = Arc::clone(&permits);
+                move |endpoint, _| {
+                    let barrier = Arc::clone(&barrier);
+                    let permits = Arc::clone(&permits);
+                    let completed_tx = completed_tx.clone();
+                    async move {
+                        barrier.wait().await;
+                        if endpoint == "accepted" {
+                            EndpointAttempt::Accepted {
+                                code: 0,
+                                message: String::new(),
+                            }
+                        } else {
+                            permits.acquire().await.expect("submission permit").forget();
+                            completed_tx.send(endpoint).expect("record completion");
+                            EndpointAttempt::NotSubmitted {
+                                message: "offline".to_string(),
+                            }
+                        }
+                    }
+                }
+            }))
+        };
+
+        assert!(matches!(result, SubmissionOutcome::Accepted { .. }));
+        permits.add_permits(2);
+        let mut completed = vec![
+            completed_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("first remaining region completed"),
+            completed_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("second remaining region completed"),
+        ];
+        completed.sort();
+        assert_eq!(completed, ["remaining-one", "remaining-two"]);
+    }
+
+    #[tokio::test]
+    async fn providers_are_attempted_sequentially() {
+        let plan = test_plan(STARDUST_ENDPOINTS[0], SubmissionMode::ProviderAware, 7);
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let result = dispatch_with(&plan, Arc::from(vec![9]), {
+            let calls = Arc::clone(&calls);
+            move |endpoint, _| {
+                let calls = Arc::clone(&calls);
+                async move {
+                    calls.lock().expect("calls lock").push(endpoint.clone());
+                    if ZEC_ROCKS_ENDPOINTS.contains(&endpoint.as_str()) {
+                        EndpointAttempt::NotSubmitted {
+                            message: "offline".to_string(),
+                        }
+                    } else {
+                        EndpointAttempt::Accepted {
+                            code: 0,
+                            message: String::new(),
+                        }
+                    }
+                }
+            }
+        })
+        .await;
+
+        assert!(matches!(result, SubmissionOutcome::Accepted { .. }));
+        let calls = calls.lock().expect("calls lock");
+        let first_stardust = calls
+            .iter()
+            .position(|endpoint| STARDUST_ENDPOINTS.contains(&endpoint.as_str()))
+            .expect("stardust fallback attempted");
+        assert_eq!(first_stardust, ZEC_ROCKS_ENDPOINTS.len());
+    }
+
+    #[tokio::test]
+    async fn fallback_provider_is_not_started_after_stop() {
+        let plan = vec![
+            configured_target("first"),
+            configured_target("must-not-run"),
+        ];
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let result = dispatch_while_with(
+            &plan,
+            Arc::from(vec![1]),
+            {
+                let calls = Arc::clone(&calls);
+                move || calls.lock().expect("calls lock").is_empty()
+            },
+            {
+                let calls = Arc::clone(&calls);
+                move |endpoint, _| {
+                    let calls = Arc::clone(&calls);
+                    async move {
+                        calls.lock().expect("calls lock").push(endpoint);
+                        EndpointAttempt::NotSubmitted {
+                            message: "offline".to_string(),
+                        }
+                    }
+                }
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            SubmissionOutcome::NotSubmitted { failures } if failures.len() == 1
+        ));
+        assert_eq!(calls.lock().expect("calls lock").as_slice(), ["first"]);
+    }
+
+    #[tokio::test]
+    async fn definite_rejection_stops_without_fallback() {
+        let plan = vec![
+            configured_target("first"),
+            configured_target("must-not-run"),
+        ];
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let result = dispatch_with(&plan, Arc::from(vec![1]), {
+            let calls = Arc::clone(&calls);
+            move |endpoint, _| {
+                let calls = Arc::clone(&calls);
+                async move {
+                    calls.lock().expect("calls lock").push(endpoint);
+                    EndpointAttempt::Rejected {
+                        code: 18,
+                        message: "invalid".to_string(),
+                    }
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(
+            result,
+            SubmissionOutcome::Rejected {
+                endpoint: "first".to_string(),
+                code: 18,
+                message: "invalid".to_string(),
+            }
+        );
+        assert_eq!(calls.lock().expect("calls lock").as_slice(), ["first"]);
+    }
+
+    #[tokio::test]
+    async fn all_pre_send_failures_are_not_submitted() {
+        let plan = vec![configured_target("first"), configured_target("second")];
+        let result = dispatch_with(&plan, Arc::from(vec![1]), |endpoint, _| async move {
+            EndpointAttempt::NotSubmitted {
+                message: format!("cannot connect to {endpoint}"),
+            }
+        })
+        .await;
+
+        assert!(matches!(
+            result,
+            SubmissionOutcome::NotSubmitted { failures } if failures.len() == 2
+        ));
+    }
+
+    #[tokio::test]
+    async fn ambiguity_can_be_resolved_by_later_acceptance() {
+        let plan = vec![configured_target("first"), configured_target("second")];
+        let outcomes = Arc::new(Mutex::new(HashMap::from([
+            (
+                "first".to_string(),
+                EndpointAttempt::Indeterminate {
+                    message: "timeout".to_string(),
+                },
+            ),
+            (
+                "second".to_string(),
+                EndpointAttempt::Accepted {
+                    code: -25,
+                    message: "already in mempool".to_string(),
+                },
+            ),
+        ])));
+        let result = dispatch_with(&plan, Arc::from(vec![1]), move |endpoint, _| {
+            let outcome = outcomes
+                .lock()
+                .expect("outcomes lock")
+                .remove(&endpoint)
+                .expect("endpoint outcome");
+            std::future::ready(outcome)
+        })
+        .await;
+
+        assert_eq!(
+            result,
+            SubmissionOutcome::Accepted {
+                endpoint: "second".to_string(),
+                code: -25,
+                message: "already in mempool".to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn ambiguity_taints_later_rejection() {
+        let plan = vec![configured_target("first"), configured_target("second")];
+        let outcomes = Arc::new(Mutex::new(HashMap::from([
+            (
+                "first".to_string(),
+                EndpointAttempt::Indeterminate {
+                    message: "timeout".to_string(),
+                },
+            ),
+            (
+                "second".to_string(),
+                EndpointAttempt::Rejected {
+                    code: 18,
+                    message: "invalid".to_string(),
+                },
+            ),
+        ])));
+        let result = dispatch_with(&plan, Arc::from(vec![1]), move |endpoint, _| {
+            let outcome = outcomes
+                .lock()
+                .expect("outcomes lock")
+                .remove(&endpoint)
+                .expect("endpoint outcome");
+            std::future::ready(outcome)
+        })
+        .await;
+
+        assert!(matches!(
+            result,
+            SubmissionOutcome::Indeterminate { failures }
+                if failures.len() == 2
+                    && failures[0].endpoint == "first"
+                    && failures[1].endpoint == "second"
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn current_only_uses_the_callers_runtime() {
+        let called = Rc::new(Cell::new(false));
+        let result = submit_current_with(COMMUNITY_ENDPOINT.to_string(), {
+            let called = Rc::clone(&called);
+            move |endpoint| async move {
+                assert_eq!(endpoint, COMMUNITY_ENDPOINT);
+                called.set(true);
+                EndpointAttempt::Accepted {
+                    code: 0,
+                    message: String::new(),
+                }
+            }
+        })
+        .await;
+
+        assert!(called.get());
+        assert_eq!(
+            result,
+            SubmissionOutcome::Accepted {
+                endpoint: COMMUNITY_ENDPOINT.to_string(),
+                code: 0,
+                message: String::new(),
+            }
+        );
+    }
+}

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -146,6 +146,7 @@ pub fn sync_wallet(db_path: &Path) {
     sync_api::run_full_sync_blocking(
         path_str(db_path),
         LIGHTWALLETD_URL.into(),
+        false,
         REGTEST_NETWORK.into(),
         1,
     )
@@ -275,6 +276,7 @@ pub fn execute_send(
     sync_api::execute_proposal(
         path_str(db_path),
         LIGHTWALLETD_URL.into(),
+        false,
         proposal.proposal_id,
         send_flow_id.into(),
         sender_mnemonic.as_bytes().to_vec(),

--- a/rust/tests/ironwood_regtest_migration.rs
+++ b/rust/tests/ironwood_regtest_migration.rs
@@ -180,6 +180,7 @@ fn sync(db_path: &str) {
     sync_api::run_full_sync_blocking(
         db_path.to_string(),
         lightwalletd_url(),
+        false,
         NETWORK.to_string(),
         1,
     )
@@ -223,6 +224,7 @@ fn migrate(db_path: &str, account_uuid: &str) -> sync_api::IronwoodMigrationResu
     sync_api::migrate_orchard_to_ironwood(
         db_path.to_string(),
         lightwalletd_url(),
+        false,
         NETWORK.to_string(),
         account_uuid.to_string(),
         MNEMONIC.as_bytes().to_vec(),

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -253,6 +253,84 @@ void main() {
     });
   });
 
+  group('transactionSubmissionRoutingFor', () {
+    test('enables managed routing for explicit mainnet presets', () {
+      for (final config in [
+        defaultRpcEndpointConfig('main'),
+        const RpcEndpointConfig(
+          networkName: 'main',
+          lightwalletdUrl: 'https://zec.rocks:443',
+          presetId: 'zec-rocks',
+        ),
+        const RpcEndpointConfig(
+          networkName: 'main',
+          lightwalletdUrl: 'https://z3.deepikaw.xyz:443',
+          presetId: 'z3-deepikaw',
+        ),
+      ]) {
+        expect(
+          transactionSubmissionRoutingFor(config),
+          TransactionSubmissionRouting.managedProviders,
+        );
+      }
+    });
+
+    test('keeps custom mainnet endpoints on the current endpoint', () {
+      for (final url in [
+        'https://custom.example:443',
+        defaultRpcEndpointConfig('main').lightwalletdUrl,
+      ]) {
+        expect(
+          transactionSubmissionRoutingFor(
+            RpcEndpointConfig(
+              networkName: 'main',
+              lightwalletdUrl: url,
+              presetId: kCustomRpcEndpointPresetId,
+            ),
+          ),
+          TransactionSubmissionRouting.currentEndpointOnly,
+        );
+      }
+    });
+
+    test('keeps legacy mainnet endpoint records on the current endpoint', () {
+      expect(
+        transactionSubmissionRoutingFor(
+          RpcEndpointConfig(
+            networkName: 'main',
+            lightwalletdUrl: defaultRpcEndpointConfig('main').lightwalletdUrl,
+          ),
+        ),
+        TransactionSubmissionRouting.currentEndpointOnly,
+      );
+    });
+
+    test('keeps testnet and regtest presets on the current endpoint', () {
+      for (final config in [
+        defaultRpcEndpointConfig('test'),
+        defaultRpcEndpointConfig('regtest'),
+      ]) {
+        expect(
+          transactionSubmissionRoutingFor(config),
+          TransactionSubmissionRouting.currentEndpointOnly,
+        );
+      }
+    });
+
+    test('keeps masquerade builds on the current endpoint', () {
+      expect(
+        transactionSubmissionRoutingFor(
+          const RpcEndpointConfig(
+            networkName: 'main',
+            lightwalletdUrl: 'https://lwd.157.245.208.35.sslip.io:443',
+            presetId: kIronwoodMasqueradeRpcEndpointPresetId,
+          ),
+        ),
+        TransactionSubmissionRouting.currentEndpointOnly,
+      );
+    });
+  });
+
   group('fallbackRpcEndpointCandidatesFor', () {
     test('uses preset order when the mainnet default is primary', () {
       final candidates = fallbackRpcEndpointCandidatesFor(

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -253,7 +253,7 @@ void main() {
     });
   });
 
-  group('transactionSubmissionRoutingFor', () {
+  group('usesManagedSubmissionRouting', () {
     test('enables managed routing for explicit mainnet presets', () {
       for (final config in [
         defaultRpcEndpointConfig('main'),
@@ -268,10 +268,7 @@ void main() {
           presetId: 'z3-deepikaw',
         ),
       ]) {
-        expect(
-          transactionSubmissionRoutingFor(config),
-          TransactionSubmissionRouting.managedProviders,
-        );
+        expect(config.usesManagedSubmissionRouting, isTrue);
       }
     });
 
@@ -280,29 +277,21 @@ void main() {
         'https://custom.example:443',
         defaultRpcEndpointConfig('main').lightwalletdUrl,
       ]) {
-        expect(
-          transactionSubmissionRoutingFor(
-            RpcEndpointConfig(
-              networkName: 'main',
-              lightwalletdUrl: url,
-              presetId: kCustomRpcEndpointPresetId,
-            ),
-          ),
-          TransactionSubmissionRouting.currentEndpointOnly,
+        final config = RpcEndpointConfig(
+          networkName: 'main',
+          lightwalletdUrl: url,
+          presetId: kCustomRpcEndpointPresetId,
         );
+        expect(config.usesManagedSubmissionRouting, isFalse);
       }
     });
 
     test('keeps legacy mainnet endpoint records on the current endpoint', () {
-      expect(
-        transactionSubmissionRoutingFor(
-          RpcEndpointConfig(
-            networkName: 'main',
-            lightwalletdUrl: defaultRpcEndpointConfig('main').lightwalletdUrl,
-          ),
-        ),
-        TransactionSubmissionRouting.currentEndpointOnly,
+      final config = RpcEndpointConfig(
+        networkName: 'main',
+        lightwalletdUrl: defaultRpcEndpointConfig('main').lightwalletdUrl,
       );
+      expect(config.usesManagedSubmissionRouting, isFalse);
     });
 
     test('keeps testnet and regtest presets on the current endpoint', () {
@@ -310,24 +299,17 @@ void main() {
         defaultRpcEndpointConfig('test'),
         defaultRpcEndpointConfig('regtest'),
       ]) {
-        expect(
-          transactionSubmissionRoutingFor(config),
-          TransactionSubmissionRouting.currentEndpointOnly,
-        );
+        expect(config.usesManagedSubmissionRouting, isFalse);
       }
     });
 
     test('keeps masquerade builds on the current endpoint', () {
-      expect(
-        transactionSubmissionRoutingFor(
-          const RpcEndpointConfig(
-            networkName: 'main',
-            lightwalletdUrl: 'https://lwd.157.245.208.35.sslip.io:443',
-            presetId: kIronwoodMasqueradeRpcEndpointPresetId,
-          ),
-        ),
-        TransactionSubmissionRouting.currentEndpointOnly,
+      const config = RpcEndpointConfig(
+        networkName: 'main',
+        lightwalletdUrl: 'https://lwd.157.245.208.35.sslip.io:443',
+        presetId: kIronwoodMasqueradeRpcEndpointPresetId,
       );
+      expect(config.usesManagedSubmissionRouting, isFalse);
     });
   });
 

--- a/test/features/migration/ironwood_migration_background_credential_store_test.dart
+++ b/test/features/migration/ironwood_migration_background_credential_store_test.dart
@@ -24,6 +24,7 @@ void main() {
       accountUuid: 'account-1',
       dbPath: '/tmp/wallet.db',
       lightwalletdUrl: 'https://lwd.example:443',
+      managedSubmissionRouting: true,
     );
 
     expect(
@@ -40,6 +41,7 @@ void main() {
       '101112131415161718191a1b1c1d1e1f',
     );
     expect(prepared.saltBase64, base64Encode(List<int>.generate(16, (i) => i)));
+    expect(prepared.managedSubmissionRouting, isTrue);
     expect(prepared.expectedRunId, isNull);
     expect(
       await store.read(network: 'test', accountUuid: 'account-1'),
@@ -79,6 +81,7 @@ void main() {
     expect(relocated.dbPath, '/new-container/wallet.db');
     expect(relocated.credentialHex, prepared.credentialHex);
     expect(relocated.saltBase64, prepared.saltBase64);
+    expect(relocated.managedSubmissionRouting, isTrue);
     expect(relocated.expectedRunId, 'run-1');
   });
 
@@ -89,6 +92,7 @@ void main() {
       'accountUuid': 'account-1',
       'dbPath': '/tmp/wallet.db',
       'lightwalletdUrl': 'https://lwd.example:443',
+      'managedSubmissionRouting': true,
       'credentialHex': List.filled(32, 'ab').join(),
       'saltBase64': base64Encode(List<int>.filled(16, 7)),
       'expectedRunId': null,
@@ -107,6 +111,8 @@ void main() {
       {...valid, 'version': '1'},
       {...valid, 'network': 'unknown'},
       {...valid, 'accountUuid': ''},
+      {...valid, 'managedSubmissionRouting': null},
+      {...valid, 'managedSubmissionRouting': 'true'},
       {...valid, 'credentialHex': List.filled(32, 'AB').join()},
       {...valid, 'credentialHex': List.filled(31, 'ab').join()},
       {...valid, 'saltBase64': base64Encode(List<int>.filled(15, 7))},
@@ -125,6 +131,30 @@ void main() {
         reason: '$invalid',
       );
     }
+  });
+
+  test('legacy manifest defaults to current-endpoint-only routing', () {
+    final legacy = <String, Object?>{
+      'version': 1,
+      'network': 'main',
+      'accountUuid': 'account-1',
+      'dbPath': '/tmp/wallet.db',
+      'lightwalletdUrl': 'https://us.zec.stardust.rest:443',
+      'credentialHex': List.filled(32, 'ab').join(),
+      'saltBase64': base64Encode(List<int>.filled(16, 7)),
+      'expectedRunId': 'run-1',
+    };
+
+    final decoded = IronwoodMigrationBackgroundCredentialManifest.decode(
+      jsonEncode(legacy),
+    );
+
+    expect(decoded.managedSubmissionRouting, isFalse);
+    expect(
+      (jsonDecode(decoded.encode())
+          as Map<String, dynamic>)['managedSubmissionRouting'],
+      isFalse,
+    );
   });
 
   test('stored manifest must match its network and account scope', () async {

--- a/test/features/migration/ironwood_migration_coordinator_provider_test.dart
+++ b/test/features/migration/ironwood_migration_coordinator_provider_test.dart
@@ -458,53 +458,50 @@ void main() {
     },
   );
 
-  test(
-    'due software broadcast retains a blocked proof permit',
-    () async {
-      final statuses = {
-        _softwareUuid: _status(
-          'ready_to_migrate',
-          scheduledHeight: 1_000,
-          signedChildPcztCount: 1,
-          nextActionHeight: 1_000,
-          proofReady: false,
-        ),
-        _hardwareUuid: _status('complete', activeRunId: null),
-      };
-      final softwareStarts = <String>[];
-      final broadcasts = <String>[];
-      final container = _container(
-        statuses: statuses,
-        softwareStarts: softwareStarts,
-        broadcasts: broadcasts,
-        usesNativeOutbox: false,
-        syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_001),
-      );
-      addTearDown(container.dispose);
-      final subscription = container.listen(
-        ironwoodMigrationCoordinatorProvider,
-        (_, _) {},
-        fireImmediately: true,
-      );
-      addTearDown(subscription.close);
-      await container.read(syncProvider.future);
+  test('due software broadcast retains a blocked proof permit', () async {
+    final statuses = {
+      _softwareUuid: _status(
+        'ready_to_migrate',
+        scheduledHeight: 1_000,
+        signedChildPcztCount: 1,
+        nextActionHeight: 1_000,
+        proofReady: false,
+      ),
+      _hardwareUuid: _status('complete', activeRunId: null),
+    };
+    final softwareStarts = <String>[];
+    final broadcasts = <String>[];
+    final container = _container(
+      statuses: statuses,
+      softwareStarts: softwareStarts,
+      broadcasts: broadcasts,
+      usesNativeOutbox: false,
+      syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_001),
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      ironwoodMigrationCoordinatorProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+    await container.read(syncProvider.future);
 
-      final coordinator = container.read(
-        ironwoodMigrationCoordinatorProvider.notifier,
-      );
-      coordinator.grantChildProofBatchPermit(_softwareUuid);
-      await coordinator.refreshNow();
+    final coordinator = container.read(
+      ironwoodMigrationCoordinatorProvider.notifier,
+    );
+    coordinator.grantChildProofBatchPermit(_softwareUuid);
+    await coordinator.refreshNow();
 
-      expect(broadcasts, [_softwareUuid]);
-      expect(softwareStarts, isEmpty);
-      expect(
-        container
-            .read(ironwoodMigrationCoordinatorProvider)
-            .childProofBatchPermits,
-        contains(_softwareUuid),
-      );
-    },
-  );
+    expect(broadcasts, [_softwareUuid]);
+    expect(softwareStarts, isEmpty);
+    expect(
+      container
+          .read(ironwoodMigrationCoordinatorProvider)
+          .childProofBatchPermits,
+      contains(_softwareUuid),
+    );
+  });
 
   test(
     'manual retry runs again after an automatic attempt in flight',
@@ -2378,6 +2375,7 @@ ProviderContainer _container({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required password,
@@ -2396,6 +2394,7 @@ ProviderContainer _container({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required password,

--- a/test/features/migration/ironwood_migration_desktop_advance_trigger_test.dart
+++ b/test/features/migration/ironwood_migration_desktop_advance_trigger_test.dart
@@ -228,6 +228,7 @@ class _Harness {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required password,
@@ -298,7 +299,12 @@ AppBootstrapState _bootstrap() {
     initialLocation: '/home',
     initialAccountState: const AccountState(
       accounts: [
-        AccountInfo(uuid: _uuid, name: 'Software', order: 0, isSeedAnchor: true),
+        AccountInfo(
+          uuid: _uuid,
+          name: 'Software',
+          order: 0,
+          isSeedAnchor: true,
+        ),
       ],
       activeAccountUuid: _uuid,
       activeAddress: 'u1test',

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -868,6 +868,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required approvedSchedule,
@@ -3572,6 +3573,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required password,
@@ -6127,6 +6129,7 @@ IronwoodMigrationService _migrationServiceForStart({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required approvedSchedule,
@@ -6158,6 +6161,7 @@ IronwoodMigrationService _migrationServiceForContinue({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required password,
@@ -6270,6 +6274,7 @@ IronwoodMigrationService _keystonePrivateReviewService({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required approvedSchedule,

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -1878,6 +1879,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -1909,6 +1911,75 @@ void main() {
       expect(returnedMnemonicBytes, hasLength(2));
       for (final bytes in returnedMnemonicBytes) {
         expect(bytes, everyElement(0));
+      }
+    },
+  );
+
+  test(
+    'software migration routes managed presets but not custom URLs',
+    () async {
+      final managedEndpoint = defaultRpcEndpointConfig('main');
+      final cases = <({RpcEndpointConfig endpoint, bool expected})>[
+        (endpoint: managedEndpoint, expected: true),
+        (
+          endpoint: RpcEndpointConfig(
+            networkName: managedEndpoint.networkName,
+            lightwalletdUrl: managedEndpoint.lightwalletdUrl,
+            presetId: kCustomRpcEndpointPresetId,
+          ),
+          expected: false,
+        ),
+      ];
+
+      for (final testCase in cases) {
+        bool? seenManagedSubmissionRouting;
+        final service = IronwoodMigrationService(
+          getWalletDbPath: () async => '/tmp/wallet.db',
+          getStatus:
+              ({
+                required dbPath,
+                required network,
+                required accountUuid,
+              }) async => _migrationStatus(),
+          getPrivatePlan:
+              ({
+                required dbPath,
+                required network,
+                required accountUuid,
+              }) async => null,
+          secureStore: AppSecureStore.testing(
+            storage: const FlutterSecureStorage(),
+          ),
+          getEndpoint: () => testCase.endpoint,
+          getSessionPassword: () => 'test-password',
+          isMobile: () => false,
+          isMacOS: () => true,
+          startMacosSoftwareMigration:
+              ({
+                required dbPath,
+                required lightwalletdUrl,
+                required managedSubmissionRouting,
+                required network,
+                required accountUuid,
+                required approvedSchedule,
+                required password,
+                required saltBase64,
+              }) async {
+                seenManagedSubmissionRouting = managedSubmissionRouting;
+                return _migrationResult();
+              },
+        );
+
+        await service.startSoftwarePrivateMigration(
+          accountUuid: 'account-1',
+          approvedSchedule: const [],
+        );
+
+        expect(
+          seenManagedSubmissionRouting,
+          testCase.expected,
+          reason: 'preset ${testCase.endpoint.presetId}',
+        );
       }
     },
   );
@@ -1955,6 +2026,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -1975,6 +2047,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -2062,6 +2135,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required requestId,
@@ -2121,6 +2195,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -2138,6 +2213,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -2195,6 +2271,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -2630,6 +2707,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required password,
@@ -2703,6 +2781,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -2717,6 +2796,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -2761,6 +2841,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required password,
@@ -2808,6 +2889,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required password,
@@ -2819,6 +2901,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required password,
@@ -2863,6 +2946,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -2872,6 +2956,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -2979,6 +3064,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required requestId,
@@ -3117,6 +3203,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required requestId,
@@ -3234,6 +3321,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required requestId,
@@ -3483,6 +3571,7 @@ void main() {
               required accountUuid,
               required runId,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required expectedTxids,
             }) async {
               recovery = {
@@ -3491,6 +3580,7 @@ void main() {
                 'accountUuid': accountUuid,
                 'runId': runId,
                 'lightwalletdUrl': lightwalletdUrl,
+                'managedSubmissionRouting': managedSubmissionRouting,
                 'expectedTxids': expectedTxids,
               };
               return true;
@@ -3515,8 +3605,135 @@ void main() {
         'accountUuid': 'account-1',
         'runId': 'legacy-run',
         'lightwalletdUrl': 'https://lwd.example:443',
+        'managedSubmissionRouting': false,
         'expectedTxids': ['persisted-tx'],
       });
+    },
+  );
+
+  test(
+    'active manifest keeps its endpoint and submission routing paired',
+    () async {
+      final managedEndpoint = defaultRpcEndpointConfig('main');
+      final customEndpoint = const RpcEndpointConfig(
+        networkName: 'main',
+        lightwalletdUrl: 'https://custom.example:443',
+        presetId: kCustomRpcEndpointPresetId,
+      );
+      final cases =
+          <
+            ({
+              RpcEndpointConfig currentEndpoint,
+              String manifestUrl,
+              bool? manifestRouting,
+              bool expectedRouting,
+            })
+          >[
+            (
+              currentEndpoint: managedEndpoint,
+              manifestUrl: managedEndpoint.normalizedLightwalletdUrl,
+              manifestRouting: null,
+              expectedRouting: false,
+            ),
+            (
+              currentEndpoint: customEndpoint,
+              manifestUrl: managedEndpoint.normalizedLightwalletdUrl,
+              manifestRouting: true,
+              expectedRouting: true,
+            ),
+            (
+              currentEndpoint: managedEndpoint,
+              manifestUrl: customEndpoint.normalizedLightwalletdUrl,
+              manifestRouting: false,
+              expectedRouting: false,
+            ),
+          ];
+
+      for (final testCase in cases) {
+        FlutterSecureStorage.setMockInitialValues({
+          'main:account-1': jsonEncode(<String, Object?>{
+            'version': 1,
+            'network': 'main',
+            'accountUuid': 'account-1',
+            'dbPath': '/tmp/wallet.db',
+            'lightwalletdUrl': testCase.manifestUrl,
+            'managedSubmissionRouting': ?testCase.manifestRouting,
+            'credentialHex': List.filled(32, '01').join(),
+            'saltBase64': base64Encode(List<int>.filled(16, 1)),
+            'expectedRunId': 'run-1',
+          }),
+        });
+        final store = _backgroundCredentialStore();
+        final rustRoutes = <(String, bool)>[];
+        Map<String, Object?>? stagedPayload;
+        final service = IronwoodMigrationService(
+          getWalletDbPath: () async => '/tmp/wallet.db',
+          getStatus:
+              ({
+                required dbPath,
+                required network,
+                required accountUuid,
+              }) async => _migrationStatus(activeRunId: 'run-1'),
+          getPrivatePlan:
+              ({
+                required dbPath,
+                required network,
+                required accountUuid,
+              }) async => null,
+          secureStore: AppSecureStore.testing(
+            storage: const FlutterSecureStorage(),
+          ),
+          backgroundCredentialStore: store,
+          getEndpoint: () => testCase.currentEndpoint,
+          getSessionPassword: () => throw StateError('session password used'),
+          isMobile: () => true,
+          isIOS: () => true,
+          isMacOS: () => false,
+          listMigrationOutboxReceipts: () async => const [],
+          prepareMigrationOutbox:
+              ({
+                required dbPath,
+                required lightwalletdUrl,
+                required managedSubmissionRouting,
+                required network,
+                required accountUuid,
+                required password,
+                required saltBase64,
+              }) async {
+                rustRoutes.add((lightwalletdUrl, managedSubmissionRouting));
+                return _migrationResult();
+              },
+          exportMigrationOutbox:
+              ({
+                required dbPath,
+                required network,
+                required accountUuid,
+                required password,
+                required saltBase64,
+              }) async => _outboxBatch(),
+          stageMigrationOutboxBatch: (payload) async {
+            stagedPayload = payload;
+            return const {'txid-1': 'digest-1'};
+          },
+          armMigrationOutboxBatch:
+              ({required batchId, required expectedDigests}) async => true,
+          runMigrationOutboxOnceNow: () async =>
+              const IronwoodMigrationOutboxRunResult(
+                outcome: IronwoodMigrationOutboxRunOutcome.noWork,
+              ),
+        );
+
+        await service.continueSoftwarePrivateMigration(
+          accountUuid: 'account-1',
+        );
+
+        final expectedRoute = (testCase.manifestUrl, testCase.expectedRouting);
+        expect(rustRoutes, [expectedRoute]);
+        expect((
+          stagedPayload?['lightwalletdUrl'],
+          stagedPayload?['managedSubmissionRouting'],
+        ), expectedRoute);
+      }
     },
   );
 
@@ -3547,6 +3764,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -3667,6 +3885,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required mnemonicBytes,
@@ -3749,6 +3968,7 @@ void main() {
               required accountUuid,
               required runId,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required expectedTxids,
             }) async => false,
         exportMigrationOutbox:
@@ -3778,6 +3998,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required mnemonicBytes,
@@ -3856,6 +4077,7 @@ void main() {
               required accountUuid,
               required runId,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required expectedTxids,
             }) async => false,
         revokeMigrationAccount:
@@ -3872,6 +4094,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required mnemonicBytes,
@@ -3935,6 +4158,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -4001,6 +4225,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -4106,6 +4331,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -4238,6 +4464,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -4330,6 +4557,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -4347,6 +4575,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required approvedSchedule,
@@ -4409,6 +4638,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required password,
@@ -4469,6 +4699,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -4537,6 +4768,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -4620,6 +4852,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -4644,6 +4877,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required requestId,
@@ -4768,6 +5002,7 @@ void main() {
               ({
                 required dbPath,
                 required lightwalletdUrl,
+                required managedSubmissionRouting,
                 required network,
                 required accountUuid,
                 required mnemonicBytes,
@@ -4782,6 +5017,7 @@ void main() {
               ({
                 required dbPath,
                 required lightwalletdUrl,
+                required managedSubmissionRouting,
                 required network,
                 required accountUuid,
                 required password,
@@ -4826,6 +5062,7 @@ void main() {
           'listOutboxReceipts',
         ]);
         expect(stagedPayload?['batchId'], 'test:account-1:run-1');
+        expect(stagedPayload?['managedSubmissionRouting'], isFalse);
         expect(stagedPayload?['nextProofHeight'], 576);
         final items = stagedPayload?['items'] as List<Object?>;
         final item = items.single as Map<Object?, Object?>;
@@ -4863,6 +5100,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required password,
@@ -4957,6 +5195,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required password,
@@ -5013,6 +5252,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required password,
@@ -5033,6 +5273,7 @@ void main() {
           ({
             required dbPath,
             required lightwalletdUrl,
+            required managedSubmissionRouting,
             required network,
             required accountUuid,
             required password,
@@ -5311,6 +5552,7 @@ IronwoodMigrationService _notificationAuthorizationService({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required password,
@@ -5328,6 +5570,7 @@ IronwoodMigrationService _notificationAuthorizationService({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required approvedSchedule,

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -152,6 +152,7 @@ class _FailingBindCredentialStore
     required String accountUuid,
     required String dbPath,
     required String lightwalletdUrl,
+    bool managedSubmissionRouting = false,
   }) async {
     _manifest = _manifestFor(null);
     return _manifest;
@@ -1134,6 +1135,7 @@ IronwoodMigrationService _migrationService({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required mnemonicBytes,
@@ -1147,6 +1149,7 @@ IronwoodMigrationService _migrationService({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required mnemonicBytes,
@@ -1170,6 +1173,7 @@ IronwoodMigrationService _migrationService({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required requestId,
@@ -1196,6 +1200,7 @@ IronwoodMigrationService _migrationService({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required requestId,
@@ -1228,6 +1233,7 @@ IronwoodMigrationService _migrationService({
         ({
           required dbPath,
           required lightwalletdUrl,
+          required managedSubmissionRouting,
           required network,
           required accountUuid,
           required password,
@@ -3630,6 +3636,7 @@ void main() {
             ({
               required dbPath,
               required lightwalletdUrl,
+              required managedSubmissionRouting,
               required network,
               required accountUuid,
               required requestId,

--- a/test/features/send/send_status_screen_test.dart
+++ b/test/features/send/send_status_screen_test.dart
@@ -76,6 +76,7 @@ void main() {
     expect(find.text(r'$1.06K'), findsOneWidget);
     expect(find.text('0.00012 ZEC'), findsOneWidget);
     expect(find.text(truncatedAddress(_address)), findsOneWidget);
+    expect(rustApi.executeManagedSubmissionRoutingCalls, [true]);
     expect(rustApi.discardCalls, isEmpty);
   });
 
@@ -215,6 +216,7 @@ void main() {
     expect(rustApi.extractCalls.single.$2, const [9, 9]);
     // needsSaplingParams=false -> no Sapling params threaded to extraction.
     expect(rustApi.extractCalls.single.$3, isNull);
+    expect(rustApi.extractManagedSubmissionRoutingCalls, [true]);
     // The replayable proposal is already consumed, but discard also releases
     // the owner-scoped wallet-input lock retained for the hardware round trip.
     expect(rustApi.discardCalls, [(BigInt.one, 'test-send-flow')]);
@@ -510,6 +512,8 @@ class _RustApiFake implements RustLibApi {
   final discardCalls = <(BigInt, String)>[];
   final retainCalls = <(BigInt, String)>[];
   final extractCalls = <(List<int>, List<int>, String?)>[];
+  final executeManagedSubmissionRoutingCalls = <bool>[];
+  final extractManagedSubmissionRoutingCalls = <bool>[];
   ExecuteProposalResult? executeResult;
   Object? executeError;
   ExtractAndBroadcastPcztResult? extractResult;
@@ -521,6 +525,8 @@ class _RustApiFake implements RustLibApi {
     discardCalls.clear();
     retainCalls.clear();
     extractCalls.clear();
+    executeManagedSubmissionRoutingCalls.clear();
+    extractManagedSubmissionRoutingCalls.clear();
     executeResult = null;
     executeError = null;
     extractResult = null;
@@ -562,9 +568,11 @@ class _RustApiFake implements RustLibApi {
     required BigInt proposalId,
     required String sendFlowId,
     required List<int> mnemonicBytes,
+    required bool managedSubmissionRouting,
     String? spendParamsPath,
     String? outputParamsPath,
   }) {
+    executeManagedSubmissionRoutingCalls.add(managedSubmissionRouting);
     return _execute();
   }
 
@@ -576,9 +584,11 @@ class _RustApiFake implements RustLibApi {
     required BigInt proposalId,
     required String sendFlowId,
     required String password,
+    required bool managedSubmissionRouting,
     String? spendParamsPath,
     String? outputParamsPath,
   }) {
+    executeManagedSubmissionRoutingCalls.add(managedSubmissionRouting);
     return _execute();
   }
 
@@ -589,9 +599,11 @@ class _RustApiFake implements RustLibApi {
     required String network,
     required List<int> pcztWithProofsBytes,
     required List<int> pcztWithSignaturesBytes,
+    required bool managedSubmissionRouting,
     String? spendParamsPath,
     String? outputParamsPath,
   }) async {
+    extractManagedSubmissionRoutingCalls.add(managedSubmissionRouting);
     extractCalls.add((
       pcztWithProofsBytes,
       pcztWithSignaturesBytes,

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -5180,6 +5180,7 @@ class _RustApiFake implements RustLibApi {
     required String lightwalletdUrl,
     required String network,
     required int mode,
+    required bool managedSubmissionRouting,
   }) {
     return const Stream.empty();
   }


### PR DESCRIPTION
Route all transaction submission independently from wallet sync for explicit mainnet presets. Provider order is transaction-ID deterministic, all regions for one provider are attempted concurrently, and provider groups fall back sequentially with the configured provider last. Custom, legacy, testnet, regtest, and masquerade endpoints remain current-endpoint-only.

All software, PCZT, migration, native iOS outbox, and sync resubmission paths share one Rust dispatcher. Active migrations persist the endpoint and routing mode together, while ambiguous submission outcomes preserve conservative local recovery state. Sync, transaction enhancement, and block download continue using the configured endpoint.

The scope deliberately excludes provider health history or persistent route selection. Current-endpoint-only paths stay pinned to the configured endpoint, although the shared dispatcher may open a fresh submission channel rather than reuse a sync channel.