### PR TITLE
Use batch PCZT for Keystone Send, Swap, and Pay

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -977,7 +977,12 @@ List<RouteBase> _desktopRoutes(Ref ref) => [
   ),
   GoRoute(
     path: '/send/keystone/scan',
-    builder: (_, _) => const KeystoneSendScanScreen(),
+    builder: (_, state) => KeystoneSendScanScreen(
+      args: switch (state.extra) {
+        final KeystoneSendScanArgs args => args,
+        _ => const KeystoneSendScanArgs.pczt(),
+      },
+    ),
   ),
   GoRoute(
     path: '/send/status',

--- a/lib/src/features/keystone/services/keystone_batch_signing.dart
+++ b/lib/src/features/keystone/services/keystone_batch_signing.dart
@@ -1,0 +1,48 @@
+import 'dart:typed_data';
+
+import '../../../rust/api/keystone.dart' as rust_keystone;
+import '../../../rust/wallet/keystone.dart' as rust_keystone_wallet;
+
+const keystoneBatchSignatureUrType = 'zcash-batch-sig-result';
+const keystoneBatchQrFragmentLength = 140;
+const keystoneSendBatchMessageId = 'zec-send';
+
+/// Encodes one wallet-owned PCZT as a compact, one-message Keystone batch.
+Future<List<String>> encodeKeystoneBatchPcztUrParts({
+  required List<int> pcztBytes,
+  required String requestId,
+  required String messageId,
+}) async {
+  final batchPczt = await rust_keystone.prepareKeystoneBatchPczt(
+    pcztBytes: pcztBytes,
+  );
+  return rust_keystone.encodeZcashSignBatchUrParts(
+    requestId: requestId,
+    messages: [
+      rust_keystone_wallet.ZcashBatchMessageInput(
+        id: messageId,
+        pcztBytes: batchPczt.redactedPczt,
+        expectedSignatureCount: batchPczt.expectedSignatureCount,
+      ),
+    ],
+    maxFragmentLen: BigInt.from(keystoneBatchQrFragmentLength),
+  );
+}
+
+/// Validates and applies a one-message Keystone batch-signing response.
+Future<Uint8List> decodeAndApplyKeystoneBatchPcztSignatures({
+  required List<int> pcztBytes,
+  required List<int> responseCbor,
+  required String requestId,
+  required String messageId,
+}) async {
+  final decoded = await rust_keystone.decodeZcashBatchSignResponse(
+    cbor: responseCbor,
+    expectedRequestId: requestId,
+    messageIds: [messageId],
+  );
+  return rust_keystone.applyKeystoneBatchPcztSignatures(
+    pcztBytes: pcztBytes,
+    signatures: decoded.results.single.sigs,
+  );
+}

--- a/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
+++ b/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
@@ -97,8 +97,8 @@ const _mobileKeystoneOrange = Color(0xFFF98F0E);
 /// Shared mobile Keystone PCZT round trip.
 ///
 /// Callers own domain-specific PCZT creation and broadcast; this widget owns the
-/// common mobile UX: animated transaction QR, camera scan for the signed PCZT,
-/// decode, and waiting for the locally-proved PCZT clone.
+/// common mobile UX: animated transaction QR, camera scan for the signature
+/// response, decode, and waiting for the locally-proved PCZT clone.
 class MobileKeystonePcztSigningFlow extends ConsumerStatefulWidget {
   const MobileKeystonePcztSigningFlow({
     required this.title,

--- a/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
+++ b/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
@@ -111,6 +111,7 @@ class MobileKeystonePcztSigningFlow extends ConsumerStatefulWidget {
     this.readingSignatureLabel = 'Reading signature...',
     this.finalizingSignatureLabel,
     this.scanCaption = _mobileKeystoneScanCaption,
+    this.signedUrType = 'zcash-pczt',
     this.stepOneProgress = _mobileKeystoneStepOneProgress,
     this.stepTwoProgress = _mobileKeystoneStepTwoProgress,
     this.logTag = 'MobileKeystonePcztSigningFlow',
@@ -130,6 +131,7 @@ class MobileKeystonePcztSigningFlow extends ConsumerStatefulWidget {
   final String readingSignatureLabel;
   final String? finalizingSignatureLabel;
   final String scanCaption;
+  final String signedUrType;
   final double stepOneProgress;
   final double stepTwoProgress;
   final String logTag;
@@ -751,7 +753,7 @@ class _MobileKeystonePcztSigningFlowState
               ) ??
               AnimatedUrScannerView(
                 controller: scanController,
-                expectedUrType: 'zcash-pczt',
+                expectedUrType: widget.signedUrType,
                 scanSessionResetToken: scanSessionResetToken,
                 // Constrain detection to the visible viewfinder (this full-screen
                 // scanner's viewfinder is positioned, not centred), so a QR is

--- a/lib/src/features/send/screens/keystone_send_scan_screen.dart
+++ b/lib/src/features/send/screens/keystone_send_scan_screen.dart
@@ -15,8 +15,27 @@ import '../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../services/qr_scanner.dart';
 import '../../keystone/widgets/keystone_qr_scanner_card.dart';
 
+class KeystoneSendScanArgs {
+  const KeystoneSendScanArgs({
+    required this.expectedUrType,
+    required this.returnRawCbor,
+  });
+
+  const KeystoneSendScanArgs.pczt()
+    : expectedUrType = 'zcash-pczt',
+      returnRawCbor = false;
+
+  final String expectedUrType;
+  final bool returnRawCbor;
+}
+
 class KeystoneSendScanScreen extends ConsumerStatefulWidget {
-  const KeystoneSendScanScreen({super.key});
+  const KeystoneSendScanScreen({
+    this.args = const KeystoneSendScanArgs.pczt(),
+    super.key,
+  });
+
+  final KeystoneSendScanArgs args;
 
   @override
   ConsumerState<KeystoneSendScanScreen> createState() =>
@@ -45,9 +64,9 @@ class _KeystoneSendScanScreenState
     });
 
     try {
-      final pcztBytes = await rust_keystone.decodePcztFromCbor(
-        cbor: result.data,
-      );
+      final pcztBytes = widget.args.returnRawCbor
+          ? Uint8List.fromList(result.data)
+          : await rust_keystone.decodePcztFromCbor(cbor: result.data);
       if (!mounted) return;
       context.pop(Uint8List.fromList(pcztBytes));
     } catch (e, st) {
@@ -123,7 +142,7 @@ class _KeystoneSendScanScreenState
                       ),
                       const SizedBox(height: AppSpacing.base),
                       KeystoneQrScannerCard(
-                        expectedUrType: 'zcash-pczt',
+                        expectedUrType: widget.args.expectedUrType,
                         decoding: _decoding,
                         error: _error,
                         onProgress: (progress) {

--- a/lib/src/features/send/screens/mobile/mobile_keystone_sign_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_keystone_sign_screen.dart
@@ -9,15 +9,15 @@ import '../../../../../main.dart' show log;
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/storage/wallet_paths.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
-import '../../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../../rust/api/sync.dart' as rust_sync;
+import '../../../keystone/services/keystone_batch_signing.dart';
 import '../../../keystone/widgets/mobile_keystone_pczt_signing_flow.dart';
 import '../../services/sapling_params.dart';
 import '../../services/send_flow.dart';
 import 'mobile_send_screen.dart' show MobileSaplingParamsSheet;
 
 /// Mobile Keystone signing. The send-specific work here is only PCZT
-/// preparation and the result payload; the QR display and signed-PCZT scan are
+/// preparation and the result payload; the QR display and signature scan are
 /// shared by every mobile Keystone signing surface.
 class MobileKeystoneSignScreen extends ConsumerStatefulWidget {
   const MobileKeystoneSignScreen({required this.args, super.key});
@@ -32,6 +32,7 @@ class MobileKeystoneSignScreen extends ConsumerStatefulWidget {
 class _MobileKeystoneSignScreenState
     extends ConsumerState<MobileKeystoneSignScreen> {
   bool _proposalOwnershipTransferred = false;
+  List<int>? _keystoneBasePczt;
 
   @override
   void dispose() {
@@ -57,6 +58,8 @@ class _MobileKeystoneSignScreenState
       preparePczt: _preparePczt,
       onSigned: _handleSignedPczt,
       friendlyError: _friendlyError,
+      signedPcztDecoder: _decodeSigningResponse,
+      signedUrType: keystoneBatchSignatureUrType,
       keyPrefix: 'mobile_keystone_sign',
       scanCaption: 'Scan the QR code on your Keystone to finish sending',
       logTag: 'MobileKeystoneSign',
@@ -105,13 +108,12 @@ class _MobileKeystoneSignScreenState
       sendFlowId: widget.args.sendFlowId,
     );
 
-    final redactedPczt = await rust_sync.redactPcztForSigner(
+    final urParts = await encodeKeystoneBatchPcztUrParts(
       pcztBytes: pcztBytes,
+      requestId: widget.args.sendFlowId,
+      messageId: keystoneSendBatchMessageId,
     );
-    final urParts = await rust_keystone.encodePcztUrParts(
-      pcztBytes: redactedPczt,
-      maxFragmentLen: BigInt.from(140),
-    );
+    _keystoneBasePczt = pcztBytes;
 
     return MobileKeystonePcztSigningPayload(
       urParts: urParts,
@@ -124,6 +126,19 @@ class _MobileKeystoneSignScreenState
             ? saplingParams.outputPath
             : null,
       ),
+    );
+  }
+
+  Future<Uint8List> _decodeSigningResponse(List<int> cbor) async {
+    final basePczt = _keystoneBasePczt;
+    if (basePczt == null) {
+      throw StateError('Keystone signing could not be prepared.');
+    }
+    return decodeAndApplyKeystoneBatchPcztSignatures(
+      pcztBytes: basePczt,
+      responseCbor: cbor,
+      requestId: widget.args.sendFlowId,
+      messageId: keystoneSendBatchMessageId,
     );
   }
 

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -17,11 +17,12 @@ import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/zec_price_change_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
-import '../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../address_book/models/address_book_contact.dart';
 import '../../address_book/providers/address_book_provider.dart';
+import '../../keystone/services/keystone_batch_signing.dart';
 import '../../keystone/widgets/keystone_signing_modal.dart';
+import 'keystone_send_scan_screen.dart';
 import '../services/sapling_params.dart';
 import '../services/send_flow.dart';
 import '../widgets/sapling_params_prompt.dart';
@@ -50,6 +51,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   KeystoneSigningModalPhase? _keystonePhase;
   String? _keystoneError;
   List<String> _keystoneUrParts = const [];
+  List<int>? _keystoneBasePczt;
   List<int>? _keystonePcztWithProofs;
   SaplingParamsStatus? _keystoneSaplingParams;
 
@@ -129,6 +131,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
       _keystonePhase = KeystoneSigningModalPhase.preparing;
       _keystoneError = null;
       _keystoneUrParts = const [];
+      _keystoneBasePczt = null;
       _keystonePcztWithProofs = null;
       _keystoneSaplingParams = null;
     });
@@ -198,18 +201,17 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
         proposalId: widget.args.proposalId,
         sendFlowId: widget.args.sendFlowId,
       );
-      final redactedPczt = await rust_sync.redactPcztForSigner(
+      final urParts = await encodeKeystoneBatchPcztUrParts(
         pcztBytes: pcztBytes,
-      );
-      final urParts = await rust_keystone.encodePcztUrParts(
-        pcztBytes: redactedPczt,
-        maxFragmentLen: BigInt.from(140),
+        requestId: widget.args.sendFlowId,
+        messageId: keystoneSendBatchMessageId,
       );
 
       if (!mounted) return;
       setState(() {
         _keystonePhase = KeystoneSigningModalPhase.ready;
         _keystoneUrParts = urParts;
+        _keystoneBasePczt = pcztBytes;
       });
 
       final pcztWithProofs = await rust_sync.addProofsToPczt(
@@ -256,16 +258,44 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   }
 
   Future<void> _getKeystoneSignature() async {
+    final basePczt = _keystoneBasePczt;
     final pcztWithProofs = _keystonePcztWithProofs;
     final saplingParams = _keystoneSaplingParams;
     if (_keystonePhase != KeystoneSigningModalPhase.ready ||
+        basePczt == null ||
         pcztWithProofs == null ||
         saplingParams == null) {
       return;
     }
 
-    final signatures = await context.push<List<int>>('/send/keystone/scan');
-    if (signatures == null || !mounted) return;
+    final responseCbor = await context.push<List<int>>(
+      '/send/keystone/scan',
+      extra: const KeystoneSendScanArgs(
+        expectedUrType: keystoneBatchSignatureUrType,
+        returnRawCbor: true,
+      ),
+    );
+    if (responseCbor == null || !mounted) return;
+
+    late final List<int> signatures;
+    try {
+      signatures = await decodeAndApplyKeystoneBatchPcztSignatures(
+        pcztBytes: basePczt,
+        responseCbor: responseCbor,
+        requestId: widget.args.sendFlowId,
+        messageId: keystoneSendBatchMessageId,
+      );
+    } catch (e, st) {
+      log('SendReview._decodeKeystoneSignature: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _keystonePhase = KeystoneSigningModalPhase.failed;
+        _keystoneError =
+            'The Keystone signature could not be verified. Return to Send and try again.';
+      });
+      return;
+    }
+    if (!mounted) return;
 
     _handoffToKeystone = true;
     final statusArgs = KeystoneBroadcastArgs(

--- a/lib/src/features/swap/providers/swap_hardware_signing_service.dart
+++ b/lib/src/features/swap/providers/swap_hardware_signing_service.dart
@@ -4,14 +4,12 @@ import '../../../../main.dart' show log;
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
-import '../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../rust/api/sync.dart' as rust_sync;
-import '../../../rust/wallet/keystone.dart' as rust_keystone_wallet;
+import '../../keystone/services/keystone_batch_signing.dart';
 import '../models/swap_models.dart';
 
-const swapKeystoneSignatureUrType = 'zcash-batch-sig-result';
+const swapKeystoneSignatureUrType = keystoneBatchSignatureUrType;
 const _swapKeystoneBatchMessageId = 'zec-deposit';
-const _keystoneQrFragmentLength = 140;
 
 final swapHardwareSigningServiceProvider = Provider<SwapHardwareSigningService>(
   (ref) => RustSwapHardwareSigningService(ref),
@@ -162,20 +160,11 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
   @override
   Future<List<String>> encodeSigningUrParts({
     required SwapHardwarePcztDraft draft,
-  }) async {
-    final batchPczt = await rust_keystone.prepareKeystoneBatchPczt(
+  }) {
+    return encodeKeystoneBatchPcztUrParts(
       pcztBytes: draft.pcztBytes,
-    );
-    return rust_keystone.encodeZcashSignBatchUrParts(
       requestId: draft.sendFlowId,
-      messages: [
-        rust_keystone_wallet.ZcashBatchMessageInput(
-          id: _swapKeystoneBatchMessageId,
-          pcztBytes: batchPczt.redactedPczt,
-          expectedSignatureCount: batchPczt.expectedSignatureCount,
-        ),
-      ],
-      maxFragmentLen: BigInt.from(_keystoneQrFragmentLength),
+      messageId: _swapKeystoneBatchMessageId,
     );
   }
 
@@ -183,16 +172,12 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
   Future<List<int>> decodeSigningResponse({
     required SwapHardwarePcztDraft draft,
     required List<int> cbor,
-  }) async {
-    final decoded = await rust_keystone.decodeZcashBatchSignResponse(
-      cbor: cbor,
-      expectedRequestId: draft.sendFlowId,
-      messageIds: const [_swapKeystoneBatchMessageId],
-    );
-    final result = decoded.results.single;
-    return rust_keystone.applyKeystoneBatchPcztSignatures(
+  }) {
+    return decodeAndApplyKeystoneBatchPcztSignatures(
       pcztBytes: draft.pcztBytes,
-      signatures: result.sigs,
+      responseCbor: cbor,
+      requestId: draft.sendFlowId,
+      messageId: _swapKeystoneBatchMessageId,
     );
   }
 

--- a/lib/src/features/swap/providers/swap_hardware_signing_service.dart
+++ b/lib/src/features/swap/providers/swap_hardware_signing_service.dart
@@ -6,7 +6,12 @@ import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../rust/api/sync.dart' as rust_sync;
+import '../../../rust/wallet/keystone.dart' as rust_keystone_wallet;
 import '../models/swap_models.dart';
+
+const swapKeystoneSignatureUrType = 'zcash-batch-sig-result';
+const _swapKeystoneBatchMessageId = 'zec-deposit';
+const _keystoneQrFragmentLength = 140;
 
 final swapHardwareSigningServiceProvider = Provider<SwapHardwareSigningService>(
   (ref) => RustSwapHardwareSigningService(ref),
@@ -20,6 +25,11 @@ abstract interface class SwapHardwareSigningService {
 
   Future<List<String>> encodeSigningUrParts({
     required SwapHardwarePcztDraft draft,
+  });
+
+  Future<List<int>> decodeSigningResponse({
+    required SwapHardwarePcztDraft draft,
+    required List<int> cbor,
   });
 
   Future<List<int>> addProofsForSigning({
@@ -153,12 +163,36 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
   Future<List<String>> encodeSigningUrParts({
     required SwapHardwarePcztDraft draft,
   }) async {
-    final redactedPczt = await rust_sync.redactPcztForSigner(
+    final batchPczt = await rust_keystone.prepareKeystoneBatchPczt(
       pcztBytes: draft.pcztBytes,
     );
-    return rust_keystone.encodePcztUrParts(
-      pcztBytes: redactedPczt,
-      maxFragmentLen: BigInt.from(140),
+    return rust_keystone.encodeZcashSignBatchUrParts(
+      requestId: draft.sendFlowId,
+      messages: [
+        rust_keystone_wallet.ZcashBatchMessageInput(
+          id: _swapKeystoneBatchMessageId,
+          pcztBytes: batchPczt.redactedPczt,
+          expectedSignatureCount: batchPczt.expectedSignatureCount,
+        ),
+      ],
+      maxFragmentLen: BigInt.from(_keystoneQrFragmentLength),
+    );
+  }
+
+  @override
+  Future<List<int>> decodeSigningResponse({
+    required SwapHardwarePcztDraft draft,
+    required List<int> cbor,
+  }) async {
+    final decoded = await rust_keystone.decodeZcashBatchSignResponse(
+      cbor: cbor,
+      expectedRequestId: draft.sendFlowId,
+      messageIds: const [_swapKeystoneBatchMessageId],
+    );
+    final result = decoded.results.single;
+    return rust_keystone.applyKeystoneBatchPcztSignatures(
+      pcztBytes: draft.pcztBytes,
+      signatures: result.sigs,
     );
   }
 

--- a/lib/src/features/swap/screens/mobile/mobile_swap_keystone_sign_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_keystone_sign_screen.dart
@@ -95,10 +95,11 @@ class _MobileSwapKeystoneSignScreenState
       onSigned: _handleSignedPczt,
       friendlyError: _friendlyError,
       onCancel: _handleCancel,
-      signedPcztDecoder: widget.signedPcztDecoder,
+      signedPcztDecoder: widget.signedPcztDecoder ?? _decodeSigningResponse,
       scannerBuilder: widget.scannerBuilder,
       forceScannerActiveForTesting: widget.forceScannerActiveForTesting,
       keyPrefix: 'mobile_swap_keystone_sign',
+      signedUrType: swapKeystoneSignatureUrType,
       scanCaption:
           'Scan the QR code on your Keystone to finish the ZEC deposit',
       finalizingSignatureLabel: 'Broadcasting ZEC deposit...',
@@ -171,6 +172,19 @@ class _MobileSwapKeystoneSignScreenState
       builder: (_) => const MobileSaplingParamsSheet(),
     );
     return confirmed == true;
+  }
+
+  Future<Uint8List> _decodeSigningResponse(List<int> cbor) async {
+    final service = _signingService;
+    final draft = _draft;
+    if (service == null || draft == null) {
+      throw StateError('Keystone signing could not be prepared.');
+    }
+    final signedPczt = await service.decodeSigningResponse(
+      draft: draft,
+      cbor: cbor,
+    );
+    return Uint8List.fromList(signedPczt);
   }
 
   Future<void> _handleSignedPczt(

--- a/lib/src/features/swap/widgets/swap_keystone_signing_overlay.dart
+++ b/lib/src/features/swap/widgets/swap_keystone_signing_overlay.dart
@@ -8,6 +8,7 @@ import '../../../../main.dart' show log;
 import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../keystone/widgets/keystone_signing_modal.dart';
+import '../../send/screens/keystone_send_scan_screen.dart';
 import '../../send/services/sapling_params.dart';
 import '../../send/widgets/sapling_params_prompt.dart';
 import '../models/swap_deposit_broadcast_result.dart';
@@ -158,9 +159,32 @@ class _SwapKeystoneSigningOverlayState
 
   Future<void> _getSignature() async {
     if (_phase != _SwapKeystonePhase.ready || _pcztWithProofs == null) return;
-    final signatures = await context.push<List<int>>('/send/keystone/scan');
-    if (signatures == null || !mounted) return;
-    await _broadcast(signatures);
+    final responseCbor = await context.push<List<int>>(
+      '/send/keystone/scan',
+      extra: const KeystoneSendScanArgs(
+        expectedUrType: swapKeystoneSignatureUrType,
+        returnRawCbor: true,
+      ),
+    );
+    if (responseCbor == null || !mounted) return;
+    final service = _signingService;
+    final draft = _draft;
+    if (service == null || draft == null) return;
+    try {
+      final signedPczt = await service.decodeSigningResponse(
+        draft: draft,
+        cbor: responseCbor,
+      );
+      if (!mounted) return;
+      await _broadcast(signedPczt);
+    } catch (e, st) {
+      log('SwapKeystoneSigning._decodeSignature: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _phase = _SwapKeystonePhase.failed;
+        _error = _friendlyError(e);
+      });
+    }
   }
 
   Future<void> _broadcast(List<int> signatures) async {

--- a/lib/src/rust/api/keystone.dart
+++ b/lib/src/rust/api/keystone.dart
@@ -7,7 +7,7 @@ import '../frb_generated.dart';
 import '../wallet/keystone.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `action_sig_to_api`, `retain_consistent_firmware_version`, `sig_result_to_api`, `signed_pczt_firmware_version`
+// These functions are ignored because they are not marked as `pub`: `action_sig_to_api`, `action_sigs_from_api`, `retain_consistent_firmware_version`, `sig_result_to_api`, `signed_pczt_firmware_version`
 
 /// Encode PCZT bytes to a UR string for QR code display.
 Future<String> encodePcztToUr({required List<int> pcztBytes}) =>
@@ -122,6 +122,25 @@ Future<List<KeystoneAccountInfo>> decodeAccountsUr({
   required String urString,
 }) => RustLib.instance.api.crateApiKeystoneDecodeAccountsUr(urString: urString);
 
+/// Redact a wallet-owned PCZT using the compact batch-signer policy and return
+/// the number of signatures Keystone must produce for it.
+Future<KeystoneBatchPczt> prepareKeystoneBatchPczt({
+  required List<int> pcztBytes,
+}) => RustLib.instance.api.crateApiKeystonePrepareKeystoneBatchPczt(
+  pcztBytes: pcztBytes,
+);
+
+/// Apply a compact, signatures-only Keystone response to the wallet-owned
+/// base PCZT. The result can be passed to the existing PCZT broadcast API as
+/// the signatures-bearing half of the transaction.
+Future<Uint8List> applyKeystoneBatchPcztSignatures({
+  required List<int> pcztBytes,
+  required List<KeystoneActionSig> signatures,
+}) => RustLib.instance.api.crateApiKeystoneApplyKeystoneBatchPcztSignatures(
+  pcztBytes: pcztBytes,
+  signatures: signatures,
+);
+
 /// One spend-authorization signature from a compact `zcash-batch-sig-result`,
 /// located by `pool` (0 = Orchard, 1 = Ironwood) and the spend action's index
 /// within that pool's bundle. `sig` is the raw 64-byte spend-authorization
@@ -150,6 +169,28 @@ class KeystoneActionSig {
           pool == other.pool &&
           actionIndex == other.actionIndex &&
           sig == other.sig;
+}
+
+/// A compact PCZT prepared for one position in a `zcash-sign-batch` request.
+class KeystoneBatchPczt {
+  final Uint8List redactedPczt;
+  final int expectedSignatureCount;
+
+  const KeystoneBatchPczt({
+    required this.redactedPczt,
+    required this.expectedSignatureCount,
+  });
+
+  @override
+  int get hashCode => redactedPczt.hashCode ^ expectedSignatureCount.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is KeystoneBatchPczt &&
+          runtimeType == other.runtimeType &&
+          redactedPczt == other.redactedPczt &&
+          expectedSignatureCount == other.expectedSignatureCount;
 }
 
 /// The signatures produced for a single requested message, correlated back to

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -81,7 +81,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 844087337;
+  int get rustContentHash => -469128443;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -124,6 +124,11 @@ abstract class RustLibApi extends BaseApi {
     required int proposalId,
     required int shareIndex,
     required List<String> newUrls,
+  });
+
+  Future<Uint8List> crateApiKeystoneApplyKeystoneBatchPcztSignatures({
+    required List<int> pcztBytes,
+    required List<KeystoneActionSig> signatures,
   });
 
   void crateApiNetworkPrivacyBeginNetworkPrivacyEnable();
@@ -853,6 +858,10 @@ abstract class RustLibApi extends BaseApi {
     required int bundleIndex,
   });
 
+  Future<KeystoneBatchPczt> crateApiKeystonePrepareKeystoneBatchPczt({
+    required List<int> pcztBytes,
+  });
+
   Future<KeystoneMigrationSigningRequest>
   crateApiSyncPrepareOrchardMigrationBatchPczt({
     required String dbPath,
@@ -1410,12 +1419,48 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<Uint8List> crateApiKeystoneApplyKeystoneBatchPcztSignatures({
+    required List<int> pcztBytes,
+    required List<KeystoneActionSig> signatures,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_list_prim_u_8_loose(pcztBytes, serializer);
+          sse_encode_list_keystone_action_sig(signatures, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 5,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_prim_u_8_strict,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiKeystoneApplyKeystoneBatchPcztSignaturesConstMeta,
+        argValues: [pcztBytes, signatures],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiKeystoneApplyKeystoneBatchPcztSignaturesConstMeta =>
+      const TaskConstMeta(
+        debugName: "apply_keystone_batch_pczt_signatures",
+        argNames: ["pcztBytes", "signatures"],
+      );
+
+  @override
   void crateApiNetworkPrivacyBeginNetworkPrivacyEnable() {
     return handler.executeSync(
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1457,7 +1502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 7,
             port: port_,
           );
         },
@@ -1519,7 +1564,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 8,
             port: port_,
           );
         },
@@ -1574,7 +1619,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 9,
             port: port_,
           );
         },
@@ -1622,7 +1667,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 9,
+              funcId: 10,
               port: port_,
             );
           },
@@ -1690,7 +1735,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 10,
+              funcId: 11,
               port: port_,
             );
           },
@@ -1761,7 +1806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 11,
+              funcId: 12,
               port: port_,
             );
           },
@@ -1810,7 +1855,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1838,7 +1883,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 14,
             port: port_,
           );
         },
@@ -1875,7 +1920,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -1924,7 +1969,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -1996,7 +2041,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -2065,7 +2110,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -2131,7 +2176,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -2183,7 +2228,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 20,
             port: port_,
           );
         },
@@ -2218,7 +2263,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 21,
             port: port_,
           );
         },
@@ -2251,7 +2296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 22,
             port: port_,
           );
         },
