### PR TITLE
Fix Keystone scan-help overlay lifecycle

### DIFF
--- a/lib/src/features/keystone/widgets/keystone_scan_help_overlay.dart
+++ b/lib/src/features/keystone/widgets/keystone_scan_help_overlay.dart
@@ -57,7 +57,7 @@ class _KeystoneScanHelpOverlayState extends State<KeystoneScanHelpOverlay> {
   void didUpdateWidget(covariant KeystoneScanHelpOverlay oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!widget.visible) {
-      _hide();
+      _scheduleHide();
       return;
     }
     if (!oldWidget.visible) {
@@ -75,6 +75,13 @@ class _KeystoneScanHelpOverlayState extends State<KeystoneScanHelpOverlay> {
         return;
       }
       _overlayController.show();
+    });
+  }
+
+  void _scheduleHide() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || widget.visible) return;
+      _hide();
     });
   }
 

--- a/test/features/keystone/keystone_scan_help_overlay_test.dart
+++ b/test/features/keystone/keystone_scan_help_overlay_test.dart
@@ -119,6 +119,20 @@ void main() {
     expect(find.text('Scanning issues?'), findsOneWidget);
   });
 
+  testWidgets('hides safely when the QR leaves the ready state', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app(visible: true));
+    await tester.pump();
+    expect(find.text('Scanning issues?'), findsOneWidget);
+
+    await tester.pumpWidget(_app(visible: false));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Scanning issues?'), findsNothing);
+  });
+
   testWidgets('close action supports keyboard focus and activation', (
     tester,
   ) async {


### PR DESCRIPTION
## Problem

On desktop Keystone signing, returning from the signature scan changes the modal phase from ready to broadcasting or preparing during a build. The scan-help OverlayPortal was hidden synchronously from didUpdateWidget, triggering the Flutter persistentCallbacks assertion and a red error screen around broadcast completion.

## Solution

- Defer visibility-driven overlay hiding until the post-frame phase.
- Guard the callback against disposal or visibility changing back.
- Add regression coverage for the visible ready-to-hidden transition.

## Scope

This fixes the OverlayPortal assertion and its subsequent framework cascade. The separate No active stream to cancel scanner cleanup race is not changed here.

## Verification

- fvm flutter test test/features/keystone/keystone_scan_help_overlay_test.dart: 7 tests passed
- fvm flutter test test/features/swap/swap_screen_test.dart --plain-name hardware-ZEC-broadcast-storage-failure: focused hardware broadcast/checkpoint test passed
- fvm flutter analyze on the changed implementation and test: no issues
- git diff --check: passed

## Tracking

A separate Linear issue is intended, but the Linear connector currently requires OAuth reauthentication; no ticket number has been fabricated.