### PR TITLE
[mobile] Fix duplicate recipient selection in Pay and Swap

### DIFF
--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -19,6 +19,7 @@ import '../../features/migration/screens/ironwood_migration_flow_screen.dart'
         MobileIronwoodMigrationKeystoneDenominationSignScreen;
 import '../../features/pay/screens/mobile/mobile_pay_screen.dart';
 import '../../features/pay/screens/mobile/mobile_pay_submitted_screen.dart';
+import '../../features/pay/models/pay_recent_recipients.dart';
 import '../../features/receive/screens/mobile/mobile_receive_screen.dart';
 import '../../features/address_book/screens/mobile/mobile_address_book_screen.dart';
 import '../../features/activity/screens/mobile/mobile_swap_activity_detail_screen.dart';
@@ -193,10 +194,16 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
     ),
     GoRoute(
       path: '/pay/review',
-      pageBuilder: (context, state) => CupertinoPage(
-        key: state.pageKey,
-        child: const MobileSwapReviewScreen(payMode: true),
-      ),
+      pageBuilder: (context, state) {
+        final extra = state.extra;
+        return CupertinoPage(
+          key: state.pageKey,
+          child: MobileSwapReviewScreen(
+            payMode: true,
+            recipientSelection: extra is PayRecipientSelection ? extra : null,
+          ),
+        );
+      },
     ),
     GoRoute(
       path: '/pay/submitted/:intentId',

--- a/lib/src/features/pay/screens/mobile/mobile_pay_screen.dart
+++ b/lib/src/features/pay/screens/mobile/mobile_pay_screen.dart
@@ -127,8 +127,30 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
   }
 
   void _handleAddressScanned(String value) {
-    ref.read(swapStateProvider.notifier).updateDestination(value);
+    _handleAddressChanged(value);
     _closePayModal();
+  }
+
+  void _handleAddressChanged(String value) {
+    ref.read(swapStateProvider.notifier).updateDestination(value);
+  }
+
+  void _chooseRecipient(PayRecipientSelection selection) {
+    final notifier = ref.read(swapStateProvider.notifier);
+    final contactId = selection.contactId;
+    if (contactId == null) {
+      notifier.updateDestination(selection.address);
+    } else {
+      notifier.selectDestinationContact(
+        address: selection.address,
+        contactId: contactId,
+      );
+    }
+  }
+
+  Future<void> _reviewRecipient(PayRecipientSelection selection) async {
+    _chooseRecipient(selection);
+    await _openReview(selection);
   }
 
   Future<void> _saveContact(
@@ -224,7 +246,7 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
     );
   }
 
-  Future<void> _openReview() async {
+  Future<void> _openReview(PayRecipientSelection selection) async {
     if (_reviewRequestInFlight) return;
     _reviewRequestInFlight = true;
     final requestGeneration = ++_reviewRequestGeneration;
@@ -243,7 +265,7 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
     if (next.reviewVisible &&
         next.reviewQuote != null &&
         next.reviewAddressPlan != null) {
-      await context.push('/pay/review');
+      await context.push('/pay/review', extra: selection);
     }
   }
 
@@ -264,9 +286,11 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
     final network = AddressBookNetwork.tryFromChainTicker(
       swapState.externalAsset.chainTicker,
     );
+    final addressBook = ref.watch(addressBookProvider);
+    final addressBookInitialLoading =
+        addressBook.isLoading && !addressBook.hasValue;
     final allContacts =
-        ref.watch(addressBookProvider).value?.contacts ??
-        const <AddressBookContact>[];
+        addressBook.value?.contacts ?? const <AddressBookContact>[];
     final contacts = network == null
         ? const <AddressBookContact>[]
         : payCompatibleContacts(allContacts, network);
@@ -281,6 +305,16 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
             network: network,
             contacts: contacts,
           );
