### PR TITLE
Persist the Tor route on the strict side, and let a pending connection be cancelled

### DIFF
--- a/lib/src/features/settings/widgets/network_privacy_control.dart
+++ b/lib/src/features/settings/widgets/network_privacy_control.dart
@@ -16,6 +16,59 @@ const _toggleShortcuts = <ShortcutActivator, Intent>{
   SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
 };
 
+/// What activating a Tor control does from the state it is showing.
+///
+/// Shared by both form factors because the state machine behind them is one
+/// provider, and because the case that matters is the one a control is most
+/// tempted to disable itself for.
+enum NetworkPrivacyToggleAction {
+  enable,
+  disable,
+
+  /// A Tor connection is still being established and the user wants out of it.
+  ///
+  /// The bootstrap has a three-minute deadline and every policy-aware request
+  /// fails closed until it resolves, so a control that goes inert for the
+  /// duration strands the user on a network that blocks Tor — and force-quitting
+  /// does not help, because the saved route is Tor and the next launch starts
+  /// the same bootstrap. Switching to direct is what ends it, so this stays
+  /// available for exactly as long as the wait does.
+  cancelPendingTor,
+
+  /// A switch to the direct route is already under way. There is nothing to
+  /// cancel toward, and re-entering Tor mid-switch is a transition rather than
+  /// an escape.
+  none,
+}
+
+NetworkPrivacyToggleAction networkPrivacyToggleAction(
+  NetworkPrivacyState state,
+) {
+  if (!state.isBusy) {
+    return state.torEnabled
+        ? NetworkPrivacyToggleAction.disable
+        : NetworkPrivacyToggleAction.enable;
+  }
+  return (state.targetTorEnabled ?? state.torEnabled)
+      ? NetworkPrivacyToggleAction.cancelPendingTor
+      : NetworkPrivacyToggleAction.none;
+}
+
+extension NetworkPrivacyToggleActionX on NetworkPrivacyToggleAction {
+  bool get isInteractive => this != NetworkPrivacyToggleAction.none;
+
+  /// The route the action asks for. Cancelling a pending Tor connection asks
+  /// for the direct route, which is what supersedes the bootstrap.
+  bool get requestedTorEnabled => this == NetworkPrivacyToggleAction.enable;
+
+  /// Assistive-technology label. Turning "Use Tor" off mid-connect is an escape
+  /// from a wait, not a second transition, so it does not announce itself as
+  /// one.
+  String get semanticsLabel => this == NetworkPrivacyToggleAction.cancelPendingTor
+      ? 'Stop connecting to Tor'
+      : 'Use Tor';
+}
+
 /// Shared desktop Tor control used both before wallet creation and in Settings.
 ///
 /// The control presents the desired route separately from its connection
@@ -30,6 +83,7 @@ class NetworkPrivacyControl extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.colors;
     final state = ref.watch(networkPrivacyProvider);
+    final toggleAction = networkPrivacyToggleAction(state);
     final presentation = _presentationFor(
       state,
       platform: defaultTargetPlatform,
@@ -104,14 +158,14 @@ class NetworkPrivacyControl extends ConsumerWidget {
                 _NetworkPrivacyToggle(
                   key: const ValueKey('network_privacy_toggle'),
                   enabled: state.torEnabled,
-                  busy: state.isBusy,
-                  onToggle: state.isBusy
-                      ? null
-                      : () => unawaited(
+                  action: toggleAction,
+                  onToggle: toggleAction.isInteractive
+                      ? () => unawaited(
                           ref
                               .read(networkPrivacyProvider.notifier)
-                              .setTorEnabled(!state.torEnabled),
-                        ),
+                              .setTorEnabled(toggleAction.requestedTorEnabled),
+                        )
+                      : null,
                 ),
               ],
             ),
