### PR TITLE
Add Pay to desktop sidebar

### DIFF
--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -18,6 +18,8 @@ import '../../providers/voting/voting_submission_guard_provider.dart';
 import '../../rust/api/sync.dart' as rust_sync;
 import '../../features/migration/providers/ironwood_migration_announcement_provider.dart';
 import '../../features/migration/providers/ironwood_migration_coordinator_provider.dart';
+import '../../features/swap/models/swap_activity_navigation.dart';
+import '../../features/swap/providers/swap_state_provider.dart';
 import '../config/network_config.dart';
 import '../config/swap_feature_config.dart';
 import '../formatting/number_format.dart';
@@ -153,6 +155,38 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
   void _openSettings() {
     if (_matchedLocation == '/settings') return;
     context.go('/settings');
+  }
+
+  Future<void> _openPay() async {
+    if (_matches('/pay')) return;
+
+    final accountUuid = ref
+        .read(accountProvider)
+        .value
+        ?.activeAccountUuid
+        ?.trim();
+    if (accountUuid == null || accountUuid.isEmpty) return;
+
+    final router = GoRouter.of(context);
+    final entryPath = router.routerDelegate.currentConfiguration.uri.path;
+    final swapNotifier = ref.read(swapStateProvider.notifier);
+    final selectedAsset = await swapNotifier.resolvePaySelectedAssetForEntry(
+      accountUuid: accountUuid,
+    );
+    if (!mounted ||
+        selectedAsset == null ||
+        router.routerDelegate.currentConfiguration.uri.path != entryPath) {
+      return;
+    }
+    final prepared = swapNotifier.preparePayFromShieldedZec(
+      preferredAsset: selectedAsset,
+      expectedAccountUuid: accountUuid,
+    );
+    if (!prepared) return;
+    router.go(
+      '/pay',
+      extra: const PayComposerNavigationArgs(preservePreparedComposer: true),
+    );
   }
 
   void _toggleAccountMenu({
@@ -398,6 +432,11 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
         ironwoodPostMigrationState?.locksNavigation ??
         (ironwoodHomeMigrationPresentation.mode ==
             IronwoodHomeMigrationCtaMode.start);
+    final payNavigationLocked =
+        ironwoodMigrationNavigationLocked ||
+        (ironwoodHomeMigrationPresentation.mode ==
+                IronwoodHomeMigrationCtaMode.resume &&
+            accountSync.ironwoodBalance <= BigInt.zero);
     final migrationCoordinator = ref.watch(
       ironwoodMigrationCoordinatorProvider,
     );
@@ -493,6 +532,19 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                                 ironwoodMigrationNavigationLocked
                             ? null
                             : () => _navigateTo('/swap'),
+                      ),
+                      const SizedBox(height: AppSpacing.xs),
+                      AppSidebarItem(
+                        key: const ValueKey('sidebar_pay_button'),
+                        label: 'Pay',
+                        iconName: AppIcons.paid,
+                        active: _matches('/pay'),
+                        onTap:
+                            isImporting ||
+                                widget.disabledRoutePaths.contains('/pay') ||
+                                payNavigationLocked
+                            ? null
+                            : () => unawaited(_openPay()),
                       ),
                     ],
                     const SizedBox(height: AppSpacing.xs),