+    final effectiveSelection = resolvePayRecipientSelection(
+      contacts,
+      swapState.destinationText,
+      explicitSelection: swapState.userExternalContactId == null
+          ? null
+          : PayRecipientSelection(
+              address: swapState.destinationText,
+              contactId: swapState.userExternalContactId,
+            ),
+    );
 
     void back() {
       if (_step == _MobilePayStep.recipient) {
@@ -344,13 +378,17 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
                     contacts: contacts,
                     recents: recents,
                     busy: swapState.quoteLoading,
-                    enabled: swapState.externalAssetIsAvailable,
+                    enabled:
+                        swapState.externalAssetIsAvailable &&
+                        !addressBookInitialLoading,
+                    selectedContactId: swapState.userExternalContactId,
                     externalAsset: swapState.externalAsset,
-                    onAddressChanged: swapNotifier.updateDestination,
+                    onAddressChanged: _handleAddressChanged,
                     onOpenScanner: () =>
                         _openModal(_PayModalSurface.addressScanner),
-                    onChooseRecipient: swapNotifier.updateDestination,
-                    onSelectRecipient: () => unawaited(_openReview()),
+                    onChooseRecipient: _chooseRecipient,
+                    onSelectRecipient: () =>
+                        unawaited(_reviewRecipient(effectiveSelection)),
                     onAddToContacts: () =>
                         _openModal(_PayModalSurface.addContact),
                   ),

--- a/lib/src/features/pay/screens/pay_screen.dart
+++ b/lib/src/features/pay/screens/pay_screen.dart
@@ -119,8 +119,30 @@ class _PayScreenState extends ConsumerState<PayScreen> {
   }
 
   void _handleAddressScanned(String value) {
-    ref.read(swapStateProvider.notifier).updateDestination(value);
+    _handleAddressChanged(value);
     _closePayModal();
+  }
+
+  void _handleAddressChanged(String value) {
+    ref.read(swapStateProvider.notifier).updateDestination(value);
+  }
+
+  void _chooseRecipient(PayRecipientSelection selection) {
+    final notifier = ref.read(swapStateProvider.notifier);
+    final contactId = selection.contactId;
+    if (contactId == null) {
+      notifier.updateDestination(selection.address);
+    } else {
+      notifier.selectDestinationContact(
+        address: selection.address,
+        contactId: contactId,
+      );
+    }
+  }
+
+  Future<void> _reviewRecipient(PayRecipientSelection selection) async {
+    _chooseRecipient(selection);
+    await _openReview();
   }
 
   Future<void> _openReview() async {
@@ -244,9 +266,11 @@ class _PayScreenState extends ConsumerState<PayScreen> {
     final network = AddressBookNetwork.tryFromChainTicker(
       swapState.externalAsset.chainTicker,
     );
+    final addressBook = ref.watch(addressBookProvider);
+    final addressBookInitialLoading =
+        addressBook.isLoading && !addressBook.hasValue;
     final allContacts =
-        ref.watch(addressBookProvider).value?.contacts ??
-        const <AddressBookContact>[];
+        addressBook.value?.contacts ?? const <AddressBookContact>[];
     final contacts = network == null
         ? const <AddressBookContact>[]
         : payCompatibleContacts(allContacts, network);
@@ -280,9 +304,19 @@ class _PayScreenState extends ConsumerState<PayScreen> {
     }
 
     final recipientAddress = swapState.destinationText.trim();
+    final effectiveSelection = resolvePayRecipientSelection(
+      contacts,
+      recipientAddress,
+      explicitSelection: swapState.userExternalContactId == null
+          ? null
+          : PayRecipientSelection(
+              address: recipientAddress,
+              contactId: swapState.userExternalContactId,
+            ),
+    );
     final recipientContact = payContactForSelection(
       contacts,
-      payRecipientSelectionForAddress(contacts, recipientAddress),
+      effectiveSelection,
     );
     final migrationSpendable = ref.watch(
       ironwoodMigrationAwareDisplaySpendableProvider(activeAccountUuid),
@@ -308,9 +342,9 @@ class _PayScreenState extends ConsumerState<PayScreen> {
       addressError: swapState.destinationAddressFormatError,
       contacts: contacts,
       busy: swapState.quoteLoading,
-      enabled: swapState.externalAssetIsAvailable,
+      enabled: swapState.externalAssetIsAvailable && !addressBookInitialLoading,
       quoteError: swapState.externalAssetSupportError ?? swapState.quoteError,
-      onSelectRecipient: () => unawaited(_openReview()),
+      onSelectRecipient: () => unawaited(_reviewRecipient(effectiveSelection)),
       onAddToContacts: network == null
           ? () {}
           : () => setState(() => _payModal = _PayModalSurface.addContact),
@@ -393,11 +427,15 @@ class _PayScreenState extends ConsumerState<PayScreen> {
                   contacts: contacts,
                   recents: recents,
                   busy: swapState.quoteLoading,
-                  onAddressChanged: swapNotifier.updateDestination,
+                  enabled:
+                      swapState.externalAssetIsAvailable &&
+                      !addressBookInitialLoading,
+                  selectedContactId: swapState.userExternalContactId,
+                  onAddressChanged: _handleAddressChanged,
                   onOpenScanner: () => setState(
                     () => _payModal = _PayModalSurface.addressScanner,
                   ),
-                  onChooseRecipient: swapNotifier.updateDestination,
+                  onChooseRecipient: _chooseRecipient,
                 ),
                 _PayWizardStep.review =>
                   quote == null

--- a/lib/src/features/pay/widgets/mobile/mobile_pay_recipient_step.dart
+++ b/lib/src/features/pay/widgets/mobile/mobile_pay_recipient_step.dart
@@ -30,6 +30,7 @@ class MobilePayRecipientStep extends StatefulWidget {
     required this.recents,
     required this.busy,
     this.enabled = true,
+    this.selectedContactId,
     required this.externalAsset,
     required this.onAddressChanged,
     required this.onOpenScanner,
@@ -47,10 +48,11 @@ class MobilePayRecipientStep extends StatefulWidget {
   final List<PayRecentRecipient> recents;
   final bool busy;
   final bool enabled;
+  final String? selectedContactId;
   final SwapAsset externalAsset;
   final ValueChanged<String> onAddressChanged;
   final VoidCallback onOpenScanner;
-  final ValueChanged<String> onChooseRecipient;
+  final ValueChanged<PayRecipientSelection> onChooseRecipient;
   final VoidCallback onSelectRecipient;
   final VoidCallback onAddToContacts;
 
@@ -78,18 +80,27 @@ class _MobilePayRecipientStepState extends State<MobilePayRecipientStep> {
     final typed = widget.typedAddress.trim();
     final hasInput = typed.isNotEmpty;
     final valid = hasInput && widget.addressError == null;
-    final contactMatch = valid ? _contactForAddress(typed) : null;
-    final recentMatch = valid ? _recentForAddress(typed) : null;
-    final unknownAddress = valid && contactMatch == null && recentMatch == null;
+    final selectableRecents = payRecentsWithoutContacts(
+      widget.recents,
+      widget.contacts,
+    );
+    final contactMatches = valid
+        ? payContactsForAddress(widget.contacts, typed)
+        : const <AddressBookContact>[];
+    final recentMatch = valid
+        ? _recentForAddress(typed, selectableRecents)
+        : null;
+    final unknownAddress =
+        valid && contactMatches.isEmpty && recentMatch == null;
     final visibleRecents = !hasInput
-        ? widget.recents
-        : contactMatch == null && recentMatch != null
+        ? selectableRecents
+        : contactMatches.isEmpty && recentMatch != null
         ? <PayRecentRecipient>[recentMatch]
         : const <PayRecentRecipient>[];
     final visibleContacts = !hasInput
         ? widget.contacts
-        : contactMatch != null
-        ? <AddressBookContact>[contactMatch]
+        : contactMatches.isNotEmpty
+        ? contactMatches
         : const <AddressBookContact>[];
 
     return Column(
@@ -125,16 +136,20 @@ class _MobilePayRecipientStepState extends State<MobilePayRecipientStep> {
                                 key: ValueKey(
                                   'mobile_pay_recent_${recent.address}',
                                 ),
-                                contact: _contactForAddress(recent.address),
+                                contact: null,
                                 address: recent.address,
                                 amountText: recent.amountText,
                                 timeLabel: payRecentTimeLabel(
                                   recent.lastUsedAt,
                                 ),
-                                onTap: widget.busy
+                                selected: false,
+                                showSelectionIndicator: false,
+                                onTap: widget.busy || !widget.enabled
                                     ? null
                                     : () => widget.onChooseRecipient(
-                                        recent.address,
+                                        PayRecipientSelection(
+                                          address: recent.address,
+                                        ),
                                       ),
                               ),
                           ],
@@ -155,10 +170,21 @@ class _MobilePayRecipientStepState extends State<MobilePayRecipientStep> {
                                 ),
                                 contact: contact,
                                 address: contact.address,
-                                onTap: widget.busy
+                                selected:
+                                    widget.selectedContactId == contact.id,
+                                showSelectionIndicator:
+                                    payContactsForAddress(
+                                      widget.contacts,
+                                      contact.address,
+                                    ).length >
+                                    1,
+                                onTap: widget.busy || !widget.enabled
                                     ? null
                                     : () => widget.onChooseRecipient(
-                                        contact.address,
+                                        PayRecipientSelection(
+                                          address: contact.address,
+                                          contactId: contact.id,
+                                        ),
                                       ),
                               ),
                           ],
@@ -207,7 +233,8 @@ class _MobilePayRecipientStepState extends State<MobilePayRecipientStep> {
                 AppButton(
                   key: const ValueKey('mobile_pay_recipient_continue_button'),
                   expand: true,
-                  leading: widget.busy ? const AppIcon(AppIcons.loader) : null,
+                  trailing: widget.busy ? const AppIcon(AppIcons.loader) : null,
+                  iconGap: AppSpacing.xxs,
                   onPressed: widget.busy || !widget.enabled
                       ? null
                       : widget.onSelectRecipient,
@@ -420,19 +447,13 @@ class _MobilePayRecipientStepState extends State<MobilePayRecipientStep> {
     );
   }
 
-  AddressBookContact? _contactForAddress(String address) {
+  PayRecentRecipient? _recentForAddress(
+    String address,
+    Iterable<PayRecentRecipient> recents,
+  ) {
     final needle = _normalizedAddress(address);
     if (needle.isEmpty) return null;
-    for (final contact in widget.contacts) {
-      if (_normalizedAddress(contact.address) == needle) return contact;
-    }
-    return null;
-  }
-
-  PayRecentRecipient? _recentForAddress(String address) {
-    final needle = _normalizedAddress(address);
-    if (needle.isEmpty) return null;
-    for (final recent in widget.recents) {
+    for (final recent in recents) {
       if (_normalizedAddress(recent.address) == needle) return recent;
     }
     return null;
@@ -506,6 +527,8 @@ class _RecipientRow extends StatelessWidget {
     this.contact,
     this.amountText,
     this.timeLabel,
+    this.selected = false,
+    this.showSelectionIndicator = false,
     this.onTap,
     super.key,
   });
@@ -514,6 +537,8 @@ class _RecipientRow extends StatelessWidget {
   final String address;
   final String? amountText;
   final String? timeLabel;
+  final bool selected;
+  final bool showSelectionIndicator;
   final VoidCallback? onTap;
 
   @override
@@ -527,6 +552,9 @@ class _RecipientRow extends StatelessWidget {
     );
     final amount = _outgoingAmountText(amountText);
     final row = SizedBox(
+      key: contact == null
+          ? null
+          : ValueKey('mobile_pay_contact_row_surface_${contact!.id}'),
       height: _recipientRowHeight,
       child: Row(
         children: [
@@ -613,18 +641,52 @@ class _RecipientRow extends StatelessWidget {
               ],
             ),
           ],
+          if (showSelectionIndicator) ...[
+            const SizedBox(width: AppSpacing.xs),
+            _ContactSelectionSlot(selected: selected, contactId: contact!.id),
+          ],
         ],
       ),
     );
 
-    if (onTap == null) return row;
+    if (onTap == null) return Semantics(selected: selected, child: row);
     return Semantics(
       button: true,
+      selected: selected,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: onTap,
         child: row,
       ),
+    );
+  }
+}
+
+class _ContactSelectionSlot extends StatelessWidget {
+  const _ContactSelectionSlot({
+    required this.selected,
+    required this.contactId,
+  });
+
+  final bool selected;
+  final String contactId;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      key: ValueKey('mobile_pay_contact_selection_slot_$contactId'),
+      width: 18,
+      height: 18,
+      child: selected
+          ? Center(
+              child: AppIcon(
+                AppIcons.check,
+                size: 16,
+                color: context.colors.icon.accent,
+                semanticLabel: 'Selected contact',
+              ),
+            )
+          : null,
     );
   }
 }

--- a/lib/src/features/pay/widgets/pay_recipient_step.dart
+++ b/lib/src/features/pay/widgets/pay_recipient_step.dart
@@ -7,7 +7,6 @@ import '../../../core/widgets/app_icon_hover_button.dart';
 import '../../../core/widgets/app_profile_picture.dart';
 import '../../../core/widgets/app_text_field.dart';
 import '../../address_book/models/address_book_contact.dart';
-import '../../address_book/models/address_book_label_lookup.dart';
 import '../../swap/models/swap_address_formatting.dart';
 import '../models/pay_recent_recipients.dart';
 import 'pay_wizard_page.dart';
@@ -22,6 +21,8 @@ class PayRecipientStep extends StatelessWidget {
     required this.contacts,
     required this.recents,
     required this.busy,
+    this.enabled = true,
+    this.selectedContactId,
     required this.onAddressChanged,
     required this.onOpenScanner,
     required this.onChooseRecipient,
@@ -41,13 +42,15 @@ class PayRecipientStep extends StatelessWidget {
 
   /// True while the review quote is being fetched — disables the CTA.
   final bool busy;
+  final bool enabled;
+  final String? selectedContactId;
 
   final ValueChanged<String> onAddressChanged;
   final VoidCallback onOpenScanner;
 
-  /// Row tap: commit this address as the selected recipient. Quote/review
-  /// starts only from the explicit "Select recipient" action.
-  final ValueChanged<String> onChooseRecipient;
+  /// Row tap: select this exact recipient. The screen owns quote/review
+  /// orchestration so the same selection contract works on desktop and mobile.
+  final ValueChanged<PayRecipientSelection> onChooseRecipient;
 
   @override
   Widget build(BuildContext context) {
@@ -55,26 +58,18 @@ class PayRecipientStep extends StatelessWidget {
     final typed = typedAddress.trim();
     final hasInput = typed.isNotEmpty;
     final validDestination = hasInput && addressError == null;
+    final selectableRecents = payRecentsWithoutContacts(recents, contacts);
     final matchedRecents = !hasInput
-        ? recents
+        ? selectableRecents
         : [
-            for (final recent in recents)
-              if (_payRecentMatchesQuery(
-                recent,
-                payRecipientContactForAddress(contacts, recent.address),
-                typed,
-              ))
-                recent,
+            for (final recent in selectableRecents)
+              if (_payRecentMatchesQuery(recent, typed)) recent,
           ];
     final matchedContacts = !hasInput
         ? contacts
         : [
             for (final contact in contacts)
-              if (_payContactMatchesQuery(contact, typed) &&
-                  !matchedRecents.any(
-                    (recent) => _payContactHasAddress(contact, recent.address),
-                  ))
-                contact,
+              if (_payContactMatchesQuery(contact, typed)) contact,
           ];
     final hasMatches = matchedRecents.isNotEmpty || matchedContacts.isNotEmpty;
     final unknownAddress = validDestination && !hasMatches;
@@ -152,16 +147,17 @@ class PayRecipientStep extends StatelessWidget {
                 for (final recent in matchedRecents)
                   _PayRecipientRow(
                     key: ValueKey('pay_recent_${recent.address}'),
-                    contact: payRecipientContactForAddress(
-                      contacts,
-                      recent.address,
-                    ),
+                    contact: null,
                     address: recent.address,
                     amountText: recent.amountText,
                     timeLabel: payRecentTimeLabel(recent.lastUsedAt),
-                    onTap: busy
+                    selected: false,
+                    showSelectionIndicator: false,
+                    onTap: busy || !enabled
                         ? null
-                        : () => onChooseRecipient(recent.address),
+                        : () => onChooseRecipient(
+                            PayRecipientSelection(address: recent.address),
+                          ),
                   ),
               ],
             ),
@@ -179,9 +175,21 @@ class PayRecipientStep extends StatelessWidget {
                     address: contact.address,
                     amountText: null,
                     timeLabel: null,
-                    onTap: busy
+                    selected: selectedContactId == contact.id,
+                    showSelectionIndicator:
+                        payContactsForAddress(
+                          contacts,
+                          contact.address,
+                        ).length >
+                        1,
+                    onTap: busy || !enabled
                         ? null
-                        : () => onChooseRecipient(contact.address),
+                        : () => onChooseRecipient(
+                            PayRecipientSelection(
+                              address: contact.address,
+                              contactId: contact.id,
+                            ),
+                          ),
                   ),
               ],
             ),
@@ -198,33 +206,10 @@ bool _payContactMatchesQuery(AddressBookContact contact, String query) {
       contact.label.trim().toLowerCase().contains(needle);
 }
 
-bool _payRecentMatchesQuery(
-  PayRecentRecipient recent,
-  AddressBookContact? contact,
-  String query,
-) {
+bool _payRecentMatchesQuery(PayRecentRecipient recent, String query) {
   final needle = query.trim().toLowerCase();
   if (needle.isEmpty) return true;
-  return recent.address.trim().toLowerCase().contains(needle) ||
-      (contact?.label.trim().toLowerCase().contains(needle) ?? false);
-}
-
-/// Contacts arrive pre-filtered to compatible networks, so address equality
-/// is the only remaining check.
-AddressBookContact? payRecipientContactForAddress(
-  Iterable<AddressBookContact> contacts,
-  String address,
-) {
-  for (final contact in contacts) {
-    if (_payContactHasAddress(contact, address)) return contact;
-  }
-  return null;
-}
-
-bool _payContactHasAddress(AddressBookContact contact, String address) {
-  final needle = normalizedAddressBookAddress(contact.network, address);
-  return needle.isNotEmpty &&
-      normalizedAddressBookAddress(contact.network, contact.address) == needle;
+  return recent.address.trim().toLowerCase().contains(needle);
 }
 
 /// Bottom-pinned actions for a valid Recipient selection.
@@ -258,8 +243,7 @@ class PayRecipientActions extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final typed = typedAddress.trim();
-    final contact = payRecipientContactForAddress(contacts, typed);
-    final canAddContact = contact == null;
+    final canAddContact = payContactsForAddress(contacts, typed).isEmpty;
 
     return Column(
       key: const ValueKey('pay_recipient_actions'),
@@ -300,6 +284,8 @@ class PayRecipientActions extends StatelessWidget {
           variant: AppButtonVariant.primary,
           size: AppButtonSize.large,
           minWidth: PayWizardActionMetrics.width,
+          trailing: busy ? const AppIcon(AppIcons.loader) : null,
+          iconGap: AppSpacing.xxs,
           onPressed: busy || !enabled ? null : onSelectRecipient,
           child: Text(busy ? 'Fetching quote' : 'Select recipient'),
         ),
@@ -361,6 +347,8 @@ class _PayRecipientRow extends StatelessWidget {
     required this.address,
     required this.amountText,
     required this.timeLabel,
+    required this.selected,
+    required this.showSelectionIndicator,
     required this.onTap,
     super.key,
   });
@@ -369,6 +357,8 @@ class _PayRecipientRow extends StatelessWidget {
   final String address;
   final String? amountText;
   final String? timeLabel;
+  final bool selected;
+  final bool showSelectionIndicator;
   final VoidCallback? onTap;
 
   @override
@@ -381,6 +371,9 @@ class _PayRecipientRow extends StatelessWidget {
       suffixLength: 5,
     );
     final row = SizedBox(
+      key: contact == null
+          ? null
+          : ValueKey('pay_contact_row_surface_${contact!.id}'),
       height: 44,
       child: Row(
         children: [
@@ -461,17 +454,54 @@ class _PayRecipientRow extends StatelessWidget {
               ],
             ),
           ],
+          if (showSelectionIndicator) ...[
+            const SizedBox(width: AppSpacing.xs),
+            _ContactSelectionSlot(selected: selected, contactId: contact!.id),
+          ],
         ],
       ),
     );
-    if (onTap == null) return row;
+    if (onTap == null) return Semantics(selected: selected, child: row);
     return MouseRegion(
       cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: row,
+      child: Semantics(
+        button: true,
+        selected: selected,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: row,
+        ),
       ),
+    );
+  }
+}
+
+class _ContactSelectionSlot extends StatelessWidget {
+  const _ContactSelectionSlot({
+    required this.selected,
+    required this.contactId,
+  });
+
+  final bool selected;
+  final String contactId;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      key: ValueKey('pay_contact_selection_slot_$contactId'),
+      width: 18,
+      height: 18,
+      child: selected
+          ? Center(
+              child: AppIcon(
+                AppIcons.check,
+                size: 16,
+                color: context.colors.icon.accent,
+                semanticLabel: 'Selected contact',
+              ),
+            )
+          : null,
     );
   }
 }