@@ -2296,7 +2341,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 23,
             port: port_,
           );
         },
@@ -2355,7 +2400,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 24,
             port: port_,
           );
         },
@@ -2415,7 +2460,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -2468,7 +2513,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -2513,7 +2558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -2552,7 +2597,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 28,
             port: port_,
           );
         },
@@ -2584,7 +2629,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 29,
             port: port_,
           );
         },
@@ -2617,7 +2662,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -2650,7 +2695,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -2685,7 +2730,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -2716,7 +2761,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -2753,7 +2798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -2786,7 +2831,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -2820,7 +2865,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -2861,7 +2906,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -2898,7 +2943,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -2934,7 +2979,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 39,
             port: port_,
           );
         },
@@ -2971,7 +3016,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -3010,7 +3055,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -3045,7 +3090,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -3080,7 +3125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -3110,7 +3155,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -3143,7 +3188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -3178,7 +3223,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -3224,7 +3269,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -3274,7 +3319,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -3309,7 +3354,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -3346,7 +3391,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -3383,7 +3428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -3418,7 +3463,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -3461,7 +3506,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -3515,7 +3560,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -3569,7 +3614,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -3600,7 +3645,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -3645,7 +3690,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 57,
             port: port_,
           );
         },
@@ -3707,7 +3752,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -3765,7 +3810,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -3816,7 +3861,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -3859,7 +3904,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3895,7 +3940,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 62,
             port: port_,
           );
         },