--- a/lib/src/features/migration/screens/ironwood_migration_flow/shell_intro_options.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/shell_intro_options.dart
@@ -173,7 +173,7 @@ class _IronwoodMigrationFrame extends StatelessWidget {
       background: ColoredBox(color: context.colors.background.window),
       sidebar: AppMainSidebar(
         disabledRoutePaths: disableSidebarActions
-            ? const {'/swap', '/voting'}
+            ? const {'/swap', '/pay', '/voting'}
             : const {},
       ),
       pane: Stack(

--- a/lib/widgetbook/activity_use_cases.dart
+++ b/lib/widgetbook/activity_use_cases.dart
@@ -227,6 +227,8 @@ class _ActivityUseCaseSidebar extends StatelessWidget {
               onTap: () {},
             ),
             const SizedBox(height: AppSpacing.xs),
+            AppSidebarItem(label: 'Pay', iconName: AppIcons.paid, onTap: () {}),
+            const SizedBox(height: AppSpacing.xs),
             const AppSidebarItem(
               label: 'Activity',
               iconName: AppIcons.history,

--- a/lib/widgetbook/address_book_use_cases.dart
+++ b/lib/widgetbook/address_book_use_cases.dart
@@ -1364,6 +1364,12 @@ class _AddressBookSidebar extends StatelessWidget {
                     onTap: () {},
                   ),
                   const SizedBox(height: AppSpacing.xs),
+                  AppSidebarItem(
+                    label: 'Pay',
+                    iconName: AppIcons.paid,
+                    onTap: () {},
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
                   const AppSidebarItem(
                     label: 'Contacts',
                     iconName: AppIcons.users,

--- a/lib/widgetbook/pay_use_cases.dart
+++ b/lib/widgetbook/pay_use_cases.dart
@@ -421,16 +421,18 @@ class _PayPreviewSidebar extends StatelessWidget {
           children: [
             const _PreviewAccountHeader(),
             const SizedBox(height: AppSpacing.md),
-            const AppSidebarItem(
-              label: 'Home',
-              iconName: AppIcons.home,
-              active: true,
-            ),
+            const AppSidebarItem(label: 'Home', iconName: AppIcons.home),
             const SizedBox(height: AppSpacing.xs),
             AppSidebarItem(
               label: 'Swap',
               iconName: AppIcons.swapArrows,
               onTap: () {},
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            const AppSidebarItem(
+              label: 'Pay',
+              iconName: AppIcons.paid,
+              active: true,
             ),
             const SizedBox(height: AppSpacing.xs),
             AppSidebarItem(

--- a/lib/widgetbook/send_use_cases.dart
+++ b/lib/widgetbook/send_use_cases.dart
@@ -643,6 +643,12 @@ class _PreviewSendSidebar extends StatelessWidget {
                   ),
                   const SizedBox(height: AppSpacing.xs),
                   AppSidebarItem(
+                    label: 'Pay',
+                    iconName: AppIcons.paid,
+                    onTap: () {},
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  AppSidebarItem(
                     label: 'Activity',
                     iconName: AppIcons.history,
                     onTap: () {},

--- a/lib/widgetbook/swap_use_cases.dart
+++ b/lib/widgetbook/swap_use_cases.dart
@@ -1437,6 +1437,12 @@ class _PreviewSwapSidebar extends StatelessWidget {
                   ),
                   const SizedBox(height: AppSpacing.xs),
                   AppSidebarItem(
+                    label: 'Pay',
+                    iconName: AppIcons.paid,
+                    onTap: () {},
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  AppSidebarItem(
                     label: 'Activity',
                     iconName: AppIcons.history,
                     onTap: () {},

--- a/test/app_main_sidebar_test.dart
+++ b/test/app_main_sidebar_test.dart
@@ -15,8 +15,11 @@ import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
 import 'package:zcash_wallet/src/core/layout/app_main_sidebar.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
+import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
+import 'package:zcash_wallet/src/features/swap/providers/pay_selected_asset_store.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_failure.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
@@ -63,6 +66,7 @@ void main() {
     );
     expect(find.byKey(const ValueKey('sidebar_home_button')), findsOneWidget);
     expect(find.byKey(const ValueKey('sidebar_swap_button')), findsOneWidget);
+    expect(find.byKey(const ValueKey('sidebar_pay_button')), findsOneWidget);
     expect(find.byKey(const ValueKey('sidebar_voting_button')), findsOneWidget);
     expect(
       find.byKey(const ValueKey('sidebar_activity_button')),
@@ -70,10 +74,15 @@ void main() {
     );
     expect(find.text('Home'), findsOneWidget);
     expect(find.text('Swap'), findsOneWidget);
+    expect(find.text('Pay'), findsOneWidget);
     expect(find.text('Vote'), findsOneWidget);
     expect(find.text('Activity'), findsOneWidget);
     expect(find.text('Settings'), findsOneWidget);
     expect(find.text('Sign out'), findsOneWidget);
+    final payItem = tester.widget<AppSidebarItem>(
+      find.byKey(const ValueKey('sidebar_pay_button')),
+    );
+    expect(payItem.iconName, AppIcons.paid);
     expect(find.text('Wallet'), findsNothing);
     expect(find.text('Send'), findsNothing);
     expect(find.text('Receive'), findsNothing);
@@ -391,6 +400,7 @@ void main() {
     final cases = [
       (route: '/home', label: 'Home'),
       (route: '/swap', label: 'Swap'),
+      (route: '/pay', label: 'Pay'),
       (route: '/voting', label: 'Vote'),
       (route: '/activity', label: 'Activity'),
       (route: '/settings', label: 'Settings'),
@@ -532,7 +542,7 @@ void main() {
     );
   });
 
-  testWidgets('sidebar hides Swap when swap feature is disabled', (
+  testWidgets('sidebar hides Swap and Pay when swap feature is disabled', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -541,7 +551,9 @@ void main() {
     await tester.pump();
 
     expect(find.byKey(const ValueKey('sidebar_swap_button')), findsNothing);
+    expect(find.byKey(const ValueKey('sidebar_pay_button')), findsNothing);
     expect(find.text('Swap'), findsNothing);
+    expect(find.text('Pay'), findsNothing);
     expect(find.byKey(const ValueKey('sidebar_home_button')), findsOneWidget);
     expect(find.text('Home'), findsOneWidget);
     expect(
@@ -559,6 +571,16 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('swap'), findsOneWidget);
+  });
+
+  testWidgets('sidebar Pay item opens the pay route', (tester) async {
+    await tester.pumpWidget(_sidebarHarness(_syncedSyncState));
+    await tester.pump();
+
+    await tester.tap(find.text('Pay'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('pay'), findsOneWidget);
   });
 
   testWidgets('sidebar Activity item opens the activity route', (tester) async {
@@ -632,6 +654,7 @@ void main() {
     final positions = [
       tester.getTopLeft(find.text('Home')).dy,
       tester.getTopLeft(find.text('Swap')).dy,
+      tester.getTopLeft(find.text('Pay')).dy,
       tester.getTopLeft(find.text('Vote')).dy,
       tester.getTopLeft(find.text('Activity')).dy,
     ];
@@ -645,7 +668,7 @@ void main() {
     }
   });
 
-  testWidgets('sidebar disables Swap, Vote, and Activity while importing', (
+  testWidgets('sidebar disables primary actions while importing', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -665,6 +688,10 @@ void main() {
     await tester.tap(find.text('Swap'));
     await tester.pump(const Duration(milliseconds: 50));
     expect(find.text('swap'), findsNothing);
+
+    await tester.tap(find.text('Pay'));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(find.text('pay'), findsNothing);
 
     await tester.tap(find.text('Vote'));
     await tester.pump(const Duration(milliseconds: 50));
@@ -690,7 +717,7 @@ void main() {
   });
 
   testWidgets(
-    'sidebar disables Swap and Vote while Ironwood migration is required',
+    'sidebar disables Swap, Pay, and Vote while Ironwood migration is required',
     (tester) async {
       await tester.pumpWidget(
         _sidebarHarness(
@@ -709,20 +736,27 @@ void main() {
       await tester.pump();
 
       final swap = _sidebarItemWithLabel(tester, 'Swap');
+      final pay = _sidebarItemWithLabel(tester, 'Pay');
       final vote = _sidebarItemWithLabel(tester, 'Vote');
       final activity = _sidebarItemWithLabel(tester, 'Activity');
       final settings = _sidebarItemWithLabel(tester, 'Settings');
 
       expect(swap.onTap, isNull);
+      expect(pay.onTap, isNull);
       expect(vote.onTap, isNull);
       expect(activity.onTap, isNotNull);
       expect(settings.onTap, isNotNull);
       expect(_opacityForText(tester, 'Swap'), 0.5);
+      expect(_opacityForText(tester, 'Pay'), 0.5);
       expect(_opacityForText(tester, 'Vote'), 0.5);
 
       await tester.tap(find.text('Swap'));
       await tester.pump(const Duration(milliseconds: 50));
       expect(find.text('swap'), findsNothing);
+
+      await tester.tap(find.text('Pay'));
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(find.text('pay'), findsNothing);
 
       await tester.tap(find.text('Vote'));
       await tester.pump(const Duration(milliseconds: 50));
@@ -738,33 +772,42 @@ void main() {
     },
   );
 
-  testWidgets(
-    'sidebar restores ordinary actions once Ironwood migration is active',
-    (tester) async {
-      await tester.pumpWidget(
-        _sidebarHarness(
-          _syncedSyncState,
-          ironwoodHomeMigrationCtaState: IronwoodHomeMigrationCtaState.resume(
-            network: 'main',
-            accountUuid: 'account-1',
-            status: _mixedMigrationStatus,
-          ),
-          ironwoodPostMigrationState: IronwoodPostMigrationState.inProgress(
-            network: 'main',
-            accountUuid: 'account-1',
-            status: _mixedMigrationStatus,
-          ),
-          migrationCoordinatorState: IronwoodMigrationCoordinatorState(
-            statuses: {'account-1': _mixedMigrationStatus},
-          ),
+  testWidgets('sidebar restores Pay once Ironwood funds are spendable', (
+    tester,
+  ) async {
+    Widget migrationHarness(BigInt ironwoodBalance) {
+      return _sidebarHarness(
+        _syncedSyncState.copyWith(ironwoodBalance: ironwoodBalance),
+        ironwoodHomeMigrationCtaState: IronwoodHomeMigrationCtaState.resume(
+          network: 'main',
+          accountUuid: 'account-1',
+          status: _mixedMigrationStatus,
+        ),
+        ironwoodPostMigrationState: IronwoodPostMigrationState.inProgress(
+          network: 'main',
+          accountUuid: 'account-1',
+          status: _mixedMigrationStatus,
+        ),
+        migrationCoordinatorState: IronwoodMigrationCoordinatorState(
+          statuses: {'account-1': _mixedMigrationStatus},
         ),
       );
-      await tester.pump();
+    }
 
-      expect(_sidebarItemWithLabel(tester, 'Swap').onTap, isNotNull);
-      expect(_sidebarItemWithLabel(tester, 'Vote').onTap, isNotNull);
-    },
-  );
+    await tester.pumpWidget(migrationHarness(BigInt.zero));
+    await tester.pump();
+
+    expect(_sidebarItemWithLabel(tester, 'Swap').onTap, isNotNull);
+    expect(_sidebarItemWithLabel(tester, 'Pay').onTap, isNull);
+    expect(_sidebarItemWithLabel(tester, 'Vote').onTap, isNotNull);
+
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump();
+    await tester.pumpWidget(migrationHarness(BigInt.one));
+    await tester.pump();
+
+    expect(_sidebarItemWithLabel(tester, 'Pay').onTap, isNotNull);
+  });
 
   testWidgets('sidebar sync indicator is pinned to the sidebar edge', (
     tester,
@@ -1164,6 +1207,13 @@ Widget _sidebarHarness(
         ),
       ),
       GoRoute(
+        path: '/pay',
+        builder: (_, _) => const AppDesktopShell(
+          sidebar: AppMainSidebar(),
+          pane: AppDesktopPane(child: Text('pay')),
+        ),
+      ),
+      GoRoute(
         path: '/voting',
         builder: (_, _) => const AppDesktopShell(
           sidebar: AppMainSidebar(),
@@ -1215,6 +1265,9 @@ Widget _sidebarHarness(
       appBootstrapProvider.overrideWithValue(bootstrap),
       syncProvider.overrideWith(() => _FakeSyncNotifier(syncState)),
       swapFeatureEnabledProvider.overrideWithValue(swapEnabled),
+      paySelectedAssetStoreProvider.overrideWithValue(
+        const _FakePaySelectedAssetStore(),
+      ),
       ironwoodHomeMigrationCtaProvider.overrideWith((ref) async {
         return ironwoodHomeMigrationCtaState;
       }),
@@ -1241,6 +1294,21 @@ Widget _sidebarHarness(
       ),
     ),
   );
+}
+
+class _FakePaySelectedAssetStore implements PaySelectedAssetStore {
+  const _FakePaySelectedAssetStore();
+
+  @override
+  Future<SwapAsset?> loadSelectedAsset({required String accountUuid}) async {
+    return SwapAsset.usdc;
+  }
+
+  @override
+  Future<void> saveSelectedAsset({
+    required String accountUuid,
+    required SwapAsset asset,
+  }) async {}
 }
 
 SyncState _networkFailureSyncState() {


### PR DESCRIPTION
## Summary

- add Pay below Swap in the desktop sidebar using the existing Pay icon
- preserve account-scoped Pay composer initialization and selected payout asset restoration
- align Pay availability with swap feature flags, importing state, and Ironwood migration spendability
- update desktop Widgetbook sidebar fixtures and sidebar coverage

## Impact

Desktop users can enter the Pay flow directly from the primary sidebar while retaining the same availability and initialization behavior as the Home Pay action.

## Validation

- `fvm flutter test test/app_main_sidebar_test.dart`
- related sidebar and Widgetbook tests (58 tests)
- `fvm flutter analyze` on changed files
- `git diff --check`