@@ -216,16 +270,14 @@ class NetworkPrivacyControl extends ConsumerWidget {
 class _NetworkPrivacyToggle extends StatefulWidget {
   const _NetworkPrivacyToggle({
     required this.enabled,
-    required this.busy,
+    required this.action,
     required this.onToggle,
     super.key,
   });
 
   final bool enabled;
 
-  /// The knob moves to the desired route as soon as the transition starts, so
-  /// the dimmed track is the only signal that the route is not effective yet.
-  final bool busy;
+  final NetworkPrivacyToggleAction action;
 
   final VoidCallback? onToggle;
 
@@ -274,7 +326,12 @@ class _NetworkPrivacyToggleState extends State<_NetworkPrivacyToggle> {
     final control = Stack(
       clipBehavior: Clip.none,
       children: [
-        Opacity(opacity: widget.busy ? 0.65 : 1, child: track),
+        // The knob moves to the desired route as soon as a transition starts,
+        // so dimming is the only signal that the route is not effective yet.
+        // A transition the user can still leave is not dimmed: the control has
+        // to look like something they may act on, because acting on it is the
+        // way out of the wait.
+        Opacity(opacity: interactive ? 1 : 0.65, child: track),
         if (_focused)
           Positioned(
             left: -3,
@@ -297,7 +354,7 @@ class _NetworkPrivacyToggleState extends State<_NetworkPrivacyToggle> {
       button: true,
       enabled: interactive,
       toggled: widget.enabled,
-      label: 'Use Tor',
+      label: widget.action.semanticsLabel,
       excludeSemantics: true,
       child: MouseRegion(
         cursor: interactive
@@ -363,7 +420,7 @@ _NetworkPrivacyPresentation _presentationFor(
     return _NetworkPrivacyPresentation(
       statusLabel: 'Connected',
       description:
-          'Vizor’s network requests go through Tor, but software updates are unavailable.',
+          'Wallet sync and most in-app requests go through Tor. Software updates are unavailable.',
       statusColor: (colors) => colors.text.destructive,
       iconColor: (colors) => colors.icon.brandCrimson,
       descriptionColor: (colors) => colors.text.destructive,
@@ -396,11 +453,17 @@ _NetworkPrivacyPresentation _presentationFor(
     (NetworkPrivacyConnectionStatus.connecting, true) =>
       _NetworkPrivacyPresentation(
         statusLabel: 'Connecting…',
+        // Names the way out. On a network that blocks Tor the wait runs to the
+        // bootstrap deadline with every request failing closed, and restarting
+        // the app only starts the same wait again, so the escape has to be
+        // stated where the user is looking.
         description: isLinux
-            ? 'New requests wait until the Tor connection is ready. Update '
+            ? 'New requests wait until the Tor connection is ready. Turn Tor '
+                  'off to stop connecting and use a direct connection. Update '
                   'pages and downloads opened in another app use that '
                   'app’s connection.'
-            : 'New requests wait until the Tor connection is ready.',
+            : 'New requests wait until the Tor connection is ready. Turn Tor '
+                  'off to stop connecting and use a direct connection.',
         statusIconName: AppIcons.loader,
         statusColor: (colors) => colors.text.secondary,
         iconColor: (colors) => colors.icon.muted,
@@ -420,8 +483,11 @@ _NetworkPrivacyPresentation _presentationFor(
       ),
     (NetworkPrivacyConnectionStatus.connected, _) => _NetworkPrivacyPresentation(
       statusLabel: 'Connected',
-      description:
-          'Vizor’s network requests go through Tor. Links opened in other apps use those apps’ network settings.',
+      description: isLinux
+          ? 'Wallet sync, most in-app requests, and software update checks go '
+                'through Tor. Update pages and downloads opened in another app '
+                'use that app’s connection.'
+          : 'Wallet sync, most in-app requests, and software updates go through Tor. Some services may be unavailable over Tor.',
       statusColor: (colors) => colors.text.brandCrimson,
       iconColor: (colors) => colors.icon.brandCrimson,
       descriptionColor: (colors) => colors.text.accent,

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -557,6 +557,39 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
         return;
       }
       if (generation != _generation) return;
+      // The saved route is written before this process changes at all. The
+      // two halves may diverge in only one direction: saved may be stricter
+      // than the route the user has been told about, never laxer. Written
+      // after `beginEnable`, a failed write would leave this process
+      // enforcing Tor while the saved route still said direct — and the
+      // saved half is what a relaunch believes, so restarting the app would
+      // silently undo a choice the user never reversed. Written first, a
+      // failure aborts a toggle that has not changed anything yet: the route
+      // is still direct, requests still flow, nothing needs rolling back.
+      try {
+        await store.writeTorEnabled(true);
+      } catch (error) {
+        if (generation != _generation) return;
+        // Undo the updater preflight so software updates are not left routed
+        // for a Tor session that never started. Best-effort: failing here
+        // only pauses update checks, and `retry()` re-runs the whole toggle.
+        var softwareUpdatesAvailable = previousState.softwareUpdatesAvailable;
+        try {
+          await nativeUpdates.setTorEnabled(false);
+        } catch (_) {
+          softwareUpdatesAvailable = false;
+        }
+        if (generation != _generation) return;
+        state = NetworkPrivacyState(
+          torEnabled: previousState.torEnabled,
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: true,
+          softwareUpdatesAvailable: softwareUpdatesAvailable,
+          error: error.toString(),
+        );
+        return;
+      }
+      if (generation != _generation) return;
       runtime.beginEnable();
     } else {
       state = NetworkPrivacyState(
@@ -606,15 +639,26 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
         if (directDrain != null) {
           _throwIfDirectDrainFailed(await directDrain);
         }
-        if (generation != _generation) return;
-        await store.writeTorEnabled(enabled);
         // Re-check after every suspension point: a superseded disable that
         // reached `configure(false)` or `allow()` would reopen clearnet
         // underneath a newer enable that has already gone fail-closed.
         if (generation != _generation) return;
         nextStatus = await runtime.configure(enabled: enabled);
-        if (!enabled && generation == _generation) {
-          directRequests.allow();
+        if (enabled || generation != _generation) return;
+        try {
+          // Written only now that the runtime has actually gone direct — the
+          // mirror of the enable ordering above. Saved any earlier, a
+          // relaunch would read direct while this process was still
+          // enforcing Tor.
+          await store.writeTorEnabled(false);
+        } finally {
+          // The gate follows the runtime, not the preference. Rust is on the
+          // direct route with its Tor client dropped, so a gate left shut
+          // would strand every direct request for the rest of the session
+          // while the UI reports Tor off. A failed write leaves the saved
+          // route at Tor — the stricter half — so the next launch comes back
+          // on Tor instead of silently staying direct.
+          if (generation == _generation) directRequests.allow();
         }
       });
       if (generation != _generation) return;

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/settings/screens/settings_screen.dart';
 import 'package:zcash_wallet/src/features/settings/settings_platform.dart';
+import 'package:zcash_wallet/src/features/settings/widgets/network_privacy_control.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
@@ -198,7 +199,10 @@ void main() {
 
     expect(find.text('Connecting…'), findsOneWidget);
     expect(
-      find.text('New requests wait until the Tor connection is ready.'),
+      find.text(
+        'New requests wait until the Tor connection is ready. Turn Tor off to '
+        'stop connecting and use a direct connection.',
+      ),
       findsOneWidget,
     );
 
@@ -206,8 +210,116 @@ void main() {
       find.byKey(const ValueKey('network_privacy_status_icon')),
     );
     expect(statusIcon.name, AppIcons.loader);
-    expect(_toggleTrackOpacity(tester), lessThan(1));
+    // Not dimmed: the control is the way out of the wait, so it has to look
+    // like something the user may act on.
+    expect(_toggleTrackOpacity(tester), 1);
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('network_privacy_toggle')),
+    );
+    await tester.tap(find.byKey(const ValueKey('network_privacy_toggle')));
+    await tester.pump();
+    // The bootstrap runs to a three-minute deadline with every request failing
+    // closed, and relaunching starts the same wait, so switching to direct has
+    // to stay reachable for the whole of it.
+    expect(calls, [false]);
+  });
+
+  test('the toggle offers an escape from a pending Tor connection', () {
+    // Every state maps to exactly one action, and the connecting-to-Tor state
+    // maps to an escape rather than to nothing.
+    NetworkPrivacyToggleAction actionFor({
+      required bool torEnabled,
+      required NetworkPrivacyConnectionStatus status,
+      bool? targetTorEnabled,
+    }) => networkPrivacyToggleAction(
+      NetworkPrivacyState(
+        torEnabled: torEnabled,
+        status: status,
+        targetTorEnabled: targetTorEnabled,
+      ),
+    );
+
+    expect(
+      actionFor(
+        torEnabled: false,
+        status: NetworkPrivacyConnectionStatus.off,
+      ),
+      NetworkPrivacyToggleAction.enable,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connected,
+      ),
+      NetworkPrivacyToggleAction.disable,
+    );
+    // A startup activation publishes no explicit target, so the effective one
+    // is the route already shown — which is the state a user relaunching into a
+    // blocked network lands in.
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+      ),
+      NetworkPrivacyToggleAction.cancelPendingTor,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+        targetTorEnabled: true,
+      ),
+      NetworkPrivacyToggleAction.cancelPendingTor,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+        targetTorEnabled: false,
+      ),
+      NetworkPrivacyToggleAction.none,
+    );
+  });
+
+  test('cancelling a pending Tor connection asks for the direct route', () {
+    expect(
+      NetworkPrivacyToggleAction.cancelPendingTor.requestedTorEnabled,
+      isFalse,
+    );
+    expect(NetworkPrivacyToggleAction.enable.requestedTorEnabled, isTrue);
+    expect(NetworkPrivacyToggleAction.disable.requestedTorEnabled, isFalse);
+    // Leaving a wait is not a second transition, and does not announce itself
+    // as one.
+    expect(
+      NetworkPrivacyToggleAction.cancelPendingTor.semanticsLabel,
+      'Stop connecting to Tor',
+    );
+    expect(NetworkPrivacyToggleAction.disable.semanticsLabel, 'Use Tor');
+    expect(NetworkPrivacyToggleAction.none.isInteractive, isFalse);
+  });
+
+  testWidgets('a switch to direct cannot be driven back into Tor', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _settingsHarness(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connecting,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pump();
+
+    // Nothing to escape from here: the route is already on its way to direct.
+    expect(_toggleTrackOpacity(tester), lessThan(1));
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('network_privacy_toggle')),
+    );
     await tester.tap(
       find.byKey(const ValueKey('network_privacy_toggle')),
       warnIfMissed: false,
@@ -230,8 +342,8 @@ void main() {
     expect(find.text('Connected'), findsOneWidget);
     expect(
       find.text(
-        'Vizor’s network requests go through Tor. Links opened in other apps '
-        'use those apps’ network settings.',
+        'Wallet sync, most in-app requests, and software updates go through '
+        'Tor. Some services may be unavailable over Tor.',
       ),
       findsOneWidget,
     );
@@ -287,8 +399,9 @@ void main() {
 
       expect(
         find.text(
-          'Vizor’s network requests go through Tor. Links opened in other apps '
-          'use those apps’ network settings.',
+          'Wallet sync, most in-app requests, and software update checks go '
+          'through Tor. Update pages and downloads opened in another app '
+          'use that app’s connection.',
         ),
         findsOneWidget,
       );
@@ -341,8 +454,8 @@ void main() {
 
     expect(
       find.text(
-        'Vizor’s network requests go through Tor, but software updates are '
-        'unavailable.',
+        'Wallet sync and most in-app requests go through Tor. Software '
+        'updates are unavailable.',
       ),
       findsOneWidget,
     );

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -132,11 +132,11 @@ void main() {
 
     expect(events, [
       'native:true',
+      'store:true',
       'begin-enable',
       'runtime-quiesce',
       'direct-quiesce',
       'restart',
-      'store:true',
       'configure:true',
       'native-resume',
     ]);
@@ -178,11 +178,11 @@ void main() {
     final state = container.read(networkPrivacyProvider);
     expect(events, [
       'native:true',
+      'store:true',
       'begin-enable',
       'runtime-quiesce',
       'direct-quiesce',
       'restart',
-      'store:true',
       'configure:true',
     ]);
     expect(state.torEnabled, isTrue);
@@ -221,8 +221,8 @@ void main() {
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
+      'store:false',
       'direct-allow',
       'native:false',
     ]);
@@ -296,8 +296,8 @@ void main() {
       'native-prepare-disable',
       'native-disable-drained',
       'restart',
-      'store:false',
       'configure:false',
+      'store:false',
       'direct-allow',
       'native:false',
     ]);
@@ -381,6 +381,7 @@ void main() {
 
       expect(events, [
         'native:true',
+        'store:true',
         'begin-enable',
         'runtime-quiesce',
         'direct-quiesce',
@@ -478,7 +479,6 @@ void main() {
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
       'native-resume',
     ]);
@@ -503,10 +503,102 @@ void main() {
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
       'native-resume',
     ]);
+  });
+
+  test('a failed strict save aborts the enable before anything changes', () async {
+    final events = <String>[];
+    final runtime = _FakeRuntime(
+      events,
+      NetworkPrivacyConnectionStatus.connected,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        networkPrivacyPreferenceStoreProvider.overrideWithValue(
+          _WriteFailingStore(events, failOn: true),
+        ),
+        networkPrivacyRuntimeProvider.overrideWithValue(runtime),
+        networkPrivacyNativeUpdateCoordinatorProvider.overrideWithValue(
+          _FakeNativeUpdateCoordinator(events),
+        ),
+        networkPrivacyDirectRequestGateProvider.overrideWithValue(
+          _FakeDirectRequestGate(events),
+        ),
+        networkPrivacyTransportRestartProvider.overrideWithValue((
+          update,
+        ) async {
+          events.add('restart');
+          await update();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
+
+    // Refused before the process changes: no fail-closed switch, no drain, no
+    // transport restart. Requests keep flowing directly, the saved route
+    // still says direct, and the updater preflight is undone — the toggle
+    // simply never happened, apart from the failure the user is shown.
+    expect(events, ['native:true', 'store:write-failed', 'native:false']);
+    expect(runtime.isTorEnabled(), isFalse);
+    final state = container.read(networkPrivacyProvider);
+    expect(state.torEnabled, isFalse);
+    expect(state.status, NetworkPrivacyConnectionStatus.failed);
+    expect(state.targetTorEnabled, isTrue);
+  });
+
+  test('a failed direct save still opens the direct request gate', () async {
+    final events = <String>[];
+    final runtime = _FakeRuntime(
+      events,
+      NetworkPrivacyConnectionStatus.connected,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        networkPrivacyPreferenceStoreProvider.overrideWithValue(
+          _WriteFailingStore(events, failOn: false),
+        ),
+        networkPrivacyRuntimeProvider.overrideWithValue(runtime),
+        networkPrivacyNativeUpdateCoordinatorProvider.overrideWithValue(
+          _FakeNativeUpdateCoordinator(events),
+        ),
+        networkPrivacyDirectRequestGateProvider.overrideWithValue(
+          _FakeDirectRequestGate(events),
+        ),
+        networkPrivacyTransportRestartProvider.overrideWithValue((
+          update,
+        ) async {
+          events.add('restart');
+          await update();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
+    events.clear();
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(false);
+
+    // The runtime is direct with its Tor client dropped, so the gate follows
+    // it: left shut, every direct request would fail for the rest of the
+    // session behind a UI that reports Tor off. The saved route stays at Tor
+    // — the stricter half — so the next launch comes back on Tor instead of
+    // silently staying direct.
+    expect(events, [
+      'native-prepare-disable',
+      'restart',
+      'configure:false',
+      'store:write-failed',
+      'direct-allow',
+    ]);
+    expect(runtime.isTorEnabled(), isFalse);
+    final state = container.read(networkPrivacyProvider);
+    expect(state.torEnabled, isFalse);
+    expect(state.status, NetworkPrivacyConnectionStatus.failed);
+    expect(state.targetTorEnabled, isFalse);
   });
 
   test(
@@ -901,6 +993,27 @@ class _FakeStore implements NetworkPrivacyPreferenceStore {
 
   @override
   Future<void> writeTorEnabled(bool enabled) async {
+    events.add('store:$enabled');
+  }
+}
+
+/// Fails the write in one direction only, the shape a full disk has: the
+/// previously saved value is already on disk when the new one is refused.
+class _WriteFailingStore implements NetworkPrivacyPreferenceStore {
+  _WriteFailingStore(this.events, {required this.failOn});
+
+  final List<String> events;
+  final bool failOn;
+
+  @override
+  Future<bool> readTorEnabled() async => false;
+
+  @override
+  Future<void> writeTorEnabled(bool enabled) async {
+    if (enabled == failOn) {
+      events.add('store:write-failed');
+      throw StateError('Could not save the Tor preference.');
+    }
     events.add('store:$enabled');
   }
 }


### PR DESCRIPTION
First of the PRs split out of #473 (closed to regroup; plan in its closing comment). Desktop-only — no mobile code, no Rust changes.

## The rule

A toggle changes two halves — the process route and the saved preference — and no ordering makes them change atomically. This PR makes the divergence rule explicit and one-directional: **the saved route may be stricter than the route the user has been told about, never laxer.**

## Enable: write first

The preference was written between the fail-closed switch and the bootstrap. A failed write left the process enforcing Tor (requests paused, failure shown) while the disk still said direct — and the disk is what a relaunch believes, so restarting the app silently undid a privacy choice the user never reversed. On mobile (later PRs) the same divergence is what a cold background wake reads before broadcasting, which is why this lands first.

The write now precedes everything. A failure aborts a toggle that has not happened yet: route still direct, requests still flowing, updater preflight undone, nothing to roll back.

## Disable: write after the switch, gate follows the runtime

The mirror failure — write succeeded, switch threw — saved direct under a process still enforcing Tor; the "Tor is still on" failure state held only until the next launch quietly completed the disable. The write now follows the switch. If the write then fails, the saved route stays at Tor (the stricter half) and the direct-request gate still opens, because the gate follows the runtime — leaving it shut would strand every direct request for the rest of the session behind a UI that reports Tor off.

## Cancellable pending connection

On a Tor-blocking network, connecting runs to the 3-minute bootstrap deadline with every request failing closed, and the toggle disabled itself for exactly that window; relaunching restarts the same wait. The toggle now cancels a pending connection, via a pure decision function (`networkPrivacyToggleAction`), with the assistive label and dimming following interactivity.

## Tests

- 2 new write-failure tests, both verified to fail without the production change (enable-abort, disable-gate).
- 6 existing order-pinning tests re-pinned to the new sequences; 3 escape-hatch tests.
- Full desktop lane: 2243 passed, 30 failures — identical to the pre-existing main baseline set.

https://claude.ai/code/session_01R9nkJCPTCahMjGiDgqFNrV