### PR TITLE
Cache ZEC market data for faster Home pricing

### DIFF
--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -662,7 +662,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     final nextMode = _amountInputIsUsd
         ? MobileSendAmountInputMode.zec
         : MobileSendAmountInputMode.usd;
-    final zecUsdUnitPrice = ref.read(zecHomeUsdUnitPriceProvider);
+    final zecUsdUnitPrice = ref.read(zecLiveUsdUnitPriceProvider);
     if (nextMode == MobileSendAmountInputMode.usd && zecUsdUnitPrice == null) {
       return;
     }
@@ -793,7 +793,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   }
 
   void _handleFiatAmountChanged(String value) {
-    final zecUsdUnitPrice = ref.read(zecHomeUsdUnitPriceProvider);
+    final zecUsdUnitPrice = ref.read(zecLiveUsdUnitPriceProvider);
     final zatoshi = sendZatoshiFromUsdText(value, zecUsdUnitPrice);
     setState(() {
       _fiatAmountText = value.trim();
@@ -885,7 +885,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       final amountText = ZecAmount.fromZatoshi(
         estimate.amountZatoshi,
       ).pretty().amountText;
-      final zecUsdUnitPrice = ref.read(zecHomeUsdUnitPriceProvider);
+      final zecUsdUnitPrice = ref.read(zecLiveUsdUnitPriceProvider);
       final fiatText = zecUsdUnitPrice == null
           ? ''
           : sendSendableUsdInputTextForZatoshi(
@@ -1958,7 +1958,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
 
   Widget _buildAmountStep(BuildContext context) {
     final colors = context.colors;
-    final zecUsdUnitPrice = ref.watch(zecHomeUsdUnitPriceProvider);
+    final zecUsdUnitPrice = ref.watch(zecLiveUsdUnitPriceProvider);
     final spendableText = ZecAmount.fromZatoshi(
       _spendable,
     ).pretty(denomStyle: ZecDenomStyle.upper).toString();
@@ -2456,7 +2456,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         ? null
         : fiatTextForZatoshi(
             amountZatoshi,
-            zecUsdUnitPrice: ref.watch(zecHomeUsdUnitPriceProvider),
+            zecUsdUnitPrice: ref.watch(zecLiveUsdUnitPriceProvider),
           );
     final feeText = _feeZatoshi == null
         ? '—'

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -808,6 +808,53 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     unawaited(_validateAmount());
   }
 
+  void _handleZecUsdPriceChanged(double? zecUsdUnitPrice) {
+    if (!_amountInputIsUsd) return;
+
+    if (_isMaxMode) {
+      _refreshMaxFiatAmountText(zecUsdUnitPrice);
+      return;
+    }
+
+    final fiatText = _fiatAmountText.trim();
+    if (fiatText.isEmpty) return;
+
+    final zatoshi = sendZatoshiFromUsdText(fiatText, zecUsdUnitPrice);
+    final nextAmountText = zatoshi == null
+        ? ''
+        : ZecAmount.fromZatoshi(zatoshi).pretty().amountText;
+    if (nextAmountText == _amountText) return;
+
+    setState(() {
+      _amountText = nextAmountText;
+      _invalidateReviewFeeQuote();
+      if (nextAmountText.isEmpty) {
+        _amountError = '';
+      }
+    });
+    unawaited(_validateAmount());
+  }
+
+  void _refreshMaxFiatAmountText(double? zecUsdUnitPrice) {
+    final zatoshi = parseZecAmount(_amountText.trim());
+    if (zatoshi == null ||
+        zatoshi <= BigInt.zero ||
+        zecUsdUnitPrice == null ||
+        !zecUsdUnitPrice.isFinite ||
+        zecUsdUnitPrice <= 0) {
+      return;
+    }
+
+    final fiatText = sendSendableUsdInputTextForZatoshi(
+      zatoshi,
+      zecUsdUnitPrice,
+    );
+    if (fiatText.isEmpty || fiatText == _fiatAmountText) return;
+
+    setState(() => _fiatAmountText = fiatText);
+    _setAmountControllerText(fiatText);
+  }
+
   void _activateMaxMode() {
     if (_isResolvingMax) return;
     _amountFocus.unfocus();
@@ -1039,6 +1086,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   bool get _amountReady =>
       !_isResolvingMax &&
       _amountError == null &&
+      (!_amountInputIsUsd || ref.read(zecLiveUsdUnitPriceProvider) != null) &&
       (parseZecAmount(_amountText.trim()) ?? BigInt.zero) > BigInt.zero &&
       (!_isMaxMode || _hasCurrentMaxQuote);
 
@@ -1494,6 +1542,11 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<double?>(zecLiveUsdUnitPriceProvider, (previous, next) {
+      if (previous == next || !mounted) return;
+      _handleZecUsdPriceChanged(next);
+    });
+
     final accountUuid = ref.watch(
       accountProvider.select((value) => value.value?.activeAccountUuid),
     );

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -395,7 +395,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   }
 
   void _handleFiatAmountChanged(String value) {
-    final zecUsdUnitPrice = ref.read(zecHomeUsdUnitPriceProvider);
+    final zecUsdUnitPrice = ref.read(zecLiveUsdUnitPriceProvider);
     final zatoshi = sendZatoshiFromUsdText(value, zecUsdUnitPrice);
     if (_isMaxMode) {
       _maxDebounceTimer?.cancel();
@@ -478,7 +478,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     final nextMode = _amountInputIsUsd
         ? _DesktopSendAmountInputMode.zec
         : _DesktopSendAmountInputMode.usd;
-    final zecUsdUnitPrice = ref.read(zecHomeUsdUnitPriceProvider);
+    final zecUsdUnitPrice = ref.read(zecLiveUsdUnitPriceProvider);
     if (nextMode == _DesktopSendAmountInputMode.usd &&
         zecUsdUnitPrice == null) {
       return;
@@ -684,7 +684,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       final amountText = ZecAmount.fromZatoshi(
         estimate.amountZatoshi,
       ).pretty().amountText;
-      final zecUsdUnitPrice = ref.read(zecHomeUsdUnitPriceProvider);
+      final zecUsdUnitPrice = ref.read(zecLiveUsdUnitPriceProvider);
       final fiatText = zecUsdUnitPrice == null
           ? ''
           : sendSendableUsdInputTextForZatoshi(
@@ -949,7 +949,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<double?>(zecHomeUsdUnitPriceProvider, (previous, next) {
+    ref.listen<double?>(zecLiveUsdUnitPriceProvider, (previous, next) {
       if (previous == next || !mounted) return;
       _handleZecUsdPriceChanged(next);
     });
@@ -966,7 +966,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     final sendFieldLabelStyle = AppTypography.labelLarge.copyWith(
       color: colors.text.secondary,
     );
-    final zecUsdUnitPrice = ref.watch(zecHomeUsdUnitPriceProvider);
+    final zecUsdUnitPrice = ref.watch(zecLiveUsdUnitPriceProvider);
     final amountZatoshi = parseZecAmount(_amountText.trim());
     final amountConversionText = _amountConversionText(
       amountZatoshi: amountZatoshi,

--- a/lib/src/providers/zec_price_change_provider.dart
+++ b/lib/src/providers/zec_price_change_provider.dart
@@ -235,12 +235,14 @@ final zecHomeMarketDataStateProvider =
     >(ZecHomeMarketDataNotifier.new);
 
 class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
-  Timer? _timer;
+  Timer? _refreshTimer;
+  Timer? _expiryTimer;
   int _epoch = 0;
 
   @override
   ZecHomeMarketDataState build() {
-    _timer?.cancel();
+    _refreshTimer?.cancel();
+    _expiryTimer?.cancel();
     final epoch = ++_epoch;
     if (!ref.watch(swapFeatureEnabledProvider)) {
       return const ZecHomeMarketDataState();
@@ -252,8 +254,32 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
 
     ref.onDispose(() {
       _epoch++;
-      _timer?.cancel();
+      _refreshTimer?.cancel();
+      _expiryTimer?.cancel();
     });
+
+    void clearMarketData() {
+      _expiryTimer?.cancel();
+      _expiryTimer = null;
+      state = const ZecHomeMarketDataState();
+    }
+
+    void scheduleExpiry(DateTime fetchedAt) {
+      _expiryTimer?.cancel();
+      final remaining = fetchedAt
+          .toUtc()
+          .add(zecMarketDataCacheTtl)
+          .difference(now().toUtc());
+      if (remaining <= Duration.zero) {
+        clearMarketData();
+        return;
+      }
+      _expiryTimer = Timer(remaining, () {
+        if (epoch != _epoch || state.fetchedAt != fetchedAt) return;
+        _expiryTimer = null;
+        state = const ZecHomeMarketDataState();
+      });
+    }
 
     Future<void> persist(CachedZecMarketData value) async {
       try {
@@ -265,7 +291,7 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
 
     Future<void> tick() async {
       if (state.displayData != null && !state.isFreshAt(now())) {
-        state = const ZecHomeMarketDataState();
+        clearMarketData();
       }
       final data = await source.fetchMarketData();
       if (epoch != _epoch) return;
@@ -276,11 +302,14 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
           liveData: data,
           fetchedAt: fetchedAt,
         );
+        scheduleExpiry(fetchedAt);
         unawaited(
           persist(CachedZecMarketData(data: data, fetchedAt: fetchedAt)),
         );
+      } else if (state.displayData != null && !state.isFreshAt(now())) {
+        clearMarketData();
       }
-      _timer = Timer(refreshInterval, () => unawaited(tick()));
+      _refreshTimer = Timer(refreshInterval, () => unawaited(tick()));
     }
 
     Future<void> initialize() async {
@@ -292,6 +321,7 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
             displayData: cached.data,
             fetchedAt: cached.fetchedAt,
           );
+          scheduleExpiry(cached.fetchedAt);
         }
       } catch (e) {
         log('zecMarketData: cache read failed: $e');

--- a/lib/src/providers/zec_price_change_provider.dart
+++ b/lib/src/providers/zec_price_change_provider.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../main.dart' show log;
 import '../core/config/swap_feature_config.dart';
@@ -16,12 +17,88 @@ const kVizorCoinGeckoPriceBaseUrl = String.fromEnvironment(
   kVizorCoinGeckoPriceBaseUrlEnvKey,
   defaultValue: kVizorCoinGeckoDefaultPriceBaseUrl,
 );
+const zecMarketDataRefreshInterval = Duration(minutes: 3);
+const zecMarketDataCacheTtl = Duration(hours: 1);
+const zecMarketDataCacheStorageKey = 'vizor_zec_market_data_v1';
 
 class ZecMarketData {
   const ZecMarketData({required this.usdPrice, this.change24hPct});
 
   final double usdPrice;
   final double? change24hPct;
+}
+
+class CachedZecMarketData {
+  const CachedZecMarketData({required this.data, required this.fetchedAt});
+
+  final ZecMarketData data;
+  final DateTime fetchedAt;
+
+  bool isFreshAt(DateTime now) {
+    final age = now.toUtc().difference(fetchedAt.toUtc());
+    return !age.isNegative && age < zecMarketDataCacheTtl;
+  }
+}
+
+abstract interface class ZecMarketDataCache {
+  Future<CachedZecMarketData?> read();
+
+  Future<void> write(CachedZecMarketData value);
+}
+
+class SharedPreferencesZecMarketDataCache implements ZecMarketDataCache {
+  const SharedPreferencesZecMarketDataCache();
+
+  @override
+  Future<CachedZecMarketData?> read() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(zecMarketDataCacheStorageKey);
+    if (raw == null || raw.isEmpty) return null;
+    return decodeCachedZecMarketData(raw);
+  }
+
+  @override
+  Future<void> write(CachedZecMarketData value) async {
+    final prefs = await SharedPreferences.getInstance();
+    final saved = await prefs.setString(
+      zecMarketDataCacheStorageKey,
+      encodeCachedZecMarketData(value),
+    );
+    if (!saved) throw StateError('Could not persist ZEC market data.');
+  }
+}
+
+String encodeCachedZecMarketData(CachedZecMarketData value) {
+  return jsonEncode({
+    'version': 1,
+    'usdPrice': value.data.usdPrice,
+    'change24hPct': value.data.change24hPct,
+    'fetchedAtMs': value.fetchedAt.toUtc().millisecondsSinceEpoch,
+  });
+}
+
+CachedZecMarketData? decodeCachedZecMarketData(String raw) {
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map<String, dynamic> || decoded['version'] != 1) {
+      return null;
+    }
+    final usdRaw = decoded['usdPrice'];
+    final changeRaw = decoded['change24hPct'];
+    final fetchedAtRaw = decoded['fetchedAtMs'];
+    if (usdRaw is! num || fetchedAtRaw is! int) return null;
+    final usdPrice = usdRaw.toDouble();
+    if (!usdPrice.isFinite || usdPrice <= 0) return null;
+    if (changeRaw != null && changeRaw is! num) return null;
+    final change24hPct = (changeRaw as num?)?.toDouble();
+    if (change24hPct != null && !change24hPct.isFinite) return null;
+    return CachedZecMarketData(
+      data: ZecMarketData(usdPrice: usdPrice, change24hPct: change24hPct),
+      fetchedAt: DateTime.fromMillisecondsSinceEpoch(fetchedAtRaw, isUtc: true),
+    );
+  } catch (_) {
+    return null;
+  }
 }
 
 /// Non-swap ZEC market data source. Swap keeps using its provider-specific
@@ -112,52 +189,136 @@ double? parseZecPriceChange24hPct(String body) {
   return parseZecMarketData(body)?.change24hPct;
 }
 
-const zecMarketDataRefreshInterval = Duration(minutes: 3);
-
 final zecMarketDataSourceProvider = Provider<ZecMarketDataSource>((ref) {
   return CoinGeckoZecMarketDataSource();
 });
 
-/// Latest known non-swap ZEC market data, or null until the first successful
-/// fetch. Stays on the last known value across transient fetch failures. Null
-/// while market-price UI is disabled on non-mainnet builds.
-final zecHomeMarketDataProvider =
-    NotifierProvider.autoDispose<ZecHomeMarketDataNotifier, ZecMarketData?>(
-      ZecHomeMarketDataNotifier.new,
-    );
+final zecMarketDataCacheProvider = Provider<ZecMarketDataCache>((ref) {
+  return const SharedPreferencesZecMarketDataCache();
+});
 
-class ZecHomeMarketDataNotifier extends Notifier<ZecMarketData?> {
+final zecMarketDataNowProvider = Provider<DateTime Function()>((ref) {
+  return DateTime.now;
+});
+
+final zecMarketDataRefreshIntervalProvider = Provider<Duration>((ref) {
+  return zecMarketDataRefreshInterval;
+});
+
+class ZecHomeMarketDataState {
+  const ZecHomeMarketDataState({
+    this.displayData,
+    this.liveData,
+    this.fetchedAt,
+  });
+
+  final ZecMarketData? displayData;
+  final ZecMarketData? liveData;
+  final DateTime? fetchedAt;
+
+  bool isFreshAt(DateTime now) {
+    final timestamp = fetchedAt;
+    if (displayData == null || timestamp == null) return false;
+    final age = now.toUtc().difference(timestamp.toUtc());
+    return !age.isNegative && age < zecMarketDataCacheTtl;
+  }
+}
+
+/// Latest usable non-swap ZEC market data. A persisted value less than one
+/// hour old is exposed while the first network refresh is in flight; transient
+/// failures retain it only until that TTL expires. Null while market-price UI
+/// is disabled on non-mainnet builds.
+final zecHomeMarketDataStateProvider =
+    NotifierProvider.autoDispose<
+      ZecHomeMarketDataNotifier,
+      ZecHomeMarketDataState
+    >(ZecHomeMarketDataNotifier.new);
+
+class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
   Timer? _timer;
   int _epoch = 0;
 
   @override
-  ZecMarketData? build() {
+  ZecHomeMarketDataState build() {
     _timer?.cancel();
     final epoch = ++_epoch;
-    if (!ref.watch(swapFeatureEnabledProvider)) return null;
+    if (!ref.watch(swapFeatureEnabledProvider)) {
+      return const ZecHomeMarketDataState();
+    }
     final source = ref.watch(zecMarketDataSourceProvider);
+    final cache = ref.watch(zecMarketDataCacheProvider);
+    final now = ref.watch(zecMarketDataNowProvider);
+    final refreshInterval = ref.watch(zecMarketDataRefreshIntervalProvider);
 
     ref.onDispose(() {
       _epoch++;
       _timer?.cancel();
     });
 
+    Future<void> persist(CachedZecMarketData value) async {
+      try {
+        await cache.write(value);
+      } catch (e) {
+        log('zecMarketData: cache write failed: $e');
+      }
+    }
+
     Future<void> tick() async {
+      if (state.displayData != null && !state.isFreshAt(now())) {
+        state = const ZecHomeMarketDataState();
+      }
       final data = await source.fetchMarketData();
       if (epoch != _epoch) return;
-      if (data != null) state = data;
-      _timer = Timer(zecMarketDataRefreshInterval, () => unawaited(tick()));
+      if (data != null) {
+        final fetchedAt = now().toUtc();
+        state = ZecHomeMarketDataState(
+          displayData: data,
+          liveData: data,
+          fetchedAt: fetchedAt,
+        );
+        unawaited(
+          persist(CachedZecMarketData(data: data, fetchedAt: fetchedAt)),
+        );
+      }
+      _timer = Timer(refreshInterval, () => unawaited(tick()));
+    }
+
+    Future<void> initialize() async {
+      try {
+        final cached = await cache.read();
+        if (epoch != _epoch) return;
+        if (cached != null && cached.isFreshAt(now())) {
+          state = ZecHomeMarketDataState(
+            displayData: cached.data,
+            fetchedAt: cached.fetchedAt,
+          );
+        }
+      } catch (e) {
+        log('zecMarketData: cache read failed: $e');
+      }
+      if (epoch == _epoch) await tick();
     }
 
     scheduleMicrotask(() {
-      if (epoch == _epoch) unawaited(tick());
+      if (epoch == _epoch) unawaited(initialize());
     });
-    return null;
+    return const ZecHomeMarketDataState();
   }
 }
 
+final zecHomeMarketDataProvider = Provider.autoDispose<ZecMarketData?>((ref) {
+  return ref.watch(zecHomeMarketDataStateProvider).displayData;
+});
+
 final zecHomeUsdUnitPriceProvider = Provider.autoDispose<double?>((ref) {
   return ref.watch(zecHomeMarketDataProvider)?.usdPrice;
+});
+
+/// ZEC/USD price fetched successfully during the current provider lifetime.
+/// Unlike the Home display price, this never exposes a persisted cache value
+/// to USD-denominated send amount calculations.
+final zecLiveUsdUnitPriceProvider = Provider.autoDispose<double?>((ref) {
+  return ref.watch(zecHomeMarketDataStateProvider).liveData?.usdPrice;
 });
 
 final zecPriceChange24hPctProvider = Provider.autoDispose<double?>((ref) {

--- a/lib/widgetbook/send_use_cases.dart
+++ b/lib/widgetbook/send_use_cases.dart
@@ -358,9 +358,7 @@ class _MobileSendHarness extends StatelessWidget {
       overrides: [
         appBootstrapProvider.overrideWithValue(_mobileSendBootstrap),
         syncProvider.overrideWith(() => _WidgetbookSendSyncNotifier()),
-        zecMarketDataSourceProvider.overrideWithValue(
-          const _WidgetbookSendMarketDataSource(),
-        ),
+        zecLiveUsdUnitPriceProvider.overrideWithValue(70),
         addressBookRepositoryProvider.overrideWithValue(
           _WidgetbookAddressBookRepository(contacts),
         ),
@@ -588,15 +586,6 @@ class _WidgetbookAddressBookRepository implements AddressBookRepository {
 
   @override
   Future<void> saveContacts(List<AddressBookContact> contacts) async {}
-}
-
-class _WidgetbookSendMarketDataSource implements ZecMarketDataSource {
-  const _WidgetbookSendMarketDataSource();
-
-  @override
-  Future<ZecMarketData?> fetchMarketData() async {
-    return const ZecMarketData(usdPrice: 70);
-  }
 }
 
 /// Preview sidebar with Home active — mirrors the live desktop nav so the

--- a/test/fakes/fake_zec_market_data_cache.dart
+++ b/test/fakes/fake_zec_market_data_cache.dart
@@ -1,0 +1,17 @@
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
+
+class FakeZecMarketDataCache implements ZecMarketDataCache {
+  FakeZecMarketDataCache({this.value});
+
+  CachedZecMarketData? value;
+  final writes = <CachedZecMarketData>[];
+
+  @override
+  Future<CachedZecMarketData?> read() async => value;
+
+  @override
+  Future<void> write(CachedZecMarketData next) async {
+    value = next;
+    writes.add(next);
+  }
+}

--- a/test/features/home/home_desktop_screen_test.dart
+++ b/test/features/home/home_desktop_screen_test.dart
@@ -36,6 +36,7 @@ import 'package:zcash_wallet/src/providers/sync_failure.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
 import '../../fakes/fake_sync_notifier.dart';
+import '../../fakes/fake_zec_market_data_cache.dart';
 
 void main() {
   // Render with the real app fonts instead of the square-glyph test font.
@@ -1349,6 +1350,7 @@ Widget _appHarness(
       zecMarketDataSourceProvider.overrideWithValue(
         _FakeMarketDataSource(priceChange24hPct),
       ),
+      zecMarketDataCacheProvider.overrideWithValue(FakeZecMarketDataCache()),
       appBootstrapProvider.overrideWithValue(
         _bootstrap(
           initialLocation,

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -36,6 +36,7 @@ import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 import '../../fakes/fake_sync_notifier.dart';
+import '../../fakes/fake_zec_market_data_cache.dart';
 
 /// Skips the secure-storage write so toggling works without a platform
 /// channel in widget tests.
@@ -307,6 +308,7 @@ Widget _app(
       zecMarketDataSourceProvider.overrideWithValue(
         _FakeMarketDataSource(marketData),
       ),
+      zecMarketDataCacheProvider.overrideWithValue(FakeZecMarketDataCache()),
       payIntroductionBadgeStoreProvider.overrideWithValue(
         badgeStore ?? _FakePayIntroductionBadgeStore(),
       ),

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -26,6 +26,8 @@ import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
+import '../../fakes/fake_zec_market_data_cache.dart';
+
 const _shieldedAddress =
     'u1testshieldedaddress00000000000000000000000000000000000000000000000';
 const _transparentAddress = 't1transparentdestination0000000000000000000';
@@ -296,6 +298,7 @@ Widget _app({
       zecMarketDataSourceProvider.overrideWithValue(
         const _FakeMarketDataSource(),
       ),
+      zecMarketDataCacheProvider.overrideWithValue(FakeZecMarketDataCache()),
       addressBookRepositoryProvider.overrideWithValue(
         _FakeAddressBookRepository(contacts),
       ),
@@ -321,7 +324,7 @@ Widget _amountStepWithPriceLoadingApp() {
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
       syncProvider.overrideWith(_FakeSyncNotifier.new),
-      zecHomeUsdUnitPriceProvider.overrideWithValue(null),
+      zecLiveUsdUnitPriceProvider.overrideWithValue(null),
       addressBookRepositoryProvider.overrideWithValue(
         _FakeAddressBookRepository(const []),
       ),
@@ -356,6 +359,7 @@ Widget _reviewApp({
       zecMarketDataSourceProvider.overrideWithValue(
         const _FakeMarketDataSource(),
       ),
+      zecMarketDataCacheProvider.overrideWithValue(FakeZecMarketDataCache()),
       addressBookRepositoryProvider.overrideWithValue(
         _FakeAddressBookRepository(const []),
       ),
@@ -463,6 +467,7 @@ Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
       zecMarketDataSourceProvider.overrideWithValue(
         const _FakeMarketDataSource(),
       ),
+      zecMarketDataCacheProvider.overrideWithValue(FakeZecMarketDataCache()),
       addressBookRepositoryProvider.overrideWithValue(
         _FakeAddressBookRepository(const []),
       ),

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -144,6 +144,15 @@ class _FakeMarketDataSource implements ZecMarketDataSource {
   }
 }
 
+class _TestZecUsdPriceNotifier extends Notifier<double?> {
+  @override
+  double? build() => 70;
+
+  void setPrice(double? price) {
+    state = price;
+  }
+}
+
 AppBootstrapState _bootstrap({AccountState? accountState}) => AppBootstrapState(
   initialLocation: '/send',
   initialAccountState:
@@ -270,6 +279,7 @@ Widget _app({
   String? initialRecipient,
   MobileSendAddressValidator? validateAddress,
   SyncNotifier Function()? syncNotifier,
+  NotifierProvider<_TestZecUsdPriceNotifier, double?>? zecUsdPriceProvider,
   IronwoodHomeMigrationCtaState migrationCta =
       const IronwoodHomeMigrationCtaState.hidden(),
 }) {
@@ -299,6 +309,10 @@ Widget _app({
         const _FakeMarketDataSource(),
       ),
       zecMarketDataCacheProvider.overrideWithValue(FakeZecMarketDataCache()),
+      if (zecUsdPriceProvider != null)
+        zecLiveUsdUnitPriceProvider.overrideWith(
+          (ref) => ref.watch(zecUsdPriceProvider),
+        ),
       addressBookRepositoryProvider.overrideWithValue(
         _FakeAddressBookRepository(contacts),
       ),
@@ -1672,6 +1686,61 @@ void main() {
 
     expect(find.text('Review Send'), findsOneWidget);
     expect(find.text('1.50 ZEC'), findsOneWidget);
+  });
+
+  testWidgets('USD input waits for a live price again after expiry', (
+    tester,
+  ) async {
+    final zecUsdPriceProvider =
+        NotifierProvider<_TestZecUsdPriceNotifier, double?>(
+          _TestZecUsdPriceNotifier.new,
+        );
+    await tester.pumpWidget(_app(zecUsdPriceProvider: zecUsdPriceProvider));
+    await tester.pumpAndSettle();
+    await _toAmountStep(tester, _shieldedAddress);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_send_amount_mode_toggle')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('mobile_send_amount_input')),
+      '105',
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('1.5 ZEC'), findsOneWidget);
+    expect(find.text('Finish & review'), findsOneWidget);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(MobileSendScreen)),
+      listen: false,
+    );
+    container.read(zecUsdPriceProvider.notifier).setPrice(null);
+    await tester.pumpAndSettle();
+
+    final amountInput = tester.widget<TextField>(
+      find.byKey(const ValueKey('mobile_send_amount_input')),
+    );
+    expect(amountInput.controller?.text, '105');
+    expect(find.text('0 ZEC'), findsOneWidget);
+    expect(find.text('Finish & review'), findsNothing);
+    expect(find.text('Enter amount to continue'), findsOneWidget);
+    expect(
+      tester
+          .widget<AppButton>(
+            find.byKey(const ValueKey('mobile_send_review_button')),
+          )
+          .onPressed,
+      isNull,
+    );
+
+    container.read(zecUsdPriceProvider.notifier).setPrice(210);
+    await tester.pumpAndSettle();
+
+    expect(amountInput.controller?.text, '105');
+    expect(find.text('0.5 ZEC'), findsOneWidget);
+    expect(find.text('Finish & review'), findsOneWidget);
   });
 
   testWidgets('USD mode clears ZEC amounts that round to zero cents', (

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -33,6 +33,8 @@ import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
+import '../../fakes/fake_zec_market_data_cache.dart';
+
 void main() {
   final rustApi = _RustApiFake();
 
@@ -730,6 +732,7 @@ Widget _harness(
       zecMarketDataSourceProvider.overrideWithValue(
         const _FakeMarketDataSource(),
       ),
+      zecMarketDataCacheProvider.overrideWithValue(FakeZecMarketDataCache()),
       addressBookRepositoryProvider.overrideWithValue(
         addressBookRepository ?? _FakeAddressBookRepository(),
       ),

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -939,8 +939,8 @@ Widget _sendHarness({
         AsyncValue.data(migrationCta),
       ),
       zecUsdPriceProvider == null
-          ? zecHomeUsdUnitPriceProvider.overrideWithValue(zecUsdPrice)
-          : zecHomeUsdUnitPriceProvider.overrideWith(
+          ? zecLiveUsdUnitPriceProvider.overrideWithValue(zecUsdPrice)
+          : zecLiveUsdUnitPriceProvider.overrideWith(
               (ref) => ref.watch(zecUsdPriceProvider),
             ),
       syncProvider.overrideWith(

--- a/test/features/send/send_status_screen_test.dart
+++ b/test/features/send/send_status_screen_test.dart
@@ -29,6 +29,8 @@ import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
+import '../../fakes/fake_zec_market_data_cache.dart';
+
 void main() {
   final rustApi = _RustApiFake();
 
@@ -399,6 +401,7 @@ Widget _harness(
       zecMarketDataSourceProvider.overrideWithValue(
         const _FakeMarketDataSource(),
       ),
+      zecMarketDataCacheProvider.overrideWithValue(FakeZecMarketDataCache()),
       addressBookRepositoryProvider.overrideWithValue(
         _FakeAddressBookRepository(),
       ),

--- a/test/providers/zec_price_change_provider_test.dart
+++ b/test/providers/zec_price_change_provider_test.dart
@@ -310,6 +310,64 @@ void main() {
       expect(cache.writes, isEmpty);
     });
 
+    test('drops cached data when a failed refresh crosses the TTL', () async {
+      var now = DateTime.utc(2026, 8, 10, 12);
+      final source = _CompleterSource();
+      final cache = _FakeCache(
+        value: CachedZecMarketData(
+          data: const ZecMarketData(usdPrice: 30),
+          fetchedAt: now.subtract(const Duration(minutes: 59, seconds: 59)),
+        ),
+      );
+      final container = makeContainer(
+        swapEnabled: true,
+        source: source,
+        cache: cache,
+        now: () => now,
+      );
+      final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
+
+      await Future<void>.delayed(Duration.zero);
+      expect(sub.read()?.usdPrice, 30);
+
+      now = now.add(const Duration(seconds: 2));
+      source.completer.complete(null);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(sub.read(), isNull);
+    });
+
+    test('expires cached data while a refresh is still in flight', () async {
+      final now = DateTime.utc(2026, 8, 10, 12);
+      final source = _CompleterSource();
+      final cache = _FakeCache(
+        value: CachedZecMarketData(
+          data: const ZecMarketData(usdPrice: 30),
+          fetchedAt: now.subtract(
+            zecMarketDataCacheTtl - const Duration(milliseconds: 10),
+          ),
+        ),
+      );
+      final container = makeContainer(
+        swapEnabled: true,
+        source: source,
+        cache: cache,
+        now: () => now,
+      );
+      final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
+
+      await Future<void>.delayed(Duration.zero);
+      expect(sub.read()?.usdPrice, 30);
+      expect(source.fetchCount, 1);
+
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(sub.read(), isNull);
+
+      source.completer.complete(null);
+      await Future<void>.delayed(Duration.zero);
+      expect(sub.read(), isNull);
+    });
+
     test('removes the last value after its one-hour TTL expires', () async {
       var now = DateTime.utc(2026, 8, 10, 12);
       final cache = _FakeCache(

--- a/test/providers/zec_price_change_provider_test.dart
+++ b/test/providers/zec_price_change_provider_test.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
 import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 
@@ -16,7 +19,44 @@ class _FakeSource implements ZecMarketDataSource {
   }
 }
 
+class _CompleterSource implements ZecMarketDataSource {
+  final completer = Completer<ZecMarketData?>();
+  int fetchCount = 0;
+
+  @override
+  Future<ZecMarketData?> fetchMarketData() {
+    fetchCount += 1;
+    return completer.future;
+  }
+}
+
+class _FakeCache implements ZecMarketDataCache {
+  _FakeCache({this.value, this.readError, this.writeError});
+
+  CachedZecMarketData? value;
+  final Object? readError;
+  final Object? writeError;
+  int readCount = 0;
+  final writes = <CachedZecMarketData>[];
+
+  @override
+  Future<CachedZecMarketData?> read() async {
+    readCount += 1;
+    if (readError != null) throw readError!;
+    return value;
+  }
+
+  @override
+  Future<void> write(CachedZecMarketData next) async {
+    if (writeError != null) throw writeError!;
+    value = next;
+    writes.add(next);
+  }
+}
+
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('parseZecMarketData', () {
     test('reads ZEC price and 24h change from a CoinGecko response', () {
       final data = parseZecMarketData(
@@ -79,15 +119,97 @@ void main() {
     });
   });
 
+  group('ZEC market data cache', () {
+    test('persists and reads a cache record from SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues({});
+      const store = SharedPreferencesZecMarketDataCache();
+      final cached = CachedZecMarketData(
+        data: const ZecMarketData(usdPrice: 33.45, change24hPct: -0.25),
+        fetchedAt: DateTime.utc(2026, 8, 10, 12),
+      );
+
+      await store.write(cached);
+      final restored = await store.read();
+
+      expect(restored?.data.usdPrice, 33.45);
+      expect(restored?.data.change24hPct, -0.25);
+      expect(restored?.fetchedAt, DateTime.utc(2026, 8, 10, 12));
+    });
+
+    test('round-trips a versioned cache record', () {
+      final cached = CachedZecMarketData(
+        data: const ZecMarketData(usdPrice: 33.45, change24hPct: -0.25852),
+        fetchedAt: DateTime.utc(2026, 8, 10, 12, 34, 56),
+      );
+
+      final decoded = decodeCachedZecMarketData(
+        encodeCachedZecMarketData(cached),
+      );
+
+      expect(decoded?.data.usdPrice, 33.45);
+      expect(decoded?.data.change24hPct, -0.25852);
+      expect(decoded?.fetchedAt, DateTime.utc(2026, 8, 10, 12, 34, 56));
+    });
+
+    test('rejects corrupt and unusable records', () {
+      expect(decodeCachedZecMarketData('not json'), isNull);
+      expect(
+        decodeCachedZecMarketData(
+          '{"version":2,"usdPrice":33.45,"fetchedAtMs":0}',
+        ),
+        isNull,
+      );
+      expect(
+        decodeCachedZecMarketData('{"version":1,"usdPrice":0,"fetchedAtMs":0}'),
+        isNull,
+      );
+      expect(
+        decodeCachedZecMarketData(
+          '{"version":1,"usdPrice":33.45,'
+          '"change24hPct":"fast","fetchedAtMs":0}',
+        ),
+        isNull,
+      );
+    });
+
+    test('accepts only timestamps less than one hour old', () {
+      final now = DateTime.utc(2026, 8, 10, 12);
+      CachedZecMarketData at(DateTime fetchedAt) => CachedZecMarketData(
+        data: const ZecMarketData(usdPrice: 33.45),
+        fetchedAt: fetchedAt,
+      );
+
+      expect(
+        at(
+          now.subtract(const Duration(minutes: 59, seconds: 59)),
+        ).isFreshAt(now),
+        isTrue,
+      );
+      expect(
+        at(now.subtract(const Duration(hours: 1))).isFreshAt(now),
+        isFalse,
+      );
+      expect(at(now.add(const Duration(seconds: 1))).isFreshAt(now), isFalse);
+    });
+  });
+
   group('zecHomeMarketDataProvider', () {
     ProviderContainer makeContainer({
       required bool swapEnabled,
       required ZecMarketDataSource source,
+      ZecMarketDataCache? cache,
+      DateTime Function()? now,
+      Duration refreshInterval = zecMarketDataRefreshInterval,
     }) {
       final container = ProviderContainer(
         overrides: [
           swapFeatureEnabledProvider.overrideWithValue(swapEnabled),
           zecMarketDataSourceProvider.overrideWithValue(source),
+          zecMarketDataCacheProvider.overrideWithValue(cache ?? _FakeCache()),
+          if (now != null) zecMarketDataNowProvider.overrideWithValue(now),
+          zecMarketDataRefreshIntervalProvider.overrideWithValue(
+            refreshInterval,
+          ),
         ],
       );
       addTearDown(container.dispose);
@@ -109,6 +231,143 @@ void main() {
       expect(source.fetchCount, 1);
     });
 
+    test('shows a fresh cache before replacing it with network data', () async {
+      final now = DateTime.utc(2026, 8, 10, 12);
+      final source = _CompleterSource();
+      final cache = _FakeCache(
+        value: CachedZecMarketData(
+          data: const ZecMarketData(usdPrice: 30, change24hPct: -1),
+          fetchedAt: now.subtract(const Duration(minutes: 30)),
+        ),
+      );
+      final container = makeContainer(
+        swapEnabled: true,
+        source: source,
+        cache: cache,
+        now: () => now,
+      );
+      final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
+
+      await Future<void>.delayed(Duration.zero);
+      expect(sub.read()?.usdPrice, 30);
+      expect(container.read(zecLiveUsdUnitPriceProvider), isNull);
+      expect(source.fetchCount, 1);
+
+      source.completer.complete(
+        const ZecMarketData(usdPrice: 33.45, change24hPct: 2),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(sub.read()?.usdPrice, 33.45);
+      expect(container.read(zecLiveUsdUnitPriceProvider), 33.45);
+      expect(cache.writes.single.data.usdPrice, 33.45);
+      expect(cache.writes.single.fetchedAt, now);
+    });
+
+    test('ignores a cache that is exactly one hour old', () async {
+      final now = DateTime.utc(2026, 8, 10, 12);
+      final source = _CompleterSource();
+      final cache = _FakeCache(
+        value: CachedZecMarketData(
+          data: const ZecMarketData(usdPrice: 30),
+          fetchedAt: now.subtract(const Duration(hours: 1)),
+        ),
+      );
+      final container = makeContainer(
+        swapEnabled: true,
+        source: source,
+        cache: cache,
+        now: () => now,
+      );
+      final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(sub.read(), isNull);
+      expect(source.fetchCount, 1);
+    });
+
+    test('retains a fresh cache when the network fetch fails', () async {
+      final now = DateTime.utc(2026, 8, 10, 12);
+      final cache = _FakeCache(
+        value: CachedZecMarketData(
+          data: const ZecMarketData(usdPrice: 30),
+          fetchedAt: now.subtract(const Duration(minutes: 30)),
+        ),
+      );
+      final container = makeContainer(
+        swapEnabled: true,
+        source: _FakeSource(null),
+        cache: cache,
+        now: () => now,
+      );
+      final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(sub.read()?.usdPrice, 30);
+      expect(container.read(zecLiveUsdUnitPriceProvider), isNull);
+      expect(cache.writes, isEmpty);
+    });
+
+    test('removes the last value after its one-hour TTL expires', () async {
+      var now = DateTime.utc(2026, 8, 10, 12);
+      final cache = _FakeCache(
+        value: CachedZecMarketData(
+          data: const ZecMarketData(usdPrice: 30),
+          fetchedAt: now.subtract(const Duration(minutes: 59)),
+        ),
+      );
+      final container = makeContainer(
+        swapEnabled: true,
+        source: _FakeSource(null),
+        cache: cache,
+        now: () => now,
+        refreshInterval: const Duration(milliseconds: 5),
+      );
+      final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
+      await Future<void>.delayed(Duration.zero);
+      expect(sub.read()?.usdPrice, 30);
+
+      now = now.add(const Duration(minutes: 2));
+      await Future<void>.delayed(const Duration(milliseconds: 15));
+
+      expect(sub.read(), isNull);
+      expect(container.read(zecLiveUsdUnitPriceProvider), isNull);
+    });
+
+    test('keeps live data when cache persistence fails', () async {
+      final source = _FakeSource(
+        const ZecMarketData(usdPrice: 33.45, change24hPct: -0.26),
+      );
+      final container = makeContainer(
+        swapEnabled: true,
+        source: source,
+        cache: _FakeCache(writeError: StateError('disk full')),
+      );
+      final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(sub.read()?.usdPrice, 33.45);
+      expect(container.read(zecLiveUsdUnitPriceProvider), 33.45);
+    });
+
+    test('continues to fetch when reading the cache fails', () async {
+      final source = _FakeSource(const ZecMarketData(usdPrice: 33.45));
+      final container = makeContainer(
+        swapEnabled: true,
+        source: source,
+        cache: _FakeCache(readError: StateError('unavailable')),
+      );
+      final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(sub.read()?.usdPrice, 33.45);
+      expect(source.fetchCount, 1);
+    });
+
     test('stays null when the source has no value yet', () async {
       final source = _FakeSource(null);
       final container = makeContainer(swapEnabled: true, source: source);
@@ -123,12 +382,23 @@ void main() {
       final source = _FakeSource(
         const ZecMarketData(usdPrice: 33.45, change24hPct: 5.0),
       );
-      final container = makeContainer(swapEnabled: false, source: source);
+      final cache = _FakeCache(
+        value: CachedZecMarketData(
+          data: const ZecMarketData(usdPrice: 30),
+          fetchedAt: DateTime.now(),
+        ),
+      );
+      final container = makeContainer(
+        swapEnabled: false,
+        source: source,
+        cache: cache,
+      );
       final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
 
       await Future<void>.delayed(Duration.zero);
       expect(sub.read(), isNull);
       expect(source.fetchCount, 0);
+      expect(cache.readCount, 0);
     });
   });
 }


### PR DESCRIPTION
## Summary

- persist the latest CoinGecko ZEC/USD market data locally
- show cached Home balance-card pricing immediately when it is less than one hour old, then refresh it from the network
- keep USD-denominated Send calculations isolated to prices fetched successfully during the current provider lifetime
- add cache, expiry, failure, Home, and Send coverage

## Why

On slow networks, the Home balance card previously stayed without fiat pricing until CoinGecko responded. A short-lived local cache provides a useful value sooner while preserving the existing background refresh behavior.

## Validation

- `fvm flutter test test/providers/zec_price_change_provider_test.dart test/features/home/home_desktop_screen_test.dart test/features/send/send_screen_test.dart test/features/send/send_review_screen_test.dart test/features/send/send_status_screen_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/home/mobile_home_screen_test.dart test/features/send/mobile_send_screen_test.dart`
- targeted `fvm flutter analyze` for the changed Dart files
- `git diff --check`