@@ -3934,7 +3979,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 63,
             port: port_,
           );
         },
@@ -3971,7 +4016,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 64,
             port: port_,
           );
         },
@@ -4008,7 +4053,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 65,
             port: port_,
           );
         },
@@ -4042,7 +4087,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 66,
             port: port_,
           );
         },
@@ -4069,7 +4114,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4099,7 +4144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 68,
             port: port_,
           );
         },
@@ -4135,7 +4180,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 69,
             port: port_,
           );
         },
@@ -4172,7 +4217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 70,
             port: port_,
           );
         },
@@ -4208,7 +4253,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 71,
             port: port_,
           );
         },
@@ -4245,7 +4290,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 72,
             port: port_,
           );
         },
@@ -4278,7 +4323,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 73,
             port: port_,
           );
         },
@@ -4311,7 +4356,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 74,
             port: port_,
           );
         },
@@ -4338,7 +4383,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_network_privacy_status,
@@ -4375,7 +4420,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 76,
             port: port_,
           );
         },
@@ -4410,7 +4455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 77,
             port: port_,
           );
         },
@@ -4448,7 +4493,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 78,
             port: port_,
           );
         },
@@ -4489,7 +4534,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 79,
             port: port_,
           );
         },
@@ -4532,7 +4577,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 80,
             port: port_,
           );
         },
@@ -4569,7 +4614,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 81,
             port: port_,
           );
         },
@@ -4608,7 +4653,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 82,
             port: port_,
           );
         },
@@ -4648,7 +4693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 83,
             port: port_,
           );
         },
@@ -4688,7 +4733,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 84,
             port: port_,
           );
         },
@@ -4724,7 +4769,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4761,7 +4806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 86,
             port: port_,
           );
         },
@@ -4788,7 +4833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -4818,7 +4863,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4852,7 +4897,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 89,
             port: port_,
           );
         },
@@ -4893,7 +4938,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4932,7 +4977,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4969,7 +5014,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 92,
             port: port_,
           );
         },
@@ -5006,7 +5051,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -5034,7 +5079,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -5074,7 +5119,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 95,
             port: port_,
           );
         },
@@ -5138,7 +5183,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -5206,7 +5251,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -5272,7 +5317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 98,
             port: port_,
           );
         },
@@ -5315,7 +5360,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 99,
             port: port_,
           );
         },
@@ -5346,7 +5391,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_64(nowSeconds, serializer);
           sse_encode_u_64(ceremonyStartSeconds, serializer);
           sse_encode_u_64(voteEndTimeSeconds, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 100,
+          )!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -5373,7 +5422,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
           )!;
         },
         codec: SseCodec(
@@ -5413,7 +5462,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 102,
             port: port_,
           );
         },
@@ -5456,7 +5505,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 103,
           )!;
         },
         codec: SseCodec(
@@ -5482,7 +5531,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 104,
           )!;
         },
         codec: SseCodec(
@@ -5508,7 +5557,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 105,
           )!;
         },
         codec: SseCodec(
@@ -5536,7 +5585,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 106,
             port: port_,
           );
         },
@@ -5571,7 +5620,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 107,
           )!;
         },
         codec: SseCodec(
@@ -5605,7 +5654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 108,
             port: port_,
           );
         },
@@ -5645,7 +5694,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 109,
             port: port_,
           );
         },
@@ -5688,7 +5737,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5745,7 +5794,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5811,7 +5860,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5881,7 +5930,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5952,7 +6001,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
             port: port_,
           );
         },
@@ -6002,7 +6051,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
           )!;
         },
         codec: SseCodec(
@@ -6033,7 +6082,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
             port: port_,
           );
         },
@@ -6068,7 +6117,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
             port: port_,
           );
         },
@@ -6101,7 +6150,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
             port: port_,
           );
         },
@@ -6144,7 +6193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 119,
             port: port_,
           );
         },
@@ -6198,7 +6247,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 120,
             port: port_,
           );
         },
@@ -6220,6 +6269,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<KeystoneBatchPczt> crateApiKeystonePrepareKeystoneBatchPczt({
+    required List<int> pcztBytes,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_list_prim_u_8_loose(pcztBytes, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 121,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_keystone_batch_pczt,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiKeystonePrepareKeystoneBatchPcztConstMeta,
+        argValues: [pcztBytes],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiKeystonePrepareKeystoneBatchPcztConstMeta =>
+      const TaskConstMeta(
+        debugName: "prepare_keystone_batch_pczt",
+        argNames: ["pcztBytes"],
+      );
+
+  @override
   Future<KeystoneMigrationSigningRequest>
   crateApiSyncPrepareOrchardMigrationBatchPczt({
     required String dbPath,
@@ -6236,7 +6318,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 122,
             port: port_,
           );
         },
@@ -6281,7 +6363,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 123,
             port: port_,
           );
         },
@@ -6341,7 +6423,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 124,
             port: port_,
           );
         },
@@ -6401,7 +6483,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 125,
             port: port_,
           );
         },
@@ -6460,7 +6542,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6513,7 +6595,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6572,7 +6654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6634,7 +6716,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6682,7 +6764,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6741,7 +6823,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6811,7 +6893,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6870,7 +6952,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6917,7 +6999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 134,
             port: port_,
           );
         },
@@ -6962,7 +7044,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 135,
             port: port_,
           );
         },
@@ -6992,7 +7074,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 136,
           )!;
         },
         codec: SseCodec(
@@ -7025,7 +7107,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 137,
             port: port_,
           );
         },
@@ -7062,7 +7144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 138,
             port: port_,
           );
         },
