### PR TITLE
Enable Tor on mobile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,10 +545,38 @@ Swift BackgroundMigrationPreparationManager
   `com.keplr.vizor.sync` is cancelled once at launch as a tombstone for requests
   submitted by older builds; no handler is registered for it.
 
+### Declaring the network route
+
+The desired route lives in Rust process memory, and a background wake can be a
+cold launch where the Dart layer never ran. So "nobody has declared yet" is a
+distinct state from "the user chose direct", and Rust refuses it at the route
+chokepoint rather than treating it as direct.
+
+- **Every native entry point that may reach lightwalletd declares the route
+  before its first network call**, by reading the saved preference and calling
+  `zcash_network_privacy_mark_tor_desired` or
+  `zcash_network_privacy_mark_direct_route`. Declaring samples nothing, never
+  bootstraps, and is ignored once the process has decided its own route, so it
+  is safe to do first and unconditionally.
+- A lane that forgets fails closed on its first connection with
+  `Network route has not been declared for this process`. That is the intended
+  outcome: the alternative is reaching lightwalletd over clearnet on a
+  Tor-configured wallet, silently and only in the lane that forgot.
+- Adding a background entry point therefore means adding a declaration. Nothing
+  fails to compile without one, and the Rust-side test that pins this
+  (`an_undeclared_route_is_refused_instead_of_resolving_to_a_direct_connection`)
+  covers the chokepoint, not your new caller.
+- On a Tor route, background network work additionally requires external power
+  on an unmetered link, and Tor must be brought up for that process
+  (`zcash_network_privacy_enable_tor_for_background_work`). A client that does
+  not come up ready leaves the process fail-closed with no transport; the
+  caller defers to the foreground and never falls back to clearnet.
+
 Key files:
 - `rust/src/migration_preparation.rs` — shared mobile preparation core
 - `rust/src/android_jni.rs` — Android preparation execution adapter
-- `rust/src/ffi.rs` — iOS read-only inspection and query adapter
+- `rust/src/ffi.rs` — iOS C adapter: read-only inspection and queries, plus the
+  route declaration and background Tor bring-up the queries run on
 - `ios/Runner/zcash_sync.h` — matching C header
 - `ios/Runner/BackgroundMigrationPreparationManager.swift` — continued-task
   confirmation tracker and foreground-handoff owner

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:allowBackup="false">
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Arti's directory records which guards this wallet chose. Carrying it to a
+  second device would carry that choice with it, so a transferred install picks
+  fresh guards at the cost of one bootstrap.
+
+  `allowBackup="false"` already covers cloud backup, but from target SDK 31
+  device-to-device transfer is governed here instead and defaults to including
+  app data. `domain="file"` is getFilesDir(), which is what
+  getApplicationSupportDirectory() resolves to on Android.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" path="tor" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="file" path="tor" />
+    </device-transfer>
+</data-extraction-rules>

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -8,3 +8,9 @@ tags:
   # See "Design Token Form Factor" in AGENTS.md.
   mobile:
     skip: "mobile token lane only: fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile"
+  # Probes that talk to the live Tor network from a booted device. They cost
+  # minutes, depend on a network nobody controls, and leave the process
+  # Tor-enabled and fail-closed for anything sharing the binary, so they stay
+  # out of `flutter test integration_test/` and are run by hand.
+  live-tor:
+    skip: "live Tor probe only: fvm flutter test --tags live-tor --run-skipped <path> -d <device>"

--- a/integration_test/mobile_tor_bootstrap_probe_test.dart
+++ b/integration_test/mobile_tor_bootstrap_probe_test.dart
@@ -23,8 +23,14 @@ import 'package:zcash_wallet/src/rust/network_privacy.dart' as rust_types;
 ///
 /// ```sh
 /// fvm flutter test --tags live-tor --run-skipped \
-///   integration_test/mobile_tor_bootstrap_probe_test.dart -d <device>
+///   integration_test/mobile_tor_bootstrap_probe_test.dart \
+///   -d <device> --dart-define=VIZOR_FORM_FACTOR=mobile
 /// ```
+///
+/// The define is what this probe is run with, and every mobile-targeted
+/// invocation carries it — the test binary is compiled per lane like any other
+/// build. Omitting it here compiles the probe against desktop tokens on a
+/// phone, which is the mismatch `lib/main.dart` asserts against.
 ///
 /// What it does not settle: whether arti's filesystem permission checks need
 /// the mobile exemption. The iOS simulator passes this with the exemption

--- a/integration_test/mobile_tor_bootstrap_probe_test.dart
+++ b/integration_test/mobile_tor_bootstrap_probe_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/rust/api/network_privacy.dart'
+    as rust_network_privacy;
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
+import 'package:zcash_wallet/src/rust/network_privacy.dart' as rust_types;
+
+/// Bootstraps Tor from the app's own support directory on a mobile OS.
+///
+/// A bootstrap failure surfaces from inside fail-closed mode — every request
+/// blocked while Tor never becomes ready — so no host test can catch it. This
+/// talks to the live Tor network and is not part of any automated lane; run it
+/// by hand against a booted simulator or device.
+///
+/// What it does not settle: whether arti's filesystem permission checks need
+/// the mobile exemption. The iOS simulator passes this with the exemption
+/// compiled out, because a simulator container is an ordinary directory in the
+/// host filesystem. Only a real device answers that.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Tor bootstraps from the mobile app sandbox', (tester) async {
+    await RustLib.init();
+    final torDirectory = await getTorDataDirectoryPath();
+
+    rust_network_privacy.beginNetworkPrivacyEnable();
+    final status = await rust_network_privacy.configureNetworkPrivacy(
+      enabled: true,
+      torDirectory: torDirectory,
+    );
+
+    expect(
+      status,
+      rust_types.NetworkPrivacyStatus.ready,
+      reason: 'bootstrap from $torDirectory did not reach ready',
+    );
+    expect(rust_network_privacy.isTorEnabled(), isTrue);
+  }, timeout: const Timeout(Duration(minutes: 5)));
+}

--- a/integration_test/mobile_tor_bootstrap_probe_test.dart
+++ b/integration_test/mobile_tor_bootstrap_probe_test.dart
@@ -1,3 +1,6 @@
+@Tags(['live-tor'])
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
@@ -9,9 +12,19 @@ import 'package:zcash_wallet/src/rust/network_privacy.dart' as rust_types;
 /// Bootstraps Tor from the app's own support directory on a mobile OS.
 ///
 /// A bootstrap failure surfaces from inside fail-closed mode — every request
-/// blocked while Tor never becomes ready — so no host test can catch it. This
-/// talks to the live Tor network and is not part of any automated lane; run it
-/// by hand against a booted simulator or device.
+/// blocked while Tor never becomes ready — so no host test can catch it.
+///
+/// This talks to the live Tor network and is not part of any automated lane.
+/// The `live-tor` tag is what keeps it out of one: `dart_test.yaml` skips that
+/// tag, so `fvm flutter test integration_test/` — which would otherwise pick
+/// this file up, spend five minutes on a network nobody controls, and leave the
+/// process Tor-enabled and fail-closed for whatever shares the binary — reports
+/// it as skipped instead. Run it by hand against a booted simulator or device:
+///
+/// ```sh
+/// fvm flutter test --tags live-tor --run-skipped \
+///   integration_test/mobile_tor_bootstrap_probe_test.dart -d <device>
+/// ```
 ///
 /// What it does not settle: whether arti's filesystem permission checks need
 /// the mobile exemption. The iOS simulator passes this with the exemption

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -382,12 +382,15 @@ import UIKit
           return
         }
         var url = URL(fileURLWithPath: path)
-        guard FileManager.default.fileExists(atPath: path) else {
-          // Tor was never enabled far enough to create it; nothing to mark.
-          result(false)
-          return
-        }
         do {
+          // Created here when it does not exist yet, so the mark can be set
+          // before the bootstrap rather than only after it: from the directory's
+          // first moment it holds guard state, and the process can be killed
+          // while that is being written.
+          try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true
+          )
           var values = URLResourceValues()
           values.isExcludedFromBackup = true
           try url.setResourceValues(values)

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -350,6 +350,56 @@ import UIKit
       }
     }
 
+    let networkPrivacyChannel = FlutterMethodChannel(
+      name: "com.zcash.wallet/network_privacy",
+      binaryMessenger: messenger
+    )
+    networkPrivacyChannel.setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "excludeFromBackup":
+        // Arti's directory records this wallet's guard choice. Restoring it
+        // onto another device would carry that choice across, so it is kept
+        // out of iCloud and finder backups; a restored install picks fresh
+        // guards at the cost of one bootstrap.
+        guard
+          let arguments = call.arguments as? [String: Any],
+          let path = arguments["path"] as? String,
+          !path.isEmpty
+        else {
+          result(
+            FlutterError(
+              code: "invalid_arguments",
+              message: "excludeFromBackup requires a path.",
+              details: nil
+            )
+          )
+          return
+        }
+        var url = URL(fileURLWithPath: path)
+        guard FileManager.default.fileExists(atPath: path) else {
+          // Tor was never enabled far enough to create it; nothing to mark.
+          result(false)
+          return
+        }
+        do {
+          var values = URLResourceValues()
+          values.isExcludedFromBackup = true
+          try url.setResourceValues(values)
+          result(true)
+        } catch {
+          result(
+            FlutterError(
+              code: "exclude_failed",
+              message: error.localizedDescription,
+              details: nil
+            )
+          )
+        }
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     let hapticsChannel = FlutterMethodChannel(
       name: "com.zcash.wallet/haptics",
       binaryMessenger: messenger

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -12,6 +12,12 @@ import UIKit
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     FreshInstallKeychainCleaner.runIfNeeded()
+    // `batteryState` reports `.unknown` until monitoring is on, and the
+    // background Tor gate reads that state to decide whether this device can
+    // afford a Tor pass. Enable it here, on the main thread, before any task
+    // handler can run — a background task launch reaches this method first, so
+    // the gate finds a real state instead of deferring on `.unknown`.
+    UIDevice.current.isBatteryMonitoringEnabled = true
     BackgroundMigrationManager.shared.registerBackgroundTask()
 
     if #available(iOS 26.0, *) {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -14,10 +14,16 @@ import UIKit
     FreshInstallKeychainCleaner.runIfNeeded()
     // `batteryState` reports `.unknown` until monitoring is on, and the
     // background Tor gate reads that state to decide whether this device can
-    // afford a Tor pass. Enable it here, on the main thread, before any task
-    // handler can run — a background task launch reaches this method first, so
-    // the gate finds a real state instead of deferring on `.unknown`.
-    UIDevice.current.isBatteryMonitoringEnabled = true
+    // afford a Tor pass. Start the monitor here, on the main thread, before
+    // any task handler can run — a background task launch reaches this method
+    // first, so the gate finds a real state instead of deferring on
+    // `.unknown`.
+    //
+    // This is the only place `UIDevice` is touched for that state. The gates
+    // themselves run on background queues, where reading it is an actor
+    // violation and writing `isBatteryMonitoringEnabled` from two of them at
+    // once is a race; they read what this monitor recorded instead.
+    BackgroundPowerSupplyMonitor.shared.start()
     BackgroundMigrationManager.shared.registerBackgroundTask()
 
     if #available(iOS 26.0, *) {

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -210,14 +210,19 @@ func ironwoodMigrationOutboxWakeDisposition(
 /// samples power and metering before it starts and can then block for a minute,
 /// so a charger pulled or a link that turned metered during it is a condition
 /// the wake was admitted under and no longer meets.
+///
+/// `routeStillAffordable` comes last and is deferred, because answering it
+/// samples power and the current path and costs up to a second. A wake the
+/// cheap flags have already ended does not spend that second; it has only
+/// seconds left, and they belong to the replacement it still owes.
 func ironwoodMigrationOutboxWakeMayStartNetworkWork(
   expired: Bool,
   disposition: IronwoodMigrationOutboxWakeDisposition,
   mutationQuiesced: Bool,
-  routeStillAffordable: Bool
+  routeStillAffordable: @autoclosure () -> Bool
 ) -> Bool {
-  !expired && !mutationQuiesced && routeStillAffordable
-    && disposition == .continueBackgroundWork
+  !expired && !mutationQuiesced && disposition == .continueBackgroundWork
+    && routeStillAffordable()
 }
 
 final class IronwoodMigrationNotificationAuthorizationMonitor {
@@ -548,6 +553,23 @@ final class BackgroundMigrationManager {
     stateLock.vizorWithLock { foregroundHandoffRequested }
   }
 
+  /// Whether this wake is still worth spending its remaining window on.
+  ///
+  /// The same predicate the wake applies on the far side of the bring-up, with
+  /// affordability supplied as established rather than re-sampled: on this side
+  /// the launch gate has just answered it, and the bring-up is the only step
+  /// that can invalidate the answer. Everything else it reads — the system
+  /// reclaiming the wake, the foreground taking it over, a wallet mutation, a
+  /// revoked permission — can already be true before a single byte is spent.
+  private var wakeMaySpendTime: Bool {
+    ironwoodMigrationOutboxWakeMayStartNetworkWork(
+      expired: isWakeExpired,
+      disposition: wakeDisposition,
+      mutationQuiesced: isMutationQuiesced,
+      routeStillAffordable: true
+    )
+  }
+
   func handoffToForeground() {
     stateLock.vizorWithLock {
       foregroundHandoffRequested = true
@@ -820,6 +842,7 @@ final class BackgroundMigrationManager {
     // costs nothing — this gate never bootstraps.
     guard BackgroundNetworkRoute.backgroundPassIsAllowed(
       routeIsTor: routeIsTor,
+      passIsLive: { self.wakeMaySpendTime },
       isAffordable: BackgroundNetworkRoute.torBackgroundPassIsAffordable
     ) else {
       finishTorDeferredWake(task)
@@ -844,7 +867,9 @@ final class BackgroundMigrationManager {
       // than on the notification-gate callback. A client that does not come up
       // ready ends the wake the same way an unaffordable one does: fail-closed,
       // no network work, the run left to the foreground.
-      guard BackgroundNetworkRoute.allowsBackgroundNetworkWork() else {
+      guard BackgroundNetworkRoute.allowsBackgroundNetworkWork(
+        while: { self.wakeMaySpendTime }
+      ) else {
         self.clearActiveCancellation()
         self.stopAuthorizationMonitoring()
         self.finishTorDeferredWake(task)

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -206,12 +206,17 @@ func ironwoodMigrationOutboxWakeDisposition(
 /// it did leaves an item that looks unsent and is not. The wake that stops here
 /// instead still holds the one thing it can act on — the ability to leave a
 /// replacement request behind before it completes.
+/// `routeStillAffordable` belongs here for the same reason: the bring-up
+/// samples power and metering before it starts and can then block for a minute,
+/// so a charger pulled or a link that turned metered during it is a condition
+/// the wake was admitted under and no longer meets.
 func ironwoodMigrationOutboxWakeMayStartNetworkWork(
   expired: Bool,
   disposition: IronwoodMigrationOutboxWakeDisposition,
-  mutationQuiesced: Bool
+  mutationQuiesced: Bool,
+  routeStillAffordable: Bool
 ) -> Bool {
-  !expired && !mutationQuiesced
+  !expired && !mutationQuiesced && routeStillAffordable
     && disposition == .continueBackgroundWork
 }
 
@@ -846,7 +851,8 @@ final class BackgroundMigrationManager {
       guard ironwoodMigrationOutboxWakeMayStartNetworkWork(
         expired: self.isWakeExpired,
         disposition: self.wakeDisposition,
-        mutationQuiesced: self.isMutationQuiesced
+        mutationQuiesced: self.isMutationQuiesced,
+        routeStillAffordable: BackgroundNetworkRoute.torBackgroundPassRemainsAffordable
       ) else {
         self.clearActiveCancellation()
         self.stopAuthorizationMonitoring()

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -174,6 +174,30 @@ func ironwoodMigrationTorDeferredWakeShouldRearm(
   disposition.shouldReschedule && !mutationQuiesced && hasRunnableWork
 }
 
+/// Whether a wake may still start network work after a step it could not
+/// interrupt.
+///
+/// Bringing Tor up blocks for tens of seconds and takes no cancellation
+/// handle, so a wake can outlive that call but never stop it. Every path that
+/// ends a wake — the system reclaiming it, the foreground taking it over, a
+/// wallet mutation, a revoked notification permission — can land inside that
+/// window and reach nothing.
+///
+/// So the state is read again on the far side. A wake the system has already
+/// reclaimed may be suspended at any moment, and it broadcasts transactions:
+/// suspension between lightwalletd accepting one and the outbox recording that
+/// it did leaves an item that looks unsent and is not. The wake that stops here
+/// instead still holds the one thing it can act on — the ability to leave a
+/// replacement request behind before it completes.
+func ironwoodMigrationOutboxWakeMayStartNetworkWork(
+  expired: Bool,
+  disposition: IronwoodMigrationOutboxWakeDisposition,
+  mutationQuiesced: Bool
+) -> Bool {
+  !expired && !mutationQuiesced
+    && disposition == .continueBackgroundWork
+}
+
 final class IronwoodMigrationNotificationAuthorizationMonitor {
   typealias StatusProvider =
     (@escaping (IronwoodMigrationNotificationAuthorizationStatus) -> Void) -> Void
@@ -475,8 +499,12 @@ final class BackgroundMigrationManager {
 
   private init() {}
 
-  private var shouldRetryCancelledWake: Bool {
+  private var isWakeExpired: Bool {
     stateLock.vizorWithLock { expired }
+  }
+
+  private var shouldRetryCancelledWake: Bool {
+    isWakeExpired
   }
 
   private var isMutationQuiesced: Bool {
@@ -759,19 +787,39 @@ final class BackgroundMigrationManager {
         task.setTaskCompleted(success: false)
         return
       }
+      // Published before the bring-up below, not after it. Expiration, a
+      // foreground handoff, and a wallet mutation all end a wake by cancelling
+      // whatever token is published; a window with none leaves them nothing to
+      // reach, and the work on the far side of it starts uncancelled.
+      let cancellation = BackgroundMigrationCancellation()
+      self.stateLock.vizorWithLock {
+        self.activeCancellation = cancellation
+      }
       // Tor before the first query or broadcast. A cold bootstrap blocks for
       // tens of seconds, so it runs here on this manager's own queue rather
       // than on the notification-gate callback. A client that does not come up
       // ready ends the wake the same way an unaffordable one does: fail-closed,
       // no network work, the run left to the foreground.
       guard BackgroundNetworkRoute.allowsBackgroundNetworkWork() else {
+        self.clearActiveCancellation()
         self.stopAuthorizationMonitoring()
         self.finishTorDeferredWake(task)
         return
       }
-      let cancellation = BackgroundMigrationCancellation()
-      self.stateLock.vizorWithLock {
-        self.activeCancellation = cancellation
+      // The bring-up above cannot be cancelled, only outlived, and it is long
+      // enough to be outlived. Ask again before the first byte goes out: the
+      // outbox is transport for already-signed transactions, so entering it on
+      // a reclaimed wake risks suspension mid-broadcast, and it would consume
+      // this execution opportunity without leaving a replacement.
+      guard ironwoodMigrationOutboxWakeMayStartNetworkWork(
+        expired: self.isWakeExpired,
+        disposition: self.wakeDisposition,
+        mutationQuiesced: self.isMutationQuiesced
+      ) else {
+        self.clearActiveCancellation()
+        self.stopAuthorizationMonitoring()
+        self.finishWakeWithoutNetworkWork(task)
+        return
       }
       // This wake is a silent BGProcessingTask. It queries the chain tip,
       // broadcasts transactions that are already signed, and notifies — it does
@@ -897,6 +945,23 @@ final class BackgroundMigrationManager {
       BackgroundMigrationPreparationManager.shared
         .notifyPreparationNeedsForeground()
     }
+    finishWakeWithoutNetworkWork(task)
+  }
+
+  /// Completes a wake that reached no network at all — refused before its
+  /// first query, or interrupted before it — and leaves a replacement behind
+  /// whenever work remains.
+  ///
+  /// Every reason a wake stops short of the network is temporary: battery, a
+  /// metered or constrained link, a Tor client that did not come up, the
+  /// system reclaiming the execution slot. None of them is evidence about the
+  /// next wake, and none of them is a reason to strand items whose signatures
+  /// expire by height. What is permanent is having nothing left to do.
+  ///
+  /// This is not an announcement path. Anything a wake owes the user is said
+  /// by the caller before it gets here, because an interrupted wake has
+  /// seconds, and the replacement is what those seconds are for.
+  private func finishWakeWithoutNetworkWork(_ task: BGProcessingTask) {
     guard ironwoodMigrationTorDeferredWakeShouldRearm(
       disposition: wakeDisposition,
       mutationQuiesced: isMutationQuiesced,
@@ -932,7 +997,7 @@ final class BackgroundMigrationManager {
       )
     ) { rescheduled in
       if !rescheduled {
-        print("[BGMigration] Tor-deferred wake could not re-arm")
+        print("[BGMigration] wake without network work could not re-arm")
       }
       complete(rescheduled)
     }

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -525,7 +525,13 @@ final class BackgroundMigrationManager {
       )
       let request = BGProcessingTaskRequest(identifier: Self.taskIdentifier)
       request.requiresNetworkConnectivity = true
-      request.requiresExternalPower = false
+      // On a Tor route this wake has to bring Tor up before it can reach
+      // lightwalletd, and a cold bootstrap is 8.45 MB and 23.7 s. Ask the
+      // scheduler for a charger so it stops waking us for a pass that would
+      // only decline; on a direct route the wake is cheap and stays
+      // unconstrained. The other half of the gate — an unmetered link — has no
+      // equivalent on any request type, so it is checked at run time.
+      request.requiresExternalPower = BackgroundNetworkRoute.persistedRouteIsTor
       request.earliestBeginDate = earliestBeginDate
       do {
         try BGTaskScheduler.shared.submit(request)
@@ -696,6 +702,19 @@ final class BackgroundMigrationManager {
   }
 
   private func handleAuthorized(_ task: BGProcessingTask) {
+    // This wake may be a cold launch where Dart never applied the saved route,
+    // and it broadcasts signed transactions. Declare the route before any
+    // other native call so a path that still reaches lightwalletd fails closed
+    // rather than putting a transaction on clearnet.
+    //
+    // On a Tor route the declaration is only half the answer: the wake also has
+    // to have established that this device can afford Tor right now. Asking
+    // here keeps an unaffordable wake from touching the outbox at all, and
+    // costs nothing — this gate never bootstraps.
+    guard BackgroundNetworkRoute.allowsBackgroundNetworkPass() else {
+      finishTorDeferredWake(task)
+      return
+    }
     guard prepareForBackgroundWake() else {
       task.setTaskCompleted(success: true)
       return
@@ -707,6 +726,16 @@ final class BackgroundMigrationManager {
     queue.async { [weak self] in
       guard let self else {
         task.setTaskCompleted(success: false)
+        return
+      }
+      // Tor before the first query or broadcast. A cold bootstrap blocks for
+      // tens of seconds, so it runs here on this manager's own queue rather
+      // than on the notification-gate callback. A client that does not come up
+      // ready ends the wake the same way an unaffordable one does: fail-closed,
+      // no network work, the run left to the foreground.
+      guard BackgroundNetworkRoute.allowsBackgroundNetworkWork() else {
+        self.stopAuthorizationMonitoring()
+        self.finishTorDeferredWake(task)
         return
       }
       let cancellation = BackgroundMigrationCancellation()
@@ -813,6 +842,32 @@ final class BackgroundMigrationManager {
           && rescheduled
       )
     }
+  }
+
+  /// Completes a silent wake that must not reach the network: the saved route
+  /// is Tor and this device cannot carry it right now — on battery, on a
+  /// metered or constrained link, or with a Tor client that did not come up.
+  ///
+  /// It queries no chain tip and broadcasts nothing, and it does not
+  /// reschedule. The foreground is the continuation for a declined wake, as it
+  /// has been for every Tor route: armed items keep their signed bytes and
+  /// their schedule, and the foreground outbox run transports them at the next
+  /// launch — before the item's expiry boundary, or it has to be signed again.
+  /// The task reports success because declining is the policy working, not a
+  /// wake that failed.
+  private func finishTorDeferredWake(_ task: BGProcessingTask) {
+    // Free of network work, and the one thing this wake can still report: a
+    // preparation run that needs the foreground for reasons of its own. The
+    // quiescence and notification fences that gate every other wake apply
+    // here unchanged.
+    if #available(iOS 26.0, *),
+      !isMutationQuiesced,
+      wakeDisposition.shouldDeliverNotifications
+    {
+      BackgroundMigrationPreparationManager.shared
+        .notifyPreparationNeedsForeground()
+    }
+    task.setTaskCompleted(success: true)
   }
 
   private func clearActiveCancellation() {

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -821,6 +821,16 @@ final class BackgroundMigrationManager {
         self.finishWakeWithoutNetworkWork(task)
         return
       }
+      // This wake has established what a confirmation tracker that stood down
+      // for the route is waiting on: a device that can carry it. The tracker's
+      // own request type cannot hold that wait — the scheduler starts it
+      // rather than scheduling it — so this is where it gets armed again.
+      // Self-gating: it submits nothing unless a run is still waiting for
+      // denomination confirmations, and it runs before the outbox so the
+      // submission is not racing this wake's completion.
+      if #available(iOS 26.0, *) {
+        BackgroundMigrationPreparationManager.shared.start { _ in }
+      }
       // This wake is a silent BGProcessingTask. It queries the chain tip,
       // broadcasts transactions that are already signed, and notifies — it does
       // not scan. The separate continued-processing task owns denomination

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -174,6 +174,23 @@ func ironwoodMigrationTorDeferredWakeShouldRearm(
   disposition.shouldReschedule && !mutationQuiesced && hasRunnableWork
 }
 
+/// What a wake is still allowed to do, from the two flags that can take it away
+/// from it.
+///
+/// Both inputs are wake-scoped: they describe the wake that set them, and a
+/// wake clears them as it starts. Reading them before that clearing answers for
+/// the previous wake — most damagingly as `.finishForegroundOnly`, which says
+/// the foreground has taken this work over and stops the wake from arming a
+/// replacement for work nobody has taken.
+func ironwoodMigrationOutboxWakeDisposition(
+  foregroundHandoffRequested: Bool,
+  notificationWorkDisabled: Bool
+) -> IronwoodMigrationOutboxWakeDisposition {
+  foregroundHandoffRequested || notificationWorkDisabled
+    ? .finishForegroundOnly
+    : .continueBackgroundWork
+}
+
 /// Whether a wake may still start network work after a step it could not
 /// interrupt.
 ///
@@ -516,9 +533,10 @@ final class BackgroundMigrationManager {
   }
 
   private var wakeDisposition: IronwoodMigrationOutboxWakeDisposition {
-    isNotificationWorkDisabled || isForegroundHandoffRequested
-      ? .finishForegroundOnly
-      : .continueBackgroundWork
+    ironwoodMigrationOutboxWakeDisposition(
+      foregroundHandoffRequested: isForegroundHandoffRequested,
+      notificationWorkDisabled: isNotificationWorkDisabled
+    )
   }
 
   private var isForegroundHandoffRequested: Bool {
@@ -764,18 +782,32 @@ final class BackgroundMigrationManager {
     // This wake may be a cold launch where Dart never applied the saved route,
     // and it broadcasts signed transactions. Declare the route before any
     // other native call so a path that still reaches lightwalletd fails closed
-    // rather than putting a transaction on clearnet.
+    // rather than putting a transaction on clearnet. Declaring samples nothing
+    // and never bootstraps, so it costs the wake nothing to do it first.
+    let routeIsTor = BackgroundNetworkRoute.declareBackgroundNetworkRoute()
+    // The wake's own flags come next, before anything reads a disposition out
+    // of them. `expired` and `foregroundHandoffRequested` describe the wake
+    // that set them and are cleared only here, so an exit taken ahead of this
+    // answers for a previous wake — a wake that ends up reading "the foreground
+    // has taken this over" when nothing has, and declining to arm a
+    // replacement because of it.
     //
+    // A refusal here is a wake with an owner: the wallet is mid-mutation, whose
+    // resume path arms the next wake, or notification permission is gone, which
+    // stopped background migration deliberately. Neither wants a replacement.
+    guard prepareForBackgroundWake() else {
+      task.setTaskCompleted(success: true)
+      return
+    }
     // On a Tor route the declaration is only half the answer: the wake also has
     // to have established that this device can afford Tor right now. Asking
     // here keeps an unaffordable wake from touching the outbox at all, and
     // costs nothing — this gate never bootstraps.
-    guard BackgroundNetworkRoute.allowsBackgroundNetworkPass() else {
+    guard BackgroundNetworkRoute.backgroundPassIsAllowed(
+      routeIsTor: routeIsTor,
+      isAffordable: BackgroundNetworkRoute.torBackgroundPassIsAffordable
+    ) else {
       finishTorDeferredWake(task)
-      return
-    }
-    guard prepareForBackgroundWake() else {
-      task.setTaskCompleted(success: true)
       return
     }
     startAuthorizationMonitoring()

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -166,12 +166,92 @@ enum IronwoodMigrationOutboxWakeDisposition: Equatable {
 /// owed announcement, no preparation run to resume. A wake that the foreground
 /// has taken over, or one on a wallet whose accounts are being mutated, also
 /// stops here; those have an owner already.
+///
+/// `hasRunnableWork` comes last and is deferred. Answering it inspects the
+/// preparation run, which opens the wallet database — the one thing a wake
+/// that has just found `mutationQuiesced` set must not do, because the fence
+/// that set it has already told Dart the wallet is free.
 func ironwoodMigrationTorDeferredWakeShouldRearm(
   disposition: IronwoodMigrationOutboxWakeDisposition,
   mutationQuiesced: Bool,
-  hasRunnableWork: Bool
+  hasRunnableWork: @autoclosure () -> Bool
 ) -> Bool {
-  disposition.shouldReschedule && !mutationQuiesced && hasRunnableWork
+  disposition.shouldReschedule && !mutationQuiesced && hasRunnableWork()
+}
+
+/// How a wake that reached no network left its replacement.
+enum IronwoodMigrationRearmOutcome: Equatable {
+  /// There was nothing to arm — no armed item, no owed announcement, no
+  /// preparation run to resume, or the work already has an owner.
+  case nothingToArm
+  /// The replacement was submitted.
+  case armed
+  /// The hold ran out while the submission was still in flight. The
+  /// submission has not answered and has not failed.
+  case stillArming
+  /// The submission answered, and the answer was no.
+  case refused
+}
+
+/// What the scheduler is told about a wake that reached no network.
+///
+/// Declining the route is the policy working, not a wake that failed, and
+/// every sibling completion says so: `finishTorDeferredTask` always reports
+/// success, and the guard in front of this one does too. This path did not,
+/// for one reason: it holds the wake open while `schedule` waits on
+/// `UNUserNotificationCenter.getNotificationSettings`, and at background
+/// launch that call can outlast the hold. The hold expiring used to report
+/// failure — for a replacement that lands moments later and is armed. Repeated
+/// on exactly the route-and-battery combination this feature exists for, that
+/// teaches `BGTaskScheduler` to stop scheduling the identifier the whole
+/// re-arm chain depends on.
+///
+/// So the hold expiring reports what it observed, which is nothing: the
+/// submission is still arming. A submission that actually came back refused is
+/// the one outcome that still reports failure — there the wake really did end
+/// with no replacement and nothing on the way.
+func ironwoodMigrationWakeWithoutNetworkWorkSucceeded(
+  _ outcome: IronwoodMigrationRearmOutcome
+) -> Bool {
+  switch outcome {
+  case .nothingToArm, .armed, .stillArming:
+    return true
+  case .refused:
+    return false
+  }
+}
+
+/// Holds a wake open while its replacement is submitted, and completes it
+/// exactly once with a status that reflects what actually happened.
+///
+/// The hold and the submission race by design — the submission must be filed
+/// before `setTaskCompleted` returns, or iOS may suspend the process with
+/// nothing armed, and the task must complete even if the submission callback
+/// never fires. Whichever arrives first decides, and the loser is dropped;
+/// what the winner reports is the whole of `ironwoodMigrationRearmOutcome`'s
+/// job.
+final class IronwoodMigrationRearmHold {
+  private let latch = MigrationPreparationCompletionLatch()
+  private let complete: (IronwoodMigrationRearmOutcome) -> Void
+
+  init(complete: @escaping (IronwoodMigrationRearmOutcome) -> Void) {
+    self.complete = complete
+  }
+
+  /// The hold's deadline passed before the submission answered.
+  func holdExpired() {
+    finish(.stillArming)
+  }
+
+  /// The submission answered.
+  func submissionFinished(armed: Bool) {
+    finish(armed ? .armed : .refused)
+  }
+
+  private func finish(_ outcome: IronwoodMigrationRearmOutcome) {
+    guard latch.claim() else { return }
+    complete(outcome)
+  }
 }
 
 /// What a wake is still allowed to do, from the two flags that can take it away
@@ -510,8 +590,23 @@ final class BackgroundMigrationManager {
   /// completes is a worse outcome than one that completes unarmed.
   private static let rearmSubmissionTimeout: TimeInterval = 10
 
+  /// Everything a wake does that can reach the wallet, and the fence a wallet
+  /// mutation drains to establish that none of it is still running.
   private let queue = DispatchQueue(
     label: "com.keplr.vizor.ironwood-migration.outbox",
+    qos: .utility
+  )
+
+  /// The Tor bring-up, and only that.
+  ///
+  /// It is the one step of a wake that takes no cancellation handle — it can
+  /// be outlived but never stopped — and a cold bootstrap holds for tens of
+  /// seconds. Run on `queue` it made `quiesce` wait out a bootstrap before it
+  /// could answer, which is a wallet-mutation fence blocking the accounts UI
+  /// for up to a minute. It touches no wallet database, so the fence has
+  /// nothing to establish about it and it belongs off the fence's queue.
+  private let torBringUpQueue = DispatchQueue(
+    label: "com.keplr.vizor.ironwood-migration.tor-bring-up",
     qos: .utility
   )
   private let stateLock = NSLock()
@@ -670,6 +765,20 @@ final class BackgroundMigrationManager {
     }
   }
 
+  /// Establishes that no native work is touching the wallet before Dart
+  /// mutates accounts, and blocks the caller's flow until it has.
+  ///
+  /// Close the gate, then drain, in that order. `stopActiveWork` sets
+  /// `mutationQuiesced` and cancels whatever is running, so work that has not
+  /// started yet refuses at its own gate; the `queue` barrier below then waits
+  /// out whatever had already started. Everything that can reach the wallet
+  /// runs on `queue`, which is what makes draining it sufficient.
+  ///
+  /// It is a real barrier and has to stay one. The thing that must never come
+  /// back into it is the Tor bring-up: that is uninterruptible, has nothing to
+  /// do with the wallet database, and runs on `torBringUpQueue` for exactly
+  /// that reason. A wake caught mid-bring-up finds the gate closed when it
+  /// hops back here and stops.
   func quiesce(completion: @escaping (Bool) -> Void) {
     stopActiveWork(quiesceForMutation: true)
     queue.async {
@@ -849,24 +958,36 @@ final class BackgroundMigrationManager {
       return
     }
     startAuthorizationMonitoring()
-    queue.async { [weak self] in
+    // Published before the bring-up below, not after it. Expiration, a
+    // foreground handoff, and a wallet mutation all end a wake by cancelling
+    // whatever token is published; a window with none leaves them nothing to
+    // reach, and the work on the far side of it starts uncancelled.
+    let cancellation = BackgroundMigrationCancellation()
+    stateLock.vizorWithLock {
+      activeCancellation = cancellation
+    }
+    torBringUpQueue.async { [weak self] in
       guard let self else {
         task.setTaskCompleted(success: false)
         return
       }
-      // Published before the bring-up below, not after it. Expiration, a
-      // foreground handoff, and a wallet mutation all end a wake by cancelling
-      // whatever token is published; a window with none leaves them nothing to
-      // reach, and the work on the far side of it starts uncancelled.
-      let cancellation = BackgroundMigrationCancellation()
-      self.stateLock.vizorWithLock {
-        self.activeCancellation = cancellation
-      }
       // Tor before the first query or broadcast. A cold bootstrap blocks for
-      // tens of seconds, so it runs here on this manager's own queue rather
-      // than on the notification-gate callback. A client that does not come up
-      // ready ends the wake the same way an unaffordable one does: fail-closed,
-      // no network work, the run left to the foreground.
+      // tens of seconds, so it runs on a queue of its own rather than on the
+      // notification-gate callback — and, just as deliberately, not on
+      // `queue`.
+      //
+      // `queue` is the fence a wallet mutation waits behind: `quiesce` cancels
+      // this wake and then drains `queue` to establish that nothing native is
+      // still touching the wallet database. This step touches no database.
+      // Running it on the fence queue made the fence wait out a bring-up it
+      // has no reason to wait for — and one that, unlike every other step
+      // here, ignores the cancellation `quiesce` just delivered — so the
+      // accounts, uninstall and forgot-passcode screens blocked for up to a
+      // minute behind a Tor bootstrap.
+      //
+      // A client that does not come up ready ends the wake the same way an
+      // unaffordable one does: fail-closed, no network work, the run left to
+      // the foreground.
       guard BackgroundNetworkRoute.allowsBackgroundNetworkWork(
         while: { self.wakeMaySpendTime }
       ) else {
@@ -875,41 +996,52 @@ final class BackgroundMigrationManager {
         self.finishTorDeferredWake(task)
         return
       }
-      // The bring-up above cannot be cancelled, only outlived, and it is long
-      // enough to be outlived. Ask again before the first byte goes out: the
-      // outbox is transport for already-signed transactions, so entering it on
-      // a reclaimed wake risks suspension mid-broadcast, and it would consume
-      // this execution opportunity without leaving a replacement.
-      guard ironwoodMigrationOutboxWakeMayStartNetworkWork(
-        expired: self.isWakeExpired,
-        disposition: self.wakeDisposition,
-        mutationQuiesced: self.isMutationQuiesced,
-        routeStillAffordable: BackgroundNetworkRoute.torBackgroundPassRemainsAffordable
-      ) else {
-        self.clearActiveCancellation()
-        self.stopAuthorizationMonitoring()
-        self.finishWakeWithoutNetworkWork(task)
-        return
+      // Back onto the fence queue for everything from here on, because
+      // everything from here on can reach the wallet. A mutation that landed
+      // during the bring-up is already past `quiesce` by now; what stops this
+      // wake is the `mutationQuiesced` read in the gate below, which was set
+      // before the fence released and is what every not-yet-started piece of
+      // work checks.
+      self.queue.async {
+        // The bring-up above cannot be cancelled, only outlived, and it is
+        // long enough to be outlived. Ask again before the first byte goes
+        // out: the outbox is transport for already-signed transactions, so
+        // entering it on a reclaimed wake risks suspension mid-broadcast, and
+        // it would consume this execution opportunity without leaving a
+        // replacement.
+        guard ironwoodMigrationOutboxWakeMayStartNetworkWork(
+          expired: self.isWakeExpired,
+          disposition: self.wakeDisposition,
+          mutationQuiesced: self.isMutationQuiesced,
+          routeStillAffordable: BackgroundNetworkRoute
+            .torBackgroundPassRemainsAffordable
+        ) else {
+          self.clearActiveCancellation()
+          self.stopAuthorizationMonitoring()
+          self.finishWakeWithoutNetworkWork(task)
+          return
+        }
+        // This wake has established what a confirmation tracker that stood
+        // down for the route is waiting on: a device that can carry it. The
+        // tracker's own request type cannot hold that wait — the scheduler
+        // starts it rather than scheduling it — so this is where it gets armed
+        // again. Self-gating: it submits nothing unless a run is still waiting
+        // for denomination confirmations, and it runs before the outbox so the
+        // submission is not racing this wake's completion.
+        if #available(iOS 26.0, *) {
+          BackgroundMigrationPreparationManager.shared.start { _ in }
+        }
+        // This wake is a silent BGProcessingTask. It queries the chain tip,
+        // broadcasts transactions that are already signed, and notifies — it
+        // does not scan. The separate continued-processing task owns
+        // denomination confirmation tracking and hands confirmed waves back to
+        // the foreground.
+        self.runOutbox(
+          task: task,
+          cancellation: cancellation,
+          preparationResult: .completed
+        )
       }
-      // This wake has established what a confirmation tracker that stood down
-      // for the route is waiting on: a device that can carry it. The tracker's
-      // own request type cannot hold that wait — the scheduler starts it
-      // rather than scheduling it — so this is where it gets armed again.
-      // Self-gating: it submits nothing unless a run is still waiting for
-      // denomination confirmations, and it runs before the outbox so the
-      // submission is not racing this wake's completion.
-      if #available(iOS 26.0, *) {
-        BackgroundMigrationPreparationManager.shared.start { _ in }
-      }
-      // This wake is a silent BGProcessingTask. It queries the chain tip,
-      // broadcasts transactions that are already signed, and notifies — it does
-      // not scan. The separate continued-processing task owns denomination
-      // confirmation tracking and hands confirmed waves back to the foreground.
-      self.runOutbox(
-        task: task,
-        cancellation: cancellation,
-        preparationResult: .completed
-      )
     }
   }
 
@@ -1042,12 +1174,17 @@ final class BackgroundMigrationManager {
   /// by the caller before it gets here, because an interrupted wake has
   /// seconds, and the replacement is what those seconds are for.
   private func finishWakeWithoutNetworkWork(_ task: BGProcessingTask) {
+    let report = { (outcome: IronwoodMigrationRearmOutcome) in
+      task.setTaskCompleted(
+        success: ironwoodMigrationWakeWithoutNetworkWorkSucceeded(outcome)
+      )
+    }
     guard ironwoodMigrationTorDeferredWakeShouldRearm(
       disposition: wakeDisposition,
       mutationQuiesced: isMutationQuiesced,
       hasRunnableWork: hasRunnableOutboxWork() || hasResumablePreparationWork()
     ) else {
-      task.setTaskCompleted(success: true)
+      report(.nothingToArm)
       return
     }
     // The replacement goes in before the completion. `schedule` runs the
@@ -1061,15 +1198,16 @@ final class BackgroundMigrationManager {
     // on power and Wi-Fi anyway, which is when a Tor route is affordable. A
     // longer floor would only push the wake past the moment the device plugs
     // in, and signed items expire by height.
-    let latch = MigrationPreparationCompletionLatch()
-    let complete = { (rescheduled: Bool) in
-      guard latch.claim() else { return }
-      task.setTaskCompleted(success: rescheduled)
-    }
+    let hold = IronwoodMigrationRearmHold(complete: report)
     // The task must finish even if the schedule callback never fires; never
-    // completing it is worse than an unarmed replacement.
+    // completing it is worse than an unarmed replacement. It reports
+    // `.stillArming` rather than a failure: at background launch the gate
+    // `schedule` waits on can outlast this hold, and the replacement it is
+    // still submitting usually lands. A wake that declined for policy and has
+    // its replacement on the way is not a failed execution opportunity, and
+    // saying it was is how the identifier stops being scheduled.
     queue.asyncAfter(deadline: .now() + Self.rearmSubmissionTimeout) {
-      complete(false)
+      hold.holdExpired()
     }
     schedule(
       earliestBeginDate: Date().addingTimeInterval(
@@ -1079,7 +1217,7 @@ final class BackgroundMigrationManager {
       if !rescheduled {
         print("[BGMigration] wake without network work could not re-arm")
       }
-      complete(rescheduled)
+      hold.submissionFinished(armed: rescheduled)
     }
   }
 

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -150,6 +150,30 @@ enum IronwoodMigrationOutboxWakeDisposition: Equatable {
   }
 }
 
+/// Whether a wake that declined the Tor route must leave a replacement request
+/// behind before it completes.
+///
+/// Starting the wake consumed the pending request, and nothing else arms one
+/// until the user opens the app. Without a replacement, a device that reaches a
+/// charger and an unmetered link an hour later gets no execution opportunity at
+/// all, and already-signed items sit past the height they were scheduled for
+/// until they have to be signed again.
+///
+/// The chain ends with the work rather than on a counter, because the reasons
+/// for declining — battery, a metered or constrained link, a Tor client that did
+/// not come up — all change on their own and none of them is evidence about the
+/// next wake. What is permanent is having nothing left to do: no armed item, no
+/// owed announcement, no preparation run to resume. A wake that the foreground
+/// has taken over, or one on a wallet whose accounts are being mutated, also
+/// stops here; those have an owner already.
+func ironwoodMigrationTorDeferredWakeShouldRearm(
+  disposition: IronwoodMigrationOutboxWakeDisposition,
+  mutationQuiesced: Bool,
+  hasRunnableWork: Bool
+) -> Bool {
+  disposition.shouldReschedule && !mutationQuiesced && hasRunnableWork
+}
+
 final class IronwoodMigrationNotificationAuthorizationMonitor {
   typealias StatusProvider =
     (@escaping (IronwoodMigrationNotificationAuthorizationStatus) -> Void) -> Void
@@ -426,6 +450,14 @@ enum IronwoodMigrationProofReadinessCheck {
 final class BackgroundMigrationManager {
   static let shared = BackgroundMigrationManager()
   static let taskIdentifier = "com.keplr.vizor.ironwood-migration"
+
+  /// How long a wake may be held open for its replacement submission.
+  ///
+  /// The hold exists so iOS cannot suspend the process between completing the
+  /// task and filing the replacement. It has to stay short: the wake is being
+  /// completed because it has nothing else to do, and a task that never
+  /// completes is a worse outcome than one that completes unarmed.
+  private static let rearmSubmissionTimeout: TimeInterval = 10
 
   private let queue = DispatchQueue(
     label: "com.keplr.vizor.ironwood-migration.outbox",
@@ -847,13 +879,12 @@ final class BackgroundMigrationManager {
   /// is Tor and this device cannot carry it right now — on battery, on a
   /// metered or constrained link, or with a Tor client that did not come up.
   ///
-  /// It queries no chain tip and broadcasts nothing, and it does not
-  /// reschedule. The foreground is the continuation for a declined wake, as it
-  /// has been for every Tor route: armed items keep their signed bytes and
-  /// their schedule, and the foreground outbox run transports them at the next
-  /// launch — before the item's expiry boundary, or it has to be signed again.
-  /// The task reports success because declining is the policy working, not a
-  /// wake that failed.
+  /// It queries no chain tip and broadcasts nothing. Declining is the policy
+  /// working rather than a wake that failed, but the outbox stays
+  /// background-capable across the deferral: this wake arms the next one, so
+  /// signed items are transported by the first wake that lands on a charger and
+  /// an unmetered link instead of waiting for the user to open the app. The
+  /// foreground remains the other continuation, not the only one.
   private func finishTorDeferredWake(_ task: BGProcessingTask) {
     // Free of network work, and the one thing this wake can still report: a
     // preparation run that needs the foreground for reasons of its own. The
@@ -866,7 +897,45 @@ final class BackgroundMigrationManager {
       BackgroundMigrationPreparationManager.shared
         .notifyPreparationNeedsForeground()
     }
-    task.setTaskCompleted(success: true)
+    guard ironwoodMigrationTorDeferredWakeShouldRearm(
+      disposition: wakeDisposition,
+      mutationQuiesced: isMutationQuiesced,
+      hasRunnableWork: hasRunnableOutboxWork() || hasResumablePreparationWork()
+    ) else {
+      task.setTaskCompleted(success: true)
+      return
+    }
+    // The replacement goes in before the completion. `schedule` runs the
+    // notification-gate status callback first, and once `setTaskCompleted`
+    // returns iOS may suspend the process before the submit gets to run, which
+    // would leave nothing armed — the failure this path exists to prevent.
+    //
+    // The delay is the outbox's own rolling cadence, not a longer wait for
+    // conditions to change. `earliestBeginDate` is a floor the system reads as
+    // "no earlier than", and it schedules these wakes when the device is idle
+    // on power and Wi-Fi anyway, which is when a Tor route is affordable. A
+    // longer floor would only push the wake past the moment the device plugs
+    // in, and signed items expire by height.
+    let latch = MigrationPreparationCompletionLatch()
+    let complete = { (rescheduled: Bool) in
+      guard latch.claim() else { return }
+      task.setTaskCompleted(success: rescheduled)
+    }
+    // The task must finish even if the schedule callback never fires; never
+    // completing it is worse than an unarmed replacement.
+    queue.asyncAfter(deadline: .now() + Self.rearmSubmissionTimeout) {
+      complete(false)
+    }
+    schedule(
+      earliestBeginDate: Date().addingTimeInterval(
+        BackgroundMigrationOutboxCadence.rollingCheckInterval
+      )
+    ) { rescheduled in
+      if !rescheduled {
+        print("[BGMigration] Tor-deferred wake could not re-arm")
+      }
+      complete(rescheduled)
+    }
   }
 
   private func clearActiveCancellation() {

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -804,6 +804,16 @@ final class BackgroundMigrationManager {
       task.setTaskCompleted(success: true)
       return
     }
+    // Installed as soon as the wake owns its own flags, and before the first
+    // step that can hold it. Sampling power and the current path takes up to a
+    // second, and the route-declined exit below holds the wake open across an
+    // asynchronous submission; an expiry landing in either window reaches
+    // nothing without this, and the process is killed with no replacement
+    // filed. Setting `expired` costs a declined wake nothing: the exits that
+    // arm a replacement deliberately do not consult it.
+    task.expirationHandler = { [weak self] in
+      self?.expire()
+    }
     // On a Tor route the declaration is only half the answer: the wake also has
     // to have established that this device can afford Tor right now. Asking
     // here keeps an unaffordable wake from touching the outbox at all, and
@@ -816,9 +826,6 @@ final class BackgroundMigrationManager {
       return
     }
     startAuthorizationMonitoring()
-    task.expirationHandler = { [weak self] in
-      self?.expire()
-    }
     queue.async { [weak self] in
       guard let self else {
         task.setTaskCompleted(success: false)

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -525,13 +525,12 @@ final class BackgroundMigrationManager {
       )
       let request = BGProcessingTaskRequest(identifier: Self.taskIdentifier)
       request.requiresNetworkConnectivity = true
-      // On a Tor route this wake has to bring Tor up before it can reach
-      // lightwalletd, and a cold bootstrap is 8.45 MB and 23.7 s. Ask the
-      // scheduler for a charger so it stops waking us for a pass that would
-      // only decline; on a direct route the wake is cheap and stays
-      // unconstrained. The other half of the gate — an unmetered link — has no
-      // equivalent on any request type, so it is checked at run time.
-      request.requiresExternalPower = BackgroundNetworkRoute.persistedRouteIsTor
+      // Deliberately not `requiresExternalPower`, even though a Tor pass wants
+      // a charger. The route is a setting the user can change after this
+      // request is submitted, and the request keeps whatever it was built with:
+      // a wake that turned direct would then wait for a charger it no longer
+      // needs, holding signed work past the height it was scheduled for.
+      // Both halves of the gate are checked when the pass runs instead.
       request.earliestBeginDate = earliestBeginDate
       do {
         try BGTaskScheduler.shared.submit(request)

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -1767,32 +1767,85 @@ final class BackgroundMigrationPreparationManager {
   /// charger over an unmetered link, and it would say it again on every wake
   /// until then. Runs that need foreground recovery for their own reasons still
   /// send their existing alerts.
+  ///
+  /// "Resume by itself" is only true while a request exists to resume with.
+  /// Starting this task consumed the one that was armed, and nothing outside
+  /// the app arms another, so the stand-down submits a replacement on exactly
+  /// the terms a mid-wave stand-down does: the wave is unchanged, still has
+  /// confirmations left to observe, and lost one execution opportunity.
   private func finishTorDeferredTask(_ task: BGContinuedProcessingTask) {
     queue.async { [weak self] in
       guard let self else {
         task.setTaskCompleted(success: false)
         return
       }
-      let notificationsDisabled = self.stateLock.withPreparationLock {
-        self.notificationAuthorization.isDisabled
+      let runtime = self.stateLock.withPreparationLock {
+        (
+          handedOff: self.foregroundHandoffRequested,
+          expired: self.expired,
+          quiesced: self.mutationQuiesced,
+          disabled: self.notificationAuthorization.isDisabled
+        )
       }
       let recoveryEvents: [MigrationPreparationNotificationEvent] =
-        notificationsDisabled
+        runtime.disabled
         ? []
         : self.foregroundRecoveryNotificationEvents()
       let recoveryAlertSubmitted =
         !recoveryEvents.isEmpty
         && self.submitNotificationEvents(recoveryEvents)
-      BGTaskScheduler.shared.cancel(
-        taskRequestWithIdentifier: Self.taskIdentifier
+      let shouldRearm = migrationPreparationTrackingShouldAttemptRearm(
+        completionFailed: false,
+        quiesced: runtime.quiesced,
+        expired: runtime.expired,
+        routeDeferred: true,
+        handedOff: runtime.handedOff,
+        notificationsDisabled: runtime.disabled
       )
-      self.recordSchedulingState("waiting_for_foreground_tor_route")
+      if !shouldRearm {
+        BGTaskScheduler.shared.cancel(
+          taskRequestWithIdentifier: Self.taskIdentifier
+        )
+      }
+      self.recordSchedulingState(
+        shouldRearm
+          ? "route_paused_rearming"
+          : "waiting_for_foreground_tor_route"
+      )
       // With no recovery alert delivered, the watchdog registered for this
       // request is the only remaining prompt to reopen Vizor, so it stays.
       if recoveryAlertSubmitted {
         self.cancelWatchdog()
       }
-      task.setTaskCompleted(success: true)
+      guard shouldRearm else {
+        task.setTaskCompleted(success: true)
+        return
+      }
+      // Submit the replacement BEFORE completing. `start` is asynchronous, and
+      // once `setTaskCompleted` returns iOS may suspend the process before the
+      // submission runs, which leaves the wave with no armed task at all — the
+      // state this path exists to avoid.
+      let latch = MigrationPreparationCompletionLatch()
+      let complete = {
+        guard latch.claim() else { return }
+        task.setTaskCompleted(success: true)
+      }
+      // The task must finish even if the submission callback never fires.
+      self.queue.asyncAfter(deadline: .now() + Self.rearmSubmissionTimeout) {
+        complete()
+      }
+      self.start { rearmed in
+        if !rearmed {
+          print("[BGPreparation] route-deferred task could not re-arm tracking")
+          // A refused submission takes the watchdog down with it, since the two
+          // share one notification identifier. Without a delivered alert that
+          // leaves no prompt at all, so put the boundary back.
+          if !recoveryAlertSubmitted {
+            self.scheduleWatchdog()
+          }
+        }
+        complete()
+      }
     }
   }
 

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -786,6 +786,37 @@ func migrationPreparationRouteDeferralAction(
     : .none
 }
 
+/// What a task whose own re-arm did not take must leave behind instead.
+///
+/// The re-arm submits another continued-processing request, and that request
+/// type declines for reasons it cannot itself wait out: the run moved to a
+/// state only the foreground app can advance, another submission is already in
+/// flight, the scheduler refused. Only one of those declines — the saved route
+/// having become uncarriable — places its own wait, and it places it on the
+/// silent processing request. Every other decline used to leave the task
+/// completing with no request queued, no watchdog (the re-arm retires it first)
+/// and no alert, which strands the run until the user reopens the app.
+///
+/// So the fallback is the same wait, decided from the same inputs. A run with
+/// nothing resumable left needs no replacement, and a run that already has an
+/// owner — the foreground app, a wallet mutation, a revoked notification
+/// permission — must not be given one.
+func migrationPreparationRearmFallbackAction(
+  rearmSubmitted: Bool,
+  hasResumableWork: Bool,
+  quiesced: Bool,
+  handedOff: Bool,
+  notificationsDisabled: Bool
+) -> MigrationPreparationRouteDeferralAction {
+  guard !rearmSubmitted, hasResumableWork else { return .none }
+  return migrationPreparationRouteDeferralAction(
+    quiesced: quiesced,
+    expired: false,
+    handedOff: handedOff,
+    notificationsDisabled: notificationsDisabled
+  )
+}
+
 func shouldMarkMigrationPreparationForegroundContinuation(
   hasPendingRequest: Bool,
   hasBoundPreparation: Bool,
@@ -1661,8 +1692,27 @@ final class BackgroundMigrationPreparationManager {
   }
 
   private func handleAuthorized(_ task: BGContinuedProcessingTask) {
+    // Every wake-scoped flag is cleared here, at the top, before anything reads
+    // a disposition out of one. `expired` and `foregroundHandoffRequested`
+    // describe the task that set them; read before this clearing they answer
+    // for a previous task, and the exits below act on both.
     stateLock.withPreparationLock {
       submissionInFlight = false
+      expired = false
+      foregroundHandoffRequested = false
+    }
+    // Installed immediately after that clearing and before the first step that
+    // can hold the task. The route gate below samples power and the current
+    // path, the inspections after it are blocking FFI reads, and the
+    // route-declined exit holds the task open across an asynchronous
+    // submission. An expiry landing in any of those windows reaches nothing
+    // without this, and the OS reclaims the slot with no replacement filed.
+    task.expirationHandler = { [weak self] in
+      guard let self else { return }
+      self.stateLock.withPreparationLock {
+        self.expired = true
+        self.trackingCancellation?.cancel()
+      }
     }
     // A request armed before the user chose Tor, or before they unplugged the
     // device, can still be started, and this process may be a cold background
@@ -1732,12 +1782,10 @@ final class BackgroundMigrationPreparationManager {
         return false
       }
       taskRunning = true
-      expired = false
       emptyObservationPassesByScope.removeAll()
       trackingProgressByScope.removeAll()
       latestTrackingProgress = nil
       displayedProgressUnits = 0
-      foregroundHandoffRequested = false
       taskProgress = task.progress
       taskProgress?.totalUnitCount = Self.progressDisplayUnitCount
       taskProgress?.completedUnitCount = 0
@@ -1752,13 +1800,6 @@ final class BackgroundMigrationPreparationManager {
     cancelWatchdog()
     startAuthorizationMonitoring()
     recordSchedulingState("tracking_confirmations")
-    task.expirationHandler = { [weak self] in
-      guard let self else { return }
-      self.stateLock.withPreparationLock {
-        self.expired = true
-        self.trackingCancellation?.cancel()
-      }
-    }
 
     queue.async { [weak self] in
       guard let self else {
@@ -1998,7 +2039,14 @@ final class BackgroundMigrationPreparationManager {
   private func runConfirmationTrackingPass(
     cancellation: BackgroundMigrationCancellation
   ) -> BackgroundMigrationPreparationTrackingPass {
-    if cancellation.isCancelled { return .cancelled }
+    // Both halves, because they cover different moments. The token is what an
+    // owner cancels once this task published it; the flags are what an owner
+    // sets, and one of them can already be set before the token exists — the
+    // system can reclaim the slot between the expiration handler being
+    // installed and the tracking slot being claimed. Asking here rather than
+    // at the loop's call sites is what keeps a stopped task from starting one
+    // more round of queries: every round enters through this function.
+    if isTrackingStopRequested || cancellation.isCancelled { return .cancelled }
     // The last gate in front of the lightwalletd queries below, re-evaluated
     // before every round rather than once at launch. The route can become Tor
     // after this task started, and the conditions that made a Tor route
@@ -2391,6 +2439,13 @@ final class BackgroundMigrationPreparationManager {
       || submitNotificationEvents(batch.notificationEvents)
     if !batch.continuationReadyScopes.isEmpty {
       stateLock.withPreparationLock {
+        // Re-read under the lock that publishes the write, not before the
+        // submission above. That submission blocks for seconds, and a wallet
+        // mutation landing inside it clears these scopes deliberately —
+        // writing the pre-submission set back afterwards resurrects state the
+        // mutation retired, and the resurrected scopes then survive
+        // `resumeAfterMutation`'s prune.
+        guard !mutationQuiesced else { return }
         foregroundContinuationScopes =
           migrationPreparationContinuationScopesAfterNotificationSubmission(
             existingScopes: foregroundContinuationScopes,
@@ -2609,11 +2664,40 @@ final class BackgroundMigrationPreparationManager {
     queue.asyncAfter(deadline: .now() + Self.rearmSubmissionTimeout) {
       complete()
     }
-    start { scheduled in
+    start { [weak self] scheduled in
+      guard let self else {
+        complete()
+        return
+      }
       if !scheduled {
         print("[BGPreparation] failed task could not re-arm tracking")
       }
-      complete()
+      // Re-read rather than reusing the snapshot above: `start` is
+      // asynchronous, so an owner can appear between the two.
+      let current = self.stateLock.withPreparationLock {
+        (
+          handedOff: self.foregroundHandoffRequested,
+          quiesced: self.mutationQuiesced,
+          disabled: self.notificationAuthorization.isDisabled
+        )
+      }
+      switch migrationPreparationRearmFallbackAction(
+        rearmSubmitted: scheduled,
+        hasResumableWork: self.hasResumablePreparation(),
+        quiesced: current.quiesced,
+        handedOff: current.handedOff,
+        notificationsDisabled: current.disabled
+      ) {
+      case .none:
+        complete()
+      case .waitOnProcessingWake:
+        self.deferRouteWaitToProcessingWake { placed in
+          if !placed {
+            print("[BGPreparation] re-arm fallback could not place its wait")
+          }
+          complete()
+        }
+      }
     }
   }
 

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -752,6 +752,21 @@ enum MigrationPreparationRouteDeferralAction: Equatable {
   case waitOnProcessingWake
 }
 
+/// The wake-scoped flags a completing task decides from.
+///
+/// Grouped so a path that has to release its bookkeeping before it completes
+/// can carry them across that release. Two of the four — `handedOff` and
+/// `expired` — describe the task run that set them and are cleared as the run
+/// ends, so a completion that reads them after the release reads a task that
+/// no longer exists and reports "nobody owns this run" for one the foreground
+/// just claimed.
+struct MigrationPreparationTaskRuntime: Equatable {
+  let handedOff: Bool
+  let expired: Bool
+  let quiesced: Bool
+  let disabled: Bool
+}
+
 /// What a tracking task that stood down for the saved route leaves behind.
 ///
 /// Never another continued-processing request. That request type has no usable
@@ -784,6 +799,18 @@ func migrationPreparationRouteDeferralAction(
   )
     ? .waitOnProcessingWake
     : .none
+}
+
+/// The same decision, from the flags a task carried out of its release.
+func migrationPreparationRouteDeferralAction(
+  _ runtime: MigrationPreparationTaskRuntime
+) -> MigrationPreparationRouteDeferralAction {
+  migrationPreparationRouteDeferralAction(
+    quiesced: runtime.quiesced,
+    expired: runtime.expired,
+    handedOff: runtime.handedOff,
+    notificationsDisabled: runtime.disabled
+  )
 }
 
 /// What a task whose own re-arm did not take must leave behind instead.
@@ -1016,8 +1043,23 @@ final class BackgroundMigrationPreparationManager {
   private static let foregroundContinuationScopesKey =
     "ironwoodMigrationPreparationForegroundContinuationScopes"
 
+  /// Everything a task does that can reach the wallet, and the fence a wallet
+  /// mutation drains to establish that none of it is still running.
   private let queue = DispatchQueue(
     label: "com.keplr.vizor.ironwood-preparation",
+    qos: .utility
+  )
+
+  /// The Tor bring-up, and only that.
+  ///
+  /// It is the one step of a task that answers no cancellation — it can be
+  /// outlived but never stopped — and a cold bootstrap holds for tens of
+  /// seconds. Run on `queue` it made `quiesce` wait out a bootstrap before it
+  /// could answer, which is a wallet-mutation fence blocking the accounts UI.
+  /// It touches no wallet database, so the fence has nothing to establish
+  /// about it and it belongs off the fence's queue.
+  private let torBringUpQueue = DispatchQueue(
+    label: "com.keplr.vizor.ironwood-preparation.tor-bring-up",
     qos: .utility
   )
   private let stateLock = NSLock()
@@ -1585,6 +1627,20 @@ final class BackgroundMigrationPreparationManager {
     resetNeedsActionNotifications()
   }
 
+  /// Establishes that no native preparation work is touching the wallet before
+  /// Dart mutates accounts, and blocks the caller's flow until it has.
+  ///
+  /// Close the gate, then drain, in that order. The flags below stop work that
+  /// has not started and the cancellation stops work that has; the `queue`
+  /// barrier then waits out whatever was already inside. Everything that can
+  /// reach the wallet runs on `queue`, which is what makes draining it
+  /// sufficient.
+  ///
+  /// It is a real barrier and has to stay one. The thing that must never come
+  /// back into it is the Tor bring-up: that answers no cancellation, has
+  /// nothing to do with the wallet database, and runs on `torBringUpQueue` for
+  /// exactly that reason. A task caught mid-bring-up finds the gate closed
+  /// when it hops back here and stands down.
   func quiesce(completion: @escaping (Bool) -> Void) {
     BGTaskScheduler.shared.cancel(
       taskRequestWithIdentifier: Self.taskIdentifier
@@ -1843,99 +1899,115 @@ final class BackgroundMigrationPreparationManager {
     startAuthorizationMonitoring()
     recordSchedulingState("tracking_confirmations")
 
-    queue.async { [weak self] in
+    torBringUpQueue.async { [weak self] in
       guard let self else {
         task.setTaskCompleted(success: false)
         return
       }
       // Tor before the first query. A cold bootstrap blocks for tens of
-      // seconds, so it runs here on this manager's own queue rather than on the
-      // notification-gate callback that delivered this task. A direct route
-      // passes straight through and bootstraps nothing. A client that does not
-      // come up ready — or a device unplugged since the gate above — ends the
-      // task exactly the way that gate does: fail-closed, no network work, and
-      // the run left to the foreground.
+      // seconds, so it runs on a queue of its own rather than on the
+      // notification-gate callback that delivered this task — and, just as
+      // deliberately, not on `queue`.
+      //
+      // `queue` is the fence a wallet mutation waits behind: `quiesce` cancels
+      // this task and then drains `queue` to establish that nothing native is
+      // still touching the wallet database. Every other step of this task
+      // answers that cancellation; the bring-up is the only one that cannot,
+      // and it touches no database, so the fence has nothing to establish
+      // about it. Running it here made the accounts, uninstall and
+      // forgot-passcode screens wait out a Tor bootstrap.
+      //
+      // A direct route passes straight through and bootstraps nothing. A
+      // client that does not come up ready — or a device unplugged since the
+      // gate above — ends the task exactly the way that gate does:
+      // fail-closed, no network work, and the run left to the foreground.
       guard BackgroundNetworkRoute.allowsBackgroundNetworkWork(
         while: { !self.isTaskEndedByOwner }
       ) else {
         self.standDownForUnavailableTorRoute(task)
         return
       }
-      var pass = self.runConfirmationTrackingPass(
-        cancellation: cancellation
-      )
-      var taskFailureObserved = false
-      // The pass above already ran, so the activity's progress bar is seeded
-      // from real confirmation counts even if the app is active. Every later
-      // pass is subject to the foreground pause.
-      var hasCompletedInitialQuery = false
-      while true {
-        switch pass {
-        case .batch(let batch):
-          hasCompletedInitialQuery = true
-          taskFailureObserved =
-            taskFailureObserved || batch.hasTaskFailure
-          let notificationSubmitted = self.applyTrackingBatch(
-            batch,
-            task: task
-          )
-          taskFailureObserved =
-            taskFailureObserved || !notificationSubmitted
-          switch migrationPreparationTrackingPostBatchAction(
-            batch,
-            taskFailureObserved: taskFailureObserved,
-            stopRequested: self.isTrackingStopRequested
-          ) {
-          case .finishConfirmed(let presentation):
-            // One task tracks one confirmation wave. The next wave cannot
-            // exist until the foreground app syncs and advances the run, so
-            // finish successfully now instead of idling until the OS expires
-            // the task and the expiry reads as a migration failure.
-            self.finishConfirmationTrackingTask(
-              task,
-              taskFailed: false,
-              completionPresentation: presentation
+      // Back onto the fence queue for the tracking loop, which reads the
+      // wallet. A mutation that landed during the bring-up has already been
+      // answered by `quiesce`; what stops this task is `isTrackingStopRequested`
+      // at the top of every pass, set before the fence released.
+      self.queue.async {
+        var pass = self.runConfirmationTrackingPass(
+          cancellation: cancellation
+        )
+        var taskFailureObserved = false
+        // The pass above already ran, so the activity's progress bar is seeded
+        // from real confirmation counts even if the app is active. Every later
+        // pass is subject to the foreground pause.
+        var hasCompletedInitialQuery = false
+        while true {
+          switch pass {
+          case .batch(let batch):
+            hasCompletedInitialQuery = true
+            taskFailureObserved =
+              taskFailureObserved || batch.hasTaskFailure
+            let notificationSubmitted = self.applyTrackingBatch(
+              batch,
+              task: task
             )
-            return
-          case .finish:
+            taskFailureObserved =
+              taskFailureObserved || !notificationSubmitted
+            switch migrationPreparationTrackingPostBatchAction(
+              batch,
+              taskFailureObserved: taskFailureObserved,
+              stopRequested: self.isTrackingStopRequested
+            ) {
+            case .finishConfirmed(let presentation):
+              // One task tracks one confirmation wave. The next wave cannot
+              // exist until the foreground app syncs and advances the run, so
+              // finish successfully now instead of idling until the OS expires
+              // the task and the expiry reads as a migration failure.
+              self.finishConfirmationTrackingTask(
+                task,
+                taskFailed: false,
+                completionPresentation: presentation
+              )
+              return
+            case .finish:
+              self.finishConfirmationTrackingTask(
+                task,
+                taskFailed: taskFailureObserved,
+                completionPresentation: nil
+              )
+              return
+            case .continueTracking:
+              break
+            }
+            guard self.waitForNextConfirmationQuery(
+              cancellation: cancellation,
+              hasCompletedInitialQuery: hasCompletedInitialQuery
+            ) else {
+              self.finishConfirmationTrackingTask(
+                task,
+                taskFailed: taskFailureObserved,
+                completionPresentation: nil
+              )
+              return
+            }
+            pass = self.runConfirmationTrackingPass(
+              cancellation: cancellation
+            )
+          case .cancelled:
             self.finishConfirmationTrackingTask(
               task,
               taskFailed: taskFailureObserved,
               completionPresentation: nil
             )
             return
-          case .continueTracking:
-            break
-          }
-          guard self.waitForNextConfirmationQuery(
-            cancellation: cancellation,
-            hasCompletedInitialQuery: hasCompletedInitialQuery
-          ) else {
+          case .routeDeferred:
             self.finishConfirmationTrackingTask(
               task,
               taskFailed: taskFailureObserved,
-              completionPresentation: nil
+              completionPresentation: nil,
+              routeDeferred: true
             )
             return
           }
-          pass = self.runConfirmationTrackingPass(
-            cancellation: cancellation
-          )
-        case .cancelled:
-          self.finishConfirmationTrackingTask(
-            task,
-            taskFailed: taskFailureObserved,
-            completionPresentation: nil
-          )
-          return
-        case .routeDeferred:
-          self.finishConfirmationTrackingTask(
-            task,
-            taskFailed: taskFailureObserved,
-            completionPresentation: nil,
-            routeDeferred: true
-          )
-          return
         }
       }
     }
@@ -1957,20 +2029,21 @@ final class BackgroundMigrationPreparationManager {
   /// was armed, and nothing outside the app arms another, so the stand-down
   /// hands that job on. It hands it to the silent processing wake rather than
   /// to another request of this kind, because this kind cannot wait.
-  private func finishTorDeferredTask(_ task: BGContinuedProcessingTask) {
+  ///
+  /// `runtime` is supplied by a caller that has already released the task's
+  /// bookkeeping, because releasing it clears flags this decision is made
+  /// from. Callers that have released nothing pass nothing and this reads the
+  /// flags itself.
+  private func finishTorDeferredTask(
+    _ task: BGContinuedProcessingTask,
+    runtime suppliedRuntime: MigrationPreparationTaskRuntime? = nil
+  ) {
     queue.async { [weak self] in
       guard let self else {
         task.setTaskCompleted(success: false)
         return
       }
-      let runtime = self.stateLock.withPreparationLock {
-        (
-          handedOff: self.foregroundHandoffRequested,
-          expired: self.expired,
-          quiesced: self.mutationQuiesced,
-          disabled: self.notificationAuthorization.isDisabled
-        )
-      }
+      let runtime = suppliedRuntime ?? self.currentTaskRuntime()
       let recoveryEvents: [MigrationPreparationNotificationEvent] =
         runtime.disabled
         ? []
@@ -1978,12 +2051,7 @@ final class BackgroundMigrationPreparationManager {
       let recoveryAlertSubmitted =
         !recoveryEvents.isEmpty
         && self.submitNotificationEvents(recoveryEvents)
-      let deferralAction = migrationPreparationRouteDeferralAction(
-        quiesced: runtime.quiesced,
-        expired: runtime.expired,
-        handedOff: runtime.handedOff,
-        notificationsDisabled: runtime.disabled
-      )
+      let deferralAction = migrationPreparationRouteDeferralAction(runtime)
       // Nothing of this kind is left queued either way. A queued request is
       // started, not held, so it cannot be what waits for the route.
       BGTaskScheduler.shared.cancel(
@@ -2034,16 +2102,104 @@ final class BackgroundMigrationPreparationManager {
     _ task: BGContinuedProcessingTask
   ) {
     stopAuthorizationMonitoring()
+    let runtime = releaseTrackingSlotForStandDown()
+    markForegroundContinuationsReadyForHandoff()
+    finishTorDeferredTask(task, runtime: runtime)
+  }
+
+  /// Releases the bookkeeping this task claimed and reports the wake-scoped
+  /// flags it still held while claiming it.
+  ///
+  /// Read first, clear second, in one lock acquisition, and the two halves are
+  /// deliberately not separable. `foregroundHandoffRequested` is what tells the
+  /// completion that the foreground has taken this run over — the one input
+  /// that turns the deferral into `.none`. A stand-down that cleared it before
+  /// the completion read it could only ever report "nobody owns this", so it
+  /// armed a background wake for a run the foreground was already advancing,
+  /// and when that arming failed it painted a "needs attention" alert over a
+  /// healthy run.
+  ///
+  /// This is reachable, not theoretical: the gate this stand-down comes from
+  /// asks `passIsLive` before the route, so a `handoffToForeground()` landing
+  /// during the tens of seconds of a cold bring-up arrives here with the flag
+  /// set. `finishConfirmationTrackingTask` has always read before it cleared;
+  /// this is the same ordering, made into one operation so a caller cannot
+  /// take only half of it.
+  private func releaseTrackingSlotForStandDown()
+    -> MigrationPreparationTaskRuntime
+  {
     stateLock.withPreparationLock {
+      let runtime = MigrationPreparationTaskRuntime(
+        handedOff: foregroundHandoffRequested,
+        expired: expired,
+        quiesced: mutationQuiesced,
+        disabled: notificationAuthorization.isDisabled
+      )
       taskRunning = false
       taskProgress = nil
       trackingCancellation = nil
       latestTrackingProgress = nil
       foregroundHandoffRequested = false
+      return runtime
     }
-    markForegroundContinuationsReadyForHandoff()
-    finishTorDeferredTask(task)
   }
+
+  private func currentTaskRuntime() -> MigrationPreparationTaskRuntime {
+    stateLock.withPreparationLock {
+      MigrationPreparationTaskRuntime(
+        handedOff: foregroundHandoffRequested,
+        expired: expired,
+        quiesced: mutationQuiesced,
+        disabled: notificationAuthorization.isDisabled
+      )
+    }
+  }
+
+  #if DEBUG || targetEnvironment(simulator)
+    /// What a stand-down handed forward, and what it left behind.
+    struct StandDownProbe {
+      /// The flags the release reported to the completion.
+      let runtime: MigrationPreparationTaskRuntime
+      /// The action the completion takes from them.
+      let action: MigrationPreparationRouteDeferralAction
+      /// `foregroundHandoffRequested` as the release left it. Both halves
+      /// matter: reporting the handoff is what stops a spurious wake, and
+      /// clearing it is what stops the next task inheriting one.
+      let handoffAfterRelease: Bool
+    }
+
+    /// Drives the stand-down's flag handling without a system task.
+    ///
+    /// Sets the wake-scoped flags a running task would hold, then calls the
+    /// production release, and reports what that release handed forward
+    /// together with the deferral action the completion would take from it.
+    /// The point is the ordering inside `releaseTrackingSlotForStandDown`, so
+    /// this must keep calling it rather than re-deriving the answer.
+    func standDownDeferralForTesting(
+      handedOff: Bool,
+      expired: Bool
+    ) -> StandDownProbe {
+      stateLock.withPreparationLock {
+        taskRunning = true
+        foregroundHandoffRequested = handedOff
+        self.expired = expired
+      }
+      let runtime = releaseTrackingSlotForStandDown()
+      let residualHandoff = stateLock.withPreparationLock {
+        foregroundHandoffRequested
+      }
+      stateLock.withPreparationLock {
+        taskRunning = false
+        foregroundHandoffRequested = false
+        self.expired = false
+      }
+      return StandDownProbe(
+        runtime: runtime,
+        action: migrationPreparationRouteDeferralAction(runtime),
+        handoffAfterRelease: residualHandoff
+      )
+    }
+  #endif
 
   private func finishForegroundOnlyTask(
     _ task: BGContinuedProcessingTask

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -319,6 +319,10 @@ func migrationPreparationTrackingBatch(
 private enum BackgroundMigrationPreparationTrackingPass {
   case batch(MigrationPreparationTrackingBatch)
   case cancelled
+  /// The pass stood down because this device stopped being able to afford the
+  /// saved route. The wave is untouched and still needs watching, so this ends
+  /// the task as an interruption rather than as a run that finished.
+  case routeDeferred
 }
 
 private enum BackgroundMigrationPreparationStepResult {
@@ -722,18 +726,24 @@ func migrationPreparationTrackingTaskSucceeded(
 
 /// Whether the manager should submit a replacement tracking request.
 ///
-/// A mid-wave expiry (or a failed completion) still has confirmations left to
-/// observe, so it re-arms. A clean wave-confirm success does not: there is
-/// nothing left for a read-only task to watch, and the foreground app submits
-/// the next wave's task after it syncs and advances the run.
+/// A mid-wave expiry, a mid-wave stand-down because the device stopped being
+/// able to afford the saved route, and a failed completion all leave
+/// confirmations still to observe, so each re-arms. Losing a charger or moving
+/// onto a metered link interrupts one execution opportunity exactly the way the
+/// OS reclaiming the slot does; neither is a verdict on the run.
+///
+/// A clean wave-confirm success does not re-arm: there is nothing left for a
+/// read-only task to watch, and the foreground app submits the next wave's task
+/// after it syncs and advances the run.
 func migrationPreparationTrackingShouldAttemptRearm(
   completionFailed: Bool,
   quiesced: Bool,
   expired: Bool,
+  routeDeferred: Bool,
   handedOff: Bool,
   notificationsDisabled: Bool
 ) -> Bool {
-  (completionFailed || expired) && !quiesced && !handedOff
+  (completionFailed || expired || routeDeferred) && !quiesced && !handedOff
     && !notificationsDisabled
 }
 
@@ -1734,6 +1744,14 @@ final class BackgroundMigrationPreparationManager {
             completionPresentation: nil
           )
           return
+        case .routeDeferred:
+          self.finishConfirmationTrackingTask(
+            task,
+            taskFailed: taskFailureObserved,
+            completionPresentation: nil,
+            routeDeferred: true
+          )
+          return
         }
       }
     }
@@ -1849,8 +1867,19 @@ final class BackgroundMigrationPreparationManager {
     // roughly 500 B/s while awake, so a task that keeps querying past that
     // moment is spending exactly what this policy exists to avoid. Tor itself
     // is already up by now, so a passing check costs a power and path sample.
+    //
+    // The two ways this refuses end differently. With Tor up in this process
+    // the refusal is affordability, the interruption this task can be re-armed
+    // out of: the replacement is gated by the same power and path question, so
+    // it is only submitted once the device can carry the route again, and the
+    // task it starts finds Tor already up instead of paying a bootstrap. With
+    // Tor not up, the user flipped the route from the foreground while this
+    // task ran; that app already owns the run, and re-arming would send wake
+    // after wake into a bootstrap this process has no reason to attempt.
     guard BackgroundNetworkRoute.allowsBackgroundNetworkWork() else {
-      return .cancelled
+      return BackgroundNetworkRoute.backgroundNetworkWorkRemainsAllowed
+        ? .routeDeferred
+        : .cancelled
     }
     guard UIApplication.shared.isProtectedDataAvailable else {
       return .batch(
@@ -2304,7 +2333,8 @@ final class BackgroundMigrationPreparationManager {
   private func finishConfirmationTrackingTask(
     _ task: BGContinuedProcessingTask,
     taskFailed: Bool,
-    completionPresentation: MigrationPreparationTrackingCompletionPresentation?
+    completionPresentation: MigrationPreparationTrackingCompletionPresentation?,
+    routeDeferred: Bool = false
   ) {
     stopAuthorizationMonitoring()
     let runtime = stateLock.withPreparationLock {
@@ -2342,10 +2372,13 @@ final class BackgroundMigrationPreparationManager {
         visibleCompletionPresentation.title,
         subtitle: visibleCompletionPresentation.subtitle
       )
-    } else if runtime.expired && !runtime.quiesced {
+    } else if (runtime.expired || routeDeferred) && !runtime.quiesced {
       // The activity is still captioned "Checking transaction confirmations".
-      // The OS reclaimed this execution slot mid-wave; say that instead of
-      // leaving a caption that implies counting is still happening.
+      // Whether the OS reclaimed this execution slot or the device stopped
+      // being able to carry the route, counting has stopped mid-wave; say so
+      // instead of leaving a caption that implies it is still happening. A
+      // replacement that does get armed replaces this caption with its own,
+      // and when none can be, reopening the app is what resumes the run.
       task.updateTitle(
         "Preparation tracking paused",
         subtitle: "Open Vizor to resume"
@@ -2375,10 +2408,11 @@ final class BackgroundMigrationPreparationManager {
       handedOff: runtime.handedOff,
       notificationsDisabled: runtime.disabled
     )
-    // A mid-wave expiry now completes successfully, but it still has
-    // confirmations left to observe and re-arms below. Cancelling the pending
-    // request here would delete the very submission that re-arm depends on.
-    if success && !runtime.expired {
+    // A mid-wave expiry, and a mid-wave stand-down for the route, both complete
+    // successfully but still have confirmations left to observe and re-arm
+    // below. Cancelling the pending request here would delete the very
+    // submission that re-arm depends on.
+    if success && !runtime.expired && !routeDeferred {
       BGTaskScheduler.shared.cancel(
         taskRequestWithIdentifier: Self.taskIdentifier
       )
@@ -2391,6 +2425,8 @@ final class BackgroundMigrationPreparationManager {
       recordSchedulingState("disabled_for_notifications")
     } else if runtime.expired {
       recordSchedulingState("confirmation_tracking_expired")
+    } else if routeDeferred {
+      recordSchedulingState("confirmation_tracking_route_paused")
     } else if completionFailed {
       recordSchedulingState("confirmation_tracking_failed")
     } else if visibleCompletionPresentation != nil {
@@ -2402,6 +2438,7 @@ final class BackgroundMigrationPreparationManager {
       completionFailed: completionFailed,
       quiesced: runtime.quiesced,
       expired: runtime.expired,
+      routeDeferred: routeDeferred,
       handedOff: runtime.handedOff,
       notificationsDisabled: runtime.disabled
     ) else {

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -747,6 +747,45 @@ func migrationPreparationTrackingShouldAttemptRearm(
     && !notificationsDisabled
 }
 
+enum MigrationPreparationRouteDeferralAction: Equatable {
+  case none
+  case waitOnProcessingWake
+}
+
+/// What a tracking task that stood down for the saved route leaves behind.
+///
+/// Never another continued-processing request. That request type has no usable
+/// start floor — the scheduler substitutes `NSDate.now` for
+/// `earliestBeginDate` and starts the work immediately or shortly after
+/// submission — so arming one to wait for a charger starts it on the same
+/// battery, where it stands down and asks for another. Each turn of that is a
+/// user-visible activity, and none of them is a pause.
+///
+/// The silent processing request is the one that honours a start floor, and
+/// the system runs it when the device is idle on power, which is when this
+/// route becomes affordable again. So the wait goes there, and the wake that
+/// lands on a device that can carry the route is what arms tracking again.
+///
+/// A run that already has an owner — the foreground app, a wallet mutation, a
+/// revoked notification permission — leaves nothing behind at all.
+func migrationPreparationRouteDeferralAction(
+  quiesced: Bool,
+  expired: Bool,
+  handedOff: Bool,
+  notificationsDisabled: Bool
+) -> MigrationPreparationRouteDeferralAction {
+  migrationPreparationTrackingShouldAttemptRearm(
+    completionFailed: false,
+    quiesced: quiesced,
+    expired: expired,
+    routeDeferred: true,
+    handedOff: handedOff,
+    notificationsDisabled: notificationsDisabled
+  )
+    ? .waitOnProcessingWake
+    : .none
+}
+
 func shouldMarkMigrationPreparationForegroundContinuation(
   hasPendingRequest: Bool,
   hasBoundPreparation: Bool,
@@ -1257,25 +1296,50 @@ final class BackgroundMigrationPreparationManager {
     completion: @escaping (Bool) -> Void
   ) {
     // On a Tor route this task can only run when the device is on external
-    // power over an unmetered link. Arming it otherwise produces a task that
-    // wakes, declines every query, and leaves a live activity claiming it is
-    // checking confirmations. Declare the route so this process is fail-closed
-    // and let the foreground carry the run, the same way an otherwise
-    // foreground-only resume target is handled below.
+    // power over an unmetered link. Declare the route so this process is
+    // fail-closed, and when the device cannot carry it, do not submit: the
+    // request would be started immediately on the same battery, decline every
+    // query, and leave a live activity claiming it is checking confirmations.
+    //
+    // Submitting anyway is not a way to wait for that to change.
+    // `BGContinuedProcessingTaskRequest` carries no power or network
+    // constraint, and the scheduler substitutes `NSDate.now` for any
+    // `earliestBeginDate` it is given, so submission is a start rather than a
+    // schedule. The wait belongs to the request type that can hold one, and
+    // the launch-time gate stays authoritative for whether any work happens.
     //
     // Only the affordability question is asked here. Submission does no network
     // work, so nothing should pay for a bootstrap before the task that needs
-    // one has actually started. `BGContinuedProcessingTaskRequest` carries no
-    // power or network constraint of its own, so this check is what stands in
-    // for one — the system starts these requests promptly after submission, so
-    // the conditions measured here are the conditions the task runs under.
+    // one has actually started.
     guard BackgroundNetworkRoute.allowsBackgroundNetworkPass() else {
       BGTaskScheduler.shared.cancel(
         taskRequestWithIdentifier: Self.taskIdentifier
       )
-      recordSchedulingState("foreground_only_tor_route")
-      cancelWatchdog()
-      completion(false)
+      // Submission has no task runtime behind it, so the only owners that can
+      // already hold this run are a wallet mutation and a revoked notification
+      // permission. Both cover the wait themselves, and a wake asked for while
+      // the wallet is mutating is refused and would announce that refusal.
+      let deferralAction = stateLock.withPreparationLock {
+        migrationPreparationRouteDeferralAction(
+          quiesced: mutationQuiesced,
+          expired: false,
+          handedOff: false,
+          notificationsDisabled: notificationAuthorization.isDisabled
+        )
+      }
+      guard deferralAction == .waitOnProcessingWake else {
+        recordSchedulingState("foreground_only_tor_route")
+        cancelWatchdog()
+        completion(false)
+        return
+      }
+      // The watchdog registered for the request this replaces stays: nothing
+      // is armed yet, and it is the boundary if the wake below never lands.
+      deferRouteWaitToProcessingWake { _ in
+        // No tracking task exists, so the run keeps its foreground-only
+        // presentation until the wake that can carry the route arms one.
+        completion(false)
+      }
       return
     }
     pruneForegroundContinuationScopes()
@@ -1541,6 +1605,41 @@ final class BackgroundMigrationPreparationManager {
     postNeedsActionNotification(reason: "processing-reschedule-failed")
   }
 
+  /// Places a wait for the saved route to become carriable on the request type
+  /// that can hold one.
+  ///
+  /// The silent processing request honours a start floor, and the system runs
+  /// it when the device is idle on external power — the same conditions that
+  /// make a Tor route affordable. That wake re-checks the route and arms
+  /// tracking once it can carry it, so a wave paused for the route resumes
+  /// without the user opening the app.
+  ///
+  /// The floor is the outbox's own rolling cadence rather than a longer guess
+  /// at when a charger appears: the system reads it as "no earlier than", and
+  /// a longer one would only push the wake past the moment the device plugs in.
+  ///
+  /// A wake that cannot be scheduled at all is the one outcome the user has to
+  /// hear about, and it announces itself the way every other failed
+  /// preparation handoff does.
+  private func deferRouteWaitToProcessingWake(
+    completion: @escaping (Bool) -> Void
+  ) {
+    BackgroundMigrationManager.shared.schedulePreparationHandoff(
+      after: BackgroundMigrationOutboxCadence.rollingCheckInterval
+    ) { [weak self] scheduled in
+      guard let self else {
+        completion(scheduled)
+        return
+      }
+      if scheduled {
+        self.recordSchedulingState("route_paused_awaiting_processing_wake")
+      } else {
+        self.recordDeferredSchedulingFailure()
+      }
+      completion(scheduled)
+    }
+  }
+
   private func handle(_ task: BGContinuedProcessingTask) {
     let authorizationEpoch = captureNotificationAuthorizationEpoch()
     IronwoodMigrationNotificationGate.shared.status { [weak self] status in
@@ -1768,11 +1867,11 @@ final class BackgroundMigrationPreparationManager {
   /// until then. Runs that need foreground recovery for their own reasons still
   /// send their existing alerts.
   ///
-  /// "Resume by itself" is only true while a request exists to resume with.
-  /// Starting this task consumed the one that was armed, and nothing outside
-  /// the app arms another, so the stand-down submits a replacement on exactly
-  /// the terms a mid-wave stand-down does: the wave is unchanged, still has
-  /// confirmations left to observe, and lost one execution opportunity.
+  /// "Resume by itself" is only true while something is left that can notice
+  /// the device becoming eligible. Starting this task consumed the request that
+  /// was armed, and nothing outside the app arms another, so the stand-down
+  /// hands that job on. It hands it to the silent processing wake rather than
+  /// to another request of this kind, because this kind cannot wait.
   private func finishTorDeferredTask(_ task: BGContinuedProcessingTask) {
     queue.async { [weak self] in
       guard let self else {
@@ -1794,37 +1893,31 @@ final class BackgroundMigrationPreparationManager {
       let recoveryAlertSubmitted =
         !recoveryEvents.isEmpty
         && self.submitNotificationEvents(recoveryEvents)
-      let shouldRearm = migrationPreparationTrackingShouldAttemptRearm(
-        completionFailed: false,
+      let deferralAction = migrationPreparationRouteDeferralAction(
         quiesced: runtime.quiesced,
         expired: runtime.expired,
-        routeDeferred: true,
         handedOff: runtime.handedOff,
         notificationsDisabled: runtime.disabled
       )
-      if !shouldRearm {
-        BGTaskScheduler.shared.cancel(
-          taskRequestWithIdentifier: Self.taskIdentifier
-        )
-      }
-      self.recordSchedulingState(
-        shouldRearm
-          ? "route_paused_rearming"
-          : "waiting_for_foreground_tor_route"
+      // Nothing of this kind is left queued either way. A queued request is
+      // started, not held, so it cannot be what waits for the route.
+      BGTaskScheduler.shared.cancel(
+        taskRequestWithIdentifier: Self.taskIdentifier
       )
       // With no recovery alert delivered, the watchdog registered for this
       // request is the only remaining prompt to reopen Vizor, so it stays.
       if recoveryAlertSubmitted {
         self.cancelWatchdog()
       }
-      guard shouldRearm else {
+      guard deferralAction == .waitOnProcessingWake else {
+        self.recordSchedulingState("waiting_for_foreground_tor_route")
         task.setTaskCompleted(success: true)
         return
       }
-      // Submit the replacement BEFORE completing. `start` is asynchronous, and
+      // Arrange the wait BEFORE completing. The handoff is asynchronous, and
       // once `setTaskCompleted` returns iOS may suspend the process before the
-      // submission runs, which leaves the wave with no armed task at all — the
-      // state this path exists to avoid.
+      // submission runs, which leaves nothing at all watching for the device to
+      // become eligible — the state this path exists to avoid.
       let latch = MigrationPreparationCompletionLatch()
       let complete = {
         guard latch.claim() else { return }
@@ -1834,15 +1927,9 @@ final class BackgroundMigrationPreparationManager {
       self.queue.asyncAfter(deadline: .now() + Self.rearmSubmissionTimeout) {
         complete()
       }
-      self.start { rearmed in
-        if !rearmed {
-          print("[BGPreparation] route-deferred task could not re-arm tracking")
-          // A refused submission takes the watchdog down with it, since the two
-          // share one notification identifier. Without a delivered alert that
-          // leaves no prompt at all, so put the boundary back.
-          if !recoveryAlertSubmitted {
-            self.scheduleWatchdog()
-          }
+      self.deferRouteWaitToProcessingWake { scheduled in
+        if !scheduled {
+          print("[BGPreparation] route-deferred task could not place its wait")
         }
         complete()
       }

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -817,6 +817,24 @@ func migrationPreparationRearmFallbackAction(
   )
 }
 
+/// Whether a launching task should stop instead of claiming the tracking slot.
+///
+/// The launch-time inspections between the route gate and the claim are
+/// blocking, and the claim is immediately followed by the bring-up, which holds
+/// the task for as long as a cold bootstrap takes. So the stop flags are read
+/// once more here, before the claim, rather than only inside the tracking loop
+/// on the far side of that bring-up.
+///
+/// A task another run already owns is not this one's to end: it falls through
+/// to the ordinary claim refusal, which leaves the running task's bookkeeping
+/// alone.
+func migrationPreparationLaunchShouldStopBeforeClaiming(
+  stopRequested: Bool,
+  taskAlreadyRunning: Bool
+) -> Bool {
+  stopRequested && !taskAlreadyRunning
+}
+
 func shouldMarkMigrationPreparationForegroundContinuation(
   hasPendingRequest: Bool,
   hasBoundPreparation: Bool,
@@ -1342,7 +1360,9 @@ final class BackgroundMigrationPreparationManager {
     // Only the affordability question is asked here. Submission does no network
     // work, so nothing should pay for a bootstrap before the task that needs
     // one has actually started.
-    guard BackgroundNetworkRoute.allowsBackgroundNetworkPass() else {
+    guard BackgroundNetworkRoute.allowsBackgroundNetworkPass(
+      while: { !self.isSubmissionOwnedElsewhere }
+    ) else {
       BGTaskScheduler.shared.cancel(
         taskRequestWithIdentifier: Self.taskIdentifier
       )
@@ -1730,7 +1750,9 @@ final class BackgroundMigrationPreparationManager {
     // confirmation-trackable run here keeps `pendingTrackableScopes` empty long
     // after the device is plugged back in, so no launch re-arms it and it stays
     // parked until the user opens its migration screen.
-    guard BackgroundNetworkRoute.allowsBackgroundNetworkPass() else {
+    guard BackgroundNetworkRoute.allowsBackgroundNetworkPass(
+      while: { !self.isTaskEndedByOwner }
+    ) else {
       markForegroundContinuationsReadyForHandoff()
       finishTorDeferredTask(task)
       return
@@ -1773,6 +1795,26 @@ final class BackgroundMigrationPreparationManager {
       task.setTaskCompleted(success: true)
       return
     }
+    if migrationPreparationLaunchShouldStopBeforeClaiming(
+      stopRequested: isTaskEndedByOwner,
+      taskAlreadyRunning: stateLock.withPreparationLock({ taskRunning })
+    ) {
+      // Ends through the completion the tracking loop uses, so an expiry that
+      // landed during the gates above still re-arms and an owner still does
+      // not.
+      queue.async { [weak self] in
+        guard let self else {
+          task.setTaskCompleted(success: true)
+          return
+        }
+        self.finishConfirmationTrackingTask(
+          task,
+          taskFailed: false,
+          completionPresentation: nil
+        )
+      }
+      return
+    }
     let cancellation = BackgroundMigrationCancellation()
     let mayRun = stateLock.withPreparationLock { () -> Bool in
       guard !mutationQuiesced
@@ -1813,7 +1855,9 @@ final class BackgroundMigrationPreparationManager {
       // come up ready — or a device unplugged since the gate above — ends the
       // task exactly the way that gate does: fail-closed, no network work, and
       // the run left to the foreground.
-      guard BackgroundNetworkRoute.allowsBackgroundNetworkWork() else {
+      guard BackgroundNetworkRoute.allowsBackgroundNetworkWork(
+        while: { !self.isTaskEndedByOwner }
+      ) else {
         self.standDownForUnavailableTorRoute(task)
         return
       }
@@ -2064,7 +2108,13 @@ final class BackgroundMigrationPreparationManager {
     // Tor not up, the user flipped the route from the foreground while this
     // task ran; that app already owns the run, and re-arming would send wake
     // after wake into a bootstrap this process has no reason to attempt.
-    guard BackgroundNetworkRoute.allowsBackgroundNetworkWork() else {
+    guard BackgroundNetworkRoute.allowsBackgroundNetworkWork(
+      while: { !self.isTaskEndedByOwner }
+    ) else {
+      // An owner that appeared while the sample above ran ends the pass rather
+      // than pausing it for the route; only the route question produces a
+      // deferral the manager can re-arm out of.
+      if isTaskEndedByOwner { return .cancelled }
       return BackgroundNetworkRoute.backgroundNetworkWorkRemainsAllowed
         ? .routeDeferred
         : .cancelled
@@ -2723,6 +2773,30 @@ final class BackgroundMigrationPreparationManager {
     monitor?.cancel()
   }
 
+  /// The flags an owner sets to end a task run, without the route question.
+  ///
+  /// This is what a gate is asked before it spends anything. The route half of
+  /// [`isTrackingStopRequested`] cannot serve there: a task that has not yet
+  /// brought Tor up reads as "route stopped" by construction, which is the
+  /// normal state of every task at launch.
+  private var isTaskEndedByOwner: Bool {
+    stateLock.withPreparationLock {
+      expired || foregroundHandoffRequested || mutationQuiesced
+        || notificationAuthorization.isDisabled
+    }
+  }
+
+  /// The owners that make a submission pointless.
+  ///
+  /// Narrower than [`isTaskEndedByOwner`] on purpose: `expired` and a foreground
+  /// handoff describe a task run and outlive it, and a submission asked for
+  /// outside one must not inherit them.
+  private var isSubmissionOwnedElsewhere: Bool {
+    stateLock.withPreparationLock {
+      mutationQuiesced || notificationAuthorization.isDisabled
+    }
+  }
+
   private var isTrackingStopRequested: Bool {
     // Only the foreground app writes the route preference, so finding Tor set
     // in a process that never brought Tor up means the user flipped it while
@@ -2736,10 +2810,7 @@ final class BackgroundMigrationPreparationManager {
     if !BackgroundNetworkRoute.backgroundNetworkWorkRemainsAllowed {
       return true
     }
-    return stateLock.withPreparationLock {
-      expired || foregroundHandoffRequested || mutationQuiesced
-        || notificationAuthorization.isDisabled
-    }
+    return isTaskEndedByOwner
   }
 
   func hasResumablePreparation() -> Bool {

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -1246,6 +1246,28 @@ final class BackgroundMigrationPreparationManager {
     authorizationEpoch: UInt64,
     completion: @escaping (Bool) -> Void
   ) {
+    // On a Tor route this task can only run when the device is on external
+    // power over an unmetered link. Arming it otherwise produces a task that
+    // wakes, declines every query, and leaves a live activity claiming it is
+    // checking confirmations. Declare the route so this process is fail-closed
+    // and let the foreground carry the run, the same way an otherwise
+    // foreground-only resume target is handled below.
+    //
+    // Only the affordability question is asked here. Submission does no network
+    // work, so nothing should pay for a bootstrap before the task that needs
+    // one has actually started. `BGContinuedProcessingTaskRequest` carries no
+    // power or network constraint of its own, so this check is what stands in
+    // for one — the system starts these requests promptly after submission, so
+    // the conditions measured here are the conditions the task runs under.
+    guard BackgroundNetworkRoute.allowsBackgroundNetworkPass() else {
+      BGTaskScheduler.shared.cancel(
+        taskRequestWithIdentifier: Self.taskIdentifier
+      )
+      recordSchedulingState("foreground_only_tor_route")
+      cancelWatchdog()
+      completion(false)
+      return
+    }
     pruneForegroundContinuationScopes()
     switch migrationPreparationContinuedTaskDisposition(
       preparationResumeTarget()
@@ -1533,6 +1555,27 @@ final class BackgroundMigrationPreparationManager {
     stateLock.withPreparationLock {
       submissionInFlight = false
     }
+    // A request armed before the user chose Tor, or before they unplugged the
+    // device, can still be started, and this process may be a cold background
+    // launch where Dart never applied the route. Declare it before the first
+    // inspection so any path that still reaches for lightwalletd fails closed,
+    // and stand down unless this device can afford Tor right now.
+    //
+    // The bootstrap itself is deliberately not here: the inspections below can
+    // still find that no run needs tracking, and nothing should spend 8.45 MB
+    // and 23.7 s to discover that. Tor comes up once this task is known to be
+    // one that queries.
+    //
+    // Record only the runs that need the foreground for their own reasons. The
+    // recorded set is durable and outlives the deferral: parking a
+    // confirmation-trackable run here keeps `pendingTrackableScopes` empty long
+    // after the device is plugged back in, so no launch re-arms it and it stays
+    // parked until the user opens its migration screen.
+    guard BackgroundNetworkRoute.allowsBackgroundNetworkPass() else {
+      markForegroundContinuationsReadyForHandoff()
+      finishTorDeferredTask(task)
+      return
+    }
     let disposition = migrationPreparationContinuedTaskDisposition(
       preparationResumeTarget()
     )
@@ -1613,6 +1656,17 @@ final class BackgroundMigrationPreparationManager {
         task.setTaskCompleted(success: false)
         return
       }
+      // Tor before the first query. A cold bootstrap blocks for tens of
+      // seconds, so it runs here on this manager's own queue rather than on the
+      // notification-gate callback that delivered this task. A direct route
+      // passes straight through and bootstraps nothing. A client that does not
+      // come up ready — or a device unplugged since the gate above — ends the
+      // task exactly the way that gate does: fail-closed, no network work, and
+      // the run left to the foreground.
+      guard BackgroundNetworkRoute.allowsBackgroundNetworkWork() else {
+        self.standDownForUnavailableTorRoute(task)
+        return
+      }
       var pass = self.runConfirmationTrackingPass(
         cancellation: cancellation
       )
@@ -1685,6 +1739,69 @@ final class BackgroundMigrationPreparationManager {
     }
   }
 
+  /// Completes a launched task whose runs must wait for the foreground because
+  /// the saved route is Tor and this pass cannot carry it — the device is on
+  /// battery, the link is metered or constrained, or Tor did not come up.
+  ///
+  /// The deferral is policy rather than failure, so the task reports success
+  /// and posts no alert for it. An alert would say "open Vizor" about a run
+  /// that is fine and will resume by itself the next time the device is on a
+  /// charger over an unmetered link, and it would say it again on every wake
+  /// until then. Runs that need foreground recovery for their own reasons still
+  /// send their existing alerts.
+  private func finishTorDeferredTask(_ task: BGContinuedProcessingTask) {
+    queue.async { [weak self] in
+      guard let self else {
+        task.setTaskCompleted(success: false)
+        return
+      }
+      let notificationsDisabled = self.stateLock.withPreparationLock {
+        self.notificationAuthorization.isDisabled
+      }
+      let recoveryEvents: [MigrationPreparationNotificationEvent] =
+        notificationsDisabled
+        ? []
+        : self.foregroundRecoveryNotificationEvents()
+      let recoveryAlertSubmitted =
+        !recoveryEvents.isEmpty
+        && self.submitNotificationEvents(recoveryEvents)
+      BGTaskScheduler.shared.cancel(
+        taskRequestWithIdentifier: Self.taskIdentifier
+      )
+      self.recordSchedulingState("waiting_for_foreground_tor_route")
+      // With no recovery alert delivered, the watchdog registered for this
+      // request is the only remaining prompt to reopen Vizor, so it stays.
+      if recoveryAlertSubmitted {
+        self.cancelWatchdog()
+      }
+      task.setTaskCompleted(success: true)
+    }
+  }
+
+  /// Stands a task down that had already claimed the tracking slot before Tor
+  /// turned out not to be available to it.
+  ///
+  /// Ends exactly where the gate that refuses a pass outright ends. Only the
+  /// bookkeeping this task itself claimed is released. The runs it was about to
+  /// track are handed off through the narrow path, which records just the ones
+  /// that need the foreground for reasons of their own: a run that is merely
+  /// mid-wave must stay re-armable, or nothing re-arms it until the user opens
+  /// its migration screen.
+  private func standDownForUnavailableTorRoute(
+    _ task: BGContinuedProcessingTask
+  ) {
+    stopAuthorizationMonitoring()
+    stateLock.withPreparationLock {
+      taskRunning = false
+      taskProgress = nil
+      trackingCancellation = nil
+      latestTrackingProgress = nil
+      foregroundHandoffRequested = false
+    }
+    markForegroundContinuationsReadyForHandoff()
+    finishTorDeferredTask(task)
+  }
+
   private func finishForegroundOnlyTask(
     _ task: BGContinuedProcessingTask
   ) {
@@ -1724,6 +1841,17 @@ final class BackgroundMigrationPreparationManager {
     cancellation: BackgroundMigrationCancellation
   ) -> BackgroundMigrationPreparationTrackingPass {
     if cancellation.isCancelled { return .cancelled }
+    // The last gate in front of the lightwalletd queries below, re-evaluated
+    // before every round rather than once at launch. The route can become Tor
+    // after this task started, and the conditions that made a Tor route
+    // affordable can end at any point: a charger comes out, or Wi-Fi drops to
+    // cellular. A bootstrapped client keeps padding its guard connection at
+    // roughly 500 B/s while awake, so a task that keeps querying past that
+    // moment is spending exactly what this policy exists to avoid. Tor itself
+    // is already up by now, so a passing check costs a power and path sample.
+    guard BackgroundNetworkRoute.allowsBackgroundNetworkWork() else {
+      return .cancelled
+    }
     guard UIApplication.shared.isProtectedDataAvailable else {
       return .batch(
         migrationPreparationTrackingBatch(
@@ -2335,7 +2463,19 @@ final class BackgroundMigrationPreparationManager {
   }
 
   private var isTrackingStopRequested: Bool {
-    stateLock.withPreparationLock {
+    // Only the foreground app writes the route preference, so finding Tor set
+    // in a process that never brought Tor up means the user flipped it while
+    // this task was running: the foreground status poll and sync already own
+    // the run, this process has no Tor transport, and its remaining queries
+    // must not go out. A task that came up on Tor legitimately keeps running
+    // and is stopped instead by the affordability check in front of each round
+    // of queries. Reading without declaring keeps this side-effect free — and
+    // cheap enough for the heartbeat that polls it — while the pass itself
+    // declares the route before it would query.
+    if !BackgroundNetworkRoute.backgroundNetworkWorkRemainsAllowed {
+      return true
+    }
+    return stateLock.withPreparationLock {
       expired || foregroundHandoffRequested || mutationQuiesced
         || notificationAuthorization.isDisabled
     }

--- a/ios/Runner/NativeLightwalletdClient.swift
+++ b/ios/Runner/NativeLightwalletdClient.swift
@@ -287,13 +287,34 @@ enum BackgroundNetworkRoute {
     return torIsUpForBackgroundWork
   }
 
+  /// The arti directory, created and marked before anything writes to it.
+  ///
+  /// Arti's directory records which guards this wallet chose, and Application
+  /// Support is backed up, so a restore would carry that choice to a second
+  /// device. Dart marks it when the foreground brings Tor up, but a cold
+  /// background launch has no Dart: whatever this pass bootstraps would be the
+  /// first thing in the directory and would go into the backup unmarked.
+  ///
+  /// Marking is best-effort. Failing to set the attribute is a weaker backup
+  /// posture, not a reason to leave a migration unbroadcast, so the bootstrap
+  /// proceeds either way.
   private static func torDataDirectoryPath() -> String? {
     guard let supportDirectory = try? resolveWalletSupportDirectory() else {
       return nil
     }
-    return supportDirectory
-      .appendingPathComponent(torDirectoryName)
-      .path
+    var directory = supportDirectory.appendingPathComponent(torDirectoryName)
+    do {
+      try FileManager.default.createDirectory(
+        at: directory,
+        withIntermediateDirectories: true
+      )
+      var values = URLResourceValues()
+      values.isExcludedFromBackup = true
+      try directory.setResourceValues(values)
+    } catch {
+      print("[BGMigration] tor directory exclude failed: \(error)")
+    }
+    return directory.path
   }
 }
 

--- a/ios/Runner/NativeLightwalletdClient.swift
+++ b/ios/Runner/NativeLightwalletdClient.swift
@@ -1,4 +1,278 @@
 import Foundation
+import Network
+import UIKit
+
+/// Where the device's power comes from, as far as a background pass can tell.
+enum BackgroundPowerSupply {
+  case external
+  case battery
+  /// The device has not reported a battery state yet. Read as "not on a
+  /// charger": a pass that cannot tell has not established anything.
+  case unknown
+}
+
+/// Whether the current network path charges for its bytes, as far as a
+/// background pass can tell.
+enum BackgroundNetworkMetering {
+  case unmetered
+  case metered
+  /// No path has been reported yet, or there is no usable path at all. Read as
+  /// "not known to be free": a pass that cannot tell has not established
+  /// anything.
+  case unknown
+}
+
+/// The route the user saved for wallet traffic, readable from a process that
+/// never ran Dart, plus the conditions under which a background pass may carry
+/// that route.
+///
+/// The route Rust honours is process-local and starts at direct, so a
+/// background launch into a cold process would reach lightwalletd over
+/// clearnet whatever the user chose. Every background pass therefore declares
+/// the saved route before its first native call.
+///
+/// A declared Tor route is not free to run, so declaring it is not enough.
+/// Measured on this stack: a cold bootstrap moves 8.45 MB down and 744 KB up
+/// over 23.7 s and leaves a 46.3 MB cache; a warm one costs 0.64 s and no
+/// bytes; and a bootstrapped client keeps padding its guard connection at
+/// roughly 500 B/s while awake and 27 B/s while dormant. On external power over
+/// an unmetered link those costs are acceptable. On battery, or over a metered
+/// or constrained link, they are not — that pass does no network work and
+/// defers to the foreground, which is what every pass used to do.
+enum BackgroundNetworkRoute {
+  /// `shared_preferences` stores Dart values in `UserDefaults.standard` behind
+  /// a `flutter.` prefix; the suffix is `kTorEnabledPreferenceKey` in
+  /// `lib/src/providers/network_privacy_provider.dart`.
+  private static let torEnabledKey = "flutter.zcash_tor_enabled"
+
+  /// Same directory Dart passes to the foreground toggle: the app's
+  /// Application Support directory plus `tor`. Arti keeps its guard state and
+  /// directory cache there, so a background bootstrap that used a different
+  /// path would pick fresh guards and re-download the 46.3 MB cache instead of
+  /// warming the one the foreground already paid for.
+  private static let torDirectoryName = "tor"
+
+  /// `UIDevice` answers `.unknown` for a moment after battery monitoring is
+  /// switched on. Bounded so a gate never stalls on a device that simply has
+  /// nothing to report.
+  private static let batteryStateReadAttempts = 10
+  private static let batteryStateReadRetryInterval: TimeInterval = 0.05
+
+  /// `NWPathMonitor` reports the current path almost immediately; this only
+  /// bounds the wait for a first report that never arrives.
+  private static let meteringSampleTimeout: TimeInterval = 1
+
+  private static let torStateLock = NSLock()
+  private static var torIsUpForBackgroundWork = false
+
+  /// Whether the saved route is Tor. A missing value — never chosen, or
+  /// cleared by a wallet reset — reads as direct, matching the Dart default.
+  static var persistedRouteIsTor: Bool {
+    UserDefaults.standard.bool(forKey: torEnabledKey)
+  }
+
+  /// Whether a background pass on a Tor route can afford to run right now.
+  ///
+  /// Both inputs fail closed while unknown. A wake that cannot yet tell where
+  /// its power or its bytes come from has not established that it may spend
+  /// either, and the cost of guessing wrong is a bootstrap on cellular or on
+  /// battery.
+  static func torBackgroundWorkIsAffordable(
+    power: BackgroundPowerSupply,
+    metering: BackgroundNetworkMetering
+  ) -> Bool {
+    power == .external && metering == .unmetered
+  }
+
+  /// The Tor half of the gate, written once so both entry points and the tests
+  /// agree on what the policy is.
+  ///
+  /// `bringTorUp` is evaluated only after affordability holds: a pass that
+  /// cannot afford Tor must not spend 8.45 MB and 23.7 s discovering that it
+  /// could not. A bring-up that does not report ready is a deferral like any
+  /// other, never a reason to reach lightwalletd some other way.
+  static func torBackgroundPassMayProceed(
+    power: BackgroundPowerSupply,
+    metering: BackgroundNetworkMetering,
+    bringTorUp: () -> Bool
+  ) -> Bool {
+    guard torBackgroundWorkIsAffordable(power: power, metering: metering) else {
+      return false
+    }
+    return bringTorUp()
+  }
+
+  /// `batteryState` is `.unknown` until battery monitoring is enabled, so
+  /// `AppDelegate` turns it on at launch — including the launch a background
+  /// task causes. Enabling here as well keeps the gate honest if it is ever
+  /// reached first, and the retry covers the moment before the first report
+  /// lands rather than letting a startable pass read `.unknown` and defer.
+  static func currentPowerSupply() -> BackgroundPowerSupply {
+    let device = UIDevice.current
+    if !device.isBatteryMonitoringEnabled {
+      device.isBatteryMonitoringEnabled = true
+    }
+    for attempt in 0..<batteryStateReadAttempts {
+      switch device.batteryState {
+      case .charging, .full:
+        return .external
+      case .unplugged:
+        return .battery
+      default:
+        break
+      }
+      if attempt < batteryStateReadAttempts - 1 {
+        Thread.sleep(forTimeInterval: batteryStateReadRetryInterval)
+      }
+    }
+    return .unknown
+  }
+
+  /// `isExpensive` covers cellular and personal hotspots, `isConstrained`
+  /// covers Low Data Mode. Either one means the user is paying for these bytes
+  /// in money or in an allowance they asked us to respect, and a Tor bootstrap
+  /// is megabytes.
+  ///
+  /// A path that is not satisfied reports `unknown` rather than `unmetered`:
+  /// there is nothing to measure, and no pass should proceed on it.
+  static func currentNetworkMetering() -> BackgroundNetworkMetering {
+    let monitor = NWPathMonitor()
+    let sample = BackgroundNetworkPathSample()
+    let reported = DispatchSemaphore(value: 0)
+    monitor.pathUpdateHandler = { path in
+      sample.store(
+        satisfied: path.status == .satisfied,
+        metered: path.isExpensive || path.isConstrained
+      )
+      reported.signal()
+    }
+    monitor.start(
+      queue: DispatchQueue(
+        label: "com.keplr.vizor.background-network-metering"
+      )
+    )
+    defer { monitor.cancel() }
+    guard reported.wait(timeout: .now() + meteringSampleTimeout) == .success,
+      let observation = sample.observation
+    else {
+      return .unknown
+    }
+    guard observation.satisfied else { return .unknown }
+    return observation.metered ? .metered : .unmetered
+  }
+
+  /// Declares a persisted Tor route to Rust and reports whether this pass has
+  /// established that it may carry that route.
+  ///
+  /// Call it before the first native call of a background pass. Declaring
+  /// first means a path that still tries to reach lightwalletd fails closed
+  /// instead of leaking; a declaration that itself fails changes nothing,
+  /// because a refused pass reaches nothing either way.
+  ///
+  /// This never bootstraps Tor, so it is also the right question for a pass
+  /// that has not decided whether it will do network work at all — scheduling
+  /// a task, or inspecting local state first.
+  static func allowsBackgroundNetworkPass() -> Bool {
+    guard persistedRouteIsTor else { return true }
+    _ = zcash_network_privacy_mark_tor_desired()
+    return torBackgroundWorkIsAffordable(
+      power: currentPowerSupply(),
+      metering: currentNetworkMetering()
+    )
+  }
+
+  /// Brings Tor up for this process and reports whether it came up ready.
+  ///
+  /// Blocks: a cold bootstrap is tens of seconds, so callers run it on their
+  /// own queue rather than on a system callback. Success is remembered for the
+  /// process because the loop-style passes ask before every round of queries;
+  /// failure is not, so a later pass in the same process may try again after
+  /// conditions change. A route flip only happens in the foreground, which
+  /// re-decides the process route itself.
+  ///
+  /// A client that does not come up ready leaves the process fail-closed with
+  /// no transport. The caller defers; it must never fall back to clearnet.
+  @discardableResult
+  static func bringUpTorForBackgroundWork() -> Bool {
+    torStateLock.lock()
+    let alreadyUp = torIsUpForBackgroundWork
+    torStateLock.unlock()
+    if alreadyUp { return true }
+
+    guard let directory = torDataDirectoryPath() else { return false }
+    let code = directory.withCString {
+      zcash_network_privacy_enable_tor_for_background_work($0)
+    }
+    // Every non-ready code — not ready, or a panic caught at the boundary —
+    // leaves the process Tor-desired and fail-closed, so a false here is a
+    // deferral, not a reason to look for another way out.
+    guard code == ZCASH_NETWORK_PRIVACY_TOR_READY else { return false }
+    torStateLock.lock()
+    torIsUpForBackgroundWork = true
+    torStateLock.unlock()
+    return true
+  }
+
+  /// Declares the saved route and reports whether this pass may reach the
+  /// network now — including bringing Tor up when the route is Tor.
+  ///
+  /// Call it immediately before network work. A pass that only wants to know
+  /// whether it should exist at all wants `allowsBackgroundNetworkPass`.
+  static func allowsBackgroundNetworkWork() -> Bool {
+    guard persistedRouteIsTor else { return true }
+    _ = zcash_network_privacy_mark_tor_desired()
+    return torBackgroundPassMayProceed(
+      power: currentPowerSupply(),
+      metering: currentNetworkMetering(),
+      bringTorUp: bringUpTorForBackgroundWork
+    )
+  }
+
+  /// Whether a pass that is already running may keep reaching the network.
+  ///
+  /// Side-effect free and cheap on purpose: it is polled on a heartbeat, so it
+  /// answers only the question that can change between gate evaluations —
+  /// whether the saved route turned to Tor inside a process that never brought
+  /// Tor up, which is a route this pass cannot carry. Power and metering are
+  /// re-sampled by the gate itself before each round of queries.
+  static var backgroundNetworkWorkRemainsAllowed: Bool {
+    guard persistedRouteIsTor else { return true }
+    torStateLock.lock()
+    defer { torStateLock.unlock() }
+    return torIsUpForBackgroundWork
+  }
+
+  private static func torDataDirectoryPath() -> String? {
+    guard let supportDirectory = try? resolveWalletSupportDirectory() else {
+      return nil
+    }
+    return supportDirectory
+      .appendingPathComponent(torDirectoryName)
+      .path
+  }
+}
+
+private final class BackgroundNetworkPathSample: @unchecked Sendable {
+  struct Observation {
+    let satisfied: Bool
+    let metered: Bool
+  }
+
+  private let lock = NSLock()
+  private var storedObservation: Observation?
+
+  func store(satisfied: Bool, metered: Bool) {
+    lock.lock()
+    storedObservation = Observation(satisfied: satisfied, metered: metered)
+    lock.unlock()
+  }
+
+  var observation: Observation? {
+    lock.lock()
+    defer { lock.unlock() }
+    return storedObservation
+  }
+}
 
 final class BackgroundMigrationCancellation: @unchecked Sendable {
   private let condition = NSCondition()

--- a/ios/Runner/NativeLightwalletdClient.swift
+++ b/ios/Runner/NativeLightwalletdClient.swift
@@ -200,6 +200,20 @@ enum BackgroundNetworkRoute {
     )
   }
 
+  /// Whether the conditions a Tor pass was admitted under still hold.
+  ///
+  /// Bringing Tor up samples power and metering first and then blocks for as
+  /// long as a cold bootstrap takes, so a charger pulled or a link that turned
+  /// metered during it leaves the pass admitted on conditions it no longer
+  /// meets. Re-samples, so ask it once, before committing to network work — not
+  /// on a heartbeat, which is what `backgroundNetworkWorkRemainsAllowed` is for.
+  ///
+  /// A direct route has nothing to afford and is always allowed.
+  static var torBackgroundPassRemainsAffordable: Bool {
+    guard persistedRouteIsTor else { return true }
+    return torBackgroundPassIsAffordable()
+  }
+
   /// Declares a persisted Tor route to Rust and reports whether this pass has
   /// established that it may carry that route.
   ///

--- a/ios/Runner/NativeLightwalletdClient.swift
+++ b/ios/Runner/NativeLightwalletdClient.swift
@@ -84,6 +84,21 @@ enum BackgroundNetworkRoute {
     power == .external && metering == .unmetered
   }
 
+  /// The shape of a background pass gate, written once so a caller that has to
+  /// declare the route earlier than it acts on the answer still composes the
+  /// same gate out of the same two questions.
+  ///
+  /// `isAffordable` is asked only on a Tor route. Sampling power and the
+  /// current path takes up to a second, and a direct route has nothing to pay
+  /// for.
+  static func backgroundPassIsAllowed(
+    routeIsTor: Bool,
+    isAffordable: () -> Bool
+  ) -> Bool {
+    guard routeIsTor else { return true }
+    return isAffordable()
+  }
+
   /// The Tor half of the gate, written once so both entry points and the tests
   /// agree on what the policy is.
   ///
@@ -161,44 +176,70 @@ enum BackgroundNetworkRoute {
     return observation.metered ? .metered : .unmetered
   }
 
+  /// Declares the saved route to Rust and reports whether it is Tor.
+  ///
+  /// Separate from the affordability question because the two belong at
+  /// different points. The declaration is what makes a path that still tries to
+  /// reach lightwalletd fail closed instead of leaking, so it has to come
+  /// before any other native call; the answer about whether this pass can carry
+  /// the route is acted on later, once the caller has put its own state in
+  /// order. It samples nothing and never bootstraps.
+  @discardableResult
+  static func declareBackgroundNetworkRoute() -> Bool {
+    guard persistedRouteIsTor else { return false }
+    _ = zcash_network_privacy_mark_tor_desired()
+    return true
+  }
+
+  /// Whether this device can carry a Tor route right now. Samples power and the
+  /// current path, so ask it only once the route has been declared.
+  static func torBackgroundPassIsAffordable() -> Bool {
+    torBackgroundWorkIsAffordable(
+      power: currentPowerSupply(),
+      metering: currentNetworkMetering()
+    )
+  }
+
   /// Declares a persisted Tor route to Rust and reports whether this pass has
   /// established that it may carry that route.
   ///
-  /// Call it before the first native call of a background pass. Declaring
-  /// first means a path that still tries to reach lightwalletd fails closed
-  /// instead of leaking; a declaration that itself fails changes nothing,
-  /// because a refused pass reaches nothing either way.
+  /// Call it before the first native call of a background pass. A declaration
+  /// that itself fails changes nothing, because a refused pass reaches nothing
+  /// either way.
   ///
   /// This never bootstraps Tor, so it is also the right question for a pass
   /// that has not decided whether it will do network work at all — scheduling
   /// a task, or inspecting local state first.
   static func allowsBackgroundNetworkPass() -> Bool {
-    guard persistedRouteIsTor else { return true }
-    _ = zcash_network_privacy_mark_tor_desired()
-    return torBackgroundWorkIsAffordable(
-      power: currentPowerSupply(),
-      metering: currentNetworkMetering()
+    backgroundPassIsAllowed(
+      routeIsTor: declareBackgroundNetworkRoute(),
+      isAffordable: torBackgroundPassIsAffordable
     )
   }
 
   /// Brings Tor up for this process and reports whether it came up ready.
   ///
   /// Blocks: a cold bootstrap is tens of seconds, so callers run it on their
-  /// own queue rather than on a system callback. Success is remembered for the
-  /// process because the loop-style passes ask before every round of queries;
-  /// failure is not, so a later pass in the same process may try again after
-  /// conditions change. A route flip only happens in the foreground, which
-  /// re-decides the process route itself.
+  /// own queue rather than on a system callback.
+  ///
+  /// Always asks, never answers from memory. The client this is about lives in
+  /// Rust, which drops it whenever the route goes direct, so a remembered
+  /// success can outlive the thing it was about: the route goes direct and back
+  /// to Tor, that bootstrap fails, and a pass that trusted the memory proceeds
+  /// with no transport at all, failing every call closed with nothing left to
+  /// recover it in the background. Asking is what re-establishes the client,
+  /// and it costs almost nothing when one is already there — the call returns
+  /// ready without bootstrapping anything.
+  ///
+  /// What is remembered is only that this process reached ready at some point,
+  /// which is a fact about this process rather than about Rust's client. It
+  /// tells a running pass whether the route turned to Tor underneath it; it
+  /// never stands in for the question above.
   ///
   /// A client that does not come up ready leaves the process fail-closed with
   /// no transport. The caller defers; it must never fall back to clearnet.
   @discardableResult
   static func bringUpTorForBackgroundWork() -> Bool {
-    torStateLock.lock()
-    let alreadyUp = torIsUpForBackgroundWork
-    torStateLock.unlock()
-    if alreadyUp { return true }
-
     guard let directory = torDataDirectoryPath() else { return false }
     let code = directory.withCString {
       zcash_network_privacy_enable_tor_for_background_work($0)
@@ -219,12 +260,15 @@ enum BackgroundNetworkRoute {
   /// Call it immediately before network work. A pass that only wants to know
   /// whether it should exist at all wants `allowsBackgroundNetworkPass`.
   static func allowsBackgroundNetworkWork() -> Bool {
-    guard persistedRouteIsTor else { return true }
-    _ = zcash_network_privacy_mark_tor_desired()
-    return torBackgroundPassMayProceed(
-      power: currentPowerSupply(),
-      metering: currentNetworkMetering(),
-      bringTorUp: bringUpTorForBackgroundWork
+    backgroundPassIsAllowed(
+      routeIsTor: declareBackgroundNetworkRoute(),
+      isAffordable: {
+        torBackgroundPassMayProceed(
+          power: currentPowerSupply(),
+          metering: currentNetworkMetering(),
+          bringTorUp: bringUpTorForBackgroundWork
+        )
+      }
     )
   }
 
@@ -234,7 +278,8 @@ enum BackgroundNetworkRoute {
   /// answers only the question that can change between gate evaluations —
   /// whether the saved route turned to Tor inside a process that never brought
   /// Tor up, which is a route this pass cannot carry. Power and metering are
-  /// re-sampled by the gate itself before each round of queries.
+  /// re-sampled by the gate itself before each round of queries, and whether a
+  /// transport exists right now is Rust's answer to give, asked there.
   static var backgroundNetworkWorkRemainsAllowed: Bool {
     guard persistedRouteIsTor else { return true }
     torStateLock.lock()

--- a/ios/Runner/NativeLightwalletdClient.swift
+++ b/ios/Runner/NativeLightwalletdClient.swift
@@ -86,15 +86,30 @@ enum BackgroundNetworkRoute {
 
   /// The shape of a background pass gate, written once so a caller that has to
   /// declare the route earlier than it acts on the answer still composes the
-  /// same gate out of the same two questions.
+  /// same gate out of the same questions.
   ///
-  /// `isAffordable` is asked only on a Tor route. Sampling power and the
-  /// current path takes up to a second, and a direct route has nothing to pay
-  /// for.
+  /// `passIsLive` is asked before anything is sampled or brought up, and it is
+  /// required rather than optional. Re-reading a value on the far side of a
+  /// blocking step has a mirror: some values have to be read *before* entering
+  /// one, because entering it at all is the harm. Sampling power and the
+  /// current path costs up to a second, and bringing Tor up holds the caller
+  /// for as long as a cold bootstrap takes and offers no way to interrupt it —
+  /// a pass the system has already reclaimed spends its whole remaining window
+  /// in there and is suspended before it can leave a replacement behind.
+  /// Making it a parameter is what stops a gate from being reached without the
+  /// question being answered.
+  ///
+  /// It is asked ahead of the route, not after it: a pass that has ended has
+  /// nothing to do on a direct route either.
+  ///
+  /// `isAffordable` is asked only on a Tor route. A direct route has nothing to
+  /// pay for.
   static func backgroundPassIsAllowed(
     routeIsTor: Bool,
+    passIsLive: () -> Bool,
     isAffordable: () -> Bool
   ) -> Bool {
+    guard passIsLive() else { return false }
     guard routeIsTor else { return true }
     return isAffordable()
   }
@@ -224,9 +239,16 @@ enum BackgroundNetworkRoute {
   /// This never bootstraps Tor, so it is also the right question for a pass
   /// that has not decided whether it will do network work at all — scheduling
   /// a task, or inspecting local state first.
-  static func allowsBackgroundNetworkPass() -> Bool {
-    backgroundPassIsAllowed(
-      routeIsTor: declareBackgroundNetworkRoute(),
+  static func allowsBackgroundNetworkPass(
+    while passIsLive: () -> Bool
+  ) -> Bool {
+    // The declaration runs whatever the answer below is: it samples nothing,
+    // never bootstraps, and it is what makes a path that still reaches for
+    // lightwalletd in this process fail closed.
+    let routeIsTor = declareBackgroundNetworkRoute()
+    return backgroundPassIsAllowed(
+      routeIsTor: routeIsTor,
+      passIsLive: passIsLive,
       isAffordable: torBackgroundPassIsAffordable
     )
   }
@@ -279,14 +301,24 @@ enum BackgroundNetworkRoute {
   ///
   /// Call it immediately before network work. A pass that only wants to know
   /// whether it should exist at all wants `allowsBackgroundNetworkPass`.
-  static func allowsBackgroundNetworkWork() -> Bool {
-    backgroundPassIsAllowed(
-      routeIsTor: declareBackgroundNetworkRoute(),
+  static func allowsBackgroundNetworkWork(
+    while passIsLive: () -> Bool
+  ) -> Bool {
+    let routeIsTor = declareBackgroundNetworkRoute()
+    return backgroundPassIsAllowed(
+      routeIsTor: routeIsTor,
+      passIsLive: passIsLive,
       isAffordable: {
         torBackgroundPassMayProceed(
           power: currentPowerSupply(),
           metering: currentNetworkMetering(),
-          bringTorUp: bringUpTorForBackgroundWork
+          bringTorUp: {
+            // Asked again on this side of the sample. Sampling power and the
+            // current path is itself a second of the window, and the bring-up
+            // below is the one step that cannot be abandoned once entered.
+            guard passIsLive() else { return false }
+            return bringUpTorForBackgroundWork()
+          }
         )
       }
     )

--- a/ios/Runner/NativeLightwalletdClient.swift
+++ b/ios/Runner/NativeLightwalletdClient.swift
@@ -255,9 +255,15 @@ enum BackgroundNetworkRoute {
   @discardableResult
   static func bringUpTorForBackgroundWork() -> Bool {
     guard let directory = torDataDirectoryPath() else { return false }
+    markTorDataDirectory(directory)
     let code = directory.withCString {
       zcash_network_privacy_enable_tor_for_background_work($0)
     }
+    // Marked again on the far side. The mark is best-effort, and the attempt
+    // that matters is the one that leaves guard state in the directory: a
+    // first mark that failed for a transient reason would otherwise not be
+    // retried until the foreground app next brings Tor up.
+    markTorDataDirectory(directory)
     // Every non-ready code — not ready, or a panic caught at the boundary —
     // leaves the process Tor-desired and fail-closed, so a false here is a
     // deferral, not a reason to look for another way out.
@@ -301,7 +307,16 @@ enum BackgroundNetworkRoute {
     return torIsUpForBackgroundWork
   }
 
-  /// The arti directory, created and marked before anything writes to it.
+  /// Where arti keeps its data. Produces the path and nothing else, so no
+  /// caller can obtain it without going through the mark below.
+  private static func torDataDirectoryPath() -> String? {
+    guard let supportDirectory = try? resolveWalletSupportDirectory() else {
+      return nil
+    }
+    return supportDirectory.appendingPathComponent(torDirectoryName).path
+  }
+
+  /// Creates the arti directory and keeps it out of device backups.
   ///
   /// Arti's directory records which guards this wallet chose, and Application
   /// Support is backed up, so a restore would carry that choice to a second
@@ -309,14 +324,15 @@ enum BackgroundNetworkRoute {
   /// background launch has no Dart: whatever this pass bootstraps would be the
   /// first thing in the directory and would go into the backup unmarked.
   ///
+  /// Creating it here rather than leaving that to the bootstrap is what lets
+  /// the mark exist from the directory's first moment, when the process can
+  /// still be killed while guard state is being written.
+  ///
   /// Marking is best-effort. Failing to set the attribute is a weaker backup
   /// posture, not a reason to leave a migration unbroadcast, so the bootstrap
   /// proceeds either way.
-  private static func torDataDirectoryPath() -> String? {
-    guard let supportDirectory = try? resolveWalletSupportDirectory() else {
-      return nil
-    }
-    var directory = supportDirectory.appendingPathComponent(torDirectoryName)
+  private static func markTorDataDirectory(_ path: String) {
+    var directory = URL(fileURLWithPath: path)
     do {
       try FileManager.default.createDirectory(
         at: directory,
@@ -328,7 +344,6 @@ enum BackgroundNetworkRoute {
     } catch {
       print("[BGMigration] tor directory exclude failed: \(error)")
     }
-    return directory.path
   }
 }
 

--- a/ios/Runner/NativeLightwalletdClient.swift
+++ b/ios/Runner/NativeLightwalletdClient.swift
@@ -43,20 +43,30 @@ enum BackgroundNetworkRoute {
   /// `shared_preferences` stores Dart values in `UserDefaults.standard` behind
   /// a `flutter.` prefix; the suffix is `kTorEnabledPreferenceKey` in
   /// `lib/src/providers/network_privacy_provider.dart`.
-  private static let torEnabledKey = "flutter.zcash_tor_enabled"
+  ///
+  /// Hand-assembled, so the two ends are one rename apart from disagreeing —
+  /// and the divergence fails OPEN: `persistedRouteIsTor` reads false for
+  /// every user, `declareBackgroundNetworkRoute` declares the direct route on
+  /// their behalf, and already-signed migration transactions go out over
+  /// clearnet for someone who chose Tor. Declaring is what lets the pass reach
+  /// the network at all, so it cannot rescue a preference read that came back
+  /// wrong — only the key agreeing with Dart's can. `testTorPreferenceKeyMatchesDart`
+  /// reads the Dart declaration and pins both halves so the rename breaks a
+  /// test instead.
+  static let torEnabledPreferenceSuffix = "zcash_tor_enabled"
+  static let torEnabledKey = "flutter.\(torEnabledPreferenceSuffix)"
 
   /// Same directory Dart passes to the foreground toggle: the app's
   /// Application Support directory plus `tor`. Arti keeps its guard state and
   /// directory cache there, so a background bootstrap that used a different
   /// path would pick fresh guards and re-download the 46.3 MB cache instead of
   /// warming the one the foreground already paid for.
-  private static let torDirectoryName = "tor"
-
-  /// `UIDevice` answers `.unknown` for a moment after battery monitoring is
-  /// switched on. Bounded so a gate never stalls on a device that simply has
-  /// nothing to report.
-  private static let batteryStateReadAttempts = 10
-  private static let batteryStateReadRetryInterval: TimeInterval = 0.05
+  ///
+  /// Named in three places — here, `getTorDataDirectoryPath` in
+  /// `lib/src/core/storage/wallet_paths.dart`, and the backup exclusions in
+  /// `android/app/src/main/res/xml/data_extraction_rules.xml` — so
+  /// `testTorDirectoryNameMatchesDartAndAndroid` pins it across all three.
+  static let torDirectoryName = "tor"
 
   /// `NWPathMonitor` reports the current path almost immediately; this only
   /// bounds the wait for a first report that never arrives.
@@ -67,8 +77,18 @@ enum BackgroundNetworkRoute {
 
   /// Whether the saved route is Tor. A missing value — never chosen, or
   /// cleared by a wallet reset — reads as direct, matching the Dart default.
+  ///
+  /// Takes its store as a parameter only so a test can supply one; every
+  /// caller reads the same `UserDefaults.standard` `shared_preferences`
+  /// writes to.
+  static func persistedRouteIsTor(
+    in defaults: UserDefaults = .standard
+  ) -> Bool {
+    defaults.bool(forKey: torEnabledKey)
+  }
+
   static var persistedRouteIsTor: Bool {
-    UserDefaults.standard.bool(forKey: torEnabledKey)
+    persistedRouteIsTor(in: .standard)
   }
 
   /// Whether a background pass on a Tor route can afford to run right now.
@@ -132,30 +152,20 @@ enum BackgroundNetworkRoute {
     return bringTorUp()
   }
 
-  /// `batteryState` is `.unknown` until battery monitoring is enabled, so
-  /// `AppDelegate` turns it on at launch — including the launch a background
-  /// task causes. Enabling here as well keeps the gate honest if it is ever
-  /// reached first, and the retry covers the moment before the first report
-  /// lands rather than letting a startable pass read `.unknown` and defer.
+  /// Where this device's power comes from, as last reported to
+  /// `BackgroundPowerSupplyMonitor`.
+  ///
+  /// Reads a recorded value rather than `UIDevice`: every caller of this gate
+  /// is off the main thread — a `UNUserNotificationCenter` callback or one of
+  /// the two `.utility` background queues — and `UIDevice` is main-actor
+  /// isolated. Hopping to main synchronously to fix that would deadlock,
+  /// because the main thread can itself be inside a wallet-mutation fence
+  /// waiting on the very queue the caller is running on.
+  ///
+  /// `.unknown` still refuses, and is still what a device that has reported
+  /// nothing answers.
   static func currentPowerSupply() -> BackgroundPowerSupply {
-    let device = UIDevice.current
-    if !device.isBatteryMonitoringEnabled {
-      device.isBatteryMonitoringEnabled = true
-    }
-    for attempt in 0..<batteryStateReadAttempts {
-      switch device.batteryState {
-      case .charging, .full:
-        return .external
-      case .unplugged:
-        return .battery
-      default:
-        break
-      }
-      if attempt < batteryStateReadAttempts - 1 {
-        Thread.sleep(forTimeInterval: batteryStateReadRetryInterval)
-      }
-    }
-    return .unknown
+    BackgroundPowerSupplyMonitor.shared.currentSupply()
   }
 
   /// `isExpensive` covers cellular and personal hotspots, `isConstrained`
@@ -201,7 +211,15 @@ enum BackgroundNetworkRoute {
   /// order. It samples nothing and never bootstraps.
   @discardableResult
   static func declareBackgroundNetworkRoute() -> Bool {
-    guard persistedRouteIsTor else { return false }
+    guard persistedRouteIsTor else {
+      // Declared too. Rust refuses a route nothing has declared rather than
+      // treating it as direct, so that an entry point which never read the
+      // preference cannot reach lightwalletd on a Tor wallet — which makes
+      // saying "direct" the direct pass's job rather than something it gets
+      // by staying quiet.
+      _ = zcash_network_privacy_mark_direct_route()
+      return false
+    }
     _ = zcash_network_privacy_mark_tor_desired()
     return true
   }
@@ -376,6 +394,129 @@ enum BackgroundNetworkRoute {
     } catch {
       print("[BGMigration] tor directory exclude failed: \(error)")
     }
+  }
+}
+
+/// Records the device's power supply where `UIDevice` may legally be touched,
+/// so the background gates can read it from where they actually run.
+///
+/// Three things were wrong with sampling `UIDevice` inside the gate. It is
+/// annotated `NS_SWIFT_UI_ACTOR` and every gate runs off the main thread, and
+/// nothing diagnosed that because this target builds in Swift 5 mode with no
+/// strict-concurrency checking. It also *wrote* `isBatteryMonitoringEnabled`,
+/// which two background samplers could do at once — the silent wake starts the
+/// preparation gate alongside its own outbox run. And it spent up to 450 ms of
+/// a wake in `Thread.sleep` waiting for a first report.
+///
+/// So the sample moves to the one place that is already main-thread and
+/// already runs before any task handler can: `didFinishLaunchingWithOptions`.
+/// Monitoring is enabled there, once, by one writer. After that the state is
+/// kept current by `UIDevice.batteryStateDidChangeNotification`, delivered on
+/// the main queue.
+///
+/// A reader still has to cope with the moment before the first report lands:
+/// `batteryState` answers `.unknown` for a beat after monitoring is switched
+/// on, and `.unknown` refuses, which costs a device that is genuinely on a
+/// charger a full deferral. So a reader that finds no report yet waits for
+/// one — on a condition the recorder signals, not on a sleep loop, so it
+/// returns the instant the report arrives and never later than the same
+/// bounded budget the old loop spent. Waiting on a condition is also what
+/// keeps this safe to call from a queue the main thread may be blocked on:
+/// nothing here requires main to run, and a main thread that never gets there
+/// costs the reader a timeout, not a deadlock.
+final class BackgroundPowerSupplyMonitor: @unchecked Sendable {
+  static let shared = BackgroundPowerSupplyMonitor()
+
+  /// How long a reader waits for the first report before answering
+  /// `.unknown`. Matches what the previous retry loop was willing to spend.
+  private static let firstReportWait: TimeInterval = 0.5
+
+  private let condition = NSCondition()
+  private var recordedSupply: BackgroundPowerSupply = .unknown
+  private var hasReport = false
+  private var started = false
+  private var observer: NSObjectProtocol?
+
+  init() {}
+
+  /// Enables battery monitoring, takes the first sample, and subscribes to
+  /// later changes. Main thread only, and idempotent.
+  @MainActor
+  func start() {
+    let alreadyStarted = condition.withPowerSupplyLock { () -> Bool in
+      defer { started = true }
+      return started
+    }
+    guard !alreadyStarted else { return }
+    let device = UIDevice.current
+    if !device.isBatteryMonitoringEnabled {
+      device.isBatteryMonitoringEnabled = true
+    }
+    observer = NotificationCenter.default.addObserver(
+      forName: UIDevice.batteryStateDidChangeNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      self?.record(UIDevice.current.batteryState)
+    }
+    record(device.batteryState)
+    // A state that settles without posting a change notification is caught
+    // here, one run-loop turn later, still on the main thread. Costs nothing
+    // when the sample above already landed a real state.
+    DispatchQueue.main.async { [weak self] in
+      self?.record(UIDevice.current.batteryState)
+    }
+  }
+
+  /// The last reported supply, waiting briefly for a first report if none has
+  /// arrived. Safe from any thread.
+  func currentSupply() -> BackgroundPowerSupply {
+    condition.lock()
+    defer { condition.unlock() }
+    if !hasReport {
+      let deadline = Date().addingTimeInterval(Self.firstReportWait)
+      while !hasReport && Date() < deadline {
+        if !condition.wait(until: deadline) { break }
+      }
+    }
+    return recordedSupply
+  }
+
+  /// Records a battery state. Called on the main thread in the app; called
+  /// directly by tests, which is why it takes the state rather than reading
+  /// `UIDevice` itself.
+  func record(_ state: UIDevice.BatteryState) {
+    let supply: BackgroundPowerSupply
+    switch state {
+    case .charging, .full:
+      supply = .external
+    case .unplugged:
+      supply = .battery
+    default:
+      // Still `.unknown`, and `.unknown` refuses. Recording it would tell a
+      // waiting reader that a report arrived, so it is deliberately not
+      // recorded as one.
+      return
+    }
+    condition.lock()
+    recordedSupply = supply
+    hasReport = true
+    condition.broadcast()
+    condition.unlock()
+  }
+
+  deinit {
+    if let observer {
+      NotificationCenter.default.removeObserver(observer)
+    }
+  }
+}
+
+extension NSCondition {
+  fileprivate func withPowerSupplyLock<T>(_ body: () -> T) -> T {
+    lock()
+    defer { unlock() }
+    return body()
   }
 }
 

--- a/ios/Runner/zcash_sync.h
+++ b/ios/Runner/zcash_sync.h
@@ -38,6 +38,24 @@ int32_t zcash_lightwalletd_observe_transaction(
     void* cancellation
 );
 
+/// Submits one signed transaction to lightwalletd.
+///
+/// On a Tor route the submission gets a circuit of its own, so no exit sees it
+/// alongside this wallet's chain queries or alongside another submission. That
+/// costs a circuit build on a route that is already bootstrapped and nothing on
+/// the direct route, where this behaves exactly like the query calls above.
+///
+/// One call is one circuit, so a caller with several transactions to send pays
+/// per transaction. That cost is the point and must not be optimised away by
+/// putting several transactions behind one circuit, which hands an exit exactly
+/// the linkage this buys.
+///
+/// Returns 0 with the server's SendResponse copied out — its error code into
+/// `response_error_code`, its message into `response_error_message`, truncated
+/// to capacity and always NUL-terminated. Returns 1 for a bad argument or a
+/// transport failure, ZCASH_LIGHTWALLETD_RESULT_CANCELLED when the cancellation
+/// fired, and 2 on a panic. Only 0 means lightwalletd answered; the answer may
+/// still be a rejection, which lives in `response_error_code`.
 int32_t zcash_lightwalletd_send_transaction(
     const char* lightwalletd_url,
     const uint8_t* raw_transaction,

--- a/ios/Runner/zcash_sync.h
+++ b/ios/Runner/zcash_sync.h
@@ -79,6 +79,21 @@ int32_t zcash_lightwalletd_send_transaction(
 /// Returns 0 on success.
 int32_t zcash_network_privacy_mark_tor_desired(void);
 
+/// Declares that the user's persisted network route is direct — the mirror of
+/// zcash_network_privacy_mark_tor_desired, and just as mandatory.
+///
+/// "Nobody has declared yet" and "the user chose direct" are deliberately
+/// different states in Rust. The first is refused wherever a route is resolved,
+/// so a background entry point that never read the preference cannot reach
+/// lightwalletd at all instead of quietly reaching it over clearnet on a
+/// Tor-configured wallet. A pass whose saved route is direct therefore declares
+/// it, exactly as a Tor pass does, or its own network calls fail closed.
+///
+/// Writes nothing but the decision, touches no filesystem, never bootstraps,
+/// and is ignored once this process has decided its own route, so it can never
+/// turn a live Tor route direct. Returns 0 on success.
+int32_t zcash_network_privacy_mark_direct_route(void);
+
 /// Tor is up and the caller may do network work over it.
 #define ZCASH_NETWORK_PRIVACY_TOR_READY 0
 /// Tor is not up. The route stays Tor-desired and fail-closed, so the caller

--- a/ios/Runner/zcash_sync.h
+++ b/ios/Runner/zcash_sync.h
@@ -48,6 +48,60 @@ int32_t zcash_lightwalletd_send_transaction(
     void* cancellation
 );
 
+/// Declares that the user's persisted network route is Tor, so this process
+/// refuses to reach the network directly.
+///
+/// The desired route lives in process memory and defaults to direct, so a
+/// background launch in which Dart never ran would otherwise send lightwalletd
+/// traffic over clearnet. The caller must have read the persisted preference
+/// itself and must call this before the first network call of the pass. It
+/// never bootstraps Tor, so a pass that only calls this can do no network work
+/// and defers to the foreground. The process then stays fail-closed for the
+/// rest of its lifetime; only the foreground route toggle returns it to direct.
+/// Returns 0 on success.
+int32_t zcash_network_privacy_mark_tor_desired(void);
+
+/// Tor is up and the caller may do network work over it.
+#define ZCASH_NETWORK_PRIVACY_TOR_READY 0
+/// Tor is not up. The route stays Tor-desired and fail-closed, so the caller
+/// must do no network work and must defer to the foreground.
+#define ZCASH_NETWORK_PRIVACY_TOR_NOT_READY 1
+/// The call panicked. Also not ready.
+#define ZCASH_NETWORK_PRIVACY_TOR_PANICKED 2
+
+/// Brings Tor up for a background pass and blocks until it is usable or has
+/// failed, so that pass can do its network work on the user's chosen route
+/// instead of waiting for the foreground.
+///
+/// Call this only once the pass has established that the device is on external
+/// power and the link is unmetered. A cold bootstrap costs 8.45 MB down,
+/// 744 KB up and 23.7 s and leaves a 46.3 MB cache behind; the client then pads
+/// its guard connection continuously while awake, roughly 500 B/s against
+/// 27 B/s dormant. A warm one costs 0.64 s and no bytes. Those are costs for a
+/// charger and an unmetered link, not for a battery and a cellular one. A pass
+/// that cannot show both conditions calls zcash_network_privacy_mark_tor_desired
+/// instead and defers.
+///
+/// The bootstrap carries its own deadline, far shorter than the foreground's,
+/// because a background execution window can be withdrawn at any moment and the
+/// bootstrap exists so that work can follow it. This call blocks for up to that
+/// deadline, so run it off the main thread.
+///
+/// `tor_directory` is the Tor data directory and is created if it is missing.
+/// It is Application Support + "/tor", matching what the foreground passes.
+///
+/// Returns ZCASH_NETWORK_PRIVACY_TOR_READY when Tor is up;
+/// ZCASH_NETWORK_PRIVACY_TOR_NOT_READY for every other outcome — a bad argument,
+/// a bootstrap failure, the deadline expiring, or a process that had already
+/// chosen the direct route — in which case the caller must do no network work
+/// and must defer to the foreground; and ZCASH_NETWORK_PRIVACY_TOR_PANICKED on a
+/// panic, which is likewise not ready. Every non-ready outcome leaves the route
+/// Tor-desired and fail-closed, never direct, so a caller that ignores the
+/// answer is blocked rather than leaked onto clearnet.
+int32_t zcash_network_privacy_enable_tor_for_background_work(
+    const char* tor_directory
+);
+
 int32_t zcash_inspect_migration_preparation(
     const char* db_path,
     const char* network,

--- a/ios/Runner/zcash_sync.h
+++ b/ios/Runner/zcash_sync.h
@@ -108,6 +108,13 @@ int32_t zcash_network_privacy_mark_tor_desired(void);
 /// `tor_directory` is the Tor data directory and is created if it is missing.
 /// It is Application Support + "/tor", matching what the foreground passes.
 ///
+/// There is no matching call to end a pass. Keeping the client awake for the
+/// work that follows is a time-bounded hold that lapses on its own, and it
+/// masks the app lifecycle's dormancy setting rather than replacing it, so a
+/// foreground entry during a pass still wins and no exit — including one taken
+/// before any network work, and including the process being suspended — can
+/// leave the client awake by failing to say something.
+///
 /// Returns ZCASH_NETWORK_PRIVACY_TOR_READY when Tor is up;
 /// ZCASH_NETWORK_PRIVACY_TOR_NOT_READY for every other outcome — a bad argument,
 /// a bootstrap failure, the deadline expiring, or a process that had already

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -704,6 +704,75 @@ class RunnerTests: XCTestCase {
     }
   }
 
+  /// The predicate above has always been right; the stand-down that feeds it
+  /// was not. `standDownForUnavailableTorRoute` released the tracking slot —
+  /// which clears `foregroundHandoffRequested` — and only then completed,
+  /// where the completion read that flag to decide. So the `.none` case pinned
+  /// by `testRouteStandDownLeavesNothingBehindForWorkThatHasAnOwner` could
+  /// never be reached from this path: a handoff landing during the tens of
+  /// seconds of a cold Tor bring-up (the gate in front of the bring-up asks
+  /// `passIsLive` *before* the route, so it does land here) arrived at the
+  /// completion as "nobody owns this run", armed a background wake for a run
+  /// the foreground was already advancing, and on a failed arming posted a
+  /// "needs attention" alert over a healthy run.
+  ///
+  /// This drives the production release rather than the predicate:
+  /// `standDownDeferralForTesting` sets the flags a running task would hold,
+  /// calls `releaseTrackingSlotForStandDown`, and reports what that release
+  /// handed forward. Reverse the read and the clear inside it and this fails.
+  @available(iOS 26.0, *)
+  func testRouteStandDownCarriesTheHandoffItHeldIntoItsCompletion() {
+    let manager = BackgroundMigrationPreparationManager.shared
+
+    let handedOff = manager.standDownDeferralForTesting(
+      handedOff: true,
+      expired: false
+    )
+    XCTAssertTrue(
+      handedOff.runtime.handedOff,
+      "the release must report the handoff the task still held"
+    )
+    XCTAssertEqual(
+      handedOff.action,
+      .none,
+      "a run the foreground has taken over gets no background wake armed for it"
+    )
+
+    // An expiry landing on a handed-off task does not change who owns the run.
+    let handedOffAndExpired = manager.standDownDeferralForTesting(
+      handedOff: true,
+      expired: true
+    )
+    XCTAssertTrue(handedOffAndExpired.runtime.handedOff)
+    XCTAssertEqual(handedOffAndExpired.action, .none)
+
+    // And the ordinary stand-down still leaves its wait behind.
+    let unowned = manager.standDownDeferralForTesting(
+      handedOff: false,
+      expired: false
+    )
+    XCTAssertFalse(unowned.runtime.handedOff)
+    XCTAssertEqual(unowned.action, .waitOnProcessingWake)
+  }
+
+  /// The other half of "read, then clear". Reporting the handoff is what stops
+  /// a spurious wake; still clearing it is what stops the next task inheriting
+  /// a handoff nobody asked for. A fix that only stopped clearing would pass
+  /// the test above and fail this one.
+  @available(iOS 26.0, *)
+  func testRouteStandDownStillClearsTheHandoffItReported() {
+    let manager = BackgroundMigrationPreparationManager.shared
+    let probe = manager.standDownDeferralForTesting(
+      handedOff: true,
+      expired: false
+    )
+    XCTAssertTrue(probe.runtime.handedOff)
+    XCTAssertFalse(
+      probe.handoffAfterRelease,
+      "the released slot must not leave a handoff behind for the next task"
+    )
+  }
+
   func testRearmThatItsOwnRequestCouldNotTakeFallsBackToTheProcessingWake() {
     // The re-arm submits another continued-processing request, and that
     // request type declines for reasons it cannot wait out — the run moved to
@@ -3250,6 +3319,272 @@ final class NativeLightwalletdClientTests: XCTestCase {
       XCTFail("Expected unavailable trailers in both byte orders to be NotFound")
       return
     }
+  }
+
+  // MARK: - Power supply is recorded on main and read from anywhere
+
+  /// The gate used to sample `UIDevice` itself, from background queues, where
+  /// touching it is an actor violation nothing in this target diagnoses. It
+  /// also wrote `isBatteryMonitoringEnabled` — from two samplers at once — and
+  /// spent up to 450 ms per call in `Thread.sleep` waiting for a first report.
+  ///
+  /// What survives all of that is the semantics: a monitor that has been told
+  /// nothing answers `.unknown`, and `.unknown` refuses.
+  func testPowerSupplyMonitorRefusesUntilSomethingIsReported() {
+    let monitor = BackgroundPowerSupplyMonitor()
+    XCTAssertEqual(monitor.currentSupply(), .unknown)
+    XCTAssertFalse(
+      BackgroundNetworkRoute.torBackgroundWorkIsAffordable(
+        power: monitor.currentSupply(),
+        metering: .unmetered
+      )
+    )
+  }
+
+  func testPowerSupplyMonitorRecordsWhatTheDeviceReports() {
+    let charging = BackgroundPowerSupplyMonitor()
+    charging.record(.charging)
+    XCTAssertEqual(charging.currentSupply(), .external)
+
+    let full = BackgroundPowerSupplyMonitor()
+    full.record(.full)
+    XCTAssertEqual(full.currentSupply(), .external)
+
+    let unplugged = BackgroundPowerSupplyMonitor()
+    unplugged.record(.unplugged)
+    XCTAssertEqual(unplugged.currentSupply(), .battery)
+  }
+
+  /// `.unknown` is the absence of a report, not a report. Recording it would
+  /// release a reader that is waiting for the first real state and hand it a
+  /// refusal — a 10-minute deferral on a device that is plugged in.
+  func testPowerSupplyMonitorDoesNotTreatUnknownAsAReport() {
+    let monitor = BackgroundPowerSupplyMonitor()
+    monitor.record(.unknown)
+    XCTAssertEqual(monitor.currentSupply(), .unknown)
+    monitor.record(.charging)
+    XCTAssertEqual(monitor.currentSupply(), .external)
+  }
+
+  /// A reader on a background queue must not block on the main thread, which
+  /// may itself be waiting inside a wallet-mutation fence on the queue that
+  /// reader is running on. It waits on a condition the recorder signals, so a
+  /// report arriving late still reaches it and a report that never arrives
+  /// costs a timeout rather than a deadlock.
+  func testPowerSupplyReaderIsReleasedByALateReport() {
+    let monitor = BackgroundPowerSupplyMonitor()
+    let read = expectation(description: "reader observes the late report")
+
+    DispatchQueue.global(qos: .utility).async {
+      XCTAssertEqual(monitor.currentSupply(), .external)
+      read.fulfill()
+    }
+    DispatchQueue.global(qos: .userInitiated).asyncAfter(
+      deadline: .now() + 0.05
+    ) {
+      monitor.record(.charging)
+    }
+
+    wait(for: [read], timeout: 2)
+  }
+
+  // MARK: - A wake that declined the route reports what actually happened
+
+  /// The hold exists because the replacement has to be filed before
+  /// `setTaskCompleted` returns, and the task has to complete even if the
+  /// submission callback never fires. At background launch the notification
+  /// gate `schedule` waits on can outlast the 10 s hold, and the hold expiring
+  /// used to complete the task `success: false` — for a replacement that lands
+  /// a moment later and IS armed.
+  ///
+  /// That matters beyond bookkeeping: repeated failure on exactly the
+  /// route-and-battery combination this feature targets is what teaches
+  /// `BGTaskScheduler` to stop scheduling the identifier the whole re-arm
+  /// chain depends on. Declining is the policy working, and every sibling
+  /// completion already says so.
+  func testHoldExpiringOnAnInFlightRearmIsNotAFailedOpportunity() {
+    var reported: [Bool] = []
+    let hold = IronwoodMigrationRearmHold { outcome in
+      reported.append(
+        ironwoodMigrationWakeWithoutNetworkWorkSucceeded(outcome)
+      )
+    }
+
+    hold.holdExpired()
+    // The submission answers after the hold gave up; it was never refused.
+    hold.submissionFinished(armed: true)
+
+    XCTAssertEqual(
+      reported,
+      [true],
+      "a wake whose replacement is still being submitted did not fail"
+    )
+  }
+
+  func testSubmissionRefusedIsTheOneOutcomeThatStillReportsFailure() {
+    var reported: [Bool] = []
+    let hold = IronwoodMigrationRearmHold { outcome in
+      reported.append(
+        ironwoodMigrationWakeWithoutNetworkWorkSucceeded(outcome)
+      )
+    }
+
+    hold.submissionFinished(armed: false)
+    // The hold fires afterwards and must not report a second time.
+    hold.holdExpired()
+
+    XCTAssertEqual(reported, [false])
+  }
+
+  func testArmedAndNothingToArmBothReportSuccess() {
+    XCTAssertTrue(
+      ironwoodMigrationWakeWithoutNetworkWorkSucceeded(.armed)
+    )
+    XCTAssertTrue(
+      ironwoodMigrationWakeWithoutNetworkWorkSucceeded(.nothingToArm)
+    )
+    XCTAssertTrue(
+      ironwoodMigrationWakeWithoutNetworkWorkSucceeded(.stillArming)
+    )
+    XCTAssertFalse(
+      ironwoodMigrationWakeWithoutNetworkWorkSucceeded(.refused)
+    )
+  }
+
+  func testRearmHoldCompletesExactlyOnce() {
+    var completions = 0
+    let hold = IronwoodMigrationRearmHold { _ in completions += 1 }
+    hold.submissionFinished(armed: true)
+    hold.submissionFinished(armed: false)
+    hold.holdExpired()
+    XCTAssertEqual(completions, 1)
+  }
+
+  // MARK: - The saved route survives the trip from Dart to a cold process
+
+  /// `persistedRouteIsTor` is the only thing standing between a user who chose
+  /// Tor and a background wake that broadcasts their already-signed migration
+  /// transactions over clearnet, and it had no coverage at all.
+  ///
+  /// Note which way it fails: a key that does not match reads `false`, so
+  /// `declareBackgroundNetworkRoute` marks nothing and the process stays
+  /// direct. There is no error, no deferral, and nothing the user can see —
+  /// the traffic just goes out unwrapped.
+  func testPersistedRouteIsTorReadsTheKeySharedPreferencesWrites() throws {
+    let suite = "com.keplr.vizor.tests.tor-route"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+    defer { defaults.removePersistentDomain(forName: suite) }
+
+    defaults.removePersistentDomain(forName: suite)
+    XCTAssertFalse(
+      BackgroundNetworkRoute.persistedRouteIsTor(in: defaults),
+      "never chosen, or cleared by a wallet reset, reads as direct"
+    )
+
+    defaults.set(true, forKey: "flutter.zcash_tor_enabled")
+    XCTAssertTrue(BackgroundNetworkRoute.persistedRouteIsTor(in: defaults))
+
+    defaults.set(false, forKey: "flutter.zcash_tor_enabled")
+    XCTAssertFalse(BackgroundNetworkRoute.persistedRouteIsTor(in: defaults))
+
+    // The `flutter.` prefix is part of the contract, not decoration. A
+    // migration to an unprefixed store — `SharedPreferencesAsync`, or a
+    // `SharedPreferences.setPrefix` call — leaves the value here and this
+    // reader finding nothing.
+    defaults.removePersistentDomain(forName: suite)
+    defaults.set(true, forKey: "zcash_tor_enabled")
+    XCTAssertFalse(BackgroundNetworkRoute.persistedRouteIsTor(in: defaults))
+  }
+
+  /// Pins the key from both ends. The Swift side hand-assembles a string that
+  /// only Dart's constant and `shared_preferences`' prefix make correct, so a
+  /// rename on either side is invisible until a user's traffic leaks. Reading
+  /// the Dart declaration is what turns that into a red test.
+  func testTorPreferenceKeyMatchesDart() throws {
+    XCTAssertEqual(
+      BackgroundNetworkRoute.torEnabledKey,
+      "flutter.\(BackgroundNetworkRoute.torEnabledPreferenceSuffix)"
+    )
+
+    let provider = try repositoryFileContents(
+      "lib/src/providers/network_privacy_provider.dart"
+    )
+    XCTAssertTrue(
+      provider.contains(
+        "const kTorEnabledPreferenceKey = "
+          + "'\(BackgroundNetworkRoute.torEnabledPreferenceSuffix)';"
+      ),
+      "kTorEnabledPreferenceKey no longer declares "
+        + "'\(BackgroundNetworkRoute.torEnabledPreferenceSuffix)'; "
+        + "BackgroundNetworkRoute.torEnabledKey must be renamed with it"
+    )
+    // The prefix half of the contract. `SharedPreferences.getInstance` is what
+    // writes under `flutter.`; the async store and `setPrefix` do not.
+    XCTAssertTrue(
+      provider.contains("SharedPreferences.getInstance()"),
+      "the Tor preference must keep using the prefixed shared_preferences API"
+    )
+    XCTAssertFalse(
+      provider.contains("SharedPreferencesAsync"),
+      "an unprefixed store would leave the background reader finding nothing"
+    )
+    XCTAssertFalse(
+      provider.contains("setPrefix"),
+      "changing the prefix would leave the background reader finding nothing"
+    )
+  }
+
+  /// The arti directory name is spelled out in three places. A divergence
+  /// costs a re-download of the 46.3 MB cache and gives one wallet a second,
+  /// independent set of guards.
+  func testTorDirectoryNameMatchesDartAndAndroid() throws {
+    let name = BackgroundNetworkRoute.torDirectoryName
+
+    let paths = try repositoryFileContents(
+      "lib/src/core/storage/wallet_paths.dart"
+    )
+    XCTAssertTrue(
+      paths.contains(#"${Platform.pathSeparator}"# + name + "'"),
+      "getTorDataDirectoryPath no longer ends in '\(name)'"
+    )
+
+    let rules = try repositoryFileContents(
+      "android/app/src/main/res/xml/data_extraction_rules.xml"
+    )
+    let excluded = rules.components(
+      separatedBy: "path=\"\(name)\""
+    ).count - 1
+    XCTAssertEqual(
+      excluded,
+      2,
+      "cloud-backup and device-transfer must both exclude '\(name)'"
+    )
+  }
+
+  /// Reads a file from the checkout this test was compiled out of.
+  ///
+  /// `#filePath` is baked in at compile time and points at
+  /// `<repo>/ios/RunnerTests/RunnerTests.swift`, which is how a test running
+  /// in a simulator reaches the Dart and Android sources it has to pin.
+  private func repositoryFileContents(
+    _ relativePath: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) throws -> String {
+    let root = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // RunnerTests
+      .deletingLastPathComponent()  // ios
+      .deletingLastPathComponent()  // repository root
+    let url = root.appendingPathComponent(relativePath)
+    guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+      XCTFail(
+        "Could not read \(relativePath) at \(url.path)",
+        file: file,
+        line: line
+      )
+      throw CocoaError(.fileNoSuchFile)
+    }
+    return contents
   }
 
   func testTorBackgroundPassRunsOnlyOnExternalPowerOverAnUnmeteredLink() {

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -678,6 +678,100 @@ class RunnerTests: XCTestCase {
     }
   }
 
+  func testRearmThatItsOwnRequestCouldNotTakeFallsBackToTheProcessingWake() {
+    // The re-arm submits another continued-processing request, and that
+    // request type declines for reasons it cannot wait out — the run moved to
+    // a state only the foreground can advance, the scheduler refused. The
+    // task has already retired its watchdog by this point and posts no alert
+    // of its own, so without a fallback the run is stranded until the user
+    // reopens the app.
+    XCTAssertEqual(
+      migrationPreparationRearmFallbackAction(
+        rearmSubmitted: false,
+        hasResumableWork: true,
+        quiesced: false,
+        handedOff: false,
+        notificationsDisabled: false
+      ),
+      .waitOnProcessingWake
+    )
+  }
+
+  func testSuccessfulRearmNeedsNoFallback() {
+    XCTAssertEqual(
+      migrationPreparationRearmFallbackAction(
+        rearmSubmitted: true,
+        hasResumableWork: true,
+        quiesced: false,
+        handedOff: false,
+        notificationsDisabled: false
+      ),
+      .none
+    )
+  }
+
+  func testRearmFallbackStopsWhenNothingResumableIsLeft() {
+    // The same permanent reason the other chains end on: a run with no
+    // resumable preparation left needs no replacement at all.
+    XCTAssertEqual(
+      migrationPreparationRearmFallbackAction(
+        rearmSubmitted: false,
+        hasResumableWork: false,
+        quiesced: false,
+        handedOff: false,
+        notificationsDisabled: false
+      ),
+      .none
+    )
+  }
+
+  func testRearmFallbackLeavesNothingBehindForWorkThatHasAnOwner() {
+    for (quiesced, handedOff, disabled) in [
+      (true, false, false),
+      (false, true, false),
+      (false, false, true),
+    ] {
+      XCTAssertEqual(
+        migrationPreparationRearmFallbackAction(
+          rearmSubmitted: false,
+          hasResumableWork: true,
+          quiesced: quiesced,
+          handedOff: handedOff,
+          notificationsDisabled: disabled
+        ),
+        .none
+      )
+    }
+  }
+
+  func testRearmFallbackAndRouteStandDownAgreeOnWhoWaits() {
+    // Both leave the same kind of wait behind, decided from the same owner
+    // inputs, so a run interrupted either way resumes through one path rather
+    // than two that can drift apart.
+    for (quiesced, handedOff, disabled) in [
+      (false, false, false),
+      (true, false, false),
+      (false, true, false),
+      (false, false, true),
+    ] {
+      XCTAssertEqual(
+        migrationPreparationRearmFallbackAction(
+          rearmSubmitted: false,
+          hasResumableWork: true,
+          quiesced: quiesced,
+          handedOff: handedOff,
+          notificationsDisabled: disabled
+        ),
+        migrationPreparationRouteDeferralAction(
+          quiesced: quiesced,
+          expired: false,
+          handedOff: handedOff,
+          notificationsDisabled: disabled
+        )
+      )
+    }
+  }
+
   func testConfirmedWaveSuccessDoesNotRearmTracking() {
     // Nothing is left for a read-only task to watch. The foreground app arms
     // the next wave's task after it syncs and advances the run.

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -159,6 +159,48 @@ class RunnerTests: XCTestCase {
     )
   }
 
+  func testTorDeferredWakeArmsItsReplacement() {
+    // Starting the wake consumed the pending request. Without a replacement,
+    // the device reaching a charger on an unmetered link later gets no
+    // execution opportunity, and already-signed items wait for the user.
+    XCTAssertTrue(
+      ironwoodMigrationTorDeferredWakeShouldRearm(
+        disposition: .continueBackgroundWork,
+        mutationQuiesced: false,
+        hasRunnableWork: true
+      )
+    )
+  }
+
+  func testTorDeferredWakeStopsWhenThereIsNothingLeftToDo() {
+    // The one permanent reason. Battery and metering change on their own, so
+    // they are not what ends the chain of replacements; running out of work is.
+    XCTAssertFalse(
+      ironwoodMigrationTorDeferredWakeShouldRearm(
+        disposition: .continueBackgroundWork,
+        mutationQuiesced: false,
+        hasRunnableWork: false
+      )
+    )
+  }
+
+  func testTorDeferredWakeDoesNotRearmWorkThatHasAnOwner() {
+    XCTAssertFalse(
+      ironwoodMigrationTorDeferredWakeShouldRearm(
+        disposition: .finishForegroundOnly,
+        mutationQuiesced: false,
+        hasRunnableWork: true
+      )
+    )
+    XCTAssertFalse(
+      ironwoodMigrationTorDeferredWakeShouldRearm(
+        disposition: .continueBackgroundWork,
+        mutationQuiesced: true,
+        hasRunnableWork: true
+      )
+    )
+  }
+
   func testMigrationPreparationRuntimeStateIsScopedToMatchingRun() {
     XCTAssertEqual(
       migrationPreparationRuntimeState(
@@ -386,6 +428,7 @@ class RunnerTests: XCTestCase {
         completionFailed: true,
         quiesced: false,
         expired: false,
+        routeDeferred: false,
         handedOff: false,
         notificationsDisabled: false
       )
@@ -400,6 +443,7 @@ class RunnerTests: XCTestCase {
         completionFailed: false,
         quiesced: false,
         expired: true,
+        routeDeferred: false,
         handedOff: false,
         notificationsDisabled: false
       )
@@ -412,6 +456,7 @@ class RunnerTests: XCTestCase {
         completionFailed: false,
         quiesced: false,
         expired: true,
+        routeDeferred: false,
         handedOff: true,
         notificationsDisabled: false
       )
@@ -421,6 +466,7 @@ class RunnerTests: XCTestCase {
         completionFailed: false,
         quiesced: false,
         expired: true,
+        routeDeferred: false,
         handedOff: false,
         notificationsDisabled: true
       )
@@ -430,6 +476,56 @@ class RunnerTests: XCTestCase {
         completionFailed: false,
         quiesced: true,
         expired: true,
+        routeDeferred: false,
+        handedOff: false,
+        notificationsDisabled: false
+      )
+    )
+  }
+
+  func testRouteDeferredMidWaveTrackingRearmsInsteadOfStopping() {
+    // The charger came out, or the link went metered, while the wave was still
+    // counting. Nothing about the run changed, so this interrupts one execution
+    // opportunity exactly the way expiration does and submits a replacement.
+    XCTAssertTrue(
+      migrationPreparationTrackingShouldAttemptRearm(
+        completionFailed: false,
+        quiesced: false,
+        expired: false,
+        routeDeferred: true,
+        handedOff: false,
+        notificationsDisabled: false
+      )
+    )
+  }
+
+  func testRouteDeferredTrackingDoesNotRearmAfterHandoffOrRevocation() {
+    XCTAssertFalse(
+      migrationPreparationTrackingShouldAttemptRearm(
+        completionFailed: false,
+        quiesced: false,
+        expired: false,
+        routeDeferred: true,
+        handedOff: true,
+        notificationsDisabled: false
+      )
+    )
+    XCTAssertFalse(
+      migrationPreparationTrackingShouldAttemptRearm(
+        completionFailed: false,
+        quiesced: false,
+        expired: false,
+        routeDeferred: true,
+        handedOff: false,
+        notificationsDisabled: true
+      )
+    )
+    XCTAssertFalse(
+      migrationPreparationTrackingShouldAttemptRearm(
+        completionFailed: false,
+        quiesced: true,
+        expired: false,
+        routeDeferred: true,
         handedOff: false,
         notificationsDisabled: false
       )
@@ -444,6 +540,7 @@ class RunnerTests: XCTestCase {
         completionFailed: false,
         quiesced: false,
         expired: false,
+        routeDeferred: false,
         handedOff: false,
         notificationsDisabled: false
       )

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -573,50 +573,47 @@ class RunnerTests: XCTestCase {
     )
   }
 
-  func testLaunchTimeRouteStandDownRearmsLikeAMidWaveOne() {
-    // A task that stands down before its first query — the device cannot afford
-    // the saved route, or Tor did not come up — has consumed the only armed
-    // request just as surely as one that stood down mid-wave, and the wave it
-    // was launched for is unchanged. Both leave a replacement behind.
-    let launchTimeStandDown = migrationPreparationTrackingShouldAttemptRearm(
-      completionFailed: false,
-      quiesced: false,
-      expired: false,
-      routeDeferred: true,
-      handedOff: false,
-      notificationsDisabled: false
-    )
-    XCTAssertTrue(launchTimeStandDown)
-    // Same verdict the OS reclaiming the slot gets: one lost execution
-    // opportunity, not a verdict on the run.
+  func testRouteStandDownLeavesTheWaitWithTheWakeThatCanHoldIt() {
+    // A stand-down before the first query — the device cannot carry the saved
+    // route, or Tor did not come up — still has confirmations left to observe,
+    // and it consumed the request that was going to observe them. What it
+    // leaves behind is never another request of the same kind: that one is
+    // started rather than held, so it would relaunch onto the same battery.
     XCTAssertEqual(
-      launchTimeStandDown,
-      migrationPreparationTrackingShouldAttemptRearm(
-        completionFailed: false,
+      migrationPreparationRouteDeferralAction(
         quiesced: false,
-        expired: true,
-        routeDeferred: false,
+        expired: false,
         handedOff: false,
         notificationsDisabled: false
-      )
+      ),
+      .waitOnProcessingWake
+    )
+    // An expiry that lands during the stand-down does not change who waits.
+    XCTAssertEqual(
+      migrationPreparationRouteDeferralAction(
+        quiesced: false,
+        expired: true,
+        handedOff: false,
+        notificationsDisabled: false
+      ),
+      .waitOnProcessingWake
     )
   }
 
-  func testLaunchTimeRouteStandDownDoesNotRearmWorkThatHasAnOwner() {
+  func testRouteStandDownLeavesNothingBehindForWorkThatHasAnOwner() {
     for (quiesced, handedOff, disabled) in [
       (true, false, false),
       (false, true, false),
       (false, false, true),
     ] {
-      XCTAssertFalse(
-        migrationPreparationTrackingShouldAttemptRearm(
-          completionFailed: false,
+      XCTAssertEqual(
+        migrationPreparationRouteDeferralAction(
           quiesced: quiesced,
           expired: false,
-          routeDeferred: true,
           handedOff: handedOff,
           notificationsDisabled: disabled
-        )
+        ),
+        .none
       )
     }
   }

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -2858,6 +2858,89 @@ final class NativeLightwalletdClientTests: XCTestCase {
       return
     }
   }
+
+  func testTorBackgroundPassRunsOnlyOnExternalPowerOverAnUnmeteredLink() {
+    let everyPower: [BackgroundPowerSupply] = [.external, .battery, .unknown]
+    let everyMetering: [BackgroundNetworkMetering] = [
+      .unmetered, .metered, .unknown,
+    ]
+
+    for power in everyPower {
+      for metering in everyMetering {
+        XCTAssertEqual(
+          BackgroundNetworkRoute.torBackgroundWorkIsAffordable(
+            power: power,
+            metering: metering
+          ),
+          power == .external && metering == .unmetered,
+          "power=\(power) metering=\(metering)"
+        )
+      }
+    }
+  }
+
+  func testTorBackgroundPassProceedsWhenTorComesUpOnACharger() {
+    var bootstrapped = false
+    XCTAssertTrue(
+      BackgroundNetworkRoute.torBackgroundPassMayProceed(
+        power: .external,
+        metering: .unmetered,
+        bringTorUp: {
+          bootstrapped = true
+          return true
+        }
+      )
+    )
+    XCTAssertTrue(bootstrapped)
+  }
+
+  func testTorBackgroundPassDefersWhenTorDoesNotComeUp() {
+    // Never a fall back to clearnet: a client that is not ready leaves the
+    // process with no transport, so the pass defers like any other.
+    XCTAssertFalse(
+      BackgroundNetworkRoute.torBackgroundPassMayProceed(
+        power: .external,
+        metering: .unmetered,
+        bringTorUp: { false }
+      )
+    )
+  }
+
+  func testTorBackgroundPassNeverBootstrapsWhenItCannotAffordTo() {
+    // A cold bootstrap is 8.45 MB and 23.7 s. Every combination that is not a
+    // charger over an unmetered link has to defer without paying that.
+    let unaffordable:
+      [(power: BackgroundPowerSupply, metering: BackgroundNetworkMetering)] = [
+        (.external, .metered),
+        (.external, .unknown),
+        (.battery, .unmetered),
+        (.battery, .metered),
+        (.battery, .unknown),
+        (.unknown, .unmetered),
+        (.unknown, .metered),
+        (.unknown, .unknown),
+      ]
+
+    for combination in unaffordable {
+      var bootstrapped = false
+      let proceeded = BackgroundNetworkRoute.torBackgroundPassMayProceed(
+        power: combination.power,
+        metering: combination.metering,
+        bringTorUp: {
+          bootstrapped = true
+          return true
+        }
+      )
+      XCTAssertFalse(
+        proceeded,
+        "power=\(combination.power) metering=\(combination.metering)"
+      )
+      XCTAssertFalse(
+        bootstrapped,
+        "power=\(combination.power) metering=\(combination.metering)"
+      )
+    }
+  }
 }
 
 /// A lock-guarded counter for asserting on concurrent callers.

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -295,11 +295,37 @@ class RunnerTests: XCTestCase {
   func testDirectRouteAlwaysRemainsAffordable() {
     // Nothing to pay for, so the re-sample is skipped rather than answered.
     XCTAssertTrue(
-      BackgroundNetworkRoute.backgroundPassIsAllowed(routeIsTor: false) {
-        XCTFail("a direct route must not sample power or metering")
-        return false
-      }
+      BackgroundNetworkRoute.backgroundPassIsAllowed(
+        routeIsTor: false,
+        passIsLive: { true },
+        isAffordable: {
+          XCTFail("a direct route must not sample power or metering")
+          return false
+        }
+      )
     )
+  }
+
+  func testEndedPassNeverSpendsTimeOnAGate() {
+    // The mirror of re-reading a value after a blocking step. Sampling power
+    // and the current path costs a second, and the bring-up behind it holds the
+    // caller for as long as a cold bootstrap takes and cannot be abandoned once
+    // entered — a pass the system has already reclaimed spends its whole
+    // remaining window there and is suspended before it can leave a replacement
+    // behind. Asked ahead of the route, because a pass that has ended has
+    // nothing to do on a direct route either.
+    for routeIsTor in [true, false] {
+      XCTAssertFalse(
+        BackgroundNetworkRoute.backgroundPassIsAllowed(
+          routeIsTor: routeIsTor,
+          passIsLive: { false },
+          isAffordable: {
+            XCTFail("an ended pass must not sample power or metering")
+            return true
+          }
+        )
+      )
+    }
   }
 
   func testMigrationPreparationRuntimeStateIsScopedToMatchingRun() {
@@ -770,6 +796,36 @@ class RunnerTests: XCTestCase {
         )
       )
     }
+  }
+
+  func testLaunchStopsBeforeClaimingTheTrackingSlot() {
+    // The inspections between the route gate and the claim are blocking, and
+    // the claim is followed immediately by the bring-up, so a task the system
+    // reclaimed during them must not claim and then spend a minute on a wave it
+    // will never observe.
+    XCTAssertTrue(
+      migrationPreparationLaunchShouldStopBeforeClaiming(
+        stopRequested: true,
+        taskAlreadyRunning: false
+      )
+    )
+  }
+
+  func testLaunchDoesNotEndATaskAnotherRunOwns() {
+    // A run already tracking owns its own bookkeeping; ending it from a second
+    // launch would clear the slot underneath it.
+    XCTAssertFalse(
+      migrationPreparationLaunchShouldStopBeforeClaiming(
+        stopRequested: true,
+        taskAlreadyRunning: true
+      )
+    )
+    XCTAssertFalse(
+      migrationPreparationLaunchShouldStopBeforeClaiming(
+        stopRequested: false,
+        taskAlreadyRunning: false
+      )
+    )
   }
 
   func testConfirmedWaveSuccessDoesNotRearmTracking() {
@@ -3250,6 +3306,7 @@ final class NativeLightwalletdClientTests: XCTestCase {
     XCTAssertTrue(
       BackgroundNetworkRoute.backgroundPassIsAllowed(
         routeIsTor: false,
+        passIsLive: { true },
         isAffordable: {
           asked = true
           return false
@@ -3267,6 +3324,7 @@ final class NativeLightwalletdClientTests: XCTestCase {
       XCTAssertEqual(
         BackgroundNetworkRoute.backgroundPassIsAllowed(
           routeIsTor: true,
+          passIsLive: { true },
           isAffordable: { affordable }
         ),
         affordable

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -201,6 +201,38 @@ class RunnerTests: XCTestCase {
     )
   }
 
+  func testWakeThatClearedItsOwnFlagsArmsAReplacementForADeclinedRoute() {
+    XCTAssertTrue(
+      ironwoodMigrationTorDeferredWakeShouldRearm(
+        disposition: ironwoodMigrationOutboxWakeDisposition(
+          foregroundHandoffRequested: false,
+          notificationWorkDisabled: false
+        ),
+        mutationQuiesced: false,
+        hasRunnableWork: true
+      )
+    )
+  }
+
+  func testAPreviousWakesHandoffFlagWouldStopThisWakeFromArmingOne() {
+    // The flag is set whenever the app comes to the foreground and is cleared
+    // only as a wake starts. Read before that, it reports a takeover that
+    // belongs to an earlier wake, and the exit it reaches leaves signed items
+    // with no execution opportunity at all.
+    let staleReading = ironwoodMigrationOutboxWakeDisposition(
+      foregroundHandoffRequested: true,
+      notificationWorkDisabled: false
+    )
+    XCTAssertEqual(staleReading, .finishForegroundOnly)
+    XCTAssertFalse(
+      ironwoodMigrationTorDeferredWakeShouldRearm(
+        disposition: staleReading,
+        mutationQuiesced: false,
+        hasRunnableWork: true
+      )
+    )
+  }
+
   func testWakeStartsNetworkWorkWhenNothingEndedItDuringBringUp() {
     XCTAssertTrue(
       ironwoodMigrationOutboxWakeMayStartNetworkWork(
@@ -3087,6 +3119,37 @@ final class NativeLightwalletdClientTests: XCTestCase {
         bringTorUp: { false }
       )
     )
+  }
+
+  func testBackgroundPassGateAsksAffordabilityOnlyOnATorRoute() {
+    // Sampling power and the current path costs up to a second, and a direct
+    // route has nothing to pay for.
+    var asked = false
+    XCTAssertTrue(
+      BackgroundNetworkRoute.backgroundPassIsAllowed(
+        routeIsTor: false,
+        isAffordable: {
+          asked = true
+          return false
+        }
+      )
+    )
+    XCTAssertFalse(asked)
+  }
+
+  func testBackgroundPassGateComposesTheSameAnswerFromSeparatedQuestions() {
+    // The declaration has to happen before any other native call, and the
+    // affordability answer is acted on later, so the two are asked apart. The
+    // gate they compose is unchanged.
+    for affordable in [true, false] {
+      XCTAssertEqual(
+        BackgroundNetworkRoute.backgroundPassIsAllowed(
+          routeIsTor: true,
+          isAffordable: { affordable }
+        ),
+        affordable
+      )
+    }
   }
 
   func testTorBackgroundPassNeverBootstrapsWhenItCannotAffordTo() {

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -201,6 +201,47 @@ class RunnerTests: XCTestCase {
     )
   }
 
+  func testWakeStartsNetworkWorkWhenNothingEndedItDuringBringUp() {
+    XCTAssertTrue(
+      ironwoodMigrationOutboxWakeMayStartNetworkWork(
+        expired: false,
+        disposition: .continueBackgroundWork,
+        mutationQuiesced: false
+      )
+    )
+  }
+
+  func testExpiredWakeDoesNotStartNetworkWorkAfterBringUpReturns() {
+    // Bringing Tor up holds the wake for tens of seconds and cannot be
+    // cancelled, so the system can reclaim the wake while it runs. Broadcasting
+    // signed transactions afterwards risks suspension between lightwalletd
+    // accepting one and the outbox recording that it did.
+    XCTAssertFalse(
+      ironwoodMigrationOutboxWakeMayStartNetworkWork(
+        expired: true,
+        disposition: .continueBackgroundWork,
+        mutationQuiesced: false
+      )
+    )
+  }
+
+  func testWakeDoesNotStartNetworkWorkOnceSomethingElseOwnsIt() {
+    XCTAssertFalse(
+      ironwoodMigrationOutboxWakeMayStartNetworkWork(
+        expired: false,
+        disposition: .continueBackgroundWork,
+        mutationQuiesced: true
+      )
+    )
+    XCTAssertFalse(
+      ironwoodMigrationOutboxWakeMayStartNetworkWork(
+        expired: false,
+        disposition: .finishForegroundOnly,
+        mutationQuiesced: false
+      )
+    )
+  }
+
   func testMigrationPreparationRuntimeStateIsScopedToMatchingRun() {
     XCTAssertEqual(
       migrationPreparationRuntimeState(
@@ -530,6 +571,54 @@ class RunnerTests: XCTestCase {
         notificationsDisabled: false
       )
     )
+  }
+
+  func testLaunchTimeRouteStandDownRearmsLikeAMidWaveOne() {
+    // A task that stands down before its first query — the device cannot afford
+    // the saved route, or Tor did not come up — has consumed the only armed
+    // request just as surely as one that stood down mid-wave, and the wave it
+    // was launched for is unchanged. Both leave a replacement behind.
+    let launchTimeStandDown = migrationPreparationTrackingShouldAttemptRearm(
+      completionFailed: false,
+      quiesced: false,
+      expired: false,
+      routeDeferred: true,
+      handedOff: false,
+      notificationsDisabled: false
+    )
+    XCTAssertTrue(launchTimeStandDown)
+    // Same verdict the OS reclaiming the slot gets: one lost execution
+    // opportunity, not a verdict on the run.
+    XCTAssertEqual(
+      launchTimeStandDown,
+      migrationPreparationTrackingShouldAttemptRearm(
+        completionFailed: false,
+        quiesced: false,
+        expired: true,
+        routeDeferred: false,
+        handedOff: false,
+        notificationsDisabled: false
+      )
+    )
+  }
+
+  func testLaunchTimeRouteStandDownDoesNotRearmWorkThatHasAnOwner() {
+    for (quiesced, handedOff, disabled) in [
+      (true, false, false),
+      (false, true, false),
+      (false, false, true),
+    ] {
+      XCTAssertFalse(
+        migrationPreparationTrackingShouldAttemptRearm(
+          completionFailed: false,
+          quiesced: quiesced,
+          expired: false,
+          routeDeferred: true,
+          handedOff: handedOff,
+          notificationsDisabled: disabled
+        )
+      )
+    }
   }
 
   func testConfirmedWaveSuccessDoesNotRearmTracking() {

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -238,7 +238,8 @@ class RunnerTests: XCTestCase {
       ironwoodMigrationOutboxWakeMayStartNetworkWork(
         expired: false,
         disposition: .continueBackgroundWork,
-        mutationQuiesced: false
+        mutationQuiesced: false,
+        routeStillAffordable: true
       )
     )
   }
@@ -252,7 +253,8 @@ class RunnerTests: XCTestCase {
       ironwoodMigrationOutboxWakeMayStartNetworkWork(
         expired: true,
         disposition: .continueBackgroundWork,
-        mutationQuiesced: false
+        mutationQuiesced: false,
+        routeStillAffordable: true
       )
     )
   }
@@ -262,15 +264,41 @@ class RunnerTests: XCTestCase {
       ironwoodMigrationOutboxWakeMayStartNetworkWork(
         expired: false,
         disposition: .continueBackgroundWork,
-        mutationQuiesced: true
+        mutationQuiesced: true,
+        routeStillAffordable: true
       )
     )
     XCTAssertFalse(
       ironwoodMigrationOutboxWakeMayStartNetworkWork(
         expired: false,
         disposition: .finishForegroundOnly,
-        mutationQuiesced: false
+        mutationQuiesced: false,
+        routeStillAffordable: true
       )
+    )
+  }
+
+  func testWakeDoesNotStartNetworkWorkOnceTheRouteStoppedBeingAffordable() {
+    // The bring-up samples power and metering before it starts and then blocks
+    // for as long as a cold bootstrap takes, so a charger pulled during it
+    // leaves the wake admitted on conditions it no longer meets.
+    XCTAssertFalse(
+      ironwoodMigrationOutboxWakeMayStartNetworkWork(
+        expired: false,
+        disposition: .continueBackgroundWork,
+        mutationQuiesced: false,
+        routeStillAffordable: false
+      )
+    )
+  }
+
+  func testDirectRouteAlwaysRemainsAffordable() {
+    // Nothing to pay for, so the re-sample is skipped rather than answered.
+    XCTAssertTrue(
+      BackgroundNetworkRoute.backgroundPassIsAllowed(routeIsTor: false) {
+        XCTFail("a direct route must not sample power or metering")
+        return false
+      }
     )
   }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -107,10 +107,8 @@ Future<void> initializeZcashWalletRuntime() async {
   WidgetsFlutterBinding.ensureInitialized();
   log('runtime: initializing RustLib');
   await RustLib.init();
-  if (kAppFormFactor == AppFormFactor.desktop) {
-    log('runtime: applying desktop network privacy policy');
-    await initializeNetworkPrivacyRuntime();
-  }
+  log('runtime: applying network privacy policy');
+  await initializeNetworkPrivacyRuntime();
   await rust_simple.configureFastTestnetMigration(
     enabled: kZcashFastTestnetMigration,
   );

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
@@ -24,6 +24,7 @@ import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/app_profile_picture.dart';
 import '../../../../providers/account_provider.dart';
+import '../../../../providers/network_privacy_provider.dart';
 import '../../../../providers/sync_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../models/ironwood_migration_presentation.dart';

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -639,11 +639,25 @@ const _migrationPreparationBackgroundUnsupportedMessage =
 const _migrationPreparationTorRouteMessage =
     'Tor confirms in the background only while charging on an unmetered '
     'network.';
+// Both blockers at once. A denied notification stops both native lanes
+// outright while the route only delays them, so the remedy leads and the route
+// condition follows: naming the route alone would let the user meet it and
+// still watch nothing happen. Held to the length of the single-cause messages
+// above — this one has to say two things inside the same dial, so each half is
+// stated in its shortest form that still names a condition the user can act on.
+const _migrationPreparationNotificationsDisabledTorRouteMessage =
+    'Allow notifications. Tor also needs charging on an unmetered network.';
 // The same condition stated where the progress surface would otherwise promise
 // that the next step arrives while Vizor is closed.
 const _migrationTorRouteExpectation =
     'Tor continues this in the background only while charging on an unmetered '
     'network. Otherwise keep Vizor open.';
+// The route condition stated after a notification block rather than instead of
+// it, so it reads as the next thing to meet and not as the reason the step is
+// stalled.
+const _migrationTorRouteAdditionalExpectation =
+    'Tor also needs charging on an unmetered network to continue this in the '
+    'background.';
 
 class _MigrationPreparationPreview extends StatelessWidget {
   const _MigrationPreparationPreview({

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -630,13 +630,27 @@ const _migrationPreparationNotificationsDisabledMessage =
 // promise something granting them cannot deliver.
 const _migrationPreparationBackgroundUnsupportedMessage =
     'This device can\u2019t confirm in the background. Keep Vizor open.';
+// A Tor route constrains the background pass instead of removing it: bringing
+// up a cold Tor client costs 8.45 MB and 23.7 s, and an idle one keeps padding
+// its guard connection, so the pass only runs on external power over an
+// unmetered link. Unlike the device limit above this one is conditional, and
+// the user cannot see the gate from this screen \u2014 so state the condition
+// rather than the current verdict, and never promise more than it delivers.
+const _migrationPreparationTorRouteMessage =
+    'Tor confirms in the background only while charging on an unmetered '
+    'network.';
+// The same condition stated where the progress surface would otherwise promise
+// that the next step arrives while Vizor is closed.
+const _migrationTorRouteExpectation =
+    'Tor continues this in the background only while charging on an unmetered '
+    'network. Otherwise keep Vizor open.';
 
 class _MigrationPreparationPreview extends StatelessWidget {
   const _MigrationPreparationPreview({
     required this.state,
     this.isKeystone = false,
     this.pausedMessage,
-    this.deviceLimitMessage,
+    this.backgroundLaneLimitMessage,
     this.onBack,
     this.onContinue,
     this.onViewSchedule,
@@ -646,11 +660,13 @@ class _MigrationPreparationPreview extends StatelessWidget {
   final bool isKeystone;
   final String? pausedMessage;
 
-  /// Set when this device cannot track preparation while Vizor is closed.
+  /// Set when background preparation tracking is limited, naming the cause —
+  /// this device, which can never do it, or a Tor route, which only does it on
+  /// external power over an unmetered link.
   ///
   /// Outranks [pausedMessage] and the waiting default because it is the only
-  /// message naming a limit the user cannot resolve from settings.
-  final String? deviceLimitMessage;
+  /// message naming a limit that granting notifications cannot lift.
+  final String? backgroundLaneLimitMessage;
   final VoidCallback? onBack;
   final VoidCallback? onContinue;
   final VoidCallback? onViewSchedule;
@@ -690,7 +706,7 @@ class _MigrationPreparationPreview extends StatelessWidget {
           _MigrationPreparationDial(
             state: state,
             pausedMessage: pausedMessage,
-            deviceLimitMessage: deviceLimitMessage,
+            backgroundLaneLimitMessage: backgroundLaneLimitMessage,
             onViewSchedule: onViewSchedule,
           ),
           const SizedBox(height: AppSpacing.base),
@@ -708,13 +724,13 @@ class _MigrationPreparationDial extends StatelessWidget {
   const _MigrationPreparationDial({
     required this.state,
     this.pausedMessage,
-    this.deviceLimitMessage,
+    this.backgroundLaneLimitMessage,
     this.onViewSchedule,
   });
 
   final _MigrationPreparationState state;
   final String? pausedMessage;
-  final String? deviceLimitMessage;
+  final String? backgroundLaneLimitMessage;
   final VoidCallback? onViewSchedule;
 
   @override
@@ -753,7 +769,7 @@ class _MigrationPreparationDial extends StatelessWidget {
                 const SizedBox(height: AppSpacing.xs),
                 Text(
                   paused
-                      ? deviceLimitMessage ??
+                      ? backgroundLaneLimitMessage ??
                             pausedMessage ??
                             'Preparation was paused because you left.'
                       : syncing
@@ -763,12 +779,12 @@ class _MigrationPreparationDial extends StatelessWidget {
                             _migrationPreparationAdvancingMessage,
                           _MigrationPreparationState.backgroundTracking =>
                             _migrationPreparationBackgroundTrackingMessage,
-                          // A waiting device that cannot track in the
-                          // background must say so here too: the neutral
-                          // duration copy would let the user close Vizor and
-                          // silently stall the run.
+                          // A wallet whose background tracking is limited must
+                          // say so here too: the neutral duration copy would
+                          // let the user close Vizor and silently stall the
+                          // run.
                           _ =>
-                            deviceLimitMessage ??
+                            backgroundLaneLimitMessage ??
                                 'Preparation will\ntake 10–20 min',
                         },
                   textAlign: TextAlign.center,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -610,6 +610,16 @@ class _MobileMigrationRedesignedStatusState
       );
     });
     final accountUuid = ref.watch(accountProvider).value?.activeAccountUuid;
+    // A Tor route constrains both native background lanes — the preparation
+    // tracking task and the outbox wake: they run only on external power over
+    // an unmetered link, because a cold bootstrap costs 8.45 MB and 23.7 s and
+    // an idle client keeps padding its guard connection. Nothing here can read
+    // power or metering, so every promise of progress without the app has to
+    // state the condition rather than a verdict. The published route tracks the
+    // same preference the native gates read.
+    final routeConstrainsBackgroundWork = ref
+        .watch(networkPrivacyProvider)
+        .torEnabled;
     final coordinator = ref.watch(ironwoodMigrationCoordinatorProvider);
     final coordinatorError = accountUuid == null
         ? null
@@ -847,28 +857,45 @@ class _MobileMigrationRedesignedStatusState
           _preparationRuntimeState !=
               IronwoodMigrationPreparationRuntimeState
                   .foregroundContinuationPending;
-      // This device has no background preparation lane at all, so neither the
-      // notification prompt nor the "you left" copy names the real cause.
+      // A device with no continued-processing task can never track preparation
+      // while Vizor is closed. This stays separate from the route constraint
+      // below: turning Tor off cannot give this device a capability it never
+      // had, and the two need different copy and different fixes.
       final backgroundTrackingUnsupported =
           _supportsBackgroundPreparationTracking == false;
+      // The route limits a lane that does exist, and only conditionally.
+      final backgroundTrackingConstrained =
+          !backgroundTrackingUnsupported && routeConstrainsBackgroundWork;
+      // The device limit outranks the route: naming a condition the user could
+      // meet would promise a lane this OS build does not have.
+      final backgroundLaneLimitMessage = backgroundTrackingUnsupported
+          ? _migrationPreparationBackgroundUnsupportedMessage
+          : backgroundTrackingConstrained
+          ? _migrationPreparationTorRouteMessage
+          : null;
       // Whether leaving now stalls the run. An advance holds the foreground
       // permit, so backgrounding drops it and nothing moves until the next
       // reentry. An armed background task keeps observing without the app.
       // Requiring the capability here is a structural guard, not the live
       // signal: iOS before 26 can never report scheduled/running because it has
       // no continued-processing task, so the "you can close Vizor" promise
-      // becomes unreachable on a device that cannot keep it.
+      // becomes unreachable on a device that cannot keep it. A constrained
+      // route is excluded for a different reason: an armed task proves only
+      // that the gate passed for this pass, and "you can close Vizor" would
+      // outlive unplugging the charger or moving onto a metered link.
       final backgroundTrackingArmed =
           !backgroundTrackingUnsupported &&
+          !backgroundTrackingConstrained &&
           (_preparationRuntimeState ==
                   IronwoodMigrationPreparationRuntimeState.scheduled ||
               _preparationRuntimeState ==
                   IronwoodMigrationPreparationRuntimeState.running);
-      // Notifications are only the blocker where the lane exists. Without one,
-      // asking the user to allow notifications promises something granting them
-      // cannot deliver.
+      // Notifications are only the blocker where the lane exists and nothing
+      // else limits it. Elsewhere, asking the user to allow notifications
+      // promises something granting them cannot deliver.
       final notificationsDisabled =
           !backgroundTrackingUnsupported &&
+          !backgroundTrackingConstrained &&
           _preparationRuntimeState ==
               IronwoodMigrationPreparationRuntimeState.disabled;
       // Display-only debounce: a user-triggered action shows its progress at
@@ -892,9 +919,7 @@ class _MobileMigrationRedesignedStatusState
                 preparationState == _MigrationPreparationState.paused
             ? _migrationPreparationNotificationsDisabledMessage
             : null,
-        deviceLimitMessage: backgroundTrackingUnsupported
-            ? _migrationPreparationBackgroundUnsupportedMessage
-            : null,
+        backgroundLaneLimitMessage: backgroundLaneLimitMessage,
         onBack: () => context.go('/home'),
         onViewSchedule: viewPreparationSchedule,
         onContinue: !needsManualResume || accountUuid == null
@@ -915,7 +940,11 @@ class _MobileMigrationRedesignedStatusState
       widget.status,
       hasChildProofBatchPermit: hasChildProofBatchPermit,
     );
-    final nextActionText = _nextActionText(widget.status, state: state);
+    final nextActionText = _nextActionText(
+      widget.status,
+      state: state,
+      routeConstrainsBackgroundWork: routeConstrainsBackgroundWork,
+    );
     final actionPart = _actionPart(widget.status);
     final batchProgress = _batchProgress(widget.status, actionPart: actionPart);
     final hasDueProofBatch = _hasDueProofBatch(widget.status);
@@ -1073,6 +1102,7 @@ class _MobileMigrationRedesignedStatusState
   String _nextActionText(
     rust_sync.MigrationStatus status, {
     required _MigrationProgressState state,
+    required bool routeConstrainsBackgroundWork,
   }) {
     final currentHeight = _currentHeight();
     final nextHeight = status.nextActionHeight;
@@ -1097,6 +1127,12 @@ class _MobileMigrationRedesignedStatusState
           timing == 'Timing is updating' || timing == 'ready now'
           ? 'Next migration step is on the way.'
           : 'Next migration step expected in\n$timing.';
+      // The background wake that would deliver this step runs on a Tor route
+      // only on external power over an unmetered link, so an authorized
+      // notification is not on its own enough to carry it.
+      if (routeConstrainsBackgroundWork) {
+        return '$expectation\n$_migrationTorRouteExpectation';
+      }
       return switch (_notificationsAuthorized) {
         true =>
           '$expectation\nNotifications are on. You can leave Vizor and check '
@@ -1112,11 +1148,19 @@ class _MobileMigrationRedesignedStatusState
           'Keep Vizor open.';
     }
     if (state == _MigrationProgressState.confirming) {
+      if (routeConstrainsBackgroundWork) {
+        return 'Confirmations are still arriving. '
+            '$_migrationTorRouteExpectation';
+      }
       return 'Confirmations are still arriving.\nYou can leave Vizor and '
           'check again later.';
     }
     if (timing == 'ready now') {
       return 'The next migration step is ready. Keep Vizor open to continue.';
+    }
+    if (routeConstrainsBackgroundWork) {
+      return '$timing until the next migration step.\n'
+          '$_migrationTorRouteExpectation';
     }
     return '$timing until the next migration step.\n'
         'Notifications are on; you can leave Vizor and check back later.';

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -866,12 +866,27 @@ class _MobileMigrationRedesignedStatusState
       // The route limits a lane that does exist, and only conditionally.
       final backgroundTrackingConstrained =
           !backgroundTrackingUnsupported && routeConstrainsBackgroundWork;
+      // Notifications block the lane wherever the lane exists: the rearm gate
+      // refuses on a denied notification whatever the route is, and submission
+      // is blocked outright. The device with no lane at all stays excluded —
+      // there, asking the user to allow notifications promises something
+      // granting them cannot deliver. A constrained route is not that case: it
+      // delays a lane that does run, so the notification block outlives it.
+      final notificationsDisabled =
+          !backgroundTrackingUnsupported &&
+          _preparationRuntimeState ==
+              IronwoodMigrationPreparationRuntimeState.disabled;
       // The device limit outranks the route: naming a condition the user could
-      // meet would promise a lane this OS build does not have.
+      // meet would promise a lane this OS build does not have. The route and
+      // the notification block are both meetable and both real, so when they
+      // coincide the message names both — meeting only the one it stated would
+      // leave the user waiting on a pass that still cannot run.
       final backgroundLaneLimitMessage = backgroundTrackingUnsupported
           ? _migrationPreparationBackgroundUnsupportedMessage
           : backgroundTrackingConstrained
-          ? _migrationPreparationTorRouteMessage
+          ? (notificationsDisabled
+                ? _migrationPreparationNotificationsDisabledTorRouteMessage
+                : _migrationPreparationTorRouteMessage)
           : null;
       // Whether leaving now stalls the run. An advance holds the foreground
       // permit, so backgrounding drops it and nothing moves until the next
@@ -890,14 +905,6 @@ class _MobileMigrationRedesignedStatusState
                   IronwoodMigrationPreparationRuntimeState.scheduled ||
               _preparationRuntimeState ==
                   IronwoodMigrationPreparationRuntimeState.running);
-      // Notifications are only the blocker where the lane exists and nothing
-      // else limits it. Elsewhere, asking the user to allow notifications
-      // promises something granting them cannot deliver.
-      final notificationsDisabled =
-          !backgroundTrackingUnsupported &&
-          !backgroundTrackingConstrained &&
-          _preparationRuntimeState ==
-              IronwoodMigrationPreparationRuntimeState.disabled;
       // Display-only debounce: a user-triggered action shows its progress at
       // once, while the coordinator's own advance probes have to persist before
       // they may relabel the dial. Reading `actionInProgress` here instead would
@@ -1127,21 +1134,30 @@ class _MobileMigrationRedesignedStatusState
           timing == 'Timing is updating' || timing == 'ready now'
           ? 'Next migration step is on the way.'
           : 'Next migration step expected in\n$timing.';
+      if (_notificationsAuthorized == false) {
+        // Notifications outrank the route. Both native lanes refuse on a
+        // denied one — the wake finishes foreground-only, the tracking task
+        // never rearms, and submission is blocked — so this is the blocker
+        // that has to be named. The route condition follows as the one the
+        // user meets next, never in place of it: stating Tor alone hands the
+        // user a condition they can satisfy while nothing moves afterwards.
+        const notificationsLine =
+            'Notifications are disabled. Open Vizor again to continue.';
+        return routeConstrainsBackgroundWork
+            ? '$expectation\n$notificationsLine\n'
+                  '$_migrationTorRouteAdditionalExpectation'
+            : '$expectation\n$notificationsLine';
+      }
       // The background wake that would deliver this step runs on a Tor route
       // only on external power over an unmetered link, so an authorized
       // notification is not on its own enough to carry it.
       if (routeConstrainsBackgroundWork) {
         return '$expectation\n$_migrationTorRouteExpectation';
       }
-      return switch (_notificationsAuthorized) {
-        true =>
-          '$expectation\nNotifications are on. You can leave Vizor and check '
-              'back later.',
-        false =>
-          '$expectation\nNotifications are disabled. Open Vizor again to '
-              'continue.',
-        null => expectation,
-      };
+      return _notificationsAuthorized == true
+          ? '$expectation\nNotifications are on. You can leave Vizor and check '
+                'back later.'
+          : expectation;
     }
     if (state == _MigrationProgressState.readyToSubmit) {
       return 'The scheduled transaction is ready for automatic submission. '

--- a/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
@@ -25,6 +25,7 @@ import '../../../../providers/sync_keep_awake_provider.dart';
 import '../../../../providers/theme_mode_provider.dart';
 import '../../../../services/biometric_unlock.dart';
 import '../../../accounts/widgets/mobile/account_edit_sheets.dart';
+import '../../widgets/mobile/mobile_network_privacy_card.dart';
 
 /// Mobile settings tab — Figma `SETTINGS` root frame (4494:65997).
 ///
@@ -177,6 +178,8 @@ class MobileSettingsScreen extends ConsumerWidget {
                     ),
                   ),
                 ),
+                const SizedBox(height: AppSpacing.md),
+                const MobileNetworkPrivacyCard(),
                 const SizedBox(height: AppSpacing.md),
                 _SettingsGroup(
                   title: 'System',

--- a/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
+++ b/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
@@ -227,16 +227,36 @@ _MobileTorPresentation _presentationFor(NetworkPrivacyState state) {
       statusColor: (colors) => colors.text.brandCrimson,
       iconColor: (colors) => colors.icon.brandCrimson,
     ),
-    // A failed disable leaves Tor connected and carrying traffic, so this
-    // must not reuse the blocked-requests copy above.
-    (NetworkPrivacyConnectionStatus.failed, false) => _MobileTorPresentation(
-      statusLabel: 'Switch failed',
-      description:
-          'Vizor could not switch to a direct connection. Tor is '
-          'still on and requests keep going through it.',
-      statusColor: (colors) => colors.text.brandCrimson,
-      iconColor: (colors) => colors.icon.brandCrimson,
-    ),
+    // A failed disable has two shapes, and they carry opposite privacy
+    // guarantees, so the route decides which is described rather than the
+    // target. Neither may reuse the blocked-requests copy above.
+    (NetworkPrivacyConnectionStatus.failed, false) =>
+      state.torEnabled
+          // The transport never switched. Tor is still up and still carrying
+          // traffic.
+          ? _MobileTorPresentation(
+              statusLabel: 'Switch failed',
+              description:
+                  'Vizor could not switch to a direct connection. Tor is '
+                  'still on and requests keep going through it.',
+              statusColor: (colors) => colors.text.brandCrimson,
+              iconColor: (colors) => colors.icon.brandCrimson,
+            )
+          // The transport did switch and only the setting could not be saved.
+          // Requests are direct from here, and the saved route is still Tor —
+          // the stricter half, so the next launch comes back on Tor rather
+          // than silently staying direct. Saying "Tor is still on" here would
+          // promise the user the opposite of what is actually carrying their
+          // traffic.
+          : _MobileTorPresentation(
+              statusLabel: 'Setting not saved',
+              description:
+                  'Requests now use a direct connection, but Vizor could not '
+                  'save the change. Tor turns back on the next time you open '
+                  'the app.',
+              statusColor: (colors) => colors.text.brandCrimson,
+              iconColor: (colors) => colors.icon.brandCrimson,
+            ),
     (NetworkPrivacyConnectionStatus.off, _) => _MobileTorPresentation(
       statusLabel: 'Off',
       description:

--- a/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
+++ b/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
@@ -7,6 +7,11 @@ import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/mobile/mobile_surface_card.dart';
 import '../../../../providers/network_privacy_provider.dart';
+// The widget is deliberately not shared; the decision behind it is, because
+// both form factors drive one provider and the escape hatch has to exist on
+// both.
+import '../network_privacy_control.dart'
+    show NetworkPrivacyToggleActionX, networkPrivacyToggleAction;
 
 const _rowHeight = 44.0;
 
@@ -25,9 +30,12 @@ class MobileNetworkPrivacyCard extends ConsumerWidget {
     final state = ref.watch(networkPrivacyProvider);
     final notifier = ref.read(networkPrivacyProvider.notifier);
     final presentation = _presentationFor(state);
-    final onToggle = state.isBusy
-        ? null
-        : () => unawaited(notifier.setTorEnabled(!state.torEnabled));
+    final toggleAction = networkPrivacyToggleAction(state);
+    final onToggle = toggleAction.isInteractive
+        ? () => unawaited(
+            notifier.setTorEnabled(toggleAction.requestedTorEnabled),
+          )
+        : null;
     // `retry()` re-runs the desired route, which is the direct connection when
     // it was the disable that failed.
     final retryLabel = (state.targetTorEnabled ?? state.torEnabled)
@@ -59,8 +67,8 @@ class MobileNetworkPrivacyCard extends ConsumerWidget {
           Semantics(
             button: true,
             toggled: state.torEnabled,
-            enabled: !state.isBusy,
-            label: 'Use Tor',
+            enabled: toggleAction.isInteractive,
+            label: toggleAction.semanticsLabel,
             // The excluded subtree holds the status text, and four of the five
             // states report `toggled: true`, so the status has to ride on the
             // node itself to reach assistive technology at all.
@@ -109,7 +117,7 @@ class MobileNetworkPrivacyCard extends ConsumerWidget {
                       _MobileTorToggle(
                         key: const ValueKey('mobile_settings_tor_toggle'),
                         enabled: state.torEnabled,
-                        busy: state.isBusy,
+                        interactive: toggleAction.isInteractive,
                       ),
                     ],
                   ),
@@ -130,7 +138,7 @@ class MobileNetworkPrivacyCard extends ConsumerWidget {
             // whitespace that separates it from the description.
             Semantics(
               button: true,
-              enabled: !state.isBusy,
+              enabled: onRetry != null,
               label: retryLabel,
               onTap: onRetry,
               excludeSemantics: true,
@@ -177,7 +185,13 @@ _MobileTorPresentation _presentationFor(NetworkPrivacyState state) {
   return switch ((state.status, targetTorEnabled)) {
     (NetworkPrivacyConnectionStatus.connecting, true) => _MobileTorPresentation(
       statusLabel: 'Connecting…',
-      description: 'New requests wait until the Tor connection is ready.',
+      // Names the way out. On a network that blocks Tor the wait runs to the
+      // bootstrap deadline with every request failing closed, and relaunching
+      // the app only starts the same wait again, so the escape has to be stated
+      // where the user is looking.
+      description:
+          'New requests wait until the Tor connection is ready. Turn Tor '
+          'off to stop connecting and use a direct connection.',
       statusColor: (colors) => colors.text.secondary,
       iconColor: (colors) => colors.icon.muted,
     ),
@@ -237,12 +251,16 @@ _MobileTorPresentation _presentationFor(NetworkPrivacyState state) {
 class _MobileTorToggle extends StatelessWidget {
   const _MobileTorToggle({
     required this.enabled,
-    required this.busy,
+    required this.interactive,
     super.key,
   });
 
   final bool enabled;
-  final bool busy;
+
+  /// Dimming says the route is not effective yet. A transition the user can
+  /// still leave is not dimmed: the control has to look like something they may
+  /// act on, because acting on it is the way out of the wait.
+  final bool interactive;
 
   @override
   Widget build(BuildContext context) {
@@ -254,7 +272,7 @@ class _MobileTorToggle extends StatelessWidget {
         ? colors.border.brandCrimsonStrong
         : colors.border.regular;
     return Opacity(
-      opacity: busy ? 0.65 : 1,
+      opacity: interactive ? 1 : 0.65,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 140),
         curve: Curves.easeOutCubic,

--- a/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
+++ b/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
@@ -1,0 +1,286 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_icon.dart';
+import '../../../../core/widgets/mobile/mobile_surface_card.dart';
+import '../../../../providers/network_privacy_provider.dart';
+
+const _rowHeight = 44.0;
+
+/// Mobile Tor control.
+///
+/// Deliberately not the desktop [NetworkPrivacyControl]: that widget's copy is
+/// mostly about desktop software updates, which mobile gets from the app
+/// stores, and its toggle geometry belongs to a settings page rather than a
+/// grouped card. The state machine behind both is the same provider.
+class MobileNetworkPrivacyCard extends ConsumerWidget {
+  const MobileNetworkPrivacyCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.colors;
+    final state = ref.watch(networkPrivacyProvider);
+    final notifier = ref.read(networkPrivacyProvider.notifier);
+    final presentation = _presentationFor(state);
+    final onToggle = state.isBusy
+        ? null
+        : () => unawaited(notifier.setTorEnabled(!state.torEnabled));
+    // `retry()` re-runs the desired route, which is the direct connection when
+    // it was the disable that failed.
+    final retryLabel = (state.targetTorEnabled ?? state.torEnabled)
+        ? 'Try again'
+        : 'Try direct connection';
+    final onRetry = state.isBusy ? null : () => unawaited(notifier.retry());
+
+    return MobileSurfaceCard(
+      cornerRadius: AppRadii.large,
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.sm,
+        AppSpacing.base,
+        AppSpacing.sm,
+        AppSpacing.base,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.xxs),
+            child: Text(
+              'Network',
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Semantics(
+            button: true,
+            toggled: state.torEnabled,
+            enabled: !state.isBusy,
+            label: 'Use Tor',
+            // The excluded subtree holds the status text, and four of the five
+            // states report `toggled: true`, so the status has to ride on the
+            // node itself to reach assistive technology at all.
+            value: presentation.statusLabel,
+            onTap: onToggle,
+            excludeSemantics: true,
+            child: GestureDetector(
+              key: const ValueKey('mobile_settings_tor_row'),
+              behavior: HitTestBehavior.opaque,
+              onTap: onToggle,
+              child: SizedBox(
+                height: _rowHeight,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.xxs,
+                  ),
+                  child: Row(
+                    children: [
+                      SizedBox.square(
+                        dimension: 32,
+                        child: Center(
+                          child: AppIcon(
+                            AppIcons.tor,
+                            size: 20,
+                            color: presentation.iconColor(colors),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.s),
+                      Expanded(
+                        child: Text(
+                          'Use Tor',
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTypography.labelLarge.copyWith(
+                            color: colors.text.accent,
+                          ),
+                        ),
+                      ),
+                      Text(
+                        presentation.statusLabel,
+                        style: AppTypography.labelLarge.copyWith(
+                          color: presentation.statusColor(colors),
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.s),
+                      _MobileTorToggle(
+                        key: const ValueKey('mobile_settings_tor_toggle'),
+                        enabled: state.torEnabled,
+                        busy: state.isBusy,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            presentation.description,
+            key: const ValueKey('mobile_settings_tor_description'),
+            style: AppTypography.bodyMedium.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+          if (state.status == NetworkPrivacyConnectionStatus.failed)
+            // No gap token in front: the touch-sized row already carries the
+            // whitespace that separates it from the description.
+            Semantics(
+              button: true,
+              enabled: !state.isBusy,
+              label: retryLabel,
+              onTap: onRetry,
+              excludeSemantics: true,
+              child: GestureDetector(
+                key: const ValueKey('mobile_settings_tor_retry'),
+                behavior: HitTestBehavior.opaque,
+                onTap: onRetry,
+                child: SizedBox(
+                  height: _rowHeight,
+                  child: Center(
+                    widthFactor: 1,
+                    child: Text(
+                      retryLabel,
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.brandCrimson,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MobileTorPresentation {
+  const _MobileTorPresentation({
+    required this.statusLabel,
+    required this.description,
+    required this.statusColor,
+    required this.iconColor,
+  });
+
+  final String statusLabel;
+  final String description;
+  final Color Function(AppColors colors) statusColor;
+  final Color Function(AppColors colors) iconColor;
+}
+
+_MobileTorPresentation _presentationFor(NetworkPrivacyState state) {
+  final targetTorEnabled = state.targetTorEnabled ?? state.torEnabled;
+  return switch ((state.status, targetTorEnabled)) {
+    (NetworkPrivacyConnectionStatus.connecting, true) => _MobileTorPresentation(
+      statusLabel: 'Connecting…',
+      description: 'New requests wait until the Tor connection is ready.',
+      statusColor: (colors) => colors.text.secondary,
+      iconColor: (colors) => colors.icon.muted,
+    ),
+    (NetworkPrivacyConnectionStatus.connecting, false) =>
+      _MobileTorPresentation(
+        statusLabel: 'Switching…',
+        description:
+            'Vizor is switching network requests to a direct '
+            'connection.',
+        statusColor: (colors) => colors.text.secondary,
+        iconColor: (colors) => colors.icon.muted,
+      ),
+    (NetworkPrivacyConnectionStatus.connected, _) => _MobileTorPresentation(
+      statusLabel: 'Connected',
+      // The closing sentence states the background gate, not a guarantee: a
+      // cold Tor bootstrap costs 8.45 MB and 23.7 s and an idle client keeps
+      // padding its guard connection, which is only acceptable on a charger
+      // over an unmetered link. Off the charger or on a metered link the
+      // background pass does nothing and the foreground has to do the work.
+      description:
+          'Wallet sync and most in-app requests go through Tor. Some '
+          'services may be unavailable over Tor, and links you open leave the '
+          'app. A migration in progress advances in the background only while '
+          'charging on an unmetered network.',
+      statusColor: (colors) => colors.text.brandCrimson,
+      iconColor: (colors) => colors.icon.brandCrimson,
+    ),
+    (NetworkPrivacyConnectionStatus.failed, true) => _MobileTorPresentation(
+      statusLabel: 'Failed',
+      description:
+          'Vizor could not connect to Tor. Requests stay blocked '
+          'until it connects or you turn Tor off.',
+      statusColor: (colors) => colors.text.brandCrimson,
+      iconColor: (colors) => colors.icon.brandCrimson,
+    ),
+    // A failed disable leaves Tor connected and carrying traffic, so this
+    // must not reuse the blocked-requests copy above.
+    (NetworkPrivacyConnectionStatus.failed, false) => _MobileTorPresentation(
+      statusLabel: 'Switch failed',
+      description:
+          'Vizor could not switch to a direct connection. Tor is '
+          'still on and requests keep going through it.',
+      statusColor: (colors) => colors.text.brandCrimson,
+      iconColor: (colors) => colors.icon.brandCrimson,
+    ),
+    (NetworkPrivacyConnectionStatus.off, _) => _MobileTorPresentation(
+      statusLabel: 'Off',
+      description:
+          'Wallet sync and in-app requests connect directly. Turn Tor '
+          'on to hide your IP address from the servers Vizor talks to.',
+      statusColor: (colors) => colors.text.secondary,
+      iconColor: (colors) => colors.icon.muted,
+    ),
+  };
+}
+
+class _MobileTorToggle extends StatelessWidget {
+  const _MobileTorToggle({
+    required this.enabled,
+    required this.busy,
+    super.key,
+  });
+
+  final bool enabled;
+  final bool busy;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final trackColor = enabled
+        ? colors.background.brandCrimsonStrong
+        : colors.background.raised;
+    final borderColor = enabled
+        ? colors.border.brandCrimsonStrong
+        : colors.border.regular;
+    return Opacity(
+      opacity: busy ? 0.65 : 1,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 140),
+        curve: Curves.easeOutCubic,
+        width: 64,
+        height: 28,
+        padding: const EdgeInsets.all(2),
+        decoration: BoxDecoration(
+          color: trackColor,
+          borderRadius: BorderRadius.circular(AppRadii.full),
+          border: Border.all(color: borderColor),
+        ),
+        child: AnimatedAlign(
+          duration: const Duration(milliseconds: 140),
+          curve: Curves.easeOutCubic,
+          alignment: enabled ? Alignment.centerRight : Alignment.centerLeft,
+          child: DecoratedBox(
+            key: const ValueKey('mobile_settings_tor_toggle_thumb'),
+            decoration: BoxDecoration(
+              color: const Color(0xFFFFFFFF),
+              borderRadius: BorderRadius.circular(AppRadii.full),
+            ),
+            // Same pill as the keep-awake toggle directly above this card.
+            child: const SizedBox(width: 40, height: 24),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/settings/widgets/network_privacy_control.dart
+++ b/lib/src/features/settings/widgets/network_privacy_control.dart
@@ -16,6 +16,59 @@ const _toggleShortcuts = <ShortcutActivator, Intent>{
   SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
 };
 
+/// What activating a Tor control does from the state it is showing.
+///
+/// Shared by both form factors because the state machine behind them is one
+/// provider, and because the case that matters is the one a control is most
+/// tempted to disable itself for.
+enum NetworkPrivacyToggleAction {
+  enable,
+  disable,
+
+  /// A Tor connection is still being established and the user wants out of it.
+  ///
+  /// The bootstrap has a three-minute deadline and every policy-aware request
+  /// fails closed until it resolves, so a control that goes inert for the
+  /// duration strands the user on a network that blocks Tor — and force-quitting
+  /// does not help, because the saved route is Tor and the next launch starts
+  /// the same bootstrap. Switching to direct is what ends it, so this stays
+  /// available for exactly as long as the wait does.
+  cancelPendingTor,
+
+  /// A switch to the direct route is already under way. There is nothing to
+  /// cancel toward, and re-entering Tor mid-switch is a transition rather than
+  /// an escape.
+  none,
+}
+
+NetworkPrivacyToggleAction networkPrivacyToggleAction(
+  NetworkPrivacyState state,
+) {
+  if (!state.isBusy) {
+    return state.torEnabled
+        ? NetworkPrivacyToggleAction.disable
+        : NetworkPrivacyToggleAction.enable;
+  }
+  return (state.targetTorEnabled ?? state.torEnabled)
+      ? NetworkPrivacyToggleAction.cancelPendingTor
+      : NetworkPrivacyToggleAction.none;
+}
+
+extension NetworkPrivacyToggleActionX on NetworkPrivacyToggleAction {
+  bool get isInteractive => this != NetworkPrivacyToggleAction.none;
+
+  /// The route the action asks for. Cancelling a pending Tor connection asks
+  /// for the direct route, which is what supersedes the bootstrap.
+  bool get requestedTorEnabled => this == NetworkPrivacyToggleAction.enable;
+
+  /// Assistive-technology label. Turning "Use Tor" off mid-connect is an escape
+  /// from a wait, not a second transition, so it does not announce itself as
+  /// one.
+  String get semanticsLabel => this == NetworkPrivacyToggleAction.cancelPendingTor
+      ? 'Stop connecting to Tor'
+      : 'Use Tor';
+}
+
 /// Shared desktop Tor control used both before wallet creation and in Settings.
 ///
 /// The control presents the desired route separately from its connection
@@ -30,6 +83,7 @@ class NetworkPrivacyControl extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.colors;
     final state = ref.watch(networkPrivacyProvider);
+    final toggleAction = networkPrivacyToggleAction(state);
     final presentation = _presentationFor(
       state,
       platform: defaultTargetPlatform,
@@ -104,14 +158,14 @@ class NetworkPrivacyControl extends ConsumerWidget {
                 _NetworkPrivacyToggle(
                   key: const ValueKey('network_privacy_toggle'),
                   enabled: state.torEnabled,
-                  busy: state.isBusy,
-                  onToggle: state.isBusy
-                      ? null
-                      : () => unawaited(
+                  action: toggleAction,
+                  onToggle: toggleAction.isInteractive
+                      ? () => unawaited(
                           ref
                               .read(networkPrivacyProvider.notifier)
-                              .setTorEnabled(!state.torEnabled),
-                        ),
+                              .setTorEnabled(toggleAction.requestedTorEnabled),
+                        )
+                      : null,
                 ),
               ],
             ),
@@ -216,16 +270,14 @@ class NetworkPrivacyControl extends ConsumerWidget {
 class _NetworkPrivacyToggle extends StatefulWidget {
   const _NetworkPrivacyToggle({
     required this.enabled,
-    required this.busy,
+    required this.action,
     required this.onToggle,
     super.key,
   });
 
   final bool enabled;
 
-  /// The knob moves to the desired route as soon as the transition starts, so
-  /// the dimmed track is the only signal that the route is not effective yet.
-  final bool busy;
+  final NetworkPrivacyToggleAction action;
 
   final VoidCallback? onToggle;
 
@@ -274,7 +326,12 @@ class _NetworkPrivacyToggleState extends State<_NetworkPrivacyToggle> {
     final control = Stack(
       clipBehavior: Clip.none,
       children: [
-        Opacity(opacity: widget.busy ? 0.65 : 1, child: track),
+        // The knob moves to the desired route as soon as a transition starts,
+        // so dimming is the only signal that the route is not effective yet.
+        // A transition the user can still leave is not dimmed: the control has
+        // to look like something they may act on, because acting on it is the
+        // way out of the wait.
+        Opacity(opacity: interactive ? 1 : 0.65, child: track),
         if (_focused)
           Positioned(
             left: -3,
@@ -297,7 +354,7 @@ class _NetworkPrivacyToggleState extends State<_NetworkPrivacyToggle> {
       button: true,
       enabled: interactive,
       toggled: widget.enabled,
-      label: 'Use Tor',
+      label: widget.action.semanticsLabel,
       excludeSemantics: true,
       child: MouseRegion(
         cursor: interactive
@@ -396,11 +453,17 @@ _NetworkPrivacyPresentation _presentationFor(
     (NetworkPrivacyConnectionStatus.connecting, true) =>
       _NetworkPrivacyPresentation(
         statusLabel: 'Connecting…',
+        // Names the way out. On a network that blocks Tor the wait runs to the
+        // bootstrap deadline with every request failing closed, and restarting
+        // the app only starts the same wait again, so the escape has to be
+        // stated where the user is looking.
         description: isLinux
-            ? 'New requests wait until the Tor connection is ready. Update '
+            ? 'New requests wait until the Tor connection is ready. Turn Tor '
+                  'off to stop connecting and use a direct connection. Update '
                   'pages and downloads opened in another app use that '
                   'app’s connection.'
-            : 'New requests wait until the Tor connection is ready.',
+            : 'New requests wait until the Tor connection is ready. Turn Tor '
+                  'off to stop connecting and use a direct connection.',
         statusIconName: AppIcons.loader,
         statusColor: (colors) => colors.text.secondary,
         iconColor: (colors) => colors.icon.muted,

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async' show unawaited;
 import 'dart:io' show Platform;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -94,6 +95,7 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
   const RustNetworkPrivacyRuntime({
     this.configureRuntime = rust_network_privacy.configureNetworkPrivacy,
     this.resolveTorDirectory = getTorDataDirectoryPath,
+    this.excludeTorDirectoryFromBackup = _excludeFromDeviceBackup,
   });
 
   final Future<rust_types.NetworkPrivacyStatus> Function({
@@ -102,6 +104,7 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
   })
   configureRuntime;
   final Future<String> Function() resolveTorDirectory;
+  final Future<void> Function(String directory) excludeTorDirectoryFromBackup;
 
   @override
   void beginEnable() {
@@ -119,11 +122,49 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
   Future<NetworkPrivacyConnectionStatus> configure({
     required bool enabled,
   }) async {
-    final status = await configureRuntime(
-      enabled: enabled,
-      torDirectory: enabled ? await resolveTorDirectory() : '',
-    );
-    return _connectionStatus(status);
+    final torDirectory = enabled ? await resolveTorDirectory() : '';
+    try {
+      final status = await configureRuntime(
+        enabled: enabled,
+        torDirectory: torDirectory,
+      );
+      return _connectionStatus(status);
+    } finally {
+      // Arti's directory records which guards this wallet chose. Restoring it
+      // onto a second device would carry that choice across, so keep it out of
+      // device backups and let a restored install pick fresh guards. A
+      // bootstrap that errors or times out has already created the directory
+      // and written guard state into it, so the mark has to run on that path
+      // too; failing to mark it must not fail the route.
+      if (enabled) {
+        try {
+          await excludeTorDirectoryFromBackup(torDirectory);
+        } catch (error, stackTrace) {
+          debugPrint(
+            'RustNetworkPrivacyRuntime: failed to keep the Tor directory out '
+            'of device backups: $error\n$stackTrace',
+          );
+        }
+      }
+    }
+  }
+}
+
+const _deviceBackupChannel = MethodChannel('com.zcash.wallet/network_privacy');
+
+Future<void> _excludeFromDeviceBackup(String directory) async {
+  // Android has no runtime equivalent. `android:allowBackup="false"` in the
+  // manifest keeps app files out of cloud backup, but from targetSdk 31 that
+  // attribute no longer covers device-to-device transfer; excluding the
+  // directory from a phone-to-phone migration takes `<device-transfer>`
+  // data-extraction rules in the manifest, which the app does not carry.
+  if (!Platform.isIOS) return;
+  try {
+    await _deviceBackupChannel.invokeMethod<void>('excludeFromBackup', {
+      'path': directory,
+    });
+  } on MissingPluginException {
+    // Test hosts and older builds have no native side to ask.
   }
 }
 

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -636,6 +636,15 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
         await store.writeTorEnabled(true);
       } catch (error) {
         if (generation != _generation) return;
+        // The route is refused, but `beginEnable` already put this process
+        // fail-closed, so the direct work it left behind still has to be
+        // drained. Rust's own in-flight sockets went with the route-epoch
+        // bump; Dart's did not — an `HttpClient` request already streaming
+        // keeps reaching clearnet until the client is torn down. Refusing
+        // without the drain leaves that traffic running behind copy that says
+        // network requests are paused.
+        final drainFailure = await _captureDirectDrain(runtime, directRequests);
+        if (generation != _generation) return;
         // Nothing proceeds on a route whose saved half could not be made safe.
         // The runtime stays fail-closed, so this process leaks nothing while
         // the user decides whether to retry.
@@ -644,7 +653,11 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
           status: NetworkPrivacyConnectionStatus.failed,
           targetTorEnabled: true,
           softwareUpdatesAvailable: false,
-          error: error.toString(),
+          error: [
+            error.toString(),
+            if (drainFailure != null)
+              'Could not stop direct requests: ${drainFailure.error}',
+          ].join(' '),
           startupNotice: kTorStartupFailureNotice,
         );
         return;
@@ -704,12 +717,20 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
         if (generation != _generation) return;
         nextStatus = await runtime.configure(enabled: enabled);
         if (enabled || generation != _generation) return;
-        // Written only now that the runtime has actually gone direct. Saving
-        // it any earlier would leave a window in which a background wake read
-        // direct while this process was still enforcing Tor.
-        await store.writeTorEnabled(false);
-        if (generation != _generation) return;
-        directRequests.allow();
+        try {
+          // Written only now that the runtime has actually gone direct. Saving
+          // it any earlier would leave a window in which a background wake read
+          // direct while this process was still enforcing Tor.
+          await store.writeTorEnabled(false);
+        } finally {
+          // The gate follows the runtime, not the preference. Rust is on the
+          // direct route with its Tor client already dropped, so a gate left
+          // latched shut would strand every direct request for the rest of the
+          // session while the UI reports Tor off. A write that failed leaves
+          // the saved route at Tor, which is the stricter half a cold
+          // background wake may read, so the refusal costs nothing here.
+          if (generation == _generation) directRequests.allow();
+        }
       });
       if (generation != _generation) return;
       String? startupNotice;

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -1,11 +1,13 @@
 import 'dart:async' show unawaited;
 import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../core/layout/app_form_factor.dart';
+import '../core/layout/app_process_work_policy.dart';
 import '../core/network/network_http_client.dart';
 import '../core/storage/wallet_paths.dart';
 import '../rust/api/network_privacy.dart' as rust_network_privacy;
@@ -399,6 +401,55 @@ const _kStartupNativeUpdatePauseTimeout = Duration(seconds: 10);
 /// routing synchronously, so blocking here would only delay the first frame —
 /// and on a network that blocks Tor it would delay it forever, leaving the
 /// user no window to turn the setting back off from.
+/// Ties the process-wide Tor dormancy intent to the app lifecycle.
+///
+/// Owned here rather than by a provider because a provider only exists once
+/// something reads it, and the launch that most needs this one reads the least:
+/// a locked app routes to `/unlock`, the keep-awake providers return early on
+/// `requiresUnlock` before they reach `syncProvider`, and the unlock screens
+/// only read it when the user submits. Meanwhile the persisted route is applied
+/// regardless of the lock, so Tor can be up and padding its guard connection
+/// with nothing constructed to put it to sleep when the user walks away.
+///
+/// Rust holds the intent process-wide and applies it to the client whenever one
+/// appears, so an intent stated before a bootstrap finishes is not lost.
+AppLifecycleListener? _torDormancyLifecycle;
+
+/// Starts the lifecycle owner, replacing any previous one.
+///
+/// Sleeping is asked for only where backgrounding actually stops this process
+/// working: a desktop app with every window hidden keeps polling, and a client
+/// put to sleep underneath it would pay a circuit build on each of those polls.
+void startTorDormancyLifecycle({
+  void Function({required bool dormant}) setTorDormant =
+      rust_network_privacy.setNetworkPrivacyDormant,
+  AppFormFactor formFactor = kAppFormFactor,
+}) {
+  _torDormancyLifecycle?.dispose();
+  _torDormancyLifecycle = AppLifecycleListener(
+    // Asked for on every foreground entry, not only after a sleep this owner
+    // requested: a request that outlived its asker — issued before Tor
+    // finished bootstrapping, so it lands on the client only once that client
+    // exists — would otherwise keep the client asleep for the whole foreground
+    // session.
+    onResume: () => setTorDormant(dormant: false),
+    onHide: () {
+      if (!canRunAppProcessWork(
+        isInForeground: false,
+        formFactor: formFactor,
+      )) {
+        setTorDormant(dormant: true);
+      }
+    },
+  );
+}
+
+@visibleForTesting
+void disposeTorDormancyLifecycle() {
+  _torDormancyLifecycle?.dispose();
+  _torDormancyLifecycle = null;
+}
+
 Future<void> initializeNetworkPrivacyRuntime({
   NetworkPrivacyPreferenceStore store =
       const SharedPreferencesNetworkPrivacyStore(),
@@ -410,6 +461,10 @@ Future<void> initializeNetworkPrivacyRuntime({
 }) async {
   _pendingStartupActivation = null;
   _startupActivationSuperseded = false;
+  // Before the route is applied, and outside the try: the owner has to exist
+  // on every launch, including the one where reading the preference throws and
+  // this process goes fail-closed Tor without ever being asked.
+  startTorDormancyLifecycle();
   late final bool enabled;
   try {
     enabled = await store.readTorEnabled();

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -342,6 +342,26 @@ void _throwIfDirectDrainFailed(_NetworkPrivacyDrainFailure? failure) {
   Error.throwWithStackTrace(failure.error, failure.stackTrace);
 }
 
+/// Whether a (saved route, enforced route) pair is one a background wake can be
+/// trusted with.
+///
+/// The saved value is the only thing a process that never ran Dart has to go
+/// on. A background wake reads it, declares that route to Rust, and — finding
+/// direct — queries lightwalletd and broadcasts already-signed transactions
+/// over a direct connection. So the saved value may be stricter than what this
+/// process is enforcing, never laxer: a wake that declares Tor and cannot
+/// afford it defers, which costs a delay, while a wake that declares direct
+/// against a session enforcing Tor leaks.
+///
+/// A route change therefore persists in whichever order keeps this true at
+/// every point in between: tightening writes before the runtime switch, so a
+/// failure in between leaves the strict value behind; loosening writes after
+/// it, so the lax value never precedes the runtime it describes.
+bool networkPrivacyPersistedRouteIsSafe({
+  required bool persistedTorEnabled,
+  required bool runtimeTorDesired,
+}) => persistedTorEnabled || !runtimeTorDesired;
+
 NetworkPrivacyConnectionStatus _connectionStatus(
   rust_types.NetworkPrivacyStatus status,
 ) => switch (status) {
@@ -606,6 +626,30 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
       }
       if (generation != _generation) return;
       runtime.beginEnable();
+      // The runtime is fail-closed Tor from this line on, so the saved route
+      // is written here rather than after the drain and transport restart
+      // below. Anything that fails in between — the direct drain timing out is
+      // the reachable one — would otherwise end the toggle with Tor enforced
+      // and direct saved, and the next background wake into a cold process
+      // reads only the saved half.
+      try {
+        await store.writeTorEnabled(true);
+      } catch (error) {
+        if (generation != _generation) return;
+        // Nothing proceeds on a route whose saved half could not be made safe.
+        // The runtime stays fail-closed, so this process leaks nothing while
+        // the user decides whether to retry.
+        state = NetworkPrivacyState(
+          torEnabled: runtime.isTorEnabled(),
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: true,
+          softwareUpdatesAvailable: false,
+          error: error.toString(),
+          startupNotice: kTorStartupFailureNotice,
+        );
+        return;
+      }
+      if (generation != _generation) return;
     } else {
       state = NetworkPrivacyState(
         torEnabled: previousState.torEnabled,
@@ -654,16 +698,18 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
         if (directDrain != null) {
           _throwIfDirectDrainFailed(await directDrain);
         }
-        if (generation != _generation) return;
-        await store.writeTorEnabled(enabled);
         // Re-check after every suspension point: a superseded disable that
         // reached `configure(false)` or `allow()` would reopen clearnet
         // underneath a newer enable that has already gone fail-closed.
         if (generation != _generation) return;
         nextStatus = await runtime.configure(enabled: enabled);
-        if (!enabled && generation == _generation) {
-          directRequests.allow();
-        }
+        if (enabled || generation != _generation) return;
+        // Written only now that the runtime has actually gone direct. Saving
+        // it any earlier would leave a window in which a background wake read
+        // direct while this process was still enforcing Tor.
+        await store.writeTorEnabled(false);
+        if (generation != _generation) return;
+        directRequests.allow();
       });
       if (generation != _generation) return;
       String? startupNotice;

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -123,6 +123,15 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
     required bool enabled,
   }) async {
     final torDirectory = enabled ? await resolveTorDirectory() : '';
+    // Arti's directory records which guards this wallet chose. Restoring it
+    // onto a second device would carry that choice across, so keep it out of
+    // device backups and let a restored install pick fresh guards.
+    //
+    // Marked before the bootstrap, because from its first moment the directory
+    // holds guard state and the process can be killed at any point during it —
+    // and again afterwards, because the mark is best-effort and the run that
+    // matters is the one that succeeds.
+    await _markTorDirectory(enabled, torDirectory);
     try {
       final status = await configureRuntime(
         enabled: enabled,
@@ -130,22 +139,20 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
       );
       return _connectionStatus(status);
     } finally {
-      // Arti's directory records which guards this wallet chose. Restoring it
-      // onto a second device would carry that choice across, so keep it out of
-      // device backups and let a restored install pick fresh guards. A
-      // bootstrap that errors or times out has already created the directory
-      // and written guard state into it, so the mark has to run on that path
-      // too; failing to mark it must not fail the route.
-      if (enabled) {
-        try {
-          await excludeTorDirectoryFromBackup(torDirectory);
-        } catch (error, stackTrace) {
-          debugPrint(
-            'RustNetworkPrivacyRuntime: failed to keep the Tor directory out '
-            'of device backups: $error\n$stackTrace',
-          );
-        }
-      }
+      await _markTorDirectory(enabled, torDirectory);
+    }
+  }
+
+  Future<void> _markTorDirectory(bool enabled, String torDirectory) async {
+    if (!enabled) return;
+    try {
+      await excludeTorDirectoryFromBackup(torDirectory);
+    } catch (error, stackTrace) {
+      // A weaker backup posture is not a reason to fail the route.
+      debugPrint(
+        'RustNetworkPrivacyRuntime: failed to keep the Tor directory out '
+        'of device backups: $error\n$stackTrace',
+      );
     }
   }
 }

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -657,7 +657,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   StreamSubscription? _syncSub;
   Timer? _displayProgressTimer;
   AppLifecycleListener? _lifecycleListener;
-
   Timer? _pollTimer;
   bool _pollCheckInFlight = false;
   int _sensitiveStateEpoch = 0;

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -10,7 +10,6 @@ import '../app_bootstrap.dart';
 import '../core/config/rpc_endpoint_config.dart';
 import '../core/layout/app_process_work_policy.dart';
 import '../core/storage/wallet_paths.dart';
-import '../rust/api/network_privacy.dart' as rust_network_privacy;
 import '../rust/api/sync.dart' as rust_sync;
 import 'account_provider.dart';
 import 'app_security_provider.dart';
@@ -630,12 +629,8 @@ bool shouldRestartSyncForMigrationEntry({
 }
 
 class SyncNotifier extends AsyncNotifier<SyncState> {
-  SyncNotifier({
-    Future<String> Function()? walletDbPathResolver,
-    void Function({required bool dormant})? setTorDormant,
-  }) : _walletDbPathResolver = walletDbPathResolver ?? getWalletDbPath,
-       _setTorDormant =
-           setTorDormant ?? rust_network_privacy.setNetworkPrivacyDormant;
+  SyncNotifier({Future<String> Function()? walletDbPathResolver})
+    : _walletDbPathResolver = walletDbPathResolver ?? getWalletDbPath;
 
   static const _displayBlockDuration = Duration(milliseconds: 20);
   static const _maxIncompleteDisplayPercentage = 0.999;
@@ -663,10 +658,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   Timer? _displayProgressTimer;
   AppLifecycleListener? _lifecycleListener;
 
-  /// Suspends or resumes Tor's circuit maintenance. Rust keeps the request
-  /// process-wide rather than per notifier, so both directions are published
-  /// unconditionally.
-  final void Function({required bool dormant}) _setTorDormant;
   Timer? _pollTimer;
   bool _pollCheckInFlight = false;
   int _sensitiveStateEpoch = 0;
@@ -775,12 +766,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _lifecycleListener = AppLifecycleListener(
       onResume: () {
         _isInForeground = true;
-        // Asked for on every foreground entry, not only when this notifier is
-        // the one that asked for the sleep: a request that outlived its
-        // asker — issued before Tor finished bootstrapping, so it lands on the
-        // client only once that client exists — would otherwise keep the
-        // client asleep for the whole foreground session.
-        _setTorDormant(dormant: false);
         unawaited(_refreshBalanceAfterResume());
         _checkAndSync();
       },
@@ -789,12 +774,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         _foregroundEpoch++;
         if (!canRunAppProcessWork(isInForeground: _isInForeground)) {
           _stopPolling();
-          // Only once this process really stops working. An idle Tor client
-          // still pads its guard connection continuously — measured at roughly
-          // 500 B/s, against 27 B/s dormant — but waking on the next request
-          // costs a circuit build, so a process that keeps polling (desktop
-          // with its windows hidden) would pay that repeatedly for nothing.
-          _setTorDormant(dormant: true);
         }
       },
     );

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -10,6 +10,7 @@ import '../app_bootstrap.dart';
 import '../core/config/rpc_endpoint_config.dart';
 import '../core/layout/app_process_work_policy.dart';
 import '../core/storage/wallet_paths.dart';
+import '../rust/api/network_privacy.dart' as rust_network_privacy;
 import '../rust/api/sync.dart' as rust_sync;
 import 'account_provider.dart';
 import 'app_security_provider.dart';
@@ -629,8 +630,12 @@ bool shouldRestartSyncForMigrationEntry({
 }
 
 class SyncNotifier extends AsyncNotifier<SyncState> {
-  SyncNotifier({Future<String> Function()? walletDbPathResolver})
-    : _walletDbPathResolver = walletDbPathResolver ?? getWalletDbPath;
+  SyncNotifier({
+    Future<String> Function()? walletDbPathResolver,
+    void Function({required bool dormant})? setTorDormant,
+  }) : _walletDbPathResolver = walletDbPathResolver ?? getWalletDbPath,
+       _setTorDormant =
+           setTorDormant ?? rust_network_privacy.setNetworkPrivacyDormant;
 
   static const _displayBlockDuration = Duration(milliseconds: 20);
   static const _maxIncompleteDisplayPercentage = 0.999;
@@ -657,6 +662,11 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   StreamSubscription? _syncSub;
   Timer? _displayProgressTimer;
   AppLifecycleListener? _lifecycleListener;
+
+  /// Suspends or resumes Tor's circuit maintenance. Rust keeps the request
+  /// process-wide rather than per notifier, so both directions are published
+  /// unconditionally.
+  final void Function({required bool dormant}) _setTorDormant;
   Timer? _pollTimer;
   bool _pollCheckInFlight = false;
   int _sensitiveStateEpoch = 0;
@@ -765,6 +775,12 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _lifecycleListener = AppLifecycleListener(
       onResume: () {
         _isInForeground = true;
+        // Asked for on every foreground entry, not only when this notifier is
+        // the one that asked for the sleep: a request that outlived its
+        // asker — issued before Tor finished bootstrapping, so it lands on the
+        // client only once that client exists — would otherwise keep the
+        // client asleep for the whole foreground session.
+        _setTorDormant(dormant: false);
         unawaited(_refreshBalanceAfterResume());
         _checkAndSync();
       },
@@ -773,6 +789,12 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         _foregroundEpoch++;
         if (!canRunAppProcessWork(isInForeground: _isInForeground)) {
           _stopPolling();
+          // Only once this process really stops working. An idle Tor client
+          // still pads its guard connection continuously — measured at roughly
+          // 500 B/s, against 27 B/s dormant — but waking on the next request
+          // costs a circuit build, so a process that keeps polling (desktop
+          // with its windows hidden) would pay that repeatedly for nothing.
+          _setTorDormant(dormant: true);
         }
       },
     );

--- a/lib/src/rust/api/network_privacy.dart
+++ b/lib/src/rust/api/network_privacy.dart
@@ -39,6 +39,14 @@ NetworkPrivacyStatus getNetworkPrivacyStatus() =>
 bool isTorEnabled() =>
     RustLib.instance.api.crateApiNetworkPrivacyIsTorEnabled();
 
+/// Suspends or resumes Tor's circuit maintenance alongside the app lifecycle.
+///
+/// A bootstrapped client otherwise keeps guard connections and directory tasks
+/// running while the app is in the background, which costs battery on mobile
+/// and does work iOS will kill the app for. A no-op until Tor is connected.
+void setNetworkPrivacyDormant({required bool dormant}) => RustLib.instance.api
+    .crateApiNetworkPrivacySetNetworkPrivacyDormant(dormant: dormant);
+
 /// Starts a token-protected loopback server that streams HTTPS update assets
 /// from the embedded Tor client directly to a native desktop updater.
 Future<String> startTorUpdateRelay() =>

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -81,7 +81,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -92948645;
+  int get rustContentHash => 844087337;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -1045,6 +1045,8 @@ abstract class RustLibApi extends BaseApi {
     required bool skipped,
     int? choice,
   });
+
+  void crateApiNetworkPrivacySetNetworkPrivacyDormant({required bool dormant});
 
   void crateApiSyncSetSyncMode({required int mode});
 
@@ -7439,6 +7441,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  void crateApiNetworkPrivacySetNetworkPrivacyDormant({required bool dormant}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_bool(dormant, serializer);
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 145,
+          )!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiNetworkPrivacySetNetworkPrivacyDormantConstMeta,
+        argValues: [dormant],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiNetworkPrivacySetNetworkPrivacyDormantConstMeta =>
+      const TaskConstMeta(
+        debugName: "set_network_privacy_dormant",
+        argNames: ["dormant"],
+      );
+
+  @override
   void crateApiSyncSetSyncMode({required int mode}) {
     return handler.executeSync(
       SyncTask(
@@ -7448,7 +7480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
           )!;
         },
         codec: SseCodec(
@@ -7483,7 +7515,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7516,7 +7548,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
             port: port_,
           );
         },
@@ -7556,7 +7588,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7597,7 +7629,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7651,7 +7683,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
             port: port_,
           );
         },
@@ -7701,7 +7733,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 151,
+              funcId: 152,
               port: port_,
             );
           },
@@ -7742,7 +7774,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 152,
+              funcId: 153,
               port: port_,
             );
           },
@@ -7774,7 +7806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7801,7 +7833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
           )!;
         },
         codec: SseCodec(
@@ -7827,7 +7859,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7869,7 +7901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 157,
             port: port_,
           );
         },
@@ -7920,7 +7952,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7959,7 +7991,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 159,
             port: port_,
           );
         },
@@ -7995,7 +8027,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8030,7 +8062,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
             port: port_,
           );
         },
@@ -8067,7 +8099,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8111,7 +8143,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8161,7 +8193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8193,7 +8225,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8221,7 +8253,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
           )!;
         },
         codec: SseCodec(
@@ -8253,7 +8285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8290,7 +8322,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8321,7 +8353,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 169,
           )!;
         },
         codec: SseCodec(
@@ -8352,7 +8384,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8389,7 +8421,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 171,
             port: port_,
           );
         },

--- a/rust/src/api/network_privacy.rs
+++ b/rust/src/api/network_privacy.rs
@@ -58,6 +58,16 @@ pub fn is_tor_enabled() -> bool {
     crate::network_privacy::is_tor_desired()
 }
 
+/// Suspends or resumes Tor's circuit maintenance alongside the app lifecycle.
+///
+/// A bootstrapped client otherwise keeps guard connections and directory tasks
+/// running while the app is in the background, which costs battery on mobile
+/// and does work iOS will kill the app for. A no-op until Tor is connected.
+#[flutter_rust_bridge::frb(sync)]
+pub fn set_network_privacy_dormant(dormant: bool) {
+    crate::network_privacy::set_tor_dormant(dormant);
+}
+
 /// Starts a token-protected loopback server that streams HTTPS update assets
 /// from the embedded Tor client directly to a native desktop updater.
 pub async fn start_tor_update_relay() -> Result<String, String> {

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -9,7 +9,7 @@ use std::ffi::CStr;
 use std::future::Future;
 use std::os::raw::c_char;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use crate::migration_preparation::{self, MigrationPreparationProgress};
@@ -99,7 +99,8 @@ fn log_panic(context: &str, panic: Box<dyn std::any::Any + Send>) {
     log::error!("ffi: panic during {context}: {message}");
 }
 
-static FFI_RUNTIME: OnceLock<Result<tokio::runtime::Runtime, String>> = OnceLock::new();
+static FFI_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+static FFI_RUNTIME_BUILD: Mutex<()> = Mutex::new(());
 
 /// The runtime every C entry point runs its async work on.
 ///
@@ -109,15 +110,42 @@ static FFI_RUNTIME: OnceLock<Result<tokio::runtime::Runtime, String>> = OnceLock
 /// dropped, leaving a client that looks installed and cannot carry traffic.
 /// Multi-threaded because separate native threads block on it concurrently.
 fn ffi_runtime() -> Result<&'static tokio::runtime::Runtime, String> {
-    FFI_RUNTIME
-        .get_or_init(|| {
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .map_err(|error| format!("Create FFI runtime: {error}"))
-        })
-        .as_ref()
-        .map_err(|error| error.clone())
+    cached_runtime(&FFI_RUNTIME, &FFI_RUNTIME_BUILD, || {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| format!("Create FFI runtime: {error}"))
+    })
+}
+
+/// Publishes a process-lifetime runtime, and only ever a working one.
+///
+/// Construction reaches for file descriptors and memory for the reactor driver,
+/// so it can fail for reasons that pass: a background pass under memory
+/// pressure, or a process at its descriptor limit. Caching the failure
+/// alongside the success would answer every later call — chain tip, transaction
+/// observation, submission, background Tor enable — with that one moment's
+/// error for the rest of the process lifetime, with nothing to reset it.
+///
+/// The lock is not what makes this correct, the cell is; it only keeps two
+/// threads that arrive together from each standing up a multi-threaded runtime
+/// so one can be thrown away.
+fn cached_runtime(
+    cell: &'static OnceLock<tokio::runtime::Runtime>,
+    build_lock: &'static Mutex<()>,
+    build: impl FnOnce() -> Result<tokio::runtime::Runtime, String>,
+) -> Result<&'static tokio::runtime::Runtime, String> {
+    if let Some(runtime) = cell.get() {
+        return Ok(runtime);
+    }
+    let _guard = build_lock
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(runtime) = cell.get() {
+        return Ok(runtime);
+    }
+    let runtime = build()?;
+    Ok(cell.get_or_init(|| runtime))
 }
 
 const LIGHTWALLETD_RESULT_CANCELLED: i32 = 3;
@@ -428,6 +456,36 @@ pub extern "C" fn zcash_network_privacy_mark_tor_desired() -> i32 {
         Ok(code) => code,
         Err(panic) => {
             log_panic("network privacy Tor declaration", panic);
+            2
+        }
+    }
+}
+
+/// Adopt the user's persisted *direct* preference before any background network
+/// call — the mirror of [`zcash_network_privacy_mark_tor_desired`], and just as
+/// mandatory.
+///
+/// The route is process-local, and "nobody has declared yet" and "the user
+/// chose direct" are deliberately different states: the first is refused at the
+/// route chokepoint so that a background entry point which never read the
+/// preference cannot reach lightwalletd at all. A pass whose saved route is
+/// direct therefore has to say so, exactly as a Tor pass does, or its own
+/// network calls fail closed.
+///
+/// Writes nothing but the decision, touches no filesystem, and is ignored once
+/// the process has decided its own route — a persisted read can be stale, and
+/// this must never turn a live Tor route direct. Returns 0 on success.
+#[no_mangle]
+pub extern "C" fn zcash_network_privacy_mark_direct_route() -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        crate::network_privacy::mark_direct_route();
+        0
+    });
+
+    match result {
+        Ok(code) => code,
+        Err(panic) => {
+            log_panic("network privacy direct route declaration", panic);
             2
         }
     }
@@ -750,6 +808,60 @@ mod tests {
             assert_eq!(result, Err(()));
             assert!(started.elapsed() < Duration::from_secs(1));
         });
+    }
+
+    /// Runtime construction fails for reasons that pass — descriptor
+    /// exhaustion, memory pressure in a background pass. Remembering the
+    /// failure would answer every later chain-tip read, transaction
+    /// observation, submission and background Tor enable with it for the rest
+    /// of the process lifetime, and nothing in the process resets that.
+    #[test]
+    fn a_transient_runtime_construction_failure_is_not_cached() {
+        static CELL: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+        static BUILD: Mutex<()> = Mutex::new(());
+
+        let failed = cached_runtime(&CELL, &BUILD, || {
+            Err("Create FFI runtime: too many open files".to_string())
+        });
+        assert_eq!(
+            failed.unwrap_err(),
+            "Create FFI runtime: too many open files"
+        );
+
+        let retried = cached_runtime(&CELL, &BUILD, || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|error| format!("Create FFI runtime: {error}"))
+        });
+
+        assert!(
+            retried.is_ok(),
+            "a transient runtime-construction failure was cached for the process lifetime"
+        );
+    }
+
+    #[test]
+    fn a_constructed_runtime_outlives_the_call_that_built_it() {
+        static CELL: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+        static BUILD: Mutex<()> = Mutex::new(());
+
+        let first = cached_runtime(&CELL, &BUILD, || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|error| format!("Create FFI runtime: {error}"))
+        })
+        .expect("build the runtime");
+        // A second call must not rebuild: arti's directory, guard and circuit
+        // tasks run on whatever runtime created the Tor client, so replacing it
+        // leaves a client that looks installed and cannot carry traffic.
+        let second = cached_runtime(&CELL, &BUILD, || {
+            Err("rebuilt a runtime that was already published".to_string())
+        })
+        .expect("reuse the published runtime");
+
+        assert!(std::ptr::eq(first, second));
     }
 
     #[test]

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -9,6 +9,7 @@ use std::ffi::CStr;
 use std::future::Future;
 use std::os::raw::c_char;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use crate::migration_preparation::{self, MigrationPreparationProgress};
@@ -98,11 +99,25 @@ fn log_panic(context: &str, panic: Box<dyn std::any::Any + Send>) {
     log::error!("ffi: panic during {context}: {message}");
 }
 
-fn ffi_runtime() -> Result<tokio::runtime::Runtime, String> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| format!("Create FFI runtime: {error}"))
+static FFI_RUNTIME: OnceLock<Result<tokio::runtime::Runtime, String>> = OnceLock::new();
+
+/// The runtime every C entry point runs its async work on.
+///
+/// It has to outlive the calls: a Tor client is created here and kept in a
+/// process-wide slot, but arti's directory, guard and circuit tasks run on
+/// whatever runtime created it. A per-call runtime would take them down as it
+/// dropped, leaving a client that looks installed and cannot carry traffic.
+/// Multi-threaded because separate native threads block on it concurrently.
+fn ffi_runtime() -> Result<&'static tokio::runtime::Runtime, String> {
+    FFI_RUNTIME
+        .get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .map_err(|error| format!("Create FFI runtime: {error}"))
+        })
+        .as_ref()
+        .map_err(|error| error.clone())
 }
 
 const LIGHTWALLETD_RESULT_CANCELLED: i32 = 3;

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crate::migration_preparation::{self, MigrationPreparationProgress};
+use crate::network_privacy::NetworkPrivacyStatus;
 use crate::wallet::keys;
 use tonic::Code;
 
@@ -97,15 +98,23 @@ fn log_panic(context: &str, panic: Box<dyn std::any::Any + Send>) {
     log::error!("ffi: panic during {context}: {message}");
 }
 
-fn lightwalletd_runtime() -> Result<tokio::runtime::Runtime, String> {
+fn ffi_runtime() -> Result<tokio::runtime::Runtime, String> {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .map_err(|error| format!("Create lightwalletd runtime: {error}"))
+        .map_err(|error| format!("Create FFI runtime: {error}"))
 }
 
 const LIGHTWALLETD_RESULT_CANCELLED: i32 = 3;
 const LIGHTWALLETD_CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Tor is up and the caller may do network work over it.
+const NETWORK_PRIVACY_TOR_READY: i32 = 0;
+/// Tor is not up. The route stays Tor-desired and fail-closed, so the caller
+/// does no network work and defers to the foreground.
+const NETWORK_PRIVACY_TOR_NOT_READY: i32 = 1;
+/// Matches the panic code the other entry points return; also not ready.
+const NETWORK_PRIVACY_TOR_PANICKED: i32 = 2;
 
 #[repr(C)]
 pub struct CLightwalletdCancellation {
@@ -185,7 +194,7 @@ pub extern "C" fn zcash_lightwalletd_latest_block_height(
         let Some(output) = (unsafe { output.as_mut() }) else {
             return 1;
         };
-        let runtime = match lightwalletd_runtime() {
+        let runtime = match ffi_runtime() {
             Ok(runtime) => runtime,
             Err(error) => {
                 log::error!("ffi: {error}");
@@ -244,7 +253,7 @@ pub extern "C" fn zcash_lightwalletd_observe_transaction(
         };
         let transaction_id =
             unsafe { std::slice::from_raw_parts(transaction_id, transaction_id_len) }.to_vec();
-        let runtime = match lightwalletd_runtime() {
+        let runtime = match ffi_runtime() {
             Ok(runtime) => runtime,
             Err(error) => {
                 log::error!("ffi: {error}");
@@ -313,7 +322,7 @@ pub extern "C" fn zcash_lightwalletd_send_transaction(
         }
         let raw_transaction =
             unsafe { std::slice::from_raw_parts(raw_transaction, raw_transaction_len) }.to_vec();
-        let runtime = match lightwalletd_runtime() {
+        let runtime = match ffi_runtime() {
             Ok(runtime) => runtime,
             Err(error) => {
                 log::error!("ffi: {error}");
@@ -364,6 +373,102 @@ pub extern "C" fn zcash_lightwalletd_send_transaction(
         Err(panic) => {
             log_panic("lightwalletd transaction submission", panic);
             2
+        }
+    }
+}
+
+/// Adopt the user's persisted Tor preference before any background network
+/// call. The desired route is process-local and defaults to direct, so a
+/// background wake into a cold process would otherwise reach lightwalletd over
+/// clearnet. The caller must have read the persisted preference itself; this
+/// only makes the process fail closed, and returns without bootstrapping Tor or
+/// touching the filesystem.
+///
+/// This is the whole of what a pass that cannot afford a bootstrap does about
+/// the route: it marks, does no network work, and leaves the run to the
+/// foreground. A pass that can afford one calls
+/// [`zcash_network_privacy_enable_tor_for_background_work`], which marks too.
+///
+/// A preference read outside Dart can be stale, so this is ignored once the
+/// process has decided its own route, and reports success either way — the
+/// caller refuses its network pass on a persisted Tor route regardless.
+#[no_mangle]
+pub extern "C" fn zcash_network_privacy_mark_tor_desired() -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        crate::network_privacy::mark_tor_desired();
+        0
+    });
+
+    match result {
+        Ok(code) => code,
+        Err(panic) => {
+            log_panic("network privacy Tor declaration", panic);
+            2
+        }
+    }
+}
+
+/// Bring Tor up for a background pass and block until it is usable or has
+/// failed, so that pass can do its network work on the user's chosen route
+/// without waiting for the foreground.
+///
+/// Call this only once the pass has established that the device is on external
+/// power and the link is unmetered. A cold bootstrap costs 8.45 MB down,
+/// 744 KB up and 23.7 s and leaves a 46.3 MB cache; the client then pads its
+/// guard connection continuously while awake, roughly 500 B/s against 27 B/s
+/// dormant. A warm one costs 0.64 s and no bytes. Those are charger-and-Wi-Fi
+/// costs, not battery-and-cellular ones. A pass that cannot show both
+/// conditions calls [`zcash_network_privacy_mark_tor_desired`] and defers.
+///
+/// `tor_directory` is the Tor data directory, created if it does not exist.
+///
+/// Returns `NETWORK_PRIVACY_TOR_READY` (0) when Tor is up and the caller may do
+/// network work over it; `NETWORK_PRIVACY_TOR_NOT_READY` (1) when it is not, for
+/// any reason at all — bad argument, bootstrap failure, the bootstrap deadline
+/// expiring, or a process that had already chosen the direct route — in which
+/// case the caller must do no network work and defer to the foreground; and
+/// `NETWORK_PRIVACY_TOR_PANICKED` (2) for a panic, which the caller treats as
+/// not ready. The route is left Tor-desired and fail-closed in every non-ready
+/// case, so a caller that ignores the answer is blocked rather than leaked.
+#[no_mangle]
+pub extern "C" fn zcash_network_privacy_enable_tor_for_background_work(
+    tor_directory: *const c_char,
+) -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        // Before the argument is even looked at: a bad path is still a pass
+        // whose persisted route is Tor, and it must not fall through to
+        // clearnet on its way out of here.
+        crate::network_privacy::mark_tor_desired();
+        let Some(tor_directory) = (unsafe { c_str_to_str(tor_directory) }) else {
+            return NETWORK_PRIVACY_TOR_NOT_READY;
+        };
+        let runtime = match ffi_runtime() {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                log::error!("ffi: {error}");
+                return NETWORK_PRIVACY_TOR_NOT_READY;
+            }
+        };
+        match runtime.block_on(crate::network_privacy::enable_tor_for_background_work(
+            std::path::Path::new(tor_directory),
+        )) {
+            Ok(NetworkPrivacyStatus::Ready) => NETWORK_PRIVACY_TOR_READY,
+            Ok(status) => {
+                log::info!("ffi: background Tor enable declined: {status:?}");
+                NETWORK_PRIVACY_TOR_NOT_READY
+            }
+            Err(error) => {
+                log::error!("ffi: background Tor enable: {error}");
+                NETWORK_PRIVACY_TOR_NOT_READY
+            }
+        }
+    });
+
+    match result {
+        Ok(code) => code,
+        Err(panic) => {
+            log_panic("network privacy background Tor enable", panic);
+            NETWORK_PRIVACY_TOR_PANICKED
         }
     }
 }
@@ -611,7 +716,7 @@ mod tests {
                 cancellation.cancelled.store(true, Ordering::Release);
             });
 
-            let runtime = lightwalletd_runtime().unwrap();
+            let runtime = ffi_runtime().unwrap();
             let started = std::time::Instant::now();
             let result = runtime.block_on(await_lightwalletd_request_or_cancellation(
                 Some(&cancellation),

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -312,6 +312,15 @@ pub extern "C" fn zcash_lightwalletd_observe_transaction(
 
 /// Submit one transaction through tonic. The error message is copied into the
 /// caller-owned buffer and safely truncated if necessary.
+///
+/// The submission takes its own Tor circuit. Sharing the process circuit would
+/// let one exit tie the transaction to this wallet's chain queries and to every
+/// other transaction it broadcasts, which is the linkage the foreground
+/// broadcast paths spend an isolated channel to avoid; a background pass that
+/// may now run over Tor has to buy the same property. Isolation costs a circuit
+/// build on a route that is already bootstrapped, and nothing at all on the
+/// direct route, where the isolated and shared openers are the same transport.
+/// One call carries one transaction, so one circuit carries one transaction.
 #[no_mangle]
 pub extern "C" fn zcash_lightwalletd_send_transaction(
     lightwalletd_url: *const c_char,
@@ -348,9 +357,10 @@ pub extern "C" fn zcash_lightwalletd_send_transaction(
         match runtime.block_on(await_lightwalletd_request_or_cancellation(
             cancellation,
             async {
-                let mut client = crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url)
-                    .await
-                    .map_err(|error| error.to_string())?;
+                let mut client =
+                    crate::wallet::sync_engine::open_isolated_lwd_channel(lightwalletd_url)
+                        .await
+                        .map_err(|error| error.to_string())?;
                 crate::wallet::sync_engine::send_transaction_with_status(
                     &mut client,
                     &raw_transaction,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -92948645;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 844087337;
 
 // Section: executor
 
@@ -5793,6 +5793,38 @@ fn wire__crate__api__voting__set_ballot_intent_impl(
         },
     )
 }
+fn wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "set_network_privacy_dormant",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_dormant = <bool>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::network_privacy::set_network_privacy_dormant(api_dormant);
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__sync__set_sync_mode_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -10208,28 +10240,28 @@ fn pde_ffi_dispatcher_primary_impl(
 142 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
 143 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
 144 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+148 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10269,10 +10301,15 @@ fn pde_ffi_dispatcher_sync_impl(
         }
         114 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
         134 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        145 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        154 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        165 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        168 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        145 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        146 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        155 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        166 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        169 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/network_privacy.rs
+++ b/rust/src/network_privacy.rs
@@ -126,22 +126,46 @@ pub fn status() -> NetworkPrivacyStatus {
 /// Runtime toggles call this synchronously before their first `await`, so no
 /// new policy-aware request can race onto clearnet during teardown.
 pub fn begin_tor_enable() {
-    ROUTE_DECIDED.store(true, Ordering::Release);
-    // The route and the status are written inside the slot lock, the way
-    // `disable_tor`, `install_bootstrapped_client` and `set_tor_failed` write
-    // them.
-    //
-    // This is strict alignment with those three, not a fix: no interleaving
-    // that actually diverges was constructed for the enable direction, which
-    // only ever tightens the policy. What it buys is one rule about where these
-    // two atomics may be written instead of three paths that follow it and one
-    // that does not, so the next reader does not have to re-derive whether this
-    // one is safe. The lock order is the same one the siblings take — slot
-    // first, then the waker map — and nothing reached while holding the waker
-    // map takes the slot, so there is no inversion to introduce.
+    enable_tor_route(RouteClaim::Unconditional);
+}
+
+/// Whether an enable may proceed over a route this process has already chosen.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RouteClaim {
+    /// The user asked for Tor in this process. Whatever the route was, it is
+    /// Tor now.
+    Unconditional,
+    /// A persisted preference is being adopted, and it loses to any route this
+    /// process decided for itself.
+    OnlyIfUndecided,
+}
+
+/// The enable, with the claim on the route and the state change it implies made
+/// as one operation.
+///
+/// The claim has to be inside the lock. Split from the writes below it, an
+/// adoption that won the claim and was then preempted let a whole
+/// `disable_tor()` run in the gap — and the writes below, arriving after it,
+/// put the route back to Tor with the client already dropped and no bootstrap
+/// behind them. That leaves every Rust request refused on a fail-closed Tor
+/// route while the app believes it is direct, which nothing recovers short of
+/// toggling Tor again. It is reachable: the native declaration runs on a
+/// background queue while the settings toggle runs on the platform thread.
+///
+/// The route and status writes are the same ones `disable_tor`,
+/// `install_bootstrapped_client` and `set_tor_failed` make under this lock, so
+/// all four paths now share one rule about where these atomics may be written.
+/// The lock order is theirs too — slot first, then the waker map — and nothing
+/// reached while holding the waker map takes the slot, so there is no inversion
+/// to introduce.
+fn enable_tor_route(claim: RouteClaim) {
     let mut slot = client_slot()
         .write()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if claim == RouteClaim::OnlyIfUndecided && ROUTE_DECIDED.load(Ordering::Acquire) {
+        return;
+    }
+    ROUTE_DECIDED.store(true, Ordering::Release);
     let wakers = {
         let mut wakers = direct_io_wakers()
             .lock()
@@ -179,13 +203,7 @@ pub fn begin_tor_enable() {
 /// otherwise a stale read could strand a deliberately-direct session in
 /// fail-closed mode with nothing left to bootstrap it.
 pub fn mark_tor_desired() {
-    if ROUTE_DECIDED
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .is_err()
-    {
-        return;
-    }
-    begin_tor_enable();
+    enable_tor_route(RouteClaim::OnlyIfUndecided);
 }
 
 /// Adopts a persisted *direct* preference in a process where the Dart layer has
@@ -476,6 +494,34 @@ fn hold_background_wake() {
     schedule_background_wake_release(deadline);
 }
 
+/// Extends a lease that is currently held, and does nothing otherwise.
+///
+/// The lease is sized for one pass, not for the longest one: a confirmation
+/// round over enough accounts and transactions runs its queries serially and
+/// can outlive a fixed window, and the client would then be handed back to a
+/// dormancy intent while the pass is still querying through it. Arti lifts a
+/// soft-dormant client on use, so what that costs is churn rather than a
+/// failure — but the intent is meant to describe an idle process, and a process
+/// mid-round is not one.
+///
+/// Renewing on use rather than at the end of a round is deliberate, and is the
+/// same reason the lease exists instead of a restore call: a round has many
+/// ways to end and any of them can be forgotten, while a round that is still
+/// running is exactly a round that is still making requests.
+///
+/// Two things it deliberately does not do. It does not start a lease, so a
+/// request outside a pass cannot mask an intent no pass asked to mask. And it
+/// renews only while the app's own intent is dormant, which is the only time
+/// the mask changes anything: renewing on foreground traffic too would push the
+/// lease out for as long as the app was in use, and the client would then stay
+/// awake and padding for a lease window after the user put the app away — the
+/// exact cost the intent exists to avoid.
+fn renew_background_wake_while_held() {
+    if TOR_DORMANT.load(Ordering::Acquire) && background_wake_is_held() {
+        hold_background_wake();
+    }
+}
+
 /// Waits out one lease and hands the client back to the app's intent.
 ///
 /// A process with no runtime here simply has no timer; the lease still lapses by
@@ -681,14 +727,50 @@ async fn install_bootstrapped_client<E: Display>(
     Ok(NetworkPrivacyStatus::Ready)
 }
 
+/// How often a running bootstrap checks whether the route it is for still
+/// exists. Short enough that the abandon is not itself a wait, long enough to
+/// cost nothing over the minutes a blocked bootstrap can take.
+const BOOTSTRAP_ROUTE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const BOOTSTRAP_ABANDONED_MESSAGE: &str = "Tor was turned off while it was connecting";
+
+/// Waits out one bootstrap, and stops waiting if the route it is for goes away.
+///
+/// Clearing the client slot does not reach the `TorClient` future already
+/// running here, so a user who turned Tor off left arti bootstrapping — talking
+/// to directory authorities for up to the full deadline, on a route they had
+/// just switched off, while holding the init lock a re-enable would have to
+/// wait behind. Nothing wrong was ever published, because the publish re-reads
+/// the route under the slot lock; what was wrong is that the work continued at
+/// all.
+///
+/// Dropping the future is what cancels it, so the abandon is the return itself.
+/// Polling rather than signalling: registering for a notification has a window
+/// between the registration and the check that a route change can fall into,
+/// and a quarter-second poll over a bootstrap measured in tens of seconds costs
+/// less than closing that window would.
 async fn await_tor_bootstrap<T, E: Display>(
     deadline: Duration,
     bootstrap: impl Future<Output = Result<T, E>>,
 ) -> Result<T, String> {
-    match tokio::time::timeout(deadline, bootstrap).await {
-        Ok(Ok(client)) => Ok(client),
-        Ok(Err(error)) => Err(format!("Bootstrap Tor: {error}")),
-        Err(_) => Err(TOR_BOOTSTRAP_TIMEOUT_MESSAGE.to_string()),
+    tokio::pin!(bootstrap);
+    let expires_at = tokio::time::Instant::now() + deadline;
+    loop {
+        tokio::select! {
+            result = &mut bootstrap => {
+                return match result {
+                    Ok(client) => Ok(client),
+                    Err(error) => Err(format!("Bootstrap Tor: {error}")),
+                }
+            }
+            _ = tokio::time::sleep_until(expires_at) => {
+                return Err(TOR_BOOTSTRAP_TIMEOUT_MESSAGE.to_string())
+            }
+            _ = tokio::time::sleep(BOOTSTRAP_ROUTE_POLL_INTERVAL) => {
+                if !is_tor_desired() {
+                    return Err(BOOTSTRAP_ABANDONED_MESSAGE.to_string());
+                }
+            }
+        }
     }
 }
 
@@ -757,6 +839,7 @@ fn is_route_decided() -> bool {
 }
 
 pub(crate) fn tor_client_for_route(isolated: bool) -> Result<Option<TorClient>, String> {
+    renew_background_wake_while_held();
     let client = client_slot()
         .read()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -830,13 +913,15 @@ mod tests {
     };
 
     use super::{
-        await_tor_bootstrap, bootstrap_tor, cancel_direct_connections, client_slot, disable_tor,
+        await_tor_bootstrap, begin_tor_enable, bootstrap_tor, cancel_direct_connections,
+        client_slot, disable_tor,
         dormant_mode_for, enable_tor_for_background_work, init_lock, install_bootstrapped_client,
         is_route_decided, is_tor_desired, mark_direct_route, mark_tor_desired, pending_dormant_mode,
-        route_decision, set_tor_dormant, set_tor_failed, status,
+        process_uptime_ms, route_decision, set_tor_dormant, set_tor_failed, status,
         test_route_policy::lock_route_policy, tor_client_for_route, DirectRouteIo, DormantMode,
         NetworkPrivacyStatus, RouteDecision, TorClient, BACKGROUND_TOR_BOOTSTRAP_TIMEOUT,
-        BACKGROUND_WAKE_UNTIL_MS, ROUTE_NOT_DECLARED_MESSAGE, STATUS_READY, TOR_BOOTSTRAP_TIMEOUT,
+        BACKGROUND_WAKE_UNTIL_MS, BOOTSTRAP_ABANDONED_MESSAGE, ROUTE_DECIDED,
+        ROUTE_NOT_DECLARED_MESSAGE, STATUS_READY, TOR_BOOTSTRAP_TIMEOUT,
         TOR_BOOTSTRAP_TIMEOUT_MESSAGE, TOR_STATUS,
     };
 
@@ -928,6 +1013,112 @@ mod tests {
         assert!(!is_tor_desired());
         assert!(matches!(tor_client_for_route(false), Ok(None)));
         assert!(matches!(tor_client_for_route(true), Ok(None)));
+    }
+
+    /// The claim on the route and the state change it implies are one
+    /// operation, so a `disable_tor` cannot run between them.
+    ///
+    /// Split, the adoption claimed the route, was preempted, and its writes
+    /// arrived after a whole disable had finished — putting the route back to
+    /// Tor with the client dropped and no bootstrap behind it, which refuses
+    /// every request on a route the app believes is direct. Held here by
+    /// blocking the adoption on the slot lock and checking that it has claimed
+    /// nothing yet: before the fix the claim was already made while it waited.
+    #[test]
+    fn an_adoption_claims_no_route_until_it_can_act_on_it() {
+        let _policy = lock_route_policy();
+        let slot = client_slot()
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let adopting = std::thread::spawn(mark_tor_desired);
+        // Long enough for the thread to reach the lock. Overshooting only
+        // makes the check stricter; it cannot turn a held claim into an
+        // unheld one.
+        std::thread::sleep(Duration::from_millis(200));
+
+        assert!(
+            !ROUTE_DECIDED.load(Ordering::Acquire),
+            "the route was claimed before the claim could be acted on"
+        );
+
+        drop(slot);
+        adopting.join().expect("the adoption thread");
+        assert!(is_tor_desired());
+    }
+
+    /// A bootstrap is for a route, and stops when that route does.
+    ///
+    /// Clearing the client slot never reached the future running inside the
+    /// bootstrap, so turning Tor off left arti talking to directory
+    /// authorities for the rest of the deadline, holding the init lock a
+    /// re-enable would wait behind.
+    #[tokio::test]
+    async fn a_bootstrap_stops_when_the_route_it_is_for_goes_away() {
+        let _policy = lock_route_policy();
+        begin_tor_enable();
+
+        let switching_to_direct = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            disable_tor();
+        });
+        let result = await_tor_bootstrap(
+            Duration::from_secs(5),
+            std::future::pending::<Result<(), String>>(),
+        )
+        .await;
+        switching_to_direct.await.expect("the disable task");
+
+        assert_eq!(result.unwrap_err(), BOOTSTRAP_ABANDONED_MESSAGE);
+    }
+
+    /// A round that is still querying is still running, so its lease renews on
+    /// the requests themselves rather than on an end-of-round call nobody has
+    /// to remember to make.
+    #[test]
+    fn a_pass_that_keeps_querying_keeps_its_wake() {
+        let _policy = lock_route_policy();
+        set_tor_dormant(true);
+        let nearly_out = process_uptime_ms().saturating_add(50);
+        BACKGROUND_WAKE_UNTIL_MS.store(nearly_out, Ordering::Release);
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
+
+        let _ = tor_client_for_route(false);
+
+        assert!(
+            BACKGROUND_WAKE_UNTIL_MS.load(Ordering::Acquire) > nearly_out,
+            "a query inside a live lease did not renew it"
+        );
+    }
+
+    /// Renewal is for a lease that exists. A foreground request on its way into
+    /// the background must not start one, or the client stays awake for a lease
+    /// window after the app asked it to sleep.
+    #[test]
+    fn a_query_outside_a_pass_starts_no_wake() {
+        let _policy = lock_route_policy();
+        set_tor_dormant(true);
+        BACKGROUND_WAKE_UNTIL_MS.store(0, Ordering::Release);
+
+        let _ = tor_client_for_route(false);
+
+        assert_eq!(BACKGROUND_WAKE_UNTIL_MS.load(Ordering::Acquire), 0);
+        assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+    }
+
+    /// Foreground traffic must not push the lease out. It would keep the client
+    /// awake for a lease window after the app was put away, which is what the
+    /// dormancy intent exists to prevent.
+    #[test]
+    fn a_query_from_an_app_that_wants_the_client_awake_renews_nothing() {
+        let _policy = lock_route_policy();
+        set_tor_dormant(false);
+        let nearly_out = process_uptime_ms().saturating_add(50);
+        BACKGROUND_WAKE_UNTIL_MS.store(nearly_out, Ordering::Release);
+
+        let _ = tor_client_for_route(false);
+
+        assert_eq!(BACKGROUND_WAKE_UNTIL_MS.load(Ordering::Acquire), nearly_out);
     }
 
     #[test]

--- a/rust/src/network_privacy.rs
+++ b/rust/src/network_privacy.rs
@@ -59,6 +59,13 @@ static ROUTE_DECIDED: AtomicBool = AtomicBool::new(false);
 /// that arrives mid-bootstrap has nothing to apply to, and neither the app
 /// lifecycle callbacks nor a background pass about to do work repeat themselves.
 static TOR_DORMANT: AtomicBool = AtomicBool::new(false);
+/// Monotonic milliseconds, from [`process_uptime_ms`], until which a background
+/// pass needs the client awake. Zero means no pass holds one.
+static BACKGROUND_WAKE_UNTIL_MS: AtomicU64 = AtomicU64::new(0);
+static PROCESS_START: OnceLock<std::time::Instant> = OnceLock::new();
+/// Serialises reading the intent and applying a mode to the client, so a pass
+/// whose wake lapses cannot overwrite an intent that changed a moment earlier.
+static DORMANT_APPLY_LOCK: Mutex<()> = Mutex::new(());
 static TOR_STATUS: AtomicU8 = AtomicU8::new(STATUS_DIRECT);
 static TOR_CLIENT: OnceLock<RwLock<Option<TorClient>>> = OnceLock::new();
 static TOR_INIT_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
@@ -326,28 +333,130 @@ impl<T: hyper::rt::Write + Unpin> hyper::rt::Write for DirectRouteIo<T> {
 /// lifecycle callbacks nor [`enable_tor_for_background_work`] repeat themselves
 /// once it finishes.
 pub fn set_tor_dormant(dormant: bool) {
-    TOR_DORMANT.store(dormant, Ordering::Release);
-    let slot = client_slot()
-        .read()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let Some(client) = slot.as_ref() else {
-        return;
-    };
-    client.set_dormant(pending_dormant_mode());
+    {
+        let _guard = dormant_apply_lock();
+        TOR_DORMANT.store(dormant, Ordering::Release);
+        apply_dormant_mode_locked();
+    }
     log::info!("network privacy: Tor dormant={dormant}");
 }
 
-/// The mode a client is put into as it is installed, so it never lands awake in
-/// a backgrounded process that is not about to use it — the one background
-/// caller that is says so by clearing the intent first. Applying `Soft` to a
-/// client that has just finished bootstrapping is safe: arti lifts it back to
-/// `Normal` on the next use.
-fn pending_dormant_mode() -> DormantMode {
-    if TOR_DORMANT.load(Ordering::Acquire) {
+fn dormant_apply_lock() -> std::sync::MutexGuard<'static, ()> {
+    DORMANT_APPLY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Pushes the mode the current state implies onto the installed client.
+/// Caller holds [`DORMANT_APPLY_LOCK`], so the value read and the value applied
+/// cannot come from different moments.
+fn apply_dormant_mode_locked() {
+    let mode = pending_dormant_mode();
+    let slot = client_slot()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(client) = slot.as_ref() {
+        client.set_dormant(mode);
+    }
+}
+
+fn process_uptime_ms() -> u64 {
+    PROCESS_START
+        .get_or_init(std::time::Instant::now)
+        .elapsed()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
+}
+
+/// How long a background pass's wake survives without being renewed.
+///
+/// A pass renews it every time it brings Tor up, and the confirmation tracker
+/// does that once per polling round, so this only has to outlast one round with
+/// slack. What it actually bounds is the other direction: how long a client
+/// keeps padding its guard connection after the last pass stopped asking for
+/// anything.
+const BACKGROUND_WAKE_LEASE: Duration = Duration::from_secs(2 * 60);
+
+fn background_wake_is_held() -> bool {
+    let until = BACKGROUND_WAKE_UNTIL_MS.load(Ordering::Acquire);
+    until != 0 && process_uptime_ms() < until
+}
+
+/// The mode the client should be in, from the app's intent and whether a
+/// background pass currently needs it awake.
+///
+/// The pass masks the intent rather than overwriting it. There is consequently
+/// nothing for a pass to restore, and no end-of-pass call for any of its exits
+/// to forget: the mask lapses on its own, and a foreground entry that clears the
+/// intent while a pass is still running wins immediately, so a pass can never
+/// put a client to sleep underneath an app that wants it awake.
+fn dormant_mode_for(app_intent_dormant: bool, background_wake_held: bool) -> DormantMode {
+    if app_intent_dormant && !background_wake_held {
         DormantMode::Soft
     } else {
         DormantMode::Normal
     }
+}
+
+/// The mode a client is put into as it is installed, so it never lands awake in
+/// a backgrounded process that is not about to use it. Applying `Soft` to a
+/// client that has just finished bootstrapping is safe: arti lifts it back to
+/// `Normal` on the next use.
+fn pending_dormant_mode() -> DormantMode {
+    dormant_mode_for(
+        TOR_DORMANT.load(Ordering::Acquire),
+        background_wake_is_held(),
+    )
+}
+
+/// Marks the client as needed by a background pass for the next lease window,
+/// and arranges for that to lapse without anything having to say so.
+///
+/// Renewing rather than extending: a later hold always wins, and the release
+/// belongs to whichever hold set the deadline that is still current when it
+/// fires.
+fn hold_background_wake() {
+    let deadline = process_uptime_ms().saturating_add(BACKGROUND_WAKE_LEASE.as_millis() as u64);
+    {
+        let _guard = dormant_apply_lock();
+        BACKGROUND_WAKE_UNTIL_MS.fetch_max(deadline, Ordering::AcqRel);
+        apply_dormant_mode_locked();
+    }
+    schedule_background_wake_release(deadline);
+}
+
+/// Waits out one lease and hands the client back to the app's intent.
+///
+/// A process with no runtime here simply has no timer; the lease still lapses by
+/// time, so the next thing to read the mode computes the released value. What is
+/// lost in that case is only the moment the client is put back to sleep, not
+/// whether it is.
+fn schedule_background_wake_release(deadline: u64) {
+    let Ok(handle) = tokio::runtime::Handle::try_current() else {
+        return;
+    };
+    handle.spawn(async move {
+        loop {
+            let current = BACKGROUND_WAKE_UNTIL_MS.load(Ordering::Acquire);
+            // Released already, or a later hold owns the release now.
+            if current == 0 || current > deadline {
+                return;
+            }
+            let now = process_uptime_ms();
+            if now < current {
+                tokio::time::sleep(Duration::from_millis(current - now)).await;
+                continue;
+            }
+            let _guard = dormant_apply_lock();
+            if BACKGROUND_WAKE_UNTIL_MS
+                .compare_exchange(current, 0, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                apply_dormant_mode_locked();
+            }
+            return;
+        }
+    });
 }
 
 pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, String> {
@@ -385,10 +494,15 @@ pub async fn enable_tor_for_background_work(
     // a process the app has already backgrounded, and a client the app put to
     // sleep on its way out would stay asleep. Neither suits a pass that is about
     // to do work, and this call is the point at which "about to do work" is
-    // known. Waking costs a circuit build, which is why the app does not do this
-    // speculatively; here the work is certain. The app's lifecycle owns the
-    // intent again from its next foreground entry.
-    set_tor_dormant(false);
+    // known.
+    //
+    // Held rather than written. The intent belongs to the app lifecycle, and a
+    // pass that overwrote it would leave the client awake for as long as the
+    // process lived: `onHide` has already run by the time a pass starts, or
+    // never runs at all on a cold background launch, and the next foreground
+    // callback asks for awake too. So nothing would ask for sleep again on
+    // exactly the battery or metered route the caller's gate exists to protect.
+    hold_background_wake();
     bootstrap_tor(tor_directory, BACKGROUND_TOR_BOOTSTRAP_TIMEOUT).await
 }
 
@@ -586,6 +700,9 @@ pub(crate) mod test_route_policy {
         fn drop(&mut self) {
             super::disable_tor();
             super::ROUTE_DECIDED.store(false, Ordering::Release);
+            // A lease outlives the test that took it, and it masks the intent
+            // every later test reads.
+            super::BACKGROUND_WAKE_UNTIL_MS.store(0, Ordering::Release);
         }
     }
 
@@ -608,12 +725,61 @@ mod tests {
 
     use super::{
         await_tor_bootstrap, cancel_direct_connections, client_slot, disable_tor,
-        enable_tor_for_background_work, init_lock, install_bootstrapped_client, is_tor_desired,
-        mark_tor_desired, pending_dormant_mode, route_decision, set_tor_dormant, set_tor_failed, status,
-        test_route_policy::lock_route_policy, tor_client_for_route, DirectRouteIo, DormantMode,
-        NetworkPrivacyStatus, RouteDecision, TorClient, BACKGROUND_TOR_BOOTSTRAP_TIMEOUT,
-        STATUS_READY, TOR_BOOTSTRAP_TIMEOUT, TOR_BOOTSTRAP_TIMEOUT_MESSAGE, TOR_STATUS,
+        dormant_mode_for, enable_tor_for_background_work, init_lock, install_bootstrapped_client,
+        is_tor_desired, mark_tor_desired, pending_dormant_mode, route_decision, set_tor_dormant,
+        set_tor_failed, status, test_route_policy::lock_route_policy, tor_client_for_route,
+        DirectRouteIo, DormantMode, NetworkPrivacyStatus, RouteDecision, TorClient,
+        BACKGROUND_TOR_BOOTSTRAP_TIMEOUT, BACKGROUND_WAKE_UNTIL_MS, STATUS_READY,
+        TOR_BOOTSTRAP_TIMEOUT, TOR_BOOTSTRAP_TIMEOUT_MESSAGE, TOR_STATUS,
     };
+
+    /// Ends whatever lease is outstanding, the way waiting out the lease would.
+    fn lapse_background_wake() {
+        BACKGROUND_WAKE_UNTIL_MS.store(0, Ordering::Release);
+    }
+
+    #[test]
+    fn a_background_pass_masks_the_app_dormancy_intent_without_replacing_it() {
+        assert_eq!(dormant_mode_for(true, false), DormantMode::Soft);
+        assert_eq!(dormant_mode_for(true, true), DormantMode::Normal);
+        assert_eq!(dormant_mode_for(false, false), DormantMode::Normal);
+        // A pass must never put a client to sleep underneath an app that has
+        // asked for it awake.
+        assert_eq!(dormant_mode_for(false, true), DormantMode::Normal);
+    }
+
+    #[tokio::test]
+    async fn a_lapsed_background_wake_returns_the_client_to_the_app_intent() {
+        let _policy = lock_route_policy();
+        let temp = tempfile::tempdir().unwrap();
+        set_tor_dormant(true);
+
+        let _ = enable_tor_for_background_work(&unusable_tor_directory(&temp)).await;
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
+
+        lapse_background_wake();
+
+        // The intent the app left behind is still the one in force, so nothing
+        // had to be restored and no exit had to remember to restore it.
+        assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+        set_tor_dormant(false);
+    }
+
+    #[tokio::test]
+    async fn a_foreground_entry_during_a_pass_wins_over_the_passes_wake() {
+        let _policy = lock_route_policy();
+        let temp = tempfile::tempdir().unwrap();
+        set_tor_dormant(true);
+        let _ = enable_tor_for_background_work(&unusable_tor_directory(&temp)).await;
+
+        // The app comes to the foreground while the pass is still holding.
+        set_tor_dormant(false);
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
+
+        lapse_background_wake();
+
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
+    }
 
     #[test]
     fn direct_route_does_not_require_a_tor_client() {

--- a/rust/src/network_privacy.rs
+++ b/rust/src/network_privacy.rs
@@ -44,6 +44,16 @@ const TOR_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(3 * 60);
 const BACKGROUND_TOR_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(60);
 const TOR_BOOTSTRAP_TIMEOUT_MESSAGE: &str =
     "Tor could not connect. Check your internet connection and try again.";
+/// Refused at the route chokepoint when nothing in this process has said which
+/// route it is on.
+///
+/// The desired route lives in process memory and defaults to direct, so an
+/// entry point that never declares would otherwise reach lightwalletd over
+/// clearnet on a Tor-configured wallet — silently, and only in the lane that
+/// forgot. Declaring is one call ([`mark_tor_desired`], [`mark_direct_route`],
+/// [`begin_tor_enable`], [`enable_tor`] or [`disable_tor`]); not declaring is
+/// now an error every caller sees rather than a leak nobody does.
+const ROUTE_NOT_DECLARED_MESSAGE: &str = "Network route has not been declared for this process";
 
 const STATUS_DIRECT: u8 = 0;
 const STATUS_BOOTSTRAPPING: u8 = 1;
@@ -117,6 +127,21 @@ pub fn status() -> NetworkPrivacyStatus {
 /// new policy-aware request can race onto clearnet during teardown.
 pub fn begin_tor_enable() {
     ROUTE_DECIDED.store(true, Ordering::Release);
+    // The route and the status are written inside the slot lock, the way
+    // `disable_tor`, `install_bootstrapped_client` and `set_tor_failed` write
+    // them.
+    //
+    // This is strict alignment with those three, not a fix: no interleaving
+    // that actually diverges was constructed for the enable direction, which
+    // only ever tightens the policy. What it buys is one rule about where these
+    // two atomics may be written instead of three paths that follow it and one
+    // that does not, so the next reader does not have to re-derive whether this
+    // one is safe. The lock order is the same one the siblings take — slot
+    // first, then the waker map — and nothing reached while holding the waker
+    // map takes the slot, so there is no inversion to introduce.
+    let mut slot = client_slot()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let wakers = {
         let mut wakers = direct_io_wakers()
             .lock()
@@ -126,12 +151,14 @@ pub fn begin_tor_enable() {
         DIRECT_ROUTE_EPOCH.fetch_add(1, Ordering::AcqRel);
         wakers.drain().map(|(_, waker)| waker).collect::<Vec<_>>()
     };
+    *slot = None;
+    drop(slot);
+    // Woken with both locks released. A woken lease re-reads the route and
+    // aborts itself without touching either, but waking underneath them would
+    // hand a scheduler the opportunity to run that on this thread.
     for waker in wakers {
         waker.wake();
     }
-    *client_slot()
-        .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
     log::info!("network privacy: Tor requested; direct requests blocked");
 }
 
@@ -159,6 +186,30 @@ pub fn mark_tor_desired() {
         return;
     }
     begin_tor_enable();
+}
+
+/// Adopts a persisted *direct* preference in a process where the Dart layer has
+/// not run yet — the mirror of [`mark_tor_desired`].
+///
+/// Direct is where the atomics start, so this writes nothing but the decision
+/// itself. That is the whole point: without it, "nobody has said yet" and "the
+/// user chose direct" are the same state, and [`route_decision`] cannot refuse
+/// the first while allowing the second. A background entry point that reaches
+/// lightwalletd on a direct-route wallet calls this, and one that forgets is
+/// refused instead of quietly reaching clearnet on a wallet whose route it
+/// never read.
+///
+/// Stale in the same way its sibling is — the caller read the preference from
+/// storage — so a process that has already decided its own route keeps it, and
+/// this never turns a live Tor route direct.
+pub fn mark_direct_route() {
+    if ROUTE_DECIDED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+    log::info!("network privacy: direct route adopted from the saved preference");
 }
 
 #[cfg(test)]
@@ -510,7 +561,26 @@ async fn bootstrap_tor(
     tor_directory: &Path,
     deadline: Duration,
 ) -> Result<NetworkPrivacyStatus, String> {
-    let _init_guard = init_lock().lock().await;
+    // The deadline covers the wait for the init lock as well as the bootstrap
+    // it guards, so it bounds the call the caller actually made.
+    //
+    // Two enables can be in flight at once — a foreground toggle and a
+    // background pass — and the holder may be spending the foreground's three
+    // minutes on a network that blocks Tor. A waiter that started its own timer
+    // only after acquiring would sit there for the holder's deadline and then
+    // its own on top. For a background pass that is the whole execution
+    // opportunity spent inside one blocking call: it holds no cancellation
+    // handle the OS expiration handler can reach, and every re-arm path lives
+    // on the far side of it, so the window ends with nothing armed.
+    let started = std::time::Instant::now();
+    let Ok(_init_guard) = tokio::time::timeout(deadline, init_lock().lock()).await else {
+        // Nothing is published here. Whichever bootstrap holds the lock owns the
+        // status, and this call only reports that it could not get Tor up inside
+        // its budget. The route stays Tor-desired either way, so every
+        // policy-aware client keeps refusing — running out of patience is not a
+        // reason to reach the network another way.
+        return Err(TOR_BOOTSTRAP_TIMEOUT_MESSAGE.to_string());
+    };
     if !is_tor_desired() {
         return Ok(NetworkPrivacyStatus::Direct);
     }
@@ -534,10 +604,17 @@ async fn bootstrap_tor(
     // body that is actively streaming enough time to complete. Small app API
     // responses retain their own shorter body deadline.
     let timeouts = TorTimeouts::default().with_response_body(Duration::from_secs(2 * 60 * 60));
+    // What is left of the budget after the wait, so waiting and bootstrapping
+    // cannot add up to more than the caller asked for. Bounding the bootstrap
+    // separately rather than wrapping the whole body in one timer is what keeps
+    // a failure published: a timer that fired out here would drop
+    // `install_bootstrapped_client` mid-await and skip the `set_tor_failed` it
+    // exists to perform, leaving the status Bootstrapping with nothing running.
+    let remaining = deadline.saturating_sub(started.elapsed());
     // Returning here drops `_init_guard`, so a bootstrap that ran out of time
     // does not block the next enable attempt.
     install_bootstrapped_client(
-        deadline,
+        remaining,
         TorClient::create_with_timeouts(
             tor_directory,
             // Arti refuses a data directory other users could reach. On desktop
@@ -642,11 +719,22 @@ fn set_tor_failed() {
 }
 
 fn route_decision(
+    route_decided: bool,
     tor_desired: bool,
     tor_status: NetworkPrivacyStatus,
     has_client: bool,
     isolated: bool,
 ) -> Result<RouteDecision, &'static str> {
+    // Direct is a decision, not a default. Every Rust lightwalletd connection
+    // funnels through here, and the entry points that reach it from outside
+    // Dart — the C background calls, and anything added beside them — carry
+    // their contract to declare in a header comment and in their callers. A
+    // lane that forgets fails here, loudly and on its first connection, instead
+    // of reaching lightwalletd over clearnet on a Tor-configured wallet with
+    // nothing failing to compile and no test going red.
+    if !route_decided {
+        return Err(ROUTE_NOT_DECLARED_MESSAGE);
+    }
     if !tor_desired {
         return Ok(RouteDecision::Direct);
     }
@@ -664,12 +752,22 @@ fn route_decision(
     })
 }
 
+fn is_route_decided() -> bool {
+    ROUTE_DECIDED.load(Ordering::Acquire)
+}
+
 pub(crate) fn tor_client_for_route(isolated: bool) -> Result<Option<TorClient>, String> {
     let client = client_slot()
         .read()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .clone();
-    match route_decision(is_tor_desired(), status(), client.is_some(), isolated) {
+    match route_decision(
+        is_route_decided(),
+        is_tor_desired(),
+        status(),
+        client.is_some(),
+        isolated,
+    ) {
         Ok(RouteDecision::Direct) => Ok(None),
         Ok(RouteDecision::TorShared) => Ok(client),
         Ok(RouteDecision::TorIsolated) => Ok(client.map(|client| client.isolated_client())),
@@ -703,6 +801,14 @@ pub(crate) mod test_route_policy {
             // A lease outlives the test that took it, and it masks the intent
             // every later test reads.
             super::BACKGROUND_WAKE_UNTIL_MS.store(0, Ordering::Release);
+            // The intent the lease masks leaks the same way, and one process
+            // runs every test in this crate: a test that asks for dormancy and
+            // returns leaves process-wide dormancy intent set for all of them,
+            // so any later assertion about the mode is decided by test order.
+            // Restored here rather than by each test's last line, because the
+            // guard is what owns handing the process back in its default state
+            // — including for a test that fails or panics before its own reset.
+            super::TOR_DORMANT.store(false, Ordering::Release);
         }
     }
 
@@ -724,13 +830,14 @@ mod tests {
     };
 
     use super::{
-        await_tor_bootstrap, cancel_direct_connections, client_slot, disable_tor,
+        await_tor_bootstrap, bootstrap_tor, cancel_direct_connections, client_slot, disable_tor,
         dormant_mode_for, enable_tor_for_background_work, init_lock, install_bootstrapped_client,
-        is_tor_desired, mark_tor_desired, pending_dormant_mode, route_decision, set_tor_dormant,
-        set_tor_failed, status, test_route_policy::lock_route_policy, tor_client_for_route,
-        DirectRouteIo, DormantMode, NetworkPrivacyStatus, RouteDecision, TorClient,
-        BACKGROUND_TOR_BOOTSTRAP_TIMEOUT, BACKGROUND_WAKE_UNTIL_MS, STATUS_READY,
-        TOR_BOOTSTRAP_TIMEOUT, TOR_BOOTSTRAP_TIMEOUT_MESSAGE, TOR_STATUS,
+        is_route_decided, is_tor_desired, mark_direct_route, mark_tor_desired, pending_dormant_mode,
+        route_decision, set_tor_dormant, set_tor_failed, status,
+        test_route_policy::lock_route_policy, tor_client_for_route, DirectRouteIo, DormantMode,
+        NetworkPrivacyStatus, RouteDecision, TorClient, BACKGROUND_TOR_BOOTSTRAP_TIMEOUT,
+        BACKGROUND_WAKE_UNTIL_MS, ROUTE_NOT_DECLARED_MESSAGE, STATUS_READY, TOR_BOOTSTRAP_TIMEOUT,
+        TOR_BOOTSTRAP_TIMEOUT_MESSAGE, TOR_STATUS,
     };
 
     /// Ends whatever lease is outstanding, the way waiting out the lease would.
@@ -762,7 +869,6 @@ mod tests {
         // The intent the app left behind is still the one in force, so nothing
         // had to be restored and no exit had to remember to restore it.
         assert_eq!(pending_dormant_mode(), DormantMode::Soft);
-        set_tor_dormant(false);
     }
 
     #[tokio::test]
@@ -784,19 +890,66 @@ mod tests {
     #[test]
     fn direct_route_does_not_require_a_tor_client() {
         assert_eq!(
-            route_decision(false, NetworkPrivacyStatus::Direct, false, false),
+            route_decision(true, false, NetworkPrivacyStatus::Direct, false, false),
             Ok(RouteDecision::Direct)
         );
     }
 
     #[test]
+    fn an_undeclared_route_is_refused_instead_of_resolving_to_a_direct_connection() {
+        let _policy = lock_route_policy();
+        // The state a process starts in, and the one a background wake into a
+        // cold process is still in until something declares.
+        assert!(!is_route_decided());
+
+        assert_eq!(
+            route_decision(false, false, NetworkPrivacyStatus::Direct, false, false),
+            Err(ROUTE_NOT_DECLARED_MESSAGE)
+        );
+        // The chokepoint every Rust lightwalletd connection funnels through:
+        // an entry point that never declared must not get a transport out of it.
+        assert!(
+            tor_client_for_route(false).is_err(),
+            "an undeclared route resolved to a direct connection"
+        );
+        assert!(
+            tor_client_for_route(true).is_err(),
+            "an undeclared route resolved to a direct connection"
+        );
+    }
+
+    #[test]
+    fn a_declared_direct_route_still_connects_directly() {
+        let _policy = lock_route_policy();
+
+        mark_direct_route();
+
+        assert!(is_route_decided());
+        assert!(!is_tor_desired());
+        assert!(matches!(tor_client_for_route(false), Ok(None)));
+        assert!(matches!(tor_client_for_route(true), Ok(None)));
+    }
+
+    #[test]
+    fn marking_a_stale_direct_preference_leaves_a_process_that_chose_tor_alone() {
+        let _policy = lock_route_policy();
+        mark_tor_desired();
+
+        mark_direct_route();
+
+        assert!(is_tor_desired());
+        assert_eq!(status(), NetworkPrivacyStatus::Bootstrapping);
+        assert!(tor_client_for_route(false).is_err());
+    }
+
+    #[test]
     fn tor_bootstrap_and_failure_are_fail_closed() {
         assert_eq!(
-            route_decision(true, NetworkPrivacyStatus::Bootstrapping, false, false),
+            route_decision(true, true, NetworkPrivacyStatus::Bootstrapping, false, false),
             Err("Tor is still connecting")
         );
         assert_eq!(
-            route_decision(true, NetworkPrivacyStatus::Failed, false, false),
+            route_decision(true, true, NetworkPrivacyStatus::Failed, false, false),
             Err("Tor connection failed")
         );
     }
@@ -804,11 +957,11 @@ mod tests {
     #[test]
     fn ready_tor_selects_shared_or_isolated_routes() {
         assert_eq!(
-            route_decision(true, NetworkPrivacyStatus::Ready, true, false),
+            route_decision(true, true, NetworkPrivacyStatus::Ready, true, false),
             Ok(RouteDecision::TorShared)
         );
         assert_eq!(
-            route_decision(true, NetworkPrivacyStatus::Ready, true, true),
+            route_decision(true, true, NetworkPrivacyStatus::Ready, true, true),
             Ok(RouteDecision::TorIsolated)
         );
     }
@@ -816,7 +969,7 @@ mod tests {
     #[test]
     fn ready_status_without_a_client_is_still_fail_closed() {
         assert_eq!(
-            route_decision(true, NetworkPrivacyStatus::Ready, false, false),
+            route_decision(true, true, NetworkPrivacyStatus::Ready, false, false),
             Err("Tor is enabled but unavailable")
         );
     }
@@ -824,16 +977,19 @@ mod tests {
     #[test]
     fn marking_a_persisted_tor_route_refuses_instead_of_going_direct() {
         let _policy = lock_route_policy();
+        // Undeclared going in: this is the cold background process the mark
+        // exists for, so the contrast below is with a refusal, not with a
+        // direct connection.
         assert_eq!(
-            route_decision(is_tor_desired(), status(), false, false),
-            Ok(RouteDecision::Direct)
+            route_decision(is_route_decided(), is_tor_desired(), status(), false, false),
+            Err(ROUTE_NOT_DECLARED_MESSAGE)
         );
 
         mark_tor_desired();
 
         assert!(is_tor_desired());
         assert_eq!(
-            route_decision(is_tor_desired(), status(), false, false),
+            route_decision(is_route_decided(), is_tor_desired(), status(), false, false),
             Err("Tor is still connecting")
         );
         assert!(tor_client_for_route(false).is_err());
@@ -964,7 +1120,7 @@ mod tests {
 
         assert_eq!(status(), NetworkPrivacyStatus::Direct);
         assert_eq!(
-            route_decision(is_tor_desired(), status(), false, false),
+            route_decision(is_route_decided(), is_tor_desired(), status(), false, false),
             Ok(RouteDecision::Direct)
         );
     }
@@ -1015,7 +1171,6 @@ mod tests {
         // Nothing here is about to do work on a Tor route, so the intent the
         // app's own lifecycle left behind is not this call's to overwrite.
         assert_eq!(pending_dormant_mode(), DormantMode::Soft);
-        set_tor_dormant(false);
     }
 
     #[tokio::test]
@@ -1028,6 +1183,66 @@ mod tests {
         let _ = enable_tor_for_background_work(&unusable_tor_directory(&temp)).await;
 
         assert_eq!(pending_dormant_mode(), DormantMode::Normal);
+    }
+
+    /// The lease and the dormancy intent are both process-wide, and `cargo
+    /// test` runs the whole crate in one process. A test that asks for
+    /// dormancy and returns is the ordinary case — the guard is what hands the
+    /// process back, so no test has to end with a reset line it could forget or
+    /// fail before reaching.
+    #[test]
+    fn the_route_policy_guard_hands_back_the_default_dormancy_intent() {
+        {
+            let _policy = lock_route_policy();
+            set_tor_dormant(true);
+            assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+        }
+
+        let _policy = lock_route_policy();
+
+        assert_eq!(
+            pending_dormant_mode(),
+            DormantMode::Normal,
+            "a test's dormancy intent outlived its route-policy guard"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_bootstrap_waiting_on_another_bootstrap_is_bounded_by_its_own_deadline() {
+        let _policy = lock_route_policy();
+        let temp = tempfile::tempdir().unwrap();
+        mark_tor_desired();
+
+        // A bootstrap already in flight, of the kind a foreground enable starts:
+        // it holds the init lock for far longer than the waiter's whole budget.
+        let (acquired_tx, acquired_rx) = tokio::sync::oneshot::channel();
+        let holder = tokio::spawn(async move {
+            let _init_guard = init_lock().lock().await;
+            let _ = acquired_tx.send(());
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        });
+        acquired_rx.await.unwrap();
+
+        let started = std::time::Instant::now();
+        let result = bootstrap_tor(&unusable_tor_directory(&temp), Duration::from_millis(100)).await;
+        let waited = started.elapsed();
+
+        holder.abort();
+        let _ = holder.await;
+
+        // The deadline covers the wait, not just the bootstrap on its far side.
+        // A background pass has one execution opportunity and no cancellation
+        // handle reaching into this call, so parking here for the holder's
+        // deadline spends the window with nothing armed.
+        assert!(
+            waited < Duration::from_secs(5),
+            "a waiting bootstrap ignored its own deadline: waited {waited:?}"
+        );
+        assert_eq!(result.unwrap_err(), TOR_BOOTSTRAP_TIMEOUT_MESSAGE);
+        // Running out of time is still not a reason to reach the network another
+        // way: the route stays Tor and every policy-aware client keeps refusing.
+        assert!(is_tor_desired());
+        assert!(tor_client_for_route(false).is_err());
     }
 
     #[tokio::test]

--- a/rust/src/network_privacy.rs
+++ b/rust/src/network_privacy.rs
@@ -467,21 +467,25 @@ async fn install_bootstrapped_client<E: Display>(
         }
     };
 
-    if !is_tor_desired() {
-        return Ok(NetworkPrivacyStatus::Direct);
-    }
-
     {
-        // Adopting the pending mode under the install lock is what keeps a
-        // request made mid-bootstrap from being overtaken by the client that
-        // request was waiting for.
+        // The route is read and the client published under one lock, because
+        // `disable_tor` takes the same one: a switch to direct that lands
+        // between a check outside and the store would otherwise leave the
+        // status Ready with the route direct, and an orphaned client awake and
+        // padding behind it.
+        //
+        // Adopting the pending mode here too is what keeps a request made
+        // mid-bootstrap from being overtaken by the client it was waiting for.
         let mut slot = client_slot()
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !is_tor_desired() {
+            return Ok(NetworkPrivacyStatus::Direct);
+        }
         client.set_dormant(pending_dormant_mode());
         *slot = Some(client);
+        TOR_STATUS.store(STATUS_READY, Ordering::Release);
     }
-    TOR_STATUS.store(STATUS_READY, Ordering::Release);
     log::info!("network privacy: Tor is ready");
     Ok(NetworkPrivacyStatus::Ready)
 }
@@ -499,18 +503,25 @@ async fn await_tor_bootstrap<T, E: Display>(
 
 pub fn disable_tor() {
     ROUTE_DECIDED.store(true, Ordering::Release);
+    // Under the same lock a finishing bootstrap publishes through, so the two
+    // cannot interleave into a Ready status on a direct route.
+    let mut slot = client_slot()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     TOR_DESIRED.store(false, Ordering::Release);
     TOR_STATUS.store(STATUS_DIRECT, Ordering::Release);
-    *client_slot()
-        .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    *slot = None;
+    drop(slot);
     log::info!("network privacy: direct route enabled");
 }
 
 fn set_tor_failed() {
-    *client_slot()
+    let mut slot = client_slot()
         .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *slot = None;
+    // Same lock as the publish and the disable: a route that went direct while
+    // this bootstrap was failing keeps its own status.
     if is_tor_desired() {
         TOR_STATUS.store(STATUS_FAILED, Ordering::Release);
     }
@@ -598,7 +609,7 @@ mod tests {
     use super::{
         await_tor_bootstrap, cancel_direct_connections, client_slot, disable_tor,
         enable_tor_for_background_work, init_lock, install_bootstrapped_client, is_tor_desired,
-        mark_tor_desired, pending_dormant_mode, route_decision, set_tor_dormant, status,
+        mark_tor_desired, pending_dormant_mode, route_decision, set_tor_dormant, set_tor_failed, status,
         test_route_policy::lock_route_policy, tor_client_for_route, DirectRouteIo, DormantMode,
         NetworkPrivacyStatus, RouteDecision, TorClient, BACKGROUND_TOR_BOOTSTRAP_TIMEOUT,
         STATUS_READY, TOR_BOOTSTRAP_TIMEOUT, TOR_BOOTSTRAP_TIMEOUT_MESSAGE, TOR_STATUS,
@@ -765,6 +776,31 @@ mod tests {
         // spending the foreground deadline here would consume most windows
         // whole and leave no time for the work the bootstrap is for.
         assert!(BACKGROUND_TOR_BOOTSTRAP_TIMEOUT < TOR_BOOTSTRAP_TIMEOUT);
+    }
+
+    #[test]
+    fn a_route_that_went_direct_keeps_its_status_when_a_bootstrap_fails() {
+        let _policy = lock_route_policy();
+        mark_tor_desired();
+        disable_tor();
+
+        assert_eq!(status(), NetworkPrivacyStatus::Direct);
+        assert!(client_slot()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_none());
+
+        // A bootstrap started before the switch reports its failure afterwards.
+        // The route is direct now, so the failure is not this route's to
+        // publish — a Failed status here would block requests the user asked to
+        // send directly.
+        set_tor_failed();
+
+        assert_eq!(status(), NetworkPrivacyStatus::Direct);
+        assert_eq!(
+            route_decision(is_tor_desired(), status(), false, false),
+            Ok(RouteDecision::Direct)
+        );
     }
 
     #[tokio::test]

--- a/rust/src/network_privacy.rs
+++ b/rust/src/network_privacy.rs
@@ -69,6 +69,14 @@ static ROUTE_DECIDED: AtomicBool = AtomicBool::new(false);
 /// that arrives mid-bootstrap has nothing to apply to, and neither the app
 /// lifecycle callbacks nor a background pass about to do work repeat themselves.
 static TOR_DORMANT: AtomicBool = AtomicBool::new(false);
+/// Whether the app lifecycle has ever stated an intent in this process.
+///
+/// Awake is the right default for a process the app is running, and the wrong
+/// one for a process the OS started for a background pass: only Flutter's
+/// lifecycle callbacks write the intent, so a cold background launch would keep
+/// the default forever and leave a client padding its guard connection with no
+/// foreground to serve.
+static DORMANCY_INTENT_DECLARED: AtomicBool = AtomicBool::new(false);
 /// Monotonic milliseconds, from [`process_uptime_ms`], until which a background
 /// pass needs the client awake. Zero means no pass holds one.
 static BACKGROUND_WAKE_UNTIL_MS: AtomicU64 = AtomicU64::new(0);
@@ -404,10 +412,26 @@ impl<T: hyper::rt::Write + Unpin> hyper::rt::Write for DirectRouteIo<T> {
 pub fn set_tor_dormant(dormant: bool) {
     {
         let _guard = dormant_apply_lock();
+        DORMANCY_INTENT_DECLARED.store(true, Ordering::Release);
         TOR_DORMANT.store(dormant, Ordering::Release);
         apply_dormant_mode_locked();
     }
     log::info!("network privacy: Tor dormant={dormant}");
+}
+
+/// Gives a process that the app never ran in the intent it was never given.
+///
+/// Only claims the undeclared default. An app that has stated an intent keeps
+/// it — including an app that asked to stay awake and is running while a pass
+/// happens to start — so this can never put a client to sleep underneath a
+/// foreground that wants it.
+fn adopt_background_dormancy_intent() {
+    let _guard = dormant_apply_lock();
+    if DORMANCY_INTENT_DECLARED.load(Ordering::Acquire) {
+        return;
+    }
+    TOR_DORMANT.store(true, Ordering::Release);
+    apply_dormant_mode_locked();
 }
 
 fn dormant_apply_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -595,10 +619,20 @@ pub async fn enable_tor_for_background_work(
     //
     // Held rather than written. The intent belongs to the app lifecycle, and a
     // pass that overwrote it would leave the client awake for as long as the
-    // process lived: `onHide` has already run by the time a pass starts, or
-    // never runs at all on a cold background launch, and the next foreground
-    // callback asks for awake too. So nothing would ask for sleep again on
-    // exactly the battery or metered route the caller's gate exists to protect.
+    // process lived: `onHide` has already run by the time a pass starts, and
+    // the next foreground callback asks for awake too. So nothing would ask for
+    // sleep again on exactly the battery or metered route the caller's gate
+    // exists to protect.
+    //
+    // Except on a cold background launch, where the lifecycle never speaks at
+    // all. There is no intent to preserve there, only a default that means
+    // "awake" and was chosen for a process the app is running — so a pass in
+    // that process would hold the client awake, finish, and hand it back to a
+    // default that keeps it awake, padding a guard connection for a foreground
+    // that does not exist. Adopting sleep as the intent is not overwriting one:
+    // it supplies the one this process was never given, and a foreground that
+    // does arrive later says so itself.
+    adopt_background_dormancy_intent();
     hold_background_wake();
     bootstrap_tor(tor_directory, BACKGROUND_TOR_BOOTSTRAP_TIMEOUT).await
 }
@@ -892,6 +926,11 @@ pub(crate) mod test_route_policy {
             // guard is what owns handing the process back in its default state
             // — including for a test that fails or panics before its own reset.
             super::TOR_DORMANT.store(false, Ordering::Release);
+            // Restored with the intent it gates. A test that let a background
+            // pass adopt the undeclared default would otherwise leave the
+            // process claiming the app had spoken, and the next test to rely on
+            // that adoption would silently stop exercising it.
+            super::DORMANCY_INTENT_DECLARED.store(false, Ordering::Release);
         }
     }
 
@@ -1104,6 +1143,37 @@ mod tests {
 
         assert_eq!(BACKGROUND_WAKE_UNTIL_MS.load(Ordering::Acquire), 0);
         assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+    }
+
+    /// A process the app never ran in has no lifecycle to state an intent, so
+    /// the default — awake, chosen for a process the app is running — would
+    /// outlive the pass and keep a client padding a guard connection for a
+    /// foreground that does not exist.
+    #[tokio::test]
+    async fn a_cold_background_pass_leaves_the_client_asleep_behind_it() {
+        let _policy = lock_route_policy();
+        let temp = tempfile::tempdir().unwrap();
+
+        let _ = enable_tor_for_background_work(&unusable_tor_directory(&temp)).await;
+
+        // Awake while the pass holds it, asleep once that lapses.
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
+        lapse_background_wake();
+        assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+    }
+
+    /// An app that has stated an intent keeps it, including one that asked to
+    /// stay awake while a pass happens to start.
+    #[tokio::test]
+    async fn a_background_pass_never_overrides_an_intent_the_app_stated() {
+        let _policy = lock_route_policy();
+        let temp = tempfile::tempdir().unwrap();
+        set_tor_dormant(false);
+
+        let _ = enable_tor_for_background_work(&unusable_tor_directory(&temp)).await;
+        lapse_background_wake();
+
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
     }
 
     /// Foreground traffic must not push the lease out. It would keep the client

--- a/rust/src/network_privacy.rs
+++ b/rust/src/network_privacy.rs
@@ -19,14 +19,29 @@ use std::{
     time::Duration,
 };
 
-use zcash_client_backend::tor::{Client as TorClient, Timeouts as TorTimeouts};
+use zcash_client_backend::tor::{Client as TorClient, DormantMode, Timeouts as TorTimeouts};
 
 /// `TorTimeouts` only bounds connect, request and response-body phases, so
 /// bootstrapping itself is unbounded: arti retries it 128 times with a growing
 /// backoff, which never terminates on a network that blocks Tor. A cold first
 /// bootstrap over a slow link legitimately takes tens of seconds, so the
-/// deadline stays generous enough to let those finish.
+/// deadline stays generous enough to let those finish. A user watching the
+/// route switch can also see it working and give up themselves, which a
+/// background pass cannot.
 const TOR_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(3 * 60);
+/// The same bootstrap started from a background pass, where nobody is watching
+/// and the execution window can be withdrawn at any moment.
+///
+/// A cold bootstrap measured 23.7 s on a fast link, so the deadline has to sit
+/// well above that figure and not at it: the link here is only known to be
+/// unmetered, not fast, and this bootstrap runs on the single-threaded FFI
+/// runtime rather than the app's. Sixty seconds is roughly two and a half times
+/// the measured cost — enough headroom for a slower link, while still leaving
+/// the rest of the window for the work the bootstrap exists to enable, and
+/// leaving a pass that gives up here time to defer cleanly instead of being
+/// killed mid-bootstrap. Spending three minutes on it would consume most windows
+/// whole and produce nothing.
+const BACKGROUND_TOR_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(60);
 const TOR_BOOTSTRAP_TIMEOUT_MESSAGE: &str =
     "Tor could not connect. Check your internet connection and try again.";
 
@@ -36,6 +51,14 @@ const STATUS_READY: u8 = 2;
 const STATUS_FAILED: u8 = 3;
 
 static TOR_DESIRED: AtomicBool = AtomicBool::new(false);
+/// Set as soon as anything in this process decides the route. A preference read
+/// from outside Dart is only a fallback for a process that has not decided yet,
+/// so it must never overwrite a decision that has already been made.
+static ROUTE_DECIDED: AtomicBool = AtomicBool::new(false);
+/// The dormancy asked for, kept whether or not a client exists yet. A request
+/// that arrives mid-bootstrap has nothing to apply to, and neither the app
+/// lifecycle callbacks nor a background pass about to do work repeat themselves.
+static TOR_DORMANT: AtomicBool = AtomicBool::new(false);
 static TOR_STATUS: AtomicU8 = AtomicU8::new(STATUS_DIRECT);
 static TOR_CLIENT: OnceLock<RwLock<Option<TorClient>>> = OnceLock::new();
 static TOR_INIT_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
@@ -86,6 +109,7 @@ pub fn status() -> NetworkPrivacyStatus {
 /// Runtime toggles call this synchronously before their first `await`, so no
 /// new policy-aware request can race onto clearnet during teardown.
 pub fn begin_tor_enable() {
+    ROUTE_DECIDED.store(true, Ordering::Release);
     let wakers = {
         let mut wakers = direct_io_wakers()
             .lock()
@@ -102,6 +126,32 @@ pub fn begin_tor_enable() {
         .write()
         .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
     log::info!("network privacy: Tor requested; direct requests blocked");
+}
+
+/// Adopts a persisted Tor preference in a process where the Dart layer has not
+/// run yet.
+///
+/// The desired route lives in process memory, so a background wake into a cold
+/// process starts in direct mode and would route wallet traffic over clearnet
+/// without ever asking the user. Marking makes that process fail closed: it
+/// never bootstraps Tor by itself, so a pass that only marks can do no network
+/// work and has to defer to the foreground. A pass that has established it can
+/// afford a bootstrap calls [`enable_tor_for_background_work`] instead, which
+/// marks first and then brings a client up.
+///
+/// The caller reads the preference from storage, so its answer can already be
+/// stale by the time it arrives here — the user may have picked direct in the
+/// meantime. A process that has decided its own route is therefore left alone;
+/// otherwise a stale read could strand a deliberately-direct session in
+/// fail-closed mode with nothing left to bootstrap it.
+pub fn mark_tor_desired() {
+    if ROUTE_DECIDED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+    begin_tor_enable();
 }
 
 #[cfg(test)]
@@ -266,9 +316,86 @@ impl<T: hyper::rt::Write + Unpin> hyper::rt::Write for DirectRouteIo<T> {
     }
 }
 
-pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, String> {
-    TOR_DESIRED.store(true, Ordering::Release);
+/// Puts a Tor client to sleep, or wakes it up.
+///
+/// Arti keeps guard connections and directory tasks running; on mobile that
+/// costs battery in the background and, on iOS, does work in a state the OS
+/// will kill. This never forces a bootstrap, but a request made while one is
+/// still running is not lost either: a cold bootstrap takes tens of seconds,
+/// long enough for the app to be backgrounded inside it, and neither the
+/// lifecycle callbacks nor [`enable_tor_for_background_work`] repeat themselves
+/// once it finishes.
+pub fn set_tor_dormant(dormant: bool) {
+    TOR_DORMANT.store(dormant, Ordering::Release);
+    let slot = client_slot()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(client) = slot.as_ref() else {
+        return;
+    };
+    client.set_dormant(pending_dormant_mode());
+    log::info!("network privacy: Tor dormant={dormant}");
+}
 
+/// The mode a client is put into as it is installed, so it never lands awake in
+/// a backgrounded process that is not about to use it — the one background
+/// caller that is says so by clearing the intent first. Applying `Soft` to a
+/// client that has just finished bootstrapping is safe: arti lifts it back to
+/// `Normal` on the next use.
+fn pending_dormant_mode() -> DormantMode {
+    if TOR_DORMANT.load(Ordering::Acquire) {
+        DormantMode::Soft
+    } else {
+        DormantMode::Normal
+    }
+}
+
+pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, String> {
+    ROUTE_DECIDED.store(true, Ordering::Release);
+    TOR_DESIRED.store(true, Ordering::Release);
+    bootstrap_tor(tor_directory, TOR_BOOTSTRAP_TIMEOUT).await
+}
+
+/// Brings Tor up inside a background pass that has already established it can
+/// afford one.
+///
+/// A cold bootstrap costs 8.45 MB down, 744 KB up and 23.7 s, and leaves a
+/// 46.3 MB cache behind; a warm one costs 0.64 s and no bytes. The client then
+/// pads its guard connection continuously for as long as it is awake — measured
+/// at roughly 500 B/s, against 27 B/s dormant. That is affordable on external
+/// power over an unmetered link and is not affordable on battery or on a metered
+/// one, and only the caller can see power and metering state, so the caller
+/// decides and this is reached only once that decision says yes.
+///
+/// The fail-closed mark comes first, so a pass refused below still cannot reach
+/// the network directly. A process that has already decided its own route keeps
+/// it: the caller's persisted read can be stale, and moving a session the user
+/// deliberately put on the direct route onto Tor is not this function's call to
+/// make. It reports `Direct` in that case, and the caller treats everything that
+/// is not `Ready` alike — no network work, defer to the foreground.
+pub async fn enable_tor_for_background_work(
+    tor_directory: &Path,
+) -> Result<NetworkPrivacyStatus, String> {
+    mark_tor_desired();
+    if !is_tor_desired() {
+        return Ok(NetworkPrivacyStatus::Direct);
+    }
+    // The dormancy intent is process-wide and is applied to a client as that
+    // client is installed, so a client bootstrapped here would come up asleep in
+    // a process the app has already backgrounded, and a client the app put to
+    // sleep on its way out would stay asleep. Neither suits a pass that is about
+    // to do work, and this call is the point at which "about to do work" is
+    // known. Waking costs a circuit build, which is why the app does not do this
+    // speculatively; here the work is certain. The app's lifecycle owns the
+    // intent again from its next foreground entry.
+    set_tor_dormant(false);
+    bootstrap_tor(tor_directory, BACKGROUND_TOR_BOOTSTRAP_TIMEOUT).await
+}
+
+async fn bootstrap_tor(
+    tor_directory: &Path,
+    deadline: Duration,
+) -> Result<NetworkPrivacyStatus, String> {
     let _init_guard = init_lock().lock().await;
     if !is_tor_desired() {
         return Ok(NetworkPrivacyStatus::Direct);
@@ -295,12 +422,44 @@ pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, St
     let timeouts = TorTimeouts::default().with_response_body(Duration::from_secs(2 * 60 * 60));
     // Returning here drops `_init_guard`, so a bootstrap that ran out of time
     // does not block the next enable attempt.
-    let client = match await_tor_bootstrap(
-        TOR_BOOTSTRAP_TIMEOUT,
-        TorClient::create_with_timeouts(tor_directory, |_| {}, timeouts),
+    install_bootstrapped_client(
+        deadline,
+        TorClient::create_with_timeouts(
+            tor_directory,
+            // Arti refuses a data directory other users could reach. On desktop
+            // those POSIX mode bits are the real boundary, so the check stays
+            // on. On mobile the app sandbox is the boundary, and the pinned
+            // fs-mistrust already knows it: on iOS and Android it compiles out
+            // the owner check and stops forbidding the group bits, which is the
+            // group-writable container ancestor that used to reject the
+            // directory outright. What it still rejects there — a world-
+            // writable ancestor, or arti's own 0o700 directories opened up — a
+            // sandboxed container is not expected to have, so this bypass is
+            // probably redundant. Dropping it needs evidence from a real
+            // device, because a rejected directory fails the bootstrap from
+            // inside fail-closed mode: every request blocked, Tor never Ready.
+            |permissions| {
+                #[cfg(any(target_os = "ios", target_os = "android"))]
+                permissions.dangerously_trust_everyone();
+                #[cfg(not(any(target_os = "ios", target_os = "android")))]
+                let _ = permissions;
+            },
+            timeouts,
+        ),
     )
     .await
-    {
+}
+
+/// Waits out one bootstrap attempt and publishes its outcome.
+///
+/// Running out of time is not a reason to reach the network another way: the
+/// route stays Tor and the status becomes `Failed`, so every policy-aware client
+/// keeps refusing until something bootstraps successfully.
+async fn install_bootstrapped_client<E: Display>(
+    deadline: Duration,
+    bootstrap: impl Future<Output = Result<TorClient, E>>,
+) -> Result<NetworkPrivacyStatus, String> {
+    let client = match await_tor_bootstrap(deadline, bootstrap).await {
         Ok(client) => client,
         Err(error) => {
             set_tor_failed();
@@ -312,9 +471,16 @@ pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, St
         return Ok(NetworkPrivacyStatus::Direct);
     }
 
-    *client_slot()
-        .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(client);
+    {
+        // Adopting the pending mode under the install lock is what keeps a
+        // request made mid-bootstrap from being overtaken by the client that
+        // request was waiting for.
+        let mut slot = client_slot()
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        client.set_dormant(pending_dormant_mode());
+        *slot = Some(client);
+    }
     TOR_STATUS.store(STATUS_READY, Ordering::Release);
     log::info!("network privacy: Tor is ready");
     Ok(NetworkPrivacyStatus::Ready)
@@ -332,6 +498,7 @@ async fn await_tor_bootstrap<T, E: Display>(
 }
 
 pub fn disable_tor() {
+    ROUTE_DECIDED.store(true, Ordering::Release);
     TOR_DESIRED.store(false, Ordering::Release);
     TOR_STATUS.store(STATUS_DIRECT, Ordering::Release);
     *client_slot()
@@ -385,16 +552,56 @@ pub(crate) fn tor_client_for_route(isolated: bool) -> Result<Option<TorClient>, 
     }
 }
 
+/// Serialises the tests that touch the process-wide route policy.
+///
+/// `cargo test` shares one process across threads, so this has to be reachable
+/// from every module whose tests read the policy — not just the ones that write
+/// it. A direct-route lease consults the desired route on every poll, so a test
+/// that merely opens a direct connection fails if a route test is mid-flight.
+#[cfg(test)]
+pub(crate) mod test_route_policy {
+    use std::sync::{atomic::Ordering, Mutex, MutexGuard};
+
+    static ROUTE_POLICY: Mutex<()> = Mutex::new(());
+
+    pub(crate) struct RoutePolicyGuard {
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl Drop for RoutePolicyGuard {
+        /// Hands the process back in its default state. The direct-route epoch
+        /// only ever moves forward and each lease compares against the value it
+        /// captured, so it needs no restoring.
+        fn drop(&mut self) {
+            super::disable_tor();
+            super::ROUTE_DECIDED.store(false, Ordering::Release);
+        }
+    }
+
+    pub(crate) fn lock_route_policy() -> RoutePolicyGuard {
+        RoutePolicyGuard {
+            _lock: ROUTE_POLICY
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
+        sync::atomic::Ordering,
         task::{Context, Poll, Waker},
         time::Duration,
     };
 
     use super::{
-        await_tor_bootstrap, cancel_direct_connections, init_lock, route_decision, DirectRouteIo,
-        NetworkPrivacyStatus, RouteDecision, TOR_BOOTSTRAP_TIMEOUT_MESSAGE,
+        await_tor_bootstrap, cancel_direct_connections, client_slot, disable_tor,
+        enable_tor_for_background_work, init_lock, install_bootstrapped_client, is_tor_desired,
+        mark_tor_desired, pending_dormant_mode, route_decision, set_tor_dormant, status,
+        test_route_policy::lock_route_policy, tor_client_for_route, DirectRouteIo, DormantMode,
+        NetworkPrivacyStatus, RouteDecision, TorClient, BACKGROUND_TOR_BOOTSTRAP_TIMEOUT,
+        STATUS_READY, TOR_BOOTSTRAP_TIMEOUT, TOR_BOOTSTRAP_TIMEOUT_MESSAGE, TOR_STATUS,
     };
 
     #[test]
@@ -438,7 +645,77 @@ mod tests {
     }
 
     #[test]
+    fn marking_a_persisted_tor_route_refuses_instead_of_going_direct() {
+        let _policy = lock_route_policy();
+        assert_eq!(
+            route_decision(is_tor_desired(), status(), false, false),
+            Ok(RouteDecision::Direct)
+        );
+
+        mark_tor_desired();
+
+        assert!(is_tor_desired());
+        assert_eq!(
+            route_decision(is_tor_desired(), status(), false, false),
+            Err("Tor is still connecting")
+        );
+        assert!(tor_client_for_route(false).is_err());
+    }
+
+    #[test]
+    fn marking_a_persisted_tor_route_does_not_bootstrap_a_client() {
+        let _policy = lock_route_policy();
+
+        mark_tor_desired();
+
+        assert_eq!(status(), NetworkPrivacyStatus::Bootstrapping);
+        assert!(client_slot()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_none());
+    }
+
+    #[test]
+    fn marking_a_persisted_tor_route_leaves_a_connected_process_alone() {
+        let _policy = lock_route_policy();
+        mark_tor_desired();
+        TOR_STATUS.store(STATUS_READY, Ordering::Release);
+
+        mark_tor_desired();
+
+        assert_eq!(status(), NetworkPrivacyStatus::Ready);
+    }
+
+    #[test]
+    fn marking_a_stale_tor_preference_leaves_a_process_that_chose_direct_alone() {
+        let _policy = lock_route_policy();
+        disable_tor();
+
+        mark_tor_desired();
+
+        assert!(!is_tor_desired());
+        assert_eq!(status(), NetworkPrivacyStatus::Direct);
+        assert!(matches!(tor_client_for_route(false), Ok(None)));
+    }
+
+    #[test]
+    fn a_dormancy_request_made_before_the_client_exists_is_applied_to_it() {
+        let _policy = lock_route_policy();
+        assert!(client_slot()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_none());
+
+        set_tor_dormant(true);
+        assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+
+        set_tor_dormant(false);
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
+    }
+
+    #[test]
     fn direct_route_io_is_cancelled_when_tor_activation_advances_the_epoch() {
+        let _policy = lock_route_policy();
         let io = DirectRouteIo::new(());
         let waker = Waker::noop();
         let mut context = Context::from_waker(waker);
@@ -470,8 +747,94 @@ mod tests {
         assert_eq!(result.unwrap_err(), TOR_BOOTSTRAP_TIMEOUT_MESSAGE);
     }
 
+    /// A path that already exists as a file, so a bootstrap started against it
+    /// fails at its first filesystem step. No test may reach a real bootstrap:
+    /// that is network work, and on a blocked network it does not terminate.
+    fn unusable_tor_directory(temp: &tempfile::TempDir) -> std::path::PathBuf {
+        let path = temp.path().join("tor");
+        std::fs::write(&path, b"").unwrap();
+        path
+    }
+
+    #[test]
+    fn the_background_bootstrap_deadline_outlasts_a_cold_bootstrap_without_eating_the_window() {
+        // A cold bootstrap measured 23.7 s on a fast link, so a deadline at or
+        // below that figure would refuse bootstraps that were going to succeed.
+        assert!(BACKGROUND_TOR_BOOTSTRAP_TIMEOUT > Duration::from_secs(24));
+        // And a background execution window is not the foreground's patience:
+        // spending the foreground deadline here would consume most windows
+        // whole and leave no time for the work the bootstrap is for.
+        assert!(BACKGROUND_TOR_BOOTSTRAP_TIMEOUT < TOR_BOOTSTRAP_TIMEOUT);
+    }
+
+    #[tokio::test]
+    async fn a_bootstrap_that_runs_out_of_time_stays_fail_closed() {
+        let _policy = lock_route_policy();
+        mark_tor_desired();
+
+        let result = install_bootstrapped_client(
+            Duration::from_millis(1),
+            std::future::pending::<Result<TorClient, String>>(),
+        )
+        .await;
+
+        assert_eq!(result.unwrap_err(), TOR_BOOTSTRAP_TIMEOUT_MESSAGE);
+        assert!(is_tor_desired());
+        assert_eq!(status(), NetworkPrivacyStatus::Failed);
+        assert!(tor_client_for_route(false).is_err());
+    }
+
+    #[tokio::test]
+    async fn a_background_enable_marks_the_route_before_it_can_fail() {
+        let _policy = lock_route_policy();
+        let temp = tempfile::tempdir().unwrap();
+
+        let result = enable_tor_for_background_work(&unusable_tor_directory(&temp)).await;
+
+        assert!(result.is_err());
+        assert!(is_tor_desired());
+        assert_eq!(status(), NetworkPrivacyStatus::Failed);
+        assert!(tor_client_for_route(false).is_err());
+    }
+
+    #[tokio::test]
+    async fn a_background_enable_leaves_a_process_that_chose_direct_alone() {
+        let _policy = lock_route_policy();
+        disable_tor();
+        set_tor_dormant(true);
+        let temp = tempfile::tempdir().unwrap();
+
+        let result = enable_tor_for_background_work(&unusable_tor_directory(&temp)).await;
+
+        assert_eq!(result, Ok(NetworkPrivacyStatus::Direct));
+        assert!(!is_tor_desired());
+        assert_eq!(status(), NetworkPrivacyStatus::Direct);
+        assert!(matches!(tor_client_for_route(false), Ok(None)));
+        // Nothing here is about to do work on a Tor route, so the intent the
+        // app's own lifecycle left behind is not this call's to overwrite.
+        assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+        set_tor_dormant(false);
+    }
+
+    #[tokio::test]
+    async fn a_background_enable_wakes_a_route_the_app_put_to_sleep() {
+        let _policy = lock_route_policy();
+        let temp = tempfile::tempdir().unwrap();
+        set_tor_dormant(true);
+        assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+
+        let _ = enable_tor_for_background_work(&unusable_tor_directory(&temp)).await;
+
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
+    }
+
     #[tokio::test]
     async fn a_stalled_tor_bootstrap_releases_the_init_lock_for_the_next_attempt() {
+        // The route-policy lock covers the init lock too: the background enable
+        // tests reach it through a real `bootstrap_tor`, and this test reads it
+        // as a global, so an unserialised run sees the other test's guard and
+        // reports it as a leak.
+        let _policy = lock_route_policy();
         let result = {
             let _init_guard = init_lock().lock().await;
             await_tor_bootstrap(

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -713,6 +713,9 @@ mod tests {
 
     #[tokio::test]
     async fn direct_connections_keep_tcp_nodelay_enabled() {
+        // A direct-route lease aborts itself whenever the process-wide route is
+        // Tor, so this has to hold the policy even though it never writes it.
+        let _policy = crate::network_privacy::test_route_policy::lock_route_policy();
         let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
             .await
             .expect("bind loopback listener");

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -788,6 +788,11 @@ mod tests {
     #[test]
     fn background_transaction_submission_takes_its_own_circuit() {
         let _policy = crate::network_privacy::test_route_policy::lock_route_policy();
+        // The declaration the native caller makes before its first network
+        // call. Without one the route resolves to a refusal and the opener
+        // never reaches a transport, so the circuit this is about is never
+        // chosen.
+        crate::network_privacy::mark_direct_route();
         let lightwalletd_url =
             std::ffi::CString::new(REFUSED_LIGHTWALLETD_URL).expect("valid lightwalletd URL");
         let raw_transaction = [0u8; 4];
@@ -814,6 +819,7 @@ mod tests {
         // Queries are linkable to one another whatever circuit carries them, so
         // they buy nothing with a circuit build the wallet would pay for.
         let _policy = crate::network_privacy::test_route_policy::lock_route_policy();
+        crate::network_privacy::mark_direct_route();
         let lightwalletd_url =
             std::ffi::CString::new(REFUSED_LIGHTWALLETD_URL).expect("valid lightwalletd URL");
         let mut height = 0u64;
@@ -832,6 +838,7 @@ mod tests {
     #[tokio::test]
     async fn isolation_leaves_the_direct_route_alone() {
         let _policy = crate::network_privacy::test_route_policy::lock_route_policy();
+        crate::network_privacy::mark_direct_route();
 
         let shared = open_lwd_channel(REFUSED_LIGHTWALLETD_URL)
             .await

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -142,10 +142,48 @@ pub(crate) async fn open_isolated_lwd_channel(
     open_lwd_channel_for_route(lightwalletd_url, true).await
 }
 
+/// Which circuit the last channel open asked for.
+///
+/// A shared open and an isolated one are the same transport unless a
+/// bootstrapped Tor client is present, and no unit test can produce one, so a
+/// caller's choice of circuit is only assertable by recording the request.
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ObservedLwdRoute {
+    Shared,
+    Isolated,
+}
+
+#[cfg(test)]
+static OBSERVED_LWD_ROUTE: std::sync::Mutex<Option<ObservedLwdRoute>> = std::sync::Mutex::new(None);
+
+#[cfg(test)]
+fn record_lwd_route(isolated: bool) {
+    let route = if isolated {
+        ObservedLwdRoute::Isolated
+    } else {
+        ObservedLwdRoute::Shared
+    };
+    *OBSERVED_LWD_ROUTE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(route);
+}
+
+#[cfg(test)]
+fn take_observed_lwd_route() -> Option<ObservedLwdRoute> {
+    OBSERVED_LWD_ROUTE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .take()
+}
+
 async fn open_lwd_channel_for_route(
     lightwalletd_url: &str,
     isolated: bool,
 ) -> Result<CompactTxStreamerClient<Channel>, SyncError> {
+    #[cfg(test)]
+    record_lwd_route(isolated);
+
     static RUSTLS_INIT: std::sync::Once = std::sync::Once::new();
     RUSTLS_INIT.call_once(|| {
         let _ = rustls::crypto::ring::default_provider().install_default();
@@ -740,6 +778,72 @@ mod tests {
             .await
             .expect("accept task")
             .expect("accepted connection");
+    }
+
+    /// A loopback port nothing can listen on, so a connect attempt is refused
+    /// immediately and the route the opener asked for is all that is left to
+    /// observe.
+    const REFUSED_LIGHTWALLETD_URL: &str = "http://127.0.0.1:1";
+
+    #[test]
+    fn background_transaction_submission_takes_its_own_circuit() {
+        let _policy = crate::network_privacy::test_route_policy::lock_route_policy();
+        let lightwalletd_url =
+            std::ffi::CString::new(REFUSED_LIGHTWALLETD_URL).expect("valid lightwalletd URL");
+        let raw_transaction = [0u8; 4];
+        let mut response_error_code = 0i32;
+        let mut response_error_message = [0 as std::os::raw::c_char; 64];
+        let _ = take_observed_lwd_route();
+
+        let code = crate::ffi::zcash_lightwalletd_send_transaction(
+            lightwalletd_url.as_ptr(),
+            raw_transaction.as_ptr(),
+            raw_transaction.len(),
+            &mut response_error_code,
+            response_error_message.as_mut_ptr(),
+            response_error_message.len(),
+            std::ptr::null(),
+        );
+
+        assert_eq!(code, 1);
+        assert_eq!(take_observed_lwd_route(), Some(ObservedLwdRoute::Isolated));
+    }
+
+    #[test]
+    fn background_chain_queries_stay_on_the_shared_circuit() {
+        // Queries are linkable to one another whatever circuit carries them, so
+        // they buy nothing with a circuit build the wallet would pay for.
+        let _policy = crate::network_privacy::test_route_policy::lock_route_policy();
+        let lightwalletd_url =
+            std::ffi::CString::new(REFUSED_LIGHTWALLETD_URL).expect("valid lightwalletd URL");
+        let mut height = 0u64;
+        let _ = take_observed_lwd_route();
+
+        let code = crate::ffi::zcash_lightwalletd_latest_block_height(
+            lightwalletd_url.as_ptr(),
+            &mut height,
+            std::ptr::null(),
+        );
+
+        assert_eq!(code, 1);
+        assert_eq!(take_observed_lwd_route(), Some(ObservedLwdRoute::Shared));
+    }
+
+    #[tokio::test]
+    async fn isolation_leaves_the_direct_route_alone() {
+        let _policy = crate::network_privacy::test_route_policy::lock_route_policy();
+
+        let shared = open_lwd_channel(REFUSED_LIGHTWALLETD_URL)
+            .await
+            .expect_err("refused loopback connect");
+        assert_eq!(take_observed_lwd_route(), Some(ObservedLwdRoute::Shared));
+        let isolated = open_isolated_lwd_channel(REFUSED_LIGHTWALLETD_URL)
+            .await
+            .expect_err("refused loopback connect");
+        assert_eq!(take_observed_lwd_route(), Some(ObservedLwdRoute::Isolated));
+
+        assert!(matches!(shared, SyncError::Network(_)));
+        assert_eq!(format!("{shared:?}"), format!("{isolated:?}"));
     }
 
     #[test]

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -23,6 +23,13 @@ pub fn repo_root() -> PathBuf {
 }
 
 pub fn exclusive_regtest() -> MutexGuard<'static, ()> {
+    // Every regtest test takes this before its first lightwalletd call, which
+    // makes it the one place this process declares its route. The library
+    // refuses a route nothing has declared instead of treating it as direct, so
+    // that a background entry point which never read the user's preference
+    // cannot reach lightwalletd on a Tor wallet; a test process is exactly such
+    // a caller, and it says direct for the same reason the native passes do.
+    rust_lib_zcash_wallet::network_privacy::mark_direct_route();
     match REGTEST_LOCK.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),

--- a/rust/tests/ironwood_regtest_migration.rs
+++ b/rust/tests/ironwood_regtest_migration.rs
@@ -164,6 +164,11 @@ fn run_harness(script: &str, args: &[&str]) -> String {
 }
 
 fn ensure_stack_up() {
+    // Declared before the first lightwalletd call. The library refuses a route
+    // nothing has declared rather than treating it as direct, so that a caller
+    // which never read the user's preference cannot reach the network; a test
+    // process says direct for the same reason the native passes do.
+    rust_lib_zcash_wallet::network_privacy::mark_direct_route();
     run_harness("up.sh", &[]);
 }
 

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -37,6 +37,7 @@ import 'package:zcash_wallet/src/features/migration/services/ironwood_migration_
 import 'package:zcash_wallet/src/features/keystone/widgets/keystone_pczt_qr_stage.dart';
 import 'package:zcash_wallet/src/features/keystone/widgets/keystone_qr_scanner_card.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/keystone.dart' as rust_keystone;
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
@@ -357,6 +358,16 @@ class _ControlledRefreshTestMigrationCoordinator
       ref.invalidate(ironwoodMigrationRouteCtaProvider);
     }
   }
+}
+
+/// A wallet whose saved route is Tor, which is the state both native
+/// background lanes only run in on external power over an unmetered link.
+class _TorRouteNetworkPrivacyNotifier extends NetworkPrivacyNotifier {
+  @override
+  NetworkPrivacyState build() => const NetworkPrivacyState(
+    torEnabled: true,
+    status: NetworkPrivacyConnectionStatus.connected,
+  );
 }
 
 class _PreparationHandoffTestMigrationCoordinator
@@ -6327,6 +6338,199 @@ void main() {
       expect(find.text('Continue preparation'), findsNothing);
     },
   );
+
+  testWidgets('states the conditions Tor needs to confirm in the background', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    final coordinator = _PreparationHandoffTestMigrationCoordinator();
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.authorized,
+          getPreparationRuntimeState:
+              ({
+                required network,
+                required accountUuid,
+                required runId,
+              }) async => IronwoodMigrationPreparationRuntimeState.idle,
+        ),
+        migrationCoordinator: () => coordinator,
+        status: _status(
+          phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        'Tor confirms in the background only while charging on an unmetered '
+        'network.',
+      ),
+      findsOneWidget,
+    );
+    // The neutral duration copy would let the user close Vizor off the charger
+    // and stall the run, and this device is capable — the route is the limit,
+    // not the OS.
+    expect(find.text('Preparation will\ntake 10–20 min'), findsNothing);
+    expect(
+      find.text(
+        'This device can’t confirm in the background. Keep Vizor open.',
+      ),
+      findsNothing,
+    );
+    // The old flat refusal is wrong now: the gate does let the pass run.
+    expect(
+      find.text('Tor can’t confirm in the background. Keep Vizor open.'),
+      findsNothing,
+    );
+  });
+
+  testWidgets('keeps stating the Tor conditions while the background task is '
+      'armed', (tester) async {
+    _useMobileViewport(tester);
+    final coordinator = _PreparationHandoffTestMigrationCoordinator();
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.authorized,
+          // An armed task proves only that the gate passed for this pass.
+          getPreparationRuntimeState:
+              ({
+                required network,
+                required accountUuid,
+                required runId,
+              }) async => IronwoodMigrationPreparationRuntimeState.running,
+        ),
+        migrationCoordinator: () => coordinator,
+        status: _status(
+          phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Unqualified, this promise outlives unplugging the charger or moving onto
+    // a metered link, either of which stands the next pass down.
+    expect(
+      find.text('Confirming in the background. You can close Vizor.'),
+      findsNothing,
+    );
+    expect(
+      find.text(
+        'Tor confirms in the background only while charging on an unmetered '
+        'network.',
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('names the device limit ahead of the Tor conditions when the '
+      'device has no background lane', (tester) async {
+    _useMobileViewport(tester);
+    final coordinator = _PreparationHandoffTestMigrationCoordinator();
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.authorized,
+          supportsBackgroundPreparationTracking: () async => false,
+          getPreparationRuntimeState:
+              ({
+                required network,
+                required accountUuid,
+                required runId,
+              }) async => IronwoodMigrationPreparationRuntimeState.idle,
+        ),
+        migrationCoordinator: () => coordinator,
+        status: _status(
+          phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Charging on an unmetered network cannot give this OS build a lane it
+    // never had, so naming a condition the user could meet would over-promise.
+    expect(
+      find.text(
+        'This device can’t confirm in the background. Keep Vizor open.',
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('only while charging on an unmetered network'),
+      findsNothing,
+    );
+  });
+
+  testWidgets('broadcasting copy promises background delivery on a Tor route '
+      'only under its conditions', (tester) async {
+    _useMobileViewport(tester);
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.authorized,
+        ),
+        status: _status(
+          phase: kIronwoodMigrationBroadcastingPhase,
+          nextActionHeight: 3_000_020,
+        ),
+        syncState: SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          scannedHeight: 3_000_000,
+          chainTipHeight: 3_000_000,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        'Next migration step expected in\n'
+        '~25 minutes.\n'
+        'Tor continues this in the background only while charging on an '
+        'unmetered network. Otherwise keep Vizor open.',
+      ),
+      findsOneWidget,
+    );
+    // Authorized notifications alone cannot carry a wake the gate can stand
+    // down, so the unconditional invitation to leave must not appear.
+    expect(find.textContaining('You can leave Vizor'), findsNothing);
+  });
 
   testWidgets('resumes software preparation on reentry without a tap', (
     tester,

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -6442,6 +6442,60 @@ void main() {
     );
   });
 
+  testWidgets('names the notification block alongside the Tor conditions', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    final coordinator = _DurablePhaseRetryTestMigrationCoordinator();
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.denied,
+          getPreparationRuntimeState:
+              ({
+                required network,
+                required accountUuid,
+                required runId,
+              }) async => IronwoodMigrationPreparationRuntimeState.disabled,
+        ),
+        migrationCoordinator: () => coordinator,
+        status: _status(
+          phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Both native lanes refuse on a denied notification whatever the route is,
+    // so stating only the route hands the user a condition they can meet while
+    // nothing moves afterwards. The route condition is transient; this one is
+    // not, so it leads.
+    expect(
+      find.text(
+        'Allow notifications. Tor also needs charging on an unmetered network.',
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.text(
+        'Tor confirms in the background only while charging on an unmetered '
+        'network.',
+      ),
+      findsNothing,
+    );
+    // It has to fit the preparation dial, which is what kept this to one
+    // message in the first place.
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('names the device limit ahead of the Tor conditions when the '
       'device has no background lane', (tester) async {
     _useMobileViewport(tester);
@@ -7632,6 +7686,49 @@ void main() {
         'Next migration step expected in\n'
         '~25 minutes.\n'
         'Notifications are disabled. Open Vizor again to continue.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Notifications are on'), findsNothing);
+  });
+
+  testWidgets('broadcasting copy names disabled notifications on a Tor route', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(),
+        status: _status(
+          phase: kIronwoodMigrationBroadcastingPhase,
+          nextActionHeight: 3_000_020,
+        ),
+        syncState: SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          scannedHeight: 3_000_000,
+          chainTipHeight: 3_000_000,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The route only delays the wake; a denied notification stops it outright.
+    // Charging on an unmetered network would still deliver nothing, so the
+    // notification block cannot be hidden behind the route condition.
+    expect(
+      find.text(
+        'Next migration step expected in\n'
+        '~25 minutes.\n'
+        'Notifications are disabled. Open Vizor again to continue.\n'
+        'Tor also needs charging on an unmetered network to continue this in '
+        'the background.',
       ),
       findsOneWidget,
     );

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -422,6 +422,41 @@ void main() {
     expect(calls, [false]);
   });
 
+  testWidgets('a save-only failure never claims Tor is carrying traffic', (
+    tester,
+  ) async {
+    // The transport did switch and only the preference write failed, so this
+    // shares `(failed, target: false)` with the case above while carrying the
+    // opposite privacy guarantee. Reading the target alone told the user Tor
+    // was still on while their requests were going out directly.
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: false,
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: <bool>[],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('mobile_settings_tor_retry')),
+      200,
+    );
+    final description = tester
+        .widget<Text>(
+          find.byKey(const ValueKey('mobile_settings_tor_description')),
+        )
+        .data;
+    expect(description, isNot(contains('Tor is still on')));
+    expect(description, contains('direct connection'));
+    // The saved route stays at Tor — the stricter half — so the next launch
+    // comes back on Tor rather than silently staying direct.
+    expect(description, contains('next time you open the app'));
+  });
+
   testWidgets('the Tor row publishes its status to assistive technology', (
     tester,
   ) async {

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -319,7 +319,34 @@ void main() {
           .data,
       contains('wait until the Tor connection is ready'),
     );
-    // Busy means the toggle cannot be driven into a second transition.
+    // The bootstrap runs to a three-minute deadline with every request failing
+    // closed, and relaunching starts the same wait, so switching to direct has
+    // to stay reachable for the whole of it.
+    expect(tester.widget<GestureDetector>(row).onTap, isNotNull);
+    await tester.tap(row);
+    await tester.pump();
+    expect(calls, [false]);
+  });
+
+  testWidgets('a switch to direct cannot be driven back into Tor', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connecting,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pump();
+
+    final row = find.byKey(const ValueKey('mobile_settings_tor_row'));
+    await tester.scrollUntilVisible(row, 200);
+    // Nothing to escape from here: the route is already on its way to direct.
     expect(tester.widget<GestureDetector>(row).onTap, isNull);
     await tester.tap(row);
     await tester.pump();

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:zcash_wallet/src/core/widgets/mobile/mobile_list_row.dart';
 import 'package:zcash_wallet/src/features/settings/screens/mobile/mobile_settings_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/biometric_unlock_provider.dart';
+import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/theme_mode_provider.dart';
@@ -120,10 +121,19 @@ Widget _app({
   BiometricUnlockState? biometric,
   BiometricUnlockNotifier Function()? biometricNotifier,
   _FakeSyncKeepAwakeNotifier? syncKeepAwakeNotifier,
+  NetworkPrivacyState? networkPrivacyState,
+  List<bool>? networkPrivacyCalls,
 }) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap(accountState)),
+      if (networkPrivacyState != null)
+        networkPrivacyProvider.overrideWith(
+          () => _FakeNetworkPrivacyNotifier(
+            networkPrivacyState,
+            networkPrivacyCalls ?? <bool>[],
+          ),
+        ),
       syncProvider.overrideWith(() => FakeSyncNotifier(SyncState())),
       themeModeProvider.overrideWith(_FakeThemeModeNotifier.new),
       syncKeepAwakeProvider.overrideWith(
@@ -143,6 +153,23 @@ Widget _app({
   );
 }
 
+class _FakeNetworkPrivacyNotifier extends NetworkPrivacyNotifier {
+  _FakeNetworkPrivacyNotifier(this._state, this.calls);
+
+  final NetworkPrivacyState _state;
+
+  /// Routes requested by the card. `retry()` funnels through here too.
+  final List<bool> calls;
+
+  @override
+  NetworkPrivacyState build() => _state;
+
+  @override
+  Future<void> setTorEnabled(bool enabled) async {
+    calls.add(enabled);
+  }
+}
+
 void main() {
   setUp(() {
     // Phone-sized surface so the lazily-built list renders every group.
@@ -150,6 +177,271 @@ void main() {
     binding.platformDispatcher.views.first
       ..physicalSize = const Size(520, 1200)
       ..devicePixelRatio = 1.0;
+  });
+
+  testWidgets('the Tor card reports the off route', (tester) async {
+    await tester.pumpWidget(
+      _app(networkPrivacyState: const NetworkPrivacyState.off()),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('mobile_settings_tor_row')),
+      200,
+    );
+    expect(find.text('Use Tor'), findsOneWidget);
+    expect(find.text('Off'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data,
+      contains('connect directly'),
+    );
+  });
+
+  testWidgets('tapping the Tor row asks for the other route', (tester) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState.off(),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final row = find.byKey(const ValueKey('mobile_settings_tor_row'));
+    await tester.scrollUntilVisible(row, 200);
+    await tester.tap(row);
+    await tester.pumpAndSettle();
+
+    expect(calls, [true]);
+  });
+
+  testWidgets('the Tor toggle matches the keep-awake toggle', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connected,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final torThumb = find.byKey(
+      const ValueKey('mobile_settings_tor_toggle_thumb'),
+    );
+    final torTrack = find.byKey(const ValueKey('mobile_settings_tor_toggle'));
+    await tester.scrollUntilVisible(torThumb, 200);
+    expect(
+      tester.getSize(torThumb),
+      tester.getSize(
+        find.byKey(
+          const ValueKey('mobile_settings_sync_keep_awake_toggle_thumb'),
+        ),
+      ),
+    );
+    expect(
+      tester.getSize(torTrack),
+      tester.getSize(
+        find.byKey(const ValueKey('mobile_settings_sync_keep_awake_toggle')),
+      ),
+    );
+    expect(
+      tester.getCenter(torThumb).dx,
+      greaterThan(tester.getCenter(torTrack).dx),
+    );
+  });
+
+  testWidgets(
+    'a connected Tor route names the conditions background work needs',
+    (tester) async {
+      await tester.pumpWidget(
+        _app(
+          networkPrivacyState: const NetworkPrivacyState(
+            torEnabled: true,
+            status: NetworkPrivacyConnectionStatus.connected,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.byKey(const ValueKey('mobile_settings_tor_row')),
+        200,
+      );
+      expect(find.text('Connected'), findsOneWidget);
+      final description = tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data;
+      expect(
+        description,
+        contains(
+          'A migration in progress advances in the background only while '
+          'charging on an unmetered network.',
+        ),
+      );
+      // The card must not carry the old foreground-only promise: background
+      // work does happen on a Tor route once the gate passes.
+      expect(description, isNot(contains('only advances while Vizor is open')));
+    },
+  );
+
+  testWidgets('a connecting Tor route says requests are paused', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connecting,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    // pump() only: a connecting card must never be pumpAndSettle'd if it ever
+    // animates.
+    await tester.pump();
+
+    final row = find.byKey(const ValueKey('mobile_settings_tor_row'));
+    await tester.scrollUntilVisible(row, 200);
+    expect(find.text('Connecting…'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data,
+      contains('wait until the Tor connection is ready'),
+    );
+    // Busy means the toggle cannot be driven into a second transition.
+    expect(tester.widget<GestureDetector>(row).onTap, isNull);
+    await tester.tap(row);
+    await tester.pump();
+    expect(calls, isEmpty);
+  });
+
+  testWidgets('a failed Tor route stays blocked and offers a retry', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final retry = find.byKey(const ValueKey('mobile_settings_tor_retry'));
+    await tester.scrollUntilVisible(retry, 200);
+    expect(find.text('Failed'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data,
+      contains('Requests stay blocked'),
+    );
+    expect(find.text('Try again'), findsOneWidget);
+
+    await tester.tap(retry);
+    await tester.pumpAndSettle();
+
+    expect(calls, [true]);
+  });
+
+  testWidgets('a failed switch to direct says Tor is still carrying traffic', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final retry = find.byKey(const ValueKey('mobile_settings_tor_retry'));
+    await tester.scrollUntilVisible(retry, 200);
+    expect(find.text('Switch failed'), findsOneWidget);
+    final description = tester
+        .widget<Text>(
+          find.byKey(const ValueKey('mobile_settings_tor_description')),
+        )
+        .data;
+    expect(description, contains('could not switch to a direct connection'));
+    expect(description, contains('Tor is still on'));
+    expect(description, isNot(contains('Requests stay blocked')));
+    expect(find.text('Try direct connection'), findsOneWidget);
+
+    await tester.tap(retry);
+    await tester.pumpAndSettle();
+
+    expect(calls, [false]);
+  });
+
+  testWidgets('the Tor row publishes its status to assistive technology', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('mobile_settings_tor_retry')),
+      200,
+    );
+    expect(
+      tester.getSemantics(
+        find.byKey(const ValueKey('mobile_settings_tor_row')),
+      ),
+      isSemantics(label: 'Use Tor', value: 'Failed', isButton: true),
+    );
+    expect(
+      tester.getSemantics(
+        find.byKey(const ValueKey('mobile_settings_tor_retry')),
+      ),
+      isSemantics(label: 'Try again', isButton: true, hasTapAction: true),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('the Tor retry action is a touch-sized target', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final retry = find.byKey(const ValueKey('mobile_settings_tor_retry'));
+    await tester.scrollUntilVisible(retry, 200);
+    expect(tester.getSize(retry).height, greaterThanOrEqualTo(44));
   });
 
   testWidgets('renders the grouped settings with live values', (tester) async {
@@ -427,6 +719,10 @@ void main() {
     await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
     await tester.pump();
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(const ValueKey('mobile_settings_biometric_row')),
     );
@@ -467,6 +763,10 @@ void main() {
     await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
     await tester.pump();
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(const ValueKey('mobile_settings_biometric_row')),
     );
@@ -503,6 +803,10 @@ void main() {
     await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
     await tester.pump();
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(const ValueKey('mobile_settings_biometric_row')),
     );

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/settings/screens/settings_screen.dart';
 import 'package:zcash_wallet/src/features/settings/settings_platform.dart';
+import 'package:zcash_wallet/src/features/settings/widgets/network_privacy_control.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
@@ -198,7 +199,10 @@ void main() {
 
     expect(find.text('Connecting…'), findsOneWidget);
     expect(
-      find.text('New requests wait until the Tor connection is ready.'),
+      find.text(
+        'New requests wait until the Tor connection is ready. Turn Tor off to '
+        'stop connecting and use a direct connection.',
+      ),
       findsOneWidget,
     );
 
@@ -206,8 +210,116 @@ void main() {
       find.byKey(const ValueKey('network_privacy_status_icon')),
     );
     expect(statusIcon.name, AppIcons.loader);
-    expect(_toggleTrackOpacity(tester), lessThan(1));
+    // Not dimmed: the control is the way out of the wait, so it has to look
+    // like something the user may act on.
+    expect(_toggleTrackOpacity(tester), 1);
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('network_privacy_toggle')),
+    );
+    await tester.tap(find.byKey(const ValueKey('network_privacy_toggle')));
+    await tester.pump();
+    // The bootstrap runs to a three-minute deadline with every request failing
+    // closed, and relaunching starts the same wait, so switching to direct has
+    // to stay reachable for the whole of it.
+    expect(calls, [false]);
+  });
+
+  test('the toggle offers an escape from a pending Tor connection', () {
+    // Every state maps to exactly one action, and the connecting-to-Tor state
+    // maps to an escape rather than to nothing.
+    NetworkPrivacyToggleAction actionFor({
+      required bool torEnabled,
+      required NetworkPrivacyConnectionStatus status,
+      bool? targetTorEnabled,
+    }) => networkPrivacyToggleAction(
+      NetworkPrivacyState(
+        torEnabled: torEnabled,
+        status: status,
+        targetTorEnabled: targetTorEnabled,
+      ),
+    );
+
+    expect(
+      actionFor(
+        torEnabled: false,
+        status: NetworkPrivacyConnectionStatus.off,
+      ),
+      NetworkPrivacyToggleAction.enable,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connected,
+      ),
+      NetworkPrivacyToggleAction.disable,
+    );
+    // A startup activation publishes no explicit target, so the effective one
+    // is the route already shown — which is the state a user relaunching into a
+    // blocked network lands in.
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+      ),
+      NetworkPrivacyToggleAction.cancelPendingTor,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+        targetTorEnabled: true,
+      ),
+      NetworkPrivacyToggleAction.cancelPendingTor,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+        targetTorEnabled: false,
+      ),
+      NetworkPrivacyToggleAction.none,
+    );
+  });
+
+  test('cancelling a pending Tor connection asks for the direct route', () {
+    expect(
+      NetworkPrivacyToggleAction.cancelPendingTor.requestedTorEnabled,
+      isFalse,
+    );
+    expect(NetworkPrivacyToggleAction.enable.requestedTorEnabled, isTrue);
+    expect(NetworkPrivacyToggleAction.disable.requestedTorEnabled, isFalse);
+    // Leaving a wait is not a second transition, and does not announce itself
+    // as one.
+    expect(
+      NetworkPrivacyToggleAction.cancelPendingTor.semanticsLabel,
+      'Stop connecting to Tor',
+    );
+    expect(NetworkPrivacyToggleAction.disable.semanticsLabel, 'Use Tor');
+    expect(NetworkPrivacyToggleAction.none.isInteractive, isFalse);
+  });
+
+  testWidgets('a switch to direct cannot be driven back into Tor', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _settingsHarness(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connecting,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pump();
+
+    // Nothing to escape from here: the route is already on its way to direct.
+    expect(_toggleTrackOpacity(tester), lessThan(1));
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('network_privacy_toggle')),
+    );
     await tester.tap(
       find.byKey(const ValueKey('network_privacy_toggle')),
       warnIfMissed: false,

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -626,13 +626,83 @@ void main() {
 
     await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
 
-    // Nothing past the write ran, and the runtime is left fail-closed, so this
-    // process reaches nothing while the user decides whether to retry.
-    expect(events, ['native:true', 'begin-enable', 'store:write-failed']);
+    // The route is refused and nothing past the drain runs, but `beginEnable`
+    // has already put this process fail-closed — so the direct work it left
+    // behind is drained on the way out. Rust's own sockets went with the
+    // route-epoch bump; a Dart request already streaming does not stop until
+    // the client is torn down, and the refusal tells the user requests are
+    // paused.
+    expect(events, [
+      'native:true',
+      'begin-enable',
+      'store:write-failed',
+      'runtime-quiesce',
+      'direct-quiesce',
+    ]);
+    // The drain tightens; it must never end by reopening the gate this route
+    // just closed.
+    expect(events, isNot(contains('direct-allow')));
     expect(runtime.isTorEnabled(), isTrue);
     final state = container.read(networkPrivacyProvider);
     expect(state.status, NetworkPrivacyConnectionStatus.failed);
     expect(state.targetTorEnabled, isTrue);
+  });
+
+  test('a failed direct save still opens the direct request gate', () async {
+    final events = <String>[];
+    final store = _DisableWriteFailingStore(events);
+    final runtime = _FakeRuntime(
+      events,
+      NetworkPrivacyConnectionStatus.connected,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        networkPrivacyPreferenceStoreProvider.overrideWithValue(store),
+        networkPrivacyRuntimeProvider.overrideWithValue(runtime),
+        networkPrivacyNativeUpdateCoordinatorProvider.overrideWithValue(
+          _FakeNativeUpdateCoordinator(events),
+        ),
+        networkPrivacyDirectRequestGateProvider.overrideWithValue(
+          _FakeDirectRequestGate(events),
+        ),
+        networkPrivacyTransportRestartProvider.overrideWithValue((
+          update,
+        ) async {
+          events.add('restart');
+          await update();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
+    events.clear();
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(false);
+
+    // The runtime is direct with its Tor client dropped, so the gate follows
+    // it. Leaving it latched shut would fail every direct request for the rest
+    // of the session behind a UI that reports Tor off.
+    expect(runtime.isTorEnabled(), isFalse);
+    expect(events, [
+      'native-prepare-disable',
+      'restart',
+      'configure:false',
+      'store:write-failed',
+      'direct-allow',
+    ]);
+    // The write is still refused, and the saved route stays at Tor — the
+    // stricter half, which is the safe thing for the next cold process to read.
+    expect(store.saved, isTrue);
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: store.saved ?? false,
+        runtimeTorDesired: runtime.isTorEnabled(),
+      ),
+      isTrue,
+    );
+    final state = container.read(networkPrivacyProvider);
+    expect(state.torEnabled, isFalse);
+    expect(state.status, NetworkPrivacyConnectionStatus.failed);
   });
 
   test('failed Tor disable preserves the effective Tor route', () async {
@@ -1097,6 +1167,28 @@ class _RecordingStore implements NetworkPrivacyPreferenceStore {
 
   @override
   Future<void> writeTorEnabled(bool enabled) async {
+    saved = enabled;
+    events.add('store:$enabled');
+  }
+}
+
+/// Saves the strict route and refuses the lax one, which is the shape a full
+/// disk has: the Tor value is already on disk when the direct write fails.
+class _DisableWriteFailingStore implements NetworkPrivacyPreferenceStore {
+  _DisableWriteFailingStore(this.events);
+
+  final List<String> events;
+  bool? saved;
+
+  @override
+  Future<bool> readTorEnabled() async => false;
+
+  @override
+  Future<void> writeTorEnabled(bool enabled) async {
+    if (!enabled) {
+      events.add('store:write-failed');
+      throw StateError('Could not save the Tor preference.');
+    }
     saved = enabled;
     events.add('store:$enabled');
   }

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -176,7 +176,7 @@ void main() {
     },
   );
 
-  test('enabling quiesces direct traffic before persistence', () async {
+  test('enabling persists Tor as soon as the runtime is fail-closed', () async {
     final events = <String>[];
     final container = ProviderContainer(
       overrides: [
@@ -207,10 +207,10 @@ void main() {
     expect(events, [
       'native:true',
       'begin-enable',
+      'store:true',
       'runtime-quiesce',
       'direct-quiesce',
       'restart',
-      'store:true',
       'configure:true',
       'native-resume',
     ]);
@@ -253,10 +253,10 @@ void main() {
     expect(events, [
       'native:true',
       'begin-enable',
+      'store:true',
       'runtime-quiesce',
       'direct-quiesce',
       'restart',
-      'store:true',
       'configure:true',
     ]);
     expect(state.torEnabled, isTrue);
@@ -295,8 +295,8 @@ void main() {
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
+      'store:false',
       'direct-allow',
       'native:false',
     ]);
@@ -370,8 +370,8 @@ void main() {
       'native-prepare-disable',
       'native-disable-drained',
       'restart',
-      'store:false',
       'configure:false',
+      'store:false',
       'direct-allow',
       'native:false',
     ]);
@@ -453,9 +453,12 @@ void main() {
 
       await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
 
+      // The saved route is already Tor by the time the drain is attempted, so
+      // a quiescence failure cannot end the toggle with direct saved.
       expect(events, [
         'native:true',
         'begin-enable',
+        'store:true',
         'runtime-quiesce',
         'direct-quiesce',
         'restart',
@@ -516,6 +519,122 @@ void main() {
     );
   });
 
+  test('the saved route may be stricter than the runtime, never laxer', () {
+    // A wake that declares Tor and cannot afford it defers; a wake that
+    // declares direct against a session enforcing Tor puts wallet queries and
+    // signed transactions on a direct connection.
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: true,
+        runtimeTorDesired: true,
+      ),
+      isTrue,
+    );
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: false,
+        runtimeTorDesired: false,
+      ),
+      isTrue,
+    );
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: true,
+        runtimeTorDesired: false,
+      ),
+      isTrue,
+    );
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: false,
+        runtimeTorDesired: true,
+      ),
+      isFalse,
+    );
+  });
+
+  test('a drain failure leaves the saved route no laxer than Tor', () async {
+    final events = <String>[];
+    final store = _RecordingStore(events);
+    final runtime = _DrainFailingRuntime(events);
+    final container = ProviderContainer(
+      overrides: [
+        networkPrivacyPreferenceStoreProvider.overrideWithValue(store),
+        networkPrivacyRuntimeProvider.overrideWithValue(runtime),
+        networkPrivacyNativeUpdateCoordinatorProvider.overrideWithValue(
+          _FakeNativeUpdateCoordinator(events),
+        ),
+        networkPrivacyDirectRequestGateProvider.overrideWithValue(
+          _FakeDirectRequestGate(events),
+        ),
+        networkPrivacyTransportRestartProvider.overrideWithValue((
+          update,
+        ) async {
+          events.add('restart');
+          await update();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
+
+    expect(container.read(networkPrivacyProvider).status,
+        NetworkPrivacyConnectionStatus.failed);
+    expect(runtime.isTorEnabled(), isTrue);
+    expect(store.saved, isTrue);
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: store.saved ?? false,
+        runtimeTorDesired: runtime.isTorEnabled(),
+      ),
+      isTrue,
+    );
+    // The write precedes the step that fails, so the strict value is already
+    // durable when it does.
+    expect(events.indexOf('store:true'), lessThan(events.indexOf('restart')));
+  });
+
+  test('a preference write failure refuses the route instead of proceeding',
+      () async {
+    final events = <String>[];
+    final runtime = _FakeRuntime(
+      events,
+      NetworkPrivacyConnectionStatus.connected,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        networkPrivacyPreferenceStoreProvider.overrideWithValue(
+          _WriteFailingStore(events),
+        ),
+        networkPrivacyRuntimeProvider.overrideWithValue(runtime),
+        networkPrivacyNativeUpdateCoordinatorProvider.overrideWithValue(
+          _FakeNativeUpdateCoordinator(events),
+        ),
+        networkPrivacyDirectRequestGateProvider.overrideWithValue(
+          _FakeDirectRequestGate(events),
+        ),
+        networkPrivacyTransportRestartProvider.overrideWithValue((
+          update,
+        ) async {
+          events.add('restart');
+          await update();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
+
+    // Nothing past the write ran, and the runtime is left fail-closed, so this
+    // process reaches nothing while the user decides whether to retry.
+    expect(events, ['native:true', 'begin-enable', 'store:write-failed']);
+    expect(runtime.isTorEnabled(), isTrue);
+    final state = container.read(networkPrivacyProvider);
+    expect(state.status, NetworkPrivacyConnectionStatus.failed);
+    expect(state.targetTorEnabled, isTrue);
+  });
+
   test('failed Tor disable preserves the effective Tor route', () async {
     final events = <String>[];
     final runtime = _FakeRuntime(
@@ -549,10 +668,11 @@ void main() {
     events.clear();
     await container.read(networkPrivacyProvider.notifier).setTorEnabled(false);
 
+    // The runtime switch threw, so the direct value is never saved: a wake
+    // into a cold process must not read direct while Tor is still enforced.
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
       'native-resume',
     ]);
@@ -574,10 +694,11 @@ void main() {
 
     events.clear();
     await container.read(networkPrivacyProvider.notifier).retry();
+    // The runtime switch threw, so the direct value is never saved: a wake
+    // into a cold process must not read direct while Tor is still enforced.
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
       'native-resume',
     ]);
@@ -962,6 +1083,69 @@ class _PendingBootstrapRuntime implements NetworkPrivacyRuntime {
     configureStarted = true;
     configuredEnable = true;
     return _bootstrap.future;
+  }
+}
+
+class _RecordingStore implements NetworkPrivacyPreferenceStore {
+  _RecordingStore(this.events);
+
+  final List<String> events;
+  bool? saved;
+
+  @override
+  Future<bool> readTorEnabled() async => false;
+
+  @override
+  Future<void> writeTorEnabled(bool enabled) async {
+    saved = enabled;
+    events.add('store:$enabled');
+  }
+}
+
+class _WriteFailingStore implements NetworkPrivacyPreferenceStore {
+  _WriteFailingStore(this.events);
+
+  final List<String> events;
+
+  @override
+  Future<bool> readTorEnabled() async => false;
+
+  @override
+  Future<void> writeTorEnabled(bool enabled) async {
+    events.add('store:write-failed');
+    throw StateError('Could not save the Tor preference.');
+  }
+}
+
+/// Fails the direct drain, the reachable failure between the runtime going
+/// fail-closed and the rest of an enable.
+class _DrainFailingRuntime implements NetworkPrivacyRuntime {
+  _DrainFailingRuntime(this.events);
+
+  final List<String> events;
+  var _torEnabled = false;
+
+  @override
+  void beginEnable() {
+    _torEnabled = true;
+    events.add('begin-enable');
+  }
+
+  @override
+  bool isTorEnabled() => _torEnabled;
+
+  @override
+  Future<void> quiesceDirectRequests() async {
+    events.add('runtime-quiesce');
+    throw StateError('Timed out waiting for direct network connections to stop');
+  }
+
+  @override
+  Future<NetworkPrivacyConnectionStatus> configure({
+    required bool enabled,
+  }) async {
+    events.add('configure:$enabled');
+    return NetworkPrivacyConnectionStatus.connected;
   }
 }
 

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -1,12 +1,63 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
 import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/rust/network_privacy.dart' as rust_types;
 
 void main() {
+  // The launch this owner exists for reads almost nothing: a locked app routes
+  // to `/unlock`, `syncKeepAwakeActiveProvider` returns early on
+  // `requiresUnlock` before it reaches `syncProvider`, and the unlock screens
+  // only read that provider when the user submits. Nothing here builds a
+  // provider at all, which is the point — the persisted route is applied
+  // regardless of the lock, so the intent has to have an owner regardless too.
+  group('Tor dormancy lifecycle', () {
+    tearDown(disposeTorDormancyLifecycle);
+
+    testWidgets('sleeps only where backgrounding stops the process', (
+      tester,
+    ) async {
+      // Lane-dependent on purpose, and the desktop half is the load-bearing
+      // one: a desktop app with every window hidden keeps polling, and a
+      // client put to sleep underneath it pays a circuit build on each poll.
+      for (final (formFactor, expected) in [
+        (AppFormFactor.mobile, [true]),
+        (AppFormFactor.desktop, <bool>[]),
+      ]) {
+        final dormancy = <bool>[];
+        startTorDormancyLifecycle(
+          setTorDormant: ({required dormant}) => dormancy.add(dormant),
+          formFactor: formFactor,
+        );
+
+        await _sendAppLifecycleState(AppLifecycleState.inactive);
+        await _sendAppLifecycleState(AppLifecycleState.hidden);
+
+        expect(dormancy, expected, reason: '$formFactor');
+      }
+    });
+
+    testWidgets('wakes on every foreground entry', (tester) async {
+      // Asked for unconditionally: a sleep request that outlived its asker —
+      // issued before Tor finished bootstrapping, so it lands on the client
+      // only once that client exists — would otherwise keep the client asleep
+      // for the whole foreground session.
+      final dormancy = <bool>[];
+      startTorDormancyLifecycle(
+        setTorDormant: ({required dormant}) => dormancy.add(dormant),
+      );
+
+      await _sendAppLifecycleState(AppLifecycleState.inactive);
+      await _sendAppLifecycleState(AppLifecycleState.resumed);
+
+      expect(dormancy, contains(false));
+    });
+  });
+
   test('preference read failure pauses native updates before launch', () async {
     final events = <String>[];
     try {
@@ -1507,4 +1558,13 @@ class _FakeDirectRequestGate implements NetworkPrivacyDirectRequestGate {
   Future<void> quiesce() async {
     events.add('direct-quiesce');
   }
+}
+
+Future<void> _sendAppLifecycleState(AppLifecycleState state) async {
+  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .handlePlatformMessage(
+        'flutter/lifecycle',
+        const StringCodec().encodeMessage(state.toString()),
+        (_) {},
+      );
 }

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -54,7 +54,10 @@ void main() {
 
     await runtime.configure(enabled: true);
 
-    expect(excluded, ['/tmp/vizor-tor']);
+    // Once before the bootstrap, because the directory holds guard state from
+    // its first moment and the process can be killed during it, and once after,
+    // because the mark is best-effort.
+    expect(excluded, ['/tmp/vizor-tor', '/tmp/vizor-tor']);
   });
 
   test('a failed bootstrap still excludes the Tor directory', () async {
@@ -75,7 +78,7 @@ void main() {
       throwsA(isA<StateError>()),
     );
 
-    expect(excluded, ['/tmp/vizor-tor']);
+    expect(excluded, ['/tmp/vizor-tor', '/tmp/vizor-tor']);
   });
 
   test('a backup exclusion failure is reported', () async {
@@ -93,8 +96,8 @@ void main() {
 
     await runtime.configure(enabled: true);
 
-    expect(logs, hasLength(1));
-    expect(logs.single, contains('attribute write refused'));
+    expect(logs, hasLength(2));
+    expect(logs.first, contains('attribute write refused'));
   });
 
   test('a backup exclusion failure does not fail the route', () async {

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
@@ -39,6 +40,76 @@ void main() {
         directRequests: _FakeDirectRequestGate(<String>[]),
       );
     }
+  });
+
+  test('enabling keeps the Tor directory out of device backups', () async {
+    final excluded = <String>[];
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          rust_types.NetworkPrivacyStatus.ready,
+      excludeTorDirectoryFromBackup: (directory) async =>
+          excluded.add(directory),
+    );
+
+    await runtime.configure(enabled: true);
+
+    expect(excluded, ['/tmp/vizor-tor']);
+  });
+
+  test('a failed bootstrap still excludes the Tor directory', () async {
+    // Rust creates the directory and Arti writes guard state into it before
+    // the bootstrap can fail, so the failure path leaves exactly the state the
+    // exclusion exists to keep off a second device.
+    final excluded = <String>[];
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          throw StateError('bootstrap failed'),
+      excludeTorDirectoryFromBackup: (directory) async =>
+          excluded.add(directory),
+    );
+
+    await expectLater(
+      runtime.configure(enabled: true),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(excluded, ['/tmp/vizor-tor']);
+  });
+
+  test('a backup exclusion failure is reported', () async {
+    final logs = <String>[];
+    final previousDebugPrint = debugPrint;
+    debugPrint = (message, {wrapWidth}) => logs.add(message ?? '');
+    addTearDown(() => debugPrint = previousDebugPrint);
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          rust_types.NetworkPrivacyStatus.ready,
+      excludeTorDirectoryFromBackup: (_) async =>
+          throw StateError('attribute write refused'),
+    );
+
+    await runtime.configure(enabled: true);
+
+    expect(logs, hasLength(1));
+    expect(logs.single, contains('attribute write refused'));
+  });
+
+  test('a backup exclusion failure does not fail the route', () async {
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          rust_types.NetworkPrivacyStatus.ready,
+      excludeTorDirectoryFromBackup: (_) async =>
+          throw StateError('no native side'),
+    );
+
+    expect(
+      await runtime.configure(enabled: true),
+      NetworkPrivacyConnectionStatus.connected,
+    );
   });
 
   test('direct runtime configuration skips Tor directory lookup', () async {

--- a/test/providers/sync_provider_test.dart
+++ b/test/providers/sync_provider_test.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
@@ -151,35 +149,6 @@ void main() {
     await expectLater(Future.wait([firstRefresh, queuedRefresh]), completes);
     expect(pathResolutionCount, 2);
     expect(notifier.balanceReadCount, 1);
-  });
-
-  test('returning to the foreground wakes Tor unprompted', () async {
-    // Rust holds the sleep request process-wide and applies it to the Tor
-    // client whenever that client appears, so a request can outlive whatever
-    // made it. Waking only after a sleep this notifier itself asked for would
-    // leave such a client suspended for the whole foreground session.
-    final dormancy = <bool>[];
-    final container = ProviderContainer(
-      overrides: [
-        appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
-        syncProvider.overrideWith(
-          () => SyncNotifier(
-            walletDbPathResolver: () async => 'wallet.db',
-            setTorDormant: ({required dormant}) => dormancy.add(dormant),
-          ),
-        ),
-      ],
-    );
-    // Deliberately not disposed: the real notifier's disposal cancels the Rust
-    // sync, and no Rust library is loaded in a widget-test host.
-    container.listen(syncProvider, (_, _) {});
-    await container.read(syncProvider.future);
-
-    // Nothing here asked Tor to sleep.
-    await _sendAppLifecycleState(AppLifecycleState.inactive);
-    await _sendAppLifecycleState(AppLifecycleState.resumed);
-
-    expect(dormancy, [false]);
   });
 
   test('in-flight progress exits quietly after notifier disposal', () async {
@@ -460,15 +429,6 @@ void main() {
       expect(current.recentTransactions, [fetchedTx]);
     },
   );
-}
-
-Future<void> _sendAppLifecycleState(AppLifecycleState state) async {
-  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .handlePlatformMessage(
-        'flutter/lifecycle',
-        const StringCodec().encodeMessage(state.toString()),
-        (_) {},
-      );
 }
 
 class _LifecycleTestSyncNotifier extends SyncNotifier {

--- a/test/providers/sync_provider_test.dart
+++ b/test/providers/sync_provider_test.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
@@ -10,6 +12,9 @@ import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 void main() {
+  // The lifecycle transitions below are delivered over the platform channel.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('a busy network only aborts a restart that changes the route', () {
     // Switching to Tor with a direct channel still up would leak.
     expect(
@@ -146,6 +151,35 @@ void main() {
     await expectLater(Future.wait([firstRefresh, queuedRefresh]), completes);
     expect(pathResolutionCount, 2);
     expect(notifier.balanceReadCount, 1);
+  });
+
+  test('returning to the foreground wakes Tor unprompted', () async {
+    // Rust holds the sleep request process-wide and applies it to the Tor
+    // client whenever that client appears, so a request can outlive whatever
+    // made it. Waking only after a sleep this notifier itself asked for would
+    // leave such a client suspended for the whole foreground session.
+    final dormancy = <bool>[];
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+        syncProvider.overrideWith(
+          () => SyncNotifier(
+            walletDbPathResolver: () async => 'wallet.db',
+            setTorDormant: ({required dormant}) => dormancy.add(dormant),
+          ),
+        ),
+      ],
+    );
+    // Deliberately not disposed: the real notifier's disposal cancels the Rust
+    // sync, and no Rust library is loaded in a widget-test host.
+    container.listen(syncProvider, (_, _) {});
+    await container.read(syncProvider.future);
+
+    // Nothing here asked Tor to sleep.
+    await _sendAppLifecycleState(AppLifecycleState.inactive);
+    await _sendAppLifecycleState(AppLifecycleState.resumed);
+
+    expect(dormancy, [false]);
   });
 
   test('in-flight progress exits quietly after notifier disposal', () async {
@@ -426,6 +460,15 @@ void main() {
       expect(current.recentTransactions, [fetchedTx]);
     },
   );
+}
+
+Future<void> _sendAppLifecycleState(AppLifecycleState state) async {
+  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .handlePlatformMessage(
+        'flutter/lifecycle',
+        const StringCodec().encodeMessage(state.toString()),
+        (_) {},
+      );
 }
 
 class _LifecycleTestSyncNotifier extends SyncNotifier {


### PR DESCRIPTION
> [!NOTE]
> Draft. Based on #472 — review the four commits after `rowan/tor-followup-fixes`; merge #472 first, then retarget this to `main`.
>
> Runs on the iOS simulator: the app builds with arti linked, launches, and Tor bootstraps from the app's own support directory. **No device run yet**, and the simulator cannot settle the filesystem-permission question either way — see "What is not verified".

## Problem

Arti already ships inside every iOS and Android binary. `zcash_client_backend`'s `tor` feature and Rust's `network_privacy` module are both unconditional, and a merged commit already patched the iOS podspec to link liblzma for it. Mobile pays the dependency and binary-size cost today and gets nothing: the only Dart entry point is gated on `kAppFormFactor == AppFormFactor.desktop`.

Every transport mobile uses is already Tor-aware — lightwalletd gRPC (sync, broadcast, migration preparation), the shared HTTP client (price, swap, Sapling params, wallet link), and even the iOS background paths, which reach lightwalletd through Rust rather than URLSession. What was missing was the entry point and a place to turn it on.

Issue #455's specific ask — a unique Tor circuit per Ironwood migration transaction — is implemented in shared Rust, so mobile inherits it for every foreground broadcast. The iOS background outbox reached lightwalletd through a C entry point that opened the shared route instead; that entry point now isolates too, so the property holds on both paths.

## Solution

**Apply the route on mobile, and give mobile settings its own control.** The desktop control is not reused: six of its eight copy branches are about desktop software updates, which the app stores own here, and its toggle geometry belongs to a settings page rather than a grouped card. The state machine behind both is the same provider.

**Two things the desktop route never needed**, both recovered from the Tor integration this repo shipped and removed in April 2026 (`b1cb18bb6`):

- Arti checks that its data directory is not readable by other users. On mobile the app sandbox is the boundary and those checks reject the directory outright — which would fail the bootstrap from inside fail-closed mode, blocking every request while Tor never becomes ready. Mobile disables them the way both ECC mobile SDKs do; desktop keeps them.
- An idle client keeps guard connections and directory tasks alive, so it now sleeps with the app — but only where the process actually stops working. Desktop keeps polling with its windows hidden, so firing on every hide made it pay a circuit rebuild for no saving.

**Background work no longer ignores the route.** Rust's route policy is process-local and starts Direct, and only Dart sets it. iOS kills the app often, so a background task can launch a cold process where Dart never ran: `route_decision` returns Direct and the background lightwalletd calls go over clearnet even though the user chose Tor. The confirmation tracker makes this the normal path — it deliberately holds its queries while the app is active and releases them once it is not.

A background pass may now use Tor on external power over an unmetered link, and defers to the foreground otherwise; each signal fails closed while it is still unknown. A cold background process has no Dart, so it brings Tor up itself under a deadline sized for a background window rather than the foreground's, and an expiry keeps the route Tor-desired and not ready rather than falling back to the clear. The native layer declares the persisted route before its first network call, so a path that slips the gate is refused rather than sent in the clear.

**Guard state stays off device backups.** Arti's directory records which guards this wallet chose, and on iOS it lands in Application Support, which iCloud backs up. A restored install should pick fresh guards; that costs one bootstrap. Android needs nothing here — `allowBackup="false"` already covers it.

## Why the constraint is power and metering

Measured with a standalone probe against arti 0.35.0 using the feature set `zcash_client_backend` enables:

| | |
|---|---|
| Cold bootstrap | 8.45 MB down / 744 KB up / 23.7 s |
| Warm bootstrap | 0.64 s, **zero bytes** |
| On-disk cache | 46.3 MB |
| Idle traffic, awake | ~500 B/s |
| Idle traffic, dormant | ~27 B/s |

The recurring cost is channel padding, not CPU — and it runs even with zero wallet traffic, because the forced `onion-service-client` feature keeps a 3+1 circuit pool alive. Dormancy removes it; it does not reduce CPU, because GuardMgr's periodic loop is dormancy-unaware.

So the expensive case is a cold bootstrap, not Tor itself: a warm client is free to reach and its steady-state cost is small. Gating background work on external power and an unmetered link is what those numbers support — it keeps the 8.45 MB case off cellular and off battery without giving up background progress entirely.

## Validation

- `fvm flutter test` — 30 failures, byte-identical to the same run on `origin/main` (pre-existing Ironwood and figma_compare). No new failures.
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile` — 17 failures, likewise identical to the `origin/main` baseline.
- `cargo test --lib` — 606 passed.
- `fvm flutter analyze` — no errors; the 23 pre-existing Ironwood warnings are unchanged.
- Rust cross-compiles with these changes: `cargo check --target aarch64-apple-ios` and `--target aarch64-linux-android` (NDK 28.2), both clean.
- Swift type-checked against the real iOS SDK at `arm64-apple-ios15.0` and `arm64-apple-ios26.0`.
- Each behavioural change was checked by reverting it and confirming its regression test fails.

On a booted iPhone 17 Pro Max simulator:

- `fvm flutter build ios --simulator` succeeds with arti linked into the app target, and the app launches and renders onboarding — mobile startup is not blocked by applying the route.
- `integration_test/mobile_tor_bootstrap_probe_test.dart` reaches `NetworkPrivacyStatus.ready` against the app's own support directory, which structurally requires the arti bootstrap to have succeeded.

## What is not verified

- **The filesystem-permission exemption is unproven.** The probe was also run with the exemption compiled out, and it still passed — a simulator container is an ordinary host directory, so arti's checks do not reject it there. The change is kept because both ECC mobile SDKs and this repo's own removed integration do the same, and because disabling a check the sandbox already enforces fails safe. It needs a device to confirm, and a device is also the only place a regression here would show up.
- **No device run**, and no Android emulator run.
- The background policy is verified by reading and type-checking, not against real `BGContinuedProcessingTask` / `BGProcessingTask` lifecycles.
- The iCloud backup exclusion is unverified end to end; it needs a device and a backup inspection.
- Android is argued from code and cross-compilation: this branch has no Android native network code (three Kotlin files, no WorkManager, no `android_jni.rs`), so the iOS background work has no Android counterpart to need.

## Follow-ups worth raising upstream

`librustzcash` does not surface arti's `PaddingLevel::Reduced`, which arti documents as being for mobile, and its `tor` feature forces `onion-service-client` on, which is what creates the always-on circuit pool that makes padding run at all.

https://claude.ai/code/session_01R9nkJCPTCahMjGiDgqFNrV
