### PR TITLE
Enable Tor on mobile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,10 +545,351 @@ Swift BackgroundMigrationPreparationManager
   `com.keplr.vizor.sync` is cancelled once at launch as a tombstone for requests
   submitted by older builds; no handler is registered for it.
 
+### Declaring the network route
+
+The desired route lives in Rust process memory, and a background wake can be a
+cold launch where the Dart layer never ran. So "nobody has declared yet" is a
+distinct state from "the user chose direct", and Rust refuses it at the route
+chokepoint rather than treating it as direct.
+
+- **Every native entry point that may reach lightwalletd declares the route
+  before its first network call**, by reading the saved preference and calling
+  `zcash_network_privacy_mark_tor_desired` or
+  `zcash_network_privacy_mark_direct_route`. Declaring samples nothing, never
+  bootstraps, and is ignored once the process has decided its own route, so it
+  is safe to do first and unconditionally.
+- A lane that forgets fails closed on its first connection with
+  `Network route has not been declared for this process`. That is the intended
+  outcome: the alternative is reaching lightwalletd over clearnet on a
+  Tor-configured wallet, silently and only in the lane that forgot.
+- Adding a background entry point therefore means adding a declaration. Nothing
+  fails to compile without one, and the Rust-side test that pins this
+  (`an_undeclared_route_is_refused_instead_of_resolving_to_a_direct_connection`)
+  covers the chokepoint, not your new caller.
+- **On a Tor route, background passes do no network work at all.** A
+  background process never brings Tor up — the foreground owns the client —
+  so every background lane that finds the saved route at Tor declines before
+  its first network call and leaves the work to the next foreground entry.
+  Declining is the policy working: it completes its task successfully, and it
+  never falls back to clearnet.
+- **The saved route may be stricter than the enforced route, never laxer.**
+  The saved preference is all a cold background process has to go on, so a
+  toggle persists in whichever order keeps this true at every intermediate
+  point: enabling writes before the runtime switch (a failed write aborts a
+  toggle that has not happened yet), disabling writes after it (a failed write
+  leaves the stricter Tor value behind). `networkPrivacyPersistedRouteIsSafe`
+  is the executable statement of this rule.
+- Surfaces that describe what background work will do must read the saved
+  route (`NetworkPrivacyState.savedRouteTorEnabled`), not `torEnabled`: the
+  two diverge in exactly one state — a disable whose transport switched and
+  whose preference write failed — and the native lanes read the saved half.
+
 Key files:
 - `rust/src/migration_preparation.rs` — shared mobile preparation core
 - `rust/src/android_jni.rs` — Android preparation execution adapter
-- `rust/src/ffi.rs` — iOS read-only inspection and query adapter
+- `rust/src/ffi.rs` — iOS C adapter: read-only inspection and queries, plus the
+  route declaration and background Tor bring-up the queries run on
+- `ios/Runner/zcash_sync.h` — matching C header
+- `ios/Runner/BackgroundMigrationPreparationManager.swift` — continued-task
+  confirmation tracker and foreground-handoff owner
+- `lib/src/providers/wallet_mutation_guard.dart` — mutation ordering fence
+- `lib/src/features/migration/services/ironwood_migration_service.dart` —
+  foreground preparation recovery
+
+### iOS Preparation Confirmation Tracking
+
+`BGContinuedProcessingTask`
+(`com.keplr.vizor.ironwood-preparation`) polls lightwalletd every 60 seconds
+while an executed denomination preparation waits for confirmations.
+
+- `BackgroundMigrationPreparationManager.swift` owns the task, reads observable
+  txids through C FFI, updates the system task `Progress`, and advances its
+  progress heartbeat every 15 seconds.
+- `NativeLightwalletdClient.swift` uses only `GetLatestBlock` and
+  `GetTransaction`; it checks both txid byte orientations.
+- `NotFound`, mempool height `0`, and fork height `UInt64.max` contribute zero
+  confirmations. A normal mined height contributes
+  `tip - minedHeight + 1`, capped at 3.
+- Reaching 3 confirmations finishes only the current observation wave. The
+  manager stores a foreground-continuation token, posts an “Open Vizor”
+  notification under its own `confirmedWaveReady` kind so healthy copy never
+  reuses failure copy, and immediately completes that system task successfully
+  without opening the wallet DB for sync or advance. It does not wait for the
+  user; a completed wave leaves nothing for a read-only task to observe.
+- Foreground reentry acknowledges the token before syncing and advancing the
+  durable run. If another transaction wave is materialized, it submits a fresh
+  read-only continued-processing task.
+- A foreground handoff records continuations only for runs that genuinely need
+  the foreground — never for a run the read-only task could still finish. A
+  multi-account task otherwise parks an account that is merely mid-wave, and
+  that account stops being re-armed until the user makes it active. The
+  "is a preparation bound to this request" boolean stays broader than the
+  recorded set on purpose: it gates cancellation of the pending request, so
+  deriving it from the recorded set would cancel healthy mid-wave runs.
+- OS expiration is completed without a failure presentation and re-arms
+  background tracking, because it interrupts one execution opportunity rather
+  than proving the migration failed. Expiry posts no notification of its own:
+  scopes whose waves already confirmed keep their earlier step-confirmed
+  alert, and the interrupted wave resumes when the re-armed task runs.
+
+### Send Flow
+
+2-step: `propose_send(account_uuid)` → confirmation dialog (shows fee) → `execute_proposal()` → broadcast via `SendTransaction` gRPC.
+
+- Integer-only ZEC-to-zatoshi parsing (no floating-point)
+- Real fee estimation via `estimate_fee(account_uuid)` on each keystroke
+- No-op Sapling provers for Orchard-only TXs (avoids 50MB param download)
+- Post-send: `refreshAfterSend()` for immediate pending TX display
+- Friendly error messages via `_friendlyError()` pattern matching
+
+### Hardware Wallet (Keystone) Send Flow
+
+Hardware send uses a **three-PCZT pipeline** that matches the
+`zcash-android-wallet-sdk` / Zashi pattern. The hardware device cannot generate
+ZK proofs (proving keys are too big for the device), and the phone cannot
+sign (spending key lives on the device), so the two sides work on separate
+clones of the same base PCZT and the phone combines them at the end.
+
+```
+1. createPcztFromProposal                      → base PCZT (phone)
+   (IO-finalized, no proofs, no signatures)
+      │
+      ├── 2a. addProofsToPczt(base, params?)   → pcztWithProofs   (phone, CPU)
+      │       (Orchard proof always; Sapling output proofs if the
+      │        proposal has needsSaplingParams=true)
+      │
+      └── 2b. redactPcztForSigner(base)        → redactedPczt     (phone)
+              → Keystone device (animated QR)
+              → device signs Orchard spend_auth_sig
+              → signed PCZT back to phone       → pcztWithSignatures
+                                                       ↓
+3. extractAndBroadcastPczt(
+     pcztWithProofs, pcztWithSignatures,
+     spend_params?, output_params?,
+   )                                             → txid
+```
+
+Roles in the split:
+
+| Step | PCZT role              | Runs on | Needs what                          |
+|------|------------------------|---------|--------------------------------------|
+| 1    | Creator + IoFinalizer  | phone   | wallet DB                            |
+| 2a   | Prover                 | phone   | proving params (Orchard always; Sapling ~50MB if target recipient is Sapling) |
+| 2b   | Redactor               | phone   | —                                    |
+| sign | Signer                 | device  | spend_auth_sig derivation (device holds USK) |
+| 3    | Combiner + TransactionExtractor | phone | verifying keys (Orchard always; Sapling if bundle non-empty) + wallet DB |
+
+**Critical invariants** (each of these was a real bug at some point in
+development; breaking them is a correctness or data-loss regression):
+
+1. **`extract_and_broadcast_pczt` must broadcast before it persists.**
+   The function order is: `TransactionExtractor::extract()` (in-memory, no
+   DB) → `send_transaction` gRPC → *only then* `extract_and_store_transaction_from_pczt`.
+   Store-then-broadcast leaves the wallet in an unrecoverable state if
+   lightwalletd rejects the tx: DB thinks the notes are spent, network
+   has no record of the tx, user has to manually rescue the wallet.
+
+2. **Local storage failure after a successful broadcast must not surface
+   as a send failure.** The primary store path is
+   `extract_and_store_transaction_from_pczt` (preserves rich PCZT
+   recipient/memo metadata). On failure, fall back to
+   `decrypt_and_store_transaction` — the same path sync uses when it
+   discovers one of our sent txs on-chain. Correctness is preserved
+   (spent notes get marked spent via nullifier matching) at the cost of
+   some PCZT-only display metadata. Only if both paths fail do we
+   return an error, and the error message must tell the user the tx is
+   on the network and not to retry.
+
+3. **Sapling params must be passed to BOTH `add_proofs_to_pczt` AND
+   `extract_and_broadcast_pczt` whenever the PCZT contains a Sapling
+   bundle.** `add_proofs_to_pczt` needs `LocalTxProver` to build Sapling
+   output proofs; `extract_and_broadcast_pczt` needs `LocalTxProver
+   ::verifying_keys()` (a) to validate the extracted transaction and
+   (b) to let `extract_and_store_transaction_from_pczt` store it. Both
+   functions share the `Option<&str>` / `Option<&str>` signature. If
+   the caller supplied paths to `add_proofs_to_pczt` but passed `None`
+   here, extraction bails with `SaplingRequired` and the user sees a
+   cryptic error after already downloading 50MB of params and
+   approving on the device. `send_screen.dart` threads the same
+   `proposal.needsSaplingParams ? spendPath : null` into both FFI
+   calls — keep it that way.
+
+4. **`PROPOSAL_STORE` is consume-on-entry for both execute paths, plus
+   explicit discard on cancel.**
+   - `create_pczt_from_proposal` and `execute_proposal` both call
+     `.remove()` at the top (dropping the store lock before any DB
+     work). A second call with the same `proposal_id` returns
+     `"Proposal not found (expired or already consumed)"`.
+   - Dart `_send()` runs the whole flow inside a `try/finally`
+     with a `proposalConsumed` flag that flips to true immediately
+     after the consume call. The `finally` block calls
+     `discardProposal(proposalId)` when the flag is still false —
+     this covers confirmation-dialog cancel, Sapling-params-dialog
+     cancel, exceptions during Sapling download, and any error
+     before the consume call. `discardProposal` is idempotent.
+   - If you add a new entry point that reads a stored proposal,
+     follow the same "consume on entry, idempotent discard on any
+     non-consuming exit" pattern. Silently reading without
+     consuming (`.get()`) reintroduces the memory-leak /
+     replayable-ID bugs that a prior revision of this branch had.
+
+The Dart flow in `lib/src/features/send/screens/send_screen.dart`
+implements this pipeline end-to-end; the Rust side lives in
+`rust/src/wallet/sync.rs::{create_pczt_from_proposal,
+add_proofs_to_pczt, redact_pczt_for_signer, extract_and_broadcast_pczt,
+discard_proposal}` with FRB wrappers in `rust/src/api/sync.rs`.
+
+### Wallet Creation
+
+`create_wallet()` fetches chain tip from lightwalletd as birthday height before creating the account. This prevents new wallets from doing a full chain scan. Birthday fetch failure blocks wallet creation (network required).
+
+### Rust API Design Constraint
+
+FRB codegen works best with simple types. Keep the `rust/src/api/` surface limited to primitives, `String`, and flat structs. Do all complex Zcash type manipulation inside `rust/src/wallet/` and return simple results through `rust/src/api/`.
+
+All per-account API functions take `account_uuid: String`. Sync-level operations (`start_full_sync`, etc.) operate on all accounts and do NOT take account_uuid.
+
+### Key Security Model
+
+`zcash_client_sqlite` intentionally does NOT store spending keys in the DB — only viewing keys (UFVK).
+
+**Software accounts**: the mnemonic/seed lives in Flutter's `flutter_secure_storage` (iOS Keychain / Android Keystore) per-account (`zcash_account_mnemonic_{uuid}`) and is passed to Rust only when needed for transaction signing. Seed is scoped in a block and dropped before network I/O (broadcast).
+
+**Hardware (Keystone) accounts**: no seed ever reaches the phone. On import the phone receives only the UFVK via QR/UR; the USK stays on the device. There is no corresponding `zcash_account_mnemonic_{uuid}` entry, and `getActiveMnemonic()` returns null for hardware accounts. Transaction signing happens inside the device via the PCZT handoff (see "Hardware Wallet (Keystone) Send Flow"), so the phone never holds spending key material for these accounts at any point.
+
+### WalletDb Initialization
+
+`WalletDb::for_path()` requires 4 params: `(path, Network, SystemClock, OsRng)`. `init_wallet_db()` must be called before `create_account()` — it runs schema migrations.
+
+Seed-relevance rule:
+- **Software bootstrap account**: `init_db_and_create_account` calls `init_wallet_db(Some(seed))` then `create_account` → `AccountSource::Derived`. This pins the seed fingerprint so future seed-requiring migrations can verify relevance.
+- **Subsequent opens**: `ensure_db_initialized` calls `init_wallet_db(None)`. Calling `init_wallet_db(Some(other_seed))` after the first account would fail the relevance check when any `Imported` account exists.
+- **Hardware-first bootstrap is allowed**: `import_hardware_account` initializes without a local seed and imports the Keystone UFVK. This can produce an `Imported`-only DB, so seed-requiring migration recovery must be handled at the product layer if such a migration appears.
+
+### Dart Sync Provider
+
+`lib/src/providers/sync_provider.dart` — Riverpod `AsyncNotifier`.
+
+**Auto-sync lifecycle:**
+- `build()` watches `accountProvider` via `ref.listen` (not `ref.watch` — avoids rebuild on switch/rename)
+- Account count increase triggers `startSync()` + `_startPolling()` (both first account and additional accounts)
+- `_checkAndSync()`: polls `getLatestBlockHeight` every 10s, re-syncs if tip > last synced height or previous sync incomplete (`percentage < 1.0`)
+- `_checkAndSync()`, `_refreshBalance()`, and `_onSyncProgress()` all bail out while
+  locked and discard late async completions via `_sensitiveStateEpoch`
+- Polling stops during `_checkAndSync` execution to prevent concurrent overlap, restarts after
+- Duplicate sync guard: `_isSyncing` (Dart-side bool) + `isSyncRunning()` (Rust AtomicBool)
+
+**startSync() is fire-and-forget:**
+- Sets up FRB stream listener and returns immediately (no Completer, no await)
+- `_syncGen` generation counter: incremented by `stopSync()`, checked in `.then()` callbacks to invalidate pending operations after user-initiated stop
+- Stream `onDone` → `_onSyncDone()` (balance refresh + start polling)
+- Stream `onError` → sets error state + starts polling for auto-retry
+
+**Sync control:**
+- `stopSync()`: increments `_syncGen` + `cancelFullSync()` + `_stopPolling()`. Polling does not restart until next `onResume`
+- `clearSensitiveStateForLock()`: increments `_syncGen`/`_sensitiveStateEpoch`,
+  clears in-memory sync state, sends `setSyncMode(0)` + `cancelFullSync()`,
+  and waits briefly for stale Rust sync / mempool work to stop
+- `startSyncAnyway()`: unlock recovery path. If Rust is still running but already
+  cancelling, waits for teardown before starting foreground sync; if teardown
+  times out, it at least restores polling so a later retry can recover
+
+**Lifecycle:**
+- `onResume`: refreshes balance → `_checkAndSync()` (which starts polling)
+- `onHide`: stops polling (no wasted network in background)
+- `SyncState.recentTransactions`: latest 10 transactions, updated on `hasNewTx`, sync completion, and app resume
+- All balance/history queries pass `activeAccountUuid` from `AccountProvider`
+
+### Desktop Window Bootstrap
+
+Desktop window appearance is managed by the external [`desktop_window_bootstrap`](https://github.com/chainapsis/desktop_window_bootstrap) package plus `window_manager`, with a strict responsibility split:
+
+- `desktop_window_bootstrap` owns window appearance and titlebar overlap handling.
+  - On macOS this means the transparent titlebar / full-size content-view shell is applied natively before the window is shown, via `macos/Runner/MainFlutterWindow.swift`.
+  - The app calls `DesktopWindowBootstrap.initialize()` in `lib/main.dart` after `initializeDesktopWindow()` has created the OS window but before `showDesktopWindow()` reveals it.
+  - `DesktopWindowTitlebarSafeArea` in `lib/app.dart` pads Flutter content below the macOS traffic-light/titlebar area. Keep it wrapped around the app root.
+- `window_manager` owns sizing/lifecycle only.
+  - `lib/src/core/layout/app_layout.dart` should remain responsible for initial size, minimum size, aspect ratio, `show()`, `focus()`, and layout-mode reconciliation from window events.
+  - Do not reintroduce `TitleBarStyle` ownership or other appearance writes through `window_manager`; that overlaps with `desktop_window_bootstrap`.
+
+Current startup order for desktop platforms:
+
+```text
+WidgetsFlutterBinding.ensureInitialized()
+→ RustLib.init()
+→ initializeDesktopWindow()      // window_manager creates the OS window
+→ DesktopWindowBootstrap.initialize()
+→ showDesktopWindow()
+→ runApp()
+```
+
+### Figma comparison tooling
+
+For deterministic code-to-Figma screenshots, use the widget-test capture as
+the normal iteration path. It renders the same `FigmaCompareApp` and registered
+scenario without building Rust, CocoaPods, Xcode, or a macOS app:
+
+```bash
+scripts/figma-compare.sh widget --scenario pay-recipient --theme dark
+```
+
+Use the native entry point only for final macOS window-shell and restoration
+verification:
+
+```bash
+scripts/figma-compare.sh native --scenario pay-recipient --theme dark
+```
+
+Registered states live in
+`lib/figma_compare/figma_compare_scenarios.dart` and must use deterministic
+dev-only mocks. Outputs go below the app sandbox's `vizor-figma-compare`
+temporary directory: `content.widget.png` is the fast app-content reference;
+`content.png` and `content.window.png` are the real-engine and native-window
+final evidence. The native entry point reuses production macOS window
+initialization without starting Rust, storage, sync, wallet, or network state,
+automatically restores a minimized window before capture, and returns it and
+the previously foreground app to their original states afterward. Full
+workflow, mobile capture, and cleanup rules are in `FIGMA-AI-FIX.md`.
+
+Important desktop design rule:
+
+- `Scaffold.backgroundColor: Colors.transparent` is required anywhere the native acrylic/translucent shell should remain visible.
+- Any opaque `Container`, `ColoredBox`, decoration color, or other filled background will cover the native effect in that region.
+- Treat transparency as opt-in per region: only paint solid backgrounds where the UI should actually be solid.
+
+### Mobile Bottom Safe Area (iOS proportional padding)
+
+Mobile bottom-sheet bodies and the floating tab bar wrap their bottom
+edge in `MobileBottomSafeArea`
+(`lib/src/core/layout/mobile/mobile_bottom_safe_area.dart`), not raw
+`SafeArea(top: false)`.
+
+- The rule: on iOS, when the wrapped content's own bottom padding is
+  `kIosHomeIndicatorClearance` (16) or more, the bottom safe-area inset
+  is skipped so the bottom gap equals the side padding. Android always
+  honors the inset — navigation-bar modes vary per device.
+- Why: the iOS home indicator is an overlay occupying only the bottom
+  ~13pt of the screen (8pt offset + 5pt bar), so it floats inside 16px
+  of empty padding; stacking the 34pt inset on top of that padding
+  makes the bottom gap visually heavier than the sides.
+- `bottomPadding` must equal the bottom padding the wrapped content
+  actually provides below its last control — when changing a sheet's
+  padding token, update the argument with it.
+- Tab bar (`AppMobileShell`): the gap below the bar is 16 on iOS
+  (matching its 16px side margins) and the Figma 12 + inset on Android.
+- Keyboard avoidance is unaffected — `viewInsets` is a separate channel
+  from the `viewPadding` this consumes.
+- Platform branching uses `defaultTargetPlatform` (overridable in
+  widget tests), not `dart:io` `Platform` checks.
+- New sheets follow `MobileBottomSafeArea(bottomPadding: token)` >
+  `Padding(...)`; both platform geometries are pinned in
+  `test/core/layout/mobile/mobile_bottom_safe_area_test.dart`.
+
+Key files:
+- `rust/src/migration_preparation.rs` — shared mobile preparation core
+- `rust/src/android_jni.rs` — Android preparation execution adapter
+- `rust/src/ffi.rs` — iOS C adapter: read-only inspection and queries, plus
+  the route declaration the queries run under
 - `ios/Runner/zcash_sync.h` — matching C header
 - `ios/Runner/BackgroundMigrationPreparationManager.swift` — continued-task
   confirmation tracker and foreground-handoff owner

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:allowBackup="false">
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Arti's directory records which guards this wallet chose. Carrying it to a
+  second device would carry that choice with it, so a transferred install picks
+  fresh guards at the cost of one bootstrap.
+
+  `allowBackup="false"` already covers cloud backup, but from target SDK 31
+  device-to-device transfer is governed here instead and defaults to including
+  app data. `domain="file"` is getFilesDir(), which is what
+  getApplicationSupportDirectory() resolves to on Android.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" path="tor" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="file" path="tor" />
+    </device-transfer>
+</data-extraction-rules>

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -8,3 +8,9 @@ tags:
   # See "Design Token Form Factor" in AGENTS.md.
   mobile:
     skip: "mobile token lane only: fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile"
+  # Probes that talk to the live Tor network from a booted device. They cost
+  # minutes, depend on a network nobody controls, and leave the process
+  # Tor-enabled and fail-closed for anything sharing the binary, so they stay
+  # out of `flutter test integration_test/` and are run by hand.
+  live-tor:
+    skip: "live Tor probe only: fvm flutter test --tags live-tor --run-skipped <path> -d <device>"

--- a/integration_test/mobile_tor_bootstrap_probe_test.dart
+++ b/integration_test/mobile_tor_bootstrap_probe_test.dart
@@ -1,0 +1,59 @@
+@Tags(['live-tor'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/rust/api/network_privacy.dart'
+    as rust_network_privacy;
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
+import 'package:zcash_wallet/src/rust/network_privacy.dart' as rust_types;
+
+/// Bootstraps Tor from the app's own support directory on a mobile OS.
+///
+/// A bootstrap failure surfaces from inside fail-closed mode — every request
+/// blocked while Tor never becomes ready — so no host test can catch it.
+///
+/// This talks to the live Tor network and is not part of any automated lane.
+/// The `live-tor` tag is what keeps it out of one: `dart_test.yaml` skips that
+/// tag, so `fvm flutter test integration_test/` — which would otherwise pick
+/// this file up, spend five minutes on a network nobody controls, and leave the
+/// process Tor-enabled and fail-closed for whatever shares the binary — reports
+/// it as skipped instead. Run it by hand against a booted simulator or device:
+///
+/// ```sh
+/// fvm flutter test --tags live-tor --run-skipped \
+///   integration_test/mobile_tor_bootstrap_probe_test.dart \
+///   -d <device> --dart-define=VIZOR_FORM_FACTOR=mobile
+/// ```
+///
+/// The define is what this probe is run with, and every mobile-targeted
+/// invocation carries it — the test binary is compiled per lane like any other
+/// build. Omitting it here compiles the probe against desktop tokens on a
+/// phone, which is the mismatch `lib/main.dart` asserts against.
+///
+/// What it does not settle: whether arti's filesystem permission checks need
+/// the mobile exemption. The iOS simulator passes this with the exemption
+/// compiled out, because a simulator container is an ordinary directory in the
+/// host filesystem. Only a real device answers that.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Tor bootstraps from the mobile app sandbox', (tester) async {
+    await RustLib.init();
+    final torDirectory = await getTorDataDirectoryPath();
+
+    rust_network_privacy.beginNetworkPrivacyEnable();
+    final status = await rust_network_privacy.configureNetworkPrivacy(
+      enabled: true,
+      torDirectory: torDirectory,
+    );
+
+    expect(
+      status,
+      rust_types.NetworkPrivacyStatus.ready,
+      reason: 'bootstrap from $torDirectory did not reach ready',
+    );
+    expect(rust_network_privacy.isTorEnabled(), isTrue);
+  }, timeout: const Timeout(Duration(minutes: 5)));
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -350,6 +350,59 @@ import UIKit
       }
     }
 
