### PR TITLE
Enable Tor on mobile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,6 +545,27 @@ Swift BackgroundMigrationPreparationManager
   `com.keplr.vizor.sync` is cancelled once at launch as a tombstone for requests
   submitted by older builds; no handler is registered for it.
 
+### Tor and the network route
+
+Tor covers the app's foreground traffic only. The desired route lives in Rust
+process memory, applied by the Dart layer at startup and by the settings
+toggle; every foreground lightwalletd and HTTP path goes through the
+policy-aware openers and fails closed while Tor is starting or broken.
+
+- **iOS background migration transport is pinned direct**
+  (`open_background_direct_lwd_channel`), bypassing the route policy as a
+  product decision. A background pass never brings Tor up or borrows the
+  foreground's client, so routing that lane through the policy would only
+  convert it into failures on a Tor wallet. The mobile settings card
+  discloses this. Nothing in the foreground may use the pinned opener.
+- **The saved route may be stricter than the enforced route, never laxer.**
+  The saved preference is all a fresh launch has to go on, so a toggle
+  persists in whichever order keeps this true at every intermediate point:
+  enabling writes before the runtime switch (a failed write aborts a toggle
+  that has not happened yet), disabling writes after it (a failed write
+  leaves the stricter Tor value behind). `networkPrivacyPersistedRouteIsSafe`
+  is the executable statement of this rule.
+
 Key files:
 - `rust/src/migration_preparation.rs` — shared mobile preparation core
 - `rust/src/android_jni.rs` — Android preparation execution adapter

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:allowBackup="false">
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Arti's directory records which guards this wallet chose. Carrying it to a
+  second device would carry that choice with it, so a transferred install picks
+  fresh guards at the cost of one bootstrap.
+
+  `allowBackup="false"` already covers cloud backup, but from target SDK 31
+  device-to-device transfer is governed here instead and defaults to including
+  app data. `domain="file"` is getFilesDir(), which is what
+  getApplicationSupportDirectory() resolves to on Android.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" path="tor" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="file" path="tor" />
+    </device-transfer>
+</data-extraction-rules>

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -8,3 +8,9 @@ tags:
   # See "Design Token Form Factor" in AGENTS.md.
   mobile:
     skip: "mobile token lane only: fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile"
+  # Probes that talk to the live Tor network from a booted device. They cost
+  # minutes, depend on a network nobody controls, and leave the process
+  # Tor-enabled and fail-closed for anything sharing the binary, so they stay
+  # out of `flutter test integration_test/` and are run by hand.
+  live-tor:
+    skip: "live Tor probe only: fvm flutter test --tags live-tor --run-skipped <path> -d <device>"

--- a/integration_test/mobile_tor_bootstrap_probe_test.dart
+++ b/integration_test/mobile_tor_bootstrap_probe_test.dart
@@ -1,0 +1,59 @@
+@Tags(['live-tor'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/rust/api/network_privacy.dart'
+    as rust_network_privacy;
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
+import 'package:zcash_wallet/src/rust/network_privacy.dart' as rust_types;
+
+/// Bootstraps Tor from the app's own support directory on a mobile OS.
+///
+/// A bootstrap failure surfaces from inside fail-closed mode — every request
+/// blocked while Tor never becomes ready — so no host test can catch it.
+///
+/// This talks to the live Tor network and is not part of any automated lane.
+/// The `live-tor` tag is what keeps it out of one: `dart_test.yaml` skips that
+/// tag, so `fvm flutter test integration_test/` — which would otherwise pick
+/// this file up, spend five minutes on a network nobody controls, and leave the
+/// process Tor-enabled and fail-closed for whatever shares the binary — reports
+/// it as skipped instead. Run it by hand against a booted simulator or device:
+///
+/// ```sh
+/// fvm flutter test --tags live-tor --run-skipped \
+///   integration_test/mobile_tor_bootstrap_probe_test.dart \
+///   -d <device> --dart-define=VIZOR_FORM_FACTOR=mobile
+/// ```
+///
+/// The define is what this probe is run with, and every mobile-targeted
+/// invocation carries it — the test binary is compiled per lane like any other
+/// build. Omitting it here compiles the probe against desktop tokens on a
+/// phone, which is the mismatch `lib/main.dart` asserts against.
+///
+/// What it does not settle: whether arti's filesystem permission checks need
+/// the mobile exemption. The iOS simulator passes this with the exemption
+/// compiled out, because a simulator container is an ordinary directory in the
+/// host filesystem. Only a real device answers that.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Tor bootstraps from the mobile app sandbox', (tester) async {
+    await RustLib.init();
+    final torDirectory = await getTorDataDirectoryPath();
+
+    rust_network_privacy.beginNetworkPrivacyEnable();
+    final status = await rust_network_privacy.configureNetworkPrivacy(
+      enabled: true,
+      torDirectory: torDirectory,
+    );
+
+    expect(
+      status,
+      rust_types.NetworkPrivacyStatus.ready,
+      reason: 'bootstrap from $torDirectory did not reach ready',
+    );
+    expect(rust_network_privacy.isTorEnabled(), isTrue);
+  }, timeout: const Timeout(Duration(minutes: 5)));
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -350,6 +350,59 @@ import UIKit
       }
     }
 
+    let networkPrivacyChannel = FlutterMethodChannel(
+      name: "com.zcash.wallet/network_privacy",
+      binaryMessenger: messenger
+    )
+    networkPrivacyChannel.setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "excludeFromBackup":
+        // Arti's directory records this wallet's guard choice. Restoring it
+        // onto another device would carry that choice across, so it is kept
+        // out of iCloud and finder backups; a restored install picks fresh
+        // guards at the cost of one bootstrap.
+        guard
+          let arguments = call.arguments as? [String: Any],
+          let path = arguments["path"] as? String,
+          !path.isEmpty
+        else {
+          result(
+            FlutterError(
+              code: "invalid_arguments",
+              message: "excludeFromBackup requires a path.",
+              details: nil
+            )
+          )
+          return
+        }
+        var url = URL(fileURLWithPath: path)
+        do {
+          // Created here when it does not exist yet, so the mark can be set
+          // before the bootstrap rather than only after it: from the directory's
+          // first moment it holds guard state, and the process can be killed
+          // while that is being written.
+          try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true
+          )
+          var values = URLResourceValues()
+          values.isExcludedFromBackup = true
+          try url.setResourceValues(values)
+          result(true)
+        } catch {
+          result(
+            FlutterError(
+              code: "exclude_failed",
+              message: error.localizedDescription,
+              details: nil
+            )
+          )
+        }
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     let hapticsChannel = FlutterMethodChannel(
       name: "com.zcash.wallet/haptics",
       binaryMessenger: messenger

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -574,7 +574,10 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
       ),
       GoRoute(
         path: '/onboarding/customise-account',
-        redirect: (_, state) => state.extra is CustomiseAccountArgs
+        redirect: (_, state) =>
+            state.extra is CustomiseAccountArgs &&
+                (state.extra as CustomiseAccountArgs).flow ==
+                    SetPasswordFlow.create
             ? null
             : OnboardingStep.secretPassphrase.routePath,
         pageBuilder: (context, state) => CustomTransitionPage<void>(
@@ -675,6 +678,25 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
           transitionsBuilder: _onboardingFadeTransition,
         ),
       ),
+      GoRoute(
+        path: KeystoneOnboardingStep.customiseAccount.routePath,
+        redirect: (_, state) {
+          final args = state.extra;
+          return args is CustomiseAccountArgs &&
+                  args.flow == SetPasswordFlow.importKeystone
+              ? null
+              : KeystoneOnboardingStep.walletBirthdayHeight.routePath;
+        },
+        pageBuilder: (context, state) => CustomTransitionPage<void>(
+          key: state.pageKey,
+          transitionDuration: kOnboardingForwardDuration,
+          reverseTransitionDuration: kOnboardingReverseDuration,
+          child: CustomiseAccountScreen(
+            args: state.extra as CustomiseAccountArgs,
+          ),
+          transitionsBuilder: _onboardingFadeTransition,
+        ),
+      ),
     ],
   ),
   ShellRoute(
@@ -741,6 +763,25 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
             transitionsBuilder: _onboardingFadeTransition,
           );
         },
+      ),
+      GoRoute(
+        path: '/import/customise-account',
+        redirect: (_, state) {
+          final args = state.extra;
+          return args is CustomiseAccountArgs &&
+                  args.flow == SetPasswordFlow.importWallet
+              ? null
+              : '/import/birthday';
+        },
+        pageBuilder: (context, state) => CustomTransitionPage<void>(
+          key: state.pageKey,
+          transitionDuration: kOnboardingForwardDuration,
+          reverseTransitionDuration: kOnboardingReverseDuration,
+          child: CustomiseAccountScreen(
+            args: state.extra as CustomiseAccountArgs,
+          ),
+          transitionsBuilder: _onboardingFadeTransition,
+        ),
       ),
     ],
   ),

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -107,10 +107,8 @@ Future<void> initializeZcashWalletRuntime() async {
   WidgetsFlutterBinding.ensureInitialized();
   log('runtime: initializing RustLib');
   await RustLib.init();
-  if (kAppFormFactor == AppFormFactor.desktop) {
-    log('runtime: applying desktop network privacy policy');
-    await initializeNetworkPrivacyRuntime();
-  }
+  log('runtime: applying network privacy policy');
+  await initializeNetworkPrivacyRuntime();
   await rust_simple.configureFastTestnetMigration(
     enabled: kZcashFastTestnetMigration,
   );
@@ -576,10 +574,7 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
       ),
       GoRoute(
         path: '/onboarding/customise-account',
-        redirect: (_, state) =>
-            state.extra is CustomiseAccountArgs &&
-                (state.extra as CustomiseAccountArgs).flow ==
-                    SetPasswordFlow.create
+        redirect: (_, state) => state.extra is CustomiseAccountArgs
             ? null
             : OnboardingStep.secretPassphrase.routePath,
         pageBuilder: (context, state) => CustomTransitionPage<void>(
@@ -680,25 +675,6 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
           transitionsBuilder: _onboardingFadeTransition,
         ),
       ),
-      GoRoute(
-        path: KeystoneOnboardingStep.customiseAccount.routePath,
-        redirect: (_, state) {
-          final args = state.extra;
-          return args is CustomiseAccountArgs &&
-                  args.flow == SetPasswordFlow.importKeystone
-              ? null
-              : KeystoneOnboardingStep.walletBirthdayHeight.routePath;
-        },
-        pageBuilder: (context, state) => CustomTransitionPage<void>(
-          key: state.pageKey,
-          transitionDuration: kOnboardingForwardDuration,
-          reverseTransitionDuration: kOnboardingReverseDuration,
-          child: CustomiseAccountScreen(
-            args: state.extra as CustomiseAccountArgs,
-          ),
-          transitionsBuilder: _onboardingFadeTransition,
-        ),
-      ),
     ],
   ),
   ShellRoute(
@@ -765,25 +741,6 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
             transitionsBuilder: _onboardingFadeTransition,
           );
         },
-      ),
-      GoRoute(
-        path: '/import/customise-account',
-        redirect: (_, state) {
-          final args = state.extra;
-          return args is CustomiseAccountArgs &&
-                  args.flow == SetPasswordFlow.importWallet
-              ? null
-              : '/import/birthday';
-        },
-        pageBuilder: (context, state) => CustomTransitionPage<void>(
-          key: state.pageKey,
-          transitionDuration: kOnboardingForwardDuration,
-          reverseTransitionDuration: kOnboardingReverseDuration,
-          child: CustomiseAccountScreen(
-            args: state.extra as CustomiseAccountArgs,
-          ),
-          transitionsBuilder: _onboardingFadeTransition,
-        ),
       ),
     ],
   ),

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart'
     show CircularProgressIndicator, Dialog, Divider, Scaffold, showDialog;
@@ -24,6 +25,7 @@ import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/app_profile_picture.dart';
 import '../../../../providers/account_provider.dart';
+import '../../../../providers/network_privacy_provider.dart';
 import '../../../../providers/sync_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../models/ironwood_migration_presentation.dart';

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -1074,6 +1074,17 @@ class _MobileMigrationRedesignedStatusState
     rust_sync.MigrationStatus status, {
     required _MigrationProgressState state,
   }) {
+    // Stated exactly where the screen invites the user to background the app,
+    // and only to the user it concerns: on iOS, background migration
+    // transport is pinned direct by design — Tor covers foreground traffic —
+    // so the invitation is the moment a Tor user's coverage expectation and
+    // the wire part ways. Android has no background migration lane, so there
+    // is nothing to disclose there.
+    final torDisclosure =
+        defaultTargetPlatform == TargetPlatform.iOS &&
+            ref.watch(networkPrivacyProvider).torEnabled
+        ? '\nMigration continues over a direct connection.'
+        : '';
     final currentHeight = _currentHeight();
     final nextHeight = status.nextActionHeight;
     final timing = nextHeight != null && currentHeight > 0
@@ -1100,7 +1111,7 @@ class _MobileMigrationRedesignedStatusState
       return switch (_notificationsAuthorized) {
         true =>
           '$expectation\nNotifications are on. You can leave Vizor and check '
-              'back later.',
+              'back later.$torDisclosure',
         false =>
           '$expectation\nNotifications are disabled. Open Vizor again to '
               'continue.',
@@ -1113,13 +1124,14 @@ class _MobileMigrationRedesignedStatusState
     }
     if (state == _MigrationProgressState.confirming) {
       return 'Confirmations are still arriving.\nYou can leave Vizor and '
-          'check again later.';
+          'check again later.$torDisclosure';
     }
     if (timing == 'ready now') {
       return 'The next migration step is ready. Keep Vizor open to continue.';
     }
     return '$timing until the next migration step.\n'
-        'Notifications are on; you can leave Vizor and check back later.';
+        'Notifications are on; you can leave Vizor and check back later.'
+        '$torDisclosure';
   }
 
   Future<void> _continuePreparation(String accountUuid) async {

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -1076,14 +1076,16 @@ class _MobileMigrationRedesignedStatusState
   }) {
     // Stated exactly where the screen invites the user to background the app,
     // and only to the user it concerns: on iOS, background migration
-    // transport is pinned direct by design — Tor covers foreground traffic —
-    // so the invitation is the moment a Tor user's coverage expectation and
-    // the wire part ways. Android has no background migration lane, so there
-    // is nothing to disclose there.
+    // transport is pinned direct by design, while foreground migration
+    // traffic rides the route policy like everything else — so the claim is
+    // scoped to "while Vizor is closed", or it would read as though the
+    // migration bypasses Tor even while the user watches it. Android has no
+    // background migration lane, so there is nothing to disclose there.
     final torDisclosure =
         defaultTargetPlatform == TargetPlatform.iOS &&
             ref.watch(networkPrivacyProvider).torEnabled
-        ? '\nMigration continues over a direct connection.'
+        ? '\nWhile Vizor is closed, migration continues over a direct '
+              'connection.'
         : '';
     final currentHeight = _currentHeight();
     final nextHeight = status.nextActionHeight;

--- a/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
@@ -25,6 +25,7 @@ import '../../../../providers/sync_keep_awake_provider.dart';
 import '../../../../providers/theme_mode_provider.dart';
 import '../../../../services/biometric_unlock.dart';
 import '../../../accounts/widgets/mobile/account_edit_sheets.dart';
+import '../../widgets/mobile/mobile_network_privacy_card.dart';
 
 /// Mobile settings tab — Figma `SETTINGS` root frame (4494:65997).
 ///
@@ -177,6 +178,8 @@ class MobileSettingsScreen extends ConsumerWidget {
                     ),
                   ),
                 ),
