### PR TITLE
Keep desktop migration broadcasts alive while hidden

### DIFF
--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -18,6 +18,15 @@ import '../services/ironwood_migration_service.dart';
 import 'ironwood_migration_announcement_provider.dart';
 
 const _migrationStatusPollInterval = Duration(seconds: 15);
+
+/// Suspension threshold for the desktop ZIP 318 wallet-open epoch. The epoch
+/// restarts when either wall time outruns the monotonic clock by this much
+/// (machine sleep — the monotonic clock pauses while asleep) or refresh
+/// activity itself gaps past it with the process awake (wallet locked for a
+/// long stretch). Must stay well above [_migrationStatusPollInterval] so
+/// occlusion alone can never restart the epoch; sweep duration is exempt from
+/// the activity-gap signal, so a slow sweep needs no headroom here.
+const kDesktopMigrationEpochSuspensionGap = Duration(minutes: 3);
 const _migrationAdvanceInterval = Duration(
   seconds: String.fromEnvironment('ZCASH_DEFAULT_NETWORK') == 'regtest'
       ? 1
@@ -27,74 +36,82 @@ const _migrationAdvanceInterval = Duration(
 );
 
 /// Enforces ZIP 318's wallet-global, one-transfer fallback allowance for
-/// transfers that were already overdue when a desktop foreground epoch began.
+/// transfers that were already overdue when a desktop wallet-open epoch began.
+///
+/// An epoch is continuous process activity, not window visibility. Desktop
+/// keeps sync and migration polling alive while every window is hidden
+/// (`canRunAppProcessWork`), so a transfer that becomes due while the app runs
+/// occluded or minimized must still broadcast at its scheduled height — it was
+/// not "overdue at open". The coordinator restarts the epoch only when process
+/// activity genuinely gapped (machine sleep, suspension, a long-locked wallet)
+/// or the wallet was reset; a restart re-arms the single on-open allowance and
+/// recaptures the wallet-wide overdue set.
 class DesktopOpenMigrationFallbackGate {
   bool _available = true;
-  bool _foreground = true;
-  int? _foregroundEntryHeight;
-  bool _openStatusSnapshotReady = false;
+  int? _epochEntryHeight;
+  final Set<String> _capturedAccounts = {};
   final Map<String, int> _openOverdueScheduleByTxid = {};
 
-  bool get needsAuthoritativeEntryHeight =>
-      _foreground && _foregroundEntryHeight == null;
-  bool get needsOpenStatusSnapshot =>
-      _foreground &&
-      _foregroundEntryHeight != null &&
-      !_openStatusSnapshotReady;
+  bool get needsAuthoritativeEntryHeight => _epochEntryHeight == null;
 
-  void enterForeground() {
-    if (_foreground) return;
-    _foreground = true;
+  /// The authoritative tip observed when this epoch began, or null while the
+  /// on-open height lookup has not succeeded yet. Threaded into the Rust
+  /// one-due broadcast so the post-accept wallet-overdue redraw covers the
+  /// whole snapshot window even while the local tip is still catching up.
+  int? get epochEntryHeight => _epochEntryHeight;
+
+  bool needsOpenStatusSnapshotFor(String accountUuid) =>
+      _epochEntryHeight != null && !_capturedAccounts.contains(accountUuid);
+
+  void restartEpoch() {
     _available = true;
-    _foregroundEntryHeight = null;
-    _openStatusSnapshotReady = false;
+    _epochEntryHeight = null;
+    _capturedAccounts.clear();
     _openOverdueScheduleByTxid.clear();
   }
 
-  void leaveForeground() {
-    _foreground = false;
-    _available = false;
-    _foregroundEntryHeight = null;
-    _openStatusSnapshotReady = false;
-    _openOverdueScheduleByTxid.clear();
-  }
-
-  void observeForegroundEntryHeight(int height) {
+  void observeEpochEntryHeight(int height) {
     if (height > 0) {
-      _foregroundEntryHeight ??= height;
+      _epochEntryHeight ??= height;
     }
   }
 
-  void captureOpenStatuses(Iterable<rust_sync.MigrationStatus> statuses) {
-    final entryHeight = _foregroundEntryHeight;
+  /// Records [accountUuid]'s overdue-at-open set from its first successful
+  /// status read of the epoch. Capture is per account so one persistently
+  /// failing account read blocks only that account's scheduled transfers, not
+  /// the whole wallet; later calls for an already-captured account are no-ops
+  /// to keep the epoch snapshot frozen.
+  void captureOpenStatus(String accountUuid, rust_sync.MigrationStatus status) {
+    final entryHeight = _epochEntryHeight;
     if (entryHeight == null || entryHeight <= 0) return;
-    _openOverdueScheduleByTxid.clear();
-    for (final status in statuses) {
-      for (final broadcast in status.scheduledBroadcasts) {
-        if (broadcast.status.toLowerCase() == 'scheduled' &&
-            broadcast.scheduledHeight > 0 &&
-            broadcast.scheduledHeight <= entryHeight) {
-          _openOverdueScheduleByTxid[broadcast.txidHex] =
-              broadcast.scheduledHeight;
-        }
+    if (!_capturedAccounts.add(accountUuid)) return;
+    for (final broadcast in status.scheduledBroadcasts) {
+      if (broadcast.status.toLowerCase() == 'scheduled' &&
+          broadcast.scheduledHeight > 0 &&
+          broadcast.scheduledHeight <= entryHeight) {
+        _openOverdueScheduleByTxid[broadcast.txidHex] =
+            broadcast.scheduledHeight;
       }
     }
-    _openStatusSnapshotReady = true;
   }
 
-  bool allows(rust_sync.MigrationStatus status) {
-    if ((_foregroundEntryHeight == null || !_openStatusSnapshotReady) &&
+  bool allows(String accountUuid, rust_sync.MigrationStatus status) {
+    if ((_epochEntryHeight == null ||
+            !_capturedAccounts.contains(accountUuid)) &&
         _hasScheduledTransfer(status)) {
-      // Neither a cached wallet height nor a partial account snapshot can
-      // establish the wallet-wide set that was overdue when the app opened.
-      // Fail closed until lightwalletd and every account status are available.
+      // Without an authoritative epoch-entry height and this account's own
+      // open snapshot, its overdue-at-open set is unknown. Fail closed for
+      // this account until both are available.
       return false;
     }
     return !isOpenOverdue(status) || _available;
   }
 
-  bool tryAcquireForAdvance(rust_sync.MigrationStatus status) {
-    if (!allows(status)) return false;
+  bool tryAcquireForAdvance(
+    String accountUuid,
+    rust_sync.MigrationStatus status,
+  ) {
+    if (!allows(accountUuid, status)) return false;
     consumeIfOpenOverdue(status);
     return true;
   }
@@ -125,13 +142,13 @@ class DesktopOpenMigrationFallbackGate {
               broadcast.scheduledHeight &&
           resultTxids.contains(broadcast.txidHex.toLowerCase()),
     );
-    if (!acceptedOpenOverdueTx && _foreground) {
+    if (!acceptedOpenOverdueTx) {
       _available = true;
     }
   }
 
   void failAdvance(rust_sync.MigrationStatus before) {
-    if (isOpenOverdue(before) && _foreground) {
+    if (isOpenOverdue(before)) {
       _available = true;
     }
   }
@@ -203,12 +220,33 @@ class IronwoodMigrationCoordinatorState {
 
 class IronwoodMigrationCoordinator
     extends Notifier<IronwoodMigrationCoordinatorState> {
+  IronwoodMigrationCoordinator({
+    DateTime Function()? now,
+    Duration Function()? monotonicNow,
+  }) : _now = now ?? DateTime.now,
+       _monotonicNow = monotonicNow ?? _defaultMonotonicNow;
+
+  static final Stopwatch _processStopwatch = Stopwatch()..start();
+  static Duration _defaultMonotonicNow() => _processStopwatch.elapsed;
+
+  final DateTime Function() _now;
+
+  /// Monotonic process clock. On macOS (mach_absolute_time) and Linux
+  /// (CLOCK_MONOTONIC) this pauses while the machine sleeps, so wall time
+  /// outrunning it is direct evidence of suspension — even when the sleep
+  /// began while a refresh sweep was in flight. On Windows the underlying
+  /// counter keeps running through sleep, so the divergence signal stays
+  /// silent there and a sleep is detected one sweep later by the idle-gap
+  /// signal instead (see `_observeDesktopEpochActivity`).
+  final Duration Function() _monotonicNow;
   Future<void>? _refreshOperation;
   bool _refreshPending = false;
   bool _forceAdvancePending = false;
   bool _foreground = true;
   int _accountStateEpoch = 0;
   final _desktopOpenFallbackGate = DesktopOpenMigrationFallbackGate();
+  DateTime? _lastDesktopActivityWallTime;
+  Duration? _lastDesktopActivityMonotonicTime;
   bool _hasObservedInitialAccountList = false;
   Future<void>? _backgroundPreparationRecovery;
   final Map<String, DateTime> _lastAdvanceAt = {};
@@ -256,26 +294,23 @@ class IronwoodMigrationCoordinator
   }
 
   void setForeground(bool foreground) {
-    final wasForeground = _foreground;
     _foreground = foreground;
     if (foreground) {
-      if (kAppFormFactor == AppFormFactor.desktop && !wasForeground) {
-        _desktopOpenFallbackGate.enterForeground();
-      }
+      // Desktop window visibility does not open or close the ZIP 318 epoch:
+      // process work (sync, status polling, scheduled broadcasts) continues
+      // while hidden, so the epoch only restarts on a genuine activity gap —
+      // see the suspension check in `_refreshOnce`.
       unawaited(resumeBackgroundPreparations());
       unawaited(
         refreshNow(forceAdvance: kAppFormFactor == AppFormFactor.desktop),
       );
-    } else {
-      if (kAppFormFactor == AppFormFactor.desktop) {
-        _desktopOpenFallbackGate.leaveForeground();
-      } else if (state.foregroundProgressPermits.isNotEmpty ||
-          state.childProofBatchPermits.isNotEmpty) {
-        state = state.copyWith(
-          foregroundProgressPermits: const {},
-          childProofBatchPermits: const {},
-        );
-      }
+    } else if (kAppFormFactor != AppFormFactor.desktop &&
+        (state.foregroundProgressPermits.isNotEmpty ||
+            state.childProofBatchPermits.isNotEmpty)) {
+      state = state.copyWith(
+        foregroundProgressPermits: const {},
+        childProofBatchPermits: const {},
+      );
     }
   }
 
@@ -700,7 +735,57 @@ class IronwoodMigrationCoordinator
       final forceAdvance = _forceAdvancePending;
       _refreshPending = false;
       _forceAdvancePending = false;
-      await _refreshOnce(forceAdvance: forceAdvance);
+      try {
+        await _refreshOnce(forceAdvance: forceAdvance);
+      } finally {
+        // A sweep can legitimately run for minutes (slow endpoint, many
+        // accounts, an in-flight advance). Record the end of every pass —
+        // including one that threw — as activity so its duration is never
+        // read as an idle gap, while the wall/monotonic divergence check
+        // still catches a sleep that interrupted it.
+        _observeDesktopEpochActivity(idleGapCounts: false);
+      }
+    }
+  }
+
+  /// Records a desktop process-activity observation and restarts the ZIP 318
+  /// wallet-open epoch when the observations prove a genuine suspension.
+  ///
+  /// Two independent signals are compared against
+  /// [kDesktopMigrationEpochSuspensionGap]:
+  ///
+  /// - Sleep: wall time advancing further than the monotonic clock since the
+  ///   last observation. Where the monotonic clock pauses across machine
+  ///   sleep (macOS, Linux — see [_monotonicNow]) the divergence measures
+  ///   suspension exactly — regardless of whether the sleep began between
+  ///   sweeps or mid-sweep, and immune to wall-clock corrections shrinking
+  ///   real gaps. On Windows both clocks advance through sleep, so this
+  ///   signal stays silent and the idle gap below catches the sleep at the
+  ///   next sweep start instead.
+  /// - Idle gap ([idleGapCounts] callers only): monotonic time since the last
+  ///   observation. Observations bound every sweep, so while the process is
+  ///   alive and unlocked they arrive at least every
+  ///   [_migrationStatusPollInterval]; a large gap means refreshes themselves
+  ///   stopped for a stretch — a wallet locked long enough that accrued
+  ///   transfers must be treated as overdue-at-open. Only the start-of-sweep
+  ///   caller sets [idleGapCounts]: measured mid- or end-of-sweep the gap is
+  ///   the sweep's own duration, which is activity, not suspension.
+  void _observeDesktopEpochActivity({required bool idleGapCounts}) {
+    if (kAppFormFactor != AppFormFactor.desktop) return;
+    final wallNow = _now();
+    final monotonicNow = _monotonicNow();
+    final lastWall = _lastDesktopActivityWallTime;
+    final lastMonotonic = _lastDesktopActivityMonotonicTime;
+    _lastDesktopActivityWallTime = wallNow;
+    _lastDesktopActivityMonotonicTime = monotonicNow;
+    if (lastWall == null || lastMonotonic == null) return;
+    final monotonicGap = monotonicNow - lastMonotonic;
+    final sleepGap = wallNow.difference(lastWall) - monotonicGap;
+    final suspended =
+        sleepGap >= kDesktopMigrationEpochSuspensionGap ||
+        (idleGapCounts && monotonicGap >= kDesktopMigrationEpochSuspensionGap);
+    if (suspended) {
+      _desktopOpenFallbackGate.restartEpoch();
     }
   }
 
@@ -712,6 +797,10 @@ class IronwoodMigrationCoordinator
     final accountState = ref.read(accountProvider).value;
     if (accountState == null || accountState.accounts.isEmpty) return;
     final accountStateEpoch = _accountStateEpoch;
+    // Transfers that became due during a genuine suspension (machine sleep,
+    // or a wallet locked for a long stretch) are "overdue at open" and must
+    // go through a fresh one-transfer ZIP 318 allowance.
+    _observeDesktopEpochActivity(idleGapCounts: true);
     if (kAppFormFactor == AppFormFactor.desktop &&
         _desktopOpenFallbackGate.needsAuthoritativeEntryHeight) {
       try {
@@ -719,13 +808,11 @@ class IronwoodMigrationCoordinator
             .read(rpcEndpointFailoverProvider.notifier)
             .getLatestBlockHeight();
         if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
-        _desktopOpenFallbackGate.observeForegroundEntryHeight(
-          entryHeight.toInt(),
-        );
+        _desktopOpenFallbackGate.observeEpochEntryHeight(entryHeight.toInt());
       } catch (error) {
         // Status reconciliation and non-broadcast migration work may continue,
         // but the gate remains fail-closed for scheduled transfers until an
-        // authoritative foreground-entry height can be read.
+        // authoritative epoch-entry height can be read.
         log(
           'Ironwood migration on-open height lookup failed; '
           'scheduled fallback remains paused: $error',
@@ -777,27 +864,25 @@ class IronwoodMigrationCoordinator
     }
     if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
 
-    final desktopOpenStatuses = <String, rust_sync.MigrationStatus>{};
-    if (kAppFormFactor == AppFormFactor.desktop &&
-        _desktopOpenFallbackGate.needsOpenStatusSnapshot) {
-      var snapshotComplete = true;
+    if (kAppFormFactor == AppFormFactor.desktop) {
       for (final account in accountState.accounts) {
+        if (!_desktopOpenFallbackGate.needsOpenStatusSnapshotFor(
+          account.uuid,
+        )) {
+          continue;
+        }
         final status = sweptStatuses[account.uuid];
         if (status == null) {
-          snapshotComplete = false;
+          // Capture is per account: only this account's scheduled transfers
+          // stay paused, and the next sweep retries its snapshot.
           log(
             'Ironwood migration on-open status snapshot failed for '
-            '${account.uuid}; scheduled fallback remains paused: '
+            '${account.uuid}; its scheduled fallback remains paused: '
             '${sweepErrors[account.uuid]}',
           );
           continue;
         }
-        desktopOpenStatuses[account.uuid] = status;
-      }
-      if (snapshotComplete) {
-        _desktopOpenFallbackGate.captureOpenStatuses(
-          desktopOpenStatuses.values,
-        );
+        _desktopOpenFallbackGate.captureOpenStatus(account.uuid, status);
       }
     }
     final nextStatuses = Map<String, rust_sync.MigrationStatus>.from(
@@ -816,7 +901,7 @@ class IronwoodMigrationCoordinator
           throw sweepErrors[account.uuid] ??
               StateError('migration status unavailable for ${account.uuid}');
         }
-        var status = desktopOpenStatuses[account.uuid] ?? sweptStatus;
+        var status = sweptStatus;
         if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
         nextStatuses[account.uuid] = status;
         nextErrors.remove(account.uuid);
@@ -934,10 +1019,9 @@ class IronwoodMigrationCoordinator
     _lastAdvanceAt.clear();
     _outboxRecoveryWindows.clear();
     _lastAdvanceProgressKeys.clear();
-    _desktopOpenFallbackGate.leaveForeground();
-    if (_foreground) {
-      _desktopOpenFallbackGate.enterForeground();
-    }
+    _lastDesktopActivityWallTime = null;
+    _lastDesktopActivityMonotonicTime = null;
+    _desktopOpenFallbackGate.restartEpoch();
     state = const IronwoodMigrationCoordinatorState();
     _invalidateMigrationProviders(null);
   }
@@ -1111,7 +1195,7 @@ class IronwoodMigrationCoordinator
     if (_stoppingAccounts.contains(accountUuid)) return false;
     if (status.activeRunId == null) return false;
     if (kAppFormFactor == AppFormFactor.desktop &&
-        !_desktopOpenFallbackGate.allows(status)) {
+        !_desktopOpenFallbackGate.allows(accountUuid, status)) {
       return false;
     }
     if (kAppFormFactor == AppFormFactor.mobile &&
@@ -1234,13 +1318,21 @@ class IronwoodMigrationCoordinator
   }) {
     final existing = _advanceOperations[accountUuid];
     if (existing != null) return existing;
+    // A machine sleep can end while a sweep is mid-flight; check for it before
+    // every advance so the accounts still ahead in the sweep go through the
+    // restarted epoch's fresh overdue-at-open gate instead of broadcasting on
+    // the pre-sleep epoch's terms.
+    _observeDesktopEpochActivity(idleGapCounts: false);
     final reservesOpenOverdueAllowance =
         kAppFormFactor == AppFormFactor.desktop &&
         status != null &&
         _desktopOpenFallbackGate.isOpenOverdue(status);
     if (kAppFormFactor == AppFormFactor.desktop &&
         (status == null ||
-            !_desktopOpenFallbackGate.tryAcquireForAdvance(status))) {
+            !_desktopOpenFallbackGate.tryAcquireForAdvance(
+              accountUuid,
+              status,
+            ))) {
       // `_advance` is also called by manual retry, which bypasses
       // `_shouldAdvance`. Keep the ZIP 318 on-open allowance centralized at
       // this last coordinator boundary so no UI or polling entry point can
@@ -1309,6 +1401,14 @@ class IronwoodMigrationCoordinator
           .continueSoftwarePrivateMigration(
             accountUuid: accountUuid,
             prepareNextProof: prepareNextProof,
+            // Floors the Rust post-accept wallet-overdue redraw at the epoch
+            // entry tip so on-open overdue parts above the locally synced tip
+            // are redrawn by the single fallback acceptance instead of
+            // wedging behind the consumed allowance. Null (mobile, or before
+            // the on-open lookup succeeds) preserves local-tip behavior.
+            walletOpenTipHeight: kAppFormFactor == AppFormFactor.desktop
+                ? _desktopOpenFallbackGate.epochEntryHeight
+                : null,
           );
     } finally {
       if (ref.mounted) {

--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -487,6 +487,15 @@ class IronwoodMigrationCoordinator
     String accountUuid, {
     rust_sync.MigrationStatus? status,
   }) async {
+    // A manual retry is user-initiated activity, not sweep-bounded work, so
+    // the gap since the last observation is genuine idleness — count it.
+    // Without this, a retry tapped right after unlocking a long-locked wallet
+    // reaches `_advance` (whose own observation exempts sweep duration) before
+    // the unlock-triggered sweep can run its counting observation, and the
+    // baseline overwrite permanently swallows the locked gap: the epoch never
+    // restarts, and transfers that became due while locked broadcast against
+    // the pre-lock epoch without the fresh overdue-at-open gate.
+    _observeDesktopEpochActivity(idleGapCounts: true);
     // A status screen can be the first migration surface after a cold launch.
     // Its route provider may already have a current status while this
     // coordinator has not completed its first polling pass. Preserve that

--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -252,6 +252,8 @@ class IronwoodMigrationCoordinator
   final _desktopOpenFallbackGate = DesktopOpenMigrationFallbackGate();
   DateTime? _lastDesktopActivityWallTime;
   Duration? _lastDesktopActivityMonotonicTime;
+  DateTime? _desktopLockStartedWallTime;
+  Duration? _desktopLockStartedMonotonicTime;
   bool _hasObservedInitialAccountList = false;
   Future<void>? _backgroundPreparationRecovery;
   final Map<String, DateTime> _lastAdvanceAt = {};
@@ -287,6 +289,12 @@ class IronwoodMigrationCoordinator
       }
     });
     ref.listen(appSecurityProvider, (previous, next) {
+      if (previous != null) {
+        _observeDesktopLockTransition(
+          wasLocked: previous.requiresUnlock,
+          isLocked: next.requiresUnlock,
+        );
+      }
       if (previous?.requiresUnlock == true && !next.requiresUnlock) {
         unawaited(resumeBackgroundPreparations());
         unawaited(refreshNow());
@@ -805,6 +813,45 @@ class IronwoodMigrationCoordinator
     }
   }
 
+  /// Tracks wallet lock duration independently from refresh activity.
+  ///
+  /// A lock can begin while a refresh sweep is already in flight. That sweep's
+  /// `finally` records its completion as process activity, which is correct for
+  /// slow unlocked work but would otherwise erase most or all of an overlapping
+  /// lock gap. Measuring the security transition directly preserves the gap and
+  /// lets unlock restart the wallet-open epoch before its refresh is queued.
+  void _observeDesktopLockTransition({
+    required bool wasLocked,
+    required bool isLocked,
+  }) {
+    if (kAppFormFactor != AppFormFactor.desktop || wasLocked == isLocked) {
+      return;
+    }
+    if (isLocked) {
+      _desktopLockStartedWallTime = _now();
+      _desktopLockStartedMonotonicTime = _monotonicNow();
+      return;
+    }
+
+    final lockStartedWallTime = _desktopLockStartedWallTime;
+    final lockStartedMonotonicTime = _desktopLockStartedMonotonicTime;
+    _desktopLockStartedWallTime = null;
+    _desktopLockStartedMonotonicTime = null;
+    if (lockStartedWallTime == null || lockStartedMonotonicTime == null) {
+      return;
+    }
+
+    final wallGap = _now().difference(lockStartedWallTime);
+    final monotonicGap = _monotonicNow() - lockStartedMonotonicTime;
+    // macOS/Linux monotonic clocks pause during sleep while Windows' advances;
+    // taking the larger duration counts both an awake lock and a lock spanning
+    // sleep, while a backward wall-clock correction cannot hide awake time.
+    final effectiveLockGap = wallGap > monotonicGap ? wallGap : monotonicGap;
+    if (effectiveLockGap >= kDesktopMigrationEpochSuspensionGap) {
+      _desktopOpenFallbackGate.restartEpoch();
+    }
+  }
+
   Future<void> _refreshOnce({required bool forceAdvance}) async {
     if (!ref.mounted) return;
     if (!canRunAppProcessWork(isInForeground: _foreground)) return;
@@ -1037,6 +1084,8 @@ class IronwoodMigrationCoordinator
     _lastAdvanceProgressKeys.clear();
     _lastDesktopActivityWallTime = null;
     _lastDesktopActivityMonotonicTime = null;
+    _desktopLockStartedWallTime = null;
+    _desktopLockStartedMonotonicTime = null;
     _desktopOpenFallbackGate.restartEpoch();
     state = const IronwoodMigrationCoordinatorState();
     _invalidateMigrationProviders(null);

--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -25,8 +25,12 @@ const _migrationStatusPollInterval = Duration(seconds: 15);
 /// (machine sleep — the monotonic clock pauses while asleep) or refresh
 /// activity itself gaps past it with the process awake (wallet locked for a
 /// long stretch). Must stay well above [_migrationStatusPollInterval] so
-/// occlusion alone can never restart the epoch; sweep duration is exempt from
-/// the activity-gap signal, so a slow sweep needs no headroom here.
+/// occlusion alone can never restart the epoch. On macOS and Linux sweep
+/// duration is exempt from the activity-gap signal, so a slow sweep needs no
+/// headroom here; Windows cannot grant that exemption (its monotonic clock
+/// runs through sleep, so a mid-sweep gap is indistinguishable from one), and
+/// a sweep stalled past this threshold there restarts the epoch — re-arming
+/// the on-open allowance rather than risking a missed sleep.
 const kDesktopMigrationEpochSuspensionGap = Duration(minutes: 3);
 const _migrationAdvanceInterval = Duration(
   seconds: String.fromEnvironment('ZCASH_DEFAULT_NETWORK') == 'regtest'

--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -760,16 +761,16 @@ class IronwoodMigrationCoordinator
   ///   suspension exactly — regardless of whether the sleep began between
   ///   sweeps or mid-sweep, and immune to wall-clock corrections shrinking
   ///   real gaps. On Windows both clocks advance through sleep, so this
-  ///   signal stays silent and the idle gap below catches the sleep at the
-  ///   next sweep start instead.
-  /// - Idle gap ([idleGapCounts] callers only): monotonic time since the last
-  ///   observation. Observations bound every sweep, so while the process is
-  ///   alive and unlocked they arrive at least every
-  ///   [_migrationStatusPollInterval]; a large gap means refreshes themselves
-  ///   stopped for a stretch — a wallet locked long enough that accrued
-  ///   transfers must be treated as overdue-at-open. Only the start-of-sweep
-  ///   caller sets [idleGapCounts]: measured mid- or end-of-sweep the gap is
-  ///   the sweep's own duration, which is activity, not suspension.
+  ///   signal stays silent, so every Windows observation also treats a large
+  ///   monotonic gap as suspension before updating the activity baseline.
+  /// - Idle gap ([idleGapCounts] callers, plus every Windows observation):
+  ///   monotonic time since the last observation. Observations bound every
+  ///   sweep, so while the process is alive and unlocked they arrive at least
+  ///   every [_migrationStatusPollInterval]; a large gap means refreshes
+  ///   themselves stopped for a stretch — a wallet locked long enough that
+  ///   accrued transfers must be treated as overdue-at-open. Non-Windows
+  ///   platforms count this only at sweep start; Windows must also count it
+  ///   mid- and end-sweep because its monotonic clock cannot distinguish sleep.
   void _observeDesktopEpochActivity({required bool idleGapCounts}) {
     if (kAppFormFactor != AppFormFactor.desktop) return;
     final wallNow = _now();
@@ -781,9 +782,11 @@ class IronwoodMigrationCoordinator
     if (lastWall == null || lastMonotonic == null) return;
     final monotonicGap = monotonicNow - lastMonotonic;
     final sleepGap = wallNow.difference(lastWall) - monotonicGap;
+    final idleGapDetected =
+        (idleGapCounts || defaultTargetPlatform == TargetPlatform.windows) &&
+        monotonicGap >= kDesktopMigrationEpochSuspensionGap;
     final suspended =
-        sleepGap >= kDesktopMigrationEpochSuspensionGap ||
-        (idleGapCounts && monotonicGap >= kDesktopMigrationEpochSuspensionGap);
+        sleepGap >= kDesktopMigrationEpochSuspensionGap || idleGapDetected;
     if (suspended) {
       _desktopOpenFallbackGate.restartEpoch();
     }

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -271,8 +271,17 @@ typedef IronwoodMigrationDueBroadcaster =
       required String accountUuid,
       required String password,
       required String saltBase64,
+      int? walletOpenTipHeight,
     });
-typedef IronwoodMigrationOutboxPreparer = IronwoodMigrationDueBroadcaster;
+typedef IronwoodMigrationOutboxPreparer =
+    Future<rust_sync.IronwoodMigrationResult> Function({
+      required String dbPath,
+      required String lightwalletdUrl,
+      required String network,
+      required String accountUuid,
+      required String password,
+      required String saltBase64,
+    });
 typedef IronwoodMigrationOutboxExporter =
     Future<rust_sync.MigrationOutboxBatch?> Function({
       required String dbPath,
@@ -1593,9 +1602,13 @@ class IronwoodMigrationService {
     }
   }
 
+  /// [walletOpenTipHeight] is the authoritative tip observed at desktop
+  /// wallet-open epoch entry; it floors the Rust post-accept wallet-overdue
+  /// redraw (see `broadcast_one_due_orchard_migration_transaction`).
   Future<rust_sync.IronwoodMigrationResult> continueSoftwarePrivateMigration({
     required String accountUuid,
     bool prepareNextProof = true,
+    int? walletOpenTipHeight,
   }) async {
     final dbPath = await getWalletDbPath();
     final endpoint = getEndpoint();
@@ -1635,6 +1648,7 @@ class IronwoodMigrationService {
           accountUuid: accountUuid,
           password: credential.password,
           saltBase64: credential.saltBase64,
+          walletOpenTipHeight: walletOpenTipHeight,
         ),
       );
     }

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -540,6 +540,12 @@ Future<IronwoodMigrationResult> broadcastDueOrchardMigrationTransactions({
   saltBase64: saltBase64,
 );
 
+/// `wallet_open_tip_height` is the authoritative chain tip observed when the
+/// desktop wallet-open epoch began. It floors the post-accept wallet-overdue
+/// redraw so on-open overdue parts scheduled between the locally synced tip
+/// and the network tip are redrawn by the single fallback acceptance instead
+/// of staying wedged behind the consumed on-open allowance. Pass `None` when
+/// no authoritative open tip is known.
 Future<IronwoodMigrationResult> broadcastOneDueOrchardMigrationTransaction({
   required String dbPath,
   required String lightwalletdUrl,
@@ -547,6 +553,7 @@ Future<IronwoodMigrationResult> broadcastOneDueOrchardMigrationTransaction({
   required String accountUuid,
   required String password,
   required String saltBase64,
+  int? walletOpenTipHeight,
 }) =>
     RustLib.instance.api.crateApiSyncBroadcastOneDueOrchardMigrationTransaction(
       dbPath: dbPath,
@@ -555,6 +562,7 @@ Future<IronwoodMigrationResult> broadcastOneDueOrchardMigrationTransaction({
       accountUuid: accountUuid,
       password: password,
       saltBase64: saltBase64,
+      walletOpenTipHeight: walletOpenTipHeight,
     );
 
 /// Prepares denomination PCZTs for the approved schedule, with expiry heights

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -142,6 +142,7 @@ abstract class RustLibApi extends BaseApi {
     required String accountUuid,
     required String password,
     required String saltBase64,
+    int? walletOpenTipHeight,
   });
 
   Future<KeystoneSigningRequest> crateApiVotingBuildKeystoneDelegationRequest({
@@ -1425,6 +1426,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String accountUuid,
     required String password,
     required String saltBase64,
+    int? walletOpenTipHeight,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1436,6 +1438,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(password, serializer);
           sse_encode_String(saltBase64, serializer);
+          sse_encode_opt_box_autoadd_u_32(walletOpenTipHeight, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1456,6 +1459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           accountUuid,
           password,
           saltBase64,
+          walletOpenTipHeight,
         ],
         apiImpl: this,
       ),
@@ -1473,6 +1477,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "accountUuid",
           "password",
           "saltBase64",
+          "walletOpenTipHeight",
         ],
       );
 

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -8,6 +8,15 @@ import Sparkle
 class AppDelegate: FlutterAppDelegate {
   @IBOutlet private weak var checkForUpdatesMenuItem: NSMenuItem!
 
+  /// Keeps App Nap from throttling the process while every window is hidden
+  /// or occluded. Wallet sync polling and ZIP 318 scheduled migration
+  /// broadcasts are Dart-timer driven and intentionally continue while the
+  /// app is not visible; App Nap coalesces/suspends those timers, which would
+  /// silently stall scheduled broadcasts. `.background` avoids App Nap
+  /// without preventing idle system sleep — a closed lid still suspends the
+  /// process, which the migration coordinator detects as an epoch restart.
+  private var appNapActivity: NSObjectProtocol?
+
 #if SPARKLE_ENABLED
   private let updaterController: SPUStandardUpdaterController?
 #endif
@@ -29,6 +38,11 @@ class AppDelegate: FlutterAppDelegate {
   }
 
   override func applicationDidFinishLaunching(_ notification: Notification) {
+    appNapActivity = ProcessInfo.processInfo.beginActivity(
+      options: .background,
+      reason: "Wallet sync and scheduled shielded broadcasts run while hidden"
+    )
+
 #if SPARKLE_ENABLED
     guard let updaterController else {
       checkForUpdatesMenuItem.isEnabled = false

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -12,9 +12,10 @@ class AppDelegate: FlutterAppDelegate {
   /// or occluded. Wallet sync polling and ZIP 318 scheduled migration
   /// broadcasts are Dart-timer driven and intentionally continue while the
   /// app is not visible; App Nap coalesces/suspends those timers, which would
-  /// silently stall scheduled broadcasts. `.background` avoids App Nap
-  /// without preventing idle system sleep — a closed lid still suspends the
-  /// process, which the migration coordinator detects as an epoch restart.
+  /// silently stall scheduled broadcasts.
+  /// `.userInitiatedAllowingIdleSystemSleep` avoids App Nap without preventing
+  /// idle system sleep — a closed lid still suspends the process, which the
+  /// migration coordinator detects as an epoch restart.
   private var appNapActivity: NSObjectProtocol?
 
 #if SPARKLE_ENABLED
@@ -39,7 +40,7 @@ class AppDelegate: FlutterAppDelegate {
 
   override func applicationDidFinishLaunching(_ notification: Notification) {
     appNapActivity = ProcessInfo.processInfo.beginActivity(
-      options: .background,
+      options: .userInitiatedAllowingIdleSystemSleep,
       reason: "Wallet sync and scheduled shielded broadcasts run while hidden"
     )
 

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -1738,6 +1738,12 @@ pub fn broadcast_due_orchard_migration_transactions(
     })
 }
 
+/// `wallet_open_tip_height` is the authoritative chain tip observed when the
+/// desktop wallet-open epoch began. It floors the post-accept wallet-overdue
+/// redraw so on-open overdue parts scheduled between the locally synced tip
+/// and the network tip are redrawn by the single fallback acceptance instead
+/// of staying wedged behind the consumed on-open allowance. Pass `None` when
+/// no authoritative open tip is known.
 pub fn broadcast_one_due_orchard_migration_transaction(
     db_path: String,
     lightwalletd_url: String,
@@ -1745,6 +1751,7 @@ pub fn broadcast_one_due_orchard_migration_transaction(
     account_uuid: String,
     password: String,
     salt_base64: String,
+    wallet_open_tip_height: Option<u32>,
 ) -> Result<IronwoodMigrationResult, String> {
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
@@ -1758,6 +1765,7 @@ pub fn broadcast_one_due_orchard_migration_transaction(
                 &account_uuid,
                 password,
                 &salt_base64,
+                wallet_open_tip_height,
             ),
         )?;
         Ok(IronwoodMigrationResult {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -294,6 +294,7 @@ fn wire__crate__api__sync__broadcast_one_due_orchard_migration_transaction_impl(
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_password = <String>::sse_decode(&mut deserializer);
             let api_salt_base64 = <String>::sse_decode(&mut deserializer);
+            let api_wallet_open_tip_height = <Option<u32>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -305,6 +306,7 @@ fn wire__crate__api__sync__broadcast_one_due_orchard_migration_transaction_impl(
                             api_account_uuid,
                             api_password,
                             api_salt_base64,
+                            api_wallet_open_tip_height,
                         )?;
                     Ok(output_ok)
                 })())

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -4950,10 +4950,12 @@ fn reschedule_overdue_pending_txs_with_options(
     let tx = conn
         .unchecked_transaction()
         .map_err(|e| format!("Begin overdue migration reschedule: {e}"))?;
+    let redraw_start_ms = now_ms()?;
     let mut needs_resign = false;
     for ((txid, expiry_height), offset) in txids.into_iter().zip(offsets) {
+        let effective_offset = offset.max(minimum_delay_blocks);
         let scheduled_height = chain_tip_height
-            .checked_add(offset.max(minimum_delay_blocks))
+            .checked_add(effective_offset)
             .ok_or("Migration rescheduled height overflow")?;
         if zip318_canonical_migration_expiry_height(scheduled_height)? != expiry_height {
             tx.execute(
@@ -4968,13 +4970,27 @@ fn reschedule_overdue_pending_txs_with_options(
             needs_resign = true;
             continue;
         }
+        // Keep `scheduled_at_ms` in step with the redrawn height using the
+        // same convention the initial insert uses (`now + offset * 1000`).
+        // Listings order by this column; leaving the original timestamp
+        // behind made redrawn parts sort — and read — as still overdue.
+        let scheduled_at_ms = redraw_start_ms
+            .checked_add(i64::from(effective_offset).saturating_mul(1000))
+            .ok_or("Migration rescheduled time overflow")?;
         tx.execute(
             &format!(
                 "UPDATE {PENDING_TXS_TABLE}
-                 SET scheduled_height = ?1, schedule_start_height = ?2
-                 WHERE run_id = ?3 AND txid_hex = ?4 AND status = 'scheduled'"
+                 SET scheduled_height = ?1, schedule_start_height = ?2,
+                     scheduled_at_ms = ?3
+                 WHERE run_id = ?4 AND txid_hex = ?5 AND status = 'scheduled'"
             ),
-            params![scheduled_height, chain_tip_height, run_id, txid],
+            params![
+                scheduled_height,
+                chain_tip_height,
+                scheduled_at_ms,
+                run_id,
+                txid
+            ],
         )
         .map_err(|e| format!("Reschedule overdue migration transaction: {e}"))?;
     }

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -1504,6 +1504,60 @@ fn on_open_reschedule_redraws_overdue_transfers_across_wallet_runs() {
 }
 
 #[test]
+fn on_open_reschedule_refreshes_scheduled_at_ms_with_the_redrawn_height() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    create_outbox_test_run(&db_path, "run-1", &[100, 200], &[Some(90), Some(90)]);
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    conn.execute(
+        &format!(
+            "UPDATE {PENDING_TXS_TABLE}
+             SET scheduled_height = 503, schedule_start_height = 502,
+                 scheduled_at_ms = 1
+             WHERE status = 'scheduled'"
+        ),
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    let before_ms = now_ms().unwrap();
+    reschedule_wallet_overdue_pending_txs(&db_path, WalletNetwork::Regtest, 503).unwrap();
+    let after_ms = now_ms().unwrap();
+
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let redrawn = conn
+        .prepare(&format!(
+            "SELECT scheduled_height, scheduled_at_ms FROM {PENDING_TXS_TABLE}
+             WHERE status = 'scheduled'"
+        ))
+        .unwrap()
+        .query_map([], |row| Ok((row.get::<_, u32>(0)?, row.get::<_, i64>(1)?)))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(redrawn.len(), 2);
+    for (scheduled_height, scheduled_at_ms) in redrawn {
+        // The redraw recomputes the timestamp with the insert convention
+        // (`redraw_start + offset * 1000`), so recovering the redraw start
+        // from the stored pair must land inside the call window. A stale
+        // timestamp left behind would fail this by ~redraw_start ms.
+        let offset_ms = i64::from(scheduled_height - 503) * 1000;
+        let implied_redraw_start_ms = scheduled_at_ms - offset_ms;
+        assert!(
+            (before_ms..=after_ms).contains(&implied_redraw_start_ms),
+            "scheduled_at_ms {scheduled_at_ms} for height {scheduled_height} \
+             implies redraw start {implied_redraw_start_ms}, outside \
+             [{before_ms}, {after_ms}]"
+        );
+    }
+}
+
+#[test]
 fn on_open_storage_recovery_keeps_accepted_tx_and_redraws_every_other_run() {
     let temp_dir = tempfile::tempdir().unwrap();
     let db_path = temp_dir

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -264,6 +264,16 @@ struct MigrationBroadcastPolicy<'a> {
     max_proofs_per_step: Option<usize>,
     defer_broadcast_after_proving: bool,
     reschedule_wallet_overdue: bool,
+    /// Minimum tip used when redrawing wallet-overdue transfers after an
+    /// accepted broadcast. The desktop wallet-open snapshot is taken against
+    /// lightwalletd's authoritative tip, which can be ahead of the locally
+    /// synced tip during early-epoch catch-up. Redrawing only up to the local
+    /// tip would leave snapshot parts in that window scheduled at their
+    /// original heights; once the on-open allowance is consumed they could
+    /// never broadcast until the next epoch. Flooring the redraw at the
+    /// wallet-open tip guarantees every part of the on-open overdue set is
+    /// redrawn by the single fallback acceptance.
+    wallet_overdue_redraw_floor: Option<u32>,
     cancel: Option<&'a AtomicBool>,
 }
 
@@ -273,6 +283,7 @@ impl MigrationBroadcastPolicy<'_> {
         max_proofs_per_step: None,
         defer_broadcast_after_proving: false,
         reschedule_wallet_overdue: false,
+        wallet_overdue_redraw_floor: None,
         cancel: None,
     };
 
@@ -281,8 +292,16 @@ impl MigrationBroadcastPolicy<'_> {
         max_proofs_per_step: None,
         defer_broadcast_after_proving: false,
         reschedule_wallet_overdue: true,
+        wallet_overdue_redraw_floor: None,
         cancel: None,
     };
+
+    fn with_wallet_overdue_redraw_floor(self, floor: Option<u32>) -> Self {
+        Self {
+            wallet_overdue_redraw_floor: floor,
+            ..self
+        }
+    }
 
     fn background_preparation(cancel: &AtomicBool) -> MigrationBroadcastPolicy<'_> {
         MigrationBroadcastPolicy {
@@ -290,6 +309,7 @@ impl MigrationBroadcastPolicy<'_> {
             max_proofs_per_step: None,
             defer_broadcast_after_proving: false,
             reschedule_wallet_overdue: false,
+            wallet_overdue_redraw_floor: None,
             cancel: Some(cancel),
         }
     }
@@ -2533,6 +2553,7 @@ pub async fn broadcast_one_due_orchard_migration_transaction(
     account_uuid: &str,
     pending_password: zeroize::Zeroizing<Vec<u8>>,
     pending_salt_base64: &str,
+    wallet_open_tip_height: Option<u32>,
 ) -> Result<IronwoodMigrationResult, String> {
     let advance = broadcast_due_orchard_migration_transactions_inner(
         db_path,
@@ -2541,7 +2562,8 @@ pub async fn broadcast_one_due_orchard_migration_transaction(
         account_uuid,
         pending_password,
         pending_salt_base64,
-        MigrationBroadcastPolicy::ONE_FOREGROUND,
+        MigrationBroadcastPolicy::ONE_FOREGROUND
+            .with_wallet_overdue_redraw_floor(wallet_open_tip_height),
     )
     .await?;
     Ok(one_due_migration_result(advance))
@@ -5296,13 +5318,16 @@ async fn broadcast_due_scheduled_migration_txs(
                 ));
             }
         };
+        let wallet_overdue_redraw_tip = policy
+            .wallet_overdue_redraw_floor
+            .map_or(chain_tip_height, |floor| chain_tip_height.max(floor));
         if let Some(mut result) = recorded {
             if policy.reschedule_wallet_overdue {
                 if let Err(error) =
                     super::migration::reschedule_wallet_overdue_pending_txs_after_accepted(
                         db_path,
                         network,
-                        chain_tip_height,
+                        wallet_overdue_redraw_tip,
                         run_id,
                         &pending.txid_hex,
                     )
@@ -5324,7 +5349,7 @@ async fn broadcast_due_scheduled_migration_txs(
             super::migration::reschedule_wallet_overdue_pending_txs(
                 db_path,
                 network,
-                chain_tip_height,
+                wallet_overdue_redraw_tip,
             )
         } else {
             super::migration::reschedule_overdue_pending_txs(

--- a/test/features/migration/desktop_migration_epoch_coordinator_test.dart
+++ b/test/features/migration/desktop_migration_epoch_coordinator_test.dart
@@ -234,6 +234,36 @@ void main() {
     );
   });
 
+  test('a manual retry after a long locked gap restarts the epoch', () async {
+    // `retry` reaches `_advance` without running a sweep first, and the
+    // advance-path observation exempts sweep duration from the idle-gap
+    // signal. If the retry entry point did not count the gap itself, a retry
+    // tapped right after unlocking a long-locked wallet would broadcast
+    // against the pre-lock epoch — and, by overwriting the activity baseline,
+    // stop the unlock-triggered sweep from ever restarting the epoch.
+    final status = _scheduledStatus(scheduledHeight: 999);
+    final harness = await _startCoordinator(accountStatus: status);
+    expect(harness.walletOpenTipHeights, [1_000]);
+
+    harness.run(kDesktopMigrationEpochSuspensionGap);
+    await harness.coordinator.retry(_accountUuid, status: status);
+
+    expect(
+      harness.authoritativeHeightReads,
+      2,
+      reason:
+          'a manual retry after an awake gap past the threshold must restart '
+          'the epoch before advancing',
+    );
+    expect(
+      harness.walletOpenTipHeights.skip(1),
+      everyElement(1_001),
+      reason:
+          'no broadcast after the restart may carry the pre-lock epoch\'s '
+          'entry tip',
+    );
+  });
+
   test('threads each epoch\'s entry tip into the one-due broadcast', () async {
     // The Rust one-due endpoint floors its post-accept wallet-overdue redraw
     // at the epoch entry tip. Losing this argument would silently reintroduce

--- a/test/features/migration/desktop_migration_epoch_coordinator_test.dart
+++ b/test/features/migration/desktop_migration_epoch_coordinator_test.dart
@@ -11,6 +11,7 @@ import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
 import 'package:zcash_wallet/src/features/migration/services/ironwood_migration_service.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 import 'package:zcash_wallet/src/providers/rpc_endpoint_failover_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
@@ -38,6 +39,7 @@ class _EpochHarness {
   int authoritativeHeightReads = 0;
   final walletOpenTipHeights = <int?>[];
   void Function()? onStatusSweep;
+  late final ProviderContainer container;
   late final IronwoodMigrationCoordinator coordinator;
 
   void sleep(Duration duration) {
@@ -48,10 +50,32 @@ class _EpochHarness {
     wallNow = wallNow.add(duration);
     monotonicNow += duration;
   }
+
+  void lock() {
+    container.read(appSecurityProvider.notifier).lock();
+  }
+
+  void unlock() {
+    final notifier =
+        container.read(appSecurityProvider.notifier)
+            as _TestAppSecurityNotifier;
+    notifier.unlockForTest();
+  }
+}
+
+class _TestAppSecurityNotifier extends AppSecurityNotifier {
+  @override
+  AppSecurityState build() =>
+      const AppSecurityState(isPasswordConfigured: true, isUnlocked: true);
+
+  void unlockForTest() {
+    state = state.copyWith(isUnlocked: true);
+  }
 }
 
 Future<_EpochHarness> _startCoordinator({
   rust_sync.MigrationStatus? accountStatus,
+  bool acceptScheduledBroadcast = false,
 }) async {
   final harness = _EpochHarness();
   final status = accountStatus ?? _completeStatus();
@@ -93,12 +117,13 @@ Future<_EpochHarness> _startCoordinator({
           int? walletOpenTipHeight,
         }) async {
           harness.walletOpenTipHeights.add(walletOpenTipHeight);
-          return _migrationResult();
+          return _migrationResult(accepted: acceptScheduledBroadcast);
         },
   );
   final container = ProviderContainer(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
+      appSecurityProvider.overrideWith(_TestAppSecurityNotifier.new),
       syncProvider.overrideWith(() => FakeSyncNotifier(SyncState())),
       ironwoodMigrationServiceProvider.overrideWithValue(service),
       rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue((
@@ -117,6 +142,7 @@ Future<_EpochHarness> _startCoordinator({
       ),
     ],
   );
+  harness.container = container;
   addTearDown(container.dispose);
   await container.read(accountProvider.future);
   final subscription = container.listen(
@@ -231,6 +257,86 @@ void main() {
           'refresh activity stopping for the threshold while the process '
           'stays awake means broadcasts could not run and must restart the '
           'epoch',
+    );
+  });
+
+  test('polling while locked preserves a long gap for unlock', () async {
+    final status = _scheduledStatus(scheduledHeight: 999);
+    final harness = await _startCoordinator(
+      accountStatus: status,
+      acceptScheduledBroadcast: true,
+    );
+    expect(harness.walletOpenTipHeights, [1_000]);
+
+    harness.lock();
+    for (
+      var elapsed = Duration.zero;
+      elapsed < kDesktopMigrationEpochSuspensionGap;
+      elapsed += const Duration(seconds: 15)
+    ) {
+      harness.run(const Duration(seconds: 15));
+      await harness.coordinator.refreshForPolling();
+    }
+
+    expect(
+      harness.authoritativeHeightReads,
+      1,
+      reason: 'locked polling must not begin a refresh or recapture the epoch',
+    );
+    expect(
+      harness.walletOpenTipHeights,
+      [1_000],
+      reason: 'locked polling must not attempt another scheduled broadcast',
+    );
+
+    harness.unlock();
+    await harness.coordinator.refreshNow(forceAdvance: true);
+
+    expect(
+      harness.authoritativeHeightReads,
+      2,
+      reason:
+          'unlock after a long locked gap must restart the wallet-open epoch',
+    );
+    expect(
+      harness.walletOpenTipHeights,
+      [1_000, 1_001],
+      reason:
+          'the first post-unlock broadcast must use the restarted epoch tip',
+    );
+  });
+
+  test('polling during a short lock preserves the current epoch', () async {
+    final status = _scheduledStatus(scheduledHeight: 999);
+    final harness = await _startCoordinator(
+      accountStatus: status,
+      acceptScheduledBroadcast: true,
+    );
+    expect(harness.walletOpenTipHeights, [1_000]);
+
+    harness.lock();
+    const shortLock = Duration(minutes: 2, seconds: 45);
+    for (
+      var elapsed = Duration.zero;
+      elapsed < shortLock;
+      elapsed += const Duration(seconds: 15)
+    ) {
+      harness.run(const Duration(seconds: 15));
+      await harness.coordinator.refreshForPolling();
+    }
+
+    harness.unlock();
+    await harness.coordinator.refreshNow(forceAdvance: true);
+
+    expect(
+      harness.authoritativeHeightReads,
+      1,
+      reason: 'a lock shorter than the suspension threshold keeps the epoch',
+    );
+    expect(
+      harness.walletOpenTipHeights,
+      [1_000],
+      reason: 'the consumed fallback allowance must not be replenished',
     );
   });
 
@@ -372,11 +478,11 @@ rust_sync.MigrationStatus _scheduledStatus({required int scheduledHeight}) {
   );
 }
 
-rust_sync.IronwoodMigrationResult _migrationResult() {
+rust_sync.IronwoodMigrationResult _migrationResult({bool accepted = false}) {
   return rust_sync.IronwoodMigrationResult(
-    txids: '',
+    txids: accepted ? 'scheduled-tx' : '',
     status: 'broadcast_scheduled',
-    broadcastedCount: 0,
+    broadcastedCount: accepted ? 1 : 0,
     totalCount: 1,
     feeZatoshi: BigInt.zero,
     migratedZatoshi: BigInt.from(100000000),

--- a/test/features/migration/desktop_migration_epoch_coordinator_test.dart
+++ b/test/features/migration/desktop_migration_epoch_coordinator_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -187,6 +188,35 @@ void main() {
           'suspension and must recapture the epoch entry height',
     );
   });
+
+  test(
+    'a Windows sleep that begins mid-sweep preserves the activity gap',
+    () async {
+      final previousPlatformOverride = debugDefaultTargetPlatformOverride;
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      addTearDown(
+        () => debugDefaultTargetPlatformOverride = previousPlatformOverride,
+      );
+      final harness = await _startCoordinator();
+
+      harness.onStatusSweep = () {
+        // QueryPerformanceCounter advances through Windows sleep, so both
+        // clocks move together and wall/monotonic divergence stays zero.
+        harness.run(kDesktopMigrationEpochSuspensionGap);
+        harness.onStatusSweep = null;
+      };
+      await harness.coordinator.refreshNow();
+      await harness.coordinator.refreshNow();
+
+      expect(
+        harness.authoritativeHeightReads,
+        2,
+        reason:
+            'the first post-sleep observation must restart the epoch before '
+            'overwriting the pre-sleep activity baseline',
+      );
+    },
+  );
 
   test('a long awake refresh gap (locked wallet) restarts the epoch', () async {
     final harness = await _startCoordinator();

--- a/test/features/migration/desktop_migration_epoch_coordinator_test.dart
+++ b/test/features/migration/desktop_migration_epoch_coordinator_test.dart
@@ -1,0 +1,348 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    as frb;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
+import 'package:zcash_wallet/src/features/migration/services/ironwood_migration_service.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/rpc_endpoint_failover_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import '../../fakes/fake_sync_notifier.dart';
+
+const _accountUuid = 'software-account';
+const _endpoint = RpcEndpointConfig(
+  networkName: 'test',
+  lightwalletdUrl: 'https://example.test:443',
+);
+
+/// Simulated desktop process clocks plus the observable epoch side effect.
+///
+/// `sleep` advances only the wall clock (the monotonic clock pauses across a
+/// machine sleep); `run` advances both in step (awake time passing, including
+/// a long-locked stretch or a slow sweep). `authoritativeHeightReads` counts
+/// epoch entry-height fetches: exactly one per wallet-open epoch, so a second
+/// read is the proof that the epoch restarted.
+class _EpochHarness {
+  _EpochHarness();
+
+  DateTime wallNow = DateTime.utc(2026, 8, 4, 12);
+  Duration monotonicNow = Duration.zero;
+  int authoritativeHeightReads = 0;
+  final walletOpenTipHeights = <int?>[];
+  void Function()? onStatusSweep;
+  late final IronwoodMigrationCoordinator coordinator;
+
+  void sleep(Duration duration) {
+    wallNow = wallNow.add(duration);
+  }
+
+  void run(Duration duration) {
+    wallNow = wallNow.add(duration);
+    monotonicNow += duration;
+  }
+}
+
+Future<_EpochHarness> _startCoordinator({
+  rust_sync.MigrationStatus? accountStatus,
+}) async {
+  final harness = _EpochHarness();
+  final status = accountStatus ?? _completeStatus();
+  final service = IronwoodMigrationService(
+    getWalletDbPath: () async => '/tmp/wallet.db',
+    getStatus:
+        ({required dbPath, required network, required accountUuid}) async =>
+            status,
+    getStatuses:
+        ({required dbPath, required network, required accountUuids}) async {
+          harness.onStatusSweep?.call();
+          return [
+            for (final accountUuid in accountUuids)
+              rust_sync.MigrationStatusEntry(
+                accountUuid: accountUuid,
+                status: status,
+              ),
+          ];
+        },
+    getPrivatePlan:
+        ({required dbPath, required network, required accountUuid}) async =>
+            null,
+    secureStore: AppSecureStore.testing(storage: const FlutterSecureStorage()),
+    getEndpoint: () => _endpoint,
+    getSessionPassword: () => 'test-password',
+    isMacOS: () => true,
+    isMobile: () => false,
+    isIOS: () => false,
+    supportsBackgroundMigration: () => false,
+    isHardwareAccount: (_) => false,
+    broadcastDueMigration:
+        ({
+          required dbPath,
+          required lightwalletdUrl,
+          required network,
+          required accountUuid,
+          required password,
+          required saltBase64,
+          int? walletOpenTipHeight,
+        }) async {
+          harness.walletOpenTipHeights.add(walletOpenTipHeight);
+          return _migrationResult();
+        },
+  );
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap()),
+      syncProvider.overrideWith(() => FakeSyncNotifier(SyncState())),
+      ironwoodMigrationServiceProvider.overrideWithValue(service),
+      rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue((
+        _,
+      ) async {
+        // Each epoch's entry read observes a fresh tip (1_000, 1_001, ...) so
+        // tests can prove which epoch's height flowed into a broadcast.
+        harness.authoritativeHeightReads++;
+        return BigInt.from(999 + harness.authoritativeHeightReads);
+      }),
+      ironwoodMigrationCoordinatorProvider.overrideWith(
+        () => IronwoodMigrationCoordinator(
+          now: () => harness.wallNow,
+          monotonicNow: () => harness.monotonicNow,
+        ),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  await container.read(accountProvider.future);
+  final subscription = container.listen(
+    ironwoodMigrationCoordinatorProvider,
+    (_, _) {},
+    fireImmediately: true,
+  );
+  addTearDown(subscription.close);
+  harness.coordinator = container.read(
+    ironwoodMigrationCoordinatorProvider.notifier,
+  );
+  await harness.coordinator.refreshNow();
+  expect(harness.authoritativeHeightReads, 1);
+  return harness;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+  });
+
+  test('desktop visibility changes preserve the epoch', () async {
+    final harness = await _startCoordinator();
+
+    harness.run(const Duration(minutes: 1));
+    harness.coordinator.setForeground(false);
+    await harness.coordinator.refreshNow();
+    harness.run(const Duration(minutes: 1));
+    harness.coordinator.setForeground(true);
+    await harness.coordinator.refreshNow();
+
+    expect(
+      harness.authoritativeHeightReads,
+      1,
+      reason: 'hiding and re-showing the window must preserve the epoch',
+    );
+  });
+
+  test('a machine sleep between sweeps restarts the epoch', () async {
+    final harness = await _startCoordinator();
+
+    harness.sleep(kDesktopMigrationEpochSuspensionGap);
+    await harness.coordinator.refreshNow();
+
+    expect(
+      harness.authoritativeHeightReads,
+      2,
+      reason: 'a genuine sleep must recapture the epoch entry height',
+    );
+  });
+
+  test('a machine sleep that begins mid-sweep restarts the epoch', () async {
+    final harness = await _startCoordinator();
+
+    harness.onStatusSweep = () {
+      harness.sleep(kDesktopMigrationEpochSuspensionGap);
+      harness.onStatusSweep = null;
+    };
+    await harness.coordinator.refreshNow();
+    await harness.coordinator.refreshNow();
+
+    expect(
+      harness.authoritativeHeightReads,
+      2,
+      reason:
+          'wall time outrunning the monotonic clock inside a sweep is a '
+          'suspension and must recapture the epoch entry height',
+    );
+  });
+
+  test('a long awake refresh gap (locked wallet) restarts the epoch', () async {
+    final harness = await _startCoordinator();
+
+    harness.run(kDesktopMigrationEpochSuspensionGap);
+    await harness.coordinator.refreshNow();
+
+    expect(
+      harness.authoritativeHeightReads,
+      2,
+      reason:
+          'refresh activity stopping for the threshold while the process '
+          'stays awake means broadcasts could not run and must restart the '
+          'epoch',
+    );
+  });
+
+  test('threads each epoch\'s entry tip into the one-due broadcast', () async {
+    // The Rust one-due endpoint floors its post-accept wallet-overdue redraw
+    // at the epoch entry tip. Losing this argument would silently reintroduce
+    // the sync-lag wedge, so pin the coordinator → service → broadcaster
+    // threading end to end, across an epoch restart.
+    final harness = await _startCoordinator(
+      accountStatus: _scheduledStatus(scheduledHeight: 999),
+    );
+
+    expect(
+      harness.walletOpenTipHeights,
+      [1_000],
+      reason: 'the broadcast must carry the first epoch\'s entry tip',
+    );
+
+    harness.sleep(kDesktopMigrationEpochSuspensionGap);
+    await harness.coordinator.refreshNow(forceAdvance: true);
+
+    expect(harness.authoritativeHeightReads, 2);
+    expect(
+      harness.walletOpenTipHeights,
+      [1_000, 1_001],
+      reason:
+          'a restarted epoch must thread its freshly captured entry tip, '
+          'not the pre-suspension one',
+    );
+  });
+
+  test('a slow sweep does not restart the epoch', () async {
+    final harness = await _startCoordinator();
+
+    harness.onStatusSweep = () {
+      harness.run(kDesktopMigrationEpochSuspensionGap * 2);
+      harness.onStatusSweep = null;
+    };
+    await harness.coordinator.refreshNow();
+    harness.run(const Duration(seconds: 15));
+    await harness.coordinator.refreshNow();
+
+    expect(
+      harness.authoritativeHeightReads,
+      1,
+      reason:
+          'a sweep running longer than the threshold is process activity, '
+          'not suspension',
+    );
+  });
+}
+
+AppBootstrapState _bootstrap() {
+  return AppBootstrapState(
+    initialLocation: '/home',
+    initialAccountState: const AccountState(
+      accounts: [
+        AccountInfo(
+          uuid: _accountUuid,
+          name: 'Software',
+          order: 0,
+          isSeedAnchor: true,
+        ),
+      ],
+      activeAccountUuid: _accountUuid,
+      activeAddress: 'u1test',
+    ),
+    initialSyncSnapshot: AppSyncSnapshot.empty,
+    network: _endpoint.networkName,
+    rpcEndpointConfig: _endpoint,
+    themeMode: ThemeMode.system,
+    privacyModeEnabled: false,
+    isPasswordConfigured: true,
+    isUnlocked: true,
+    passwordRotationRecoveryFailed: false,
+  );
+}
+
+rust_sync.MigrationStatus _scheduledStatus({required int scheduledHeight}) {
+  return rust_sync.MigrationStatus(
+    phase: 'broadcast_scheduled',
+    activeRunId: 'run-1',
+    targetValuesZatoshi: frb.Uint64List.fromList([100000000]),
+    preparedNoteCount: 1,
+    denominationConfirmationCount: 3,
+    denominationConfirmationTarget: 3,
+    denominationSplitCompletedCount: 1,
+    denominationSplitTotalCount: 1,
+    pendingTxCount: 1,
+    broadcastedTxCount: 0,
+    confirmedTxCount: 0,
+    totalCount: 1,
+    signedChildPcztCount: 0,
+    pendingSplitStageCount: 0,
+    canAbandon: false,
+    signingBatchLimit: 35,
+    scheduleMeanDelayBlocks: 144,
+    scheduleMaxDelayBlocks: 576,
+    scheduledBroadcasts: [
+      rust_sync.MigrationScheduledBroadcast(
+        txidHex: 'scheduled-tx',
+        valueZatoshi: BigInt.from(100000000),
+        scheduledAtMs: 0,
+        scheduledHeight: scheduledHeight,
+        status: 'scheduled',
+      ),
+    ],
+    parts: const [],
+  );
+}
+
+rust_sync.IronwoodMigrationResult _migrationResult() {
+  return rust_sync.IronwoodMigrationResult(
+    txids: '',
+    status: 'broadcast_scheduled',
+    broadcastedCount: 0,
+    totalCount: 1,
+    feeZatoshi: BigInt.zero,
+    migratedZatoshi: BigInt.from(100000000),
+  );
+}
+
+rust_sync.MigrationStatus _completeStatus() {
+  return rust_sync.MigrationStatus(
+    phase: 'complete',
+    targetValuesZatoshi: frb.Uint64List.fromList([100000000]),
+    preparedNoteCount: 1,
+    denominationConfirmationCount: 3,
+    denominationConfirmationTarget: 3,
+    denominationSplitCompletedCount: 1,
+    denominationSplitTotalCount: 1,
+    pendingTxCount: 0,
+    broadcastedTxCount: 1,
+    confirmedTxCount: 1,
+    totalCount: 1,
+    signedChildPcztCount: 0,
+    pendingSplitStageCount: 0,
+    canAbandon: false,
+    signingBatchLimit: 35,
+    scheduleMeanDelayBlocks: 144,
+    scheduleMaxDelayBlocks: 576,
+    scheduledBroadcasts: const [],
+    parts: const [],
+  );
+}

--- a/test/features/migration/desktop_migration_epoch_coordinator_test.dart
+++ b/test/features/migration/desktop_migration_epoch_coordinator_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -38,7 +40,7 @@ class _EpochHarness {
   Duration monotonicNow = Duration.zero;
   int authoritativeHeightReads = 0;
   final walletOpenTipHeights = <int?>[];
-  void Function()? onStatusSweep;
+  FutureOr<void> Function()? onStatusSweep;
   late final ProviderContainer container;
   late final IronwoodMigrationCoordinator coordinator;
 
@@ -86,7 +88,7 @@ Future<_EpochHarness> _startCoordinator({
             status,
     getStatuses:
         ({required dbPath, required network, required accountUuids}) async {
-          harness.onStatusSweep?.call();
+          await harness.onStatusSweep?.call();
           return [
             for (final accountUuid in accountUuids)
               rust_sync.MigrationStatusEntry(
@@ -339,6 +341,97 @@ void main() {
       reason: 'the consumed fallback allowance must not be replenished',
     );
   });
+
+  test(
+    'a long lock overlapping an in-flight sweep restarts the epoch',
+    () async {
+      final status = _scheduledStatus(scheduledHeight: 999);
+      final harness = await _startCoordinator(
+        accountStatus: status,
+        acceptScheduledBroadcast: true,
+      );
+      expect(harness.walletOpenTipHeights, [1_000]);
+
+      final sweepStarted = Completer<void>();
+      final releaseSweep = Completer<void>();
+      harness.onStatusSweep = () async {
+        harness.onStatusSweep = null;
+        sweepStarted.complete();
+        await releaseSweep.future;
+      };
+      final sweep = harness.coordinator.refreshNow();
+      await sweepStarted.future;
+
+      harness.lock();
+      harness.run(kDesktopMigrationEpochSuspensionGap);
+      releaseSweep.complete();
+      await sweep;
+
+      expect(
+        harness.authoritativeHeightReads,
+        1,
+        reason: 'the in-flight sweep must finish against the original epoch',
+      );
+
+      harness.unlock();
+      await harness.coordinator.refreshNow(forceAdvance: true);
+
+      expect(
+        harness.authoritativeHeightReads,
+        2,
+        reason:
+            'sweep completion while locked must not erase the lock duration at '
+            'unlock',
+      );
+      expect(
+        harness.walletOpenTipHeights.last,
+        1_001,
+        reason: 'post-unlock work must use the restarted epoch tip',
+      );
+    },
+  );
+
+  test(
+    'a short lock overlapping an in-flight sweep preserves the epoch',
+    () async {
+      final status = _scheduledStatus(scheduledHeight: 999);
+      final harness = await _startCoordinator(
+        accountStatus: status,
+        acceptScheduledBroadcast: true,
+      );
+      expect(harness.walletOpenTipHeights, [1_000]);
+
+      final sweepStarted = Completer<void>();
+      final releaseSweep = Completer<void>();
+      harness.onStatusSweep = () async {
+        harness.onStatusSweep = null;
+        sweepStarted.complete();
+        await releaseSweep.future;
+      };
+      final sweep = harness.coordinator.refreshNow();
+      await sweepStarted.future;
+
+      harness.lock();
+      harness.run(const Duration(minutes: 2, seconds: 45));
+      releaseSweep.complete();
+      await sweep;
+
+      harness.unlock();
+      await harness.coordinator.refreshNow(forceAdvance: true);
+
+      expect(
+        harness.authoritativeHeightReads,
+        1,
+        reason: 'an overlapping lock below the threshold must keep the epoch',
+      );
+      expect(
+        harness.walletOpenTipHeights,
+        [1_000],
+        reason:
+            'a short lock must not replenish the consumed fallback allowance',
+      );
+    },
+  );
 
   test('a manual retry after a long locked gap restarts the epoch', () async {
     // `retry` reaches `_advance` without running a sweep first, and the

--- a/test/features/migration/desktop_open_migration_fallback_gate_test.dart
+++ b/test/features/migration/desktop_open_migration_fallback_gate_test.dart
@@ -4,17 +4,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
+const _accountA = 'account-a';
+const _accountB = 'account-b';
+
 void main() {
   test('fails closed before an authoritative desktop-open height', () {
     final gate = DesktopOpenMigrationFallbackGate();
 
-    expect(gate.allows(_statusWithScheduledHeight(999)), isFalse);
+    expect(gate.allows(_accountA, _statusWithScheduledHeight(999)), isFalse);
     expect(gate.needsAuthoritativeEntryHeight, isTrue);
+    expect(gate.epochEntryHeight, isNull);
   });
 
   test('allows only one account that was overdue at desktop open', () {
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final firstAccount = _statusWithScheduledHeight(
       999,
       scheduledTxid: 'first',
@@ -23,59 +27,129 @@ void main() {
       1_000,
       scheduledTxid: 'second',
     );
-    gate.captureOpenStatuses([firstAccount, secondAccount]);
+    gate.captureOpenStatus(_accountA, firstAccount);
+    gate.captureOpenStatus(_accountB, secondAccount);
 
-    expect(gate.allows(firstAccount), isTrue);
+    expect(gate.allows(_accountA, firstAccount), isTrue);
     gate.consumeIfOpenOverdue(firstAccount);
 
-    expect(gate.allows(secondAccount), isFalse);
+    expect(gate.allows(_accountB, secondAccount), isFalse);
   });
 
   test('does not block a transfer that becomes due after desktop open', () {
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final overdueAtOpen = _statusWithScheduledHeight(999);
     final scheduledAfterOpen = _statusWithScheduledHeight(1_001);
-    gate.captureOpenStatuses([overdueAtOpen, scheduledAfterOpen]);
+    gate.captureOpenStatus(_accountA, overdueAtOpen);
+    gate.captureOpenStatus(_accountB, scheduledAfterOpen);
 
     gate.consumeIfOpenOverdue(overdueAtOpen);
 
-    expect(gate.allows(scheduledAfterOpen), isTrue);
+    expect(gate.allows(_accountB, scheduledAfterOpen), isTrue);
   });
 
-  test('grants a new wallet-global allowance after the next foreground', () {
+  test('grants a new wallet-global allowance after an epoch restart', () {
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final overdue = _statusWithScheduledHeight(999);
-    gate.captureOpenStatuses([overdue]);
+    gate.captureOpenStatus(_accountA, overdue);
     gate.consumeIfOpenOverdue(overdue);
-    expect(gate.allows(overdue), isFalse);
+    expect(gate.allows(_accountA, overdue), isFalse);
 
     gate
-      ..leaveForeground()
-      ..enterForeground()
-      ..observeForegroundEntryHeight(1_100);
-    gate.captureOpenStatuses([overdue]);
+      ..restartEpoch()
+      ..observeEpochEntryHeight(1_100);
+    gate.captureOpenStatus(_accountA, overdue);
 
-    expect(gate.allows(overdue), isTrue);
+    expect(gate.allows(_accountA, overdue), isTrue);
   });
 
-  test('duplicate foreground notification does not replenish allowance', () {
+  test('window visibility changes alone do not replenish the allowance', () {
+    // Hiding and re-showing the desktop window is not an epoch boundary; only
+    // an explicit restart (process suspension or wallet reset) re-arms the
+    // one-transfer allowance. The coordinator therefore never notifies the
+    // gate about visibility, so a consumed allowance must stay consumed.
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final overdue = _statusWithScheduledHeight(999);
-    gate.captureOpenStatuses([overdue]);
+    gate.captureOpenStatus(_accountA, overdue);
     gate.consumeIfOpenOverdue(overdue);
 
-    gate.enterForeground();
+    expect(gate.allows(_accountA, overdue), isFalse);
+  });
 
-    expect(gate.allows(overdue), isFalse);
+  test('keeps allowing scheduled transfers that come due while hidden', () {
+    // While the desktop process keeps running (hidden or visible), a transfer
+    // whose height arrives after the epoch snapshot is a normal scheduled
+    // broadcast — it must not depend on the one-transfer open allowance even
+    // after that allowance is consumed.
+    final gate = DesktopOpenMigrationFallbackGate()
+      ..observeEpochEntryHeight(1_000);
+    final overdueAtOpen = _statusWithScheduledHeight(999, scheduledTxid: 'a');
+    gate.captureOpenStatus(_accountA, overdueAtOpen);
+    gate.consumeIfOpenOverdue(overdueAtOpen);
+
+    final dueWhileHidden = _statusWithScheduledHeight(
+      1_050,
+      scheduledTxid: 'b',
+    );
+    gate.captureOpenStatus(_accountB, _statusWithoutScheduledTransfers());
+    expect(gate.tryAcquireForAdvance(_accountB, dueWhileHidden), isTrue);
+  });
+
+  test('one failing account snapshot blocks only that account', () {
+    // Account B's status read keeps failing, so it is never captured. Its own
+    // scheduled transfers must stay paused (its overdue-at-open set is
+    // unknown), but account A — captured normally — must broadcast on
+    // schedule instead of the whole wallet failing closed.
+    final gate = DesktopOpenMigrationFallbackGate()
+      ..observeEpochEntryHeight(1_000);
+    final capturedAccount = _statusWithScheduledHeight(
+      999,
+      scheduledTxid: 'captured',
+    );
+    gate.captureOpenStatus(_accountA, capturedAccount);
+
+    final uncaptured = _statusWithScheduledHeight(
+      998,
+      scheduledTxid: 'uncaptured',
+    );
+    expect(gate.allows(_accountA, capturedAccount), isTrue);
+    expect(gate.allows(_accountB, uncaptured), isFalse);
+    expect(gate.needsOpenStatusSnapshotFor(_accountB), isTrue);
+
+    // The failing account recovers on a later sweep and is captured then;
+    // its overdue-at-open transfers join the fallback set mid-epoch.
+    gate.captureOpenStatus(_accountB, uncaptured);
+    expect(gate.needsOpenStatusSnapshotFor(_accountB), isFalse);
+    expect(gate.allows(_accountB, uncaptured), isTrue);
+    gate.consumeIfOpenOverdue(uncaptured);
+    expect(gate.allows(_accountA, capturedAccount), isFalse);
+  });
+
+  test('recapture cannot widen an account snapshot mid-epoch', () {
+    final gate = DesktopOpenMigrationFallbackGate()
+      ..observeEpochEntryHeight(1_000);
+    gate.captureOpenStatus(_accountA, _statusWithoutScheduledTransfers());
+
+    // A transfer observed later in the epoch (for example redrawn to a height
+    // below the entry tip by a Rust catch-up reschedule) must not be
+    // reclassified as overdue-at-open.
+    final laterObservation = _statusWithScheduledHeight(
+      999,
+      scheduledTxid: 'redrawn-low',
+    );
+    gate.captureOpenStatus(_accountA, laterObservation);
+
+    expect(gate.isOpenOverdue(laterObservation), isFalse);
+    expect(gate.allows(_accountA, laterObservation), isTrue);
   });
 
   test('uses the authoritative tip instead of a stale cached sync height', () {
     const staleCachedHeight = 900;
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final firstAccount = _statusWithScheduledHeight(
       staleCachedHeight + 50,
       scheduledTxid: 'first',
@@ -84,17 +158,18 @@ void main() {
       staleCachedHeight + 60,
       scheduledTxid: 'second',
     );
-    gate.captureOpenStatuses([firstAccount, secondAccount]);
+    gate.captureOpenStatus(_accountA, firstAccount);
+    gate.captureOpenStatus(_accountB, secondAccount);
 
-    expect(gate.allows(firstAccount), isTrue);
+    expect(gate.allows(_accountA, firstAccount), isTrue);
     gate.consumeIfOpenOverdue(firstAccount);
 
-    expect(gate.allows(secondAccount), isFalse);
+    expect(gate.allows(_accountB, secondAccount), isFalse);
   });
 
   test('keeps the original open snapshot through wallet-wide reschedule', () {
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final firstAccount = _statusWithScheduledHeight(
       999,
       scheduledTxid: 'first',
@@ -103,19 +178,23 @@ void main() {
       998,
       scheduledTxid: 'second',
     );
-    gate.captureOpenStatuses([firstAccount, secondAccount]);
+    gate.captureOpenStatus(_accountA, firstAccount);
+    gate.captureOpenStatus(_accountB, secondAccount);
     gate.consumeIfOpenOverdue(firstAccount);
 
-    expect(gate.allows(secondAccount), isFalse);
+    expect(gate.allows(_accountB, secondAccount), isFalse);
     expect(
-      gate.allows(_statusWithScheduledHeight(1_001, scheduledTxid: 'second')),
+      gate.allows(
+        _accountB,
+        _statusWithScheduledHeight(1_001, scheduledTxid: 'second'),
+      ),
       isTrue,
     );
   });
 
   test('central advance acquisition rejects a manual second attempt', () {
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final automatic = _statusWithScheduledHeight(
       999,
       scheduledTxid: 'automatic',
@@ -124,15 +203,16 @@ void main() {
       998,
       scheduledTxid: 'manual-retry',
     );
-    gate.captureOpenStatuses([automatic, manualRetry]);
+    gate.captureOpenStatus(_accountA, automatic);
+    gate.captureOpenStatus(_accountB, manualRetry);
 
-    expect(gate.tryAcquireForAdvance(automatic), isTrue);
-    expect(gate.tryAcquireForAdvance(manualRetry), isFalse);
+    expect(gate.tryAcquireForAdvance(_accountA, automatic), isTrue);
+    expect(gate.tryAcquireForAdvance(_accountB, manualRetry), isFalse);
   });
 
   test('returns an unused reservation after a no-op advance', () {
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final firstAttempt = _statusWithScheduledHeight(
       999,
       scheduledTxid: 'first-attempt',
@@ -141,17 +221,18 @@ void main() {
       998,
       scheduledTxid: 'later-retry',
     );
-    gate.captureOpenStatuses([firstAttempt, laterRetry]);
+    gate.captureOpenStatus(_accountA, firstAttempt);
+    gate.captureOpenStatus(_accountB, laterRetry);
 
-    expect(gate.tryAcquireForAdvance(firstAttempt), isTrue);
+    expect(gate.tryAcquireForAdvance(_accountA, firstAttempt), isTrue);
     gate.completeAdvance(firstAttempt, _result());
 
-    expect(gate.tryAcquireForAdvance(laterRetry), isTrue);
+    expect(gate.tryAcquireForAdvance(_accountB, laterRetry), isTrue);
   });
 
   test('returns a reservation after an advance fails before acceptance', () {
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final firstAttempt = _statusWithScheduledHeight(
       999,
       scheduledTxid: 'first-attempt',
@@ -160,17 +241,18 @@ void main() {
       998,
       scheduledTxid: 'later-retry',
     );
-    gate.captureOpenStatuses([firstAttempt, laterRetry]);
+    gate.captureOpenStatus(_accountA, firstAttempt);
+    gate.captureOpenStatus(_accountB, laterRetry);
 
-    expect(gate.tryAcquireForAdvance(firstAttempt), isTrue);
+    expect(gate.tryAcquireForAdvance(_accountA, firstAttempt), isTrue);
     gate.failAdvance(firstAttempt);
 
-    expect(gate.tryAcquireForAdvance(laterRetry), isTrue);
+    expect(gate.tryAcquireForAdvance(_accountB, laterRetry), isTrue);
   });
 
   test('confirmed transfers do not make a no-op look newly accepted', () {
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final firstAttempt = _statusWithScheduledHeight(
       999,
       scheduledTxid: 'first-attempt',
@@ -181,17 +263,18 @@ void main() {
       scheduledTxid: 'later-retry',
       confirmedTxCount: 1,
     );
-    gate.captureOpenStatuses([firstAttempt, laterRetry]);
+    gate.captureOpenStatus(_accountA, firstAttempt);
+    gate.captureOpenStatus(_accountB, laterRetry);
 
-    expect(gate.tryAcquireForAdvance(firstAttempt), isTrue);
+    expect(gate.tryAcquireForAdvance(_accountA, firstAttempt), isTrue);
     gate.completeAdvance(firstAttempt, _result(broadcastedCount: 1));
 
-    expect(gate.tryAcquireForAdvance(laterRetry), isTrue);
+    expect(gate.tryAcquireForAdvance(_accountB, laterRetry), isTrue);
   });
 
   test('commits a reservation after a durable broadcast', () {
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final firstAttempt = _statusWithScheduledHeight(
       999,
       scheduledTxid: 'first-attempt',
@@ -200,20 +283,21 @@ void main() {
       998,
       scheduledTxid: 'later-retry',
     );
-    gate.captureOpenStatuses([firstAttempt, laterRetry]);
+    gate.captureOpenStatus(_accountA, firstAttempt);
+    gate.captureOpenStatus(_accountB, laterRetry);
 
-    expect(gate.tryAcquireForAdvance(firstAttempt), isTrue);
+    expect(gate.tryAcquireForAdvance(_accountA, firstAttempt), isTrue);
     gate.completeAdvance(
       firstAttempt,
       _result(broadcastedCount: 1, txids: 'first-attempt'),
     );
 
-    expect(gate.tryAcquireForAdvance(laterRetry), isFalse);
+    expect(gate.tryAcquireForAdvance(_accountB, laterRetry), isFalse);
   });
 
   test('denomination broadcast does not commit the fallback reservation', () {
     final gate = DesktopOpenMigrationFallbackGate()
-      ..observeForegroundEntryHeight(1_000);
+      ..observeEpochEntryHeight(1_000);
     final firstAttempt = _statusWithScheduledHeight(
       999,
       scheduledTxid: 'migration-transfer',
@@ -222,15 +306,16 @@ void main() {
       998,
       scheduledTxid: 'later-retry',
     );
-    gate.captureOpenStatuses([firstAttempt, laterRetry]);
+    gate.captureOpenStatus(_accountA, firstAttempt);
+    gate.captureOpenStatus(_accountB, laterRetry);
 
-    expect(gate.tryAcquireForAdvance(firstAttempt), isTrue);
+    expect(gate.tryAcquireForAdvance(_accountA, firstAttempt), isTrue);
     gate.completeAdvance(
       firstAttempt,
       _result(broadcastedCount: 1, txids: 'denomination-stage'),
     );
 
-    expect(gate.tryAcquireForAdvance(laterRetry), isTrue);
+    expect(gate.tryAcquireForAdvance(_accountB, laterRetry), isTrue);
   });
 }
 
@@ -248,9 +333,14 @@ rust_sync.IronwoodMigrationResult _result({
   );
 }
 
+rust_sync.MigrationStatus _statusWithoutScheduledTransfers() {
+  return _statusWithScheduledHeight(0, scheduledStatus: 'confirmed');
+}
+
 rust_sync.MigrationStatus _statusWithScheduledHeight(
   int scheduledHeight, {
   String scheduledTxid = 'scheduled-tx',
+  String scheduledStatus = 'scheduled',
   int broadcastedTxCount = 0,
   int confirmedTxCount = 0,
 }) {
@@ -279,7 +369,7 @@ rust_sync.MigrationStatus _statusWithScheduledHeight(
         valueZatoshi: BigInt.from(100000000),
         scheduledAtMs: 0,
         scheduledHeight: scheduledHeight,
-        status: 'scheduled',
+        status: scheduledStatus,
       ),
     ],
     parts: const [],

--- a/test/features/migration/ironwood_migration_coordinator_provider_test.dart
+++ b/test/features/migration/ironwood_migration_coordinator_provider_test.dart
@@ -2382,6 +2382,7 @@ ProviderContainer _container({
           required accountUuid,
           required password,
           required saltBase64,
+          int? walletOpenTipHeight,
         }) async {
           broadcasts.add(accountUuid);
           if (broadcast != null) return broadcast(accountUuid);

--- a/test/features/migration/ironwood_migration_desktop_advance_trigger_test.dart
+++ b/test/features/migration/ironwood_migration_desktop_advance_trigger_test.dart
@@ -232,6 +232,7 @@ class _Harness {
             required accountUuid,
             required password,
             required saltBase64,
+            int? walletOpenTipHeight,
           }) async {
             broadcasts.add(accountUuid);
             // Hold the run in `broadcast_scheduled` so the status -- and

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -3576,6 +3576,7 @@ void main() {
             required accountUuid,
             required password,
             required saltBase64,
+            int? walletOpenTipHeight,
           }) {
             softwareContinued = true;
             return Future.value(_migrationResult());
@@ -6162,6 +6163,7 @@ IronwoodMigrationService _migrationServiceForContinue({
           required accountUuid,
           required password,
           required saltBase64,
+          int? walletOpenTipHeight,
         }) {
           return onContinue(accountUuid: accountUuid);
         },

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -2765,6 +2765,7 @@ void main() {
             required accountUuid,
             required password,
             required saltBase64,
+            int? walletOpenTipHeight,
           }) {
             seenPassword = password;
             seenSalts.add(saltBase64);
@@ -2812,6 +2813,7 @@ void main() {
             required accountUuid,
             required password,
             required saltBase64,
+            int? walletOpenTipHeight,
           }) {
             return Future.value(_migrationResult(status: 'ready_to_migrate'));
           },
@@ -2867,6 +2869,7 @@ void main() {
               required accountUuid,
               required password,
               required saltBase64,
+              int? walletOpenTipHeight,
             }) async => _migrationResult(status: 'ready_to_migrate'),
         startMacosSoftwareMigration:
             ({
@@ -3551,6 +3554,7 @@ void main() {
               required accountUuid,
               required password,
               required saltBase64,
+              int? walletOpenTipHeight,
             }) async {
               broadcastCalled = true;
               return _migrationResult();
@@ -4413,6 +4417,7 @@ void main() {
             required accountUuid,
             required password,
             required saltBase64,
+            int? walletOpenTipHeight,
           }) {
             rustCalled = true;
             return Future.value(_migrationResult());
@@ -5037,6 +5042,7 @@ void main() {
             required accountUuid,
             required password,
             required saltBase64,
+            int? walletOpenTipHeight,
           }) async {
             dueBroadcastCount++;
             return _migrationResult();

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -1232,6 +1232,7 @@ IronwoodMigrationService _migrationService({
           required accountUuid,
           required password,
           required saltBase64,
+          int? walletOpenTipHeight,
         }) => onContinue?.call(accountUuid) ?? Future.value(_migrationResult()),
     scheduleBackgroundMigration: () async => true,
   );


### PR DESCRIPTION
## Summary

- keep scheduled desktop migration broadcasts running while the app window is hidden by scoping the ZIP 318 fallback epoch to continuous process activity
- restart the epoch after genuine suspension or long inactivity, with per-account overdue snapshots and a refreshed authoritative entry height
- thread the wallet-open tip through the one-due broadcast path so one fallback acceptance redraws the complete opening-overdue set, even when local sync is far behind
- refresh persisted wall-clock schedule timestamps during overdue redraws and prevent macOS App Nap from throttling hidden-window timers

## Motivation / Why

When Vizor’s desktop window was hidden, minimized, or closed without quitting, the old code cleared the ZIP 318 epoch entry height and overdue snapshot even though the process continued running. Transactions that became due while hidden were therefore blocked by the gate.

When the window reopened, Vizor treated those transactions as overdue at the start of a new epoch. Only one could proceed immediately, while the rest were rescheduled, creating the apparent one-per-reopen backlog.

The fix preserves the epoch while the desktop process remains active, regardless of window visibility. Transactions that become due while hidden remain normal scheduled transactions and can broadcast on time.

## Solution

The 15-second refresh loop records that the desktop process is still active; hiding the window no longer resets the migration epoch.

A gap of three minutes or more indicates sleep, suspension, a long lock, or process restart, so Vizor starts a new epoch.

While hidden but running, newly due transactions remain normal scheduled transfers and can broadcast on time.
After real inactivity, Vizor snapshots overdue transactions, broadcasts one under ZIP 318, and reschedules the rest to future heights.

Window close without quitting and locks shorter than three minutes preserve the epoch.

## Tests

- focused Flutter migration suite: 218 passed, 1 skipped
- `cd rust && cargo test on_open_`: 4 passed
- Flutter analysis: no issues
- Rust formatting/codegen and `git diff --check`: clean