@@ -7097,7 +7179,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7139,7 +7221,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7174,7 +7256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7215,7 +7297,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7264,7 +7346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7302,7 +7384,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 144,
             port: port_,
           );
         },
@@ -7357,7 +7439,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7427,7 +7509,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 146,
             port: port_,
           );
         },
@@ -7474,7 +7556,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 147,
           )!;
         },
         codec: SseCodec(
@@ -7504,7 +7586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 148,
           )!;
         },
         codec: SseCodec(
@@ -7539,7 +7621,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7572,7 +7654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7612,7 +7694,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 151,
             port: port_,
           );
         },
@@ -7653,7 +7735,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7707,7 +7789,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7757,7 +7839,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 152,
+              funcId: 154,
               port: port_,
             );
           },
@@ -7798,7 +7880,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 153,
+              funcId: 155,
               port: port_,
             );
           },
@@ -7830,7 +7912,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7857,7 +7939,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 157,
           )!;
         },
         codec: SseCodec(
@@ -7883,7 +7965,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7925,7 +8007,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 159,
             port: port_,
           );
         },
@@ -7976,7 +8058,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8015,7 +8097,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 161,
             port: port_,
           );
         },
@@ -8051,7 +8133,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8086,7 +8168,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8123,7 +8205,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8167,7 +8249,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8217,7 +8299,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 166,
             port: port_,
           );
         },
@@ -8249,7 +8331,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8277,7 +8359,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 168,
           )!;
         },
         codec: SseCodec(
@@ -8309,7 +8391,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8346,7 +8428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8377,7 +8459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 171,
           )!;
         },
         codec: SseCodec(
@@ -8408,7 +8490,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8445,7 +8527,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 173,
             port: port_,
           );
         },
@@ -9109,6 +9191,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       pool: dco_decode_u_8(arr[0]),
       actionIndex: dco_decode_u_32(arr[1]),
       sig: dco_decode_list_prim_u_8_strict(arr[2]),
+    );
+  }
+
+  @protected
+  KeystoneBatchPczt dco_decode_keystone_batch_pczt(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return KeystoneBatchPczt(
+      redactedPczt: dco_decode_list_prim_u_8_strict(arr[0]),
+      expectedSignatureCount: dco_decode_u_32(arr[1]),
     );
   }
 
@@ -11576,6 +11670,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       pool: var_pool,
       actionIndex: var_actionIndex,
       sig: var_sig,
+    );
+  }
+
+  @protected
+  KeystoneBatchPczt sse_decode_keystone_batch_pczt(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_redactedPczt = sse_decode_list_prim_u_8_strict(deserializer);
+    var var_expectedSignatureCount = sse_decode_u_32(deserializer);
+    return KeystoneBatchPczt(
+      redactedPczt: var_redactedPczt,
+      expectedSignatureCount: var_expectedSignatureCount,
     );
   }
 
@@ -14585,6 +14692,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_u_8(self.pool, serializer);
     sse_encode_u_32(self.actionIndex, serializer);
     sse_encode_list_prim_u_8_strict(self.sig, serializer);