--- a/lib/src/features/swap/screens/mobile/mobile_swap_review_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_review_screen.dart
@@ -10,13 +10,14 @@ import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/profile_pictures.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../providers/account_provider.dart';
+import '../../../address_book/models/address_book_contact.dart';
 import '../../../pay/widgets/mobile/mobile_pay_review_content.dart';
+import '../../../pay/models/pay_recent_recipients.dart';
 import '../../../address_book/providers/address_book_provider.dart';
 import '../../../migration/providers/ironwood_migration_announcement_provider.dart';
 import '../../domain/swap_direction.dart';
 import '../../domain/swap_quote.dart';
 import '../../models/swap_activity_navigation.dart';
-import '../../models/swap_address_book_helpers.dart';
 import '../../models/swap_state.dart';
 import '../../providers/swap_state_provider.dart';
 import '../../widgets/mobile/mobile_swap_review_content.dart';
@@ -30,9 +31,14 @@ const _keystoneSigningReviewInactiveDelay = Duration(milliseconds: 500);
 /// surface that fits the phone; smaller devices scale down) with the
 /// same quote/start orchestration as the desktop review screen.
 class MobileSwapReviewScreen extends ConsumerStatefulWidget {
-  const MobileSwapReviewScreen({this.payMode = false, super.key});
+  const MobileSwapReviewScreen({
+    this.payMode = false,
+    this.recipientSelection,
+    super.key,
+  });
 
   final bool payMode;
+  final PayRecipientSelection? recipientSelection;
 
   @override
   ConsumerState<MobileSwapReviewScreen> createState() =>
@@ -301,12 +307,17 @@ class _MobileSwapReviewScreenState
         swapState.quoteExpired ||
         (_expiryRemaining != null && _expiryRemaining! <= Duration.zero);
     final recipientAddress = addressPlan.userExternalAddress.trim();
+    final recipientNetwork = AddressBookNetwork.tryFromChainTicker(
+      quote.receiveAsset.chainTicker,
+    );
+    final recipientContacts = recipientNetwork == null
+        ? const <AddressBookContact>[]
+        : payCompatibleContacts(addressBookContacts, recipientNetwork);
+    final recipientSelection =
+        widget.recipientSelection ??
+        payRecipientSelectionForAddress(recipientContacts, recipientAddress);
     final recipientContact = widget.payMode
-        ? addressBookContactForSwapAsset(
-            contacts: addressBookContacts,
-            asset: quote.receiveAsset,
-            address: recipientAddress,
-          )
+        ? payContactForSelection(recipientContacts, recipientSelection)
         : null;
     final payingFiatText = widget.payMode
         ? swapReviewFiatTextForAsset(
@@ -378,6 +389,7 @@ class _MobileSwapReviewScreenState
                         quote: quote,
                         addressPlan: addressPlan,
                         addressBookContacts: addressBookContacts,
+                        userExternalContactId: swapState.userExternalContactId,
                         accountLabel: accountLabel,
                         accountProfilePictureId: accountProfilePictureId,
                         expired: widget.payMode

--- a/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
@@ -142,7 +142,12 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
   }
 
   void _selectAddressBookContact(AddressBookContact contact) {
-    ref.read(swapStateProvider.notifier).updateDestination(contact.address);
+    ref
+        .read(swapStateProvider.notifier)
+        .selectDestinationContact(
+          address: contact.address,
+          contactId: contact.id,
+        );
     _closeSwapModal();
   }
 

--- a/lib/src/features/swap/screens/swap_review_screen.dart
+++ b/lib/src/features/swap/screens/swap_review_screen.dart
@@ -172,6 +172,7 @@ class _SwapReviewScreenState extends ConsumerState<SwapReviewScreen> {
                       addressBookContacts:
                           ref.watch(addressBookProvider).value?.contacts ??
                           const [],
+                      userExternalContactId: swapState.userExternalContactId,
                       expired: swapState.quoteExpired,
                       amountWarning: swapState.reviewAmountDifferenceWarning,
                       startError: swapState.statusError,

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -106,7 +106,12 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
   }
 
   void _selectAddressBookContact(AddressBookContact contact) {
-    ref.read(swapStateProvider.notifier).updateDestination(contact.address);
+    ref
+        .read(swapStateProvider.notifier)
+        .selectDestinationContact(
+          address: contact.address,
+          contactId: contact.id,
+        );
     _closeSwapModal();
   }
 

--- a/lib/src/features/swap/widgets/mobile/mobile_swap_review_content.dart
+++ b/lib/src/features/swap/widgets/mobile/mobile_swap_review_content.dart
@@ -27,6 +27,7 @@ class MobileSwapReviewContent extends StatelessWidget {
     required this.accountLabel,
     required this.accountProfilePictureId,
     this.addressBookContacts = const [],
+    this.userExternalContactId,
     required this.expired,
     required this.amountWarning,
     required this.startError,
@@ -42,6 +43,7 @@ class MobileSwapReviewContent extends StatelessWidget {
   final String? accountLabel;
   final String accountProfilePictureId;
   final Iterable<AddressBookContact> addressBookContacts;
+  final String? userExternalContactId;
   final bool expired;
   final String? amountWarning;
   final String? startError;
@@ -59,6 +61,7 @@ class MobileSwapReviewContent extends StatelessWidget {
       contacts: addressBookContacts,
       asset: sendsZec ? quote.receiveAsset : quote.sellAsset,
       address: externalAddress,
+      contactId: userExternalContactId,
     )?.label.trim();
     final externalCompact = compactSwapAddress(
       externalAddress,

--- a/lib/src/features/swap/widgets/swap_activity_panel.dart
+++ b/lib/src/features/swap/widgets/swap_activity_panel.dart
@@ -828,12 +828,16 @@ class _SwapStatusForIntentState extends ConsumerState<_SwapStatusForIntent> {
       final paymentMode = presentation.paymentMode;
       final recipient = intent.oneClickRecipient?.trim();
       final hasRecipient = recipient != null && recipient.isNotEmpty;
+      final recipientContactId = intent.direction == SwapDirection.externalToZec
+          ? null
+          : intent.userExternalContactId;
       final payStatus = presentation.payStatus;
       final recipientContact = hasRecipient
           ? addressBookContactForSwapAsset(
               contacts: addressBookContacts,
               asset: presentation.receiveAsset,
               address: recipient,
+              contactId: recipientContactId,
             )
           : null;
       final recipientFullAddress = mobileSwapStatusRecipientFullAddress(intent);
@@ -866,7 +870,7 @@ class _SwapStatusForIntentState extends ConsumerState<_SwapStatusForIntent> {
           amountText: trimSwapAmountText(presentation.receiveAmountText),
           asset: presentation.receiveAsset,
           bottomText: hasRecipient
-              ? 'To: ${_headerRecipientText(recipient, presentation: presentation, contacts: addressBookContacts)}'
+              ? 'To: ${_headerRecipientText(recipient, presentation: presentation, contacts: addressBookContacts, contactId: recipientContactId)}'
               : presentation.receiveFiatText,
           fullAddress: recipientFullAddress,
         ),
@@ -893,6 +897,7 @@ class _SwapStatusForIntentState extends ConsumerState<_SwapStatusForIntent> {
         contacts: addressBookContacts,
         asset: presentation.receiveAsset,
         address: recipientAddress,
+        contactId: intent.userExternalContactId,
       );
       final txIdUri = payStatus.txIdUri;
       return PayActivityStatusContent(
@@ -1002,11 +1007,13 @@ String _headerRecipientText(
   String recipient, {
   required SwapActivityStatusPresentation presentation,
   required Iterable<AddressBookContact> contacts,
+  String? contactId,
 }) {
   final label = addressBookContactForSwapAsset(
     contacts: contacts,
     asset: presentation.receiveAsset,
     address: recipient,
+    contactId: contactId,
   )?.label.trim();
   final compact = _truncateHeaderAddress(recipient);
   if (label == null || label.isEmpty) return compact;

--- a/lib/src/features/swap/widgets/swap_review_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_review_page_content.dart
@@ -33,6 +33,7 @@ class SwapReviewPageContent extends StatelessWidget {
     this.onCopy,
     this.showTitle = true,
     this.addressBookContacts = const [],
+    this.userExternalContactId,
     this.payMode = false,
     super.key,
   });
@@ -43,6 +44,7 @@ class SwapReviewPageContent extends StatelessWidget {
   /// Saved contacts used to label the recipient/refund address lines when
   /// they match an address-book entry.
   final Iterable<AddressBookContact> addressBookContacts;
+  final String? userExternalContactId;
   final bool expired;
   final String? amountWarning;
   final String? startError;
@@ -182,6 +184,7 @@ class SwapReviewPageContent extends StatelessWidget {
       contacts: addressBookContacts,
       asset: asset,
       address: address,
+      contactId: userExternalContactId,
     )?.label.trim();
     final compact = compactSwapAddress(address);
     if (label == null || label.isEmpty) return compact;

--- a/lib/widgetbook/mobile_pay_use_cases.dart
+++ b/lib/widgetbook/mobile_pay_use_cases.dart
@@ -23,6 +23,8 @@ import '../src/features/swap/providers/swap_state_provider.dart';
 const _mikeAddress = '0x52908400098527886E0F7030069857D2E4169EE7';
 const _aliceAddress = '0xde709f2102306220921060314715629080e2fb77';
 const _newAddress = '0x1111111111111111111111111111111111111111';
+const _recentAddress = '0x2222222222222222222222222222222222222222';
+const _otherRecentAddress = '0x3333333333333333333333333333333333333333';
 
 const _payContacts = [
   AddressBookContact(
@@ -47,12 +49,12 @@ const _payContacts = [
 
 final _payRecents = [
   PayRecentRecipient(
-    address: _mikeAddress,
+    address: _recentAddress,
     amountText: '990 USDC',
     lastUsedAt: DateTime(2026, 7, 8),
   ),
   PayRecentRecipient(
-    address: _aliceAddress,
+    address: _otherRecentAddress,
     amountText: '125 USDC',
     lastUsedAt: DateTime(2026, 4, 27),
   ),
@@ -419,7 +421,8 @@ class _MobilePayRecipientPreviewViewState
     );
   }
 
-  void _selectRecipient(String address) {
+  void _selectRecipient(PayRecipientSelection selection) {
+    final address = selection.address;
     setState(() {
       _typedAddress = address;
       _controller.text = address;

--- a/lib/widgetbook/pay_use_cases.dart
+++ b/lib/widgetbook/pay_use_cases.dart
@@ -207,7 +207,8 @@ class _PayRecipientPreviewState extends State<_PayRecipientPreview> {
     super.dispose();
   }
 
-  void _selectAddress(String address) {
+  void _selectAddress(PayRecipientSelection selection) {
+    final address = selection.address;
     setState(() {
       _typedAddress = address;
       _controller.value = TextEditingValue(
@@ -556,7 +557,7 @@ final _previewContacts = [
 
 final _previewRecents = [
   PayRecentRecipient(
-    address: _contactAddress,
+    address: '0x4444444444444444444444444444444444444444',
     amountText: '-24 USDC',
     lastUsedAt: DateTime.now().subtract(const Duration(days: 2)),
   ),

--- a/test/features/pay/mobile_pay_activity_status_test.dart
+++ b/test/features/pay/mobile_pay_activity_status_test.dart
@@ -9,6 +9,7 @@ import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/review_list_row.dart';
 import 'package:zcash_wallet/src/features/activity/screens/mobile/mobile_swap_activity_detail_screen.dart';
+import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_activity_status_mapper.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
@@ -386,6 +387,59 @@ void main() {
     },
   );
 
+  testWidgets('mobile Pay Activity shows the selected duplicate contact', (
+    tester,
+  ) async {
+    final intent = _intent(
+      status: SwapIntentStatus.processing,
+      userExternalContactId: 'second',
+    ).copyWith(accountUuid: 'account-1');
+    final state = SwapState(
+      direction: SwapDirection.zecToExternal,
+      amountText: '',
+      receiveAmountText: '',
+      destinationText: '',
+      externalAsset: SwapAsset.usdc,
+      reviewVisible: false,
+      intents: [intent],
+      selectedIntentId: intent.id,
+      payMode: true,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountProvider.overrideWith(_PayAccountNotifier.new),
+          addressBookProvider.overrideWith(_DuplicateAddressBookNotifier.new),
+          swapStateProvider.overrideWith(() => _PayStatusNotifier(state)),
+          syncProvider.overrideWith(FakeSyncNotifier.new),
+        ],
+        child: _harness(
+          SwapActivityDetailPagePanel(
+            state: state,
+            intent: intent,
+            layout: SwapActivityDetailLayout.mobile,
+            depositChecking: false,
+            depositCheckWarning: null,
+            onRefreshStatus: () {},
+            onMarkDeposited: () {},
+            onDepositTxHashChanged: (_) {},
+            onSubmitDepositTransaction: () {},
+            onReviewFreshQuote: () {},
+            onSignZecDeposit: (_) {},
+            intentIsHardware: false,
+          ),
+          scroll: false,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Second'), findsOneWidget);
+    expect(find.text('First'), findsNothing);
+  });
+
   test('mobile activity titles distinguish paying and paid from swap', () {
     expect(
       mobileSwapActivityTitle(
@@ -439,6 +493,7 @@ SwapIntent _intent({
   String? depositTxHash = 'zec-shielded-spend-txid',
   String? originChainTxHash,
   SwapProviderRefundInfo? providerRefundInfo,
+  String? userExternalContactId,
 }) {
   return SwapIntent(
     id: 'mobile-pay-status',
@@ -462,6 +517,7 @@ SwapIntent _intent({
         ? DateTime.utc(2026, 5, 20, 13, 21)
         : null,
     payMode: payMode,
+    userExternalContactId: userExternalContactId,
   );
 }
 
@@ -505,4 +561,30 @@ class _PayAccountNotifier extends AccountNotifier {
 class _EmptyAddressBookNotifier extends AddressBookNotifier {
   @override
   AddressBookState build() => const AddressBookState();
+}
+
+class _DuplicateAddressBookNotifier extends AddressBookNotifier {
+  @override
+  AddressBookState build() => const AddressBookState(
+    contacts: [
+      AddressBookContact(
+        id: 'first',
+        label: 'First',
+        network: AddressBookNetwork.ethereum,
+        address: _recipient,
+        profilePictureId: 'pfp-01',
+        createdAtMs: 0,
+        updatedAtMs: 0,
+      ),
+      AddressBookContact(
+        id: 'second',
+        label: 'Second',
+        network: AddressBookNetwork.ethereum,
+        address: _recipient,
+        profilePictureId: 'pfp-02',
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      ),
+    ],
+  );
 }

--- a/test/features/pay/mobile_pay_review_screen_test.dart
+++ b/test/features/pay/mobile_pay_review_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
+import 'package:zcash_wallet/src/features/pay/models/pay_recent_recipients.dart';
 import 'package:zcash_wallet/src/features/pay/screens/mobile/mobile_pay_submitted_screen.dart';
 import 'package:zcash_wallet/src/features/pay/widgets/mobile/mobile_pay_review_content.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
@@ -69,6 +70,64 @@ void main() {
       expect(confirm, findsOneWidget);
       expect(tester.widget<AppButton>(confirm).onPressed, isNotNull);
       expect(find.text('Not enough ZEC'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'payment review renders the explicitly selected duplicate contact',
+    (tester) async {
+      tester.view.physicalSize = const Size(393, 852);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      const contacts = [
+        AddressBookContact(
+          id: 'first',
+          label: 'First',
+          network: AddressBookNetwork.ethereum,
+          address: _recipient,
+          profilePictureId: 'pfp-01',
+          createdAtMs: 0,
+          updatedAtMs: 0,
+        ),
+        AddressBookContact(
+          id: 'second',
+          label: 'Second',
+          network: AddressBookNetwork.ethereum,
+          address: _recipient,
+          profilePictureId: 'pfp-02',
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        ),
+      ];
+      final router = GoRouter(
+        initialLocation: '/pay/review',
+        routes: [
+          GoRoute(
+            path: '/pay/review',
+            builder: (_, _) => const MobileSwapReviewScreen(
+              payMode: true,
+              recipientSelection: PayRecipientSelection(
+                address: _recipient,
+                contactId: 'second',
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        _app(
+          router,
+          quoteLifetime: const Duration(minutes: 5),
+          contacts: contacts,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Second'), findsOneWidget);
+      expect(find.text('First'), findsNothing);
     },
   );
 
@@ -324,12 +383,13 @@ Widget _app(
   required Duration quoteLifetime,
   SwapNotifier Function()? swapNotifier,
   SyncState? syncState,
+  List<AddressBookContact> contacts = const [],
 }) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap),
       addressBookRepositoryProvider.overrideWithValue(
-        const _EmptyAddressBookRepository(),
+        _TestAddressBookRepository(contacts),
       ),
       swapStateProvider.overrideWith(
         swapNotifier ?? () => _ExpiringPayReviewNotifier(quoteLifetime),
@@ -479,11 +539,13 @@ class _DelayedRefreshingPayReviewNotifier extends _ExpiringPayReviewNotifier {
   }
 }
 
-class _EmptyAddressBookRepository implements AddressBookRepository {
-  const _EmptyAddressBookRepository();
+class _TestAddressBookRepository implements AddressBookRepository {
+  const _TestAddressBookRepository(this.contacts);
+
+  final List<AddressBookContact> contacts;
 
   @override
-  Future<List<AddressBookContact>> loadContacts() async => const [];
+  Future<List<AddressBookContact>> loadContacts() async => [...contacts];
 
   @override
   Future<void> saveContacts(List<AddressBookContact> contacts) async {}

--- a/test/features/pay/mobile_pay_screen_test.dart
+++ b/test/features/pay/mobile_pay_screen_test.dart
@@ -13,6 +13,9 @@ import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
+import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
+import 'package:zcash_wallet/src/features/pay/models/pay_recent_recipients.dart';
 import 'package:zcash_wallet/src/features/pay/screens/mobile/mobile_pay_screen.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_state_provider.dart';
@@ -260,10 +263,18 @@ class _TorBlockablePayNotifier extends SwapNotifier {
   }
 }
 
-Widget _routedPayApp(GoRouter router, SwapNotifier notifier) {
+Widget _routedPayApp(
+  GoRouter router,
+  SwapNotifier notifier, {
+  List<AddressBookContact> contacts = const [],
+  AddressBookRepository? addressBookRepository,
+}) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
+      addressBookRepositoryProvider.overrideWithValue(
+        addressBookRepository ?? _FakeAddressBookRepository(contacts),
+      ),
       swapStateProvider.overrideWith(() => notifier),
       syncProvider.overrideWith(
         () => FakeSyncNotifier(
@@ -285,6 +296,32 @@ Widget _routedPayApp(GoRouter router, SwapNotifier notifier) {
       ),
     ),
   );
+}
+
+class _FakeAddressBookRepository implements AddressBookRepository {
+  _FakeAddressBookRepository(this.contacts);
+
+  final List<AddressBookContact> contacts;
+
+  @override
+  Future<List<AddressBookContact>> loadContacts() async => [...contacts];
+
+  @override
+  Future<void> saveContacts(List<AddressBookContact> contacts) async {}
+}
+
+class _DelayedAddressBookRepository implements AddressBookRepository {
+  final _contacts = Completer<List<AddressBookContact>>();
+
+  void complete(List<AddressBookContact> contacts) {
+    _contacts.complete(contacts);
+  }
+
+  @override
+  Future<List<AddressBookContact>> loadContacts() => _contacts.future;
+
+  @override
+  Future<void> saveContacts(List<AddressBookContact> contacts) async {}
 }
 
 Future<void> _setMobileViewport(WidgetTester tester, Size size) async {
@@ -461,6 +498,169 @@ void main() {
       find.byKey(const ValueKey('mobile_pay_amount_input')),
     );
     expect(amountInput.controller?.text, '10');
+  });
+
+  testWidgets('contact row selects the clicked identity before review', (
+    tester,
+  ) async {
+    await _setMobileViewport(tester, const Size(393, 852));
+    const address = '0x1111111111111111111111111111111111111111';
+    const contacts = [
+      AddressBookContact(
+        id: 'first',
+        label: 'First',
+        network: AddressBookNetwork.ethereum,
+        address: address,
+        profilePictureId: 'pfp-01',
+        createdAtMs: 0,
+        updatedAtMs: 0,
+      ),
+      AddressBookContact(
+        id: 'second',
+        label: 'Second',
+        network: AddressBookNetwork.ethereum,
+        address: address,
+        profilePictureId: 'pfp-02',
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      ),
+    ];
+    Object? reviewExtra;
+    final router = GoRouter(
+      initialLocation: '/pay',
+      routes: [
+        GoRoute(
+          path: '/pay',
+          builder: (_, _) =>
+              const MobilePayScreen(preservePreparedComposer: true),
+        ),
+        GoRoute(
+          path: '/pay/review',
+          builder: (_, state) {
+            reviewExtra = state.extra;
+            return const Text('Review route');
+          },
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      _routedPayApp(
+        router,
+        _RefreshFailPayReviewNotifier(),
+        contacts: contacts,
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_pay_amount_continue_button')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('2 contacts'), findsOneWidget);
+    await tester.tap(find.text('Second'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review route'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('mobile_pay_contact_second')),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is AppIcon && widget.name == AppIcons.check,
+        ),
+      ),
+      findsOneWidget,
+    );
+    final firstSelectionSlot = find.byKey(
+      const ValueKey('mobile_pay_contact_selection_slot_first'),
+    );
+    final secondSelectionSlot = find.byKey(
+      const ValueKey('mobile_pay_contact_selection_slot_second'),
+    );
+    expect(firstSelectionSlot, findsOneWidget);
+    expect(secondSelectionSlot, findsOneWidget);
+    expect(tester.getSize(firstSelectionSlot), const Size.square(18));
+    expect(tester.getSize(secondSelectionSlot), const Size.square(18));
+    expect(
+      tester.getRect(firstSelectionSlot).center.dx,
+      tester.getRect(secondSelectionSlot).center.dx,
+    );
+    expect(
+      find.descendant(
+        of: firstSelectionSlot,
+        matching: find.byWidgetPredicate(
+          (widget) => widget is AppIcon && widget.name == AppIcons.check,
+        ),
+      ),
+      findsNothing,
+    );
+    expect(
+      tester.widget(
+        find.byKey(const ValueKey('mobile_pay_contact_row_surface_second')),
+      ),
+      isA<SizedBox>(),
+    );
+    expect(
+      tester.widget<Text>(find.text('Second')).style?.fontWeight,
+      tester.widget<Text>(find.text('First')).style?.fontWeight,
+    );
+    expect(
+      find.byKey(const ValueKey('mobile_pay_recipient_continue_button')),
+      findsOneWidget,
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_pay_recipient_continue_button')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review route'), findsOneWidget);
+    expect(reviewExtra, isA<PayRecipientSelection>());
+    expect((reviewExtra! as PayRecipientSelection).contactId, 'second');
+  });
+
+  testWidgets('recipient actions wait for the initial address book load', (
+    tester,
+  ) async {
+    await _setMobileViewport(tester, const Size(393, 852));
+    final repository = _DelayedAddressBookRepository();
+    final router = GoRouter(
+      initialLocation: '/pay',
+      routes: [
+        GoRoute(
+          path: '/pay',
+          builder: (_, _) =>
+              const MobilePayScreen(preservePreparedComposer: true),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      _routedPayApp(
+        router,
+        _RefreshFailPayReviewNotifier(),
+        addressBookRepository: repository,
+      ),
+    );
+    await tester.pump();
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_pay_amount_continue_button')),
+    );
+    await tester.pump();
+
+    var continueButton = tester.widget<AppButton>(
+      find.byKey(const ValueKey('mobile_pay_recipient_continue_button')),
+    );
+    expect(continueButton.onPressed, isNull);
+
+    repository.complete(const []);
+    await tester.pumpAndSettle();
+
+    continueButton = tester.widget<AppButton>(
+      find.byKey(const ValueKey('mobile_pay_recipient_continue_button')),
+    );
+    expect(continueButton.onPressed, isNotNull);
   });
 
   testWidgets(
@@ -749,9 +949,7 @@ void main() {
     expect(
       tester
           .widget<AppButton>(
-            find.byKey(
-              const ValueKey('mobile_pay_recipient_continue_button'),
-            ),
+            find.byKey(const ValueKey('mobile_pay_recipient_continue_button')),
           )
           .onPressed,
       isNotNull,
@@ -764,9 +962,7 @@ void main() {
     expect(
       tester
           .widget<AppButton>(
-            find.byKey(
-              const ValueKey('mobile_pay_recipient_continue_button'),
-            ),
+            find.byKey(const ValueKey('mobile_pay_recipient_continue_button')),
           )
           .onPressed,
       isNull,

--- a/test/features/pay/mobile_pay_steps_test.dart
+++ b/test/features/pay/mobile_pay_steps_test.dart
@@ -17,6 +17,8 @@ import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 const _recipient = '0x1111111111111111111111111111111111111111';
 const _otherRecipient = '0x2222222222222222222222222222222222222222';
 const _unknownRecipient = '0x3333333333333333333333333333333333333333';
+const _recentRecipient = '0x4444444444444444444444444444444444444444';
+const _otherRecentRecipient = '0x5555555555555555555555555555555555555555';
 const _solanaRecipient = '4Nd1mYQx4jJXAWe3zUKgnQz5pFa9qTqfjEBWWWk3tS9e';
 
 const _amountState = SwapState(
@@ -54,12 +56,12 @@ final _contacts = [
 
 final _recents = [
   PayRecentRecipient(
-    address: _recipient,
+    address: _recentRecipient,
     amountText: '1.25 USDC',
     lastUsedAt: DateTime(2026, 7, 7),
   ),
   PayRecentRecipient(
-    address: _otherRecipient,
+    address: _otherRecentRecipient,
     amountText: '4 USDC',
     lastUsedAt: DateTime(2026, 7, 1),
   ),
@@ -397,8 +399,8 @@ void main() {
       expect(find.text('Recently sent'), findsOneWidget);
       expect(find.text('-1.25 USDC'), findsOneWidget);
       expect(find.text('2 contacts'), findsOneWidget);
-      expect(find.text('Mike'), findsNWidgets(2));
-      expect(find.text('Alice'), findsNWidgets(2));
+      expect(find.text('Mike'), findsOneWidget);
+      expect(find.text('Alice'), findsOneWidget);
       expect(
         find.byKey(const ValueKey('mobile_pay_recipient_continue_button')),
         findsNothing,
@@ -462,14 +464,14 @@ void main() {
     testWidgets('known recent address keeps one row and only Continue', (
       tester,
     ) async {
-      final controller = TextEditingController(text: _recipient);
+      final controller = TextEditingController(text: _recentRecipient);
       addTearDown(controller.dispose);
 
       await _pumpStep(
         tester,
         MobilePayRecipientStep(
           controller: controller,
-          typedAddress: _recipient,
+          typedAddress: _recentRecipient,
           addressError: null,
           contacts: const [],
           recents: [_recents.first],
@@ -498,14 +500,14 @@ void main() {
     testWidgets('replaces Continue while the payment quote is loading', (
       tester,
     ) async {
-      final controller = TextEditingController(text: _recipient);
+      final controller = TextEditingController(text: _recentRecipient);
       addTearDown(controller.dispose);
 
       await _pumpStep(
         tester,
         MobilePayRecipientStep(
           controller: controller,
-          typedAddress: _recipient,
+          typedAddress: _recentRecipient,
           addressError: null,
           contacts: const [],
           recents: [_recents.first],
@@ -534,7 +536,7 @@ void main() {
       expect(loader, findsOneWidget);
       expect(
         tester.getCenter(loader).dx,
-        lessThan(tester.getCenter(find.text('Fetching quote')).dx),
+        greaterThan(tester.getCenter(find.text('Fetching quote')).dx),
       );
       expect(
         tester
@@ -549,14 +551,14 @@ void main() {
     testWidgets('shows support errors and blocks recipient continuation', (
       tester,
     ) async {
-      final controller = TextEditingController(text: _recipient);
+      final controller = TextEditingController(text: _recentRecipient);
       addTearDown(controller.dispose);
 
       await _pumpStep(
         tester,
         MobilePayRecipientStep(
           controller: controller,
-          typedAddress: _recipient,
+          typedAddress: _recentRecipient,
           addressError: null,
           quoteError: 'USDC on Base is not currently supported.',
           contacts: const [],
@@ -586,6 +588,130 @@ void main() {
             .onPressed,
         isNull,
       );
+    });
+
+    testWidgets('blocks recipient rows on an unsupported Pay rail', (
+      tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      PayRecipientSelection? chosen;
+
+      await _pumpStep(
+        tester,
+        MobilePayRecipientStep(
+          controller: controller,
+          typedAddress: '',
+          addressError: null,
+          contacts: _contacts,
+          recents: _recents,
+          busy: false,
+          enabled: false,
+          externalAsset: SwapAsset.usdc,
+          onAddressChanged: (_) {},
+          onOpenScanner: () {},
+          onChooseRecipient: (selection) => chosen = selection,
+          onSelectRecipient: () {},
+          onAddToContacts: () {},
+        ),
+      );
+
+      await tester.tap(find.text('Mike'));
+      await tester.tap(
+        find.byKey(ValueKey('mobile_pay_recent_${_recents.first.address}')),
+      );
+      expect(chosen, isNull);
+    });
+
+    testWidgets('keeps duplicate-address contacts individually selectable', (
+      tester,
+    ) async {
+      final controller = TextEditingController(text: _recipient);
+      addTearDown(controller.dispose);
+      final second = AddressBookContact(
+        id: 'contact-duplicate',
+        label: 'Second Mike',
+        network: AddressBookNetwork.ethereum,
+        address: _recipient,
+        profilePictureId: 'pfp-03',
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      );
+      PayRecipientSelection? chosen;
+
+      await _pumpStep(
+        tester,
+        MobilePayRecipientStep(
+          controller: controller,
+          typedAddress: _recipient,
+          addressError: null,
+          contacts: [_contacts.first, second],
+          recents: const [PayRecentRecipient(address: _recipient)],
+          busy: false,
+          selectedContactId: second.id,
+          externalAsset: SwapAsset.usdc,
+          onAddressChanged: (_) {},
+          onOpenScanner: () {},
+          onChooseRecipient: (selection) => chosen = selection,
+          onSelectRecipient: () {},
+          onAddToContacts: () {},
+        ),
+      );
+
+      expect(find.text('2 contacts'), findsOneWidget);
+      expect(find.text('Mike'), findsOneWidget);
+      expect(find.text('Second Mike'), findsOneWidget);
+      expect(find.text('Recently sent'), findsNothing);
+      expect(
+        find.byKey(
+          const ValueKey('mobile_pay_contact_selection_slot_contact-1'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(
+          const ValueKey('mobile_pay_contact_selection_slot_contact-duplicate'),
+        ),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel('Selected contact'), findsOneWidget);
+
+      await tester.tap(find.text('Second Mike'));
+      expect(chosen?.contactId, 'contact-duplicate');
+    });
+
+    testWidgets('unique selected contact does not show a selection check', (
+      tester,
+    ) async {
+      final controller = TextEditingController(text: _recipient);
+      addTearDown(controller.dispose);
+
+      await _pumpStep(
+        tester,
+        MobilePayRecipientStep(
+          controller: controller,
+          typedAddress: _recipient,
+          addressError: null,
+          contacts: [_contacts.first],
+          recents: const [],
+          busy: false,
+          selectedContactId: _contacts.first.id,
+          externalAsset: SwapAsset.usdc,
+          onAddressChanged: (_) {},
+          onOpenScanner: () {},
+          onChooseRecipient: (_) {},
+          onSelectRecipient: () {},
+          onAddToContacts: () {},
+        ),
+      );
+
+      expect(
+        find.byKey(
+          const ValueKey('mobile_pay_contact_selection_slot_contact-1'),
+        ),
+        findsNothing,
+      );
+      expect(find.bySemanticsLabel('Selected contact'), findsNothing);
     });
 
     testWidgets('Solana recipient matching remains case-sensitive', (

--- a/test/features/pay/pay_wizard_steps_test.dart
+++ b/test/features/pay/pay_wizard_steps_test.dart
@@ -59,11 +59,13 @@ Widget _recipientStep({
   String? addressError,
   List<AddressBookContact> contacts = const [],
   List<PayRecentRecipient> recents = const [],
-  ValueChanged<String>? onChooseRecipient,
+  ValueChanged<PayRecipientSelection>? onChooseRecipient,
   VoidCallback? onSelectRecipient,
   VoidCallback? onAddToContacts,
   String? quoteError,
   bool actionsEnabled = true,
+  bool busy = false,
+  String? selectedContactId,
 }) {
   final step = PayRecipientStep(
     controller: TextEditingController(text: typedAddress),
@@ -71,7 +73,9 @@ Widget _recipientStep({
     addressError: addressError,
     contacts: contacts,
     recents: recents,
-    busy: false,
+    busy: busy,
+    enabled: actionsEnabled,
+    selectedContactId: selectedContactId,
     onAddressChanged: (_) {},
     onOpenScanner: () {},
     onChooseRecipient: onChooseRecipient ?? (_) {},
@@ -80,7 +84,7 @@ Widget _recipientStep({
     typedAddress: typedAddress,
     addressError: addressError,
     contacts: contacts,
-    busy: false,
+    busy: busy,
     enabled: actionsEnabled,
     quoteError: quoteError,
     onSelectRecipient: onSelectRecipient ?? () {},
@@ -127,11 +131,8 @@ void main() {
     );
 
     expect(
-      payRecipientContactForAddress(
-        [contact],
-        _solanaAddress.replaceFirst('N', 'n'),
-      ),
-      isNull,
+      payContactsForAddress([contact], _solanaAddress.replaceFirst('N', 'n')),
+      isEmpty,
     );
   });
 
@@ -548,13 +549,13 @@ void main() {
   });
 
   group('PayRecipientStep', () {
-    testWidgets('empty input decorates recent contacts and shows no CTA', (
+    testWidgets('empty input keeps contact and distinct recent sections', (
       tester,
     ) async {
       await tester.pumpWidget(
         _harness(
           _recipientStep(
-            contacts: [_contact, _recentContact],
+            contacts: [_contact],
             recents: const [
               PayRecentRecipient(
                 address: _recentAddress,
@@ -571,7 +572,6 @@ void main() {
       );
       expect(find.byKey(const ValueKey('pay_contacts_card')), findsOneWidget);
       expect(find.text('Mike'), findsOneWidget);
-      expect(find.text('Recent Mike'), findsWidgets);
       expect(find.text('-24 USDC'), findsOneWidget);
       final userIcon = tester.widget<AppIcon>(
         find.descendant(
@@ -648,41 +648,72 @@ void main() {
       );
     });
 
-    testWidgets(
-      'recent result wins over the same contact and bypasses eager validation',
-      (tester) async {
-        await tester.pumpWidget(
-          _harness(
-            _recipientStep(
-              typedAddress: 'recent mike',
-              addressError: 'Not a valid Ethereum address.',
-              contacts: [_recentContact],
-              recents: const [
-                PayRecentRecipient(
-                  address: _recentAddress,
-                  amountText: '-24 USDC',
-                ),
-              ],
-            ),
+    testWidgets('shows the app spinner while the payment quote is loading', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          _recipientStep(
+            typedAddress: _recentAddress,
+            recents: const [PayRecentRecipient(address: _recentAddress)],
+            busy: true,
           ),
-        );
+        ),
+      );
 
-        expect(
-          find.byKey(const ValueKey('pay_recent_recipients_card')),
-          findsOneWidget,
-        );
-        expect(find.byKey(const ValueKey('pay_contacts_card')), findsNothing);
-        expect(find.text('Recent Mike'), findsOneWidget);
-        expect(find.text('-24 USDC'), findsOneWidget);
-        expect(find.text('Not a valid Ethereum address.'), findsNothing);
-        expect(
-          find.byKey(const ValueKey('pay_select_recipient_button')),
-          findsNothing,
-        );
-      },
-    );
+      final selectButton = find.byKey(
+        const ValueKey('pay_select_recipient_button'),
+      );
+      final loader = find.descendant(
+        of: selectButton,
+        matching: find.byWidgetPredicate(
+          (widget) => widget is AppIcon && widget.name == AppIcons.loader,
+        ),
+      );
 
-    testWidgets('exact recent contact keeps recent selected state', (
+      expect(find.text('Fetching quote'), findsOneWidget);
+      expect(tester.widget<AppButton>(selectButton).onPressed, isNull);
+      expect(loader, findsOneWidget);
+      expect(
+        tester.getCenter(loader).dx,
+        greaterThan(tester.getCenter(find.text('Fetching quote')).dx),
+      );
+    });
+
+    testWidgets('contact result wins over same-address recent history', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          _recipientStep(
+            typedAddress: 'recent mike',
+            addressError: 'Not a valid Ethereum address.',
+            contacts: [_recentContact],
+            recents: const [
+              PayRecentRecipient(
+                address: _recentAddress,
+                amountText: '-24 USDC',
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(
+        find.byKey(const ValueKey('pay_recent_recipients_card')),
+        findsNothing,
+      );
+      expect(find.byKey(const ValueKey('pay_contacts_card')), findsOneWidget);
+      expect(find.text('Recent Mike'), findsOneWidget);
+      expect(find.text('-24 USDC'), findsNothing);
+      expect(find.text('Not a valid Ethereum address.'), findsNothing);
+      expect(
+        find.byKey(const ValueKey('pay_select_recipient_button')),
+        findsNothing,
+      );
+    });
+
+    testWidgets('exact address prefers its saved contact over recent history', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -702,9 +733,9 @@ void main() {
 
       expect(
         find.byKey(const ValueKey('pay_recent_recipients_card')),
-        findsOneWidget,
+        findsNothing,
       );
-      expect(find.byKey(const ValueKey('pay_contacts_card')), findsNothing);
+      expect(find.byKey(const ValueKey('pay_contacts_card')), findsOneWidget);
       expect(
         find.byKey(const ValueKey('pay_add_to_contacts_button')),
         findsNothing,
@@ -816,6 +847,7 @@ void main() {
       tester,
     ) async {
       var reviewRequested = false;
+      var addRequested = false;
       await tester.pumpWidget(
         _harness(
           _recipientStep(
@@ -823,6 +855,7 @@ void main() {
             quoteError: 'USDC on Base is not currently supported.',
             actionsEnabled: false,
             onSelectRecipient: () => reviewRequested = true,
+            onAddToContacts: () => addRequested = true,
           ),
         ),
       );
@@ -835,33 +868,138 @@ void main() {
         find.byKey(const ValueKey('pay_select_recipient_button')),
       );
       expect(button.onPressed, isNull);
+      await tester.tap(
+        find.byKey(const ValueKey('pay_add_to_contacts_button')),
+      );
+      expect(addRequested, isTrue);
       expect(reviewRequested, isFalse);
     });
 
-    testWidgets('row selection does not request review until the CTA', (
-      tester,
-    ) async {
-      String? chosen;
-      var reviewRequested = false;
+    testWidgets('unsupported asset disables recipient rows', (tester) async {
+      PayRecipientSelection? chosen;
       await tester.pumpWidget(
         _harness(
           _recipientStep(
-            typedAddress: _contactAddress,
             contacts: [_contact],
-            onChooseRecipient: (address) => chosen = address,
-            onSelectRecipient: () => reviewRequested = true,
+            recents: const [PayRecentRecipient(address: _recentAddress)],
+            actionsEnabled: false,
+            onChooseRecipient: (selection) => chosen = selection,
           ),
         ),
       );
 
       await tester.tap(find.text('Mike'));
-      expect(chosen, _contactAddress);
-      expect(reviewRequested, isFalse);
+      await tester.tap(
+        find.byKey(const ValueKey('pay_recent_$_recentAddress')),
+      );
+      expect(chosen, isNull);
+    });
+
+    testWidgets('row selection returns the exact contact identity', (
+      tester,
+    ) async {
+      PayRecipientSelection? chosen;
+      await tester.pumpWidget(
+        _harness(
+          _recipientStep(
+            typedAddress: _contactAddress,
+            contacts: [_contact],
+            onChooseRecipient: (selection) => chosen = selection,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Mike'));
+      expect(chosen?.address, _contactAddress);
+      expect(chosen?.contactId, _contact.id);
+    });
+
+    testWidgets('recent row selection returns an address-only recipient', (
+      tester,
+    ) async {
+      PayRecipientSelection? chosen;
+      await tester.pumpWidget(
+        _harness(
+          _recipientStep(
+            recents: const [PayRecentRecipient(address: _recentAddress)],
+            onChooseRecipient: (selection) => chosen = selection,
+          ),
+        ),
+      );
 
       await tester.tap(
-        find.byKey(const ValueKey('pay_select_recipient_button')),
+        find.byKey(const ValueKey('pay_recent_$_recentAddress')),
       );
-      expect(reviewRequested, isTrue);
+      expect(chosen?.address, _recentAddress);
+      expect(chosen?.contactId, isNull);
+    });
+
+    testWidgets('duplicate-address contacts remain individually selectable', (
+      tester,
+    ) async {
+      final duplicate = _contact.copyWith(label: 'Second Mike');
+      final second = AddressBookContact(
+        id: 'second-mike',
+        label: duplicate.label,
+        network: duplicate.network,
+        address: duplicate.address,
+        profilePictureId: duplicate.profilePictureId,
+        createdAtMs: duplicate.createdAtMs,
+        updatedAtMs: duplicate.updatedAtMs,
+      );
+      PayRecipientSelection? chosen;
+
+      await tester.pumpWidget(
+        _harness(
+          _recipientStep(
+            typedAddress: _contactAddress,
+            contacts: [_contact, second],
+            recents: const [PayRecentRecipient(address: _contactAddress)],
+            selectedContactId: second.id,
+            onChooseRecipient: (selection) => chosen = selection,
+          ),
+        ),
+      );
+
+      expect(find.byKey(const ValueKey('pay_contacts_card')), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('pay_recent_recipients_card')),
+        findsNothing,
+      );
+      expect(find.text('Mike'), findsOneWidget);
+      expect(find.text('Second Mike'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('pay_contact_selection_slot_mike')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('pay_contact_selection_slot_second-mike')),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel('Selected contact'), findsOneWidget);
+
+      await tester.tap(find.text('Second Mike'));
+      expect(chosen?.contactId, 'second-mike');
+    });
+
+    testWidgets('unique selected contact does not show a selection check', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          _recipientStep(
+            typedAddress: _contactAddress,
+            contacts: [_contact],
+            selectedContactId: _contact.id,
+          ),
+        ),
+      );
+
+      expect(
+        find.byKey(const ValueKey('pay_contact_selection_slot_mike')),
+        findsNothing,
+      );
+      expect(find.bySemanticsLabel('Selected contact'), findsNothing);
     });
   });
 

--- a/test/features/swap/mobile_swap_review_content_test.dart
+++ b/test/features/swap/mobile_swap_review_content_test.dart
@@ -30,6 +30,7 @@ Widget _harness(Widget child) {
 
 MobileSwapReviewContent _content({
   Iterable<AddressBookContact> addressBookContacts = const [],
+  String? userExternalContactId,
   SwapDirection direction = SwapDirection.zecToExternal,
 }) {
   const externalAddress = '0x9aDFd236b6ccD57bd571ca3C538dbB55FE4819E2';
@@ -53,6 +54,7 @@ MobileSwapReviewContent _content({
     accountLabel: 'Main account',
     accountProfilePictureId: 'default',
     addressBookContacts: addressBookContacts,
+    userExternalContactId: userExternalContactId,
     expired: false,
     amountWarning: null,
     startError: null,
@@ -127,6 +129,46 @@ void main() {
       separator: ' ... ',
     );
     expect(find.text('To: Treasury ($compactAddress)'), findsOneWidget);
+  });
+
+  testWidgets('header names the selected duplicate contact', (tester) async {
+    const address = '0x9aDFd236b6ccD57bd571ca3C538dbB55FE4819E2';
+    await tester.pumpWidget(
+      _harness(
+        _content(
+          userExternalContactId: 'second',
+          addressBookContacts: const [
+            AddressBookContact(
+              id: 'first',
+              label: 'First',
+              network: AddressBookNetwork.ethereum,
+              address: address,
+              profilePictureId: 'default',
+              createdAtMs: 0,
+              updatedAtMs: 0,
+            ),
+            AddressBookContact(
+              id: 'second',
+              label: 'Second',
+              network: AddressBookNetwork.ethereum,
+              address: address,
+              profilePictureId: 'default',
+              createdAtMs: 0,
+              updatedAtMs: 0,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final compactAddress = compactSwapAddress(
+      address,
+      prefixLength: 6,
+      suffixLength: 5,
+      separator: ' ... ',
+    );
+    expect(find.text('To: Second ($compactAddress)'), findsOneWidget);
+    expect(find.textContaining('First'), findsNothing);
   });
 
   testWidgets('review detail help icons use desktop tooltip copy', (

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -287,6 +287,51 @@ void main() {
     );
   });
 
+  testWidgets('review summary names the selected duplicate contact', (
+    tester,
+  ) async {
+    const address = '0x52908400098527886e0f7030069857d2e4169ee7';
+    await tester.pumpWidget(
+      _themeHarnessWithOverlay(
+        _reviewTestPage(
+          direction: SwapDirection.zecToExternal,
+          sellAsset: SwapAsset.zec,
+          receiveAsset: SwapAsset.usdc,
+          sellAmountText: '0.251 ZEC',
+          receiveAmountText: '999.99 USDC',
+          userExternalContactId: 'second',
+          addressBookContacts: [
+            _addressBookContact(
+              id: 'first',
+              label: 'First',
+              network: AddressBookNetwork.ethereum,
+              address: address,
+            ),
+            _addressBookContact(
+              id: 'second',
+              label: 'Second',
+              network: AddressBookNetwork.ethereum,
+              address: address,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final receiveSide = find.byKey(const ValueKey('swap_review_info_receive'));
+    expect(
+      find.descendant(
+        of: receiveSide,
+        matching: find.text('To: Second (0x5290840 ... 4169ee7) on Ethereum'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: receiveSide, matching: find.textContaining('First')),
+      findsNothing,
+    );
+  });
+
   testWidgets('review summary shows the refund address line with copy', (
     tester,
   ) async {
@@ -865,6 +910,106 @@ void main() {
     );
   });
 
+  testWidgets('Pay contact row selects the clicked duplicate before review', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    const address = '0x52908400098527886e0f7030069857d2e4169ee7';
+    final router = GoRouter(initialLocation: '/pay', routes: [_payRoute()]);
+
+    await tester.pumpWidget(
+      _routerHarness(
+        router,
+        seedSwapActivityFixtures: false,
+        addressBookRepository: _FakeAddressBookRepository([
+          const AddressBookContact(
+            id: 'first',
+            label: 'First',
+            network: AddressBookNetwork.ethereum,
+            address: address,
+            profilePictureId: 'pfp-01',
+            createdAtMs: 0,
+            updatedAtMs: 0,
+          ),
+          const AddressBookContact(
+            id: 'second',
+            label: 'Second',
+            network: AddressBookNetwork.ethereum,
+            address: address,
+            profilePictureId: 'pfp-02',
+            createdAtMs: 1,
+            updatedAtMs: 1,
+          ),
+        ]),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('pay_amount_input')),
+      '25',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pay_amount_continue_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('First'), findsOneWidget);
+    expect(find.text('Second'), findsOneWidget);
+    await tester.tap(find.text('Second'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('pay_recipient_step')), findsOneWidget);
+    expect(find.byKey(const ValueKey('pay_review_step')), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('pay_contact_second')),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is AppIcon && widget.name == AppIcons.check,
+        ),
+      ),
+      findsOneWidget,
+    );
+    final firstSelectionSlot = find.byKey(
+      const ValueKey('pay_contact_selection_slot_first'),
+    );
+    final secondSelectionSlot = find.byKey(
+      const ValueKey('pay_contact_selection_slot_second'),
+    );
+    expect(firstSelectionSlot, findsOneWidget);
+    expect(secondSelectionSlot, findsOneWidget);
+    expect(tester.getSize(firstSelectionSlot), const Size.square(18));
+    expect(tester.getSize(secondSelectionSlot), const Size.square(18));
+    expect(
+      tester.getRect(firstSelectionSlot).center.dx,
+      tester.getRect(secondSelectionSlot).center.dx,
+    );
+    expect(
+      find.descendant(
+        of: firstSelectionSlot,
+        matching: find.byWidgetPredicate(
+          (widget) => widget is AppIcon && widget.name == AppIcons.check,
+        ),
+      ),
+      findsNothing,
+    );
+    expect(
+      tester.widget(
+        find.byKey(const ValueKey('pay_contact_row_surface_second')),
+      ),
+      isA<SizedBox>(),
+    );
+    expect(
+      tester.widget<Text>(find.text('Second')).style?.fontWeight,
+      tester.widget<Text>(find.text('First')).style?.fontWeight,
+    );
+    await tester.tap(find.byKey(const ValueKey('pay_select_recipient_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('pay_review_step')), findsOneWidget);
+    expect(find.text('Second'), findsOneWidget);
+    expect(find.text('First'), findsNothing);
+  });
+
   testWidgets('Pay retry waits for its original dynamic asset', (tester) async {
     await _setDesktopViewport(tester);
     final savedBaseUsdc = SwapAsset.live(
@@ -895,6 +1040,7 @@ void main() {
           receiveEstimate: '100 USDC',
           externalAsset: savedBaseUsdc,
           payMode: true,
+          userExternalContactId: 'second',
         );
     final sessionStore = _DelayedPayAssetLoadSwapPersistenceStore(
       initialIntents: [payIntent],
@@ -922,6 +1068,7 @@ void main() {
     expect(state.externalAsset, savedBaseUsdc);
     expect(state.receiveAmountText, '100');
     expect(state.destinationText, '0x52908400098527886e0f7030069857d2e4169ee7');
+    expect(state.userExternalContactId, 'second');
     expect(
       tester
           .widget<AppButton>(
@@ -938,6 +1085,7 @@ void main() {
     expect(state.externalAsset, liveBaseUsdc);
     expect(state.receiveAmountText, '100');
     expect(state.destinationText, '0x52908400098527886e0f7030069857d2e4169ee7');
+    expect(state.userExternalContactId, 'second');
     expect(container.read(paySelectedAssetProvider), liveBaseUsdc);
     expect(
       tester
@@ -2585,6 +2733,12 @@ void main() {
             address: '0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb',
           ),
           _addressBookContact(
+            id: 'usdc-second',
+            label: 'Second USDC Friend',
+            network: AddressBookNetwork.ethereum,
+            address: '0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb',
+          ),
+          _addressBookContact(
             id: 'zcash',
             label: 'Zcash Friend',
             network: AddressBookNetwork.zcash,
@@ -2607,10 +2761,13 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('USDC Friend'), findsOneWidget);
+    expect(find.text('Second USDC Friend'), findsOneWidget);
     expect(find.text('Zcash Friend'), findsNothing);
 
     await tester.tap(
-      find.byKey(const ValueKey('address_book_contact_picker_contact_usdc')),
+      find.byKey(
+        const ValueKey('address_book_contact_picker_contact_usdc-second'),
+      ),
     );
     await tester.pumpAndSettle();
 
@@ -2619,7 +2776,7 @@ void main() {
       findsNothing,
     );
     // The chip shows the matched contact's name instead of the raw address.
-    expect(_destinationSummaryText(tester), 'USDC Friend');
+    expect(_destinationSummaryText(tester), 'Second USDC Friend');
   });
 
   testWidgets('swap contact picker cancel returns to address editor', (
@@ -8138,6 +8295,20 @@ void main() {
         swapProvider: swapProvider,
         depositSender: depositSender,
         sessionStore: sessionStore,
+        addressBookRepository: _FakeAddressBookRepository([
+          _addressBookContact(
+            id: 'first',
+            label: 'First',
+            network: AddressBookNetwork.ethereum,
+            address: '0x52908400098527886e0f7030069857d2e4169ee7',
+          ),
+          _addressBookContact(
+            id: 'second',
+            label: 'Second',
+            network: AddressBookNetwork.ethereum,
+            address: '0x52908400098527886e0f7030069857d2e4169ee7',
+          ),
+        ]),
       ),
     );
     await tester.pumpAndSettle();
@@ -8150,6 +8321,16 @@ void main() {
       tester,
       '0x52908400098527886e0f7030069857d2e4169ee7',
     );
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(SwapScreen)),
+      listen: false,
+    );
+    container
+        .read(swapStateProvider.notifier)
+        .selectDestinationContact(
+          address: '0x52908400098527886e0f7030069857d2e4169ee7',
+          contactId: 'second',
+        );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -8193,9 +8374,12 @@ void main() {
       sessionStore.savedIntents.single.oneClickRefundTo,
       'u1actualshieldedrecipient',
     );
+    expect(sessionStore.savedIntents.single.userExternalContactId, 'second');
     await _openSwapStatusDetails(tester, expand: true);
     expect(find.text('USDC recipient'), findsOneWidget);
-    expect(find.text('0x5290840 ... 4169ee7'), findsOneWidget);
+    expect(find.text('Second'), findsOneWidget);
+    expect(find.text('First'), findsNothing);
+    expect(find.text('0x52908…69ee7'), findsOneWidget);
     expect(find.text('t1live-deposit'), findsWidgets);
     expect(find.text('ZEC deposit tx hash'), findsNothing);
     expect(find.text('Submit ZEC deposit'), findsNothing);
@@ -9472,12 +9656,14 @@ Widget _reviewTestPage({
   required String receiveAmountText,
   ValueChanged<String>? onCopy,
   List<AddressBookContact> addressBookContacts = const [],
+  String? userExternalContactId,
   bool payMode = false,
 }) {
   final externalAsset = direction.sendsZec ? receiveAsset : sellAsset;
   return SwapReviewPageContent(
     onCopy: onCopy,
     addressBookContacts: addressBookContacts,
+    userExternalContactId: userExternalContactId,
     quote: SwapQuote(
       direction: direction,
       sellAsset: sellAsset,


### PR DESCRIPTION
## Problem
Mobile Pay had the same address-only recipient ambiguity and quote-fetch timing issue as desktop. The selected duplicate contact also needed to survive route handoff into review and later Activity rendering.

## Solution
- Pass the explicit recipient selection through the mobile review route.
- Keep contact row taps on the recipient step and fetch the quote only from Continue.
- Preserve the selected contact ID through mobile Pay, Swap review, and Activity.
- Show a bare check only for duplicate-address contact groups with a fixed trailing slot.
- Gate recipient actions on the initial address-book load and use the app loader while fetching a quote.

## Stack
3 of 3. Depends on #494, which depends on #493.

## Verification
- fvm flutter test mobile lane: 46 focused tests
- fvm flutter analyze: 12 changed mobile files
- git diff --check
- Deterministic mobile recipient-step capture verified

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>