### PR TITLE
Refine Ironwood migration copy

### DIFF
--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_intro_options.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_intro_options.dart
@@ -270,7 +270,7 @@ class _MobileMigrationOptionsState
               title: 'Private',
               body: widget.privateEnabled
                   ? 'Splits transactions into multiple parts to minimize '
-                        'traceability, but takes longer.'
+                        'traceability but will take several hours to days.'
                   : 'Not available on Android.',
               selected: privateSelected,
               icon: _MigrationChoiceIcon.private,
@@ -285,7 +285,7 @@ class _MobileMigrationOptionsState
               title: 'Immediate',
               body:
                   'Migrates your entire balance in one batch. '
-                  'Fast, but less private.',
+                  'Fast (~10 mins) but less private.',
               selected: immediateSelected,
               icon: _MigrationChoiceIcon.immediate,
               onTap: _isContinuing

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_live_states.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_live_states.dart
@@ -51,7 +51,7 @@ class _MobileMigrationPreparing extends StatelessWidget {
               child: Column(
                 children: [
                   Text(
-                    'Migration in Progress',
+                    'Ironwood Migration',
                     key: const ValueKey(
                       'mobile_ironwood_migration_preparing_title',
                     ),
@@ -226,7 +226,7 @@ class _MobileMigrationMigratingState
       children: [
         SizedBox(height: compact ? 20 : 46),
         Text(
-          'Migration in Progress',
+          'Ironwood Migration',
           textAlign: TextAlign.center,
           style: AppTypography.headlineLarge.copyWith(
             color: colors.text.accent,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -1152,6 +1152,7 @@ class _MigrationProgressPreview extends StatelessWidget {
     this.totalParts = 24,
     this.completedBatches,
     this.totalBatches,
+    this.currentBatchNumber = 1,
     this.completedRingSegments,
     this.awaitingRingSegments,
     this.currentSigningPartIndices = const {},
@@ -1181,6 +1182,7 @@ class _MigrationProgressPreview extends StatelessWidget {
   final int totalParts;
   final int? completedBatches;
   final int? totalBatches;
+  final int currentBatchNumber;
   final Set<int>? completedRingSegments;
   final Set<int>? awaitingRingSegments;
   final Set<int> currentSigningPartIndices;
@@ -1307,6 +1309,7 @@ class _MigrationProgressPreview extends StatelessWidget {
                 else
                   _MigrationProgressStatus(
                     state: state,
+                    currentBatchNumber: currentBatchNumber,
                     bodyOverride: nextActionText,
                   ),
               ],
@@ -1819,8 +1822,7 @@ class _MigrationProgressSummary extends StatelessWidget {
             completionEstimateText ??
             switch (state) {
               _MigrationProgressState.syncing => 'Syncing',
-              _MigrationProgressState.broadcasting =>
-                'All is well. Broadcasting notes…',
+              _MigrationProgressState.broadcasting => 'Migration in progress',
               _MigrationProgressState.confirming => 'Waiting for confirmations',
               _MigrationProgressState.needsInput =>
                 'Waiting for your confirmation',
@@ -1855,9 +1857,14 @@ class _MigrationSummaryRows extends StatelessWidget {
 }
 
 class _MigrationProgressStatus extends StatelessWidget {
-  const _MigrationProgressStatus({required this.state, this.bodyOverride});
+  const _MigrationProgressStatus({
+    required this.state,
+    required this.currentBatchNumber,
+    this.bodyOverride,
+  });
 
   final _MigrationProgressState state;
+  final int currentBatchNumber;
   final String? bodyOverride;
 
   @override
@@ -1889,7 +1896,7 @@ class _MigrationProgressStatus extends StatelessWidget {
       ),
       _MigrationProgressState.broadcasting => (
         AppIcons.notificationBell,
-        'All is well. Broadcasting notes…',
+        'All clear. Processing batch #$currentBatchNumber',
         'Next migration step expected in\n'
             '~2 hrs 15 mins.\n'
             'Notifications are on. You can leave Vizor and check back later.',
@@ -1897,7 +1904,7 @@ class _MigrationProgressStatus extends StatelessWidget {
       _MigrationProgressState.confirming => (
         AppIcons.migrationTimer,
         'Waiting for confirmations',
-        'Confirmations are still arriving. You can leave Vizor and check '
+        'Confirmations are still arriving.\nYou can leave Vizor and check '
             'again later.',
       ),
       _MigrationProgressState.needsInput => (
@@ -1951,15 +1958,23 @@ class _MigrationProgressStatus extends StatelessWidget {
                 color: context.colors.text.accent,
               ),
             )
-          else if (broadcasting)
+          else if (broadcasting) ...[
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: AppTypography.labelMedium.copyWith(
+                color: context.colors.text.accent,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
             Text(
               bodyOverride ?? body,
               textAlign: TextAlign.center,
               style: AppTypography.bodyMediumStrong.copyWith(
                 color: context.colors.text.accent,
               ),
-            )
-          else ...[
+            ),
+          ] else ...[
             Text(
               title,
               textAlign: TextAlign.center,
@@ -2088,9 +2103,11 @@ class _PreparationCompleteModalBody extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.s),
           Text(
-            'What’s Next?',
+            'Preparation is complete, but we are waiting for the next '
+            'available signing window.\nWe\'ll let you know when it\'s time '
+            'to take action.',
             textAlign: TextAlign.center,
-            style: AppTypography.headlineSmall.copyWith(
+            style: AppTypography.bodyMedium.copyWith(
               color: context.colors.text.secondary,
             ),
           ),

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -940,6 +940,7 @@ class _MobileMigrationRedesignedStatusState
       segmentValuesZatoshi: _migrationRingSegmentValues(widget.status),
       completedBatches: batchProgress.completedBatches,
       totalBatches: batchProgress.totalBatches,
+      currentBatchNumber: batchProgress.currentBatchNumber,
       completedRingSegments: _completedRingSegments(widget.status),
       awaitingRingSegments: _awaitingRingSegments(widget.status),
       currentSigningPartIndices: _currentSigningRingSegments(widget.status),
@@ -1110,7 +1111,7 @@ class _MobileMigrationRedesignedStatusState
           'Keep Vizor open.';
     }
     if (state == _MigrationProgressState.confirming) {
-      return 'Confirmations are still arriving. You can leave Vizor and '
+      return 'Confirmations are still arriving.\nYou can leave Vizor and '
           'check again later.';
     }
     if (timing == 'ready now') {

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -1518,8 +1518,8 @@ void main() {
     );
     expect(
       find.text(
-        'Splits transactions into multiple parts to minimize traceability, '
-        'but takes longer.',
+        'Splits transactions into multiple parts to minimize traceability '
+        'but will take several hours to days.',
       ),
       findsOneWidget,
     );
@@ -1530,7 +1530,8 @@ void main() {
     );
     expect(
       find.text(
-        'Migrates your entire balance in one batch. Fast, but less private.',
+        'Migrates your entire balance in one batch. '
+        'Fast (~10 mins) but less private.',
       ),
       findsOneWidget,
     );
@@ -1553,7 +1554,7 @@ void main() {
           .widget<Text>(
             find.text(
               'Migrates your entire balance in one batch. '
-              'Fast, but less private.',
+              'Fast (~10 mins) but less private.',
             ),
           )
           .style
@@ -3068,7 +3069,7 @@ void main() {
     await tester.pumpWidget(_app(step: MobileIronwoodMigrationStep.preparing));
     await tester.pumpAndSettle();
 
-    expect(find.text('Migration in Progress'), findsOneWidget);
+    expect(find.text('Ironwood Migration'), findsOneWidget);
     expect(
       find.text(
         'Preparing your balance for migration. This step usually takes '
@@ -3141,7 +3142,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Migration in Progress'), findsOneWidget);
+    expect(find.text('Ironwood Migration'), findsOneWidget);
     expect(find.text('Migration 12 notes'), findsOneWidget);
     expect(find.text('142.20 ZEC'), findsOneWidget);
     expect(find.text('Part 1'), findsOneWidget);
@@ -3229,7 +3230,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Migration in Progress'), findsOneWidget);
+    expect(find.text('Ironwood Migration'), findsOneWidget);
     expect(find.text('Fast Migration'), findsNothing);
   });
 
@@ -5741,6 +5742,14 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Preparation is done'), findsOneWidget);
+      expect(
+        find.text(
+          'Preparation is complete, but we are waiting for the next '
+          'available signing window.\nWe\'ll let you know when it\'s time '
+          'to take action.',
+        ),
+        findsOneWidget,
+      );
 
       syncNotifier.emit(
         SyncState(
@@ -6491,7 +6500,10 @@ void main() {
     expect(find.text('8.24 ZEC'), findsOneWidget);
     expect(find.text('Est. completion'), findsOneWidget);
     expect(
-      find.textContaining('Confirmations are still arriving'),
+      find.text(
+        'Confirmations are still arriving.\nYou can leave Vizor and check '
+        'again later.',
+      ),
       findsOneWidget,
     );
     expect(find.textContaining('Signing window expected'), findsNothing);
@@ -7303,6 +7315,21 @@ void main() {
         status: _status(
           phase: kIronwoodMigrationBroadcastingPhase,
           nextActionHeight: 3_000_020,
+          targetValues: List<int>.filled(9, 100_000_000),
+          parts: [
+            for (var index = 0; index < 9; index++)
+              rust_sync.MigrationPartStatus(
+                partIndex: index,
+                valueZatoshi: BigInt.from(100_000_000),
+                state: index < 8
+                    ? rust_sync.MigrationPartState.completed
+                    : rust_sync.MigrationPartState.scheduled,
+                txidHex: 'tx-$index',
+                scheduledHeight: 3_000_000 + index,
+                confirmationCount: index < 8 ? 3 : 0,
+                confirmationTarget: 3,
+              ),
+          ],
         ),
         syncState: SyncState(
           accountUuid: 'account-1',
@@ -7315,6 +7342,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Next migration'), findsOneWidget);
+    expect(find.text('All clear. Processing batch #2'), findsOneWidget);
     // The timing and the notification promise are stated once each.
     expect(
       find.text(
@@ -7348,6 +7376,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    expect(find.text('All clear. Processing batch #1'), findsOneWidget);
     expect(
       find.text(
         'Next migration step expected in\n'
@@ -7389,6 +7418,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    expect(find.text('All clear. Processing batch #1'), findsOneWidget);
     expect(
       find.text('Next migration step expected in\n~25 minutes.'),
       findsOneWidget,


### PR DESCRIPTION
## What changed

- Port the intended mobile Ironwood migration copy updates from #346 onto the current `main` implementation.
- Keep the latest notification-aware broadcasting messages and real completion estimate.
- Show `All clear. Processing batch #N` in the migration status area, including the calculated current batch.
- Preserve the current desktop migration redesign instead of restoring obsolete desktop UI.

## Why

PR #346 was authored against an older migration implementation and no longer merges cleanly into `main`. This replacement keeps its user-facing intent while adapting it to the current mobile migration flow.

## Validation

- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/migration/mobile_ironwood_migration_flow_screen_test.dart` (157 passed)
- `fvm flutter test test/features/migration/ironwood_migration_flow_screen_test.dart` (111 passed)
- `fvm flutter analyze` on the five changed files (no issues)