+  }
+
+  @protected
+  void sse_encode_keystone_batch_pczt(
+    KeystoneBatchPczt self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_prim_u_8_strict(self.redactedPczt, serializer);
+    sse_encode_u_32(self.expectedSignatureCount, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -240,6 +240,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   KeystoneActionSig dco_decode_keystone_action_sig(dynamic raw);
 
   @protected
+  KeystoneBatchPczt dco_decode_keystone_batch_pczt(dynamic raw);
+
+  @protected
   KeystoneMigrationMessage dco_decode_keystone_migration_message(dynamic raw);
 
   @protected
@@ -1036,6 +1039,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   KeystoneActionSig sse_decode_keystone_action_sig(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  KeystoneBatchPczt sse_decode_keystone_batch_pczt(
     SseDeserializer deserializer,
   );
 
@@ -2023,6 +2031,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_keystone_action_sig(
     KeystoneActionSig self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_keystone_batch_pczt(
+    KeystoneBatchPczt self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -242,6 +242,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   KeystoneActionSig dco_decode_keystone_action_sig(dynamic raw);
 
   @protected
+  KeystoneBatchPczt dco_decode_keystone_batch_pczt(dynamic raw);
+
+  @protected
   KeystoneMigrationMessage dco_decode_keystone_migration_message(dynamic raw);
 
   @protected
@@ -1038,6 +1041,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   KeystoneActionSig sse_decode_keystone_action_sig(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  KeystoneBatchPczt sse_decode_keystone_batch_pczt(
     SseDeserializer deserializer,
   );
 
@@ -2025,6 +2033,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_keystone_action_sig(
     KeystoneActionSig self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_keystone_batch_pczt(
+    KeystoneBatchPczt self,
     SseSerializer serializer,
   );
 

--- a/rust/src/api/keystone.rs
+++ b/rust/src/api/keystone.rs
@@ -97,16 +97,46 @@ pub struct KeystoneSigResult {
     pub results: Vec<KeystoneMsgSig>,
 }
 
+pub(crate) fn action_sigs_from_api(
+    actions: Vec<KeystoneActionSig>,
+    context: &str,
+) -> Result<Vec<pczt::roles::signer::SpendAuthSignature>, String> {
+    actions
+        .into_iter()
+        .map(|action| {
+            let sig: [u8; keystone::ZCASH_SIG_LEN] =
+                action.sig.as_slice().try_into().map_err(|_| {
+                    format!(
+                        "Keystone signature for {context} must be \
+                         {} bytes, got {}",
+                        keystone::ZCASH_SIG_LEN,
+                        action.sig.len()
+                    )
+                })?;
+            let value_pool = keystone::decode_signature_pool(u32::from(action.pool))
+                .map_err(|error| format!("Keystone signature for {context}: {error}"))?;
+            let action_index = usize::try_from(action.action_index).map_err(|_| {
+                format!(
+                    "Keystone signature action index {} exceeds usize",
+                    action.action_index
+                )
+            })?;
+            Ok(pczt::roles::signer::SpendAuthSignature::from_parts(
+                value_pool,
+                action_index,
+                sig,
+            ))
+        })
+        .collect()
+}
+
 /// Reshape a PCZT [`SpendAuthSignature`] into the FRB-boundary form.
 ///
 /// [`SpendAuthSignature`]: pczt::roles::signer::SpendAuthSignature
 fn action_sig_to_api(
     action: &pczt::roles::signer::SpendAuthSignature,
 ) -> Result<KeystoneActionSig, String> {
-    let pool = match action.value_pool() {
-        orchard::ValuePool::Orchard => 0,
-        orchard::ValuePool::Ironwood => 1,
-    };
+    let pool = keystone::encode_signature_pool(action.value_pool());
     let action_index = u32::try_from(action.action_index())
         .map_err(|_| "PCZT signature action index exceeds u32".to_string())?;
     Ok(KeystoneActionSig {
@@ -315,6 +345,34 @@ pub fn decode_pczt_from_cbor(cbor: Vec<u8>) -> Result<Vec<u8>, String> {
 pub fn decode_accounts_ur(ur_string: String) -> Result<Vec<KeystoneAccountInfo>, String> {
     let (_seed_fp, infos) = keystone::decode_accounts_ur(&ur_string)?;
     Ok(infos)
+}
+
+/// A compact PCZT prepared for one position in a `zcash-sign-batch` request.
+pub struct KeystoneBatchPczt {
+    pub redacted_pczt: Vec<u8>,
+    pub expected_signature_count: u32,
+}
+
+/// Redact a wallet-owned PCZT using the compact batch-signer policy and return
+/// the number of signatures Keystone must produce for it.
+pub fn prepare_keystone_batch_pczt(pczt_bytes: Vec<u8>) -> Result<KeystoneBatchPczt, String> {
+    let (redacted_pczt, expected_signature_count) =
+        crate::wallet::sync::prepare_pczt_for_batch_signer(&pczt_bytes)?;
+    Ok(KeystoneBatchPczt {
+        redacted_pczt,
+        expected_signature_count,
+    })
+}
+
+/// Apply a compact, signatures-only Keystone response to the wallet-owned
+/// base PCZT. The result can be passed to the existing PCZT broadcast API as
+/// the signatures-bearing half of the transaction.
+pub fn apply_keystone_batch_pczt_signatures(
+    pczt_bytes: Vec<u8>,
+    signatures: Vec<KeystoneActionSig>,
+) -> Result<Vec<u8>, String> {
+    let signatures = action_sigs_from_api(signatures, "batch PCZT")?;
+    crate::wallet::sync::apply_compact_sigs_to_pczt(&pczt_bytes, &signatures)
 }
 
 #[cfg(test)]

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -1848,40 +1848,7 @@ fn to_wallet_signed_messages(
     signed_messages
         .into_iter()
         .map(|message| {
-            let sigs = message
-                .sigs
-                .into_iter()
-                .map(|action| {
-                    let sig: [u8; 64] = action.sig.as_slice().try_into().map_err(|_| {
-                        format!(
-                            "Keystone signature for {} must be 64 bytes, got {}",
-                            message.id,
-                            action.sig.len()
-                        )
-                    })?;
-                    let value_pool = match action.pool {
-                        0 => orchard::ValuePool::Orchard,
-                        1 => orchard::ValuePool::Ironwood,
-                        other => {
-                            return Err(format!(
-                                "Keystone signature for {} has unsupported pool {other}",
-                                message.id
-                            ));
-                        }
-                    };
-                    let action_index = usize::try_from(action.action_index).map_err(|_| {
-                        format!(
-                            "Keystone signature action index {} exceeds usize",
-                            action.action_index
-                        )
-                    })?;
-                    Ok(pczt::roles::signer::SpendAuthSignature::from_parts(
-                        value_pool,
-                        action_index,
-                        sig,
-                    ))
-                })
-                .collect::<Result<Vec<_>, String>>()?;
+            let sigs = crate::api::keystone::action_sigs_from_api(message.sigs, &message.id)?;
             Ok(wallet_sync::KeystoneSignedMigrationMessage {
                 id: message.id,
                 sigs,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 844087337;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -469128443;
 
 // Section: executor
 
@@ -214,6 +214,44 @@ fn wire__crate__api__voting__add_sent_servers_impl(
                         api_proposal_id,
                         api_share_index,
                         api_new_urls,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__keystone__apply_keystone_batch_pczt_signatures_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "apply_keystone_batch_pczt_signatures",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_pczt_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_signatures =
+                <Vec<crate::api::keystone::KeystoneActionSig>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::keystone::apply_keystone_batch_pczt_signatures(
+                        api_pczt_bytes,
+                        api_signatures,
                     )?;
                     Ok(output_ok)
                 })())
@@ -4729,6 +4767,40 @@ fn wire__crate__api__voting__precompute_delegation_pir_impl(
         },
     )
 }
+fn wire__crate__api__keystone__prepare_keystone_batch_pczt_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "prepare_keystone_batch_pczt",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_pczt_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok =
+                        crate::api::keystone::prepare_keystone_batch_pczt(api_pczt_bytes)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -7797,6 +7869,18 @@ impl SseDecode for crate::api::keystone::KeystoneActionSig {
     }
 }
 
+impl SseDecode for crate::api::keystone::KeystoneBatchPczt {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_redactedPczt = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_expectedSignatureCount = <u32>::sse_decode(deserializer);
+        return crate::api::keystone::KeystoneBatchPczt {
+            redacted_pczt: var_redactedPczt,
+            expected_signature_count: var_expectedSignatureCount,
+        };
+    }
+}
+
 impl SseDecode for crate::api::sync::KeystoneMigrationMessage {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -10123,153 +10207,155 @@ fn pde_ffi_dispatcher_primary_impl(
 2 => wire__crate__api__wallet__add_account_impl(port, ptr, rust_vec_len, data_len),
 3 => wire__crate__api__sync__add_proofs_to_pczt_impl(port, ptr, rust_vec_len, data_len),
 4 => wire__crate__api__voting__add_sent_servers_impl(port, ptr, rust_vec_len, data_len),
-6 => wire__crate__api__sync__broadcast_due_orchard_migration_transactions_impl(port, ptr, rust_vec_len, data_len),
-7 => wire__crate__api__sync__broadcast_one_due_orchard_migration_transaction_impl(port, ptr, rust_vec_len, data_len),
-8 => wire__crate__api__voting__build_keystone_delegation_request_impl(port, ptr, rust_vec_len, data_len),
-9 => wire__crate__api__voting__build_prove_and_sign_delegation_payload_with_progress_impl(port, ptr, rust_vec_len, data_len),
-10 => wire__crate__api__voting__build_prove_delegation_payload_with_keystone_signature_with_progress_impl(port, ptr, rust_vec_len, data_len),
-11 => wire__crate__api__voting__build_vote_commitments_with_progress_impl(port, ptr, rust_vec_len, data_len),
-13 => wire__crate__api__voting__check_voting_eligibility_impl(port, ptr, rust_vec_len, data_len),
-14 => wire__crate__api__voting__clear_recovery_state_impl(port, ptr, rust_vec_len, data_len),
-15 => wire__crate__api__sync__complete_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-16 => wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-17 => wire__crate__api__sync__complete_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-18 => wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-19 => wire__crate__api__simple__configure_fast_testnet_migration_impl(port, ptr, rust_vec_len, data_len),
-20 => wire__crate__api__network_privacy__configure_network_privacy_impl(port, ptr, rust_vec_len, data_len),
-21 => wire__crate__api__simple__configure_regtest_ironwood_activation_height_impl(port, ptr, rust_vec_len, data_len),
-22 => wire__crate__api__voting__confirm_delegation_submission_impl(port, ptr, rust_vec_len, data_len),
-23 => wire__crate__api__voting__confirm_vote_submission_impl(port, ptr, rust_vec_len, data_len),
-24 => wire__crate__api__sync__create_or_resume_private_migration_draft_impl(port, ptr, rust_vec_len, data_len),
-25 => wire__crate__api__sync__create_pczt_from_proposal_impl(port, ptr, rust_vec_len, data_len),
-26 => wire__crate__api__sync__create_shield_transparent_pczt_impl(port, ptr, rust_vec_len, data_len),
-27 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
-28 => wire__crate__api__keystone__decode_accounts_from_cbor_impl(port, ptr, rust_vec_len, data_len),
-29 => wire__crate__api__keystone__decode_accounts_ur_impl(port, ptr, rust_vec_len, data_len),
-30 => wire__crate__api__keystone__decode_pczt_from_cbor_impl(port, ptr, rust_vec_len, data_len),
-31 => wire__crate__api__keystone__decode_ur_part_impl(port, ptr, rust_vec_len, data_len),
-32 => wire__crate__api__keystone__decode_ur_to_pczt_impl(port, ptr, rust_vec_len, data_len),
-33 => wire__crate__api__keystone__decode_zcash_batch_sign_response_impl(port, ptr, rust_vec_len, data_len),
-34 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_impl(port, ptr, rust_vec_len, data_len),
-35 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_as_sig_result_impl(port, ptr, rust_vec_len, data_len),
-36 => wire__crate__api__sync__decrypt_and_store_transaction_impl(port, ptr, rust_vec_len, data_len),
-37 => wire__crate__api__secret__decrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
-38 => wire__crate__api__voting__delegation_submission_wire_json_impl(port, ptr, rust_vec_len, data_len),
-39 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
-40 => wire__crate__api__voting__delete_skipped_bundles_impl(port, ptr, rust_vec_len, data_len),
-41 => wire__crate__api__voting__delete_voting_account_state_impl(port, ptr, rust_vec_len, data_len),
-42 => wire__crate__api__secret__derive_secret_password_verifier_impl(port, ptr, rust_vec_len, data_len),
-43 => wire__crate__api__sync__discard_all_keystone_migration_requests_impl(port, ptr, rust_vec_len, data_len),
-44 => wire__crate__api__sync__discard_keystone_migration_request_impl(port, ptr, rust_vec_len, data_len),
-45 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
-46 => wire__crate__api__wallet__discover_software_wallet_import_accounts_impl(port, ptr, rust_vec_len, data_len),
-47 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
-48 => wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len),
-49 => wire__crate__api__keystone__encode_zcash_sign_batch_ur_parts_impl(port, ptr, rust_vec_len, data_len),
-50 => wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
-51 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(port, ptr, rust_vec_len, data_len),
-52 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
-53 => wire__crate__api__network_privacy__estimate_import_birthday_height_impl(port, ptr, rust_vec_len, data_len),
-54 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
-55 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
-56 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-57 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-58 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-59 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
-61 => wire__crate__api__voting__generate_van_witness_impl(port, ptr, rust_vec_len, data_len),
-62 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
-63 => wire__crate__api__wallet__get_account_export_metadata_impl(port, ptr, rust_vec_len, data_len),
-64 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-65 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
-67 => wire__crate__api__wallet__get_chain_upgrade_status_impl(port, ptr, rust_vec_len, data_len),
-68 => wire__crate__api__wallet__get_chain_upgrade_status_at_height_impl(port, ptr, rust_vec_len, data_len),
-69 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
-70 => wire__crate__api__network_privacy__get_import_birthday_metadata_impl(port, ptr, rust_vec_len, data_len),
-71 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
-72 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
-73 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
-75 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
-76 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
-77 => wire__crate__api__sync__get_orchard_migration_immediate_plan_impl(port, ptr, rust_vec_len, data_len),
-78 => wire__crate__api__sync__get_orchard_migration_private_plan_impl(port, ptr, rust_vec_len, data_len),
-79 => wire__crate__api__sync__get_orchard_migration_status_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__sync__get_orchard_migration_statuses_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__sync__get_previous_transaction_count_for_address_impl(port, ptr, rust_vec_len, data_len),
-82 => wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__voting__get_round_recovery_state_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__wallet__import_software_account_at_index_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
-107 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-116 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
-117 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
-119 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-135 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+5 => wire__crate__api__keystone__apply_keystone_batch_pczt_signatures_impl(port, ptr, rust_vec_len, data_len),
+7 => wire__crate__api__sync__broadcast_due_orchard_migration_transactions_impl(port, ptr, rust_vec_len, data_len),
+8 => wire__crate__api__sync__broadcast_one_due_orchard_migration_transaction_impl(port, ptr, rust_vec_len, data_len),
+9 => wire__crate__api__voting__build_keystone_delegation_request_impl(port, ptr, rust_vec_len, data_len),
+10 => wire__crate__api__voting__build_prove_and_sign_delegation_payload_with_progress_impl(port, ptr, rust_vec_len, data_len),
+11 => wire__crate__api__voting__build_prove_delegation_payload_with_keystone_signature_with_progress_impl(port, ptr, rust_vec_len, data_len),
+12 => wire__crate__api__voting__build_vote_commitments_with_progress_impl(port, ptr, rust_vec_len, data_len),
+14 => wire__crate__api__voting__check_voting_eligibility_impl(port, ptr, rust_vec_len, data_len),
+15 => wire__crate__api__voting__clear_recovery_state_impl(port, ptr, rust_vec_len, data_len),
+16 => wire__crate__api__sync__complete_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+17 => wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+18 => wire__crate__api__sync__complete_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+19 => wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+20 => wire__crate__api__simple__configure_fast_testnet_migration_impl(port, ptr, rust_vec_len, data_len),
+21 => wire__crate__api__network_privacy__configure_network_privacy_impl(port, ptr, rust_vec_len, data_len),
+22 => wire__crate__api__simple__configure_regtest_ironwood_activation_height_impl(port, ptr, rust_vec_len, data_len),
+23 => wire__crate__api__voting__confirm_delegation_submission_impl(port, ptr, rust_vec_len, data_len),
+24 => wire__crate__api__voting__confirm_vote_submission_impl(port, ptr, rust_vec_len, data_len),
+25 => wire__crate__api__sync__create_or_resume_private_migration_draft_impl(port, ptr, rust_vec_len, data_len),
+26 => wire__crate__api__sync__create_pczt_from_proposal_impl(port, ptr, rust_vec_len, data_len),
+27 => wire__crate__api__sync__create_shield_transparent_pczt_impl(port, ptr, rust_vec_len, data_len),
+28 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
+29 => wire__crate__api__keystone__decode_accounts_from_cbor_impl(port, ptr, rust_vec_len, data_len),
+30 => wire__crate__api__keystone__decode_accounts_ur_impl(port, ptr, rust_vec_len, data_len),
+31 => wire__crate__api__keystone__decode_pczt_from_cbor_impl(port, ptr, rust_vec_len, data_len),
+32 => wire__crate__api__keystone__decode_ur_part_impl(port, ptr, rust_vec_len, data_len),
+33 => wire__crate__api__keystone__decode_ur_to_pczt_impl(port, ptr, rust_vec_len, data_len),
+34 => wire__crate__api__keystone__decode_zcash_batch_sign_response_impl(port, ptr, rust_vec_len, data_len),
+35 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_impl(port, ptr, rust_vec_len, data_len),
+36 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_as_sig_result_impl(port, ptr, rust_vec_len, data_len),
+37 => wire__crate__api__sync__decrypt_and_store_transaction_impl(port, ptr, rust_vec_len, data_len),
+38 => wire__crate__api__secret__decrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
+39 => wire__crate__api__voting__delegation_submission_wire_json_impl(port, ptr, rust_vec_len, data_len),
+40 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
+41 => wire__crate__api__voting__delete_skipped_bundles_impl(port, ptr, rust_vec_len, data_len),
+42 => wire__crate__api__voting__delete_voting_account_state_impl(port, ptr, rust_vec_len, data_len),
+43 => wire__crate__api__secret__derive_secret_password_verifier_impl(port, ptr, rust_vec_len, data_len),
+44 => wire__crate__api__sync__discard_all_keystone_migration_requests_impl(port, ptr, rust_vec_len, data_len),
+45 => wire__crate__api__sync__discard_keystone_migration_request_impl(port, ptr, rust_vec_len, data_len),
+46 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
+47 => wire__crate__api__wallet__discover_software_wallet_import_accounts_impl(port, ptr, rust_vec_len, data_len),
+48 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
+49 => wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len),
+50 => wire__crate__api__keystone__encode_zcash_sign_batch_ur_parts_impl(port, ptr, rust_vec_len, data_len),
+51 => wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
+52 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(port, ptr, rust_vec_len, data_len),
+53 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
+54 => wire__crate__api__network_privacy__estimate_import_birthday_height_impl(port, ptr, rust_vec_len, data_len),
+55 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
+56 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
+57 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+59 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+60 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__voting__generate_van_witness_impl(port, ptr, rust_vec_len, data_len),
+63 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
+64 => wire__crate__api__wallet__get_account_export_metadata_impl(port, ptr, rust_vec_len, data_len),
+65 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+66 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
+68 => wire__crate__api__wallet__get_chain_upgrade_status_impl(port, ptr, rust_vec_len, data_len),
+69 => wire__crate__api__wallet__get_chain_upgrade_status_at_height_impl(port, ptr, rust_vec_len, data_len),
+70 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
+71 => wire__crate__api__network_privacy__get_import_birthday_metadata_impl(port, ptr, rust_vec_len, data_len),
+72 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
+73 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
+74 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
+77 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__sync__get_orchard_migration_immediate_plan_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__sync__get_orchard_migration_private_plan_impl(port, ptr, rust_vec_len, data_len),
+80 => wire__crate__api__sync__get_orchard_migration_status_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__sync__get_orchard_migration_statuses_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__sync__get_previous_transaction_count_for_address_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__voting__get_round_recovery_state_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__wallet__import_software_account_at_index_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
+106 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+116 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+117 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
+118 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__keystone__prepare_keystone_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+146 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10282,42 +10368,42 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        5 => wire__crate__api__network_privacy__begin_network_privacy_enable_impl(
+        6 => wire__crate__api__network_privacy__begin_network_privacy_enable_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        12 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        66 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        74 => wire__crate__api__network_privacy__get_network_privacy_status_impl(
+        13 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        67 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        75 => wire__crate__api__network_privacy__get_network_privacy_status_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        86 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        93 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        99 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
-        100 => {
+        87 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        100 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
+        101 => {
             wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len)
         }
-        102 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        103 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        104 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
-        106 => {
+        103 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        104 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        105 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
+        107 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        114 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        134 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        145 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        115 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        136 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        147 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        146 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        155 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        166 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        169 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        148 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        157 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        168 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        171 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -11102,6 +11188,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::keystone::KeystoneActionSig>
     for crate::api::keystone::KeystoneActionSig
 {
     fn into_into_dart(self) -> crate::api::keystone::KeystoneActionSig {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::keystone::KeystoneBatchPczt {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.redacted_pczt.into_into_dart().into_dart(),
+            self.expected_signature_count.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::keystone::KeystoneBatchPczt
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::keystone::KeystoneBatchPczt>
+    for crate::api::keystone::KeystoneBatchPczt
+{
+    fn into_into_dart(self) -> crate::api::keystone::KeystoneBatchPczt {
         self
     }
 }
@@ -13417,6 +13524,14 @@ impl SseEncode for crate::api::keystone::KeystoneActionSig {
         <u8>::sse_encode(self.pool, serializer);
         <u32>::sse_encode(self.action_index, serializer);
         <Vec<u8>>::sse_encode(self.sig, serializer);
+    }
+}
+
+impl SseEncode for crate::api::keystone::KeystoneBatchPczt {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<u8>>::sse_encode(self.redacted_pczt, serializer);
+        <u32>::sse_encode(self.expected_signature_count, serializer);
     }
 }
 

--- a/rust/src/wallet/keystone.rs
+++ b/rust/src/wallet/keystone.rs
@@ -140,16 +140,16 @@ pub(crate) const ZCASH_SIGN_BATCH_MAX_RESOLVED_TOTAL_BYTES: usize =
 const ZCASH_SIG_POOL_ORCHARD: u32 = 0;
 const ZCASH_SIG_POOL_IRONWOOD: u32 = 1;
 /// A Zcash spend-authorization signature is a 64-byte RedPallas signature.
-const ZCASH_SIG_LEN: usize = 64;
+pub(crate) const ZCASH_SIG_LEN: usize = 64;
 
-fn encode_signature_pool(value_pool: orchard::ValuePool) -> u8 {
+pub(crate) fn encode_signature_pool(value_pool: orchard::ValuePool) -> u8 {
     match value_pool {
-        orchard::ValuePool::Orchard => 0,
-        orchard::ValuePool::Ironwood => 1,
+        orchard::ValuePool::Orchard => ZCASH_SIG_POOL_ORCHARD as u8,
+        orchard::ValuePool::Ironwood => ZCASH_SIG_POOL_IRONWOOD as u8,
     }
 }
 
-fn decode_signature_pool(pool: u32) -> Result<orchard::ValuePool, String> {
+pub(crate) fn decode_signature_pool(pool: u32) -> Result<orchard::ValuePool, String> {
     match pool {
         ZCASH_SIG_POOL_ORCHARD => Ok(orchard::ValuePool::Orchard),
         ZCASH_SIG_POOL_IRONWOOD => Ok(orchard::ValuePool::Ironwood),

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -47,10 +47,12 @@ pub(crate) use migration::{
     MigrationPreparationTransactionState, MigrationScheduleEntry, MigrationStatus,
     PreparationTimingPolicy,
 };
-pub(crate) use pczt::extract_compact_sigs_from_pczt;
 pub use pczt::{
     add_proofs_to_pczt, create_pczt_from_proposal, discard_proposal, extract_and_broadcast_pczt,
     redact_pczt_for_signer, retain_proposal_lock_until_expiry, ExtractAndBroadcastPcztResult,
+};
+pub(crate) use pczt::{
+    apply_compact_sigs_to_pczt, extract_compact_sigs_from_pczt, prepare_pczt_for_batch_signer,
 };
 pub(crate) use proposal_locks::recover_previous_process as recover_orphaned_send_locks;
 pub(crate) use send::estimate_send_max;

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -441,7 +441,7 @@ pub fn redact_pczt_for_signer(pczt_bytes: &[u8]) -> Result<Vec<u8>, String> {
     redact_pczt_for_signer_inner(pczt_bytes, false)
 }
 
-/// Redact a PCZT for a Keystone **migration batch** request.
+/// Redact a PCZT for a compact Keystone batch-signing request.
 ///
 /// The v6 path uses librustzcash's batch signer policy, including its checked
 /// compaction of regenerable Orchard and Ironwood fields. Keystone requires an
@@ -478,7 +478,7 @@ fn apply_signer_redaction(pczt: pczt::Pczt, for_batch: bool) -> pczt::Pczt {
     use pczt::roles::redactor::Redactor;
 
     // The compact signer view requires PCZT v2, while legacy v5 signing uses
-    // v1 on the wire. Keep the existing local policy for v5 and ordinary sends.
+    // v1 on the wire. Keep the existing local policy for legacy PCZT signing.
     let compact =
         for_batch && *pczt.global().tx_version() == zcash_protocol::constants::V6_TX_VERSION;
     let pczt = if compact {

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -449,10 +449,27 @@ pub fn redact_pczt_for_signer(pczt_bytes: &[u8]) -> Result<Vec<u8>, String> {
 /// retained on preauthorized padding spends. The wallet keeps the unredacted
 /// PCZT for proof and signature combination.
 ///
-/// Only use this for the migration batch flow; the single-transaction hardware
-/// send keeps [`redact_pczt_for_signer`].
+/// Use this for `zcash-sign-batch` requests, including a batch containing a
+/// single payment. The legacy `zcash-pczt` flow keeps
+/// [`redact_pczt_for_signer`].
 pub fn redact_pczt_for_batch_signer(pczt_bytes: &[u8]) -> Result<Vec<u8>, String> {
     redact_pczt_for_signer_inner(pczt_bytes, true)
+}
+
+/// Prepare the compact signer view for one PCZT and count the signatures the
+/// external signer must return.
+///
+/// The count comes from the wallet-owned base PCZT, where IO-finalized dummy
+/// spends are already authorized. Batch redaction clears those retained dummy
+/// signatures from the transport copy, so counting the redacted PCZT would
+/// incorrectly ask the hardware wallet to sign them again.
+pub(crate) fn prepare_pczt_for_batch_signer(pczt_bytes: &[u8]) -> Result<(Vec<u8>, u32), String> {
+    let pczt = pczt::Pczt::parse(pczt_bytes)
+        .map_err(|e| format!("Parse base PCZT for batch signing: {e:?}"))?;
+    let signature_count = u32::try_from(unsigned_orchard_action_locations(&pczt).len())
+        .map_err(|_| "Batch PCZT signature count exceeds u32".to_string())?;
+    let redacted = redact_pczt_for_batch_signer(pczt_bytes)?;
+    Ok((redacted, signature_count))
 }
 
 /// Applies the standard signer policy, plus Keystone's additional migration
@@ -848,6 +865,23 @@ pub(crate) fn apply_sigs_and_extract(
         .map_err(|e| format!("Parse PCZT with proofs: {e:?}"))?;
     let signed = apply_compact_orchard_spend_auth_signatures(pczt, sigs)?;
     finalize_and_extract(signed, sapling_vks.as_ref())
+}
+
+/// Apply a complete compact signature response to a wallet-owned base PCZT.
+///
+/// This adapts a `zcash-batch-sig-result` response to the existing ordinary
+/// hardware-send pipeline, which combines this signed PCZT with its separately
+/// proved counterpart before extraction and broadcast.
+pub(crate) fn apply_compact_sigs_to_pczt(
+    base_pczt_bytes: &[u8],
+    sigs: &[pczt::roles::signer::SpendAuthSignature],
+) -> Result<Vec<u8>, String> {
+    preflight_orchard_spend_auth_signatures(base_pczt_bytes, sigs)?;
+    let pczt = pczt::Pczt::parse(base_pczt_bytes)
+        .map_err(|e| format!("Parse base PCZT for compact signatures: {e:?}"))?;
+    apply_compact_orchard_spend_auth_signatures(pczt, sigs)?
+        .serialize()
+        .map_err(|e| format!("Serialize PCZT with compact signatures: {e:?}"))
 }
 
 /// Read the spend-authorization signatures out of a fully-signed PCZT as a
@@ -1299,9 +1333,10 @@ mod tests {
         // The functions under test live at the module file scope, which is two
         // levels up from this nested test module.
         use super::super::{
-            apply_sigs_and_extract, extract_compact_sigs_from_signed_pczt,
-            extract_transaction_from_pczt, ironwood_orchard_proving_key,
-            preflight_orchard_spend_auth_signatures, redact_pczt_for_signer,
+            apply_compact_sigs_to_pczt, apply_sigs_and_extract,
+            extract_compact_sigs_from_signed_pczt, extract_transaction_from_pczt,
+            ironwood_orchard_proving_key, preflight_orchard_spend_auth_signatures,
+            prepare_pczt_for_batch_signer, redact_pczt_for_signer,
             set_orchard_anchor_and_witnesses, txid_from_io_finalized_pczt,
         };
         use orchard::tree::MerkleHashOrchard;
@@ -1732,6 +1767,10 @@ mod tests {
             )];
             let new = apply_sigs_and_extract(&proofs_bytes, &sigs, None, None)
                 .expect("compact apply_sigs_and_extract path should succeed");
+            let signed_base = apply_compact_sigs_to_pczt(&base_bytes, &sigs)
+                .expect("compact signatures should adapt to a signed PCZT");
+            let adapted = extract_transaction_from_pczt(&proofs_bytes, &signed_base, None, None)
+                .expect("adapted signed PCZT should use the ordinary extraction path");
 
             // The software migration path applies the FULL extracted set
             // (dummy-spend signatures included) onto a proofs base that already
@@ -1752,6 +1791,10 @@ mod tests {
             assert_eq!(
                 old.txid, new.txid,
                 "compact sigs-only path must produce the same txid as the full signed-PCZT path"
+            );
+            assert_eq!(
+                adapted.txid, new.txid,
+                "batch response adapter must preserve the compact-path txid"
             );
 
             // The transactions are the same size down to the byte.
@@ -1832,6 +1875,10 @@ mod tests {
             assert_eq!(ironwood_preauthorized.len(), 1);
 
             let batch = redact_pczt_for_batch_signer(&base_bytes).unwrap();
+            let (prepared, expected_signature_count) =
+                prepare_pczt_for_batch_signer(&base_bytes).unwrap();
+            assert_eq!(prepared, batch);
+            assert_eq!(expected_signature_count, 1);
             // The point of the compact format: a migration child small enough
             // for a short device QR carousel. The retained bytes are dominated
             // by the still-required `out_ciphertext`s and the

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -2758,6 +2758,232 @@ fn batch_signer_redaction_compacts_and_preserves_signable_spends() {
     );
 }
 
+/// Builds the ordinary-send shape used for the four-action Swap/Pay round-trip
+/// test: three real Orchard inputs and one wallet-controlled zero-value spend
+/// paired with the output.
+fn built_v6_four_action_swap_pczt() -> (BuiltPczt, orchard::keys::SpendingKey) {
+    use incrementalmerkletree::Retention;
+    use orchard::tree::MerkleHashOrchard;
+    use shardtree::{store::memory::MemoryShardStore, ShardTree};
+
+    const INPUT_COUNT: u8 = 3;
+    const INPUT_VALUE: u64 = 250_000;
+    const TARGET_HEIGHT: u32 = 120;
+    const EXPIRY_HEIGHT: u32 = 69_120;
+
+    crate::wallet::network::configure_regtest_nu6_3_activation_height(2).unwrap();
+    let network = WalletNetwork::Regtest;
+    let spending_key = orchard::keys::SpendingKey::from_bytes([27; 32]).unwrap();
+    let fvk = orchard::keys::FullViewingKey::from(&spending_key);
+    let recipient = fvk.address_at(0u32, orchard::keys::Scope::Internal);
+    let mut tree =
+        ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+    let notes = (0u8..INPUT_COUNT)
+        .map(|index| {
+            let rho = orchard::note::Rho::from_bytes(&[index + 10; 32]).unwrap();
+            let rseed = (0u8..=255)
+                .find_map(|byte| {
+                    orchard::note::RandomSeed::from_bytes([byte; 32], &rho).into_option()
+                })
+                .unwrap();
+            let note = orchard::Note::from_parts(
+                recipient,
+                orchard::value::NoteValue::from_raw(INPUT_VALUE),
+                rho,
+                rseed,
+                orchard::note::NoteVersion::V2,
+            )
+            .unwrap();
+            let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+            tree.append(MerkleHashOrchard::from_cmx(&cmx), Retention::Marked)
+                .unwrap();
+            note
+        })
+        .collect::<Vec<_>>();
+    tree.checkpoint(1).unwrap();
+    let inputs = notes
+        .iter()
+        .enumerate()
+        .map(|(index, note)| {
+            let path = tree
+                .witness_at_checkpoint_depth(Position::from(u64::try_from(index).unwrap()), 0)
+                .unwrap()
+                .unwrap();
+            (*note, path.into())
+        })
+        .collect::<Vec<(orchard::Note, orchard::tree::MerklePath)>>();
+    let first_cmx: orchard::note::ExtractedNoteCommitment = notes[0].commitment().into();
+    let anchor = inputs[0].1.root(first_cmx).into();
+    let fee_rule = ConservativeZip317FeeRule;
+    let build = |output_value| {
+        make_orchard_split_builder_with_padding(
+            network,
+            TARGET_HEIGHT,
+            EXPIRY_HEIGHT,
+            anchor,
+            &inputs,
+            &fvk,
+            Some(fvk.to_ovk(orchard::keys::Scope::Internal)),
+            recipient,
+            &[output_value],
+            &MemoBytes::empty(),
+            BundlePadding::DEFAULT,
+        )
+    };
+    let fee = build(100_000).unwrap().get_fee(&fee_rule).unwrap();
+    let result = build(INPUT_VALUE * u64::from(INPUT_COUNT) - u64::from(fee))
+        .unwrap()
+        .build_for_pczt(rand_core::OsRng, &fee_rule)
+        .unwrap();
+    assert_eq!(
+        result.pczt_parts.orchard.as_ref().unwrap().actions().len(),
+        4
+    );
+    let built = pczt_from_build_result(result, network, None, usize::from(INPUT_COUNT), 1).unwrap();
+    (built, spending_key)
+}
+
+#[test]
+fn swap_batch_round_trip_matches_legacy_for_four_actions() {
+    use pczt::roles::{
+        prover::Prover,
+        signer::{
+            batch::{BatchSignRequest, BatchSignResponse},
+            Signer,
+        },
+    };
+    use ur_registry::zcash::{
+        zcash_batch_sig_result::ZcashBatchSigResult, zcash_sign_batch::ZcashSignBatch,
+    };
+
+    const REQUEST_ID: &str = "swap-hw-deposit-test";
+    const MESSAGE_ID: &str = "zec-deposit";
+    const TEST_FIRMWARE_VERSION: [u8; 3] = [12, 5, 1];
+
+    let (built_pczt, spending_key) = built_v6_four_action_swap_pczt();
+    assert_eq!(built_pczt.orchard_spend_action_indices.len(), 4);
+
+    // Exercise the same FRB-facing preparation and animated request encoder
+    // that the Swap/Pay service calls.
+    let prepared =
+        crate::api::keystone::prepare_keystone_batch_pczt(built_pczt.bytes.clone()).unwrap();
+    assert_eq!(prepared.expected_signature_count, 4);
+    let request_parts = crate::api::keystone::encode_zcash_sign_batch_ur_parts(
+        REQUEST_ID.to_string(),
+        vec![crate::wallet::keystone::ZcashBatchMessageInput {
+            id: MESSAGE_ID.to_string(),
+            pczt_bytes: prepared.redacted_pczt.clone(),
+            expected_signature_count: prepared.expected_signature_count,
+        }],
+        140,
+    )
+    .unwrap();
+    assert!(request_parts.len() > 1);
+
+    let mut request_decoder = ur::Decoder::default();
+    for part in &request_parts {
+        request_decoder.receive(&part.to_lowercase()).unwrap();
+        if request_decoder.complete() {
+            break;
+        }
+    }
+    assert!(request_decoder.complete());
+    let request_cbor = request_decoder.message().unwrap().unwrap();
+    let request_envelope = ZcashSignBatch::try_from(request_cbor).unwrap();
+    assert_eq!(request_envelope.get_request_id(), REQUEST_ID.as_bytes());
+    let request = BatchSignRequest::parse(request_envelope.get_data()).unwrap();
+    assert_eq!(request.pczts().len(), 1);
+    let request_pczt = request.pczts()[0].clone();
+    assert_eq!(
+        request_pczt.clone().serialize().unwrap(),
+        prepared.redacted_pczt,
+    );
+
+    // Simulate Keystone's four signatures, then return the compact response
+    // envelope that the production scanner hands to Dart.
+    let base_pczt = pczt::Pczt::parse(&built_pczt.bytes).unwrap();
+    let base_sighash = Signer::new(base_pczt.clone()).unwrap().shielded_sighash();
+    let mut resolved_request = request_pczt.clone();
+    resolved_request.resolve_fields().unwrap();
+    let request_sighash = Signer::new(resolved_request).unwrap().shielded_sighash();
+    assert_eq!(request_sighash, base_sighash);
+
+    let ask = orchard::keys::SpendAuthorizingKey::from(&spending_key);
+    let signed_request = pczt::roles::low_level_signer::Signer::new(request_pczt)
+        .sign_orchard_with::<pczt::roles::low_level_signer::OrchardParseError, _>(|_, bundle, _| {
+            for &action_index in &built_pczt.orchard_spend_action_indices {
+                bundle.actions_mut()[action_index]
+                    .sign(request_sighash, &ask, rand_core::OsRng)
+                    .unwrap();
+            }
+            Ok(())
+        })
+        .unwrap()
+        .finish();
+    let signatures = pczt::roles::signer::extract_orchard_spend_auth_signatures(&signed_request);
+    assert_eq!(signatures.len(), 4);
+    let response_postcard = BatchSignResponse::new(vec![signatures])
+        .serialize()
+        .unwrap();
+    let response_cbor: Vec<u8> = ZcashBatchSigResult::new(
+        REQUEST_ID.as_bytes().to_vec(),
+        response_postcard,
+        TEST_FIRMWARE_VERSION,
+    )
+    .try_into()
+    .unwrap();
+
+    // Exercise response correlation and the public signature adapter before
+    // entering the existing proof-combination and extraction path.
+    let mut decoded = crate::api::keystone::decode_zcash_batch_sign_response(
+        response_cbor,
+        REQUEST_ID.to_string(),
+        vec![MESSAGE_ID.to_string()],
+    )
+    .unwrap();
+    assert_eq!(decoded.results.len(), 1);
+    let result = decoded.results.pop().unwrap();
+    assert_eq!(result.message_id, MESSAGE_ID.as_bytes());
+    let batch_signed_pczt = crate::api::keystone::apply_keystone_batch_pczt_signatures(
+        built_pczt.bytes.clone(),
+        result.sigs,
+    )
+    .unwrap();
+
+    let proving_key =
+        orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::PostNu6_3);
+    let proofs_pczt = Prover::new(pczt::Pczt::parse(&built_pczt.bytes).unwrap())
+        .create_orchard_proof(&proving_key)
+        .unwrap()
+        .finish()
+        .serialize()
+        .unwrap();
+    let mut legacy_signer = Signer::new(base_pczt).unwrap();
+    for &action_index in &built_pczt.orchard_spend_action_indices {
+        legacy_signer.sign_orchard(action_index, &ask).unwrap();
+    }
+    let signed_pczt = legacy_signer.finish().serialize().unwrap();
+    let legacy_signed_pczt =
+        crate::wallet::sync::pczt::redact_pczt_for_signer(&signed_pczt).unwrap();
+    let legacy = crate::wallet::sync::pczt::extract_transaction_from_pczt(
+        &proofs_pczt,
+        &legacy_signed_pczt,
+        None,
+        None,
+    )
+    .unwrap();
+    let batch = crate::wallet::sync::pczt::extract_transaction_from_pczt(
+        &proofs_pczt,
+        &batch_signed_pczt,
+        None,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(batch.txid, legacy.txid);
+    assert_eq!(batch.raw_tx.len(), legacy.raw_tx.len());
+}
+
 #[test]
 #[ignore = "slow librustzcash transaction-construction regression (~100s); run explicitly when touching shielding transaction construction"]
 fn many_utxo_shielding_builds_with_conservative_zip317_fee() {

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -533,7 +533,15 @@ class _FakeSwapHardwareSigningService implements SwapHardwareSigningService {
   Future<List<String>> encodeSigningUrParts({
     required SwapHardwarePcztDraft draft,
   }) async {
-    return const ['ur:zcash-pczt/route-test'];
+    return const ['ur:zcash-sign-batch/route-test'];
+  }
+
+  @override
+  Future<List<int>> decodeSigningResponse({
+    required SwapHardwarePcztDraft draft,
+    required List<int> cbor,
+  }) async {
+    return cbor;
   }
 
   @override

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -20,6 +20,7 @@ import 'package:zcash_wallet/src/core/widgets/app_profile_picture.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
 import 'package:zcash_wallet/src/features/keystone/widgets/keystone_signing_modal.dart';
+import 'package:zcash_wallet/src/features/send/screens/keystone_send_scan_screen.dart';
 import 'package:zcash_wallet/src/features/send/screens/send_review_screen.dart';
 import 'package:zcash_wallet/src/features/send/services/send_flow.dart'
     show
@@ -31,7 +32,10 @@ import 'package:zcash_wallet/src/features/send/widgets/verify_address_modal.dart
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
+import 'package:zcash_wallet/src/rust/api/keystone.dart' as rust_keystone;
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
+import 'package:zcash_wallet/src/rust/wallet/keystone.dart'
+    as rust_keystone_wallet;
 
 void main() {
   final rustApi = _RustApiFake();
@@ -401,12 +405,14 @@ void main() {
     tester,
   ) async {
     final statusExtras = <Object?>[];
+    final scanExtras = <Object?>[];
 
     await _setDesktopViewport(tester);
     await tester.pumpWidget(
       _harness(
         _reviewArgs(addressType: 'unified'),
         bootstrap: _bootstrap(isHardware: true),
+        scanExtras: scanExtras,
         statusExtras: statusExtras,
       ),
     );
@@ -418,6 +424,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('keystone-scan-route'), findsOneWidget);
+    final scanArgs = scanExtras.single as KeystoneSendScanArgs;
+    expect(scanArgs.expectedUrType, 'zcash-batch-sig-result');
+    expect(scanArgs.returnRawCbor, isTrue);
     await tester.tap(find.text('keystone-scan-route'));
     await tester.pumpAndSettle();
 
@@ -428,6 +437,15 @@ void main() {
     expect(keystoneArgs.pcztWithProofsBytes, _fakeProofsBytes);
     expect(keystoneArgs.pcztWithSignaturesBytes, _fakeSignatureBytes);
     expect(keystoneArgs.reviewArgs.proposalId, BigInt.one);
+    expect(rustApi.batchRequestId, 'test-send-flow');
+    expect(rustApi.batchMessageId, 'zec-send');
+    expect(rustApi.encodedBatchPczt, [4, 5, 6]);
+    expect(rustApi.encodedBatchExpectedSignatureCount, 1);
+    expect(rustApi.encodedBatchMaxFragmentLength, BigInt.from(140));
+    expect(rustApi.decodedResponseCbor, _fakeResponseCbor);
+    expect(rustApi.appliedBasePczt, [1, 2, 3]);
+    expect(rustApi.legacyRedactCalls, 0);
+    expect(rustApi.legacyEncodeCalls, 0);
 
     // The proposal was consumed by createPcztFromProposal; the handoff must
     // not discard it.
@@ -685,6 +703,7 @@ Widget _harness(
   AppBootstrapState? bootstrap,
   AddressBookRepository? addressBookRepository,
   List<Object?>? statusExtras,
+  List<Object?>? scanExtras,
   Listenable? routerRefresh,
 }) {
   final router = GoRouter(
@@ -698,10 +717,13 @@ Widget _harness(
       ),
       GoRoute(
         path: '/send/keystone/scan',
-        builder: (context, _) => GestureDetector(
-          onTap: () => context.pop(Uint8List.fromList(_fakeSignatureBytes)),
-          child: const Text('keystone-scan-route'),
-        ),
+        builder: (context, state) {
+          scanExtras?.add(state.extra);
+          return GestureDetector(
+            onTap: () => context.pop(Uint8List.fromList(_fakeResponseCbor)),
+            child: const Text('keystone-scan-route'),
+          );
+        },
       ),
       GoRoute(
         path: '/send/status',
@@ -849,6 +871,7 @@ const _veryLongMemo =
 
 const _fakeProofsBytes = <int>[3, 3, 3];
 const _fakeSignatureBytes = <int>[9, 9];
+const _fakeResponseCbor = <int>[8, 8];
 
 class _FakePathProviderPlatform extends Fake
     with MockPlatformInterfaceMixin
@@ -875,6 +898,15 @@ class _RustApiFake implements RustLibApi {
   final discardCalls = <(BigInt, String)>[];
   int createPcztCalls = 0;
   int previousTransactionCount = 0;
+  String? batchRequestId;
+  String? batchMessageId;
+  List<int>? encodedBatchPczt;
+  int? encodedBatchExpectedSignatureCount;
+  BigInt? encodedBatchMaxFragmentLength;
+  List<int>? decodedResponseCbor;
+  List<int>? appliedBasePczt;
+  int legacyRedactCalls = 0;
+  int legacyEncodeCalls = 0;
   String unifiedAddress = 'u1ownaccountaddressnotmatchingrecipient';
   String transparentAddress = 't1ownaccountaddressnotmatchingrecipient';
 
@@ -882,6 +914,15 @@ class _RustApiFake implements RustLibApi {
     discardCalls.clear();
     createPcztCalls = 0;
     previousTransactionCount = 0;
+    batchRequestId = null;
+    batchMessageId = null;
+    encodedBatchPczt = null;
+    encodedBatchExpectedSignatureCount = null;
+    encodedBatchMaxFragmentLength = null;
+    decodedResponseCbor = null;
+    appliedBasePczt = null;
+    legacyRedactCalls = 0;
+    legacyEncodeCalls = 0;
     unifiedAddress = 'u1ownaccountaddressnotmatchingrecipient';
     transparentAddress = 't1ownaccountaddressnotmatchingrecipient';
   }
@@ -948,7 +989,68 @@ class _RustApiFake implements RustLibApi {
   Future<Uint8List> crateApiSyncRedactPcztForSigner({
     required List<int> pcztBytes,
   }) async {
+    legacyRedactCalls++;
     return Uint8List.fromList([4, 5, 6]);
+  }
+
+  @override
+  Future<rust_keystone.KeystoneBatchPczt>
+  crateApiKeystonePrepareKeystoneBatchPczt({
+    required List<int> pcztBytes,
+  }) async {
+    return rust_keystone.KeystoneBatchPczt(
+      redactedPczt: Uint8List.fromList([4, 5, 6]),
+      expectedSignatureCount: 1,
+    );
+  }
+
+  @override
+  Future<List<String>> crateApiKeystoneEncodeZcashSignBatchUrParts({
+    required String requestId,
+    required List<rust_keystone_wallet.ZcashBatchMessageInput> messages,
+    required BigInt maxFragmentLen,
+  }) async {
+    batchRequestId = requestId;
+    batchMessageId = messages.single.id;
+    encodedBatchPczt = messages.single.pcztBytes;
+    encodedBatchExpectedSignatureCount = messages.single.expectedSignatureCount;
+    encodedBatchMaxFragmentLength = maxFragmentLen;
+    return const ['UR:ZCASH-SIGN-BATCH/TESTPART'];
+  }
+
+  @override
+  Future<rust_keystone.KeystoneSigResult>
+  crateApiKeystoneDecodeZcashBatchSignResponse({
+    required List<int> cbor,
+    required String expectedRequestId,
+    required List<String> messageIds,
+  }) async {
+    decodedResponseCbor = cbor;
+    return rust_keystone.KeystoneSigResult(
+      firmwareVersion: Uint8List.fromList([12, 5, 1]),
+      requestId: Uint8List.fromList(expectedRequestId.codeUnits),
+      results: [
+        rust_keystone.KeystoneMsgSig(
+          messageId: Uint8List.fromList(messageIds.single.codeUnits),
+          sigs: [
+            rust_keystone.KeystoneActionSig(
+              pool: 0,
+              actionIndex: 0,
+              sig: Uint8List(64),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  @override
+  Future<Uint8List> crateApiKeystoneApplyKeystoneBatchPcztSignatures({
+    required List<int> pcztBytes,
+    required List<rust_keystone.KeystoneActionSig> signatures,
+  }) async {
+    appliedBasePczt = pcztBytes;
+    return Uint8List.fromList(_fakeSignatureBytes);
   }
 
   @override
@@ -956,6 +1058,7 @@ class _RustApiFake implements RustLibApi {
     required List<int> pcztBytes,
     required BigInt maxFragmentLen,
   }) async {
+    legacyEncodeCalls++;
     return const ['UR:ZCASH-PCZT/TESTPART'];
   }
 

--- a/test/features/swap/mobile_swap_keystone_signing_test.dart
+++ b/test/features/swap/mobile_swap_keystone_signing_test.dart
@@ -1113,7 +1113,15 @@ class _FakeSwapHardwareSigningService implements SwapHardwareSigningService {
   Future<List<String>> encodeSigningUrParts({
     required SwapHardwarePcztDraft draft,
   }) async {
-    return const ['ur:zcash-pczt/test'];
+    return const ['ur:zcash-sign-batch/test'];
+  }
+
+  @override
+  Future<List<int>> decodeSigningResponse({
+    required SwapHardwarePcztDraft draft,
+    required List<int> cbor,
+  }) async {
+    return cbor;
   }
 
   @override

--- a/test/features/swap/support/swap_screen_test_fakes.dart
+++ b/test/features/swap/support/swap_screen_test_fakes.dart
@@ -912,7 +912,15 @@ class _FakeSwapHardwareSigningService implements SwapHardwareSigningService {
   Future<List<String>> encodeSigningUrParts({
     required SwapHardwarePcztDraft draft,
   }) async {
-    return const ['ur:zcash-pczt/test'];
+    return const ['ur:zcash-sign-batch/test'];
+  }
+
+  @override
+  Future<List<int>> decodeSigningResponse({
+    required SwapHardwarePcztDraft draft,
+    required List<int> cbor,
+  }) async {
+    return cbor;
   }
 
   @override


### PR DESCRIPTION
## Summary

- encode Send, Swap, and Pay Keystone signing requests as one-message
  `zcash-sign-batch` envelopes using the compact batch redaction policy
- scan `zcash-batch-sig-result` responses and verify/reapply the compact
  signatures to the wallet-owned PCZT before the existing broadcast pipeline
- support the compact response type on desktop and mobile; transparent
  shielding and voting remain on legacy `zcash-pczt` because those flows need
  signature types the compact response does not carry
- regenerate the Flutter Rust Bridge bindings for the new preparation and
  signature-application APIs

## Why

The legacy Send/Swap/Pay flows transported a full signed PCZT back from
Keystone. Using the batch API for this single-PCZT case removes fields Keystone
does not need from the request and returns only spend-authorization signatures,
making the animated QR payload substantially smaller in both directions.

Four-action spends are now a more representative payment case because
completed ZIP-318 migrations commonly leave Vizor users' balances distributed
across multiple denomination notes, so subsequent sends, swaps, and payments
select multiple inputs more often.

### Four-action QR benchmark

A real v6 PCZT with four signable actions was encoded with the production
140-byte fragment limit and the same fountain-code redundancy in both cases:

| Direction | Legacy CBOR | Batch CBOR | Data reduction | Legacy frames | Batch frames | Frame reduction |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Vizor to Keystone | 4,959 B | 1,895 B | 61.8% (2.62x smaller) | 40 | 16 | 60.0% (2.5x fewer) |
| Keystone to Vizor | 5,215 B | 319 B | 93.9% (16.35x smaller) | 42 | 5 | 88.1% (8.4x fewer) |
| Round trip | 10,174 B | 2,214 B | 78.2% (4.60x smaller) | 82 | 21 | 74.4% (3.90x fewer) |

At Vizor's 100 ms outbound frame interval, one complete request carousel falls
from about 4.0 seconds to 1.6 seconds. Inbound playback is controlled by
Keystone, so its wall-clock improvement depends on the device's frame rate;
the equal-rate comparison is 8.4x fewer response frames.

## Validation

- `cd rust && cargo test` (615 passed, 4 ignored; Docker regtests remain ignored)
- `cargo test swap_batch_round_trip_matches_legacy_for_four_actions`
- `cargo test sigs_only_byte_identity` (6 passed)
- `fvm flutter test test/features/send/send_review_screen_test.dart test/features/swap/swap_screen_test.dart` (183 passed)
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/send/mobile_send_screen_test.dart test/core/navigation/mobile_routes_test.dart test/features/keystone/mobile_keystone_pczt_signing_flow_test.dart` (68 passed)
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/swap/mobile_swap_keystone_signing_test.dart test/core/navigation/mobile_routes_test.dart test/features/keystone/mobile_keystone_pczt_signing_flow_test.dart` (38 passed)
- `flutter_rust_bridge_codegen generate`
- `fvm flutter analyze` reports the repository's existing 23 warnings in
  unrelated migration screens; no diagnostics are in the changed files
