### PR TITLE
Fix Tor updater route-switch races

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1661,14 +1661,21 @@ class _LinuxUpdateNoticeListener extends ConsumerWidget {
         if (!context.mounted) return;
         final messenger = ScaffoldMessenger.maybeOf(context);
         if (messenger == null) return;
+        final torEnabled = ref.read(networkPrivacyProvider).torEnabled;
 
         messenger.hideCurrentSnackBar();
         messenger.showSnackBar(
           SnackBar(
-            content: Text('Vizor ${update.assetVersion} is available.'),
+            content: Text(
+              torEnabled
+                  ? 'Vizor ${update.assetVersion} is available. The release '
+                        'page opens in your browser, outside Vizor’s Tor '
+                        'connection.'
+                  : 'Vizor ${update.assetVersion} is available.',
+            ),
             duration: const Duration(seconds: 8),
             action: SnackBarAction(
-              label: 'View release',
+              label: torEnabled ? 'Open in browser' : 'View release',
               onPressed: () => unawaited(_openLinuxUpdateRelease(update)),
             ),
           ),

--- a/lib/src/features/settings/widgets/network_privacy_control.dart
+++ b/lib/src/features/settings/widgets/network_privacy_control.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -28,7 +30,10 @@ class NetworkPrivacyControl extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.colors;
     final state = ref.watch(networkPrivacyProvider);
-    final presentation = _presentationFor(state);
+    final presentation = _presentationFor(
+      state,
+      platform: defaultTargetPlatform,
+    );
 
     final assetList = Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -323,7 +328,10 @@ class _NetworkPrivacyPresentation {
   final Color Function(AppColors colors) descriptionColor;
 }
 
-_NetworkPrivacyPresentation _presentationFor(NetworkPrivacyState state) {
+_NetworkPrivacyPresentation _presentationFor(
+  NetworkPrivacyState state, {
+  required TargetPlatform platform,
+}) {
   if (!state.softwareUpdatesAvailable &&
       state.status == NetworkPrivacyConnectionStatus.connected) {
     return _NetworkPrivacyPresentation(
@@ -347,11 +355,14 @@ _NetworkPrivacyPresentation _presentationFor(NetworkPrivacyState state) {
     );
   }
   final targetTorEnabled = state.targetTorEnabled ?? state.torEnabled;
+  final isLinux = platform == TargetPlatform.linux;
   return switch ((state.status, targetTorEnabled)) {
     (NetworkPrivacyConnectionStatus.off, _) => _NetworkPrivacyPresentation(
       statusLabel: 'Direct',
-      description:
-          'Tor is off. Requests to the Zcash network, in-app services, and software updates connect directly.',
+      description: isLinux
+          ? 'Tor is off. Vizor requests, including software update checks, '
+                'connect directly. Update pages and downloads open in another app.'
+          : 'Tor is off. Requests to the Zcash network, in-app services, and software updates connect directly.',
       statusColor: (colors) => colors.text.secondary,
       iconColor: (colors) => colors.icon.muted,
       descriptionColor: (colors) => colors.text.accent,
@@ -359,8 +370,11 @@ _NetworkPrivacyPresentation _presentationFor(NetworkPrivacyState state) {
     (NetworkPrivacyConnectionStatus.connecting, true) =>
       _NetworkPrivacyPresentation(
         statusLabel: 'Connecting ...',
-        description:
-            'Requests to the Zcash network, in-app services, and software updates use Tor. Some services may be unavailable over Tor.',
+        description: isLinux
+            ? 'Vizor requests, including software update checks, will use Tor. '
+                  'Update pages and downloads opened in another app use that '
+                  'app’s connection.'
+            : 'Requests to the Zcash network, in-app services, and software updates use Tor. Some services may be unavailable over Tor.',
         statusColor: (colors) => colors.text.secondary,
         iconColor: (colors) => colors.icon.muted,
         descriptionColor: (colors) => colors.text.accent,
@@ -368,16 +382,21 @@ _NetworkPrivacyPresentation _presentationFor(NetworkPrivacyState state) {
     (NetworkPrivacyConnectionStatus.connecting, false) =>
       _NetworkPrivacyPresentation(
         statusLabel: 'Switching to direct…',
-        description:
-            'Vizor is switching network requests and software updates to a direct connection.',
+        description: isLinux
+            ? 'Vizor is switching its requests, including software update '
+                  'checks, to a direct connection.'
+            : 'Vizor is switching network requests and software updates to a direct connection.',
         statusColor: (colors) => colors.text.secondary,
         iconColor: (colors) => colors.icon.brandCrimson,
         descriptionColor: (colors) => colors.text.accent,
       ),
     (NetworkPrivacyConnectionStatus.connected, _) => _NetworkPrivacyPresentation(
       statusLabel: 'Connected',
-      description:
-          'Requests to the Zcash network, in-app services, and software updates use Tor. Some services may be unavailable over Tor.',
+      description: isLinux
+          ? 'Vizor requests, including software update checks, use Tor. '
+                'Update pages and downloads opened in another app use that '
+                'app’s connection.'
+          : 'Requests to the Zcash network, in-app services, and software updates use Tor. Some services may be unavailable over Tor.',
       statusColor: (colors) => colors.text.brandCrimson,
       iconColor: (colors) => colors.icon.brandCrimson,
       descriptionColor: (colors) => colors.text.accent,

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -17,6 +17,8 @@ const kTorStartupFailureNotice =
     "Couldn't connect to Tor. Network requests are paused.";
 const kTorUpdateInProgressNotice =
     'Finish the current software update before turning on Tor.';
+const kTorDisableUpdateInProgressNotice =
+    'Finish the current software update before turning off Tor.';
 const kTorUpdateUnavailableNotice =
     'Tor is connected, but software updates are unavailable. Turn off Tor to update directly.';
 const kSoftwareUpdateUnavailableNotice =
@@ -125,6 +127,8 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
 }
 
 abstract interface class NetworkPrivacyNativeUpdateCoordinator {
+  Future<void> prepareForTorDisable();
+
   Future<void> setTorEnabled(bool enabled);
 
   Future<void> pauseForFailClosedStartup();
@@ -154,6 +158,20 @@ class PlatformNetworkPrivacyNativeUpdateCoordinator
 
   static void clearDisableTorForUpdateHandler() {
     _macosChannel.setMethodCallHandler(null);
+  }
+
+  @override
+  Future<void> prepareForTorDisable() async {
+    if (Platform.isWindows) {
+      await WindowsUpdateService().prepareForTorDisable();
+      return;
+    }
+    if (!Platform.isMacOS) return;
+    try {
+      await _macosChannel.invokeMethod<void>('prepareForTorDisable');
+    } on MissingPluginException {
+      // Development builds without Sparkle have no updater to drain.
+    }
   }
 
   @override
@@ -462,6 +480,31 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
       }
       if (generation != _generation) return;
       runtime.beginEnable();
+    } else {
+      state = NetworkPrivacyState(
+        torEnabled: previousState.torEnabled,
+        status: NetworkPrivacyConnectionStatus.connecting,
+        targetTorEnabled: false,
+        softwareUpdatesAvailable: previousState.softwareUpdatesAvailable,
+      );
+      try {
+        // Keep the current Tor updater proxy alive until a running native
+        // update cycle has finished. Only then may the shared Tor runtime and
+        // its loopback relay be switched back to direct routing.
+        await nativeUpdates.prepareForTorDisable();
+      } catch (error) {
+        if (generation != _generation) return;
+        state = NetworkPrivacyState(
+          torEnabled: previousState.torEnabled,
+          status: previousState.status,
+          targetTorEnabled: false,
+          softwareUpdatesAvailable: previousState.softwareUpdatesAvailable,
+          error: error.toString(),
+          startupNotice: kTorDisableUpdateInProgressNotice,
+        );
+        return;
+      }
+      if (generation != _generation) return;
     }
 
     final directDrain = enabled
@@ -519,14 +562,26 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
     } catch (error) {
       if (generation != _generation) return;
       final effectiveTorEnabled = runtime.isTorEnabled();
+      var softwareUpdatesAvailable = enabled
+          ? false
+          : previousState.softwareUpdatesAvailable;
+      String? startupNotice;
+      if (!enabled && effectiveTorEnabled) {
+        try {
+          await nativeUpdates.resumeTorUpdates();
+        } catch (_) {
+          softwareUpdatesAvailable = false;
+          startupNotice = kTorUpdateUnavailableNotice;
+        }
+      }
+      if (generation != _generation) return;
       state = NetworkPrivacyState(
         torEnabled: effectiveTorEnabled,
         status: NetworkPrivacyConnectionStatus.failed,
         targetTorEnabled: enabled,
-        softwareUpdatesAvailable: enabled
-            ? false
-            : previousState.softwareUpdatesAvailable,
+        softwareUpdatesAvailable: softwareUpdatesAvailable,
         error: error.toString(),
+        startupNotice: startupNotice,
       );
     }
   }

--- a/lib/src/providers/windows_update_provider.dart
+++ b/lib/src/providers/windows_update_provider.dart
@@ -158,7 +158,13 @@ class WindowsUpdateNotifier extends Notifier<WindowsUpdateState> {
 
   Future<void> checkForUpdates() async {
     if (!await _updateNetworkReady()) return;
-    await _runAndPoll(ref.read(windowsUpdateServiceProvider).checkForUpdates());
+    try {
+      await _runAndPoll(
+        ref.read(windowsUpdateServiceProvider).checkForUpdates(),
+      );
+    } catch (error) {
+      _setFailed(_updateErrorMessage(error));
+    }
   }
 
   Future<WindowsUpdateDownloadResult> downloadUpdate() async {
@@ -194,9 +200,13 @@ class WindowsUpdateNotifier extends Notifier<WindowsUpdateState> {
 
   Future<void> applyUpdateAndRestart() async {
     if (!state.canRestart) return;
-    await _runAndPoll(
-      ref.read(windowsUpdateServiceProvider).applyUpdateAndRestart(),
-    );
+    try {
+      await _runAndPoll(
+        ref.read(windowsUpdateServiceProvider).applyUpdateAndRestart(),
+      );
+    } catch (error) {
+      _setFailed(_updateErrorMessage(error));
+    }
   }
 
   bool get _torEnabled => ref.read(windowsUpdateTorEnabledProvider)();

--- a/lib/src/services/windows_update_service.dart
+++ b/lib/src/services/windows_update_service.dart
@@ -84,6 +84,15 @@ class WindowsUpdateService {
   Future<WindowsUpdateSnapshot> applyUpdateAndRestart() =>
       _invoke('applyUpdateAndRestart');
 
+  Future<void> prepareForTorDisable() async {
+    if (!Platform.isWindows) return;
+    try {
+      await _channel.invokeMethod<void>('prepareForTorDisable');
+    } on MissingPluginException {
+      // Development builds without Velopack have no updater to reserve.
+    }
+  }
+
   Future<String?> getUpdateBaseUrl() async {
     if (!Platform.isWindows) return null;
     try {

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -203,7 +203,7 @@ private final class TorUpdateFeedDelegate: NSObject, SPUUpdaterDelegate {
   private static let directUpdateRetryTimeout: TimeInterval = 10
   var feedURL: String?
   var resourceProxyURL: URL?
-  private var failClosedPauseCompletions: [() -> Void] = []
+  private var updateCycleDrainCompletions: [() -> Void] = []
   private var pendingDirectUpdateCheck: (() -> Void)?
   private var directUpdateRetryDeadline: DispatchTime?
   private var directUpdateRetryWorkItem: DispatchWorkItem?
@@ -276,7 +276,7 @@ private final class TorUpdateFeedDelegate: NSObject, SPUUpdaterDelegate {
     request.timeoutInterval = torUpdateTransferTimeout
   }
 
-  func awaitCurrentUpdateCycleBeforeFailClosedPause(
+  func awaitCurrentUpdateCycle(
     updater: SPUUpdater,
     completion: @escaping () -> Void
   ) {
@@ -284,7 +284,7 @@ private final class TorUpdateFeedDelegate: NSObject, SPUUpdaterDelegate {
       completion()
       return
     }
-    failClosedPauseCompletions.append(completion)
+    updateCycleDrainCompletions.append(completion)
   }
 
   func updater(
@@ -292,8 +292,8 @@ private final class TorUpdateFeedDelegate: NSObject, SPUUpdaterDelegate {
     didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
     error: Error?
   ) {
-    let completions = failClosedPauseCompletions
-    failClosedPauseCompletions.removeAll()
+    let completions = updateCycleDrainCompletions
+    updateCycleDrainCompletions.removeAll()
     completions.forEach { $0() }
     DispatchQueue.main.async { [weak self, weak updater] in
       guard let self, let updater else { return }
@@ -429,6 +429,23 @@ class AppDelegate: FlutterAppDelegate {
     return true
   }
 
+  func prepareForTorDisable(completion: @escaping () -> Void) {
+    updaterController?.updater.automaticallyChecksForUpdates = false
+    configureUpdateMenu(enabled: false)
+    guard let updater = updaterController?.updater else {
+      completion()
+      return
+    }
+
+    // Keep the existing feed and resource proxies installed while an active
+    // Sparkle cycle drains. Flutter tears those proxies down only after this
+    // completion is delivered.
+    updateFeedDelegate.awaitCurrentUpdateCycle(
+      updater: updater,
+      completion: completion
+    )
+  }
+
   func pauseUpdatesForFailClosedStartup(completion: @escaping () -> Void) {
     updaterController?.updater.automaticallyChecksForUpdates = false
     updateFeedDelegate.feedURL = nil
@@ -443,7 +460,7 @@ class AppDelegate: FlutterAppDelegate {
     // An already-running Sparkle transfer cannot be rerouted. Delay the
     // fail-closed startup result until that session has fully quiesced, so the
     // Flutter layer cannot report paused traffic while Sparkle is still direct.
-    updateFeedDelegate.awaitCurrentUpdateCycleBeforeFailClosedPause(
+    updateFeedDelegate.awaitCurrentUpdateCycle(
       updater: updater,
       completion: completion
     )
@@ -545,6 +562,18 @@ final class NativeUpdatePrivacyChannel {
       case "getUpdateFeedUrl":
 #if SPARKLE_ENABLED
         result(AppDelegate.configuredUpdateFeedURL())
+#else
+        result(nil)
+#endif
+      case "prepareForTorDisable":
+#if SPARKLE_ENABLED
+        guard let delegate = NSApp.delegate as? AppDelegate else {
+          result(nil)
+          return
+        }
+        delegate.prepareForTorDisable {
+          result(nil)
+        }
 #else
         result(nil)
 #endif

--- a/test/app_linux_update_notice_test.dart
+++ b/test/app_linux_update_notice_test.dart
@@ -7,44 +7,85 @@ import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/features/onboarding/unlock_screen.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/linux_update_provider.dart';
+import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
 import 'fakes/fake_sync_notifier.dart';
 
 void main() {
-  testWidgets('shows the detected Linux release without blocking the app', (
+  testWidgets('shows the standard Linux release notice while Tor is off', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          appBootstrapProvider.overrideWithValue(_lockedBootstrap),
-          syncProvider.overrideWith(FakeSyncNotifier.new),
-          linuxUpdateProvider.overrideWith(
-            (ref) async => const LinuxUpdateInfo(
-              version: '1.2.3',
-              assetVersion: '1.2.3',
-              buildNumber: 123,
-              releaseTag: 'release/v1.2.3',
-              releaseUrl:
-                  'https://github.com/chainapsis/vizor-wallet/releases/tag/release/v1.2.3',
-              appImageUrl: 'https://updates.example/Vizor.AppImage',
-              sha256Url: 'https://updates.example/Vizor.AppImage.sha256',
-              signatureUrl: 'https://updates.example/Vizor.AppImage.asc',
-              zsyncUrl: null,
-            ),
-          ),
-        ],
-        child: const ZcashWalletApp(),
-      ),
-    );
-    await tester.pump();
-    await tester.pump();
+    await _pumpUpdateNotice(tester, torEnabled: false);
 
     expect(find.byType(UnlockScreen), findsOneWidget);
     expect(find.text('Vizor 1.2.3 is available.'), findsOneWidget);
     expect(find.text('View release'), findsOneWidget);
+    expect(find.textContaining('outside Vizor’s Tor connection'), findsNothing);
   });
+
+  testWidgets('warns about the external browser while Tor is on', (
+    tester,
+  ) async {
+    await _pumpUpdateNotice(tester, torEnabled: true);
+
+    expect(
+      find.text(
+        'Vizor 1.2.3 is available. The release page opens in your browser, '
+        'outside Vizor’s Tor connection.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Open in browser'), findsOneWidget);
+  });
+}
+
+Future<void> _pumpUpdateNotice(
+  WidgetTester tester, {
+  required bool torEnabled,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_lockedBootstrap),
+        syncProvider.overrideWith(FakeSyncNotifier.new),
+        networkPrivacyProvider.overrideWith(
+          () => _TestNetworkPrivacyNotifier(torEnabled),
+        ),
+        linuxUpdateProvider.overrideWith(
+          (ref) async => const LinuxUpdateInfo(
+            version: '1.2.3',
+            assetVersion: '1.2.3',
+            buildNumber: 123,
+            releaseTag: 'release/v1.2.3',
+            releaseUrl:
+                'https://github.com/chainapsis/vizor-wallet/releases/tag/release/v1.2.3',
+            appImageUrl: 'https://updates.example/Vizor.AppImage',
+            sha256Url: 'https://updates.example/Vizor.AppImage.sha256',
+            signatureUrl: 'https://updates.example/Vizor.AppImage.asc',
+            zsyncUrl: null,
+          ),
+        ),
+      ],
+      child: const ZcashWalletApp(),
+    ),
+  );
+  await tester.pump();
+  await tester.pump();
+}
+
+class _TestNetworkPrivacyNotifier extends NetworkPrivacyNotifier {
+  _TestNetworkPrivacyNotifier(this.torEnabled);
+
+  final bool torEnabled;
+
+  @override
+  NetworkPrivacyState build() => torEnabled
+      ? const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connected,
+        )
+      : const NetworkPrivacyState.off();
 }
 
 final _lockedBootstrap = AppBootstrapState(

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -262,6 +262,34 @@ void main() {
     expect(description.style?.color, AppThemeData.light.colors.text.accent);
   });
 
+  testWidgets('Linux Tor copy excludes external update traffic', (
+    tester,
+  ) async {
+    _overridePlatform(TargetPlatform.linux);
+    try {
+      await tester.pumpWidget(
+        _settingsHarness(
+          networkPrivacyState: const NetworkPrivacyState(
+            torEnabled: true,
+            status: NetworkPrivacyConnectionStatus.connected,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        find.text(
+          'Vizor requests, including software update checks, use Tor. Update '
+          'pages and downloads opened in another app use that app’s connection.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('software updates use Tor'), findsNothing);
+    } finally {
+      _resetPlatformOverride();
+    }
+  });
+
   testWidgets('Tor stays effective while switching to direct', (tester) async {
     await tester.pumpWidget(
       _settingsHarness(

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -219,6 +219,7 @@ void main() {
     await container.read(networkPrivacyProvider.notifier).setTorEnabled(false);
 
     expect(events, [
+      'native-prepare-disable',
       'restart',
       'store:false',
       'configure:false',
@@ -233,6 +234,119 @@ void main() {
             (state) => state.status,
             'status',
             NetworkPrivacyConnectionStatus.off,
+          ),
+    );
+  });
+
+  test('disabling waits for the native Tor update cycle to drain', () async {
+    final events = <String>[];
+    final nativeUpdates = _DeferredDisableNativeUpdateCoordinator(events);
+    final container = ProviderContainer(
+      overrides: [
+        networkPrivacyPreferenceStoreProvider.overrideWithValue(
+          _FakeStore(events),
+        ),
+        networkPrivacyRuntimeProvider.overrideWithValue(
+          _FakeRuntime(events, NetworkPrivacyConnectionStatus.connected),
+        ),
+        networkPrivacyNativeUpdateCoordinatorProvider.overrideWithValue(
+          nativeUpdates,
+        ),
+        networkPrivacyDirectRequestGateProvider.overrideWithValue(
+          _FakeDirectRequestGate(events),
+        ),
+        networkPrivacyTransportRestartProvider.overrideWithValue((
+          update,
+        ) async {
+          events.add('restart');
+          await update();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
+    events.clear();
+
+    final disabling = container
+        .read(networkPrivacyProvider.notifier)
+        .setTorEnabled(false);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events, ['native-prepare-disable']);
+    expect(
+      container.read(networkPrivacyProvider),
+      isA<NetworkPrivacyState>()
+          .having((state) => state.torEnabled, 'torEnabled', isTrue)
+          .having(
+            (state) => state.status,
+            'status',
+            NetworkPrivacyConnectionStatus.connecting,
+          )
+          .having(
+            (state) => state.targetTorEnabled,
+            'targetTorEnabled',
+            isFalse,
+          ),
+    );
+
+    nativeUpdates.completeDrain();
+    await disabling;
+
+    expect(events, [
+      'native-prepare-disable',
+      'native-disable-drained',
+      'restart',
+      'store:false',
+      'configure:false',
+      'direct-allow',
+      'native:false',
+    ]);
+  });
+
+  test('failed native disable preflight preserves the Tor route', () async {
+    final events = <String>[];
+    final container = ProviderContainer(
+      overrides: [
+        networkPrivacyPreferenceStoreProvider.overrideWithValue(
+          _FakeStore(events),
+        ),
+        networkPrivacyRuntimeProvider.overrideWithValue(
+          _FakeRuntime(events, NetworkPrivacyConnectionStatus.connected),
+        ),
+        networkPrivacyNativeUpdateCoordinatorProvider.overrideWithValue(
+          _RejectingDisableNativeUpdateCoordinator(events),
+        ),
+        networkPrivacyDirectRequestGateProvider.overrideWithValue(
+          _FakeDirectRequestGate(events),
+        ),
+        networkPrivacyTransportRestartProvider.overrideWithValue((
+          update,
+        ) async {
+          events.add('restart');
+          await update();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
+    events.clear();
+
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(false);
+
+    expect(events, ['native-prepare-disable']);
+    expect(
+      container.read(networkPrivacyProvider),
+      isA<NetworkPrivacyState>()
+          .having((state) => state.torEnabled, 'torEnabled', isTrue)
+          .having(
+            (state) => state.status,
+            'status',
+            NetworkPrivacyConnectionStatus.connected,
+          )
+          .having(
+            (state) => state.startupNotice,
+            'startupNotice',
+            kTorDisableUpdateInProgressNotice,
           ),
     );
   });
@@ -361,7 +475,13 @@ void main() {
     events.clear();
     await container.read(networkPrivacyProvider.notifier).setTorEnabled(false);
 
-    expect(events, ['restart', 'store:false', 'configure:false']);
+    expect(events, [
+      'native-prepare-disable',
+      'restart',
+      'store:false',
+      'configure:false',
+      'native-resume',
+    ]);
     expect(
       container.read(networkPrivacyProvider),
       isA<NetworkPrivacyState>()
@@ -380,7 +500,13 @@ void main() {
 
     events.clear();
     await container.read(networkPrivacyProvider.notifier).retry();
-    expect(events, ['restart', 'store:false', 'configure:false']);
+    expect(events, [
+      'native-prepare-disable',
+      'restart',
+      'store:false',
+      'configure:false',
+      'native-resume',
+    ]);
   });
 
   test(
@@ -600,6 +726,11 @@ class _FakeNativeUpdateCoordinator
   final List<String> events;
 
   @override
+  Future<void> prepareForTorDisable() async {
+    events.add('native-prepare-disable');
+  }
+
+  @override
   Future<void> setTorEnabled(bool enabled) async {
     events.add('native:$enabled');
   }
@@ -620,6 +751,11 @@ class _RejectingNativeUpdateCoordinator
   _RejectingNativeUpdateCoordinator(this.events);
 
   final List<String> events;
+
+  @override
+  Future<void> prepareForTorDisable() async {
+    events.add('native-prepare-disable');
+  }
 
   @override
   Future<void> setTorEnabled(bool enabled) async {
@@ -651,6 +787,33 @@ class _DeferredPauseNativeUpdateCoordinator
     events.add('native:force-pause');
     await _pause.future;
     events.add('native:paused');
+  }
+}
+
+class _DeferredDisableNativeUpdateCoordinator
+    extends _FakeNativeUpdateCoordinator {
+  _DeferredDisableNativeUpdateCoordinator(super.events);
+
+  final _drain = Completer<void>();
+
+  void completeDrain() => _drain.complete();
+
+  @override
+  Future<void> prepareForTorDisable() async {
+    events.add('native-prepare-disable');
+    await _drain.future;
+    events.add('native-disable-drained');
+  }
+}
+
+class _RejectingDisableNativeUpdateCoordinator
+    extends _FakeNativeUpdateCoordinator {
+  _RejectingDisableNativeUpdateCoordinator(super.events);
+
+  @override
+  Future<void> prepareForTorDisable() async {
+    events.add('native-prepare-disable');
+    throw StateError('update in progress');
   }
 }
 

--- a/test/providers/windows_update_provider_test.dart
+++ b/test/providers/windows_update_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/providers/windows_update_provider.dart';
@@ -31,6 +32,84 @@ void main() {
       'Signed feed verification failed.',
     );
     expect(service.downloadCalls, 1);
+  });
+
+  test('download reports a reserved native route as not started', () async {
+    final service = _FakeWindowsUpdateService(
+      downloadError: PlatformException(
+        code: 'update_route_transition',
+        message: 'Software update routing is changing.',
+      ),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        windowsUpdateTorEnabledProvider.overrideWithValue(() => false),
+        windowsUpdateServiceProvider.overrideWithValue(service),
+        windowsUpdateProvider.overrideWith(_AvailableWindowsUpdateNotifier.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container
+        .read(windowsUpdateProvider.notifier)
+        .downloadUpdate();
+
+    expect(result.started, isFalse);
+    expect(result.message, 'Software update routing is changing.');
+    expect(
+      container.read(windowsUpdateProvider).status,
+      WindowsUpdateStatus.failed,
+    );
+  });
+
+  test('check surfaces a reserved native route', () async {
+    final service = _FakeWindowsUpdateService(
+      checkError: PlatformException(
+        code: 'update_route_transition',
+        message: 'Software update routing is changing.',
+      ),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        windowsUpdateTorEnabledProvider.overrideWithValue(() => false),
+        windowsUpdateServiceProvider.overrideWithValue(service),
+        windowsUpdateProvider.overrideWith(_AvailableWindowsUpdateNotifier.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(windowsUpdateProvider.notifier).checkForUpdates();
+
+    expect(
+      container.read(windowsUpdateProvider).message,
+      'Software update routing is changing.',
+    );
+  });
+
+  test('apply surfaces a reserved native route', () async {
+    final service = _FakeWindowsUpdateService(
+      applyError: PlatformException(
+        code: 'update_route_transition',
+        message: 'Software update routing is changing.',
+      ),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        windowsUpdateTorEnabledProvider.overrideWithValue(() => false),
+        windowsUpdateServiceProvider.overrideWithValue(service),
+        windowsUpdateProvider.overrideWith(_ReadyWindowsUpdateNotifier.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(windowsUpdateProvider.notifier)
+        .applyUpdateAndRestart();
+
+    expect(
+      container.read(windowsUpdateProvider).message,
+      'Software update routing is changing.',
+    );
   });
 
   test(
@@ -116,11 +195,36 @@ class _AvailableWindowsUpdateNotifier extends WindowsUpdateNotifier {
   );
 }
 
+class _ReadyWindowsUpdateNotifier extends WindowsUpdateNotifier {
+  @override
+  WindowsUpdateState build() => const WindowsUpdateState(
+    supported: true,
+    status: WindowsUpdateStatus.ready,
+    currentVersion: '1.0.0',
+    appId: 'Vizor',
+    repoUrl: 'https://updates.example.invalid/vizor',
+    availableVersion: '9.9.9',
+    downloadProgress: 100,
+    pendingRestart: true,
+    torProxyReady: false,
+    message: '',
+  );
+}
+
 class _FakeWindowsUpdateService extends WindowsUpdateService {
-  _FakeWindowsUpdateService({this.stateResult, this.downloadResult});
+  _FakeWindowsUpdateService({
+    this.stateResult,
+    this.downloadResult,
+    this.downloadError,
+    this.checkError,
+    this.applyError,
+  });
 
   final WindowsUpdateSnapshot? stateResult;
   final WindowsUpdateSnapshot? downloadResult;
+  final Object? downloadError;
+  final Object? checkError;
+  final Object? applyError;
   var downloadCalls = 0;
 
   @override
@@ -130,7 +234,20 @@ class _FakeWindowsUpdateService extends WindowsUpdateService {
   @override
   Future<WindowsUpdateSnapshot> downloadUpdate() async {
     downloadCalls++;
+    if (downloadError case final error?) throw error;
     return downloadResult ?? _snapshot(status: 'downloading');
+  }
+
+  @override
+  Future<WindowsUpdateSnapshot> checkForUpdates() async {
+    if (checkError case final error?) throw error;
+    return _snapshot(status: 'checking');
+  }
+
+  @override
+  Future<WindowsUpdateSnapshot> applyUpdateAndRestart() async {
+    if (applyError case final error?) throw error;
+    return _snapshot(status: 'applying');
   }
 }
 

--- a/windows/runner/velopack_update.cpp
+++ b/windows/runner/velopack_update.cpp
@@ -85,6 +85,7 @@ AssetPtr g_pending_asset;
 UpdateStatus g_status = UpdateStatus::kIdle;
 bool g_supported = true;
 bool g_busy = false;
+bool g_update_route_transition_reserved = false;
 bool g_pending_restart = false;
 int32_t g_download_progress = 0;
 std::string g_current_version = FLUTTER_VERSION;
@@ -211,6 +212,28 @@ void SetTorRouting(bool enabled, std::string proxy_base_url) {
   std::lock_guard<std::mutex> lock(g_update_route_mutex);
   g_tor_routing_required = enabled;
   g_tor_proxy_base_url = enabled ? std::move(proxy_base_url) : std::string();
+}
+
+bool ReserveTorDisable() {
+  std::lock_guard<std::mutex> lock(g_update_mutex);
+  if (g_update_route_transition_reserved) {
+    return true;
+  }
+  if (g_busy) {
+    return false;
+  }
+  g_update_route_transition_reserved = true;
+  return true;
+}
+
+bool CommitTorRouting(bool enabled, std::string proxy_base_url) {
+  std::lock_guard<std::mutex> lock(g_update_mutex);
+  if (g_busy) {
+    return false;
+  }
+  SetTorRouting(enabled, std::move(proxy_base_url));
+  g_update_route_transition_reserved = false;
+  return true;
 }
 
 bool TorProxyReady() {
@@ -786,7 +809,8 @@ void StartCheckForUpdates() {
   vpkc_update_manager_t* manager = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_update_mutex);
-    if (!EnsureManagerLocked() || g_busy) {
+    if (!EnsureManagerLocked() || g_busy ||
+        g_update_route_transition_reserved) {
       return;
     }
     RefreshPendingRestartLocked();
@@ -842,7 +866,8 @@ void StartDownloadUpdate() {
   vpkc_update_info_t* update = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_update_mutex);
-    if (!EnsureManagerLocked() || g_busy) {
+    if (!EnsureManagerLocked() || g_busy ||
+        g_update_route_transition_reserved) {
       return;
     }
     if (!g_update_info) {
@@ -902,7 +927,8 @@ void StartApplyUpdateAndRestart() {
   vpkc_asset_t* asset = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_update_mutex);
-    if (!EnsureManagerLocked() || g_busy) {
+    if (!EnsureManagerLocked() || g_busy ||
+        g_update_route_transition_reserved) {
       return;
     }
     if (g_pending_asset) {
@@ -953,6 +979,17 @@ CreateVelopackUpdateChannel(flutter::BinaryMessenger* messenger) {
       result->Success(flutter::EncodableValue(DirectReleaseBaseUrl()));
       return;
     }
+    if (method == "prepareForTorDisable") {
+      if (!ReserveTorDisable()) {
+        result->Error(
+            "update_in_progress",
+            "Wait for the current software update operation to finish before "
+            "turning off Tor.");
+        return;
+      }
+      result->Success();
+      return;
+    }
     if (method == "setTorRouting") {
       const auto* arguments = call.arguments();
       if (arguments == nullptr ||
@@ -975,8 +1012,14 @@ CreateVelopackUpdateChannel(flutter::BinaryMessenger* messenger) {
           std::holds_alternative<std::string>(proxy_it->second)) {
         proxy_base_url = std::get<std::string>(proxy_it->second);
       }
-      SetTorRouting(std::get<bool>(enabled_it->second),
-                    std::move(proxy_base_url));
+      if (!CommitTorRouting(std::get<bool>(enabled_it->second),
+                            std::move(proxy_base_url))) {
+        result->Error(
+            "update_in_progress",
+            "Wait for the current software update operation to finish before "
+            "changing Tor routing.");
+        return;
+      }
       result->Success();
       return;
     }

--- a/windows/runner/velopack_update.cpp
+++ b/windows/runner/velopack_update.cpp
@@ -50,6 +50,11 @@ enum class UpdateStatus {
   kFailed,
 };
 
+enum class UpdateOperationStartResult {
+  kHandled,
+  kRouteTransitionReserved,
+};
+
 struct ManagerDeleter {
   void operator()(vpkc_update_manager_t* value) const {
     if (value != nullptr) {
@@ -805,17 +810,19 @@ void DownloadProgress(void* user_data, size_t progress) {
       static_cast<int32_t>(std::min<size_t>(progress, 100));
 }
 
-void StartCheckForUpdates() {
+UpdateOperationStartResult StartCheckForUpdates() {
   vpkc_update_manager_t* manager = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_update_mutex);
-    if (!EnsureManagerLocked() || g_busy ||
-        g_update_route_transition_reserved) {
-      return;
+    if (!EnsureManagerLocked() || g_busy) {
+      return UpdateOperationStartResult::kHandled;
+    }
+    if (g_update_route_transition_reserved) {
+      return UpdateOperationStartResult::kRouteTransitionReserved;
     }
     RefreshPendingRestartLocked();
     if (g_status == UpdateStatus::kReady) {
-      return;
+      return UpdateOperationStartResult::kHandled;
     }
     g_busy = true;
     g_status = UpdateStatus::kChecking;
@@ -859,21 +866,24 @@ void StartCheckForUpdates() {
     g_status = UpdateStatus::kNoUpdate;
     g_message.clear();
   }).detach();
+  return UpdateOperationStartResult::kHandled;
 }
 
-void StartDownloadUpdate() {
+UpdateOperationStartResult StartDownloadUpdate() {
   vpkc_update_manager_t* manager = nullptr;
   vpkc_update_info_t* update = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_update_mutex);
-    if (!EnsureManagerLocked() || g_busy ||
-        g_update_route_transition_reserved) {
-      return;
+    if (!EnsureManagerLocked() || g_busy) {
+      return UpdateOperationStartResult::kHandled;
+    }
+    if (g_update_route_transition_reserved) {
+      return UpdateOperationStartResult::kRouteTransitionReserved;
     }
     if (!g_update_info) {
       g_status = UpdateStatus::kFailed;
       g_message = "No update is ready to download.";
-      return;
+      return UpdateOperationStartResult::kHandled;
     }
     g_busy = true;
     g_status = UpdateStatus::kDownloading;
@@ -920,16 +930,19 @@ void StartDownloadUpdate() {
     g_status = UpdateStatus::kReady;
     g_message.clear();
   }).detach();
+  return UpdateOperationStartResult::kHandled;
 }
 
-void StartApplyUpdateAndRestart() {
+UpdateOperationStartResult StartApplyUpdateAndRestart() {
   vpkc_update_manager_t* manager = nullptr;
   vpkc_asset_t* asset = nullptr;
   {
     std::lock_guard<std::mutex> lock(g_update_mutex);
-    if (!EnsureManagerLocked() || g_busy ||
-        g_update_route_transition_reserved) {
-      return;
+    if (!EnsureManagerLocked() || g_busy) {
+      return UpdateOperationStartResult::kHandled;
+    }
+    if (g_update_route_transition_reserved) {
+      return UpdateOperationStartResult::kRouteTransitionReserved;
     }
     if (g_pending_asset) {
       asset = g_pending_asset.get();
@@ -940,7 +953,7 @@ void StartApplyUpdateAndRestart() {
     if (asset == nullptr) {
       g_status = UpdateStatus::kFailed;
       g_message = "No downloaded update is ready to apply.";
-      return;
+      return UpdateOperationStartResult::kHandled;
     }
 
     g_busy = true;
@@ -963,6 +976,7 @@ void StartApplyUpdateAndRestart() {
     g_status = UpdateStatus::kFailed;
     g_message = CoalesceMessage(error);
   }).detach();
+  return UpdateOperationStartResult::kHandled;
 }
 
 }  // namespace
@@ -1028,17 +1042,38 @@ CreateVelopackUpdateChannel(flutter::BinaryMessenger* messenger) {
       return;
     }
     if (method == "checkForUpdates") {
-      StartCheckForUpdates();
+      if (StartCheckForUpdates() ==
+          UpdateOperationStartResult::kRouteTransitionReserved) {
+        result->Error(
+            "update_route_transition",
+            "Software update routing is changing. Try again when the network "
+            "privacy switch finishes.");
+        return;
+      }
       result->Success(BuildStateValue());
       return;
     }
     if (method == "downloadUpdate") {
-      StartDownloadUpdate();
+      if (StartDownloadUpdate() ==
+          UpdateOperationStartResult::kRouteTransitionReserved) {
+        result->Error(
+            "update_route_transition",
+            "Software update routing is changing. Try again when the network "
+            "privacy switch finishes.");
+        return;
+      }
       result->Success(BuildStateValue());
       return;
     }
     if (method == "applyUpdateAndRestart") {
-      StartApplyUpdateAndRestart();
+      if (StartApplyUpdateAndRestart() ==
+          UpdateOperationStartResult::kRouteTransitionReserved) {
+        result->Error(
+            "update_route_transition",
+            "Software update routing is changing. Try again when the network "
+            "privacy switch finishes.");
+        return;
+      }
       result->Success(BuildStateValue());
       return;
     }


### PR DESCRIPTION
## Summary

- drain active macOS Sparkle update cycles before disabling Tor
- keep the loopback Tor proxy alive during drain and block new automatic or manual Sparkle checks
- reserve Windows updater routing atomically so checks, downloads, and apply operations cannot start during the route switch
- restore Tor updater availability when a direct-route transition fails

## Root cause

Disabling Tor could clear the native updater proxy while Sparkle or Velopack was still using it. The UI could report direct mode while the in-flight updater request lost its loopback transport. A separate check-then-switch sequence on Windows also left a race where a new update operation could start between the busy check and proxy teardown.

## Validation

- `fvm flutter test test/providers/network_privacy_provider_test.dart test/services/desktop_tor_update_proxy_test.dart`
- `fvm flutter analyze lib/src/providers/network_privacy_provider.dart lib/src/services/windows_update_service.dart test/providers/network_privacy_provider_test.dart`
- macOS native build with `SPARKLE_ENABLED`
- `git diff --check`

Windows native code was reviewed on macOS, where a Windows cross-compiler is not available.