+                const SizedBox(height: AppSpacing.md),
+                const MobileNetworkPrivacyCard(),
                 const SizedBox(height: AppSpacing.md),
                 _SettingsGroup(
                   title: 'System',

--- a/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
+++ b/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
@@ -1,0 +1,339 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_icon.dart';
+import '../../../../core/widgets/mobile/mobile_surface_card.dart';
+import '../../../../providers/network_privacy_provider.dart';
+// The widget is deliberately not shared; the decision behind it is, because
+// both form factors drive one provider and the escape hatch has to exist on
+// both.
+import '../network_privacy_control.dart'
+    show NetworkPrivacyToggleActionX, networkPrivacyToggleAction;
+
+const _rowHeight = 44.0;
+
+/// Mobile Tor control.
+///
+/// Deliberately not the desktop [NetworkPrivacyControl]: that widget's copy is
+/// mostly about desktop software updates, which mobile gets from the app
+/// stores, and its toggle geometry belongs to a settings page rather than a
+/// grouped card. The state machine behind both is the same provider.
+class MobileNetworkPrivacyCard extends ConsumerWidget {
+  const MobileNetworkPrivacyCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.colors;
+    final state = ref.watch(networkPrivacyProvider);
+    final notifier = ref.read(networkPrivacyProvider.notifier);
+    final presentation = _presentationFor(state);
+    final toggleAction = networkPrivacyToggleAction(state);
+    final onToggle = toggleAction.isInteractive
+        ? () => unawaited(
+            notifier.setTorEnabled(toggleAction.requestedTorEnabled),
+          )
+        : null;
+    // `retry()` re-runs the desired route, which is the direct connection when
+    // it was the disable that failed.
+    final retryLabel = (state.targetTorEnabled ?? state.torEnabled)
+        ? 'Try again'
+        : 'Try direct connection';
+    final onRetry = state.isBusy ? null : () => unawaited(notifier.retry());
+
+    return MobileSurfaceCard(
+      cornerRadius: AppRadii.large,
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.sm,
+        AppSpacing.base,
+        AppSpacing.sm,
+        AppSpacing.base,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.xxs),
+            child: Text(
+              'Network',
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Semantics(
+            button: true,
+            toggled: state.torEnabled,
+            enabled: toggleAction.isInteractive,
+            label: toggleAction.semanticsLabel,
+            // The excluded subtree holds the status text, and four of the five
+            // states report `toggled: true`, so the status has to ride on the
+            // node itself to reach assistive technology at all.
+            value: presentation.statusLabel,
+            onTap: onToggle,
+            excludeSemantics: true,
+            child: GestureDetector(
+              key: const ValueKey('mobile_settings_tor_row'),
+              behavior: HitTestBehavior.opaque,
+              onTap: onToggle,
+              child: SizedBox(
+                height: _rowHeight,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.xxs,
+                  ),
+                  child: Row(
+                    children: [
+                      SizedBox.square(
+                        dimension: 32,
+                        child: Center(
+                          child: AppIcon(
+                            AppIcons.tor,
+                            size: 20,
+                            color: presentation.iconColor(colors),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.s),
+                      Expanded(
+                        child: Text(
+                          'Use Tor',
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTypography.labelLarge.copyWith(
+                            color: colors.text.accent,
+                          ),
+                        ),
+                      ),
+                      Text(
+                        presentation.statusLabel,
+                        style: AppTypography.labelLarge.copyWith(
+                          color: presentation.statusColor(colors),
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.s),
+                      _MobileTorToggle(
+                        key: const ValueKey('mobile_settings_tor_toggle'),
+                        enabled: state.torEnabled,
+                        interactive: toggleAction.isInteractive,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            presentation.description,
+            key: const ValueKey('mobile_settings_tor_description'),
+            style: AppTypography.bodyMedium.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+          if (state.status == NetworkPrivacyConnectionStatus.failed)
+            // No gap token in front: the touch-sized row already carries the
+            // whitespace that separates it from the description.
+            Semantics(
+              button: true,
+              enabled: onRetry != null,
+              label: retryLabel,
+              onTap: onRetry,
+              excludeSemantics: true,
+              child: GestureDetector(
+                key: const ValueKey('mobile_settings_tor_retry'),
+                behavior: HitTestBehavior.opaque,
+                onTap: onRetry,
+                child: SizedBox(
+                  height: _rowHeight,
+                  child: Center(
+                    widthFactor: 1,
+                    child: Text(
+                      retryLabel,
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.brandCrimson,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MobileTorPresentation {
+  const _MobileTorPresentation({
+    required this.statusLabel,
+    required this.description,
+    required this.statusColor,
+    required this.iconColor,
+  });
+
+  final String statusLabel;
+  final String description;
+  final Color Function(AppColors colors) statusColor;
+  final Color Function(AppColors colors) iconColor;
+}
+
+_MobileTorPresentation _presentationFor(NetworkPrivacyState state) {
+  final targetTorEnabled = state.targetTorEnabled ?? state.torEnabled;
+  return switch ((state.status, targetTorEnabled)) {
+    (NetworkPrivacyConnectionStatus.connecting, true) => _MobileTorPresentation(
+      statusLabel: 'Connecting…',
+      // Names the way out. On a network that blocks Tor the wait runs to the
+      // bootstrap deadline with every request failing closed, and relaunching
+      // the app only starts the same wait again, so the escape has to be stated
+      // where the user is looking.
+      description:
+          'New requests wait until the Tor connection is ready. Turn Tor '
+          'off to stop connecting and use a direct connection.',
+      statusColor: (colors) => colors.text.secondary,
+      iconColor: (colors) => colors.icon.muted,
+    ),
+    (NetworkPrivacyConnectionStatus.connecting, false) =>
+      _MobileTorPresentation(
+        statusLabel: 'Switching…',
+        description:
+            'Vizor is switching network requests to a direct '
+            'connection.',
+        statusColor: (colors) => colors.text.secondary,
+        iconColor: (colors) => colors.icon.muted,
+      ),
+    (NetworkPrivacyConnectionStatus.connected, _) => _MobileTorPresentation(
+      statusLabel: 'Connected',
+      // The closing sentence is a disclosure, not a limitation: background
+      // migration keeps the direct transport it has always had, by design —
+      // a background pass never brings Tor up, and converting that lane into
+      // failures would only stall migrations. A user who chose Tor deserves
+      // to know which of their traffic it does not cover.
+      description:
+          'Wallet sync and most in-app requests go through Tor. Some '
+          'services may be unavailable over Tor, and links you open leave '
+          'the app. Background migration activity uses a direct connection.',
+      statusColor: (colors) => colors.text.brandCrimson,
+      iconColor: (colors) => colors.icon.brandCrimson,
+    ),
+    // A failed enable has two shapes with opposite request behaviour, so the
+    // route decides which is described. A bootstrap failure left the process
+    // fail-closed; a save failure aborted the toggle before anything changed.
+    (NetworkPrivacyConnectionStatus.failed, true) =>
+      state.torEnabled
+          ? _MobileTorPresentation(
+              statusLabel: 'Failed',
+              description:
+                  'Vizor could not connect to Tor. Requests stay blocked '
+                  'until it connects or you turn Tor off.',
+              statusColor: (colors) => colors.text.brandCrimson,
+              iconColor: (colors) => colors.icon.brandCrimson,
+            )
+          // Saying "requests stay blocked" here would describe the opposite
+          // of what is happening: nothing was enabled, and requests keep
+          // flowing directly.
+          : _MobileTorPresentation(
+              statusLabel: 'Setting not saved',
+              description:
+                  'Vizor could not save the change, so Tor was not turned '
+                  'on. Requests keep using a direct connection.',
+              statusColor: (colors) => colors.text.brandCrimson,
+              iconColor: (colors) => colors.icon.brandCrimson,
+            ),
+    // A failed disable has two shapes, and they carry opposite privacy
+    // guarantees, so the route decides which is described rather than the
+    // target. Neither may reuse the blocked-requests copy above.
+    (NetworkPrivacyConnectionStatus.failed, false) =>
+      state.torEnabled
+          // The transport never switched. Tor is still up and still carrying
+          // traffic.
+          ? _MobileTorPresentation(
+              statusLabel: 'Switch failed',
+              description:
+                  'Vizor could not switch to a direct connection. Tor is '
+                  'still on and requests keep going through it.',
+              statusColor: (colors) => colors.text.brandCrimson,
+              iconColor: (colors) => colors.icon.brandCrimson,
+            )
+          // The transport did switch and only the setting could not be saved.
+          // Requests are direct from here, and the saved route is still Tor —
+          // the stricter half, so the next launch comes back on Tor rather
+          // than silently staying direct. Saying "Tor is still on" here would
+          // promise the user the opposite of what is actually carrying their
+          // traffic.
+          : _MobileTorPresentation(
+              statusLabel: 'Setting not saved',
+              description:
+                  'Requests now use a direct connection, but Vizor could not '
+                  'save the change. Tor turns back on the next time you open '
+                  'the app.',
+              statusColor: (colors) => colors.text.brandCrimson,
+              iconColor: (colors) => colors.icon.brandCrimson,
+            ),
+    (NetworkPrivacyConnectionStatus.off, _) => _MobileTorPresentation(
+      statusLabel: 'Off',
+      description:
+          'Wallet sync and in-app requests connect directly. Turn Tor '
+          'on to hide your IP address from the servers Vizor talks to.',
+      statusColor: (colors) => colors.text.secondary,
+      iconColor: (colors) => colors.icon.muted,
+    ),
+  };
+}
+
+class _MobileTorToggle extends StatelessWidget {
+  const _MobileTorToggle({
+    required this.enabled,
+    required this.interactive,
+    super.key,
+  });
+
+  final bool enabled;
+
+  /// Dimming says the route is not effective yet. A transition the user can
+  /// still leave is not dimmed: the control has to look like something they may
+  /// act on, because acting on it is the way out of the wait.
+  final bool interactive;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final trackColor = enabled
+        ? colors.background.brandCrimsonStrong
+        : colors.background.raised;
+    final borderColor = enabled
+        ? colors.border.brandCrimsonStrong
+        : colors.border.regular;
+    return Opacity(
+      opacity: interactive ? 1 : 0.65,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 140),
+        curve: Curves.easeOutCubic,
+        width: 64,
+        height: 28,
+        padding: const EdgeInsets.all(2),
+        decoration: BoxDecoration(
+          color: trackColor,
+          borderRadius: BorderRadius.circular(AppRadii.full),
+          border: Border.all(color: borderColor),
+        ),
+        child: AnimatedAlign(
+          duration: const Duration(milliseconds: 140),
+          curve: Curves.easeOutCubic,
+          alignment: enabled ? Alignment.centerRight : Alignment.centerLeft,
+          child: DecoratedBox(
+            key: const ValueKey('mobile_settings_tor_toggle_thumb'),
+            decoration: BoxDecoration(
+              color: const Color(0xFFFFFFFF),
+              borderRadius: BorderRadius.circular(AppRadii.full),
+            ),
+            // Same pill as the keep-awake toggle directly above this card.
+            child: const SizedBox(width: 40, height: 24),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
+++ b/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
@@ -206,15 +206,14 @@ _MobileTorPresentation _presentationFor(NetworkPrivacyState state) {
       ),
     (NetworkPrivacyConnectionStatus.connected, _) => _MobileTorPresentation(
       statusLabel: 'Connected',
-      // The closing sentence is a disclosure, not a limitation: background
-      // migration keeps the direct transport it has always had, by design —
-      // a background pass never brings Tor up, and converting that lane into
-      // failures would only stall migrations. A user who chose Tor deserves
-      // to know which of their traffic it does not cover.
+      // "Most", not "all": background migration transport is pinned direct
+      // by design, and the boundary is disclosed on the migration screen at
+      // the moment it invites the user to background the app — a permanent
+      // settings card is the wrong home for a transient feature's caveat.
       description:
           'Wallet sync and most in-app requests go through Tor. Some '
           'services may be unavailable over Tor, and links you open leave '
-          'the app. Background migration activity uses a direct connection.',
+          'the app.',
       statusColor: (colors) => colors.text.brandCrimson,
       iconColor: (colors) => colors.icon.brandCrimson,
     ),

--- a/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
+++ b/lib/src/features/settings/widgets/mobile/mobile_network_privacy_card.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -29,7 +31,10 @@ class MobileNetworkPrivacyCard extends ConsumerWidget {
     final colors = context.colors;
     final state = ref.watch(networkPrivacyProvider);
     final notifier = ref.read(networkPrivacyProvider.notifier);
-    final presentation = _presentationFor(state);
+    final presentation = _presentationFor(
+      state,
+      platform: defaultTargetPlatform,
+    );
     final toggleAction = networkPrivacyToggleAction(state);
     final onToggle = toggleAction.isInteractive
         ? () => unawaited(
@@ -180,7 +185,10 @@ class _MobileTorPresentation {
   final Color Function(AppColors colors) iconColor;
 }
 
-_MobileTorPresentation _presentationFor(NetworkPrivacyState state) {
+_MobileTorPresentation _presentationFor(
+  NetworkPrivacyState state, {
+  required TargetPlatform platform,
+}) {
   final targetTorEnabled = state.targetTorEnabled ?? state.torEnabled;
   return switch ((state.status, targetTorEnabled)) {
     (NetworkPrivacyConnectionStatus.connecting, true) => _MobileTorPresentation(
@@ -206,14 +214,16 @@ _MobileTorPresentation _presentationFor(NetworkPrivacyState state) {
       ),
     (NetworkPrivacyConnectionStatus.connected, _) => _MobileTorPresentation(
       statusLabel: 'Connected',
-      // "Most", not "all": background migration transport is pinned direct
-      // by design, and the boundary is disclosed on the migration screen at
-      // the moment it invites the user to background the app — a permanent
-      // settings card is the wrong home for a transient feature's caveat.
-      description:
-          'Wallet sync and most in-app requests go through Tor. Some '
-          'services may be unavailable over Tor, and links you open leave '
-          'the app.',
+      // iOS can continue Ironwood private migration through its native
+      // background task after Vizor closes. That task is pinned direct, so
+      // name the exception instead of weakening the foreground guarantee with
+      // "most". Android has no corresponding background migration lane.
+      description: platform == TargetPlatform.iOS
+          ? 'Vizor’s network requests go through Tor. Ironwood private '
+                'migration uses a direct connection while Vizor is closed. '
+                'Links opened in other apps use those apps’ network settings.'
+          : 'Vizor’s network requests go through Tor. Links opened in other '
+                'apps use those apps’ network settings.',
       statusColor: (colors) => colors.text.brandCrimson,
       iconColor: (colors) => colors.icon.brandCrimson,
     ),

--- a/lib/src/features/settings/widgets/network_privacy_control.dart
+++ b/lib/src/features/settings/widgets/network_privacy_control.dart
@@ -420,7 +420,7 @@ _NetworkPrivacyPresentation _presentationFor(
     return _NetworkPrivacyPresentation(
       statusLabel: 'Connected',
       description:
-          'Wallet sync and most in-app requests go through Tor. Software updates are unavailable.',
+          'Vizor’s network requests go through Tor, but software updates are unavailable.',
       statusColor: (colors) => colors.text.destructive,
       iconColor: (colors) => colors.icon.brandCrimson,
       descriptionColor: (colors) => colors.text.destructive,
@@ -483,11 +483,8 @@ _NetworkPrivacyPresentation _presentationFor(
       ),
     (NetworkPrivacyConnectionStatus.connected, _) => _NetworkPrivacyPresentation(
       statusLabel: 'Connected',
-      description: isLinux
-          ? 'Wallet sync, most in-app requests, and software update checks go '
-                'through Tor. Update pages and downloads opened in another app '
-                'use that app’s connection.'
-          : 'Wallet sync, most in-app requests, and software updates go through Tor. Some services may be unavailable over Tor.',
+      description:
+          'Vizor’s network requests go through Tor. Links opened in other apps use those apps’ network settings.',
       statusColor: (colors) => colors.text.brandCrimson,
       iconColor: (colors) => colors.icon.brandCrimson,
       descriptionColor: (colors) => colors.text.accent,

--- a/lib/src/features/settings/widgets/network_privacy_control.dart
+++ b/lib/src/features/settings/widgets/network_privacy_control.dart
@@ -16,6 +16,59 @@ const _toggleShortcuts = <ShortcutActivator, Intent>{
   SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
 };
 
+/// What activating a Tor control does from the state it is showing.
+///
+/// Shared by both form factors because the state machine behind them is one
+/// provider, and because the case that matters is the one a control is most
+/// tempted to disable itself for.
+enum NetworkPrivacyToggleAction {
+  enable,
+  disable,
+
+  /// A Tor connection is still being established and the user wants out of it.
+  ///
+  /// The bootstrap has a three-minute deadline and every policy-aware request
+  /// fails closed until it resolves, so a control that goes inert for the
+  /// duration strands the user on a network that blocks Tor — and force-quitting
+  /// does not help, because the saved route is Tor and the next launch starts
+  /// the same bootstrap. Switching to direct is what ends it, so this stays
+  /// available for exactly as long as the wait does.
+  cancelPendingTor,
+
+  /// A switch to the direct route is already under way. There is nothing to
+  /// cancel toward, and re-entering Tor mid-switch is a transition rather than
+  /// an escape.
+  none,
+}
+
+NetworkPrivacyToggleAction networkPrivacyToggleAction(
+  NetworkPrivacyState state,
+) {
+  if (!state.isBusy) {
+    return state.torEnabled
+        ? NetworkPrivacyToggleAction.disable
+        : NetworkPrivacyToggleAction.enable;
+  }
+  return (state.targetTorEnabled ?? state.torEnabled)
+      ? NetworkPrivacyToggleAction.cancelPendingTor
+      : NetworkPrivacyToggleAction.none;
+}
+
+extension NetworkPrivacyToggleActionX on NetworkPrivacyToggleAction {
+  bool get isInteractive => this != NetworkPrivacyToggleAction.none;
+
+  /// The route the action asks for. Cancelling a pending Tor connection asks
+  /// for the direct route, which is what supersedes the bootstrap.
+  bool get requestedTorEnabled => this == NetworkPrivacyToggleAction.enable;
+
+  /// Assistive-technology label. Turning "Use Tor" off mid-connect is an escape
+  /// from a wait, not a second transition, so it does not announce itself as
+  /// one.
+  String get semanticsLabel => this == NetworkPrivacyToggleAction.cancelPendingTor
+      ? 'Stop connecting to Tor'
+      : 'Use Tor';
+}
+
 /// Shared desktop Tor control used both before wallet creation and in Settings.
 ///
 /// The control presents the desired route separately from its connection
@@ -30,6 +83,7 @@ class NetworkPrivacyControl extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.colors;
     final state = ref.watch(networkPrivacyProvider);
+    final toggleAction = networkPrivacyToggleAction(state);
     final presentation = _presentationFor(
       state,
       platform: defaultTargetPlatform,
@@ -104,14 +158,14 @@ class NetworkPrivacyControl extends ConsumerWidget {
                 _NetworkPrivacyToggle(
                   key: const ValueKey('network_privacy_toggle'),
                   enabled: state.torEnabled,
-                  busy: state.isBusy,
-                  onToggle: state.isBusy
-                      ? null
-                      : () => unawaited(
+                  action: toggleAction,
+                  onToggle: toggleAction.isInteractive
+                      ? () => unawaited(
                           ref
                               .read(networkPrivacyProvider.notifier)
-                              .setTorEnabled(!state.torEnabled),
-                        ),
+                              .setTorEnabled(toggleAction.requestedTorEnabled),
+                        )
+                      : null,
                 ),
               ],
             ),
@@ -216,16 +270,14 @@ class NetworkPrivacyControl extends ConsumerWidget {
 class _NetworkPrivacyToggle extends StatefulWidget {
   const _NetworkPrivacyToggle({
     required this.enabled,
-    required this.busy,
+    required this.action,
     required this.onToggle,
     super.key,
   });
 
   final bool enabled;
 
-  /// The knob moves to the desired route as soon as the transition starts, so
-  /// the dimmed track is the only signal that the route is not effective yet.
-  final bool busy;
+  final NetworkPrivacyToggleAction action;
 
   final VoidCallback? onToggle;
 
@@ -274,7 +326,12 @@ class _NetworkPrivacyToggleState extends State<_NetworkPrivacyToggle> {
     final control = Stack(
       clipBehavior: Clip.none,
       children: [
-        Opacity(opacity: widget.busy ? 0.65 : 1, child: track),
+        // The knob moves to the desired route as soon as a transition starts,
+        // so dimming is the only signal that the route is not effective yet.
+        // A transition the user can still leave is not dimmed: the control has
+        // to look like something they may act on, because acting on it is the
+        // way out of the wait.
+        Opacity(opacity: interactive ? 1 : 0.65, child: track),
         if (_focused)
           Positioned(
             left: -3,
@@ -297,7 +354,7 @@ class _NetworkPrivacyToggleState extends State<_NetworkPrivacyToggle> {
       button: true,
       enabled: interactive,
       toggled: widget.enabled,
-      label: 'Use Tor',
+      label: widget.action.semanticsLabel,
       excludeSemantics: true,
       child: MouseRegion(
         cursor: interactive
@@ -363,7 +420,7 @@ _NetworkPrivacyPresentation _presentationFor(
     return _NetworkPrivacyPresentation(
       statusLabel: 'Connected',
       description:
-          'Vizor’s network requests go through Tor, but software updates are unavailable.',
+          'Wallet sync and most in-app requests go through Tor. Software updates are unavailable.',
       statusColor: (colors) => colors.text.destructive,
       iconColor: (colors) => colors.icon.brandCrimson,
       descriptionColor: (colors) => colors.text.destructive,
@@ -396,11 +453,17 @@ _NetworkPrivacyPresentation _presentationFor(
     (NetworkPrivacyConnectionStatus.connecting, true) =>
       _NetworkPrivacyPresentation(
         statusLabel: 'Connecting…',
+        // Names the way out. On a network that blocks Tor the wait runs to the
+        // bootstrap deadline with every request failing closed, and restarting
+        // the app only starts the same wait again, so the escape has to be
+        // stated where the user is looking.
         description: isLinux
-            ? 'New requests wait until the Tor connection is ready. Update '
+            ? 'New requests wait until the Tor connection is ready. Turn Tor '
+                  'off to stop connecting and use a direct connection. Update '
                   'pages and downloads opened in another app use that '
                   'app’s connection.'
-            : 'New requests wait until the Tor connection is ready.',
+            : 'New requests wait until the Tor connection is ready. Turn Tor '
+                  'off to stop connecting and use a direct connection.',
         statusIconName: AppIcons.loader,
         statusColor: (colors) => colors.text.secondary,
         iconColor: (colors) => colors.icon.muted,
@@ -420,8 +483,11 @@ _NetworkPrivacyPresentation _presentationFor(
       ),
     (NetworkPrivacyConnectionStatus.connected, _) => _NetworkPrivacyPresentation(
       statusLabel: 'Connected',
-      description:
-          'Vizor’s network requests go through Tor. Links opened in other apps use those apps’ network settings.',
+      description: isLinux
+          ? 'Wallet sync, most in-app requests, and software update checks go '
+                'through Tor. Update pages and downloads opened in another app '
+                'use that app’s connection.'
+          : 'Wallet sync, most in-app requests, and software updates go through Tor. Some services may be unavailable over Tor.',
       statusColor: (colors) => colors.text.brandCrimson,
       iconColor: (colors) => colors.icon.brandCrimson,
       descriptionColor: (colors) => colors.text.accent,

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -557,6 +557,39 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
         return;
       }
       if (generation != _generation) return;
+      // The saved route is written before this process changes at all. The
+      // two halves may diverge in only one direction: saved may be stricter
+      // than the route the user has been told about, never laxer. Written
+      // after `beginEnable`, a failed write would leave this process
+      // enforcing Tor while the saved route still said direct — and the
+      // saved half is what a relaunch believes, so restarting the app would
+      // silently undo a choice the user never reversed. Written first, a
+      // failure aborts a toggle that has not changed anything yet: the route
+      // is still direct, requests still flow, nothing needs rolling back.
+      try {
+        await store.writeTorEnabled(true);
+      } catch (error) {
+        if (generation != _generation) return;
+        // Undo the updater preflight so software updates are not left routed
+        // for a Tor session that never started. Best-effort: failing here
+        // only pauses update checks, and `retry()` re-runs the whole toggle.
+        var softwareUpdatesAvailable = previousState.softwareUpdatesAvailable;
+        try {
+          await nativeUpdates.setTorEnabled(false);
+        } catch (_) {
+          softwareUpdatesAvailable = false;
+        }
+        if (generation != _generation) return;
+        state = NetworkPrivacyState(
+          torEnabled: previousState.torEnabled,
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: true,
+          softwareUpdatesAvailable: softwareUpdatesAvailable,
+          error: error.toString(),
+        );
+        return;
+      }
+      if (generation != _generation) return;
       runtime.beginEnable();
     } else {
       state = NetworkPrivacyState(
@@ -606,15 +639,26 @@ class NetworkPrivacyNotifier extends Notifier<NetworkPrivacyState> {
         if (directDrain != null) {
           _throwIfDirectDrainFailed(await directDrain);
         }
-        if (generation != _generation) return;
-        await store.writeTorEnabled(enabled);
         // Re-check after every suspension point: a superseded disable that
         // reached `configure(false)` or `allow()` would reopen clearnet
         // underneath a newer enable that has already gone fail-closed.
         if (generation != _generation) return;
         nextStatus = await runtime.configure(enabled: enabled);
-        if (!enabled && generation == _generation) {
-          directRequests.allow();
+        if (enabled || generation != _generation) return;
+        try {
+          // Written only now that the runtime has actually gone direct — the
+          // mirror of the enable ordering above. Saved any earlier, a
+          // relaunch would read direct while this process was still
+          // enforcing Tor.
+          await store.writeTorEnabled(false);
+        } finally {
+          // The gate follows the runtime, not the preference. Rust is on the
+          // direct route with its Tor client dropped, so a gate left shut
+          // would strand every direct request for the rest of the session
+          // while the UI reports Tor off. A failed write leaves the saved
+          // route at Tor — the stricter half — so the next launch comes back
+          // on Tor instead of silently staying direct.
+          if (generation == _generation) directRequests.allow();
         }
       });
       if (generation != _generation) return;

--- a/lib/src/providers/network_privacy_provider.dart
+++ b/lib/src/providers/network_privacy_provider.dart
@@ -2,9 +2,12 @@ import 'dart:async' show unawaited;
 import 'dart:io' show Platform;
 
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../core/layout/app_form_factor.dart';
+import '../core/layout/app_process_work_policy.dart';
 import '../core/network/network_http_client.dart';
 import '../core/storage/wallet_paths.dart';
 import '../rust/api/network_privacy.dart' as rust_network_privacy;
@@ -94,6 +97,7 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
   const RustNetworkPrivacyRuntime({
     this.configureRuntime = rust_network_privacy.configureNetworkPrivacy,
     this.resolveTorDirectory = getTorDataDirectoryPath,
+    this.excludeTorDirectoryFromBackup = _excludeFromDeviceBackup,
   });
 
   final Future<rust_types.NetworkPrivacyStatus> Function({
@@ -102,6 +106,7 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
   })
   configureRuntime;
   final Future<String> Function() resolveTorDirectory;
+  final Future<void> Function(String directory) excludeTorDirectoryFromBackup;
 
   @override
   void beginEnable() {
@@ -119,11 +124,56 @@ class RustNetworkPrivacyRuntime implements NetworkPrivacyRuntime {
   Future<NetworkPrivacyConnectionStatus> configure({
     required bool enabled,
   }) async {
-    final status = await configureRuntime(
-      enabled: enabled,
-      torDirectory: enabled ? await resolveTorDirectory() : '',
-    );
-    return _connectionStatus(status);
+    final torDirectory = enabled ? await resolveTorDirectory() : '';
+    // Arti's directory records which guards this wallet chose. Restoring it
+    // onto a second device would carry that choice across, so keep it out of
+    // device backups and let a restored install pick fresh guards.
+    //
+    // Marked before the bootstrap, because from its first moment the directory
+    // holds guard state and the process can be killed at any point during it —
+    // and again afterwards, because the mark is best-effort and the run that
+    // matters is the one that succeeds.
+    await _markTorDirectory(enabled, torDirectory);
+    try {
+      final status = await configureRuntime(
+        enabled: enabled,
+        torDirectory: torDirectory,
+      );
+      return _connectionStatus(status);
+    } finally {
+      await _markTorDirectory(enabled, torDirectory);
+    }
+  }
+
+  Future<void> _markTorDirectory(bool enabled, String torDirectory) async {
+    if (!enabled) return;
+    try {
+      await excludeTorDirectoryFromBackup(torDirectory);
+    } catch (error, stackTrace) {
+      // A weaker backup posture is not a reason to fail the route.
+      debugPrint(
+        'RustNetworkPrivacyRuntime: failed to keep the Tor directory out '
+        'of device backups: $error\n$stackTrace',
+      );
+    }
+  }
+}
+
+const _deviceBackupChannel = MethodChannel('com.zcash.wallet/network_privacy');
+
+Future<void> _excludeFromDeviceBackup(String directory) async {
+  // Android has no runtime equivalent. `android:allowBackup="false"` in the
+  // manifest keeps app files out of cloud backup, but from targetSdk 31 that
+  // attribute no longer covers device-to-device transfer; excluding the
+  // directory from a phone-to-phone migration takes `<device-transfer>`
+  // data-extraction rules in the manifest, which the app does not carry.
+  if (!Platform.isIOS) return;
+  try {
+    await _deviceBackupChannel.invokeMethod<void>('excludeFromBackup', {
+      'path': directory,
+    });
+  } on MissingPluginException {
+    // Test hosts and older builds have no native side to ask.
   }
 }
 
@@ -294,6 +344,24 @@ void _throwIfDirectDrainFailed(_NetworkPrivacyDrainFailure? failure) {
   Error.throwWithStackTrace(failure.error, failure.stackTrace);
 }
 
+/// Whether a (saved route, enforced route) pair is one the next launch can be
+/// trusted with.
+///
+/// The saved value is all a fresh launch has to go on, so it may be stricter
+/// than what this process is enforcing, never laxer. Saved Tor under an
+/// enforced direct route costs a relaunch a bootstrap the user can cancel;
+/// saved direct under an enforced Tor route silently undoes a privacy choice
+/// the user never reversed, the moment they restart the app.
+///
+/// A route change therefore persists in whichever order keeps this true at
+/// every point in between: tightening writes before the runtime switch, so a
+/// failure in between leaves the strict value behind; loosening writes after
+/// it, so the lax value never precedes the runtime it describes.
+bool networkPrivacyPersistedRouteIsSafe({
+  required bool persistedTorEnabled,
+  required bool runtimeTorDesired,
+}) => persistedTorEnabled || !runtimeTorDesired;
+
 NetworkPrivacyConnectionStatus _connectionStatus(
   rust_types.NetworkPrivacyStatus status,
 ) => switch (status) {
@@ -323,6 +391,55 @@ var _startupActivationSuperseded = false;
 /// update session to finish.
 const _kStartupNativeUpdatePauseTimeout = Duration(seconds: 10);
 
+/// Ties the process-wide Tor dormancy intent to the app lifecycle.
+///
+/// Owned here rather than by a provider because a provider only exists once
+/// something reads it, and the launch that most needs this one reads the least:
+/// a locked app routes to `/unlock`, the keep-awake providers return early on
+/// `requiresUnlock` before they reach `syncProvider`, and the unlock screens
+/// only read it when the user submits. Meanwhile the persisted route is applied
+/// regardless of the lock, so Tor can be up and padding its guard connection
+/// with nothing constructed to put it to sleep when the user walks away.
+///
+/// Rust holds the intent process-wide and applies it to the client whenever one
+/// appears, so an intent stated before a bootstrap finishes is not lost.
+AppLifecycleListener? _torDormancyLifecycle;
+
+/// Starts the lifecycle owner, replacing any previous one.
+///
+/// Sleeping is asked for only where backgrounding actually stops this process
+/// working: a desktop app with every window hidden keeps polling, and a client
+/// put to sleep underneath it would pay a circuit build on each of those polls.
+void startTorDormancyLifecycle({
+  void Function({required bool dormant}) setTorDormant =
+      rust_network_privacy.setNetworkPrivacyDormant,
+  AppFormFactor formFactor = kAppFormFactor,
+}) {
+  _torDormancyLifecycle?.dispose();
+  _torDormancyLifecycle = AppLifecycleListener(
+    // Asked for on every foreground entry, not only after a sleep this owner
+    // requested: a request that outlived its asker — issued before Tor
+    // finished bootstrapping, so it lands on the client only once that client
+    // exists — would otherwise keep the client asleep for the whole foreground
+    // session.
+    onResume: () => setTorDormant(dormant: false),
+    onHide: () {
+      if (!canRunAppProcessWork(
+        isInForeground: false,
+        formFactor: formFactor,
+      )) {
+        setTorDormant(dormant: true);
+      }
+    },
+  );
+}
+
+@visibleForTesting
+void disposeTorDormancyLifecycle() {
+  _torDormancyLifecycle?.dispose();
+  _torDormancyLifecycle = null;
+}
+
 /// Applies the persisted route before app bootstrap or providers can start any
 /// network work. Failure is retained as an enabled/failed state; Rust has
 /// already switched to fail-closed routing at that point.
@@ -342,6 +459,10 @@ Future<void> initializeNetworkPrivacyRuntime({
 }) async {
   _pendingStartupActivation = null;
   _startupActivationSuperseded = false;
+  // Before the route is applied, and outside the try: the owner has to exist
+  // on every launch, including the one where reading the preference throws and
+  // this process goes fail-closed Tor without ever being asked.
+  startTorDormancyLifecycle();
   late final bool enabled;
   try {
     enabled = await store.readTorEnabled();

--- a/lib/src/rust/api/network_privacy.dart
+++ b/lib/src/rust/api/network_privacy.dart
@@ -39,6 +39,14 @@ NetworkPrivacyStatus getNetworkPrivacyStatus() =>
 bool isTorEnabled() =>
     RustLib.instance.api.crateApiNetworkPrivacyIsTorEnabled();
 
+/// Suspends or resumes Tor's circuit maintenance alongside the app lifecycle.
+///
+/// A bootstrapped client otherwise keeps guard connections and directory tasks
+/// running while the app is in the background, which costs battery on mobile
+/// and does work iOS will kill the app for. A no-op until Tor is connected.
+void setNetworkPrivacyDormant({required bool dormant}) => RustLib.instance.api
+    .crateApiNetworkPrivacySetNetworkPrivacyDormant(dormant: dormant);
+
 /// Starts a token-protected loopback server that streams HTTPS update assets
 /// from the embedded Tor client directly to a native desktop updater.
 Future<String> startTorUpdateRelay() =>

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -81,7 +81,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -92948645;
+  int get rustContentHash => 844087337;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -1045,6 +1045,8 @@ abstract class RustLibApi extends BaseApi {
     required bool skipped,
     int? choice,
   });
+
+  void crateApiNetworkPrivacySetNetworkPrivacyDormant({required bool dormant});
 
   void crateApiSyncSetSyncMode({required int mode});
 
@@ -7439,6 +7441,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  void crateApiNetworkPrivacySetNetworkPrivacyDormant({required bool dormant}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_bool(dormant, serializer);
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 145,
+          )!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiNetworkPrivacySetNetworkPrivacyDormantConstMeta,
+        argValues: [dormant],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiNetworkPrivacySetNetworkPrivacyDormantConstMeta =>
+      const TaskConstMeta(
+        debugName: "set_network_privacy_dormant",
+        argNames: ["dormant"],
+      );
+
+  @override
   void crateApiSyncSetSyncMode({required int mode}) {
     return handler.executeSync(
       SyncTask(
@@ -7448,7 +7480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
           )!;
         },
         codec: SseCodec(
@@ -7483,7 +7515,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7516,7 +7548,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
             port: port_,
           );
         },
@@ -7556,7 +7588,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7597,7 +7629,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7651,7 +7683,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
             port: port_,
           );
         },
@@ -7701,7 +7733,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 151,
+              funcId: 152,
               port: port_,
             );
           },
@@ -7742,7 +7774,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 152,
+              funcId: 153,
               port: port_,
             );
           },
@@ -7774,7 +7806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7801,7 +7833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
           )!;
         },
         codec: SseCodec(
@@ -7827,7 +7859,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7869,7 +7901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 157,
             port: port_,
           );
         },
@@ -7920,7 +7952,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7959,7 +7991,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 159,
             port: port_,
           );
         },
@@ -7995,7 +8027,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8030,7 +8062,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
             port: port_,
           );
         },
@@ -8067,7 +8099,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8111,7 +8143,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8161,7 +8193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8193,7 +8225,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8221,7 +8253,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
           )!;
         },
         codec: SseCodec(
@@ -8253,7 +8285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8290,7 +8322,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8321,7 +8353,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 169,
           )!;
         },
         codec: SseCodec(
@@ -8352,7 +8384,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8389,7 +8421,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 171,
             port: port_,
           );
         },

--- a/rust/src/api/network_privacy.rs
+++ b/rust/src/api/network_privacy.rs
@@ -58,6 +58,16 @@ pub fn is_tor_enabled() -> bool {
     crate::network_privacy::is_tor_desired()
 }
 
+/// Suspends or resumes Tor's circuit maintenance alongside the app lifecycle.
+///
+/// A bootstrapped client otherwise keeps guard connections and directory tasks
+/// running while the app is in the background, which costs battery on mobile
+/// and does work iOS will kill the app for. A no-op until Tor is connected.
+#[flutter_rust_bridge::frb(sync)]
+pub fn set_network_privacy_dormant(dormant: bool) {
+    crate::network_privacy::set_tor_dormant(dormant);
+}
+
 /// Starts a token-protected loopback server that streams HTTPS update assets
 /// from the embedded Tor client directly to a native desktop updater.
 pub async fn start_tor_update_relay() -> Result<String, String> {

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -197,7 +197,7 @@ pub extern "C" fn zcash_lightwalletd_latest_block_height(
             cancellation,
             async {
                 let mut client =
-                    crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await?;
+                    crate::wallet::sync_engine::open_background_direct_lwd_channel(lightwalletd_url).await?;
                 crate::wallet::sync_engine::get_latest_block(&mut client).await
             },
         )) {
@@ -255,7 +255,7 @@ pub extern "C" fn zcash_lightwalletd_observe_transaction(
         match runtime.block_on(await_lightwalletd_request_or_cancellation(
             cancellation,
             async {
-                let mut client = crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url)
+                let mut client = crate::wallet::sync_engine::open_background_direct_lwd_channel(lightwalletd_url)
                     .await
                     .map_err(|error| tonic::Status::unavailable(error.to_string()))?;
                 crate::wallet::sync_engine::get_transaction(&mut client, transaction_id).await
@@ -324,7 +324,7 @@ pub extern "C" fn zcash_lightwalletd_send_transaction(
         match runtime.block_on(await_lightwalletd_request_or_cancellation(
             cancellation,
             async {
-                let mut client = crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url)
+                let mut client = crate::wallet::sync_engine::open_background_direct_lwd_channel(lightwalletd_url)
                     .await
                     .map_err(|error| error.to_string())?;
                 crate::wallet::sync_engine::send_transaction_with_status(

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -92948645;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 844087337;
 
 // Section: executor
 
@@ -5793,6 +5793,38 @@ fn wire__crate__api__voting__set_ballot_intent_impl(
         },
     )
 }
+fn wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "set_network_privacy_dormant",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_dormant = <bool>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::network_privacy::set_network_privacy_dormant(api_dormant);
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__sync__set_sync_mode_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -10208,28 +10240,28 @@ fn pde_ffi_dispatcher_primary_impl(
 142 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
 143 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
 144 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+148 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10269,10 +10301,15 @@ fn pde_ffi_dispatcher_sync_impl(
         }
         114 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
         134 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        145 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        154 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        165 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        168 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        145 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        146 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        155 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        166 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        169 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/network_privacy.rs
+++ b/rust/src/network_privacy.rs
@@ -390,7 +390,24 @@ async fn bootstrap_tor(
         remaining,
         TorClient::create_with_timeouts(
             tor_directory,
-            |_| {},
+            // Arti refuses a data directory other users could reach. On desktop
+            // those POSIX mode bits are the real boundary, so the check stays
+            // on. On mobile the app sandbox is the boundary, and the pinned
+            // fs-mistrust already knows it: on iOS and Android it compiles out
+            // the owner check and stops forbidding the group bits, which is the
+            // group-writable container ancestor that used to reject the
+            // directory outright. What it still rejects there — a world-
+            // writable ancestor, or arti's own 0o700 directories opened up — a
+            // sandboxed container is not expected to have, so this bypass is
+            // probably redundant. Dropping it needs evidence from a real
+            // device, because a rejected directory fails the bootstrap from
+            // inside fail-closed mode: every request blocked, Tor never Ready.
+            |permissions| {
+                #[cfg(any(target_os = "ios", target_os = "android"))]
+                permissions.dangerously_trust_everyone();
+                #[cfg(not(any(target_os = "ios", target_os = "android")))]
+                let _ = permissions;
+            },
             timeouts,
         ),
     )

--- a/rust/src/network_privacy.rs
+++ b/rust/src/network_privacy.rs
@@ -19,13 +19,15 @@ use std::{
     time::Duration,
 };
 
-use zcash_client_backend::tor::{Client as TorClient, Timeouts as TorTimeouts};
+use zcash_client_backend::tor::{Client as TorClient, DormantMode, Timeouts as TorTimeouts};
 
 /// `TorTimeouts` only bounds connect, request and response-body phases, so
 /// bootstrapping itself is unbounded: arti retries it 128 times with a growing
 /// backoff, which never terminates on a network that blocks Tor. A cold first
 /// bootstrap over a slow link legitimately takes tens of seconds, so the
-/// deadline stays generous enough to let those finish.
+/// deadline stays generous enough to let those finish. A user watching the
+/// route switch can also see it working and give up themselves, which a
+/// background pass cannot.
 const TOR_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(3 * 60);
 const TOR_BOOTSTRAP_TIMEOUT_MESSAGE: &str =
     "Tor could not connect. Check your internet connection and try again.";
@@ -36,6 +38,14 @@ const STATUS_READY: u8 = 2;
 const STATUS_FAILED: u8 = 3;
 
 static TOR_DESIRED: AtomicBool = AtomicBool::new(false);
+/// The dormancy asked for, kept whether or not a client exists yet. A request
+/// that arrives mid-bootstrap has nothing to apply to, and the app lifecycle
+/// callbacks do not repeat themselves once it finishes.
+static TOR_DORMANT: AtomicBool = AtomicBool::new(false);
+/// Serialises reading the intent and applying a mode to the client, so two
+/// lifecycle callbacks racing cannot apply a mode from a different moment than
+/// the intent they read.
+static DORMANT_APPLY_LOCK: Mutex<()> = Mutex::new(());
 static TOR_STATUS: AtomicU8 = AtomicU8::new(STATUS_DIRECT);
 static TOR_CLIENT: OnceLock<RwLock<Option<TorClient>>> = OnceLock::new();
 static TOR_INIT_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
@@ -266,10 +276,84 @@ impl<T: hyper::rt::Write + Unpin> hyper::rt::Write for DirectRouteIo<T> {
     }
 }
 
+/// Puts a Tor client to sleep, or wakes it up.
+///
+/// Arti keeps guard connections and directory tasks running; an idle client
+/// pads its guard connection continuously — measured at roughly 500 B/s,
+/// against 27 B/s dormant. On mobile that costs battery in a state the OS will
+/// kill the app for, so the app asks for sleep on its way out and for
+/// wakefulness on every foreground entry. This never forces a bootstrap, but a
+/// request made while one is still running is not lost either: the intent is
+/// process-wide, and a client picks it up as it is installed.
+pub fn set_tor_dormant(dormant: bool) {
+    {
+        let _guard = dormant_apply_lock();
+        TOR_DORMANT.store(dormant, Ordering::Release);
+        apply_dormant_mode_locked();
+    }
+    log::info!("network privacy: Tor dormant={dormant}");
+}
+
+fn dormant_apply_lock() -> std::sync::MutexGuard<'static, ()> {
+    DORMANT_APPLY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// The mode a client is put into as it is installed, so it never lands awake in
+/// a process the app has already backgrounded. Applying `Soft` to a client that
+/// has just finished bootstrapping is safe: arti lifts it back to `Normal` on
+/// the next use.
+fn pending_dormant_mode() -> DormantMode {
+    if TOR_DORMANT.load(Ordering::Acquire) {
+        DormantMode::Soft
+    } else {
+        DormantMode::Normal
+    }
+}
+
+/// Pushes the mode the current state implies onto the installed client.
+/// Caller holds [`DORMANT_APPLY_LOCK`], so the value read and the value applied
+/// cannot come from different moments.
+fn apply_dormant_mode_locked() {
+    let mode = pending_dormant_mode();
+    let slot = client_slot()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(client) = slot.as_ref() {
+        client.set_dormant(mode);
+    }
+}
+
 pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, String> {
     TOR_DESIRED.store(true, Ordering::Release);
+    bootstrap_tor(tor_directory, TOR_BOOTSTRAP_TIMEOUT).await
+}
 
-    let _init_guard = init_lock().lock().await;
+async fn bootstrap_tor(
+    tor_directory: &Path,
+    deadline: Duration,
+) -> Result<NetworkPrivacyStatus, String> {
+    // The deadline covers the wait for the init lock as well as the bootstrap
+    // it guards, so it bounds the call the caller actually made.
+    //
+    // Two enables can be in flight at once — a foreground toggle and a
+    // background pass — and the holder may be spending the foreground's three
+    // minutes on a network that blocks Tor. A waiter that started its own timer
+    // only after acquiring would sit there for the holder's deadline and then
+    // its own on top. For a background pass that is the whole execution
+    // opportunity spent inside one blocking call: it holds no cancellation
+    // handle the OS expiration handler can reach, and every re-arm path lives
+    // on the far side of it, so the window ends with nothing armed.
+    let started = std::time::Instant::now();
+    let Ok(_init_guard) = tokio::time::timeout(deadline, init_lock().lock()).await else {
+        // Nothing is published here. Whichever bootstrap holds the lock owns the
+        // status, and this call only reports that it could not get Tor up inside
+        // its budget. The route stays Tor-desired either way, so every
+        // policy-aware client keeps refusing — running out of patience is not a
+        // reason to reach the network another way.
+        return Err(TOR_BOOTSTRAP_TIMEOUT_MESSAGE.to_string());
+    };
     if !is_tor_desired() {
         return Ok(NetworkPrivacyStatus::Direct);
     }
@@ -293,14 +377,36 @@ pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, St
     // body that is actively streaming enough time to complete. Small app API
     // responses retain their own shorter body deadline.
     let timeouts = TorTimeouts::default().with_response_body(Duration::from_secs(2 * 60 * 60));
+    // What is left of the budget after the wait, so waiting and bootstrapping
+    // cannot add up to more than the caller asked for. Bounding the bootstrap
+    // separately rather than wrapping the whole body in one timer is what keeps
+    // a failure published: a timer that fired out here would drop
+    // `install_bootstrapped_client` mid-await and skip the `set_tor_failed` it
+    // exists to perform, leaving the status Bootstrapping with nothing running.
+    let remaining = deadline.saturating_sub(started.elapsed());
     // Returning here drops `_init_guard`, so a bootstrap that ran out of time
     // does not block the next enable attempt.
-    let client = match await_tor_bootstrap(
-        TOR_BOOTSTRAP_TIMEOUT,
-        TorClient::create_with_timeouts(tor_directory, |_| {}, timeouts),
+    install_bootstrapped_client(
+        remaining,
+        TorClient::create_with_timeouts(
+            tor_directory,
+            |_| {},
+            timeouts,
+        ),
     )
     .await
-    {
+}
+
+/// Waits out one bootstrap attempt and publishes its outcome.
+///
+/// Running out of time is not a reason to reach the network another way: the
+/// route stays Tor and the status becomes `Failed`, so every policy-aware client
+/// keeps refusing until something bootstraps successfully.
+async fn install_bootstrapped_client<E: Display>(
+    deadline: Duration,
+    bootstrap: impl Future<Output = Result<TorClient, E>>,
+) -> Result<NetworkPrivacyStatus, String> {
+    let client = match await_tor_bootstrap(deadline, bootstrap).await {
         Ok(client) => client,
         Err(error) => {
             set_tor_failed();
@@ -308,42 +414,95 @@ pub async fn enable_tor(tor_directory: &Path) -> Result<NetworkPrivacyStatus, St
         }
     };
 
-    if !is_tor_desired() {
-        return Ok(NetworkPrivacyStatus::Direct);
+    {
+        // The route is read and the client published under one lock, because
+        // `disable_tor` takes the same one: a switch to direct that lands
+        // between a check outside and the store would otherwise leave the
+        // status Ready with the route direct, and an orphaned client awake and
+        // padding behind it.
+        let mut slot = client_slot()
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !is_tor_desired() {
+            return Ok(NetworkPrivacyStatus::Direct);
+        }
+        // Adopting the pending mode here is what keeps a sleep asked for
+        // mid-bootstrap from being overtaken by the client it was waiting for.
+        client.set_dormant(pending_dormant_mode());
+        *slot = Some(client);
+        TOR_STATUS.store(STATUS_READY, Ordering::Release);
     }
-
-    *client_slot()
-        .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(client);
-    TOR_STATUS.store(STATUS_READY, Ordering::Release);
     log::info!("network privacy: Tor is ready");
     Ok(NetworkPrivacyStatus::Ready)
 }
 
+/// How often a running bootstrap checks whether the route it is for still
+/// exists. Short enough that the abandon is not itself a wait, long enough to
+/// cost nothing over the minutes a blocked bootstrap can take.
+const BOOTSTRAP_ROUTE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const BOOTSTRAP_ABANDONED_MESSAGE: &str = "Tor was turned off while it was connecting";
+
+/// Waits out one bootstrap, and stops waiting if the route it is for goes away.
+///
+/// Clearing the client slot does not reach the `TorClient` future already
+/// running here, so a user who turned Tor off left arti bootstrapping — talking
+/// to directory authorities for up to the full deadline, on a route they had
+/// just switched off, while holding the init lock a re-enable would have to
+/// wait behind. Nothing wrong was ever published, because the publish re-reads
+/// the route under the slot lock; what was wrong is that the work continued at
+/// all.
+///
+/// Dropping the future is what cancels it, so the abandon is the return itself.
+/// Polling rather than signalling: registering for a notification has a window
+/// between the registration and the check that a route change can fall into,
+/// and a quarter-second poll over a bootstrap measured in tens of seconds costs
+/// less than closing that window would.
 async fn await_tor_bootstrap<T, E: Display>(
     deadline: Duration,
     bootstrap: impl Future<Output = Result<T, E>>,
 ) -> Result<T, String> {
-    match tokio::time::timeout(deadline, bootstrap).await {
-        Ok(Ok(client)) => Ok(client),
-        Ok(Err(error)) => Err(format!("Bootstrap Tor: {error}")),
-        Err(_) => Err(TOR_BOOTSTRAP_TIMEOUT_MESSAGE.to_string()),
+    tokio::pin!(bootstrap);
+    let expires_at = tokio::time::Instant::now() + deadline;
+    loop {
+        tokio::select! {
+            result = &mut bootstrap => {
+                return match result {
+                    Ok(client) => Ok(client),
+                    Err(error) => Err(format!("Bootstrap Tor: {error}")),
+                }
+            }
+            _ = tokio::time::sleep_until(expires_at) => {
+                return Err(TOR_BOOTSTRAP_TIMEOUT_MESSAGE.to_string())
+            }
+            _ = tokio::time::sleep(BOOTSTRAP_ROUTE_POLL_INTERVAL) => {
+                if !is_tor_desired() {
+                    return Err(BOOTSTRAP_ABANDONED_MESSAGE.to_string());
+                }
+            }
+        }
     }
 }
 
 pub fn disable_tor() {
+    // Under the same lock a finishing bootstrap publishes through, so the two
+    // cannot interleave into a Ready status on a direct route.
+    let mut slot = client_slot()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     TOR_DESIRED.store(false, Ordering::Release);
     TOR_STATUS.store(STATUS_DIRECT, Ordering::Release);
-    *client_slot()
-        .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    *slot = None;
+    drop(slot);
     log::info!("network privacy: direct route enabled");
 }
 
 fn set_tor_failed() {
-    *client_slot()
+    let mut slot = client_slot()
         .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *slot = None;
+    // Same lock as the publish and the disable: a route that went direct while
+    // this bootstrap was failing keeps its own status.
     if is_tor_desired() {
         TOR_STATUS.store(STATUS_FAILED, Ordering::Release);
     }
@@ -385,6 +544,44 @@ pub(crate) fn tor_client_for_route(isolated: bool) -> Result<Option<TorClient>, 
     }
 }
 
+/// Serialises the tests that touch the process-wide route policy.
+///
+/// `cargo test` shares one process across threads, so this has to be reachable
+/// from every module whose tests read the policy — not just the ones that write
+/// it. A direct-route lease consults the desired route on every poll, so a test
+/// that merely opens a direct connection fails if a route test is mid-flight.
+#[cfg(test)]
+pub(crate) mod test_route_policy {
+    use std::sync::{atomic::Ordering, Mutex, MutexGuard};
+
+    static ROUTE_POLICY: Mutex<()> = Mutex::new(());
+
+    pub(crate) struct RoutePolicyGuard {
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl Drop for RoutePolicyGuard {
+        /// Hands the process back in its default state. The direct-route epoch
+        /// only ever moves forward and each lease compares against the value it
+        /// captured, so it needs no restoring.
+        fn drop(&mut self) {
+            super::disable_tor();
+            // The intent is process-wide and one process runs every test in
+            // this crate: a test that asks for dormancy and returns would
+            // otherwise decide later assertions by execution order.
+            super::TOR_DORMANT.store(false, Ordering::Release);
+        }
+    }
+
+    pub(crate) fn lock_route_policy() -> RoutePolicyGuard {
+        RoutePolicyGuard {
+            _lock: ROUTE_POLICY
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -393,8 +590,12 @@ mod tests {
     };
 
     use super::{
-        await_tor_bootstrap, cancel_direct_connections, init_lock, route_decision, DirectRouteIo,
-        NetworkPrivacyStatus, RouteDecision, TOR_BOOTSTRAP_TIMEOUT_MESSAGE,
+        await_tor_bootstrap, begin_tor_enable, bootstrap_tor, cancel_direct_connections,
+        client_slot, disable_tor, init_lock, install_bootstrapped_client, is_tor_desired,
+        pending_dormant_mode, route_decision, set_tor_dormant, set_tor_failed, status,
+        test_route_policy::lock_route_policy, tor_client_for_route, DirectRouteIo, DormantMode,
+        NetworkPrivacyStatus, RouteDecision, TorClient, BOOTSTRAP_ABANDONED_MESSAGE,
+        TOR_BOOTSTRAP_TIMEOUT_MESSAGE,
     };
 
     #[test]
@@ -403,6 +604,25 @@ mod tests {
             route_decision(false, NetworkPrivacyStatus::Direct, false, false),
             Ok(RouteDecision::Direct)
         );
+    }
+
+    #[tokio::test]
+    async fn a_bootstrap_stops_when_the_route_it_is_for_goes_away() {
+        let _policy = lock_route_policy();
+        begin_tor_enable();
+
+        let switching_to_direct = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            disable_tor();
+        });
+        let result = await_tor_bootstrap(
+            Duration::from_secs(5),
+            std::future::pending::<Result<(), String>>(),
+        )
+        .await;
+        switching_to_direct.await.expect("the disable task");
+
+        assert_eq!(result.unwrap_err(), BOOTSTRAP_ABANDONED_MESSAGE);
     }
 
     #[test]
@@ -438,7 +658,37 @@ mod tests {
     }
 
     #[test]
+    fn a_dormancy_request_made_before_the_client_exists_is_applied_to_it() {
+        let _policy = lock_route_policy();
+        assert!(client_slot()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_none());
+
+        set_tor_dormant(true);
+        assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+
+        set_tor_dormant(false);
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
+    }
+
+    /// A test's dormancy intent must not outlive its route-policy guard.
+    #[test]
+    fn the_route_policy_guard_hands_back_the_default_dormancy_intent() {
+        {
+            let _policy = lock_route_policy();
+            set_tor_dormant(true);
+            assert_eq!(pending_dormant_mode(), DormantMode::Soft);
+        }
+
+        let _policy = lock_route_policy();
+
+        assert_eq!(pending_dormant_mode(), DormantMode::Normal);
+    }
+
+    #[test]
     fn direct_route_io_is_cancelled_when_tor_activation_advances_the_epoch() {
+        let _policy = lock_route_policy();
         let io = DirectRouteIo::new(());
         let waker = Waker::noop();
         let mut context = Context::from_waker(waker);
@@ -470,8 +720,102 @@ mod tests {
         assert_eq!(result.unwrap_err(), TOR_BOOTSTRAP_TIMEOUT_MESSAGE);
     }
 
+    /// A path that already exists as a file, so a bootstrap started against it
+    /// fails at its first filesystem step. No test may reach a real bootstrap:
+    /// that is network work, and on a blocked network it does not terminate.
+    fn unusable_tor_directory(temp: &tempfile::TempDir) -> std::path::PathBuf {
+        let path = temp.path().join("tor");
+        std::fs::write(&path, b"").unwrap();
+        path
+    }
+
+    #[test]
+    fn a_route_that_went_direct_keeps_its_status_when_a_bootstrap_fails() {
+        let _policy = lock_route_policy();
+        begin_tor_enable();
+        disable_tor();
+
+        assert_eq!(status(), NetworkPrivacyStatus::Direct);
+        assert!(client_slot()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_none());
+
+        // A bootstrap started before the switch reports its failure afterwards.
+        // The route is direct now, so the failure is not this route's to
+        // publish — a Failed status here would block requests the user asked to
+        // send directly.
+        set_tor_failed();
+
+        assert_eq!(status(), NetworkPrivacyStatus::Direct);
+        assert_eq!(
+            route_decision(is_tor_desired(), status(), false, false),
+            Ok(RouteDecision::Direct)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_bootstrap_that_runs_out_of_time_stays_fail_closed() {
+        let _policy = lock_route_policy();
+        begin_tor_enable();
+
+        let result = install_bootstrapped_client(
+            Duration::from_millis(1),
+            std::future::pending::<Result<TorClient, String>>(),
+        )
+        .await;
+
+        assert_eq!(result.unwrap_err(), TOR_BOOTSTRAP_TIMEOUT_MESSAGE);
+        assert!(is_tor_desired());
+        assert_eq!(status(), NetworkPrivacyStatus::Failed);
+        assert!(tor_client_for_route(false).is_err());
+    }
+
+    #[tokio::test]
+    async fn a_bootstrap_waiting_on_another_bootstrap_is_bounded_by_its_own_deadline() {
+        let _policy = lock_route_policy();
+        let temp = tempfile::tempdir().unwrap();
+        begin_tor_enable();
+
+        // A bootstrap already in flight, of the kind a foreground enable starts:
+        // it holds the init lock for far longer than the waiter's whole budget.
+        let (acquired_tx, acquired_rx) = tokio::sync::oneshot::channel();
+        let holder = tokio::spawn(async move {
+            let _init_guard = init_lock().lock().await;
+            let _ = acquired_tx.send(());
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        });
+        acquired_rx.await.unwrap();
+
+        let started = std::time::Instant::now();
+        let result = bootstrap_tor(&unusable_tor_directory(&temp), Duration::from_millis(100)).await;
+        let waited = started.elapsed();
+
+        holder.abort();
+        let _ = holder.await;
+
+        // The deadline covers the wait, not just the bootstrap on its far side.
+        // A background pass has one execution opportunity and no cancellation
+        // handle reaching into this call, so parking here for the holder's
+        // deadline spends the window with nothing armed.
+        assert!(
+            waited < Duration::from_secs(5),
+            "a waiting bootstrap ignored its own deadline: waited {waited:?}"
+        );
+        assert_eq!(result.unwrap_err(), TOR_BOOTSTRAP_TIMEOUT_MESSAGE);
+        // Running out of time is still not a reason to reach the network another
+        // way: the route stays Tor and every policy-aware client keeps refusing.
+        assert!(is_tor_desired());
+        assert!(tor_client_for_route(false).is_err());
+    }
+
     #[tokio::test]
     async fn a_stalled_tor_bootstrap_releases_the_init_lock_for_the_next_attempt() {
+        // The route-policy lock covers the init lock too: the background enable
+        // tests reach it through a real `bootstrap_tor`, and this test reads it
+        // as a global, so an unserialised run sees the other test's guard and
+        // reports it as a leak.
+        let _policy = lock_route_policy();
         let result = {
             let _init_guard = init_lock().lock().await;
             await_tor_bootstrap(

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -142,6 +142,46 @@ pub(crate) async fn open_isolated_lwd_channel(
     open_lwd_channel_for_route(lightwalletd_url, true).await
 }
 
+/// Opens a lightwalletd channel that is always direct, bypassing the
+/// process-wide route policy entirely.
+///
+/// This is the transport for iOS background migration work, and it is pinned
+/// direct as a product decision: Tor covers the app's foreground traffic, and
+/// a background pass never brings Tor up or borrows the foreground's client —
+/// a launch where Dart never ran has no client, and a warm process may drop
+/// its client at any moment. Routing background work through the policy would
+/// therefore only convert it into failures whenever Tor is on. It uses a
+/// plain connector rather than the leased one, so a foreground toggle to Tor
+/// does not abort a background broadcast already in flight.
+///
+/// Nothing in the foreground may use this: every foreground path goes through
+/// [`open_lwd_channel`] or [`open_isolated_lwd_channel`], which respect the
+/// user's chosen route and fail closed while Tor is starting or broken.
+pub(crate) async fn open_background_direct_lwd_channel(
+    lightwalletd_url: &str,
+) -> Result<CompactTxStreamerClient<Channel>, SyncError> {
+    static RUSTLS_INIT: std::sync::Once = std::sync::Once::new();
+    RUSTLS_INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+
+    let endpoint = Endpoint::from_shared(lightwalletd_url.to_string())
+        .map_err(|e| SyncError::net(format!("invalid URL: {e}")))?
+        .connect_timeout(LIGHTWALLETD_CONNECT_TIMEOUT);
+    let endpoint = if lightwalletd_url.starts_with("https://") {
+        endpoint
+            .tls_config(ClientTlsConfig::new().with_webpki_roots())
+            .map_err(|e| SyncError::net(format!("TLS error: {e}")))?
+    } else {
+        endpoint
+    };
+    let channel = endpoint
+        .connect()
+        .await
+        .map_err(|e| SyncError::net(format!("gRPC connect failed: {e}")))?;
+    Ok(CompactTxStreamerClient::new(channel))
+}
+
 async fn open_lwd_channel_for_route(
     lightwalletd_url: &str,
     isolated: bool,
@@ -709,6 +749,27 @@ mod tests {
                 if message.contains("get_address_utxos_stream")
                     && message.contains("timed out")
         ));
+    }
+
+    #[tokio::test]
+    async fn background_transport_stays_direct_while_tor_is_desired() {
+        // The background lane is pinned direct as a product decision: Tor
+        // covers foreground traffic, and a background pass never brings Tor
+        // up or borrows the foreground's client. Routed through the policy,
+        // this call would be refused the moment Tor was desired; pinned, it
+        // reaches the socket and fails only because nothing is listening.
+        let _policy = crate::network_privacy::test_route_policy::lock_route_policy();
+        crate::network_privacy::begin_tor_enable();
+
+        let error = open_background_direct_lwd_channel("http://127.0.0.1:1")
+            .await
+            .expect_err("nothing listens on port 1");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("gRPC connect failed"),
+            "expected a transport failure, got a policy refusal: {message}"
+        );
     }
 
     #[tokio::test]

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -713,6 +713,9 @@ mod tests {
 
     #[tokio::test]
     async fn direct_connections_keep_tcp_nodelay_enabled() {
+        // A direct-route lease aborts itself whenever the process-wide route is
+        // Tor, so this has to hold the policy even though it never writes it.
+        let _policy = crate::network_privacy::test_route_policy::lock_route_policy();
         let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
             .await
             .expect("bind loopback listener");

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -53,6 +53,7 @@ pub(crate) use error::SyncError;
 use error::{RecoveryStrategy, MAX_REWINDS_PER_RUN};
 use lwd::{download_blocks, download_subtree_roots, get_address_utxos_stream, get_tree_state};
 pub(crate) use lwd::{
+    open_background_direct_lwd_channel,
     get_latest_block, get_taddress_txids, get_transaction, next_stream_message,
     open_isolated_lwd_channel, open_lwd_channel, send_transaction, send_transaction_with_status,
 };

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -18,9 +18,12 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugDefaultTargetPlatformOverride;
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
+import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
@@ -7353,6 +7356,69 @@ void main() {
     );
   });
 
+  testWidgets('the backgrounding invitation discloses the direct route on Tor', (
+    tester,
+  ) async {
+    // The background transport is pinned direct by design, so the moment
+    // this screen invites a Tor user to background the app is the moment
+    // their coverage expectation and the wire part ways. iOS only: Android
+    // has no background migration lane to disclose.
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    _useMobileViewport(tester);
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(
+          ios: true,
+          getNotificationAuthorizationStatus: () async =>
+              IronwoodMigrationNotificationAuthorizationStatus.authorized,
+        ),
+        extraOverrides: [
+          networkPrivacyProvider.overrideWith(
+            _TorRouteNetworkPrivacyNotifier.new,
+          ),
+        ],
+        status: _status(
+          phase: kIronwoodMigrationBroadcastingPhase,
+          nextActionHeight: 3_000_020,
+          targetValues: List<int>.filled(9, 100_000_000),
+          parts: [
+            for (var index = 0; index < 9; index++)
+              rust_sync.MigrationPartStatus(
+                partIndex: index,
+                valueZatoshi: BigInt.from(100_000_000),
+                state: index < 8
+                    ? rust_sync.MigrationPartState.completed
+                    : rust_sync.MigrationPartState.scheduled,
+                txidHex: 'tx-$index',
+                scheduledHeight: 3_000_000 + index,
+                confirmationCount: index < 8 ? 3 : 0,
+                confirmationTarget: 3,
+              ),
+          ],
+        ),
+        syncState: SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          scannedHeight: 3_000_000,
+          chainTipHeight: 3_000_000,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        'Next migration step expected in\n'
+        '~25 minutes.\n'
+        'Notifications are on. You can leave Vizor and check back later.\n'
+        'Migration continues over a direct connection.',
+      ),
+      findsOneWidget,
+    );
+    debugDefaultTargetPlatformOverride = null;
+  });
+
   testWidgets('keeps the actual batch number for Keystone broadcasting', (
     tester,
   ) async {
@@ -8554,4 +8620,13 @@ class _RecordingCompletionStore implements IronwoodMigrationCompletionStore {
   }) async {
     seen.add('$network:$accountUuid:$completionId');
   }
+}
+
+/// A connected Tor route, for surfaces that disclose what it does not cover.
+class _TorRouteNetworkPrivacyNotifier extends NetworkPrivacyNotifier {
+  @override
+  NetworkPrivacyState build() => const NetworkPrivacyState(
+    torEnabled: true,
+    status: NetworkPrivacyConnectionStatus.connected,
+  );
 }

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -7412,7 +7412,8 @@ void main() {
         'Next migration step expected in\n'
         '~25 minutes.\n'
         'Notifications are on. You can leave Vizor and check back later.\n'
-        'Migration continues over a direct connection.',
+        'While Vizor is closed, migration continues over a direct '
+        'connection.',
       ),
       findsOneWidget,
     );

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:zcash_wallet/src/core/widgets/mobile/mobile_list_row.dart';
 import 'package:zcash_wallet/src/features/settings/screens/mobile/mobile_settings_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/biometric_unlock_provider.dart';
+import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/theme_mode_provider.dart';
@@ -120,10 +121,19 @@ Widget _app({
   BiometricUnlockState? biometric,
   BiometricUnlockNotifier Function()? biometricNotifier,
   _FakeSyncKeepAwakeNotifier? syncKeepAwakeNotifier,
+  NetworkPrivacyState? networkPrivacyState,
+  List<bool>? networkPrivacyCalls,
 }) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap(accountState)),
+      if (networkPrivacyState != null)
+        networkPrivacyProvider.overrideWith(
+          () => _FakeNetworkPrivacyNotifier(
+            networkPrivacyState,
+            networkPrivacyCalls ?? <bool>[],
+          ),
+        ),
       syncProvider.overrideWith(() => FakeSyncNotifier(SyncState())),
       themeModeProvider.overrideWith(_FakeThemeModeNotifier.new),
       syncKeepAwakeProvider.overrideWith(
@@ -143,6 +153,23 @@ Widget _app({
   );
 }
 
+class _FakeNetworkPrivacyNotifier extends NetworkPrivacyNotifier {
+  _FakeNetworkPrivacyNotifier(this._state, this.calls);
+
+  final NetworkPrivacyState _state;
+
+  /// Routes requested by the card. `retry()` funnels through here too.
+  final List<bool> calls;
+
+  @override
+  NetworkPrivacyState build() => _state;
+
+  @override
+  Future<void> setTorEnabled(bool enabled) async {
+    calls.add(enabled);
+  }
+}
+
 void main() {
   setUp(() {
     // Phone-sized surface so the lazily-built list renders every group.
@@ -150,6 +177,367 @@ void main() {
     binding.platformDispatcher.views.first
       ..physicalSize = const Size(520, 1200)
       ..devicePixelRatio = 1.0;
+  });
+
+  testWidgets('the Tor card reports the off route', (tester) async {
+    await tester.pumpWidget(
+      _app(networkPrivacyState: const NetworkPrivacyState.off()),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('mobile_settings_tor_row')),
+      200,
+    );
+    expect(find.text('Use Tor'), findsOneWidget);
+    expect(find.text('Off'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data,
+      contains('connect directly'),
+    );
+  });
+
+  testWidgets('tapping the Tor row asks for the other route', (tester) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState.off(),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final row = find.byKey(const ValueKey('mobile_settings_tor_row'));
+    await tester.scrollUntilVisible(row, 200);
+    await tester.tap(row);
+    await tester.pumpAndSettle();
+
+    expect(calls, [true]);
+  });
+
+  testWidgets('the Tor toggle matches the keep-awake toggle', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connected,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final torThumb = find.byKey(
+      const ValueKey('mobile_settings_tor_toggle_thumb'),
+    );
+    final torTrack = find.byKey(const ValueKey('mobile_settings_tor_toggle'));
+    await tester.scrollUntilVisible(torThumb, 200);
+    expect(
+      tester.getSize(torThumb),
+      tester.getSize(
+        find.byKey(
+          const ValueKey('mobile_settings_sync_keep_awake_toggle_thumb'),
+        ),
+      ),
+    );
+    expect(
+      tester.getSize(torTrack),
+      tester.getSize(
+        find.byKey(const ValueKey('mobile_settings_sync_keep_awake_toggle')),
+      ),
+    );
+    expect(
+      tester.getCenter(torThumb).dx,
+      greaterThan(tester.getCenter(torTrack).dx),
+    );
+  });
+
+  testWidgets(
+    'a connected Tor route names the conditions background work needs',
+    (tester) async {
+      await tester.pumpWidget(
+        _app(
+          networkPrivacyState: const NetworkPrivacyState(
+            torEnabled: true,
+            status: NetworkPrivacyConnectionStatus.connected,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.byKey(const ValueKey('mobile_settings_tor_row')),
+        200,
+      );
+      expect(find.text('Connected'), findsOneWidget);
+      final description = tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data;
+      expect(
+        description,
+        contains(
+          'Background migration activity uses a direct connection.',
+        ),
+      );
+      // The card must not promise Tor coverage the background lane does not
+      // have, and must not promise conditional background progress either —
+      // there is no charger-and-Wi-Fi gate to meet.
+      expect(description, isNot(contains('charging on an unmetered network')));
+      expect(description, isNot(contains('only while Vizor is open')));
+    },
+  );
+
+  testWidgets('a connecting Tor route says requests are paused', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connecting,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    // pump() only: a connecting card must never be pumpAndSettle'd if it ever
+    // animates.
+    await tester.pump();
+
+    final row = find.byKey(const ValueKey('mobile_settings_tor_row'));
+    await tester.scrollUntilVisible(row, 200);
+    expect(find.text('Connecting…'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data,
+      contains('wait until the Tor connection is ready'),
+    );
+    // The bootstrap runs to a three-minute deadline with every request failing
+    // closed, and relaunching starts the same wait, so switching to direct has
+    // to stay reachable for the whole of it.
+    expect(tester.widget<GestureDetector>(row).onTap, isNotNull);
+    await tester.tap(row);
+    await tester.pump();
+    expect(calls, [false]);
+  });
+
+  testWidgets('a switch to direct cannot be driven back into Tor', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connecting,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pump();
+
+    final row = find.byKey(const ValueKey('mobile_settings_tor_row'));
+    await tester.scrollUntilVisible(row, 200);
+    // Nothing to escape from here: the route is already on its way to direct.
+    expect(tester.widget<GestureDetector>(row).onTap, isNull);
+    await tester.tap(row);
+    await tester.pump();
+    expect(calls, isEmpty);
+  });
+
+  testWidgets('a failed Tor route stays blocked and offers a retry', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final retry = find.byKey(const ValueKey('mobile_settings_tor_retry'));
+    await tester.scrollUntilVisible(retry, 200);
+    expect(find.text('Failed'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data,
+      contains('Requests stay blocked'),
+    );
+    expect(find.text('Try again'), findsOneWidget);
+
+    await tester.tap(retry);
+    await tester.pumpAndSettle();
+
+    expect(calls, [true]);
+  });
+
+  testWidgets('a failed switch to direct says Tor is still carrying traffic', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final retry = find.byKey(const ValueKey('mobile_settings_tor_retry'));
+    await tester.scrollUntilVisible(retry, 200);
+    expect(find.text('Switch failed'), findsOneWidget);
+    final description = tester
+        .widget<Text>(
+          find.byKey(const ValueKey('mobile_settings_tor_description')),
+        )
+        .data;
+    expect(description, contains('could not switch to a direct connection'));
+    expect(description, contains('Tor is still on'));
+    expect(description, isNot(contains('Requests stay blocked')));
+    expect(find.text('Try direct connection'), findsOneWidget);
+
+    await tester.tap(retry);
+    await tester.pumpAndSettle();
+
+    expect(calls, [false]);
+  });
+
+  testWidgets('an aborted enable never claims requests are blocked', (
+    tester,
+  ) async {
+    // The write-first ordering aborts an enable whose save failed before the
+    // process changes at all, so requests keep flowing directly. The
+    // bootstrap-failure copy — requests stay blocked — would describe the
+    // opposite of what is happening.
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: false,
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: true,
+        ),
+        networkPrivacyCalls: <bool>[],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('mobile_settings_tor_retry')),
+      200,
+    );
+    final description = tester
+        .widget<Text>(
+          find.byKey(const ValueKey('mobile_settings_tor_description')),
+        )
+        .data;
+    expect(description, isNot(contains('stay blocked')));
+    expect(description, contains('was not turned on'));
+    expect(find.text('Setting not saved'), findsOneWidget);
+  });
+
+  testWidgets('a save-only failure never claims Tor is carrying traffic', (
+    tester,
+  ) async {
+    // The transport did switch and only the preference write failed, so this
+    // shares `(failed, target: false)` with the case above while carrying the
+    // opposite privacy guarantee. Reading the target alone told the user Tor
+    // was still on while their requests were going out directly.
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: false,
+          status: NetworkPrivacyConnectionStatus.failed,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: <bool>[],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('mobile_settings_tor_retry')),
+      200,
+    );
+    final description = tester
+        .widget<Text>(
+          find.byKey(const ValueKey('mobile_settings_tor_description')),
+        )
+        .data;
+    expect(description, isNot(contains('Tor is still on')));
+    expect(description, contains('direct connection'));
+    // The saved route stays at Tor — the stricter half — so the next launch
+    // comes back on Tor rather than silently staying direct.
+    expect(description, contains('next time you open the app'));
+  });
+
+  testWidgets('the Tor row publishes its status to assistive technology', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('mobile_settings_tor_retry')),
+      200,
+    );
+    expect(
+      tester.getSemantics(
+        find.byKey(const ValueKey('mobile_settings_tor_row')),
+      ),
+      isSemantics(label: 'Use Tor', value: 'Failed', isButton: true),
+    );
+    expect(
+      tester.getSemantics(
+        find.byKey(const ValueKey('mobile_settings_tor_retry')),
+      ),
+      isSemantics(label: 'Try again', isButton: true, hasTapAction: true),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('the Tor retry action is a touch-sized target', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.failed,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final retry = find.byKey(const ValueKey('mobile_settings_tor_retry'));
+    await tester.scrollUntilVisible(retry, 200);
+    expect(tester.getSize(retry).height, greaterThanOrEqualTo(44));
   });
 
   testWidgets('renders the grouped settings with live values', (tester) async {
@@ -427,6 +815,10 @@ void main() {
     await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
     await tester.pump();
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(const ValueKey('mobile_settings_biometric_row')),
     );
@@ -467,6 +859,10 @@ void main() {
     await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
     await tester.pump();
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(const ValueKey('mobile_settings_biometric_row')),
     );
@@ -503,6 +899,10 @@ void main() {
     await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
     await tester.pump();
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(const ValueKey('mobile_settings_biometric_row')),
     );

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -1,6 +1,8 @@
 @Tags(['mobile'])
 library;
 
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugDefaultTargetPlatformOverride;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -255,9 +257,12 @@ void main() {
     );
   });
 
-  testWidgets(
-    'a connected Tor route names the conditions background work needs',
-    (tester) async {
+  testWidgets('a connected Tor route names the iOS migration exception', (
+    tester,
+  ) async {
+    final previousPlatformOverride = debugDefaultTargetPlatformOverride;
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    try {
       await tester.pumpWidget(
         _app(
           networkPrivacyState: const NetworkPrivacyState(
@@ -278,13 +283,53 @@ void main() {
             find.byKey(const ValueKey('mobile_settings_tor_description')),
           )
           .data;
-      // "Most in-app requests" carries the coverage hedge; the background
-      // migration boundary is disclosed on the migration screen instead, at
-      // the moment it invites the user to background the app.
-      expect(description, contains('most in-app requests go through Tor'));
+      expect(
+        description,
+        'Vizor’s network requests go through Tor. Ironwood private migration '
+        'uses a direct connection while Vizor is closed. Links opened in other '
+        'apps use those apps’ network settings.',
+      );
+    } finally {
+      debugDefaultTargetPlatformOverride = previousPlatformOverride;
+    }
+  });
+
+  testWidgets('a connected Tor route omits the iOS exception on Android', (
+    tester,
+  ) async {
+    final previousPlatformOverride = debugDefaultTargetPlatformOverride;
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    try {
+      await tester.pumpWidget(
+        _app(
+          networkPrivacyState: const NetworkPrivacyState(
+            torEnabled: true,
+            status: NetworkPrivacyConnectionStatus.connected,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.byKey(const ValueKey('mobile_settings_tor_row')),
+        200,
+      );
+      expect(find.text('Connected'), findsOneWidget);
+      final description = tester
+          .widget<Text>(
+            find.byKey(const ValueKey('mobile_settings_tor_description')),
+          )
+          .data;
+      expect(
+        description,
+        'Vizor’s network requests go through Tor. Links opened in other apps '
+        'use those apps’ network settings.',
+      );
       expect(description, isNot(contains('migration')));
-    },
-  );
+    } finally {
+      debugDefaultTargetPlatformOverride = previousPlatformOverride;
+    }
+  });
 
   testWidgets('a connecting Tor route says requests are paused', (
     tester,

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -278,17 +278,11 @@ void main() {
             find.byKey(const ValueKey('mobile_settings_tor_description')),
           )
           .data;
-      expect(
-        description,
-        contains(
-          'Background migration activity uses a direct connection.',
-        ),
-      );
-      // The card must not promise Tor coverage the background lane does not
-      // have, and must not promise conditional background progress either —
-      // there is no charger-and-Wi-Fi gate to meet.
-      expect(description, isNot(contains('charging on an unmetered network')));
-      expect(description, isNot(contains('only while Vizor is open')));
+      // "Most in-app requests" carries the coverage hedge; the background
+      // migration boundary is disclosed on the migration screen instead, at
+      // the moment it invites the user to background the app.
+      expect(description, contains('most in-app requests go through Tor'));
+      expect(description, isNot(contains('migration')));
     },
   );
 

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/settings/screens/settings_screen.dart';
 import 'package:zcash_wallet/src/features/settings/settings_platform.dart';
+import 'package:zcash_wallet/src/features/settings/widgets/network_privacy_control.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
@@ -198,7 +199,10 @@ void main() {
 
     expect(find.text('Connecting…'), findsOneWidget);
     expect(
-      find.text('New requests wait until the Tor connection is ready.'),
+      find.text(
+        'New requests wait until the Tor connection is ready. Turn Tor off to '
+        'stop connecting and use a direct connection.',
+      ),
       findsOneWidget,
     );
 
@@ -206,8 +210,116 @@ void main() {
       find.byKey(const ValueKey('network_privacy_status_icon')),
     );
     expect(statusIcon.name, AppIcons.loader);
-    expect(_toggleTrackOpacity(tester), lessThan(1));
+    // Not dimmed: the control is the way out of the wait, so it has to look
+    // like something the user may act on.
+    expect(_toggleTrackOpacity(tester), 1);
 
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('network_privacy_toggle')),
+    );
+    await tester.tap(find.byKey(const ValueKey('network_privacy_toggle')));
+    await tester.pump();
+    // The bootstrap runs to a three-minute deadline with every request failing
+    // closed, and relaunching starts the same wait, so switching to direct has
+    // to stay reachable for the whole of it.
+    expect(calls, [false]);
+  });
+
+  test('the toggle offers an escape from a pending Tor connection', () {
+    // Every state maps to exactly one action, and the connecting-to-Tor state
+    // maps to an escape rather than to nothing.
+    NetworkPrivacyToggleAction actionFor({
+      required bool torEnabled,
+      required NetworkPrivacyConnectionStatus status,
+      bool? targetTorEnabled,
+    }) => networkPrivacyToggleAction(
+      NetworkPrivacyState(
+        torEnabled: torEnabled,
+        status: status,
+        targetTorEnabled: targetTorEnabled,
+      ),
+    );
+
+    expect(
+      actionFor(
+        torEnabled: false,
+        status: NetworkPrivacyConnectionStatus.off,
+      ),
+      NetworkPrivacyToggleAction.enable,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connected,
+      ),
+      NetworkPrivacyToggleAction.disable,
+    );
+    // A startup activation publishes no explicit target, so the effective one
+    // is the route already shown — which is the state a user relaunching into a
+    // blocked network lands in.
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+      ),
+      NetworkPrivacyToggleAction.cancelPendingTor,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+        targetTorEnabled: true,
+      ),
+      NetworkPrivacyToggleAction.cancelPendingTor,
+    );
+    expect(
+      actionFor(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+        targetTorEnabled: false,
+      ),
+      NetworkPrivacyToggleAction.none,
+    );
+  });
+
+  test('cancelling a pending Tor connection asks for the direct route', () {
+    expect(
+      NetworkPrivacyToggleAction.cancelPendingTor.requestedTorEnabled,
+      isFalse,
+    );
+    expect(NetworkPrivacyToggleAction.enable.requestedTorEnabled, isTrue);
+    expect(NetworkPrivacyToggleAction.disable.requestedTorEnabled, isFalse);
+    // Leaving a wait is not a second transition, and does not announce itself
+    // as one.
+    expect(
+      NetworkPrivacyToggleAction.cancelPendingTor.semanticsLabel,
+      'Stop connecting to Tor',
+    );
+    expect(NetworkPrivacyToggleAction.disable.semanticsLabel, 'Use Tor');
+    expect(NetworkPrivacyToggleAction.none.isInteractive, isFalse);
+  });
+
+  testWidgets('a switch to direct cannot be driven back into Tor', (
+    tester,
+  ) async {
+    final calls = <bool>[];
+    await tester.pumpWidget(
+      _settingsHarness(
+        networkPrivacyState: const NetworkPrivacyState(
+          torEnabled: true,
+          status: NetworkPrivacyConnectionStatus.connecting,
+          targetTorEnabled: false,
+        ),
+        networkPrivacyCalls: calls,
+      ),
+    );
+    await tester.pump();
+
+    // Nothing to escape from here: the route is already on its way to direct.
+    expect(_toggleTrackOpacity(tester), lessThan(1));
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('network_privacy_toggle')),
+    );
     await tester.tap(
       find.byKey(const ValueKey('network_privacy_toggle')),
       warnIfMissed: false,
@@ -230,8 +342,8 @@ void main() {
     expect(find.text('Connected'), findsOneWidget);
     expect(
       find.text(
-        'Vizor’s network requests go through Tor. Links opened in other apps '
-        'use those apps’ network settings.',
+        'Wallet sync, most in-app requests, and software updates go through '
+        'Tor. Some services may be unavailable over Tor.',
       ),
       findsOneWidget,
     );
@@ -287,8 +399,9 @@ void main() {
 
       expect(
         find.text(
-          'Vizor’s network requests go through Tor. Links opened in other apps '
-          'use those apps’ network settings.',
+          'Wallet sync, most in-app requests, and software update checks go '
+          'through Tor. Update pages and downloads opened in another app '
+          'use that app’s connection.',
         ),
         findsOneWidget,
       );
@@ -341,8 +454,8 @@ void main() {
 
     expect(
       find.text(
-        'Vizor’s network requests go through Tor, but software updates are '
-        'unavailable.',
+        'Wallet sync and most in-app requests go through Tor. Software '
+        'updates are unavailable.',
       ),
       findsOneWidget,
     );

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -328,7 +328,9 @@ void main() {
     expect(calls, isEmpty);
   });
 
-  testWidgets('connected Tor state includes software updates', (tester) async {
+  testWidgets('connected Tor state describes Vizor and external app routes', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       _settingsHarness(
         networkPrivacyState: const NetworkPrivacyState(
@@ -342,8 +344,8 @@ void main() {
     expect(find.text('Connected'), findsOneWidget);
     expect(
       find.text(
-        'Wallet sync, most in-app requests, and software updates go through '
-        'Tor. Some services may be unavailable over Tor.',
+        'Vizor’s network requests go through Tor. Links opened in other apps '
+        'use those apps’ network settings.',
       ),
       findsOneWidget,
     );
@@ -382,7 +384,7 @@ void main() {
     expect(description.style?.color, AppThemeData.light.colors.text.accent);
   });
 
-  testWidgets('Linux Tor copy excludes external update traffic', (
+  testWidgets('Linux Tor copy assigns external traffic to the other app', (
     tester,
   ) async {
     _overridePlatform(TargetPlatform.linux);
@@ -399,9 +401,8 @@ void main() {
 
       expect(
         find.text(
-          'Wallet sync, most in-app requests, and software update checks go '
-          'through Tor. Update pages and downloads opened in another app '
-          'use that app’s connection.',
+          'Vizor’s network requests go through Tor. Links opened in other apps '
+          'use those apps’ network settings.',
         ),
         findsOneWidget,
       );
@@ -454,8 +455,8 @@ void main() {
 
     expect(
       find.text(
-        'Wallet sync and most in-app requests go through Tor. Software '
-        'updates are unavailable.',
+        'Vizor’s network requests go through Tor, but software updates are '
+        'unavailable.',
       ),
       findsOneWidget,
     );

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -1,11 +1,64 @@
 import 'dart:async';
 
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
 import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/rust/network_privacy.dart' as rust_types;
 
 void main() {
+  // The launch this owner exists for reads almost nothing: a locked app routes
+  // to `/unlock`, `syncKeepAwakeActiveProvider` returns early on
+  // `requiresUnlock` before it reaches `syncProvider`, and the unlock screens
+  // only read that provider when the user submits. Nothing here builds a
+  // provider at all, which is the point — the persisted route is applied
+  // regardless of the lock, so the intent has to have an owner regardless too.
+  group('Tor dormancy lifecycle', () {
+    tearDown(disposeTorDormancyLifecycle);
+
+    testWidgets('sleeps only where backgrounding stops the process', (
+      tester,
+    ) async {
+      // Lane-dependent on purpose, and the desktop half is the load-bearing
+      // one: a desktop app with every window hidden keeps polling, and a
+      // client put to sleep underneath it pays a circuit build on each poll.
+      for (final (formFactor, expected) in [
+        (AppFormFactor.mobile, [true]),
+        (AppFormFactor.desktop, <bool>[]),
+      ]) {
+        final dormancy = <bool>[];
+        startTorDormancyLifecycle(
+          setTorDormant: ({required dormant}) => dormancy.add(dormant),
+          formFactor: formFactor,
+        );
+
+        await _sendAppLifecycleState(AppLifecycleState.inactive);
+        await _sendAppLifecycleState(AppLifecycleState.hidden);
+
+        expect(dormancy, expected, reason: '$formFactor');
+      }
+    });
+
+    testWidgets('wakes on every foreground entry', (tester) async {
+      // Asked for unconditionally: a sleep request that outlived its asker —
+      // issued before Tor finished bootstrapping, so it lands on the client
+      // only once that client exists — would otherwise keep the client asleep
+      // for the whole foreground session.
+      final dormancy = <bool>[];
+      startTorDormancyLifecycle(
+        setTorDormant: ({required dormant}) => dormancy.add(dormant),
+      );
+
+      await _sendAppLifecycleState(AppLifecycleState.inactive);
+      await _sendAppLifecycleState(AppLifecycleState.resumed);
+
+      expect(dormancy, contains(false));
+    });
+  });
+
+
   test('preference read failure pauses native updates before launch', () async {
     final events = <String>[];
     try {
@@ -40,6 +93,80 @@ void main() {
       );
     }
   });
+
+  test('enabling keeps the Tor directory out of device backups', () async {
+    final excluded = <String>[];
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          rust_types.NetworkPrivacyStatus.ready,
+      excludeTorDirectoryFromBackup: (directory) async =>
+          excluded.add(directory),
+    );
+
+    await runtime.configure(enabled: true);
+
+    // Once before the bootstrap, because the directory holds guard state from
+    // its first moment and the process can be killed during it, and once after,
+    // because the mark is best-effort.
+    expect(excluded, ['/tmp/vizor-tor', '/tmp/vizor-tor']);
+  });
+
+  test('a failed bootstrap still excludes the Tor directory', () async {
+    // Rust creates the directory and Arti writes guard state into it before
+    // the bootstrap can fail, so the failure path leaves exactly the state the
+    // exclusion exists to keep off a second device.
+    final excluded = <String>[];
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          throw StateError('bootstrap failed'),
+      excludeTorDirectoryFromBackup: (directory) async =>
+          excluded.add(directory),
+    );
+
+    await expectLater(
+      runtime.configure(enabled: true),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(excluded, ['/tmp/vizor-tor', '/tmp/vizor-tor']);
+  });
+
+  test('a backup exclusion failure is reported', () async {
+    final logs = <String>[];
+    final previousDebugPrint = debugPrint;
+    debugPrint = (message, {wrapWidth}) => logs.add(message ?? '');
+    addTearDown(() => debugPrint = previousDebugPrint);
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          rust_types.NetworkPrivacyStatus.ready,
+      excludeTorDirectoryFromBackup: (_) async =>
+          throw StateError('attribute write refused'),
+    );
+
+    await runtime.configure(enabled: true);
+
+    expect(logs, hasLength(2));
+    expect(logs.first, contains('attribute write refused'));
+  });
+
+  test('a backup exclusion failure does not fail the route', () async {
+    final runtime = RustNetworkPrivacyRuntime(
+      resolveTorDirectory: () async => '/tmp/vizor-tor',
+      configureRuntime: ({required enabled, required torDirectory}) async =>
+          rust_types.NetworkPrivacyStatus.ready,
+      excludeTorDirectoryFromBackup: (_) async =>
+          throw StateError('no native side'),
+    );
+
+    expect(
+      await runtime.configure(enabled: true),
+      NetworkPrivacyConnectionStatus.connected,
+    );
+  });
+
 
   test('direct runtime configuration skips Tor directory lookup', () async {
     var directoryLookups = 0;
@@ -506,6 +633,40 @@ void main() {
       'configure:false',
       'native-resume',
     ]);
+  });
+
+  test('the saved route may be stricter than the runtime, never laxer', () {
+    // A wake that declares Tor and cannot afford it defers; a wake that
+    // declares direct against a session enforcing Tor puts wallet queries and
+    // signed transactions on a direct connection.
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: true,
+        runtimeTorDesired: true,
+      ),
+      isTrue,
+    );
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: false,
+        runtimeTorDesired: false,
+      ),
+      isTrue,
+    );
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: true,
+        runtimeTorDesired: false,
+      ),
+      isTrue,
+    );
+    expect(
+      networkPrivacyPersistedRouteIsSafe(
+        persistedTorEnabled: false,
+        runtimeTorDesired: true,
+      ),
+      isFalse,
+    );
   });
 
   test('a failed strict save aborts the enable before anything changes', () async {
@@ -1271,3 +1432,13 @@ class _FakeDirectRequestGate implements NetworkPrivacyDirectRequestGate {
     events.add('direct-quiesce');
   }
 }
+
+Future<void> _sendAppLifecycleState(AppLifecycleState state) async {
+  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .handlePlatformMessage(
+        'flutter/lifecycle',
+        const StringCodec().encodeMessage(state.toString()),
+        (_) {},
+      );
+}
+

--- a/test/providers/network_privacy_provider_test.dart
+++ b/test/providers/network_privacy_provider_test.dart
@@ -132,11 +132,11 @@ void main() {
 
     expect(events, [
       'native:true',
+      'store:true',
       'begin-enable',
       'runtime-quiesce',
       'direct-quiesce',
       'restart',
-      'store:true',
       'configure:true',
       'native-resume',
     ]);
@@ -178,11 +178,11 @@ void main() {
     final state = container.read(networkPrivacyProvider);
     expect(events, [
       'native:true',
+      'store:true',
       'begin-enable',
       'runtime-quiesce',
       'direct-quiesce',
       'restart',
-      'store:true',
       'configure:true',
     ]);
     expect(state.torEnabled, isTrue);
@@ -221,8 +221,8 @@ void main() {
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
+      'store:false',
       'direct-allow',
       'native:false',
     ]);
@@ -296,8 +296,8 @@ void main() {
       'native-prepare-disable',
       'native-disable-drained',
       'restart',
-      'store:false',
       'configure:false',
+      'store:false',
       'direct-allow',
       'native:false',
     ]);
@@ -381,6 +381,7 @@ void main() {
 
       expect(events, [
         'native:true',
+        'store:true',
         'begin-enable',
         'runtime-quiesce',
         'direct-quiesce',
@@ -478,7 +479,6 @@ void main() {
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
       'native-resume',
     ]);
@@ -503,10 +503,102 @@ void main() {
     expect(events, [
       'native-prepare-disable',
       'restart',
-      'store:false',
       'configure:false',
       'native-resume',
     ]);
+  });
+
+  test('a failed strict save aborts the enable before anything changes', () async {
+    final events = <String>[];
+    final runtime = _FakeRuntime(
+      events,
+      NetworkPrivacyConnectionStatus.connected,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        networkPrivacyPreferenceStoreProvider.overrideWithValue(
+          _WriteFailingStore(events, failOn: true),
+        ),
+        networkPrivacyRuntimeProvider.overrideWithValue(runtime),
+        networkPrivacyNativeUpdateCoordinatorProvider.overrideWithValue(
+          _FakeNativeUpdateCoordinator(events),
+        ),
+        networkPrivacyDirectRequestGateProvider.overrideWithValue(
+          _FakeDirectRequestGate(events),
+        ),
+        networkPrivacyTransportRestartProvider.overrideWithValue((
+          update,
+        ) async {
+          events.add('restart');
+          await update();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
+
+    // Refused before the process changes: no fail-closed switch, no drain, no
+    // transport restart. Requests keep flowing directly, the saved route
+    // still says direct, and the updater preflight is undone — the toggle
+    // simply never happened, apart from the failure the user is shown.
+    expect(events, ['native:true', 'store:write-failed', 'native:false']);
+    expect(runtime.isTorEnabled(), isFalse);
+    final state = container.read(networkPrivacyProvider);
+    expect(state.torEnabled, isFalse);
+    expect(state.status, NetworkPrivacyConnectionStatus.failed);
+    expect(state.targetTorEnabled, isTrue);
+  });
+
+  test('a failed direct save still opens the direct request gate', () async {
+    final events = <String>[];
+    final runtime = _FakeRuntime(
+      events,
+      NetworkPrivacyConnectionStatus.connected,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        networkPrivacyPreferenceStoreProvider.overrideWithValue(
+          _WriteFailingStore(events, failOn: false),
+        ),
+        networkPrivacyRuntimeProvider.overrideWithValue(runtime),
+        networkPrivacyNativeUpdateCoordinatorProvider.overrideWithValue(
+          _FakeNativeUpdateCoordinator(events),
+        ),
+        networkPrivacyDirectRequestGateProvider.overrideWithValue(
+          _FakeDirectRequestGate(events),
+        ),
+        networkPrivacyTransportRestartProvider.overrideWithValue((
+          update,
+        ) async {
+          events.add('restart');
+          await update();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(true);
+    events.clear();
+    await container.read(networkPrivacyProvider.notifier).setTorEnabled(false);
+
+    // The runtime is direct with its Tor client dropped, so the gate follows
+    // it: left shut, every direct request would fail for the rest of the
+    // session behind a UI that reports Tor off. The saved route stays at Tor
+    // — the stricter half — so the next launch comes back on Tor instead of
+    // silently staying direct.
+    expect(events, [
+      'native-prepare-disable',
+      'restart',
+      'configure:false',
+      'store:write-failed',
+      'direct-allow',
+    ]);
+    expect(runtime.isTorEnabled(), isFalse);
+    final state = container.read(networkPrivacyProvider);
+    expect(state.torEnabled, isFalse);
+    expect(state.status, NetworkPrivacyConnectionStatus.failed);
+    expect(state.targetTorEnabled, isFalse);
   });
 
   test(
@@ -901,6 +993,27 @@ class _FakeStore implements NetworkPrivacyPreferenceStore {
 
   @override
   Future<void> writeTorEnabled(bool enabled) async {
+    events.add('store:$enabled');
+  }
+}
+
+/// Fails the write in one direction only, the shape a full disk has: the
+/// previously saved value is already on disk when the new one is refused.
+class _WriteFailingStore implements NetworkPrivacyPreferenceStore {
+  _WriteFailingStore(this.events, {required this.failOn});
+
+  final List<String> events;
+  final bool failOn;
+
+  @override
+  Future<bool> readTorEnabled() async => false;
+
+  @override
+  Future<void> writeTorEnabled(bool enabled) async {
+    if (enabled == failOn) {
+      events.add('store:write-failed');
+      throw StateError('Could not save the Tor preference.');
+    }
     events.add('store:$enabled');
   }
 }


### PR DESCRIPTION
Successor to #473/#480/#481. **Tor covers foreground traffic only.** Background migration work keeps the direct transport it has always had — for every wallet, on every launch shape — pinned explicitly in Rust rather than left to route-policy coincidence. No background machinery of any kind: the iOS diff is 53 lines of backup-exclusion channel in AppDelegate, and the background migration managers are untouched.

## The model

- **Foreground**: the route policy governs every lightwalletd and HTTP path. Tor on = fail-closed while starting or broken; toggling off cancels a pending bootstrap.
- **Background (iOS migration wakes)**: the three C entry points open `open_background_direct_lwd_channel`, which bypasses the route policy by design. A background pass never brings Tor up or borrows the foreground's client, so routing that lane through the policy would only convert it into failures on a Tor wallet. The mobile settings card discloses it: "Background migration activity uses a direct connection."

## Commits

1. **Persist the Tor route on the strict side** (desktop) — enable writes before anything changes, disable writes after the switch, the direct-request gate follows the runtime.
2. **Cancellable pending connection** (desktop).
3. **Harden the bootstrap + lifecycle dormancy** (rust) — a bootstrap stops when its route goes away; the deadline covers the init-lock wait; an idle client sleeps with the app lifecycle (~500 B/s padding awake vs ~27 B/s dormant).
4. **Enable Tor on iOS and Android** — startup gate removed, sandbox-aware fs-mistrust, guard state excluded from backups and device transfer, launch-owned dormancy lifecycle, hand-run live-Tor probe tagged out of automated lanes.
5. **Pin background migration transport to direct** — the product decision above, with a test proving the pin (with Tor desired and no client, the background opener reaches the socket where the policy-aware opener is refused).
6. **Mobile Tor control** — the settings card, cancellable pending state, route-truthful failure copy, and the background disclosure.
7. **Docs** — the foreground-only contract and strict-side persistence rule in AGENTS.md.

## Verification

- Rust: 610 passed / 0 failed; behavioural fixes verified to fail with only the production change reverted (toggle ordering ×2, bootstrap abandon, deadline, transport pin).
- Desktop lane 2250 passed / 30 pre-existing; mobile lane 786 passed / 18 — 17 pre-existing plus one confirmed failing on clean origin/main.
- iOS simulator: full build, live Tor bootstrap probe passes.

Residual, stated on the card and in AGENTS.md: a Tor user's background migration queries and broadcasts travel over a direct connection. Device-only check remaining: whether the fs-mistrust exemption is required on real hardware (recorded in the probe).

https://claude.ai/code/session_01R9nkJCPTCahMjGiDgqFNrV