### PR TITLE
Optimize mainnet birthday height lookup

### DIFF
--- a/lib/src/features/onboarding/import/import_birthday_estimator.dart
+++ b/lib/src/features/onboarding/import/import_birthday_estimator.dart
@@ -1,6 +1,14 @@
 import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../rust/api/network_privacy.dart' as rust_network_privacy;
 
+const _importBirthdaySafetyMargin = Duration(days: 15);
+
+DateTime importBirthdaySearchDate(DateTime selectedDate) => DateTime(
+  selectedDate.year,
+  selectedDate.month,
+  selectedDate.day,
+).subtract(_importBirthdaySafetyMargin);
+
 class ImportBirthdayMetadata {
   const ImportBirthdayMetadata({
     required this.saplingActivationHeight,
@@ -23,6 +31,7 @@ class ImportBirthdayEstimator {
   }) async {
     final metadata = await rust_network_privacy.getImportBirthdayMetadata(
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      useMainnetFastPath: _useMainnetFastPath(endpoint),
     );
     return ImportBirthdayMetadata(
       saplingActivationHeight: metadata.saplingActivationHeight.toInt(),
@@ -37,19 +46,18 @@ class ImportBirthdayEstimator {
   static Future<int> estimateBirthdayHeight({
     required RpcEndpointConfig endpoint,
     required DateTime selectedDate,
+    ImportBirthdayMetadata? metadata,
   }) async {
-    final normalizedSelectedDate = DateTime(
-      selectedDate.year,
-      selectedDate.month,
-      selectedDate.day,
-    );
-    final searchDate = normalizedSelectedDate.subtract(
-      const Duration(days: 15),
-    );
+    final searchDate = importBirthdaySearchDate(selectedDate);
     final targetEpoch = searchDate.toUtc().millisecondsSinceEpoch ~/ 1000;
     final height = await rust_network_privacy.estimateImportBirthdayHeight(
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
       targetEpochSeconds: targetEpoch,
+      useMainnetFastPath: _useMainnetFastPath(endpoint),
+      tipHeight: metadata == null ? null : BigInt.from(metadata.tipHeight),
+      tipTime: metadata == null
+          ? null
+          : metadata.tipDate.toUtc().millisecondsSinceEpoch ~/ 1000,
     );
     return height.toInt();
   }
@@ -60,4 +68,7 @@ class ImportBirthdayEstimator {
       isUtc: true,
     ).toLocal();
   }
+
+  static bool _useMainnetFastPath(RpcEndpointConfig endpoint) =>
+      endpoint.network == ZcashNetwork.mainnet && !kZcashIronwoodMasquerade;
 }

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -154,6 +154,7 @@ class _ImportWalletBirthdayScreenState
                 ImportBirthdayEstimator.estimateBirthdayHeight(
                   endpoint: endpoint,
                   selectedDate: date,
+                  metadata: _metadata,
                 ),
           );
       if (!mounted || seq != _estimateSeq) return;

--- a/lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart
@@ -124,6 +124,7 @@ class _KeystoneWalletBirthdayScreenState
           await ImportBirthdayEstimator.estimateBirthdayHeight(
             endpoint: endpoint,
             selectedDate: date,
+            metadata: _metadata,
           );
       if (!mounted || seq != _estimateSeq) return;
       setState(() {

--- a/lib/src/features/onboarding/mobile/mobile_import_birthday_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_birthday_screen.dart
@@ -249,6 +249,7 @@ class _MobileImportBirthdayScreenState
           final height = await ImportBirthdayEstimator.estimateBirthdayHeight(
             endpoint: endpoint,
             selectedDate: _selectedDate!,
+            metadata: _metadata,
           );
           if (!mounted) return;
           await _submit(height);

--- a/lib/src/rust/api/network_privacy.dart
+++ b/lib/src/rust/api/network_privacy.dart
@@ -7,7 +7,9 @@ import '../frb_generated.dart';
 import '../network_privacy.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `apply_headers`, `block_at_height`, `collect_body`, `network_http_response`, `timed_birthday_request`, `with_api_response_body_timeout`, `write_body_to_file`
+// These functions are ignored because they are not marked as `pub`: `apply_headers`, `binary_search_birthday_height`, `block_at_height`, `collect_body`, `correct_estimated_height`, `divide_round_nearest`, `estimate_mainnet_birthday_height`, `interpolate_height`, `is_mainnet`, `mainnet_anchor_segment`, `network_http_response`, `timed_birthday_request`, `with_api_response_body_timeout`, `write_body_to_file`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `BirthdayAnchor`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `eq`, `fmt`
 
 /// Blocks new policy-aware direct requests immediately. Tor bootstrap is
 /// intentionally separate so the caller can first quiesce channels that were
@@ -86,16 +88,24 @@ Future<NetworkHttpResponse> torHttpDownload({
 
 Future<ImportBirthdayMetadata> getImportBirthdayMetadata({
   required String lightwalletdUrl,
+  required bool useMainnetFastPath,
 }) => RustLib.instance.api.crateApiNetworkPrivacyGetImportBirthdayMetadata(
   lightwalletdUrl: lightwalletdUrl,
+  useMainnetFastPath: useMainnetFastPath,
 );
 
 Future<BigInt> estimateImportBirthdayHeight({
   required String lightwalletdUrl,
   required PlatformInt64 targetEpochSeconds,
+  required bool useMainnetFastPath,
+  BigInt? tipHeight,
+  int? tipTime,
 }) => RustLib.instance.api.crateApiNetworkPrivacyEstimateImportBirthdayHeight(
   lightwalletdUrl: lightwalletdUrl,
   targetEpochSeconds: targetEpochSeconds,
+  useMainnetFastPath: useMainnetFastPath,
+  tipHeight: tipHeight,
+  tipTime: tipTime,
 );
 
 class ImportBirthdayMetadata {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -437,6 +437,9 @@ abstract class RustLibApi extends BaseApi {
   Future<BigInt> crateApiNetworkPrivacyEstimateImportBirthdayHeight({
     required String lightwalletdUrl,
     required PlatformInt64 targetEpochSeconds,
+    required bool useMainnetFastPath,
+    BigInt? tipHeight,
+    int? tipTime,
   });
 
   Future<SendMaxEstimateResult> crateApiSyncEstimateSendMax({
@@ -541,6 +544,7 @@ abstract class RustLibApi extends BaseApi {
   Future<ImportBirthdayMetadata>
   crateApiNetworkPrivacyGetImportBirthdayMetadata({
     required String lightwalletdUrl,
+    required bool useMainnetFastPath,
   });
 
   Future<List<KeystoneSignatureRecord>> crateApiVotingGetKeystoneSignatures({
@@ -3493,6 +3497,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<BigInt> crateApiNetworkPrivacyEstimateImportBirthdayHeight({
     required String lightwalletdUrl,
     required PlatformInt64 targetEpochSeconds,
+    required bool useMainnetFastPath,
+    BigInt? tipHeight,
+    int? tipTime,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -3500,6 +3507,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(lightwalletdUrl, serializer);
           sse_encode_i_64(targetEpochSeconds, serializer);
+          sse_encode_bool(useMainnetFastPath, serializer);
+          sse_encode_opt_box_autoadd_u_64(tipHeight, serializer);
+          sse_encode_opt_box_autoadd_u_32(tipTime, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -3512,7 +3522,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiNetworkPrivacyEstimateImportBirthdayHeightConstMeta,
-        argValues: [lightwalletdUrl, targetEpochSeconds],
+        argValues: [
+          lightwalletdUrl,
+          targetEpochSeconds,
+          useMainnetFastPath,
+          tipHeight,
+          tipTime,
+        ],
         apiImpl: this,
       ),
     );
@@ -3522,7 +3538,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   get kCrateApiNetworkPrivacyEstimateImportBirthdayHeightConstMeta =>
       const TaskConstMeta(
         debugName: "estimate_import_birthday_height",
-        argNames: ["lightwalletdUrl", "targetEpochSeconds"],
+        argNames: [
+          "lightwalletdUrl",
+          "targetEpochSeconds",
+          "useMainnetFastPath",
+          "tipHeight",
+          "tipTime",
+        ],
       );
 
   @override
@@ -4173,12 +4195,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<ImportBirthdayMetadata>
   crateApiNetworkPrivacyGetImportBirthdayMetadata({
     required String lightwalletdUrl,
+    required bool useMainnetFastPath,
   }) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(useMainnetFastPath, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -4191,7 +4215,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiNetworkPrivacyGetImportBirthdayMetadataConstMeta,
-        argValues: [lightwalletdUrl],
+        argValues: [lightwalletdUrl, useMainnetFastPath],
         apiImpl: this,
       ),
     );
@@ -4200,7 +4224,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiNetworkPrivacyGetImportBirthdayMetadataConstMeta =>
       const TaskConstMeta(
         debugName: "get_import_birthday_metadata",
-        argNames: ["lightwalletdUrl"],
+        argNames: ["lightwalletdUrl", "useMainnetFastPath"],
       );
 
   @override

--- a/rust/src/api/network_privacy.rs
+++ b/rust/src/api/network_privacy.rs
@@ -16,6 +16,51 @@ use zcash_client_backend::tor::http::{HttpError, TimeoutPhase};
 pub use crate::network_privacy::NetworkPrivacyStatus;
 
 const TOR_API_RESPONSE_BODY_TIMEOUT: Duration = Duration::from_secs(30);
+const MAINNET_SAPLING_ACTIVATION_HEIGHT: u64 = 419_200;
+const MAINNET_SAPLING_ACTIVATION_TIME: u32 = 1_540_779_337;
+const BIRTHDAY_ESTIMATE_TOLERANCE_SECONDS: i64 = 6 * 60 * 60;
+const MAX_BIRTHDAY_CORRECTION_PROBES: usize = 2;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct BirthdayAnchor {
+    height: u64,
+    time: u32,
+}
+
+// Deep mainnet blocks are immutable enough to serve as interpolation anchors.
+// Blossom is included explicitly because its activation halved the target block
+// interval. Later anchors keep accumulated mining-rate drift well below the
+// existing 15-day wallet-birthday safety margin.
+const MAINNET_BIRTHDAY_ANCHORS: [BirthdayAnchor; 7] = [
+    BirthdayAnchor {
+        height: MAINNET_SAPLING_ACTIVATION_HEIGHT,
+        time: MAINNET_SAPLING_ACTIVATION_TIME,
+    },
+    BirthdayAnchor {
+        height: 653_600,
+        time: 1_576_101_005,
+    },
+    BirthdayAnchor {
+        height: 1_000_000,
+        time: 1_602_206_541,
+    },
+    BirthdayAnchor {
+        height: 1_500_000,
+        time: 1_639_913_234,
+    },
+    BirthdayAnchor {
+        height: 2_000_000,
+        time: 1_677_602_242,
+    },
+    BirthdayAnchor {
+        height: 2_500_000,
+        time: 1_715_296_781,
+    },
+    BirthdayAnchor {
+        height: 3_000_000,
+        time: 1_752_983_473,
+    },
+];
 
 /// Blocks new policy-aware direct requests immediately. Tor bootstrap is
 /// intentionally separate so the caller can first quiesce channels that were
@@ -237,10 +282,45 @@ fn network_http_response(response: http::Response<Vec<u8>>) -> Result<NetworkHtt
 
 pub async fn get_import_birthday_metadata(
     lightwalletd_url: String,
+    use_mainnet_fast_path: bool,
 ) -> Result<ImportBirthdayMetadata, String> {
     let mut client = crate::wallet::sync_engine::open_lwd_channel(&lightwalletd_url)
         .await
         .map_err(|error| error.to_string())?;
+
+    if use_mainnet_fast_path {
+        match client
+            .get_latest_tree_state(timed_birthday_request(Empty {}))
+            .await
+        {
+            Ok(response) => {
+                let tip = response.into_inner();
+                if !is_mainnet(&tip.network) {
+                    return Err(format!(
+                        "Expected mainnet birthday metadata, endpoint reported {}",
+                        tip.network
+                    ));
+                }
+                if tip.height < MAINNET_SAPLING_ACTIVATION_HEIGHT
+                    || tip.time < MAINNET_SAPLING_ACTIVATION_TIME
+                {
+                    return Err("Mainnet tip predates Sapling activation".to_string());
+                }
+                return Ok(ImportBirthdayMetadata {
+                    sapling_activation_height: MAINNET_SAPLING_ACTIVATION_HEIGHT,
+                    sapling_activation_time: MAINNET_SAPLING_ACTIVATION_TIME,
+                    tip_height: tip.height,
+                    tip_time: tip.time,
+                });
+            }
+            Err(error) if error.code() == tonic::Code::Unimplemented => {
+                // Older custom lightwalletd servers may not expose the combined
+                // tip state. Continue with the legacy four-request metadata path.
+            }
+            Err(error) => return Err(format!("GetLatestTreeState: {error}")),
+        }
+    }
+
     let info = client
         .get_lightd_info(timed_birthday_request(Empty {}))
         .await
@@ -268,10 +348,39 @@ pub async fn get_import_birthday_metadata(
 pub async fn estimate_import_birthday_height(
     lightwalletd_url: String,
     target_epoch_seconds: i64,
+    use_mainnet_fast_path: bool,
+    tip_height: Option<u64>,
+    tip_time: Option<u32>,
 ) -> Result<u64, String> {
     let mut client = crate::wallet::sync_engine::open_lwd_channel(&lightwalletd_url)
         .await
         .map_err(|error| error.to_string())?;
+
+    if use_mainnet_fast_path {
+        if let (Some(tip_height), Some(tip_time)) = (tip_height, tip_time) {
+            if let Some(height) = estimate_mainnet_birthday_height(
+                &mut client,
+                target_epoch_seconds,
+                BirthdayAnchor {
+                    height: tip_height,
+                    time: tip_time,
+                },
+            )
+            .await?
+            {
+                return Ok(height);
+            }
+
+            return binary_search_birthday_height(
+                &mut client,
+                MAINNET_SAPLING_ACTIVATION_HEIGHT,
+                tip_height,
+                target_epoch_seconds,
+            )
+            .await;
+        }
+    }
+
     let info = client
         .get_lightd_info(timed_birthday_request(Empty {}))
         .await
@@ -283,20 +392,140 @@ pub async fn estimate_import_birthday_height(
         .map_err(|error| format!("GetLatestBlock: {error}"))?
         .into_inner();
 
-    let mut low = info.sapling_activation_height;
-    let mut high = tip.height;
-    let sapling_time = i64::from(block_at_height(&mut client, low).await?.time);
+    binary_search_birthday_height(
+        &mut client,
+        info.sapling_activation_height,
+        tip.height,
+        target_epoch_seconds,
+    )
+    .await
+}
+
+async fn estimate_mainnet_birthday_height(
+    client: &mut CompactTxStreamerClient<tonic::transport::Channel>,
+    target_epoch_seconds: i64,
+    tip: BirthdayAnchor,
+) -> Result<Option<u64>, String> {
+    if target_epoch_seconds <= i64::from(MAINNET_SAPLING_ACTIVATION_TIME) {
+        return Ok(Some(MAINNET_SAPLING_ACTIVATION_HEIGHT));
+    }
+    if target_epoch_seconds >= i64::from(tip.time) {
+        return Ok(Some(tip.height));
+    }
+
+    let Some((lower, upper)) = mainnet_anchor_segment(target_epoch_seconds, tip) else {
+        return Ok(None);
+    };
+    let Some(mut candidate) = interpolate_height(lower, upper, target_epoch_seconds) else {
+        return Ok(None);
+    };
+
+    for probe_index in 0..=MAX_BIRTHDAY_CORRECTION_PROBES {
+        let candidate_time = i64::from(block_at_height(client, candidate).await?.time);
+        let error = target_epoch_seconds - candidate_time;
+        if error.abs() <= BIRTHDAY_ESTIMATE_TOLERANCE_SECONDS {
+            return Ok(Some(candidate));
+        }
+        if probe_index == MAX_BIRTHDAY_CORRECTION_PROBES {
+            break;
+        }
+
+        let Some(corrected) = correct_estimated_height(lower, upper, candidate, error) else {
+            return Ok(None);
+        };
+        if corrected == candidate {
+            return Ok(None);
+        }
+        candidate = corrected;
+    }
+
+    Ok(None)
+}
+
+fn mainnet_anchor_segment(
+    target_epoch_seconds: i64,
+    tip: BirthdayAnchor,
+) -> Option<(BirthdayAnchor, BirthdayAnchor)> {
+    let mut anchors = MAINNET_BIRTHDAY_ANCHORS
+        .iter()
+        .copied()
+        .take_while(|anchor| anchor.height < tip.height)
+        .collect::<Vec<_>>();
+    let previous = anchors.last().copied()?;
+    if tip.height <= previous.height || tip.time <= previous.time {
+        return None;
+    }
+    anchors.push(tip);
+
+    anchors.windows(2).find_map(|pair| {
+        let lower = pair[0];
+        let upper = pair[1];
+        (target_epoch_seconds <= i64::from(upper.time)).then_some((lower, upper))
+    })
+}
+
+fn interpolate_height(
+    lower: BirthdayAnchor,
+    upper: BirthdayAnchor,
+    target_epoch_seconds: i64,
+) -> Option<u64> {
+    let time_span = i128::from(upper.time.checked_sub(lower.time)?);
+    let height_span = i128::from(upper.height.checked_sub(lower.height)?);
+    let target_delta = i128::from(target_epoch_seconds - i64::from(lower.time));
+    let height_delta = divide_round_nearest(target_delta * height_span, time_span)?;
+    u64::try_from(
+        (i128::from(lower.height) + height_delta)
+            .clamp(i128::from(lower.height), i128::from(upper.height)),
+    )
+    .ok()
+}
+
+fn correct_estimated_height(
+    lower: BirthdayAnchor,
+    upper: BirthdayAnchor,
+    current_height: u64,
+    time_error_seconds: i64,
+) -> Option<u64> {
+    let time_span = i128::from(upper.time.checked_sub(lower.time)?);
+    let height_span = i128::from(upper.height.checked_sub(lower.height)?);
+    let correction = divide_round_nearest(i128::from(time_error_seconds) * height_span, time_span)?;
+    u64::try_from(
+        (i128::from(current_height) + correction)
+            .clamp(i128::from(lower.height), i128::from(upper.height)),
+    )
+    .ok()
+}
+
+fn divide_round_nearest(numerator: i128, denominator: i128) -> Option<i128> {
+    if denominator <= 0 {
+        return None;
+    }
+    let adjustment = denominator / 2;
+    Some(if numerator >= 0 {
+        (numerator + adjustment) / denominator
+    } else {
+        (numerator - adjustment) / denominator
+    })
+}
+
+async fn binary_search_birthday_height(
+    client: &mut CompactTxStreamerClient<tonic::transport::Channel>,
+    mut low: u64,
+    mut high: u64,
+    target_epoch_seconds: i64,
+) -> Result<u64, String> {
+    let sapling_time = i64::from(block_at_height(client, low).await?.time);
     if target_epoch_seconds <= sapling_time {
         return Ok(low);
     }
-    let tip_time = i64::from(block_at_height(&mut client, high).await?.time);
+    let tip_time = i64::from(block_at_height(client, high).await?.time);
     if target_epoch_seconds >= tip_time {
         return Ok(high);
     }
 
     while low < high {
         let mid = low + (high - low) / 2;
-        let mid_time = i64::from(block_at_height(&mut client, mid).await?.time);
+        let mid_time = i64::from(block_at_height(client, mid).await?.time);
         if mid_time < target_epoch_seconds {
             low = mid + 1;
         } else {
@@ -304,6 +533,10 @@ pub async fn estimate_import_birthday_height(
         }
     }
     Ok(low)
+}
+
+fn is_mainnet(network: &str) -> bool {
+    matches!(network.trim(), "main" | "mainnet")
 }
 
 async fn block_at_height(
@@ -335,7 +568,70 @@ mod tests {
         Error,
     };
 
-    use super::with_api_response_body_timeout;
+    use super::{
+        correct_estimated_height, interpolate_height, mainnet_anchor_segment,
+        with_api_response_body_timeout, BirthdayAnchor, MAINNET_BIRTHDAY_ANCHORS,
+    };
+
+    #[test]
+    fn mainnet_anchor_interpolation_preserves_anchor_heights() {
+        let lower = MAINNET_BIRTHDAY_ANCHORS[1];
+        let upper = MAINNET_BIRTHDAY_ANCHORS[2];
+
+        assert_eq!(
+            interpolate_height(lower, upper, i64::from(lower.time)),
+            Some(lower.height)
+        );
+        assert_eq!(
+            interpolate_height(lower, upper, i64::from(upper.time)),
+            Some(upper.height)
+        );
+    }
+
+    #[test]
+    fn mainnet_anchor_interpolation_uses_blossom_as_interval_boundary() {
+        let tip = BirthdayAnchor {
+            height: 3_439_381,
+            time: 1_786_094_043,
+        };
+        let blossom = MAINNET_BIRTHDAY_ANCHORS[1];
+
+        assert_eq!(
+            mainnet_anchor_segment(i64::from(blossom.time), tip),
+            Some((MAINNET_BIRTHDAY_ANCHORS[0], blossom))
+        );
+        assert_eq!(
+            mainnet_anchor_segment(i64::from(blossom.time) + 1, tip),
+            Some((blossom, MAINNET_BIRTHDAY_ANCHORS[2]))
+        );
+    }
+
+    #[test]
+    fn mainnet_height_correction_moves_in_the_time_error_direction() {
+        let lower = MAINNET_BIRTHDAY_ANCHORS[3];
+        let upper = MAINNET_BIRTHDAY_ANCHORS[4];
+        let current = 1_750_000;
+
+        let later = correct_estimated_height(lower, upper, current, 3_600).unwrap();
+        let earlier = correct_estimated_height(lower, upper, current, -3_600).unwrap();
+
+        assert!(later > current);
+        assert!(earlier < current);
+    }
+
+    #[test]
+    fn inconsistent_mainnet_tip_disables_fast_estimation() {
+        let last = *MAINNET_BIRTHDAY_ANCHORS.last().unwrap();
+        let stale_tip = BirthdayAnchor {
+            height: last.height + 1,
+            time: last.time,
+        };
+
+        assert_eq!(
+            mainnet_anchor_segment(i64::from(last.time), stale_tip),
+            None
+        );
+    }
 
     #[tokio::test]
     async fn ordinary_http_body_stall_is_cancelled_before_download_deadline() {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2136,6 +2136,9 @@ fn wire__crate__api__network_privacy__estimate_import_birthday_height_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
             let api_target_epoch_seconds = <i64>::sse_decode(&mut deserializer);
+            let api_use_mainnet_fast_path = <bool>::sse_decode(&mut deserializer);
+            let api_tip_height = <Option<u64>>::sse_decode(&mut deserializer);
+            let api_tip_time = <Option<u32>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, String>(
@@ -2144,6 +2147,9 @@ fn wire__crate__api__network_privacy__estimate_import_birthday_height_impl(
                             crate::api::network_privacy::estimate_import_birthday_height(
                                 api_lightwalletd_url,
                                 api_target_epoch_seconds,
+                                api_use_mainnet_fast_path,
+                                api_tip_height,
+                                api_tip_time,
                             )
                             .await?;
                         Ok(output_ok)
@@ -2802,12 +2808,14 @@ fn wire__crate__api__network_privacy__get_import_birthday_metadata_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_use_mainnet_fast_path = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, String>(
                     (move || async move {
                         let output_ok = crate::api::network_privacy::get_import_birthday_metadata(
                             api_lightwalletd_url,
+                            api_use_mainnet_fast_path,
                         )
                         .await?;
                         Ok(output_ok)

--- a/test/features/onboarding/import_birthday_estimator_test.dart
+++ b/test/features/onboarding/import_birthday_estimator_test.dart
@@ -14,6 +14,13 @@ typedef _EstimateBirthdayWithEndpoint =
     });
 
 void main() {
+  test('keeps the 15-day birthday safety margin', () {
+    expect(
+      importBirthdaySearchDate(DateTime(2026, 8, 7, 18, 30)),
+      DateTime(2026, 7, 23),
+    );
+  });
+
   test('estimator APIs accept the configured RPC endpoint', () {
     final _LoadMetadataWithEndpoint loadMetadata =
         ImportBirthdayEstimator.loadMetadata;


### PR DESCRIPTION
## Summary

- replace repeated mainnet birthday-height binary-search RPCs with interpolation over verified block height/timestamp anchors
- load the current mainnet tip height and timestamp in one `GetLatestTreeState` request and reuse that metadata across desktop, mobile, and Keystone onboarding
- preserve the existing 15-day birthday safety margin, verify the interpolated block within a six-hour tolerance, and retain bounded correction plus the legacy binary-search fallback
- keep testnet, regtest, and Ironwood masquerade on the existing lookup path

## Impact

The normal mainnet date-based import path drops from roughly 29–30 RPC requests to 2. A live representative check used 2 requests and produced a timestamp error of 5.4 minutes.

## Validation

- `cd rust && cargo test` — 607 passed, 4 ignored
- desktop birthday estimator/screen tests — 14 passed
- mobile birthday screen lane — 10 passed
- changed-file `fvm flutter analyze` — no issues
- `flutter_rust_bridge_codegen generate`