+    let networkPrivacyChannel = FlutterMethodChannel(
+      name: "com.zcash.wallet/network_privacy",
+      binaryMessenger: messenger
+    )
+    networkPrivacyChannel.setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "excludeFromBackup":
+        // Arti's directory records this wallet's guard choice. Restoring it
+        // onto another device would carry that choice across, so it is kept
+        // out of iCloud and finder backups; a restored install picks fresh
+        // guards at the cost of one bootstrap.
+        guard
+          let arguments = call.arguments as? [String: Any],
+          let path = arguments["path"] as? String,
+          !path.isEmpty
+        else {
+          result(
+            FlutterError(
+              code: "invalid_arguments",
+              message: "excludeFromBackup requires a path.",
+              details: nil
+            )
+          )
+          return
+        }
+        var url = URL(fileURLWithPath: path)
+        do {
+          // Created here when it does not exist yet, so the mark can be set
+          // before the bootstrap rather than only after it: from the directory's
+          // first moment it holds guard state, and the process can be killed
+          // while that is being written.
+          try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true
+          )
+          var values = URLResourceValues()
+          values.isExcludedFromBackup = true
+          try url.setResourceValues(values)
+          result(true)
+        } catch {
+          result(
+            FlutterError(
+              code: "exclude_failed",
+              message: error.localizedDescription,
+              details: nil
+            )
+          )
+        }
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     let hapticsChannel = FlutterMethodChannel(
       name: "com.zcash.wallet/haptics",
       binaryMessenger: messenger

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -700,6 +700,18 @@ final class BackgroundMigrationManager {
       task.setTaskCompleted(success: true)
       return
     }
+    // This wake queries the chain tip and broadcasts signed transactions, and
+    // it can be a cold launch where Dart never applied the saved route.
+    // Declare that route before any other native call, so a path that still
+    // reaches lightwalletd fails closed rather than putting a transaction on
+    // clearnet — and on a Tor route do no background network work at all.
+    // This process never brings Tor up; the foreground owns the client, and
+    // the outbox holds already-signed items for it. Declining is the policy
+    // working, so the task reports success, exactly like the declines above.
+    guard !BackgroundNetworkRoute.declareBackgroundNetworkRoute() else {
+      task.setTaskCompleted(success: true)
+      return
+    }
     startAuthorizationMonitoring()
     task.expirationHandler = { [weak self] in
       self?.expire()

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -1246,6 +1246,10 @@ final class BackgroundMigrationPreparationManager {
     authorizationEpoch: UInt64,
     completion: @escaping (Bool) -> Void
   ) {
+    // Submission does no network work itself, but this process can be a cold
+    // launch: declare the saved route first, so anything that does reach
+    // lightwalletd fails closed rather than defaulting to direct.
+    let routeIsTor = BackgroundNetworkRoute.declareBackgroundNetworkRoute()
     pruneForegroundContinuationScopes()
     switch migrationPreparationContinuedTaskDisposition(
       preparationResumeTarget()
@@ -1282,6 +1286,12 @@ final class BackgroundMigrationPreparationManager {
       if mutationQuiesced { return "blocked_mutation_quiesced" }
       if submissionInFlight { return "blocked_submission_in_flight" }
       if taskRunning { return "blocked_task_running" }
+      // A tracking task on a Tor route could only decline every query: this
+      // process never brings Tor up in the background, so submitting would
+      // start a user-visible activity that claims to be checking
+      // confirmations and cannot. The wave waits for the foreground, which
+      // owns the Tor client.
+      if routeIsTor { return "blocked_tor_route" }
       if pendingScopes.isEmpty {
         // Not "blocked": nothing is waiting for denomination confirmations
         // that has not already been handed to the foreground.
@@ -1297,6 +1307,7 @@ final class BackgroundMigrationPreparationManager {
       recordSchedulingState(submissionBlockedReason)
       let canContinue = stateLock.withPreparationLock {
         !mutationQuiesced
+          && !routeIsTor
           && !notificationAuthorization.isDisabled
           && (submissionInFlight || taskRunning
             || !foregroundContinuationScopes.isEmpty)
@@ -1530,6 +1541,16 @@ final class BackgroundMigrationPreparationManager {
   }
 
   private func handleAuthorized(_ task: BGContinuedProcessingTask) {
+    // A task submitted before Tor was enabled can launch after it. Declare
+    // the saved route before any native call; on a Tor route this task can
+    // only decline every query, so it stands down at once and leaves the wave
+    // to the foreground. Completing successfully is deliberate — declining
+    // for policy is not a failed execution opportunity.
+    if BackgroundNetworkRoute.declareBackgroundNetworkRoute() {
+      recordSchedulingState("tor_route_stand_down")
+      task.setTaskCompleted(success: true)
+      return
+    }
     stateLock.withPreparationLock {
       submissionInFlight = false
     }

--- a/ios/Runner/NativeLightwalletdClient.swift
+++ b/ios/Runner/NativeLightwalletdClient.swift
@@ -1,5 +1,68 @@
 import Foundation
 
+/// The network route a background pass runs under.
+///
+/// The desired route lives in Rust process memory and a background wake can be
+/// a cold launch where Dart never applied the saved preference, so every entry
+/// point that may reach lightwalletd declares the saved route before its first
+/// native call. Rust refuses a route nothing has declared rather than treating
+/// it as direct, so a lane that forgets fails closed on its first connection
+/// instead of putting wallet queries — or signed transactions — on clearnet
+/// for a user who chose Tor.
+///
+/// On a Tor route, background passes do no network work at all. This process
+/// never brings Tor up; the foreground owns the client, and every background
+/// lane that finds the saved route at Tor stands down and leaves its work to
+/// the next foreground entry. Declining is the policy working, not a failure.
+enum BackgroundNetworkRoute {
+  /// `shared_preferences` stores Dart values in `UserDefaults.standard` behind
+  /// a `flutter.` prefix; the suffix is `kTorEnabledPreferenceKey` in
+  /// `lib/src/providers/network_privacy_provider.dart`.
+  ///
+  /// Hand-assembled, so the two ends are one rename apart from disagreeing —
+  /// and the divergence fails OPEN: `persistedRouteIsTor` reads false for
+  /// every user and background work runs direct for someone who chose Tor.
+  /// `testTorPreferenceKeyMatchesDart` reads the Dart declaration and pins
+  /// both halves so a rename breaks a test instead.
+  static let torEnabledPreferenceSuffix = "zcash_tor_enabled"
+  static let torEnabledKey = "flutter.\(torEnabledPreferenceSuffix)"
+
+  /// Whether the saved route is Tor. A missing value — never chosen, or
+  /// cleared by a wallet reset — reads as direct, matching the Dart default.
+  ///
+  /// Takes its store as a parameter only so a test can supply one; every
+  /// caller reads the same `UserDefaults.standard` `shared_preferences`
+  /// writes to.
+  static func persistedRouteIsTor(
+    in defaults: UserDefaults = .standard
+  ) -> Bool {
+    defaults.bool(forKey: torEnabledKey)
+  }
+
+  static var persistedRouteIsTor: Bool {
+    persistedRouteIsTor(in: .standard)
+  }
+
+  /// Declares the saved route to Rust and reports whether it is Tor.
+  ///
+  /// Call it before the first native call of a background pass. It samples
+  /// nothing and never bootstraps; a persisted read can be stale, so Rust
+  /// ignores a declaration once this process has decided its own route — it
+  /// can never turn a live Tor route direct.
+  @discardableResult
+  static func declareBackgroundNetworkRoute() -> Bool {
+    guard persistedRouteIsTor else {
+      // Declared too. Rust refuses a route nothing has declared rather than
+      // treating it as direct, so saying "direct" is the direct pass's job
+      // rather than something it gets by staying quiet.
+      _ = zcash_network_privacy_mark_direct_route()
+      return false
+    }
+    _ = zcash_network_privacy_mark_tor_desired()
+    return true
+  }
+}
+
 final class BackgroundMigrationCancellation: @unchecked Sendable {
   private let condition = NSCondition()
   private var cancelled = false

--- a/ios/Runner/zcash_sync.h
+++ b/ios/Runner/zcash_sync.h
@@ -76,4 +76,32 @@ int32_t zcash_inspect_migration_proof_readiness(
     bool* output
 );
 
+/// Declares that the user's persisted network route is Tor, so this process
+/// refuses to reach the network directly.
+///
+/// The desired route lives in process memory and defaults to direct, so a
+/// background launch in which Dart never ran would otherwise send lightwalletd
+/// traffic over clearnet. The caller must have read the persisted preference
+/// itself and must call this before the first network call of the pass. It
+/// never bootstraps Tor, so a pass that only calls this can do no network work
+/// and defers to the foreground. The process then stays fail-closed for the
+/// rest of its lifetime; only the foreground route toggle returns it to direct.
+/// Returns 0 on success.
+int32_t zcash_network_privacy_mark_tor_desired(void);
+
+/// Declares that the user's persisted network route is direct — the mirror of
+/// zcash_network_privacy_mark_tor_desired, and just as mandatory.
+///
+/// "Nobody has declared yet" and "the user chose direct" are deliberately
+/// different states in Rust. The first is refused wherever a route is resolved,
+/// so a background entry point that never read the preference cannot reach
+/// lightwalletd at all instead of quietly reaching it over clearnet on a
+/// Tor-configured wallet. A pass whose saved route is direct therefore declares
+/// it, exactly as a Tor pass does, or its own network calls fail closed.
+///
+/// Writes nothing but the decision, touches no filesystem, never bootstraps,
+/// and is ignored once this process has decided its own route, so it can never
+/// turn a live Tor route direct. Returns 0 on success.
+int32_t zcash_network_privacy_mark_direct_route(void);
+
 #endif // ZCASH_SYNC_H

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -3050,4 +3050,117 @@ private final class KeychainAccessibilityMigrationCompletionStoreHarness:
   private func key(service: String, version: Int) -> String {
     "\(version):\(service)"
   }
+  // MARK: - The saved route is a contract between Dart and every native gate
+
+  /// `persistedRouteIsTor` is the only thing standing between a user who chose
+  /// Tor and a background wake that broadcasts their already-signed migration
+  /// transactions over clearnet, and it had no coverage at all.
+  ///
+  /// Note which way it fails: a key that does not match reads `false`, so
+  /// `declareBackgroundNetworkRoute` marks nothing and the process stays
+  /// direct. There is no error, no deferral, and nothing the user can see —
+  /// the traffic just goes out unwrapped.
+  func testPersistedRouteIsTorReadsTheKeySharedPreferencesWrites() throws {
+    let suite = "com.keplr.vizor.tests.tor-route"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+    defer { defaults.removePersistentDomain(forName: suite) }
+
+    defaults.removePersistentDomain(forName: suite)
+    XCTAssertFalse(
+      BackgroundNetworkRoute.persistedRouteIsTor(in: defaults),
+      "never chosen, or cleared by a wallet reset, reads as direct"
+    )
+
+    defaults.set(true, forKey: "flutter.zcash_tor_enabled")
+    XCTAssertTrue(BackgroundNetworkRoute.persistedRouteIsTor(in: defaults))
+
+    defaults.set(false, forKey: "flutter.zcash_tor_enabled")
+    XCTAssertFalse(BackgroundNetworkRoute.persistedRouteIsTor(in: defaults))
+
+    // The `flutter.` prefix is part of the contract, not decoration. A
+    // migration to an unprefixed store — `SharedPreferencesAsync`, or a
+    // `SharedPreferences.setPrefix` call — leaves the value here and this
+    // reader finding nothing.
+    defaults.removePersistentDomain(forName: suite)
+    defaults.set(true, forKey: "zcash_tor_enabled")
+    XCTAssertFalse(BackgroundNetworkRoute.persistedRouteIsTor(in: defaults))
+  }
+
+  /// Pins the key from both ends. The Swift side hand-assembles a string that
+  /// only Dart's constant and `shared_preferences`' prefix make correct, so a
+  /// rename on either side is invisible until a user's traffic leaks. Reading
+  /// the Dart declaration is what turns that into a red test.
+  func testTorPreferenceKeyMatchesDart() throws {
+    XCTAssertEqual(
+      BackgroundNetworkRoute.torEnabledKey,
+      "flutter.\(BackgroundNetworkRoute.torEnabledPreferenceSuffix)"
+    )
+
+    let provider = try repositoryFileContents(
+      "lib/src/providers/network_privacy_provider.dart"
+    )
+    XCTAssertTrue(
+      provider.contains(
+        "const kTorEnabledPreferenceKey = "
+          + "'\(BackgroundNetworkRoute.torEnabledPreferenceSuffix)';"
+      ),
+      "kTorEnabledPreferenceKey no longer declares "
+        + "'\(BackgroundNetworkRoute.torEnabledPreferenceSuffix)'; "
+        + "BackgroundNetworkRoute.torEnabledKey must be renamed with it"
+    )
+    // The prefix half of the contract. `SharedPreferences.getInstance` is what
+    // writes under `flutter.`; the async store and `setPrefix` do not.
+    XCTAssertTrue(
+      provider.contains("SharedPreferences.getInstance()"),
+      "the Tor preference must keep using the prefixed shared_preferences API"
+    )
+    XCTAssertFalse(
+      provider.contains("SharedPreferencesAsync"),
+      "an unprefixed store would leave the background reader finding nothing"
+    )
+    XCTAssertFalse(
+      provider.contains("setPrefix"),
+      "changing the prefix would leave the background reader finding nothing"
+    )
+  }
+
+  /// Tor-route background passes decline before any native call, and the
+  /// decline is deliberate: this process never brings Tor up, so proceeding
+  /// could only fail every query, and falling back to a direct connection is
+  /// the leak the declaration exists to prevent.
+  func testDeclareReportsTheSavedRoute() throws {
+    let suite = "com.keplr.vizor.tests.tor-route-declare"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+    defer { defaults.removePersistentDomain(forName: suite) }
+    defaults.set(true, forKey: BackgroundNetworkRoute.torEnabledKey)
+    XCTAssertTrue(BackgroundNetworkRoute.persistedRouteIsTor(in: defaults))
+    defaults.set(false, forKey: BackgroundNetworkRoute.torEnabledKey)
+    XCTAssertFalse(BackgroundNetworkRoute.persistedRouteIsTor(in: defaults))
+  }
+
+  /// `#filePath` is baked in at compile time and points at
+  /// `<repo>/ios/RunnerTests/RunnerTests.swift`, which is how a test running
+  /// in a simulator reaches the Dart and Android sources it has to pin.
+  private func repositoryFileContents(
+    _ relativePath: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) throws -> String {
+    let root = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // RunnerTests
+      .deletingLastPathComponent()  // ios
+      .deletingLastPathComponent()  // repository root
+    let url = root.appendingPathComponent(relativePath)
+    guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+      XCTFail(
+        "Could not read \(relativePath) at \(url.path)",
+        file: file,
+        line: line
+      )
+      throw CocoaError(.fileNoSuchFile)
+    }
+    return contents
+  }
+
+
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -107,10 +107,8 @@ Future<void> initializeZcashWalletRuntime() async {
   WidgetsFlutterBinding.ensureInitialized();
   log('runtime: initializing RustLib');
   await RustLib.init();
-  if (kAppFormFactor == AppFormFactor.desktop) {
-    log('runtime: applying desktop network privacy policy');
-    await initializeNetworkPrivacyRuntime();
-  }
+  log('runtime: applying network privacy policy');
+  await initializeNetworkPrivacyRuntime();
   await rust_simple.configureFastTestnetMigration(
     enabled: kZcashFastTestnetMigration,
   );
@@ -576,10 +574,7 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
       ),
       GoRoute(
         path: '/onboarding/customise-account',
-        redirect: (_, state) =>
-            state.extra is CustomiseAccountArgs &&
-                (state.extra as CustomiseAccountArgs).flow ==
-                    SetPasswordFlow.create
+        redirect: (_, state) => state.extra is CustomiseAccountArgs
             ? null
             : OnboardingStep.secretPassphrase.routePath,
         pageBuilder: (context, state) => CustomTransitionPage<void>(
@@ -680,25 +675,6 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
           transitionsBuilder: _onboardingFadeTransition,
         ),
       ),
-      GoRoute(
-        path: KeystoneOnboardingStep.customiseAccount.routePath,
-        redirect: (_, state) {
-          final args = state.extra;
-          return args is CustomiseAccountArgs &&
-                  args.flow == SetPasswordFlow.importKeystone
-              ? null
-              : KeystoneOnboardingStep.walletBirthdayHeight.routePath;
-        },
-        pageBuilder: (context, state) => CustomTransitionPage<void>(
-          key: state.pageKey,
-          transitionDuration: kOnboardingForwardDuration,
-          reverseTransitionDuration: kOnboardingReverseDuration,
-          child: CustomiseAccountScreen(
-            args: state.extra as CustomiseAccountArgs,
-          ),
-          transitionsBuilder: _onboardingFadeTransition,
-        ),
-      ),
     ],
   ),
   ShellRoute(
@@ -765,25 +741,6 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
             transitionsBuilder: _onboardingFadeTransition,
           );
         },
-      ),
-      GoRoute(
-        path: '/import/customise-account',
-        redirect: (_, state) {
-          final args = state.extra;
-          return args is CustomiseAccountArgs &&
-                  args.flow == SetPasswordFlow.importWallet
-              ? null
-              : '/import/birthday';
-        },
-        pageBuilder: (context, state) => CustomTransitionPage<void>(
-          key: state.pageKey,
-          transitionDuration: kOnboardingForwardDuration,
-          reverseTransitionDuration: kOnboardingReverseDuration,
-          child: CustomiseAccountScreen(
-            args: state.extra as CustomiseAccountArgs,
-          ),
-          transitionsBuilder: _onboardingFadeTransition,
-        ),
       ),
     ],
   ),

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
@@ -24,6 +24,7 @@ import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/app_profile_picture.dart';
 import '../../../../providers/account_provider.dart';
+import '../../../../providers/network_privacy_provider.dart';
 import '../../../../providers/sync_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../models/ironwood_migration_presentation.dart';

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -630,13 +630,37 @@ const _migrationPreparationNotificationsDisabledMessage =
 // promise something granting them cannot deliver.
 const _migrationPreparationBackgroundUnsupportedMessage =
     'This device can\u2019t confirm in the background. Keep Vizor open.';
+// A Tor route constrains the background pass instead of removing it: bringing
+// up a cold Tor client costs 8.45 MB and 23.7 s, and an idle one keeps padding
+// its guard connection, so the pass only runs on external power over an
+// unmetered link. Unlike the device limit above this one is conditional, and
+// the user cannot see the gate from this screen \u2014 so state the condition
+// rather than the current verdict, and never promise more than it delivers.
+const _migrationPreparationTorRouteMessage =
+    'While Tor is on, migration continues only while Vizor is open.';
+// Both blockers at once, and both absolute: on a Tor route no background lane
+// runs at all, and a denied notification blocks the lane even off Tor. The
+// route consequence leads because it holds regardless of what the user grants;
+// the notification remedy follows so that turning Tor off later does not land
+// in a second surprise.
+const _migrationPreparationNotificationsDisabledTorRouteMessage =
+    'Allow notifications. With Tor on, migration continues only in the app.';
+// The same condition stated where the progress surface would otherwise promise
+// that the next step arrives while Vizor is closed.
+const _migrationTorRouteExpectation =
+    'While Tor is on, this continues only while Vizor is open.';
+// The route condition stated after a notification block rather than instead of
+// it, so it reads as the next thing to meet and not as the reason the step is
+// stalled.
+const _migrationTorRouteAdditionalExpectation =
+    'While Tor is on, this continues only while Vizor is open.';
 
 class _MigrationPreparationPreview extends StatelessWidget {
   const _MigrationPreparationPreview({
     required this.state,
     this.isKeystone = false,
     this.pausedMessage,
-    this.deviceLimitMessage,
+    this.backgroundLaneLimitMessage,
     this.onBack,
     this.onContinue,
     this.onViewSchedule,
@@ -646,11 +670,13 @@ class _MigrationPreparationPreview extends StatelessWidget {
   final bool isKeystone;
   final String? pausedMessage;
 
-  /// Set when this device cannot track preparation while Vizor is closed.
+  /// Set when background preparation tracking is limited, naming the cause —
+  /// this device, which can never do it, or a Tor route, which only does it on
+  /// external power over an unmetered link.
   ///
   /// Outranks [pausedMessage] and the waiting default because it is the only
-  /// message naming a limit the user cannot resolve from settings.
-  final String? deviceLimitMessage;
+  /// message naming a limit that granting notifications cannot lift.
+  final String? backgroundLaneLimitMessage;
   final VoidCallback? onBack;
   final VoidCallback? onContinue;
   final VoidCallback? onViewSchedule;
@@ -690,7 +716,7 @@ class _MigrationPreparationPreview extends StatelessWidget {
           _MigrationPreparationDial(
             state: state,
             pausedMessage: pausedMessage,
-            deviceLimitMessage: deviceLimitMessage,
+            backgroundLaneLimitMessage: backgroundLaneLimitMessage,
             onViewSchedule: onViewSchedule,
           ),
           const SizedBox(height: AppSpacing.base),
@@ -708,13 +734,13 @@ class _MigrationPreparationDial extends StatelessWidget {
   const _MigrationPreparationDial({
     required this.state,
     this.pausedMessage,
-    this.deviceLimitMessage,
+    this.backgroundLaneLimitMessage,
     this.onViewSchedule,
   });
 
   final _MigrationPreparationState state;
   final String? pausedMessage;
-  final String? deviceLimitMessage;
+  final String? backgroundLaneLimitMessage;
   final VoidCallback? onViewSchedule;
 
   @override
@@ -753,7 +779,7 @@ class _MigrationPreparationDial extends StatelessWidget {
                 const SizedBox(height: AppSpacing.xs),
                 Text(
                   paused
-                      ? deviceLimitMessage ??
+                      ? backgroundLaneLimitMessage ??
                             pausedMessage ??
                             'Preparation was paused because you left.'
                       : syncing
@@ -763,12 +789,12 @@ class _MigrationPreparationDial extends StatelessWidget {
                             _migrationPreparationAdvancingMessage,
                           _MigrationPreparationState.backgroundTracking =>
                             _migrationPreparationBackgroundTrackingMessage,
-                          // A waiting device that cannot track in the
-                          // background must say so here too: the neutral
-                          // duration copy would let the user close Vizor and
-                          // silently stall the run.
+                          // A wallet whose background tracking is limited must
+                          // say so here too: the neutral duration copy would
+                          // let the user close Vizor and silently stall the
+                          // run.
                           _ =>
-                            deviceLimitMessage ??
+                            backgroundLaneLimitMessage ??
                                 'Preparation will\ntake 10–20 min',
                         },
                   textAlign: TextAlign.center,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -610,6 +610,21 @@ class _MobileMigrationRedesignedStatusState
       );
     });
     final accountUuid = ref.watch(accountProvider).value?.activeAccountUuid;
+    // A Tor route constrains both native background lanes — the preparation
+    // tracking task and the outbox wake: they run only on external power over
+    // an unmetered link, because a cold bootstrap costs 8.45 MB and 23.7 s and
+    // an idle client keeps padding its guard connection. Nothing here can read
+    // power or metering, so every promise of progress without the app has to
+    // state the condition rather than a verdict. The published route tracks the
+    // same preference the native gates read.
+    // The saved route, not this process's: the native lanes that run the
+    // background work read the saved preference from a process where Dart may
+    // never have run, and the two can diverge — a disable whose save failed
+    // leaves requests direct here while every background wake still declares
+    // Tor and defers off the charger.
+    final routeConstrainsBackgroundWork = ref
+        .watch(networkPrivacyProvider)
+        .savedRouteTorEnabled;
     final coordinator = ref.watch(ironwoodMigrationCoordinatorProvider);
     final coordinatorError = accountUuid == null
         ? null
@@ -847,30 +862,54 @@ class _MobileMigrationRedesignedStatusState
           _preparationRuntimeState !=
               IronwoodMigrationPreparationRuntimeState
                   .foregroundContinuationPending;
-      // This device has no background preparation lane at all, so neither the
-      // notification prompt nor the "you left" copy names the real cause.
+      // A device with no continued-processing task can never track preparation
+      // while Vizor is closed. This stays separate from the route constraint
+      // below: turning Tor off cannot give this device a capability it never
+      // had, and the two need different copy and different fixes.
       final backgroundTrackingUnsupported =
           _supportsBackgroundPreparationTracking == false;
+      // The route limits a lane that does exist, and only conditionally.
+      final backgroundTrackingConstrained =
+          !backgroundTrackingUnsupported && routeConstrainsBackgroundWork;
+      // Notifications block the lane wherever the lane exists: the rearm gate
+      // refuses on a denied notification whatever the route is, and submission
+      // is blocked outright. The device with no lane at all stays excluded —
+      // there, asking the user to allow notifications promises something
+      // granting them cannot deliver. A constrained route is not that case: it
+      // delays a lane that does run, so the notification block outlives it.
+      final notificationsDisabled =
+          !backgroundTrackingUnsupported &&
+          _preparationRuntimeState ==
+              IronwoodMigrationPreparationRuntimeState.disabled;
+      // The device limit outranks the route: naming a condition the user could
+      // meet would promise a lane this OS build does not have. The route and
+      // the notification block are both meetable and both real, so when they
+      // coincide the message names both — meeting only the one it stated would
+      // leave the user waiting on a pass that still cannot run.
+      final backgroundLaneLimitMessage = backgroundTrackingUnsupported
+          ? _migrationPreparationBackgroundUnsupportedMessage
+          : backgroundTrackingConstrained
+          ? (notificationsDisabled
+                ? _migrationPreparationNotificationsDisabledTorRouteMessage
+                : _migrationPreparationTorRouteMessage)
+          : null;
       // Whether leaving now stalls the run. An advance holds the foreground
       // permit, so backgrounding drops it and nothing moves until the next
       // reentry. An armed background task keeps observing without the app.
       // Requiring the capability here is a structural guard, not the live
       // signal: iOS before 26 can never report scheduled/running because it has
       // no continued-processing task, so the "you can close Vizor" promise
-      // becomes unreachable on a device that cannot keep it.
+      // becomes unreachable on a device that cannot keep it. A constrained
+      // route is excluded for a different reason: an armed task proves only
+      // that the gate passed for this pass, and "you can close Vizor" would
+      // outlive unplugging the charger or moving onto a metered link.
       final backgroundTrackingArmed =
           !backgroundTrackingUnsupported &&
+          !backgroundTrackingConstrained &&
           (_preparationRuntimeState ==
                   IronwoodMigrationPreparationRuntimeState.scheduled ||
               _preparationRuntimeState ==
                   IronwoodMigrationPreparationRuntimeState.running);
-      // Notifications are only the blocker where the lane exists. Without one,
-      // asking the user to allow notifications promises something granting them
-      // cannot deliver.
-      final notificationsDisabled =
-          !backgroundTrackingUnsupported &&
-          _preparationRuntimeState ==
-              IronwoodMigrationPreparationRuntimeState.disabled;
       // Display-only debounce: a user-triggered action shows its progress at
       // once, while the coordinator's own advance probes have to persist before
       // they may relabel the dial. Reading `actionInProgress` here instead would
@@ -892,9 +931,7 @@ class _MobileMigrationRedesignedStatusState
                 preparationState == _MigrationPreparationState.paused
             ? _migrationPreparationNotificationsDisabledMessage
             : null,
-        deviceLimitMessage: backgroundTrackingUnsupported
-            ? _migrationPreparationBackgroundUnsupportedMessage
-            : null,
+        backgroundLaneLimitMessage: backgroundLaneLimitMessage,
         onBack: () => context.go('/home'),
         onViewSchedule: viewPreparationSchedule,
         onContinue: !needsManualResume || accountUuid == null
@@ -915,7 +952,11 @@ class _MobileMigrationRedesignedStatusState
       widget.status,
       hasChildProofBatchPermit: hasChildProofBatchPermit,
     );
-    final nextActionText = _nextActionText(widget.status, state: state);
+    final nextActionText = _nextActionText(
+      widget.status,
+      state: state,
+      routeConstrainsBackgroundWork: routeConstrainsBackgroundWork,
+    );
     final actionPart = _actionPart(widget.status);
     final batchProgress = _batchProgress(widget.status, actionPart: actionPart);
     final hasDueProofBatch = _hasDueProofBatch(widget.status);
@@ -1073,6 +1114,7 @@ class _MobileMigrationRedesignedStatusState
   String _nextActionText(
     rust_sync.MigrationStatus status, {
     required _MigrationProgressState state,
+    required bool routeConstrainsBackgroundWork,
   }) {
     final currentHeight = _currentHeight();
     final nextHeight = status.nextActionHeight;
@@ -1097,26 +1139,49 @@ class _MobileMigrationRedesignedStatusState
           timing == 'Timing is updating' || timing == 'ready now'
           ? 'Next migration step is on the way.'
           : 'Next migration step expected in\n$timing.';
-      return switch (_notificationsAuthorized) {
-        true =>
-          '$expectation\nNotifications are on. You can leave Vizor and check '
-              'back later.',
-        false =>
-          '$expectation\nNotifications are disabled. Open Vizor again to '
-              'continue.',
-        null => expectation,
-      };
+      if (_notificationsAuthorized == false) {
+        // Notifications outrank the route. Both native lanes refuse on a
+        // denied one — the wake finishes foreground-only, the tracking task
+        // never rearms, and submission is blocked — so this is the blocker
+        // that has to be named. The route condition follows as the one the
+        // user meets next, never in place of it: stating Tor alone hands the
+        // user a condition they can satisfy while nothing moves afterwards.
+        const notificationsLine =
+            'Notifications are disabled. Open Vizor again to continue.';
+        return routeConstrainsBackgroundWork
+            ? '$expectation\n$notificationsLine\n'
+                  '$_migrationTorRouteAdditionalExpectation'
+            : '$expectation\n$notificationsLine';
+      }
+      // The background wake that would deliver this step runs on a Tor route
+      // only on external power over an unmetered link, so an authorized
+      // notification is not on its own enough to carry it.
+      if (routeConstrainsBackgroundWork) {
+        return '$expectation\n$_migrationTorRouteExpectation';
+      }
+      return _notificationsAuthorized == true
+          ? '$expectation\nNotifications are on. You can leave Vizor and check '
+                'back later.'
+          : expectation;
     }
     if (state == _MigrationProgressState.readyToSubmit) {
       return 'The scheduled transaction is ready for automatic submission. '
           'Keep Vizor open.';
     }
     if (state == _MigrationProgressState.confirming) {
+      if (routeConstrainsBackgroundWork) {
+        return 'Confirmations are still arriving. '
+            '$_migrationTorRouteExpectation';
+      }
       return 'Confirmations are still arriving.\nYou can leave Vizor and '
           'check again later.';
     }
     if (timing == 'ready now') {
       return 'The next migration step is ready. Keep Vizor open to continue.';
+    }
+    if (routeConstrainsBackgroundWork) {
+      return '$timing until the next migration step.\n'
+          '$_migrationTorRouteExpectation';
     }
     return '$timing until the next migration step.\n'
         'Notifications are on; you can leave Vizor and check back later.';

--- a/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
@@ -25,6 +25,7 @@ import '../../../../providers/sync_keep_awake_provider.dart';
 import '../../../../providers/theme_mode_provider.dart';
 import '../../../../services/biometric_unlock.dart';
 import '../../../accounts/widgets/mobile/account_edit_sheets.dart';
+import '../../widgets/mobile/mobile_network_privacy_card.dart';
 
 /// Mobile settings tab — Figma `SETTINGS` root frame (4494:65997).
 ///
@@ -177,6 +178,8 @@ class MobileSettingsScreen extends ConsumerWidget {
                     ),
                   ),
                 ),
+                const SizedBox(height: AppSpacing.md),
+                const MobileNetworkPrivacyCard(),
                 const SizedBox(height: AppSpacing.md),
                 _SettingsGroup(
                   title: 'System',

--- a/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
+++ b/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
@@ -1,0 +1,339 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_icon.dart';
+import '../../../../core/widgets/mobile/mobile_surface_card.dart';
+import '../../../../providers/network_privacy_provider.dart';
+// The widget is deliberately not shared; the decision behind it is, because
+// both form factors drive one provider and the escape hatch has to exist on
+// both.
+import '../network_privacy_control.dart'
+    show NetworkPrivacyToggleActionX, networkPrivacyToggleAction;
+
+const _rowHeight = 44.0;
+
+/// Mobile Tor control.
+///
+/// Deliberately not the desktop [NetworkPrivacyControl]: that widget's copy is
+/// mostly about desktop software updates, which mobile gets from the app
+/// stores, and its toggle geometry belongs to a settings page rather than a
+/// grouped card. The state machine behind both is the same provider.
+class MobileNetworkPrivacyCard extends ConsumerWidget {
+  const MobileNetworkPrivacyCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.colors;
+    final state = ref.watch(networkPrivacyProvider);
+    final notifier = ref.read(networkPrivacyProvider.notifier);
+    final presentation = _presentationFor(state);
+    final toggleAction = networkPrivacyToggleAction(state);
+    final onToggle = toggleAction.isInteractive
+        ? () => unawaited(
+            notifier.setTorEnabled(toggleAction.requestedTorEnabled),
+          )
+        : null;
+    // `retry()` re-runs the desired route, which is the direct connection when
+    // it was the disable that failed.
+    final retryLabel = (state.targetTorEnabled ?? state.torEnabled)
+        ? 'Try again'
+        : 'Try direct connection';
+    final onRetry = state.isBusy ? null : () => unawaited(notifier.retry());
+
+    return MobileSurfaceCard(
+      cornerRadius: AppRadii.large,
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.sm,
+        AppSpacing.base,
+        AppSpacing.sm,
+        AppSpacing.base,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.xxs),
+            child: Text(
+              'Network',
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Semantics(
+            button: true,
+            toggled: state.torEnabled,
+            enabled: toggleAction.isInteractive,
+            label: toggleAction.semanticsLabel,
+            // The excluded subtree holds the status text, and four of the five
+            // states report `toggled: true`, so the status has to ride on the
+            // node itself to reach assistive technology at all.
+            value: presentation.statusLabel,
+            onTap: onToggle,
+            excludeSemantics: true,
+            child: GestureDetector(
+              key: const ValueKey('mobile_settings_tor_row'),
+              behavior: HitTestBehavior.opaque,
+              onTap: onToggle,
+              child: SizedBox(
+                height: _rowHeight,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.xxs,
+                  ),
+                  child: Row(
+                    children: [
+                      SizedBox.square(
+                        dimension: 32,
+                        child: Center(
+                          child: AppIcon(
+                            AppIcons.tor,
+                            size: 20,
+                            color: presentation.iconColor(colors),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.s),
+                      Expanded(
+                        child: Text(
+                          'Use Tor',
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTypography.labelLarge.copyWith(
+                            color: colors.text.accent,
+                          ),
+                        ),
+                      ),
+                      Text(
+                        presentation.statusLabel,
+                        style: AppTypography.labelLarge.copyWith(
+                          color: presentation.statusColor(colors),
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.s),
+                      _MobileTorToggle(
+                        key: const ValueKey('mobile_settings_tor_toggle'),
+                        enabled: state.torEnabled,
+                        interactive: toggleAction.isInteractive,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            presentation.description,
+            key: const ValueKey('mobile_settings_tor_description'),
+            style: AppTypography.bodyMedium.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+          if (state.status == NetworkPrivacyConnectionStatus.failed)
+            // No gap token in front: the touch-sized row already carries the
+            // whitespace that separates it from the description.
+            Semantics(
+              button: true,
+              enabled: onRetry != null,
+              label: retryLabel,
+              onTap: onRetry,
+              excludeSemantics: true,
+              child: GestureDetector(
+                key: const ValueKey('mobile_settings_tor_retry'),
+                behavior: HitTestBehavior.opaque,
+                onTap: onRetry,
+                child: SizedBox(
+                  height: _rowHeight,
+                  child: Center(
+                    widthFactor: 1,
+                    child: Text(
+                      retryLabel,
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.brandCrimson,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MobileTorPresentation {
+  const _MobileTorPresentation({
+    required this.statusLabel,
+    required this.description,
+    required this.statusColor,
+    required this.iconColor,
+  });
+
+  final String statusLabel;
+  final String description;
+  final Color Function(AppColors colors) statusColor;
+  final Color Function(AppColors colors) iconColor;
+}
+
+_MobileTorPresentation _presentationFor(NetworkPrivacyState state) {
+  final targetTorEnabled = state.targetTorEnabled ?? state.torEnabled;
+  return switch ((state.status, targetTorEnabled)) {
+    (NetworkPrivacyConnectionStatus.connecting, true) => _MobileTorPresentation(
+      statusLabel: 'Connecting…',
+      // Names the way out. On a network that blocks Tor the wait runs to the
+      // bootstrap deadline with every request failing closed, and relaunching
+      // the app only starts the same wait again, so the escape has to be stated
+      // where the user is looking.
+      description:
+          'New requests wait until the Tor connection is ready. Turn Tor '
+          'off to stop connecting and use a direct connection.',
+      statusColor: (colors) => colors.text.secondary,
+      iconColor: (colors) => colors.icon.muted,
+    ),
+    (NetworkPrivacyConnectionStatus.connecting, false) =>
+      _MobileTorPresentation(
+        statusLabel: 'Switching…',
+        description:
+            'Vizor is switching network requests to a direct '
+            'connection.',
+        statusColor: (colors) => colors.text.secondary,
+        iconColor: (colors) => colors.icon.muted,
+      ),
+    (NetworkPrivacyConnectionStatus.connected, _) => _MobileTorPresentation(
+      statusLabel: 'Connected',
+      // The closing sentence states the policy, not a limitation of the
+      // moment: background passes never bring Tor up — the foreground owns
+      // the client — so migration work on a Tor route runs only while the
+      // app is open.
+      description:
+          'Wallet sync and most in-app requests go through Tor. Some '
+          'services may be unavailable over Tor, and links you open leave the '
+          'app. While Tor is on, a migration in progress advances only while '
+          'Vizor is open.',
+      statusColor: (colors) => colors.text.brandCrimson,
+      iconColor: (colors) => colors.icon.brandCrimson,
+    ),
+    // A failed enable has two shapes with opposite request behaviour, so the
+    // route decides which is described. A bootstrap failure left the process
+    // fail-closed; a save failure aborted the toggle before anything changed.
+    (NetworkPrivacyConnectionStatus.failed, true) =>
+      state.torEnabled
+          ? _MobileTorPresentation(
+              statusLabel: 'Failed',
+              description:
+                  'Vizor could not connect to Tor. Requests stay blocked '
+                  'until it connects or you turn Tor off.',
+              statusColor: (colors) => colors.text.brandCrimson,
+              iconColor: (colors) => colors.icon.brandCrimson,
+            )
+          // Saying "requests stay blocked" here would describe the opposite
+          // of what is happening: nothing was enabled, and requests keep
+          // flowing directly.
+          : _MobileTorPresentation(
+              statusLabel: 'Setting not saved',
+              description:
+                  'Vizor could not save the change, so Tor was not turned '
+                  'on. Requests keep using a direct connection.',
+              statusColor: (colors) => colors.text.brandCrimson,
+              iconColor: (colors) => colors.icon.brandCrimson,
+            ),
+    // A failed disable has two shapes, and they carry opposite privacy
+    // guarantees, so the route decides which is described rather than the
+    // target. Neither may reuse the blocked-requests copy above.
+    (NetworkPrivacyConnectionStatus.failed, false) =>
+      state.torEnabled
+          // The transport never switched. Tor is still up and still carrying
+          // traffic.
+          ? _MobileTorPresentation(
+              statusLabel: 'Switch failed',
+              description:
+                  'Vizor could not switch to a direct connection. Tor is '
+                  'still on and requests keep going through it.',
+              statusColor: (colors) => colors.text.brandCrimson,
+              iconColor: (colors) => colors.icon.brandCrimson,
+            )
+          // The transport did switch and only the setting could not be saved.
+          // Requests are direct from here, and the saved route is still Tor —
+          // the stricter half, so the next launch comes back on Tor rather
+          // than silently staying direct. Saying "Tor is still on" here would
+          // promise the user the opposite of what is actually carrying their
+          // traffic.
+          : _MobileTorPresentation(
+              statusLabel: 'Setting not saved',
+              description:
+                  'Requests now use a direct connection, but Vizor could not '
+                  'save the change. Tor turns back on the next time you open '
+                  'the app.',
+              statusColor: (colors) => colors.text.brandCrimson,
+              iconColor: (colors) => colors.icon.brandCrimson,
+            ),
+    (NetworkPrivacyConnectionStatus.off, _) => _MobileTorPresentation(
+      statusLabel: 'Off',
+      description:
+          'Wallet sync and in-app requests connect directly. Turn Tor '
+          'on to hide your IP address from the servers Vizor talks to.',
+      statusColor: (colors) => colors.text.secondary,
+      iconColor: (colors) => colors.icon.muted,
+    ),
+  };
+}
+
+class _MobileTorToggle extends StatelessWidget {
+  const _MobileTorToggle({
+    required this.enabled,
+    required this.interactive,
+    super.key,
+  });
+
+  final bool enabled;
+
+  /// Dimming says the route is not effective yet. A transition the user can
+  /// still leave is not dimmed: the control has to look like something they may
+  /// act on, because acting on it is the way out of the wait.
+  final bool interactive;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final trackColor = enabled
+        ? colors.background.brandCrimsonStrong
+        : colors.background.raised;
+    final borderColor = enabled
+        ? colors.border.brandCrimsonStrong
+        : colors.border.regular;
+    return Opacity(
+      opacity: interactive ? 1 : 0.65,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 140),
+        curve: Curves.easeOutCubic,
+        width: 64,
+        height: 28,
+        padding: const EdgeInsets.all(2),
+        decoration: BoxDecoration(
+          color: trackColor,
+          borderRadius: BorderRadius.circular(AppRadii.full),
+          border: Border.all(color: borderColor),
+        ),
+        child: AnimatedAlign(
+          duration: const Duration(milliseconds: 140),
+          curve: Curves.easeOutCubic,
+          alignment: enabled ? Alignment.centerRight : Alignment.centerLeft,
+          child: DecoratedBox(
+            key: const ValueKey('mobile_settings_tor_toggle_thumb'),
+            decoration: BoxDecoration(
+              color: const Color(0xFFFFFFFF),
+              borderRadius: BorderRadius.circular(AppRadii.full),
+            ),
+            // Same pill as the keep-awake toggle directly above this card.
+            child: const SizedBox(width: 40, height: 24),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/settings/widgets/network_privacy_control.dart
+++ b/lib/src/features/settings/widgets/network_privacy_control.dart
@@ -492,15 +492,28 @@ _NetworkPrivacyPresentation _presentationFor(
       iconColor: (colors) => colors.icon.brandCrimson,
       descriptionColor: (colors) => colors.text.accent,
     ),
+    // Two failure shapes with opposite request behaviour: a bootstrap that
+    // failed after the process went fail-closed, and a save that aborted the
+    // toggle before anything changed.
     (NetworkPrivacyConnectionStatus.failed, true) =>
-      _NetworkPrivacyPresentation(
-        statusLabel: 'Connection failed',
-        description:
-            'Direct requests remain blocked. Try again or turn off Tor.',
-        statusColor: (colors) => colors.text.destructive,
-        iconColor: (colors) => colors.icon.destructive,
-        descriptionColor: (colors) => colors.text.destructive,
-      ),
+      state.torEnabled
+          ? _NetworkPrivacyPresentation(
+              statusLabel: 'Connection failed',
+              description:
+                  'Direct requests remain blocked. Try again or turn off Tor.',
+              statusColor: (colors) => colors.text.destructive,
+              iconColor: (colors) => colors.icon.destructive,
+              descriptionColor: (colors) => colors.text.destructive,
+            )
+          : _NetworkPrivacyPresentation(
+              statusLabel: 'Setting not saved',
+              description:
+                  'Vizor could not save the change, so Tor was not turned '
+                  'on. Requests keep using a direct connection.',
+              statusColor: (colors) => colors.text.destructive,
+              iconColor: (colors) => colors.icon.destructive,
+              descriptionColor: (colors) => colors.text.destructive,
+            ),
     (NetworkPrivacyConnectionStatus.failed, false) =>
       _NetworkPrivacyPresentation(
         statusLabel: 'Switch failed',

--- a/lib/src/features/settings/widgets/network_privacy_control.dart
+++ b/lib/src/features/settings/widgets/network_privacy_control.dart
@@ -16,6 +16,59 @@ const _toggleShortcuts = <ShortcutActivator, Intent>{
   SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
 };
 
+/// What activating a Tor control does from the state it is showing.
+///
+/// Shared by both form factors because the state machine behind them is one
+/// provider, and because the case that matters is the one a control is most
+/// tempted to disable itself for.
+enum NetworkPrivacyToggleAction {
+  enable,
+  disable,
+
+  /// A Tor connection is still being established and the user wants out of it.
+  ///
+  /// The bootstrap has a three-minute deadline and every policy-aware request
+  /// fails closed until it resolves, so a control that goes inert for the
+  /// duration strands the user on a network that blocks Tor — and force-quitting
+  /// does not help, because the saved route is Tor and the next launch starts
+  /// the same bootstrap. Switching to direct is what ends it, so this stays
+  /// available for exactly as long as the wait does.
+  cancelPendingTor,
+
+  /// A switch to the direct route is already under way. There is nothing to
+  /// cancel toward, and re-entering Tor mid-switch is a transition rather than
+  /// an escape.
+  none,
+}
+
+NetworkPrivacyToggleAction networkPrivacyToggleAction(
+  NetworkPrivacyState state,
+) {
+  if (!state.isBusy) {
+    return state.torEnabled
+        ? NetworkPrivacyToggleAction.disable
+        : NetworkPrivacyToggleAction.enable;
+  }
+  return (state.targetTorEnabled ?? state.torEnabled)
+      ? NetworkPrivacyToggleAction.cancelPendingTor
+      : NetworkPrivacyToggleAction.none;
+}
+
+extension NetworkPrivacyToggleActionX on NetworkPrivacyToggleAction {
+  bool get isInteractive => this != NetworkPrivacyToggleAction.none;
+
+  /// The route the action asks for. Cancelling a pending Tor connection asks
+  /// for the direct route, which is what supersedes the bootstrap.
+  bool get requestedTorEnabled => this == NetworkPrivacyToggleAction.enable;
+
+  /// Assistive-technology label. Turning "Use Tor" off mid-connect is an escape
+  /// from a wait, not a second transition, so it does not announce itself as
+  /// one.
+  String get semanticsLabel => this == NetworkPrivacyToggleAction.cancelPendingTor
+      ? 'Stop connecting to Tor'
+      : 'Use Tor';
+}
+
 /// Shared desktop Tor control used both before wallet creation and in Settings.
 ///
 /// The control presents the desired route separately from its connection
@@ -30,6 +83,7 @@ class NetworkPrivacyControl extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.colors;
     final state = ref.watch(networkPrivacyProvider);
+    final toggleAction = networkPrivacyToggleAction(state);
     final presentation = _presentationFor(
       state,
       platform: defaultTargetPlatform,
@@ -104,14 +158,14 @@ class NetworkPrivacyControl extends ConsumerWidget {
                 _NetworkPrivacyToggle(
                   key: const ValueKey('network_privacy_toggle'),
                   enabled: state.torEnabled,
-                  busy: state.isBusy,
-                  onToggle: state.isBusy
-                      ? null
-                      : () => unawaited(
+                  action: toggleAction,
+                  onToggle: toggleAction.isInteractive
+                      ? () => unawaited(
                           ref
                               .read(networkPrivacyProvider.notifier)
-                              .setTorEnabled(!state.torEnabled),
-                        ),
+                              .setTorEnabled(toggleAction.requestedTorEnabled),
+                        )
+                      : null,
                 ),
               ],
             ),
@@ -216,16 +270,14 @@ class NetworkPrivacyControl extends ConsumerWidget {
 class _NetworkPrivacyToggle extends StatefulWidget {
   const _NetworkPrivacyToggle({
     required this.enabled,
-    required this.busy,
+    required this.action,
     required this.onToggle,
     super.key,
   });
 
   final bool enabled;
 
-  /// The knob moves to the desired route as soon as the transition starts, so
-  /// the dimmed track is the only signal that the route is not effective yet.
-  final bool busy;
+  final NetworkPrivacyToggleAction action;
 
   final VoidCallback? onToggle;
 
@@ -274,7 +326,12 @@ class _NetworkPrivacyToggleState extends State<_NetworkPrivacyToggle> {
     final control = Stack(
       clipBehavior: Clip.none,
       children: [
-        Opacity(opacity: widget.busy ? 0.65 : 1, child: track),
+        // The knob moves to the desired route as soon as a transition starts,
+        // so dimming is the only signal that the route is not effective yet.
+        // A transition the user can still leave is not dimmed: the control has
+        // to look like something they may act on, because acting on it is the
+        // way out of the wait.
+        Opacity(opacity: interactive ? 1 : 0.65, child: track),
         if (_focused)
           Positioned(
             left: -3,
@@ -297,7 +354,7 @@ class _NetworkPrivacyToggleState extends State<_NetworkPrivacyToggle> {
       button: true,
       enabled: interactive,
       toggled: widget.enabled,
-      label: 'Use Tor',
+      label: widget.action.semanticsLabel,
       excludeSemantics: true,
       child: MouseRegion(
         cursor: interactive
@@ -363,7 +420,7 @@ _NetworkPrivacyPresentation _presentationFor(
     return _NetworkPrivacyPresentation(
       statusLabel: 'Connected',
       description:
-          'Vizor’s network requests go through Tor, but software updates are unavailable.',
+          'Wallet sync and most in-app requests go through Tor. Software updates are unavailable.',
       statusColor: (colors) => colors.text.destructive,
       iconColor: (colors) => colors.icon.brandCrimson,
       descriptionColor: (colors) => colors.text.destructive,
@@ -396,11 +453,17 @@ _NetworkPrivacyPresentation _presentationFor(
     (NetworkPrivacyConnectionStatus.connecting, true) =>
       _NetworkPrivacyPresentation(
         statusLabel: 'Connecting…',
+        // Names the way out. On a network that blocks Tor the wait runs to the
+        // bootstrap deadline with every request failing closed, and restarting
+        // the app only starts the same wait again, so the escape has to be
+        // stated where the user is looking.
         description: isLinux
-            ? 'New requests wait until the Tor connection is ready. Update '
+            ? 'New requests wait until the Tor connection is ready. Turn Tor '
+                  'off to stop connecting and use a direct connection. Update '
                   'pages and downloads opened in another app use that '
                   'app’s connection.'
-            : 'New requests wait until the Tor connection is ready.',
+            : 'New requests wait until the Tor connection is ready. Turn Tor '
+                  'off to stop connecting and use a direct connection.',
         statusIconName: AppIcons.loader,
         statusColor: (colors) => colors.text.secondary,
         iconColor: (colors) => colors.icon.muted,
@@ -420,8 +483,11 @@ _NetworkPrivacyPresentation _presentationFor(
       ),
     (NetworkPrivacyConnectionStatus.connected, _) => _NetworkPrivacyPresentation(
       statusLabel: 'Connected',
-      description:
-          'Vizor’s network requests go through Tor. Links opened in other apps use those apps’ network settings.',
+      description: isLinux
+          ? 'Wallet sync, most in-app requests, and software update checks go '
+                'through Tor. Update pages and downloads opened in another app '
+                'use that app’s connection.'
+          : 'Wallet sync, most in-app requests, and software updates go through Tor. Some services may be unavailable over Tor.',
       statusColor: (colors) => colors.text.brandCrimson,
       iconColor: (colors) => colors.icon.brandCrimson,
       descriptionColor: (colors) => colors.text.accent,

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -557,6 +557,39 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
         return;
       }
       if (generation != _generation) return;
+      // The saved route is written before this process changes at all. The
+      // two halves may diverge in only one direction: saved may be stricter
+      // than the route the user has been told about, never laxer. Written
+      // after `beginEnable`, a failed write would leave this process
+      // enforcing Tor while the saved route still said direct — and the
+      // saved half is what a relaunch believes, so restarting the app would
+      // silently undo a choice the user never reversed. Written first, a
+      // failure aborts a toggle that has not changed anything yet: the route
+      // is still direct, requests still flow, nothing needs rolling back.
+      try {
+        await store.writeTorEnabled(true);
+      } catch (error) {
+        if (generation != _generation) return;
+        // Undo the updater preflight so software updates are not left routed
+        // for a Tor session that never started. Best-effort: failing here
+        // only pauses update checks, and `retry()` re-runs the whole toggle.
+        var softwareUpdatesAvailable = previousState.softwareUpdatesAvailable;
+        try {
+          await nativeUpdates.setTorEnabled(false);
+        } catch (_) {
+          softwareUpdatesAvailable = false;
+        }
+        if (generation != _generation) return;
+        state = NetworkPrivacyState(
+          torEnabled: previousState.torEnabled,
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: true,
+          softwareUpdatesAvailable: softwareUpdatesAvailable,
+          error: error.toString(),
+        );
+        return;
+      }
+      if (generation != _generation) return;
       runtime.beginEnable();
     } else {
       state = NetworkPrivacyState(
@@ -606,15 +639,26 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
         if (directDrain != null) {
           _throwIfDirectDrainFailed(await directDrain);
         }
-        if (generation != _generation) return;
-        await store.writeTorEnabled(enabled);
         // Re-check after every suspension point: a superseded disable that
         // reached `configure(false)` or `allow()` would reopen clearnet
         // underneath a newer enable that has already gone fail-closed.
         if (generation != _generation) return;
         nextStatus = await runtime.configure(enabled: enabled);
-        if (!enabled && generation == _generation) {
-          directRequests.allow();
+        if (enabled || generation != _generation) return;
+        try {
+          // Written only now that the runtime has actually gone direct — the
+          // mirror of the enable ordering above. Saved any earlier, a
+          // relaunch would read direct while this process was still
+          // enforcing Tor.
+          await store.writeTorEnabled(false);
+        } finally {
+          // The gate follows the runtime, not the preference. Rust is on the
+          // direct route with its Tor client dropped, so a gate left shut
+          // would strand every direct request for the rest of the session
+          // while the UI reports Tor off. A failed write leaves the saved
+          // route at Tor — the stricter half — so the next launch comes back
+          // on Tor instead of silently staying direct.
+          if (generation == _generation) directRequests.allow();
         }
       });
       if (generation != _generation) return;

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -2,9 +2,12 @@ import 'dart:async' show unawaited;
 import 'dart:io' show Platform;
 
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../core/layout/app_form_factor.dart';
+import '../core/layout/app_process_work_policy.dart';
 import '../core/network/network_http_client.dart';
 import '../core/storage/wallet_paths.dart';
 import '../rust/api/network_privacy.dart' as rust_network_privacy;
@@ -94,6 +97,7 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
   const RustNetworkPrivacyRuntime({
     this.configureRuntime = rust_network_privacy.configureNetworkPrivacy,
     this.resolveTorDirectory = getTorDataDirectoryPath,
+    this.excludeTorDirectoryFromBackup = _excludeFromDeviceBackup,
   });
 
   final Future<rust_types.NetworkPrivacyStatus> Function({
@@ -102,6 +106,7 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
   })
   configureRuntime;
   final Future<String> Function() resolveTorDirectory;
+  final Future<void> Function(String directory) excludeTorDirectoryFromBackup;
 
   @override
   void beginEnable() {
@@ -119,11 +124,56 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
   Future<NetworkPrivacyConnectionStatus> configure({
     required bool enabled,
   }) async {
-    final status = await configureRuntime(
-      enabled: enabled,
-      torDirectory: enabled ? await resolveTorDirectory() : '',
-    );
-    return _connectionStatus(status);
+    final torDirectory = enabled ? await resolveTorDirectory() : '';
+    // Arti's directory records which guards this wallet chose. Restoring it
+    // onto a second device would carry that choice across, so keep it out of
+    // device backups and let a restored install pick fresh guards.
+    //
+    // Marked before the bootstrap, because from its first moment the directory
+    // holds guard state and the process can be killed at any point during it —
+    // and again afterwards, because the mark is best-effort and the run that
+    // matters is the one that succeeds.
+    await _markTorDirectory(enabled, torDirectory);
+    try {
+      final status = await configureRuntime(
+        enabled: enabled,
+        torDirectory: torDirectory,
+      );
+      return _connectionStatus(status);
+    } finally {
+      await _markTorDirectory(enabled, torDirectory);
+    }
+  }
+
+  Future<void> _markTorDirectory(bool enabled, String torDirectory) async {
+    if (!enabled) return;
+    try {
+      await excludeTorDirectoryFromBackup(torDirectory);
+    } catch (error, stackTrace) {
+      // A weaker backup posture is not a reason to fail the route.
+      debugPrint(
+        'RustNetworkPrivacyRuntime: failed to keep the Tor directory out '
+        'of device backups: $error\n$stackTrace',
+      );
+    }
+  }
+}
+
+const _deviceBackupChannel = MethodChannel('com.zcash.wallet/network_privacy');
+
+Future<void> _excludeFromDeviceBackup(String directory) async {
+  // Android has no runtime equivalent. `android:allowBackup="false"` in the
+  // manifest keeps app files out of cloud backup, but from targetSdk 31 that
+  // attribute no longer covers device-to-device transfer; excluding the
+  // directory from a phone-to-phone migration takes `<device-transfer>`
+  // data-extraction rules in the manifest, which the app does not carry.
+  if (!Platform.isIOS) return;
+  try {
+    await _deviceBackupChannel.invokeMethod<void>('excludeFromBackup', {
+      'path': directory,
+    });
+  } on MissingPluginException {
+    // Test hosts and older builds have no native side to ask.
   }
 }
 
@@ -294,6 +344,26 @@ void _throwIfDirectDrainFailed(_NetworkPrivacyDrainFailure? failure) {
   Error.throwWithStackTrace(failure.error, failure.stackTrace);
 }
 
+/// Whether a (saved route, enforced route) pair is one a background wake can be
+/// trusted with.
+///
+/// The saved value is the only thing a process that never ran Dart has to go
+/// on. A background wake reads it, declares that route to Rust, and — finding
+/// direct — queries lightwalletd and broadcasts already-signed transactions
+/// over a direct connection. So the saved value may be stricter than what this
+/// process is enforcing, never laxer: a wake that declares Tor and cannot
+/// afford it defers, which costs a delay, while a wake that declares direct
+/// against a session enforcing Tor leaks.
+///
+/// A route change therefore persists in whichever order keeps this true at
+/// every point in between: tightening writes before the runtime switch, so a
+/// failure in between leaves the strict value behind; loosening writes after
+/// it, so the lax value never precedes the runtime it describes.
+bool networkPrivacyPersistedRouteIsSafe({
+  required bool persistedTorEnabled,
+  required bool runtimeTorDesired,
+}) => persistedTorEnabled || !runtimeTorDesired;
+
 NetworkPrivacyConnectionStatus _connectionStatus(
   rust_types.NetworkPrivacyStatus status,
 ) => switch (status) {
@@ -323,6 +393,55 @@ var _startupActivationSuperseded = false;
 /// update session to finish.
 const _kStartupNativeUpdatePauseTimeout = Duration(seconds: 10);
 
+/// Ties the process-wide Tor dormancy intent to the app lifecycle.
+///
+/// Owned here rather than by a provider because a provider only exists once
+/// something reads it, and the launch that most needs this one reads the least:
+/// a locked app routes to `/unlock`, the keep-awake providers return early on
+/// `requiresUnlock` before they reach `syncProvider`, and the unlock screens
+/// only read it when the user submits. Meanwhile the persisted route is applied
+/// regardless of the lock, so Tor can be up and padding its guard connection
+/// with nothing constructed to put it to sleep when the user walks away.
+///
+/// Rust holds the intent process-wide and applies it to the client whenever one
+/// appears, so an intent stated before a bootstrap finishes is not lost.
+AppLifecycleListener? _torDormancyLifecycle;
+
+/// Starts the lifecycle owner, replacing any previous one.
+///
+/// Sleeping is asked for only where backgrounding actually stops this process
+/// working: a desktop app with every window hidden keeps polling, and a client
+/// put to sleep underneath it would pay a circuit build on each of those polls.
+void startTorDormancyLifecycle({
+  void Function({required bool dormant}) setTorDormant =
+      rust_network_privacy.setNetworkPrivacyDormant,
+  AppFormFactor formFactor = kAppFormFactor,
+}) {
+  _torDormancyLifecycle?.dispose();
+  _torDormancyLifecycle = AppLifecycleListener(
+    // Asked for on every foreground entry, not only after a sleep this owner
+    // requested: a request that outlived its asker — issued before Tor
+    // finished bootstrapping, so it lands on the client only once that client
+    // exists — would otherwise keep the client asleep for the whole foreground
+    // session.
+    onResume: () => setTorDormant(dormant: false),
+    onHide: () {
+      if (!canRunAppProcessWork(
+        isInForeground: false,
+        formFactor: formFactor,
+      )) {
+        setTorDormant(dormant: true);
+      }
+    },
+  );
+}
+
+@visibleForTesting
+void disposeTorDormancyLifecycle() {
+  _torDormancyLifecycle?.dispose();
+  _torDormancyLifecycle = null;
+}
+
 /// Applies the persisted route before app bootstrap or providers can start any
 /// network work. Failure is retained as an enabled/failed state; Rust has
 /// already switched to fail-closed routing at that point.
@@ -342,6 +461,10 @@ Future<void> initializeNetworkPrivacyRuntime({
 }) async {
   _pendingStartupActivation = null;
   _startupActivationSuperseded = false;
+  // Before the route is applied, and outside the try: the owner has to exist
+  // on every launch, including the one where reading the preference throws and
+  // this process goes fail-closed Tor without ever being asked.
+  startTorDormancyLifecycle();
   late final bool enabled;
   try {
     enabled = await store.readTorEnabled();

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -38,7 +38,8 @@ class NetworkPrivacyState {
     this.softwareUpdatesAvailable = true,
     this.error,
     this.startupNotice,
-  });
+    bool? savedRouteTorEnabled,
+  }) : savedRouteTorEnabled = savedRouteTorEnabled ?? torEnabled;
 
   const NetworkPrivacyState.off()
     : torEnabled = false,
@@ -46,9 +47,19 @@ class NetworkPrivacyState {
       targetTorEnabled = null,
       softwareUpdatesAvailable = true,
       error = null,
-      startupNotice = null;
+      startupNotice = null,
+      savedRouteTorEnabled = false;
 
   final bool torEnabled;
+  /// The route a background wake into a cold process will read.
+  ///
+  /// Saved and enforced may diverge in one direction only — saved stricter —
+  /// and exactly one published state carries the divergence: a disable whose
+  /// transport switched and whose preference write then failed. Surfaces that
+  /// describe what the native background lanes will do must read this rather
+  /// than [torEnabled], because those lanes read the saved preference, not
+  /// this process's memory.
+  final bool savedRouteTorEnabled;
   final NetworkPrivacyConnectionStatus status;
   final bool? targetTorEnabled;
   final bool softwareUpdatesAvailable;
@@ -831,6 +842,11 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
         softwareUpdatesAvailable: softwareUpdatesAvailable,
         error: error.toString(),
         startupNotice: startupNotice,
+        // A disable that switched the transport and then failed to save is
+        // the one state whose saved half is stricter than its enforced half:
+        // the preference still says Tor, and that is what a background wake
+        // will read.
+        savedRouteTorEnabled: !enabled && !effectiveTorEnabled ? true : null,
       );
     }
   }

--- a/lib/src/rust/api/network_privacy.dart
+++ b/lib/src/rust/api/network_privacy.dart
@@ -39,6 +39,14 @@ NetworkPrivacyStatus getNetworkPrivacyStatus() =>
 bool isTorEnabled() =>
     RustLib.instance.api.crateApiNetworkPrivacyIsTorEnabled();
 
+/// Suspends or resumes Tor's circuit maintenance alongside the app lifecycle.
+///
+/// A bootstrapped client otherwise keeps guard connections and directory tasks
+/// running while the app is in the background, which costs battery on mobile
+/// and does work iOS will kill the app for. A no-op until Tor is connected.
+void setNetworkPrivacyDormant({required bool dormant}) => RustLib.instance.api
+    .crateApiNetworkPrivacySetNetworkPrivacyDormant(dormant: dormant);
+
 /// Starts a token-protected loopback server that streams HTTPS update assets
 /// from the embedded Tor client directly to a native desktop updater.
 Future<String> startTorUpdateRelay() =>

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -81,7 +81,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -92948645;
+  int get rustContentHash => 844087337;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -1045,6 +1045,8 @@ abstract class RustLibApi extends BaseApi {
     required bool skipped,
     int? choice,
   });
+
+  void crateApiNetworkPrivacySetNetworkPrivacyDormant({required bool dormant});
 
   void crateApiSyncSetSyncMode({required int mode});
 
@@ -7439,6 +7441,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  void crateApiNetworkPrivacySetNetworkPrivacyDormant({required bool dormant}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_bool(dormant, serializer);
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 145,
+          )!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiNetworkPrivacySetNetworkPrivacyDormantConstMeta,
+        argValues: [dormant],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiNetworkPrivacySetNetworkPrivacyDormantConstMeta =>
+      const TaskConstMeta(
+        debugName: "set_network_privacy_dormant",
+        argNames: ["dormant"],
+      );
+
+  @override
   void crateApiSyncSetSyncMode({required int mode}) {
     return handler.executeSync(
       SyncTask(
@@ -7448,7 +7480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
           )!;
         },
         codec: SseCodec(
@@ -7483,7 +7515,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7516,7 +7548,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
             port: port_,
           );
         },
@@ -7556,7 +7588,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7597,7 +7629,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7651,7 +7683,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
             port: port_,
           );
         },
@@ -7701,7 +7733,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 151,
+              funcId: 152,
               port: port_,
             );
           },
@@ -7742,7 +7774,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 152,
+              funcId: 153,
               port: port_,
             );
           },
@@ -7774,7 +7806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7801,7 +7833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
           )!;
         },
         codec: SseCodec(
@@ -7827,7 +7859,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7869,7 +7901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 157,
             port: port_,
           );
         },
@@ -7920,7 +7952,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7959,7 +7991,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 159,
             port: port_,
           );
         },
@@ -7995,7 +8027,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8030,7 +8062,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
             port: port_,
           );
         },
@@ -8067,7 +8099,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8111,7 +8143,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8161,7 +8193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8193,7 +8225,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8221,7 +8253,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
           )!;
         },
         codec: SseCodec(
@@ -8253,7 +8285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8290,7 +8322,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8321,7 +8353,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 169,
           )!;
         },
         codec: SseCodec(
@@ -8352,7 +8384,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8389,7 +8421,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 171,
             port: port_,
           );
         },

--- a/rust/src/api/network_privacy.rs
+++ b/rust/src/api/network_privacy.rs
@@ -58,6 +58,16 @@ pub fn is_tor_enabled() -> bool {
     crate::network_privacy::is_tor_desired()
 }
 
+/// Suspends or resumes Tor's circuit maintenance alongside the app lifecycle.
+///
+/// A bootstrapped client otherwise keeps guard connections and directory tasks
+/// running while the app is in the background, which costs battery on mobile
+/// and does work iOS will kill the app for. A no-op until Tor is connected.
+#[flutter_rust_bridge::frb(sync)]
+pub fn set_network_privacy_dormant(dormant: bool) {
+    crate::network_privacy::set_tor_dormant(dormant);
+}
+
 /// Starts a token-protected loopback server that streams HTTPS update assets
 /// from the embedded Tor client directly to a native desktop updater.
 pub async fn start_tor_update_relay() -> Result<String, String> {

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -560,6 +560,67 @@ pub extern "C" fn zcash_inspect_migration_proof_readiness(
     }
 }
 
+/// Adopt the user's persisted Tor preference before any background network
+/// call. The desired route is process-local and defaults to direct, so a
+/// background wake into a cold process would otherwise reach lightwalletd over
+/// clearnet. The caller must have read the persisted preference itself; this
+/// only makes the process fail closed, and returns without bootstrapping Tor or
+/// touching the filesystem.
+///
+/// This is the whole of what a background pass does about a Tor route: it
+/// marks, does no network work, and leaves the run to the foreground. This
+/// process never brings Tor up in the background; the foreground owns the
+/// client.
+///
+/// A preference read outside Dart can be stale, so this is ignored once the
+/// process has decided its own route, and reports success either way — the
+/// caller refuses its network pass on a persisted Tor route regardless.
+#[no_mangle]
+pub extern "C" fn zcash_network_privacy_mark_tor_desired() -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        crate::network_privacy::mark_tor_desired();
+        0
+    });
+
+    match result {
+        Ok(code) => code,
+        Err(panic) => {
+            log_panic("network privacy Tor declaration", panic);
+            2
+        }
+    }
+}
+
+/// Adopt the user's persisted *direct* preference before any background network
+/// call — the mirror of [`zcash_network_privacy_mark_tor_desired`], and just as
+/// mandatory.
+///
+/// The route is process-local, and "nobody has declared yet" and "the user
+/// chose direct" are deliberately different states: the first is refused at the
+/// route chokepoint so that a background entry point which never read the
+/// preference cannot reach lightwalletd at all. A pass whose saved route is
+/// direct therefore has to say so, exactly as a Tor pass does, or its own
+/// network calls fail closed.
+///
+/// Writes nothing but the decision, touches no filesystem, and is ignored once
+/// the process has decided its own route — a persisted read can be stale, and
+/// this must never turn a live Tor route direct. Returns 0 on success.
+#[no_mangle]
+pub extern "C" fn zcash_network_privacy_mark_direct_route() -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        crate::network_privacy::mark_direct_route();
+        0
+    });
+
+    match result {
+        Ok(code) => code,
+        Err(panic) => {
+            log_panic("network privacy direct route declaration", panic);
+            2
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -92948645;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 844087337;
 
 // Section: executor
 
@@ -5793,6 +5793,38 @@ fn wire__crate__api__voting__set_ballot_intent_impl(
         },
     )
 }
+fn wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "set_network_privacy_dormant",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_dormant = <bool>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::network_privacy::set_network_privacy_dormant(api_dormant);
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__sync__set_sync_mode_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -10208,28 +10240,28 @@ fn pde_ffi_dispatcher_primary_impl(
 142 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
 143 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
 144 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+148 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10269,10 +10301,15 @@ fn pde_ffi_dispatcher_sync_impl(
         }
         114 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
         134 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        145 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        154 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        165 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        168 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        145 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        146 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        155 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        166 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        169 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/network_privacy.rs
+++ b/rust/src/network_privacy.rs
@@ -19,7 +19,7 @@ use std::{
     time::Duration,
 };
 
-use zcash_client_backend::tor::{Client as TorClient, Timeouts as TorTimeouts};
+use zcash_client_backend::tor::{Client as TorClient, DormantMode, Timeouts as TorTimeouts};
 
 /// `TorTimeouts` only bounds connect, request and response-body phases, so
 /// bootstrapping itself is unbounded: arti retries it 128 times with a growing
@@ -52,6 +52,14 @@ static TOR_DESIRED: AtomicBool = AtomicBool::new(false);
 /// from outside Dart is only a fallback for a process that has not decided yet,
 /// so it must never overwrite a decision that has already been made.
 static ROUTE_DECIDED: AtomicBool = AtomicBool::new(false);
+/// The dormancy asked for, kept whether or not a client exists yet. A request
+/// that arrives mid-bootstrap has nothing to apply to, and the app lifecycle
+/// callbacks do not repeat themselves once it finishes.
+static TOR_DORMANT: AtomicBool = AtomicBool::new(false);
+/// Serialises reading the intent and applying a mode to the client, so two
+/// lifecycle callbacks racing cannot apply a mode from a different moment than
+/// the intent they read.
+static DORMANT_APPLY_LOCK: Mutex<()> = Mutex::new(());
 static TOR_STATUS: AtomicU8 = AtomicU8::new(STATUS_DIRECT);
 static TOR_CLIENT: OnceLock<RwLock<Option<TorClient>>> = OnceLock::new();
 static TOR_INIT_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
@@ -368,6 +376,55 @@ impl<T: hyper::rt::Write + Unpin> hyper::rt::Write for DirectRouteIo<T> {
     }
 }
 
+/// Puts a Tor client to sleep, or wakes it up.
+///
+/// Arti keeps guard connections and directory tasks running; an idle client
+/// pads its guard connection continuously — measured at roughly 500 B/s,
+/// against 27 B/s dormant. On mobile that costs battery in a state the OS will
+/// kill the app for, so the app asks for sleep on its way out and for
+/// wakefulness on every foreground entry. This never forces a bootstrap, but a
+/// request made while one is still running is not lost either: the intent is
+/// process-wide, and a client picks it up as it is installed.
+pub fn set_tor_dormant(dormant: bool) {
+    {
+        let _guard = dormant_apply_lock();
+        TOR_DORMANT.store(dormant, Ordering::Release);
+        apply_dormant_mode_locked();
+    }
+    log::info!("network privacy: Tor dormant={dormant}");
+}
+
+fn dormant_apply_lock() -> std::sync::MutexGuard<'static, ()> {
+    DORMANT_APPLY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// The mode a client is put into as it is installed, so it never lands awake in
+/// a process the app has already backgrounded. Applying `Soft` to a client that
+/// has just finished bootstrapping is safe: arti lifts it back to `Normal` on
+/// the next use.
+fn pending_dormant_mode() -> DormantMode {
+    if TOR_DORMANT.load(Ordering::Acquire) {
+        DormantMode::Soft
+    } else {
+        DormantMode::Normal
+    }
+}
+
+/// Pushes the mode the current state implies onto the installed client.
+/// Caller holds [`DORMANT_APPLY_LOCK`], so the value read and the value applied
+/// cannot come from different moments.
+fn apply_dormant_mode_locked() {
+    let mode = pending_dormant_mode();
+    let slot = client_slot()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(client) = slot.as_ref() {
+        client.set_dormant(mode);
+    }
+}
+
 pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, String> {
     ROUTE_DECIDED.store(true, Ordering::Release);
     TOR_DESIRED.store(true, Ordering::Release);
@@ -470,6 +527,9 @@ async fn install_bootstrapped_client<E: Display>(
         if !is_tor_desired() {
             return Ok(NetworkPrivacyStatus::Direct);
         }
+        // Adopting the pending mode here is what keeps a sleep asked for
+        // mid-bootstrap from being overtaken by the client it was waiting for.
+        client.set_dormant(pending_dormant_mode());
         *slot = Some(client);
         TOR_STATUS.store(STATUS_READY, Ordering::Release);
     }
@@ -630,6 +690,10 @@ pub(crate) mod test_route_policy {
         fn drop(&mut self) {
             super::disable_tor();
             super::ROUTE_DECIDED.store(false, Ordering::Release);
+            // The intent is process-wide and one process runs every test in
+            // this crate: a test that asks for dormancy and returns would
+            // otherwise decide later assertions by execution order.
+            super::TOR_DORMANT.store(false, Ordering::Release);
         }
     }
 
@@ -654,7 +718,8 @@ mod tests {
         await_tor_bootstrap, begin_tor_enable, bootstrap_tor, cancel_direct_connections,
         client_slot, disable_tor, init_lock, install_bootstrapped_client, is_route_decided,
         is_tor_desired, mark_direct_route, mark_tor_desired, route_decision, set_tor_failed,
-        status, test_route_policy::lock_route_policy, tor_client_for_route, DirectRouteIo,
+        pending_dormant_mode, set_tor_dormant, status, test_route_policy::lock_route_policy,
+        tor_client_for_route, DirectRouteIo, DormantMode,
         NetworkPrivacyStatus, RouteDecision, TorClient, BOOTSTRAP_ABANDONED_MESSAGE,
         ROUTE_DECIDED, ROUTE_NOT_DECLARED_MESSAGE, STATUS_READY,
         TOR_BOOTSTRAP_TIMEOUT_MESSAGE, TOR_STATUS,
@@ -859,6 +924,35 @@ mod tests {
         assert!(!is_tor_desired());
         assert_eq!(status(), NetworkPrivacyStatus::Direct);
         assert!(matches!(tor_client_for_route(false), Ok(None)));
+    }
+
+    #[test]
+    fn a_dormancy_request_made_before_the_client_exists_is_applied_to_it() {
+        let _policy = lock_route_policy();
+        assert!(client_slot()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_none());
+
+        set_tor_dormant(true);
+        assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+
+        set_tor_dormant(false);
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
+    }
+
+    /// A test's dormancy intent must not outlive its route-policy guard.
+    #[test]
+    fn the_route_policy_guard_hands_back_the_default_dormancy_intent() {
+        {
+            let _policy = lock_route_policy();
+            set_tor_dormant(true);
+            assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+        }
+
+        let _policy = lock_route_policy();
+
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
     }
 
     #[test]

--- a/rust/src/network_privacy.rs
+++ b/rust/src/network_privacy.rs
@@ -491,7 +491,24 @@ async fn bootstrap_tor(
         remaining,
         TorClient::create_with_timeouts(
             tor_directory,
-            |_| {},
+            // Arti refuses a data directory other users could reach. On desktop
+            // those POSIX mode bits are the real boundary, so the check stays
+            // on. On mobile the app sandbox is the boundary, and the pinned
+            // fs-mistrust already knows it: on iOS and Android it compiles out
+            // the owner check and stops forbidding the group bits, which is the
+            // group-writable container ancestor that used to reject the
+            // directory outright. What it still rejects there — a world-
+            // writable ancestor, or arti's own 0o700 directories opened up — a
+            // sandboxed container is not expected to have, so this bypass is
+            // probably redundant. Dropping it needs evidence from a real
+            // device, because a rejected directory fails the bootstrap from
+            // inside fail-closed mode: every request blocked, Tor never Ready.
+            |permissions| {
+                #[cfg(any(target_os = "ios", target_os = "android"))]
+                permissions.dangerously_trust_everyone();
+                #[cfg(not(any(target_os = "ios", target_os = "android")))]
+                let _ = permissions;
+            },
             timeouts,
         ),
     )

--- a/rust/src/network_privacy.rs
+++ b/rust/src/network_privacy.rs
@@ -25,10 +25,22 @@ use zcash_client_backend::tor::{Client as TorClient, Timeouts as TorTimeouts};
 /// bootstrapping itself is unbounded: arti retries it 128 times with a growing
 /// backoff, which never terminates on a network that blocks Tor. A cold first
 /// bootstrap over a slow link legitimately takes tens of seconds, so the
-/// deadline stays generous enough to let those finish.
+/// deadline stays generous enough to let those finish. A user watching the
+/// route switch can also see it working and give up themselves, which a
+/// background pass cannot.
 const TOR_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(3 * 60);
 const TOR_BOOTSTRAP_TIMEOUT_MESSAGE: &str =
     "Tor could not connect. Check your internet connection and try again.";
+/// Refused at the route chokepoint when nothing in this process has said which
+/// route it is on.
+///
+/// The desired route lives in process memory and defaults to direct, so an
+/// entry point that never declares would otherwise reach lightwalletd over
+/// clearnet on a Tor-configured wallet — silently, and only in the lane that
+/// forgot. Declaring is one call ([`mark_tor_desired`], [`mark_direct_route`],
+/// [`begin_tor_enable`], [`enable_tor`] or [`disable_tor`]); not declaring is
+/// now an error every caller sees rather than a leak nobody does.
+const ROUTE_NOT_DECLARED_MESSAGE: &str = "Network route has not been declared for this process";
 
 const STATUS_DIRECT: u8 = 0;
 const STATUS_BOOTSTRAPPING: u8 = 1;
@@ -36,6 +48,10 @@ const STATUS_READY: u8 = 2;
 const STATUS_FAILED: u8 = 3;
 
 static TOR_DESIRED: AtomicBool = AtomicBool::new(false);
+/// Set as soon as anything in this process decides the route. A preference read
+/// from outside Dart is only a fallback for a process that has not decided yet,
+/// so it must never overwrite a decision that has already been made.
+static ROUTE_DECIDED: AtomicBool = AtomicBool::new(false);
 static TOR_STATUS: AtomicU8 = AtomicU8::new(STATUS_DIRECT);
 static TOR_CLIENT: OnceLock<RwLock<Option<TorClient>>> = OnceLock::new();
 static TOR_INIT_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
@@ -86,6 +102,46 @@ pub fn status() -> NetworkPrivacyStatus {
 /// Runtime toggles call this synchronously before their first `await`, so no
 /// new policy-aware request can race onto clearnet during teardown.
 pub fn begin_tor_enable() {
+    enable_tor_route(RouteClaim::Unconditional);
+}
+
+/// Whether an enable may proceed over a route this process has already chosen.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RouteClaim {
+    /// The user asked for Tor in this process. Whatever the route was, it is
+    /// Tor now.
+    Unconditional,
+    /// A persisted preference is being adopted, and it loses to any route this
+    /// process decided for itself.
+    OnlyIfUndecided,
+}
+
+/// The enable, with the claim on the route and the state change it implies made
+/// as one operation.
+///
+/// The claim has to be inside the lock. Split from the writes below it, an
+/// adoption that won the claim and was then preempted let a whole
+/// `disable_tor()` run in the gap — and the writes below, arriving after it,
+/// put the route back to Tor with the client already dropped and no bootstrap
+/// behind them. That leaves every Rust request refused on a fail-closed Tor
+/// route while the app believes it is direct, which nothing recovers short of
+/// toggling Tor again. It is reachable: the native declaration runs on a
+/// background queue while the settings toggle runs on the platform thread.
+///
+/// The route and status writes are the same ones `disable_tor`,
+/// `install_bootstrapped_client` and `set_tor_failed` make under this lock, so
+/// all four paths now share one rule about where these atomics may be written.
+/// The lock order is theirs too — slot first, then the waker map — and nothing
+/// reached while holding the waker map takes the slot, so there is no inversion
+/// to introduce.
+fn enable_tor_route(claim: RouteClaim) {
+    let mut slot = client_slot()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if claim == RouteClaim::OnlyIfUndecided && ROUTE_DECIDED.load(Ordering::Acquire) {
+        return;
+    }
+    ROUTE_DECIDED.store(true, Ordering::Release);
     let wakers = {
         let mut wakers = direct_io_wakers()
             .lock()
@@ -95,13 +151,59 @@ pub fn begin_tor_enable() {
         DIRECT_ROUTE_EPOCH.fetch_add(1, Ordering::AcqRel);
         wakers.drain().map(|(_, waker)| waker).collect::<Vec<_>>()
     };
+    *slot = None;
+    drop(slot);
+    // Woken with both locks released. A woken lease re-reads the route and
+    // aborts itself without touching either, but waking underneath them would
+    // hand a scheduler the opportunity to run that on this thread.
     for waker in wakers {
         waker.wake();
     }
-    *client_slot()
-        .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
     log::info!("network privacy: Tor requested; direct requests blocked");
+}
+
+/// Adopts a persisted Tor preference in a process where the Dart layer has not
+/// run yet.
+///
+/// The desired route lives in process memory, so a background wake into a cold
+/// process starts in direct mode and would route wallet traffic over clearnet
+/// without ever asking the user. Marking makes that process fail closed: it
+/// never bootstraps Tor by itself, so a pass that only marks can do no network
+/// work and has to defer to the foreground. A pass that has established it can
+/// afford a bootstrap calls [`enable_tor_for_background_work`] instead, which
+/// marks first and then brings a client up.
+///
+/// The caller reads the preference from storage, so its answer can already be
+/// stale by the time it arrives here — the user may have picked direct in the
+/// meantime. A process that has decided its own route is therefore left alone;
+/// otherwise a stale read could strand a deliberately-direct session in
+/// fail-closed mode with nothing left to bootstrap it.
+pub fn mark_tor_desired() {
+    enable_tor_route(RouteClaim::OnlyIfUndecided);
+}
+
+/// Adopts a persisted *direct* preference in a process where the Dart layer has
+/// not run yet — the mirror of [`mark_tor_desired`].
+///
+/// Direct is where the atomics start, so this writes nothing but the decision
+/// itself. That is the whole point: without it, "nobody has said yet" and "the
+/// user chose direct" are the same state, and [`route_decision`] cannot refuse
+/// the first while allowing the second. A background entry point that reaches
+/// lightwalletd on a direct-route wallet calls this, and one that forgets is
+/// refused instead of quietly reaching clearnet on a wallet whose route it
+/// never read.
+///
+/// Stale in the same way its sibling is — the caller read the preference from
+/// storage — so a process that has already decided its own route keeps it, and
+/// this never turns a live Tor route direct.
+pub fn mark_direct_route() {
+    if ROUTE_DECIDED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+    log::info!("network privacy: direct route adopted from the saved preference");
 }
 
 #[cfg(test)]
@@ -267,9 +369,35 @@ impl<T: hyper::rt::Write + Unpin> hyper::rt::Write for DirectRouteIo<T> {
 }
 
 pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, String> {
+    ROUTE_DECIDED.store(true, Ordering::Release);
     TOR_DESIRED.store(true, Ordering::Release);
+    bootstrap_tor(tor_directory, TOR_BOOTSTRAP_TIMEOUT).await
+}
 
-    let _init_guard = init_lock().lock().await;
+async fn bootstrap_tor(
+    tor_directory: &Path,
+    deadline: Duration,
+) -> Result<NetworkPrivacyStatus, String> {
+    // The deadline covers the wait for the init lock as well as the bootstrap
+    // it guards, so it bounds the call the caller actually made.
+    //
+    // Two enables can be in flight at once — a foreground toggle and a
+    // background pass — and the holder may be spending the foreground's three
+    // minutes on a network that blocks Tor. A waiter that started its own timer
+    // only after acquiring would sit there for the holder's deadline and then
+    // its own on top. For a background pass that is the whole execution
+    // opportunity spent inside one blocking call: it holds no cancellation
+    // handle the OS expiration handler can reach, and every re-arm path lives
+    // on the far side of it, so the window ends with nothing armed.
+    let started = std::time::Instant::now();
+    let Ok(_init_guard) = tokio::time::timeout(deadline, init_lock().lock()).await else {
+        // Nothing is published here. Whichever bootstrap holds the lock owns the
+        // status, and this call only reports that it could not get Tor up inside
+        // its budget. The route stays Tor-desired either way, so every
+        // policy-aware client keeps refusing — running out of patience is not a
+        // reason to reach the network another way.
+        return Err(TOR_BOOTSTRAP_TIMEOUT_MESSAGE.to_string());
+    };
     if !is_tor_desired() {
         return Ok(NetworkPrivacyStatus::Direct);
     }
@@ -293,14 +421,36 @@ pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, St
     // body that is actively streaming enough time to complete. Small app API
     // responses retain their own shorter body deadline.
     let timeouts = TorTimeouts::default().with_response_body(Duration::from_secs(2 * 60 * 60));
+    // What is left of the budget after the wait, so waiting and bootstrapping
+    // cannot add up to more than the caller asked for. Bounding the bootstrap
+    // separately rather than wrapping the whole body in one timer is what keeps
+    // a failure published: a timer that fired out here would drop
+    // `install_bootstrapped_client` mid-await and skip the `set_tor_failed` it
+    // exists to perform, leaving the status Bootstrapping with nothing running.
+    let remaining = deadline.saturating_sub(started.elapsed());
     // Returning here drops `_init_guard`, so a bootstrap that ran out of time
     // does not block the next enable attempt.
-    let client = match await_tor_bootstrap(
-        TOR_BOOTSTRAP_TIMEOUT,
-        TorClient::create_with_timeouts(tor_directory, |_| {}, timeouts),
+    install_bootstrapped_client(
+        remaining,
+        TorClient::create_with_timeouts(
+            tor_directory,
+            |_| {},
+            timeouts,
+        ),
     )
     .await
-    {
+}
+
+/// Waits out one bootstrap attempt and publishes its outcome.
+///
+/// Running out of time is not a reason to reach the network another way: the
+/// route stays Tor and the status becomes `Failed`, so every policy-aware client
+/// keeps refusing until something bootstraps successfully.
+async fn install_bootstrapped_client<E: Display>(
+    deadline: Duration,
+    bootstrap: impl Future<Output = Result<TorClient, E>>,
+) -> Result<NetworkPrivacyStatus, String> {
+    let client = match await_tor_bootstrap(deadline, bootstrap).await {
         Ok(client) => client,
         Err(error) => {
             set_tor_failed();
@@ -308,53 +458,115 @@ pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, St
         }
     };
 
-    if !is_tor_desired() {
-        return Ok(NetworkPrivacyStatus::Direct);
+    {
+        // The route is read and the client published under one lock, because
+        // `disable_tor` takes the same one: a switch to direct that lands
+        // between a check outside and the store would otherwise leave the
+        // status Ready with the route direct, and an orphaned client awake and
+        // padding behind it.
+        let mut slot = client_slot()
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !is_tor_desired() {
+            return Ok(NetworkPrivacyStatus::Direct);
+        }
+        *slot = Some(client);
+        TOR_STATUS.store(STATUS_READY, Ordering::Release);
     }
-
-    *client_slot()
-        .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(client);
-    TOR_STATUS.store(STATUS_READY, Ordering::Release);
     log::info!("network privacy: Tor is ready");
     Ok(NetworkPrivacyStatus::Ready)
 }
 
+/// How often a running bootstrap checks whether the route it is for still
+/// exists. Short enough that the abandon is not itself a wait, long enough to
+/// cost nothing over the minutes a blocked bootstrap can take.
+const BOOTSTRAP_ROUTE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const BOOTSTRAP_ABANDONED_MESSAGE: &str = "Tor was turned off while it was connecting";
+
+/// Waits out one bootstrap, and stops waiting if the route it is for goes away.
+///
+/// Clearing the client slot does not reach the `TorClient` future already
+/// running here, so a user who turned Tor off left arti bootstrapping — talking
+/// to directory authorities for up to the full deadline, on a route they had
+/// just switched off, while holding the init lock a re-enable would have to
+/// wait behind. Nothing wrong was ever published, because the publish re-reads
+/// the route under the slot lock; what was wrong is that the work continued at
+/// all.
+///
+/// Dropping the future is what cancels it, so the abandon is the return itself.
+/// Polling rather than signalling: registering for a notification has a window
+/// between the registration and the check that a route change can fall into,
+/// and a quarter-second poll over a bootstrap measured in tens of seconds costs
+/// less than closing that window would.
 async fn await_tor_bootstrap<T, E: Display>(
     deadline: Duration,
     bootstrap: impl Future<Output = Result<T, E>>,
 ) -> Result<T, String> {
-    match tokio::time::timeout(deadline, bootstrap).await {
-        Ok(Ok(client)) => Ok(client),
-        Ok(Err(error)) => Err(format!("Bootstrap Tor: {error}")),
-        Err(_) => Err(TOR_BOOTSTRAP_TIMEOUT_MESSAGE.to_string()),
+    tokio::pin!(bootstrap);
+    let expires_at = tokio::time::Instant::now() + deadline;
+    loop {
+        tokio::select! {
+            result = &mut bootstrap => {
+                return match result {
+                    Ok(client) => Ok(client),
+                    Err(error) => Err(format!("Bootstrap Tor: {error}")),
+                }
+            }
+            _ = tokio::time::sleep_until(expires_at) => {
+                return Err(TOR_BOOTSTRAP_TIMEOUT_MESSAGE.to_string())
+            }
+            _ = tokio::time::sleep(BOOTSTRAP_ROUTE_POLL_INTERVAL) => {
+                if !is_tor_desired() {
+                    return Err(BOOTSTRAP_ABANDONED_MESSAGE.to_string());
+                }
+            }
+        }
     }
 }
 
 pub fn disable_tor() {
+    ROUTE_DECIDED.store(true, Ordering::Release);
+    // Under the same lock a finishing bootstrap publishes through, so the two
+    // cannot interleave into a Ready status on a direct route.
+    let mut slot = client_slot()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     TOR_DESIRED.store(false, Ordering::Release);
     TOR_STATUS.store(STATUS_DIRECT, Ordering::Release);
-    *client_slot()
-        .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    *slot = None;
+    drop(slot);
     log::info!("network privacy: direct route enabled");
 }
 
 fn set_tor_failed() {
-    *client_slot()
+    let mut slot = client_slot()
         .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *slot = None;
+    // Same lock as the publish and the disable: a route that went direct while
+    // this bootstrap was failing keeps its own status.
     if is_tor_desired() {
         TOR_STATUS.store(STATUS_FAILED, Ordering::Release);
     }
 }
 
 fn route_decision(
+    route_decided: bool,
     tor_desired: bool,
     tor_status: NetworkPrivacyStatus,
     has_client: bool,
     isolated: bool,
 ) -> Result<RouteDecision, &'static str> {
+    // Direct is a decision, not a default. Every Rust lightwalletd connection
+    // funnels through here, and the entry points that reach it from outside
+    // Dart — the C background calls, and anything added beside them — carry
+    // their contract to declare in a header comment and in their callers. A
+    // lane that forgets fails here, loudly and on its first connection, instead
+    // of reaching lightwalletd over clearnet on a Tor-configured wallet with
+    // nothing failing to compile and no test going red.
+    if !route_decided {
+        return Err(ROUTE_NOT_DECLARED_MESSAGE);
+    }
     if !tor_desired {
         return Ok(RouteDecision::Direct);
     }
@@ -372,12 +584,22 @@ fn route_decision(
     })
 }
 
+fn is_route_decided() -> bool {
+    ROUTE_DECIDED.load(Ordering::Acquire)
+}
+
 pub(crate) fn tor_client_for_route(isolated: bool) -> Result<Option<TorClient>, String> {
     let client = client_slot()
         .read()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .clone();
-    match route_decision(is_tor_desired(), status(), client.is_some(), isolated) {
+    match route_decision(
+        is_route_decided(),
+        is_tor_desired(),
+        status(),
+        client.is_some(),
+        isolated,
+    ) {
         Ok(RouteDecision::Direct) => Ok(None),
         Ok(RouteDecision::TorShared) => Ok(client),
         Ok(RouteDecision::TorIsolated) => Ok(client.map(|client| client.isolated_client())),
@@ -385,34 +607,179 @@ pub(crate) fn tor_client_for_route(isolated: bool) -> Result<Option<TorClient>, 
     }
 }
 
+/// Serialises the tests that touch the process-wide route policy.
+///
+/// `cargo test` shares one process across threads, so this has to be reachable
+/// from every module whose tests read the policy — not just the ones that write
+/// it. A direct-route lease consults the desired route on every poll, so a test
+/// that merely opens a direct connection fails if a route test is mid-flight.
+#[cfg(test)]
+pub(crate) mod test_route_policy {
+    use std::sync::{atomic::Ordering, Mutex, MutexGuard};
+
+    static ROUTE_POLICY: Mutex<()> = Mutex::new(());
+
+    pub(crate) struct RoutePolicyGuard {
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl Drop for RoutePolicyGuard {
+        /// Hands the process back in its default state. The direct-route epoch
+        /// only ever moves forward and each lease compares against the value it
+        /// captured, so it needs no restoring.
+        fn drop(&mut self) {
+            super::disable_tor();
+            super::ROUTE_DECIDED.store(false, Ordering::Release);
+        }
+    }
+
+    pub(crate) fn lock_route_policy() -> RoutePolicyGuard {
+        RoutePolicyGuard {
+            _lock: ROUTE_POLICY
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
+        sync::atomic::Ordering,
         task::{Context, Poll, Waker},
         time::Duration,
     };
 
     use super::{
-        await_tor_bootstrap, cancel_direct_connections, init_lock, route_decision, DirectRouteIo,
-        NetworkPrivacyStatus, RouteDecision, TOR_BOOTSTRAP_TIMEOUT_MESSAGE,
+        await_tor_bootstrap, begin_tor_enable, bootstrap_tor, cancel_direct_connections,
+        client_slot, disable_tor, init_lock, install_bootstrapped_client, is_route_decided,
+        is_tor_desired, mark_direct_route, mark_tor_desired, route_decision, set_tor_failed,
+        status, test_route_policy::lock_route_policy, tor_client_for_route, DirectRouteIo,
+        NetworkPrivacyStatus, RouteDecision, TorClient, BOOTSTRAP_ABANDONED_MESSAGE,
+        ROUTE_DECIDED, ROUTE_NOT_DECLARED_MESSAGE, STATUS_READY,
+        TOR_BOOTSTRAP_TIMEOUT_MESSAGE, TOR_STATUS,
     };
 
     #[test]
     fn direct_route_does_not_require_a_tor_client() {
         assert_eq!(
-            route_decision(false, NetworkPrivacyStatus::Direct, false, false),
+            route_decision(true, false, NetworkPrivacyStatus::Direct, false, false),
             Ok(RouteDecision::Direct)
         );
     }
 
     #[test]
+    fn an_undeclared_route_is_refused_instead_of_resolving_to_a_direct_connection() {
+        let _policy = lock_route_policy();
+        // The state a process starts in, and the one a background wake into a
+        // cold process is still in until something declares.
+        assert!(!is_route_decided());
+
+        assert_eq!(
+            route_decision(false, false, NetworkPrivacyStatus::Direct, false, false),
+            Err(ROUTE_NOT_DECLARED_MESSAGE)
+        );
+        // The chokepoint every Rust lightwalletd connection funnels through:
+        // an entry point that never declared must not get a transport out of it.
+        assert!(
+            tor_client_for_route(false).is_err(),
+            "an undeclared route resolved to a direct connection"
+        );
+        assert!(
+            tor_client_for_route(true).is_err(),
+            "an undeclared route resolved to a direct connection"
+        );
+    }
+
+    #[test]
+    fn a_declared_direct_route_still_connects_directly() {
+        let _policy = lock_route_policy();
+
+        mark_direct_route();
+
+        assert!(is_route_decided());
+        assert!(!is_tor_desired());
+        assert!(matches!(tor_client_for_route(false), Ok(None)));
+        assert!(matches!(tor_client_for_route(true), Ok(None)));
+    }
+
+    /// The claim on the route and the state change it implies are one
+    /// operation, so a `disable_tor` cannot run between them.
+    ///
+    /// Split, the adoption claimed the route, was preempted, and its writes
+    /// arrived after a whole disable had finished — putting the route back to
+    /// Tor with the client dropped and no bootstrap behind it, which refuses
+    /// every request on a route the app believes is direct. Held here by
+    /// blocking the adoption on the slot lock and checking that it has claimed
+    /// nothing yet: before the fix the claim was already made while it waited.
+    #[test]
+    fn an_adoption_claims_no_route_until_it_can_act_on_it() {
+        let _policy = lock_route_policy();
+        let slot = client_slot()
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let adopting = std::thread::spawn(mark_tor_desired);
+        // Long enough for the thread to reach the lock. Overshooting only
+        // makes the check stricter; it cannot turn a held claim into an
+        // unheld one.
+        std::thread::sleep(Duration::from_millis(200));
+
+        assert!(
+            !ROUTE_DECIDED.load(Ordering::Acquire),
+            "the route was claimed before the claim could be acted on"
+        );
+
+        drop(slot);
+        adopting.join().expect("the adoption thread");
+        assert!(is_tor_desired());
+    }
+
+    /// A bootstrap is for a route, and stops when that route does.
+    ///
+    /// Clearing the client slot never reached the future running inside the
+    /// bootstrap, so turning Tor off left arti talking to directory
+    /// authorities for the rest of the deadline, holding the init lock a
+    /// re-enable would wait behind.
+    #[tokio::test]
+    async fn a_bootstrap_stops_when_the_route_it_is_for_goes_away() {
+        let _policy = lock_route_policy();
+        begin_tor_enable();
+
+        let switching_to_direct = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            disable_tor();
+        });
+        let result = await_tor_bootstrap(
+            Duration::from_secs(5),
+            std::future::pending::<Result<(), String>>(),
+        )
+        .await;
+        switching_to_direct.await.expect("the disable task");
+
+        assert_eq!(result.unwrap_err(), BOOTSTRAP_ABANDONED_MESSAGE);
+    }
+
+    #[test]
+    fn marking_a_stale_direct_preference_leaves_a_process_that_chose_tor_alone() {
+        let _policy = lock_route_policy();
+        mark_tor_desired();
+
+        mark_direct_route();
+
+        assert!(is_tor_desired());
+        assert_eq!(status(), NetworkPrivacyStatus::Bootstrapping);
+        assert!(tor_client_for_route(false).is_err());
+    }
+
+    #[test]
     fn tor_bootstrap_and_failure_are_fail_closed() {
         assert_eq!(
-            route_decision(true, NetworkPrivacyStatus::Bootstrapping, false, false),
+            route_decision(true, true, NetworkPrivacyStatus::Bootstrapping, false, false),
             Err("Tor is still connecting")
         );
         assert_eq!(
-            route_decision(true, NetworkPrivacyStatus::Failed, false, false),
+            route_decision(true, true, NetworkPrivacyStatus::Failed, false, false),
             Err("Tor connection failed")
         );
     }
@@ -420,11 +787,11 @@ mod tests {
     #[test]
     fn ready_tor_selects_shared_or_isolated_routes() {
         assert_eq!(
-            route_decision(true, NetworkPrivacyStatus::Ready, true, false),
+            route_decision(true, true, NetworkPrivacyStatus::Ready, true, false),
             Ok(RouteDecision::TorShared)
         );
         assert_eq!(
-            route_decision(true, NetworkPrivacyStatus::Ready, true, true),
+            route_decision(true, true, NetworkPrivacyStatus::Ready, true, true),
             Ok(RouteDecision::TorIsolated)
         );
     }
@@ -432,13 +799,71 @@ mod tests {
     #[test]
     fn ready_status_without_a_client_is_still_fail_closed() {
         assert_eq!(
-            route_decision(true, NetworkPrivacyStatus::Ready, false, false),
+            route_decision(true, true, NetworkPrivacyStatus::Ready, false, false),
             Err("Tor is enabled but unavailable")
         );
     }
 
     #[test]
+    fn marking_a_persisted_tor_route_refuses_instead_of_going_direct() {
+        let _policy = lock_route_policy();
+        // Undeclared going in: this is the cold background process the mark
+        // exists for, so the contrast below is with a refusal, not with a
+        // direct connection.
+        assert_eq!(
+            route_decision(is_route_decided(), is_tor_desired(), status(), false, false),
+            Err(ROUTE_NOT_DECLARED_MESSAGE)
+        );
+
+        mark_tor_desired();
+
+        assert!(is_tor_desired());
+        assert_eq!(
+            route_decision(is_route_decided(), is_tor_desired(), status(), false, false),
+            Err("Tor is still connecting")
+        );
+        assert!(tor_client_for_route(false).is_err());
+    }
+
+    #[test]
+    fn marking_a_persisted_tor_route_does_not_bootstrap_a_client() {
+        let _policy = lock_route_policy();
+
+        mark_tor_desired();
+
+        assert_eq!(status(), NetworkPrivacyStatus::Bootstrapping);
+        assert!(client_slot()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_none());
+    }
+
+    #[test]
+    fn marking_a_persisted_tor_route_leaves_a_connected_process_alone() {
+        let _policy = lock_route_policy();
+        mark_tor_desired();
+        TOR_STATUS.store(STATUS_READY, Ordering::Release);
+
+        mark_tor_desired();
+
+        assert_eq!(status(), NetworkPrivacyStatus::Ready);
+    }
+
+    #[test]
+    fn marking_a_stale_tor_preference_leaves_a_process_that_chose_direct_alone() {
+        let _policy = lock_route_policy();
+        disable_tor();
+
+        mark_tor_desired();
+
+        assert!(!is_tor_desired());
+        assert_eq!(status(), NetworkPrivacyStatus::Direct);
+        assert!(matches!(tor_client_for_route(false), Ok(None)));
+    }
+
+    #[test]
     fn direct_route_io_is_cancelled_when_tor_activation_advances_the_epoch() {
+        let _policy = lock_route_policy();
         let io = DirectRouteIo::new(());
         let waker = Waker::noop();
         let mut context = Context::from_waker(waker);
@@ -470,8 +895,102 @@ mod tests {
         assert_eq!(result.unwrap_err(), TOR_BOOTSTRAP_TIMEOUT_MESSAGE);
     }
 
+    /// A path that already exists as a file, so a bootstrap started against it
+    /// fails at its first filesystem step. No test may reach a real bootstrap:
+    /// that is network work, and on a blocked network it does not terminate.
+    fn unusable_tor_directory(temp: &tempfile::TempDir) -> std::path::PathBuf {
+        let path = temp.path().join("tor");
+        std::fs::write(&path, b"").unwrap();
+        path
+    }
+
+    #[test]
+    fn a_route_that_went_direct_keeps_its_status_when_a_bootstrap_fails() {
+        let _policy = lock_route_policy();
+        mark_tor_desired();
+        disable_tor();
+
+        assert_eq!(status(), NetworkPrivacyStatus::Direct);
+        assert!(client_slot()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_none());
+
+        // A bootstrap started before the switch reports its failure afterwards.
+        // The route is direct now, so the failure is not this route's to
+        // publish — a Failed status here would block requests the user asked to
+        // send directly.
+        set_tor_failed();
+
+        assert_eq!(status(), NetworkPrivacyStatus::Direct);
+        assert_eq!(
+            route_decision(is_route_decided(), is_tor_desired(), status(), false, false),
+            Ok(RouteDecision::Direct)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_bootstrap_that_runs_out_of_time_stays_fail_closed() {
+        let _policy = lock_route_policy();
+        mark_tor_desired();
+
+        let result = install_bootstrapped_client(
+            Duration::from_millis(1),
+            std::future::pending::<Result<TorClient, String>>(),
+        )
+        .await;
+
+        assert_eq!(result.unwrap_err(), TOR_BOOTSTRAP_TIMEOUT_MESSAGE);
+        assert!(is_tor_desired());
+        assert_eq!(status(), NetworkPrivacyStatus::Failed);
+        assert!(tor_client_for_route(false).is_err());
+    }
+
+    #[tokio::test]
+    async fn a_bootstrap_waiting_on_another_bootstrap_is_bounded_by_its_own_deadline() {
+        let _policy = lock_route_policy();
+        let temp = tempfile::tempdir().unwrap();
+        mark_tor_desired();
+
+        // A bootstrap already in flight, of the kind a foreground enable starts:
+        // it holds the init lock for far longer than the waiter's whole budget.
+        let (acquired_tx, acquired_rx) = tokio::sync::oneshot::channel();
+        let holder = tokio::spawn(async move {
+            let _init_guard = init_lock().lock().await;
+            let _ = acquired_tx.send(());
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        });
+        acquired_rx.await.unwrap();
+
+        let started = std::time::Instant::now();
+        let result = bootstrap_tor(&unusable_tor_directory(&temp), Duration::from_millis(100)).await;
+        let waited = started.elapsed();
+
+        holder.abort();
+        let _ = holder.await;
+
+        // The deadline covers the wait, not just the bootstrap on its far side.
+        // A background pass has one execution opportunity and no cancellation
+        // handle reaching into this call, so parking here for the holder's
+        // deadline spends the window with nothing armed.
+        assert!(
+            waited < Duration::from_secs(5),
+            "a waiting bootstrap ignored its own deadline: waited {waited:?}"
+        );
+        assert_eq!(result.unwrap_err(), TOR_BOOTSTRAP_TIMEOUT_MESSAGE);
+        // Running out of time is still not a reason to reach the network another
+        // way: the route stays Tor and every policy-aware client keeps refusing.
+        assert!(is_tor_desired());
+        assert!(tor_client_for_route(false).is_err());
+    }
+
     #[tokio::test]
     async fn a_stalled_tor_bootstrap_releases_the_init_lock_for_the_next_attempt() {
+        // The route-policy lock covers the init lock too: the background enable
+        // tests reach it through a real `bootstrap_tor`, and this test reads it
+        // as a global, so an unserialised run sees the other test's guard and
+        // reports it as a leak.
+        let _policy = lock_route_policy();
         let result = {
             let _init_guard = init_lock().lock().await;
             await_tor_bootstrap(

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -713,6 +713,9 @@ mod tests {
 
     #[tokio::test]
     async fn direct_connections_keep_tcp_nodelay_enabled() {
+        // A direct-route lease aborts itself whenever the process-wide route is
+        // Tor, so this has to hold the policy even though it never writes it.
+        let _policy = crate::network_privacy::test_route_policy::lock_route_policy();
         let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
             .await
             .expect("bind loopback listener");

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -23,6 +23,13 @@ pub fn repo_root() -> PathBuf {
 }
 
 pub fn exclusive_regtest() -> MutexGuard<'static, ()> {
+    // Every regtest test takes this before its first lightwalletd call, which
+    // makes it the one place this process declares its route. The library
+    // refuses a route nothing has declared instead of treating it as direct, so
+    // that a background entry point which never read the user's preference
+    // cannot reach lightwalletd on a Tor wallet; a test process is exactly such
+    // a caller, and it says direct for the same reason the native passes do.
+    rust_lib_zcash_wallet::network_privacy::mark_direct_route();
     match REGTEST_LOCK.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),

--- a/rust/tests/ironwood_regtest_migration.rs
+++ b/rust/tests/ironwood_regtest_migration.rs
@@ -164,6 +164,11 @@ fn run_harness(script: &str, args: &[&str]) -> String {
 }
 
 fn ensure_stack_up() {
+    // Declared before the first lightwalletd call. The library refuses a route
+    // nothing has declared rather than treating it as direct, so that a caller
+    // which never read the user's preference cannot reach the network; a test
+    // process says direct for the same reason the native passes do.
+    rust_lib_zcash_wallet::network_privacy::mark_direct_route();
     run_harness("up.sh", &[]);
 }
 

--- a/test/core/storage/tor_directory_backup_exclusion_test.dart
+++ b/test/core/storage/tor_directory_backup_exclusion_test.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// The Tor data directory name is declared twice: `getTorDataDirectoryPath`
+/// appends it in Dart, and Android's data-extraction rules exclude the same
+/// path from backup and device-to-device transfer. The two are hand-typed
+/// literals, and a divergence fails quietly: arti re-downloads its directory
+/// cache under the new name while the old exclusion guards an empty path, so
+/// the wallet's guard choice rides along to a transferred device.
+void main() {
+  test('the Android backup exclusion names the Tor directory Dart uses', () {
+    final dart = File(
+      'lib/src/core/storage/wallet_paths.dart',
+    ).readAsStringSync();
+    expect(
+      dart,
+      contains(r"${Platform.pathSeparator}tor"),
+      reason: 'getTorDataDirectoryPath no longer appends the tor directory; '
+          'update android/app/src/main/res/xml/data_extraction_rules.xml '
+          'with it',
+    );
+
+    final rules = File(
+      'android/app/src/main/res/xml/data_extraction_rules.xml',
+    ).readAsStringSync();
+    expect(rules, contains('path="tor"'));
+  });
+}

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -37,6 +37,7 @@ import 'package:zcash_wallet/src/features/migration/services/ironwood_migration_
 import 'package:zcash_wallet/src/features/keystone/widgets/keystone_pczt_qr_stage.dart';
 import 'package:zcash_wallet/src/features/keystone/widgets/keystone_qr_scanner_card.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/keystone.dart' as rust_keystone;
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
@@ -357,6 +358,29 @@ class _ControlledRefreshTestMigrationCoordinator
       ref.invalidate(ironwoodMigrationRouteCtaProvider);
     }
   }
+}
+
+/// A wallet whose saved route is Tor, which is the state both native
+/// background lanes only run in on external power over an unmetered link.
+class _TorRouteNetworkPrivacyNotifier extends NetworkPrivacyNotifier {
+  @override
+  NetworkPrivacyState build() => const NetworkPrivacyState(
+    torEnabled: true,
+    status: NetworkPrivacyConnectionStatus.connected,
+  );
+}
+
+/// A disable whose transport switched and whose preference write failed: this
+/// process sends directly, but the saved route — the only thing a background
+/// wake reads — still says Tor.
+class _SaveFailedDisableNetworkPrivacyNotifier extends NetworkPrivacyNotifier {
+  @override
+  NetworkPrivacyState build() => const NetworkPrivacyState(
+    torEnabled: false,
+    status: NetworkPrivacyConnectionStatus.failed,
+    targetTorEnabled: false,
+    savedRouteTorEnabled: true,
+  );
 }
 
 class _PreparationHandoffTestMigrationCoordinator
@@ -6328,6 +6352,295 @@ void main() {
     },
   );
 
+  testWidgets('background copy follows the saved route after a failed save', (
+    tester,
+  ) async {
+    // The native lanes read the saved preference from a process where Dart
+    // may never run, so a disable whose save failed leaves them constrained
+    // even though this process now sends directly. Copy that promised
+    // unconstrained background progress here would have the user close Vizor
+    // and wait for a wake that defers off the charger.
+    _useMobileViewport(tester);
+    final coordinator = _PreparationHandoffTestMigrationCoordinator();
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.authorized,
+          getPreparationRuntimeState:
+              ({
+                required network,
+                required accountUuid,
+                required runId,
+              }) async => IronwoodMigrationPreparationRuntimeState.scheduled,
+        ),
+        migrationCoordinator: () => coordinator,
+        status: _status(
+          phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _SaveFailedDisableNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        'While Tor is on, migration continues only while Vizor is open.',
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('states the conditions Tor needs to confirm in the background', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    final coordinator = _PreparationHandoffTestMigrationCoordinator();
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.authorized,
+          getPreparationRuntimeState:
+              ({
+                required network,
+                required accountUuid,
+                required runId,
+              }) async => IronwoodMigrationPreparationRuntimeState.idle,
+        ),
+        migrationCoordinator: () => coordinator,
+        status: _status(
+          phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        'While Tor is on, migration continues only while Vizor is open.',
+      ),
+      findsOneWidget,
+    );
+    // The neutral duration copy would let the user close Vizor off the charger
+    // and stall the run, and this device is capable — the route is the limit,
+    // not the OS.
+    expect(find.text('Preparation will\ntake 10–20 min'), findsNothing);
+    expect(
+      find.text(
+        'This device can’t confirm in the background. Keep Vizor open.',
+      ),
+      findsNothing,
+    );
+    // The old flat refusal is wrong now: the gate does let the pass run.
+    expect(
+      find.text('Tor can’t confirm in the background. Keep Vizor open.'),
+      findsNothing,
+    );
+  });
+
+  testWidgets('keeps stating the Tor conditions while the background task is '
+      'armed', (tester) async {
+    _useMobileViewport(tester);
+    final coordinator = _PreparationHandoffTestMigrationCoordinator();
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.authorized,
+          // An armed task proves only that the gate passed for this pass.
+          getPreparationRuntimeState:
+              ({
+                required network,
+                required accountUuid,
+                required runId,
+              }) async => IronwoodMigrationPreparationRuntimeState.running,
+        ),
+        migrationCoordinator: () => coordinator,
+        status: _status(
+          phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Unqualified, this promise outlives unplugging the charger or moving onto
+    // a metered link, either of which stands the next pass down.
+    expect(
+      find.text('Confirming in the background. You can close Vizor.'),
+      findsNothing,
+    );
+    expect(
+      find.text(
+        'While Tor is on, migration continues only while Vizor is open.',
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('names the notification block alongside the Tor conditions', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    final coordinator = _DurablePhaseRetryTestMigrationCoordinator();
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.denied,
+          getPreparationRuntimeState:
+              ({
+                required network,
+                required accountUuid,
+                required runId,
+              }) async => IronwoodMigrationPreparationRuntimeState.disabled,
+        ),
+        migrationCoordinator: () => coordinator,
+        status: _status(
+          phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Both native lanes refuse on a denied notification whatever the route is,
+    // so stating only the route hands the user a condition they can meet while
+    // nothing moves afterwards. The route condition is transient; this one is
+    // not, so it leads.
+    expect(
+      find.text(
+        'Allow notifications. With Tor on, migration continues only in the '
+        'app.',
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.text(
+        'While Tor is on, migration continues only while Vizor is open.',
+      ),
+      findsNothing,
+    );
+    // It has to fit the preparation dial, which is what kept this to one
+    // message in the first place.
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('names the device limit ahead of the Tor conditions when the '
+      'device has no background lane', (tester) async {
+    _useMobileViewport(tester);
+    final coordinator = _PreparationHandoffTestMigrationCoordinator();
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.authorized,
+          supportsBackgroundPreparationTracking: () async => false,
+          getPreparationRuntimeState:
+              ({
+                required network,
+                required accountUuid,
+                required runId,
+              }) async => IronwoodMigrationPreparationRuntimeState.idle,
+        ),
+        migrationCoordinator: () => coordinator,
+        status: _status(
+          phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Charging on an unmetered network cannot give this OS build a lane it
+    // never had, so naming a condition the user could meet would over-promise.
+    expect(
+      find.text(
+        'This device can’t confirm in the background. Keep Vizor open.',
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('only while Vizor is open'),
+      findsNothing,
+    );
+  });
+
+  testWidgets('broadcasting copy promises background delivery on a Tor route '
+      'only under its conditions', (tester) async {
+    _useMobileViewport(tester);
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.authorized,
+        ),
+        status: _status(
+          phase: kIronwoodMigrationBroadcastingPhase,
+          nextActionHeight: 3_000_020,
+        ),
+        syncState: SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          scannedHeight: 3_000_000,
+          chainTipHeight: 3_000_000,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        'Next migration step expected in\n'
+        '~25 minutes.\n'
+        'While Tor is on, this continues only while Vizor is open.',
+      ),
+      findsOneWidget,
+    );
+    // Authorized notifications alone cannot carry a wake the gate can stand
+    // down, so the unconditional invitation to leave must not appear.
+    expect(find.textContaining('You can leave Vizor'), findsNothing);
+  });
+
   testWidgets('resumes software preparation on reentry without a tap', (
     tester,
   ) async {
@@ -7428,6 +7741,48 @@ void main() {
         'Next migration step expected in\n'
         '~25 minutes.\n'
         'Notifications are disabled. Open Vizor again to continue.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Notifications are on'), findsNothing);
+  });
+
+  testWidgets('broadcasting copy names disabled notifications on a Tor route', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(),
+        status: _status(
+          phase: kIronwoodMigrationBroadcastingPhase,
+          nextActionHeight: 3_000_020,
+        ),
+        syncState: SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          scannedHeight: 3_000_000,
+          chainTipHeight: 3_000_000,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The route only delays the wake; a denied notification stops it outright.
+    // Charging on an unmetered network would still deliver nothing, so the
+    // notification block cannot be hidden behind the route condition.
+    expect(
+      find.text(
+        'Next migration step expected in\n'
+        '~25 minutes.\n'
+        'Notifications are disabled. Open Vizor again to continue.\n'
+        'While Tor is on, this continues only while Vizor is open.',
       ),
       findsOneWidget,
     );

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:zcash_wallet/src/core/widgets/mobile/mobile_list_row.dart';
 import 'package:zcash_wallet/src/features/settings/screens/mobile/mobile_settings_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/biometric_unlock_provider.dart';
+import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/theme_mode_provider.dart';
@@ -120,10 +121,19 @@ Widget _app({
   BiometricUnlockState? biometric,
   BiometricUnlockNotifier Function()? biometricNotifier,
   _FakeSyncKeepAwakeNotifier? syncKeepAwakeNotifier,
+  NetworkPrivacyState? networkPrivacyState,
+  List<bool>? networkPrivacyCalls,
 }) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap(accountState)),
+      if (networkPrivacyState != null)
+        networkPrivacyProvider.overrideWith(
+          () => _FakeNetworkPrivacyNotifier(
+            networkPrivacyState,
+            networkPrivacyCalls ?? <bool>[],
+          ),
+        ),
       syncProvider.overrideWith(() => FakeSyncNotifier(SyncState())),
       themeModeProvider.overrideWith(_FakeThemeModeNotifier.new),
       syncKeepAwakeProvider.overrideWith(
@@ -143,6 +153,23 @@ Widget _app({
   );
 }
 
+class _FakeNetworkPrivacyNotifier extends NetworkPrivacyNotifier {
+  _FakeNetworkPrivacyNotifier(this._state, this.calls);
+
+  final NetworkPrivacyState _state;
+
+  /// Routes requested by the card. `retry()` funnels through here too.
+  final List<bool> calls;
+
+  @override
+  NetworkPrivacyState build() => _state;
+
+  @override
+  Future<void> setTorEnabled(bool enabled) async {
+    calls.add(enabled);
+  }
+}
+
 void main() {
   setUp(() {
     // Phone-sized surface so the lazily-built list renders every group.
@@ -150,6 +177,367 @@ void main() {
     binding.platformDispatcher.views.first
       ..physicalSize = const Size(520, 1200)
       ..devicePixelRatio = 1.0;
+  });
+
+  testWidgets('the Tor card reports the off route', (tester) async {
+    await tester.pumpWidget(
+      _app(networkPrivacyState: const NetworkPrivacyState.off()),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('mobile_settings_tor_row')),
+      200,
+    );
+    expect(find.text('Use Tor'), findsOneWidget);
+    expect(find.text('Off'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data,
+      contains('connect directly'),
+    );
+  });
+
+  testWidgets('tapping the Tor row asks for the other route', (tester) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState.off(),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final row = find.byKey(const ValueKey('mobile_settings_tor_row'));
+    await tester.scrollUntilVisible(row, 200);
+    await tester.tap(row);
+    await tester.pumpAndSettle();
+
+    expect(calls, [true]);
+  });
+
+  testWidgets('the Tor toggle matches the keep-awake toggle', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connected,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final torThumb = find.byKey(
+      const ValueKey('mobile_settings_tor_toggle_thumb'),
+    );
+    final torTrack = find.byKey(const ValueKey('mobile_settings_tor_toggle'));
+    await tester.scrollUntilVisible(torThumb, 200);
+    expect(
+      tester.getSize(torThumb),
+      tester.getSize(
+        find.byKey(
+          const ValueKey('mobile_settings_sync_keep_awake_toggle_thumb'),
+        ),
+      ),
+    );
+    expect(
+      tester.getSize(torTrack),
+      tester.getSize(
+        find.byKey(const ValueKey('mobile_settings_sync_keep_awake_toggle')),
+      ),
+    );
+    expect(
+      tester.getCenter(torThumb).dx,
+      greaterThan(tester.getCenter(torTrack).dx),
+    );
+  });
+
+  testWidgets(
+    'a connected Tor route names the conditions background work needs',
+    (tester) async {
+      await tester.pumpWidget(
+        _app(
+          networkPrivacyState: const NetworkPrivacyState(
+            torEnabled: true,
+            status: NetworkPrivacyConnectionStatus.connected,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.byKey(const ValueKey('mobile_settings_tor_row')),
+        200,
+      );
+      expect(find.text('Connected'), findsOneWidget);
+      final description = tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data;
+      expect(
+        description,
+        contains(
+          'While Tor is on, a migration in progress advances only while '
+          'Vizor is open.',
+        ),
+      );
+      // The card must not promise conditional background progress: background
+      // passes never bring Tor up, so there is no charger-and-Wi-Fi gate to
+      // meet.
+      expect(description, isNot(contains('charging on an unmetered network')));
+    },
+  );
+
+  testWidgets('a connecting Tor route says requests are paused', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connecting,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    // pump() only: a connecting card must never be pumpAndSettle'd if it ever
+    // animates.
+    await tester.pump();
+
+    final row = find.byKey(const ValueKey('mobile_settings_tor_row'));
+    await tester.scrollUntilVisible(row, 200);
+    expect(find.text('Connecting…'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data,
+      contains('wait until the Tor connection is ready'),
+    );
+    // The bootstrap runs to a three-minute deadline with every request failing
+    // closed, and relaunching starts the same wait, so switching to direct has
+    // to stay reachable for the whole of it.
+    expect(tester.widget<GestureDetector>(row).onTap, isNotNull);
+    await tester.tap(row);
+    await tester.pump();
+    expect(calls, [false]);
+  });
+
+  testWidgets('a switch to direct cannot be driven back into Tor', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connecting,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pump();
+
+    final row = find.byKey(const ValueKey('mobile_settings_tor_row'));
+    await tester.scrollUntilVisible(row, 200);
+    // Nothing to escape from here: the route is already on its way to direct.
+    expect(tester.widget<GestureDetector>(row).onTap, isNull);
+    await tester.tap(row);
+    await tester.pump();
+    expect(calls, isEmpty);
+  });
+
+  testWidgets('a failed Tor route stays blocked and offers a retry', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final retry = find.byKey(const ValueKey('mobile_settings_tor_retry'));
+    await tester.scrollUntilVisible(retry, 200);
+    expect(find.text('Failed'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data,
+      contains('Requests stay blocked'),
+    );
+    expect(find.text('Try again'), findsOneWidget);
+
+    await tester.tap(retry);
+    await tester.pumpAndSettle();
+
+    expect(calls, [true]);
+  });
+
+  testWidgets('a failed switch to direct says Tor is still carrying traffic', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final retry = find.byKey(const ValueKey('mobile_settings_tor_retry'));
+    await tester.scrollUntilVisible(retry, 200);
+    expect(find.text('Switch failed'), findsOneWidget);
+    final description = tester
+        .widget<Text>(
+          find.byKey(const ValueKey('mobile_settings_tor_description')),
+        )
+        .data;
+    expect(description, contains('could not switch to a direct connection'));
+    expect(description, contains('Tor is still on'));
+    expect(description, isNot(contains('Requests stay blocked')));
+    expect(find.text('Try direct connection'), findsOneWidget);
+
+    await tester.tap(retry);
+    await tester.pumpAndSettle();
+
+    expect(calls, [false]);
+  });
+
+  testWidgets('an aborted enable never claims requests are blocked', (
+    tester,
+  ) async {
+    // The write-first ordering aborts an enable whose save failed before the
+    // process changes at all, so requests keep flowing directly. The
+    // bootstrap-failure copy — requests stay blocked — would describe the
+    // opposite of what is happening.
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: false,
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: true,
+        ),
+        networkPrivacyCalls: <bool>[],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('mobile_settings_tor_retry')),
+      200,
+    );
+    final description = tester
+        .widget<Text>(
+          find.byKey(const ValueKey('mobile_settings_tor_description')),
+        )
+        .data;
+    expect(description, isNot(contains('stay blocked')));
+    expect(description, contains('was not turned on'));
+    expect(find.text('Setting not saved'), findsOneWidget);
+  });
+
+  testWidgets('a save-only failure never claims Tor is carrying traffic', (
+    tester,
+  ) async {
+    // The transport did switch and only the preference write failed, so this
+    // shares `(failed, target: false)` with the case above while carrying the
+    // opposite privacy guarantee. Reading the target alone told the user Tor
+    // was still on while their requests were going out directly.
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: false,
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: <bool>[],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('mobile_settings_tor_retry')),
+      200,
+    );
+    final description = tester
+        .widget<Text>(
+          find.byKey(const ValueKey('mobile_settings_tor_description')),
+        )
+        .data;
+    expect(description, isNot(contains('Tor is still on')));
+    expect(description, contains('direct connection'));
+    // The saved route stays at Tor — the stricter half — so the next launch
+    // comes back on Tor rather than silently staying direct.
+    expect(description, contains('next time you open the app'));
+  });
+
+  testWidgets('the Tor row publishes its status to assistive technology', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('mobile_settings_tor_retry')),
+      200,
+    );
+    expect(
+      tester.getSemantics(
+        find.byKey(const ValueKey('mobile_settings_tor_row')),
+      ),
+      isSemantics(label: 'Use Tor', value: 'Failed', isButton: true),
+    );
+    expect(
+      tester.getSemantics(
+        find.byKey(const ValueKey('mobile_settings_tor_retry')),
+      ),
+      isSemantics(label: 'Try again', isButton: true, hasTapAction: true),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('the Tor retry action is a touch-sized target', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final retry = find.byKey(const ValueKey('mobile_settings_tor_retry'));
+    await tester.scrollUntilVisible(retry, 200);
+    expect(tester.getSize(retry).height, greaterThanOrEqualTo(44));
   });
 
   testWidgets('renders the grouped settings with live values', (tester) async {
@@ -427,6 +815,10 @@ void main() {
     await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
     await tester.pump();
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(const ValueKey('mobile_settings_biometric_row')),
     );
@@ -467,6 +859,10 @@ void main() {
     await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
     await tester.pump();
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(const ValueKey('mobile_settings_biometric_row')),
     );
@@ -503,6 +899,10 @@ void main() {
     await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
     await tester.pump();
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(const ValueKey('mobile_settings_biometric_row')),
     );

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/settings/screens/settings_screen.dart';
 import 'package:zcash_wallet/src/features/settings/settings_platform.dart';
+import 'package:zcash_wallet/src/features/settings/widgets/network_privacy_control.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
@@ -198,7 +199,10 @@ void main() {
 
     expect(find.text('Connecting…'), findsOneWidget);
     expect(
-      find.text('New requests wait until the Tor connection is ready.'),
+      find.text(
+        'New requests wait until the Tor connection is ready. Turn Tor off to '
+        'stop connecting and use a direct connection.',
+      ),
       findsOneWidget,
     );
 
@@ -206,8 +210,116 @@ void main() {
       find.byKey(const ValueKey('network_privacy_status_icon')),
     );
     expect(statusIcon.name, AppIcons.loader);
-    expect(_toggleTrackOpacity(tester), lessThan(1));
+    // Not dimmed: the control is the way out of the wait, so it has to look
+    // like something the user may act on.
+    expect(_toggleTrackOpacity(tester), 1);
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('network_privacy_toggle')),
+    );
+    await tester.tap(find.byKey(const ValueKey('network_privacy_toggle')));
+    await tester.pump();
+    // The bootstrap runs to a three-minute deadline with every request failing
+    // closed, and relaunching starts the same wait, so switching to direct has
+    // to stay reachable for the whole of it.
+    expect(calls, [false]);
+  });
+
+  test('the toggle offers an escape from a pending Tor connection', () {
+    // Every state maps to exactly one action, and the connecting-to-Tor state
+    // maps to an escape rather than to nothing.
+    NetworkPrivacyToggleAction actionFor({
+      required bool torEnabled,
+      required NetworkPrivacyConnectionStatus status,
+      bool? targetTorEnabled,
+    }) => networkPrivacyToggleAction(
+      NetworkPrivacyState(
+        torEnabled: torEnabled,
+        status: status,
+        targetTorEnabled: targetTorEnabled,
+      ),
+    );
+
+    expect(
+      actionFor(
+        torEnabled: false,
+        status: NetworkPrivacyConnectionStatus.off,
+      ),
+      NetworkPrivacyToggleAction.enable,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connected,
+      ),
+      NetworkPrivacyToggleAction.disable,
+    );
+    // A startup activation publishes no explicit target, so the effective one
+    // is the route already shown — which is the state a user relaunching into a
+    // blocked network lands in.
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+      ),
+      NetworkPrivacyToggleAction.cancelPendingTor,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+        targetTorEnabled: true,
+      ),
+      NetworkPrivacyToggleAction.cancelPendingTor,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+        targetTorEnabled: false,
+      ),
+      NetworkPrivacyToggleAction.none,
+    );
+  });
+
+  test('cancelling a pending Tor connection asks for the direct route', () {
+    expect(
+      NetworkPrivacyToggleAction.cancelPendingTor.requestedTorEnabled,
+      isFalse,
+    );
+    expect(NetworkPrivacyToggleAction.enable.requestedTorEnabled, isTrue);
+    expect(NetworkPrivacyToggleAction.disable.requestedTorEnabled, isFalse);
+    // Leaving a wait is not a second transition, and does not announce itself
+    // as one.
+    expect(
+      NetworkPrivacyToggleAction.cancelPendingTor.semanticsLabel,
+      'Stop connecting to Tor',
+    );
+    expect(NetworkPrivacyToggleAction.disable.semanticsLabel, 'Use Tor');
+    expect(NetworkPrivacyToggleAction.none.isInteractive, isFalse);
+  });
+
+  testWidgets('a switch to direct cannot be driven back into Tor', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _settingsHarness(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connecting,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pump();
+
+    // Nothing to escape from here: the route is already on its way to direct.
+    expect(_toggleTrackOpacity(tester), lessThan(1));
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('network_privacy_toggle')),
+    );
     await tester.tap(
       find.byKey(const ValueKey('network_privacy_toggle')),
       warnIfMissed: false,
@@ -230,8 +342,8 @@ void main() {
     expect(find.text('Connected'), findsOneWidget);
     expect(
       find.text(
-        'Vizor’s network requests go through Tor. Links opened in other apps '
-        'use those apps’ network settings.',
+        'Wallet sync, most in-app requests, and software updates go through '
+        'Tor. Some services may be unavailable over Tor.',
       ),
       findsOneWidget,
     );
@@ -287,8 +399,9 @@ void main() {
 
       expect(
         find.text(
-          'Vizor’s network requests go through Tor. Links opened in other apps '
-          'use those apps’ network settings.',
+          'Wallet sync, most in-app requests, and software update checks go '
+          'through Tor. Update pages and downloads opened in another app '
+          'use that app’s connection.',
         ),
         findsOneWidget,
       );
@@ -341,8 +454,8 @@ void main() {
 
     expect(
       find.text(
-        'Vizor’s network requests go through Tor, but software updates are '
-        'unavailable.',
+        'Wallet sync and most in-app requests go through Tor. Software '
+        'updates are unavailable.',
       ),
       findsOneWidget,
     );

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -709,6 +709,8 @@ void main() {
     expect(state.torEnabled, isFalse);
     expect(state.status, NetworkPrivacyConnectionStatus.failed);
     expect(state.targetTorEnabled, isTrue);
+    // Nothing was saved and nothing was enabled; saved and enforced agree.
+    expect(state.savedRouteTorEnabled, isFalse);
   });
 
   test('a failed direct save still opens the direct request gate', () async {
@@ -760,6 +762,9 @@ void main() {
     expect(state.torEnabled, isFalse);
     expect(state.status, NetworkPrivacyConnectionStatus.failed);
     expect(state.targetTorEnabled, isFalse);
+    // What a background wake will read: the write failed, so the saved half
+    // is still Tor, and surfaces describing background behaviour follow it.
+    expect(state.savedRouteTorEnabled, isTrue);
   });
 
   test(

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -1,11 +1,64 @@
 import 'dart:async';
 
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
 import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/rust/network_privacy.dart' as rust_types;
 
 void main() {
+  // The launch this owner exists for reads almost nothing: a locked app routes
+  // to `/unlock`, `syncKeepAwakeActiveProvider` returns early on
+  // `requiresUnlock` before it reaches `syncProvider`, and the unlock screens
+  // only read that provider when the user submits. Nothing here builds a
+  // provider at all, which is the point — the persisted route is applied
+  // regardless of the lock, so the intent has to have an owner regardless too.
+  group('Tor dormancy lifecycle', () {
+    tearDown(disposeTorDormancyLifecycle);
+
+    testWidgets('sleeps only where backgrounding stops the process', (
+      tester,
+    ) async {
+      // Lane-dependent on purpose, and the desktop half is the load-bearing
+      // one: a desktop app with every window hidden keeps polling, and a
+      // client put to sleep underneath it pays a circuit build on each poll.
+      for (final (formFactor, expected) in [
+        (AppFormFactor.mobile, [true]),
+        (AppFormFactor.desktop, <bool>[]),
+      ]) {
+        final dormancy = <bool>[];
+        startTorDormancyLifecycle(
+          setTorDormant: ({required dormant}) => dormancy.add(dormant),
+          formFactor: formFactor,
+        );
+
+        await _sendAppLifecycleState(AppLifecycleState.inactive);
+        await _sendAppLifecycleState(AppLifecycleState.hidden);
+
+        expect(dormancy, expected, reason: '$formFactor');
+      }
+    });
+
+    testWidgets('wakes on every foreground entry', (tester) async {
+      // Asked for unconditionally: a sleep request that outlived its asker —
+      // issued before Tor finished bootstrapping, so it lands on the client
+      // only once that client exists — would otherwise keep the client asleep
+      // for the whole foreground session.
+      final dormancy = <bool>[];
+      startTorDormancyLifecycle(
+        setTorDormant: ({required dormant}) => dormancy.add(dormant),
+      );
+
+      await _sendAppLifecycleState(AppLifecycleState.inactive);
+      await _sendAppLifecycleState(AppLifecycleState.resumed);
+
+      expect(dormancy, contains(false));
+    });
+  });
+
+
   test('preference read failure pauses native updates before launch', () async {
     final events = <String>[];
     try {
@@ -40,6 +93,80 @@ void main() {
       );
     }
   });
+
+  test('enabling keeps the Tor directory out of device backups', () async {
+    final excluded = <String>[];
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          rust_types.NetworkPrivacyStatus.ready,
+      excludeTorDirectoryFromBackup: (directory) async =>
+          excluded.add(directory),
+    );
+
+    await runtime.configure(enabled: true);
+
+    // Once before the bootstrap, because the directory holds guard state from
+    // its first moment and the process can be killed during it, and once after,
+    // because the mark is best-effort.
+    expect(excluded, ['/tmp/vizor-tor', '/tmp/vizor-tor']);
+  });
+
+  test('a failed bootstrap still excludes the Tor directory', () async {
+    // Rust creates the directory and Arti writes guard state into it before
+    // the bootstrap can fail, so the failure path leaves exactly the state the
+    // exclusion exists to keep off a second device.
+    final excluded = <String>[];
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          throw StateError('bootstrap failed'),
+      excludeTorDirectoryFromBackup: (directory) async =>
+          excluded.add(directory),
+    );
+
+    await expectLater(
+      runtime.configure(enabled: true),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(excluded, ['/tmp/vizor-tor', '/tmp/vizor-tor']);
+  });
+
+  test('a backup exclusion failure is reported', () async {
+    final logs = <String>[];
+    final previousDebugPrint = debugPrint;
+    debugPrint = (message, {wrapWidth}) => logs.add(message ?? '');
+    addTearDown(() => debugPrint = previousDebugPrint);
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          rust_types.NetworkPrivacyStatus.ready,
+      excludeTorDirectoryFromBackup: (_) async =>
+          throw StateError('attribute write refused'),
+    );
+
+    await runtime.configure(enabled: true);
+
+    expect(logs, hasLength(2));
+    expect(logs.first, contains('attribute write refused'));
+  });
+
+  test('a backup exclusion failure does not fail the route', () async {
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          rust_types.NetworkPrivacyStatus.ready,
+      excludeTorDirectoryFromBackup: (_) async =>
+          throw StateError('no native side'),
+    );
+
+    expect(
+      await runtime.configure(enabled: true),
+      NetworkPrivacyConnectionStatus.connected,
+    );
+  });
+
 
   test('direct runtime configuration skips Tor directory lookup', () async {
     var directoryLookups = 0;
@@ -506,6 +633,40 @@ void main() {
       'configure:false',
       'native-resume',
     ]);
+  });
+
+  test('the saved route may be stricter than the runtime, never laxer', () {
+    // A wake that declares Tor and cannot afford it defers; a wake that
+    // declares direct against a session enforcing Tor puts wallet queries and
+    // signed transactions on a direct connection.
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: true,
+        runtimeTorDesired: true,
+      ),
+      isTrue,
+    );
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: false,
+        runtimeTorDesired: false,
+      ),
+      isTrue,
+    );
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: true,
+        runtimeTorDesired: false,
+      ),
+      isTrue,
+    );
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: false,
+        runtimeTorDesired: true,
+      ),
+      isFalse,
+    );
   });
 
   test('a failed strict save aborts the enable before anything changes', () async {
@@ -1271,3 +1432,13 @@ class _FakeDirectRequestGate implements NetworkPrivacyDirectRequestGate {
     events.add('direct-quiesce');
   }
 }
+
+Future<void> _sendAppLifecycleState(AppLifecycleState state) async {
+  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .handlePlatformMessage(
+        'flutter/lifecycle',
+        const StringCodec().encodeMessage(state.toString()),
+        (_) {},
+      );
+}
+

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -132,11 +132,11 @@ void main() {
 
     expect(events, [
       'native:true',
+      'store:true',
       'begin-enable',
       'runtime-quiesce',
       'direct-quiesce',
       'restart',
-      'store:true',
       'configure:true',
       'native-resume',
     ]);
@@ -178,11 +178,11 @@ void main() {
     final state = container.read(networkPrivacyProvider);
     expect(events, [
       'native:true',
+      'store:true',
       'begin-enable',
       'runtime-quiesce',
       'direct-quiesce',
       'restart',
-      'store:true',
       'configure:true',
     ]);
     expect(state.torEnabled, isTrue);
@@ -221,8 +221,8 @@ void main() {
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
+      'store:false',
       'direct-allow',
       'native:false',
     ]);
@@ -296,8 +296,8 @@ void main() {
       'native-prepare-disable',
       'native-disable-drained',
       'restart',
-      'store:false',
       'configure:false',
+      'store:false',
       'direct-allow',
       'native:false',
     ]);
@@ -381,6 +381,7 @@ void main() {
 
       expect(events, [
         'native:true',
+        'store:true',
         'begin-enable',
         'runtime-quiesce',
         'direct-quiesce',
@@ -478,7 +479,6 @@ void main() {
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
       'native-resume',
     ]);
@@ -503,10 +503,102 @@ void main() {
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
       'native-resume',
     ]);
+  });
+
+  test('a failed strict save aborts the enable before anything changes', () async {
+    final events = <String>[];
+    final runtime = _FakeRuntime(
+      events,
+      NetworkPrivacyConnectionStatus.connected,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        networkPrivacyPreferenceStoreProvider.overrideWithValue(
+          _WriteFailingStore(events, failOn: true),
+        ),
+        networkPrivacyRuntimeProvider.overrideWithValue(runtime),
+        networkPrivacyNativeUpdateCoordinatorProvider.overrideWithValue(
+          _FakeNativeUpdateCoordinator(events),
+        ),
+        networkPrivacyDirectRequestGateProvider.overrideWithValue(
+          _FakeDirectRequestGate(events),
+        ),
+        networkPrivacyTransportRestartProvider.overrideWithValue((
+          update,
+        ) async {
+          events.add('restart');
+          await update();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
+
+    // Refused before the process changes: no fail-closed switch, no drain, no
+    // transport restart. Requests keep flowing directly, the saved route
+    // still says direct, and the updater preflight is undone — the toggle
+    // simply never happened, apart from the failure the user is shown.
+    expect(events, ['native:true', 'store:write-failed', 'native:false']);
+    expect(runtime.isTorEnabled(), isFalse);
+    final state = container.read(networkPrivacyProvider);
+    expect(state.torEnabled, isFalse);
+    expect(state.status, NetworkPrivacyConnectionStatus.failed);
+    expect(state.targetTorEnabled, isTrue);
+  });
+
+  test('a failed direct save still opens the direct request gate', () async {
+    final events = <String>[];
+    final runtime = _FakeRuntime(
+      events,
+      NetworkPrivacyConnectionStatus.connected,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        networkPrivacyPreferenceStoreProvider.overrideWithValue(
+          _WriteFailingStore(events, failOn: false),
+        ),
+        networkPrivacyRuntimeProvider.overrideWithValue(runtime),
+        networkPrivacyNativeUpdateCoordinatorProvider.overrideWithValue(
+          _FakeNativeUpdateCoordinator(events),
+        ),
+        networkPrivacyDirectRequestGateProvider.overrideWithValue(
+          _FakeDirectRequestGate(events),
+        ),
+        networkPrivacyTransportRestartProvider.overrideWithValue((
+          update,
+        ) async {
+          events.add('restart');
+          await update();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
+    events.clear();
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(false);
+
+    // The runtime is direct with its Tor client dropped, so the gate follows
+    // it: left shut, every direct request would fail for the rest of the
+    // session behind a UI that reports Tor off. The saved route stays at Tor
+    // — the stricter half — so the next launch comes back on Tor instead of
+    // silently staying direct.
+    expect(events, [
+      'native-prepare-disable',
+      'restart',
+      'configure:false',
+      'store:write-failed',
+      'direct-allow',
+    ]);
+    expect(runtime.isTorEnabled(), isFalse);
+    final state = container.read(networkPrivacyProvider);
+    expect(state.torEnabled, isFalse);
+    expect(state.status, NetworkPrivacyConnectionStatus.failed);
+    expect(state.targetTorEnabled, isFalse);
   });
 
   test(
@@ -901,6 +993,27 @@ class _FakeStore implements NetworkPrivacyPreferenceStore {
 
   @override
   Future<void> writeTorEnabled(bool enabled) async {
+    events.add('store:$enabled');
+  }
+}
+
+/// Fails the write in one direction only, the shape a full disk has: the
+/// previously saved value is already on disk when the new one is refused.
+class _WriteFailingStore implements NetworkPrivacyPreferenceStore {
+  _WriteFailingStore(this.events, {required this.failOn});
+
+  final List<String> events;
+  final bool failOn;
+
+  @override
+  Future<bool> readTorEnabled() async => false;
+
+  @override
+  Future<void> writeTorEnabled(bool enabled) async {
+    if (enabled == failOn) {
+      events.add('store:write-failed');
+      throw StateError('Could not save the Tor preference.');
+    }
     events.add('store:$enabled');
   }
 }


### PR DESCRIPTION
Rebuild of #473, closed to regroup. Same scope, reorganized as eight logical commits built from that branch's final reviewed state — plus fixes for the three findings that were still open when it closed. The old branch `rowan/mobile-tor` remains as the review archive; the background lane and Rust core here are byte-identical to it.

## Commits

1. **Persist the Tor route on the strict side** (desktop) — the saved route may be stricter than the enforced one, never laxer. Enabling writes before anything changes, so a failed save aborts a toggle that never happened; disabling writes after the switch, with the direct-request gate following the runtime. This replaces the closed PR's ordering and fixes its open P1: no state exists anymore in which a relaunch or cold wake reads direct against a session that was told Tor.
2. **Cancellable pending connection** (desktop) — the toggle is an escape from the fail-closed connecting window instead of disabling itself for exactly that window.
3. **Refuse a route nothing has declared** (rust) — undeclared ≠ direct at the one chokepoint every lightwalletd connection passes; adoption of a persisted route is atomic with the state change; a bootstrap stops when its route goes away; the deadline covers the init-lock wait.
4. **Dormancy and the background wake lease** (rust) — idle clients sleep with the app lifecycle; a pass masks the intent with a self-lapsing, request-renewed lease; a cold background process adopts the intent it was never given.
5. **Enable Tor on iOS and Android** — startup gate removed, sandbox-aware fs-mistrust, guard state kept out of backups and device transfer, a launch-owned dormancy lifecycle that exists even on locked launches, and a hand-run live-Tor probe tagged out of the automated lanes.
6. **iOS background lane** — route declaration before any native call, charger+unmetered affordability, per-request-type gates, the wallet-mutation fence kept off the uncancellable bring-up, and a main-thread power monitor whose every read requests a fresh sample (fixes the open staleness P2: a suspended process no longer answers with the charger state from before the suspension).
7. **Mobile Tor control and route-truthful copy** — every failure state names the route actually carrying requests; migration background copy reads the saved route via a new `savedRouteTorEnabled` (fixes the open P2: the native lanes read the saved preference, and the two diverge in exactly one state).
8. **Docs** — the declaration contract and both saved-route rules in AGENTS.md.

## Verification

- Rust: 634 passed / 0 failed (every commit in the series compiles and passes independently for the Rust stages).
- Desktop lane: 2250 passed / 30 failed — the pre-existing main set.
- Mobile lane: 793 passed / 18 failed — 17 pre-existing plus one (`mobile_onboarding_progress_test`) confirmed failing on clean origin/main.
- iOS simulator: full app build; RunnerTests 223 passed, including new coverage for the power-staleness fix; live Tor bootstrap probe passes on the simulator.
- New behavioural tests were each verified to fail with only the production change reverted (toggle ordering ×2, saved-route migration copy, route chokepoint, claim atomicity, bootstrap abandon, dormancy default).

Still device-only: whether the fs-mistrust exemption is required on real hardware (recorded in the probe), power/network state transitions on device, and cancellation during a genuine cold bootstrap.

https://claude.ai/code/session_01R9nkJCPTCahMjGiDgqFNrV