### PR TITLE
Limit wallet reset help to mobile unlock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,9 @@ target account exists before removing account-scoped wallet rows.
   (6 on mobile, 8 on desktop) because the security provider enforces it
   on commit; the mobile passcode screens additionally require exactly
   6 digits (`kMobilePasscodeLength`).
+- The passcode keypad's `?` help action resets the wallet and must appear only
+  on the app-start `/unlock` screen. Never show it in any other passcode keypad
+  context.
 
 ### Dart Provider Structure
 

--- a/lib/src/features/settings/screens/mobile/mobile_change_passcode_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_change_passcode_screen.dart
@@ -6,17 +6,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../../main.dart' show log;
-import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/storage/app_secure_store.dart';
 import '../../../../core/feedback/app_haptics.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../providers/app_security_provider.dart';
 import '../../../../providers/biometric_unlock_provider.dart';
-import '../../../../providers/device_owner_auth_provider.dart';
 import '../../../../providers/router_refresh_provider.dart';
-import '../../../../services/device_owner_auth.dart';
-import '../../../onboarding/mobile/forgot_passcode_sheet.dart';
 import '../../../onboarding/mobile/mobile_passcode_screen.dart'
     show kMobilePasscodeLength;
 import '../../../onboarding/mobile/passcode_widgets.dart';
@@ -25,10 +21,9 @@ enum _Phase { verify, create, confirm }
 
 /// Mobile passcode change — Figma `Enter Passcode` / `Set New Passcode` /
 /// `Confirm Passcode` (4885:24611 / 4885:24699 / 4885:24770). Three numpad
-/// phases: verify the current passcode (with the Forgot Passcode reset sheet
-/// behind the help key), enter the new one, confirm it. The change goes
-/// through the same `appSecurityProvider.changePassword` rotation as the
-/// desktop flow. Pops `true` after a successful change.
+/// phases: verify the current passcode, enter the new one, confirm it. The
+/// change goes through the same `appSecurityProvider.changePassword` rotation
+/// as the desktop flow. Pops `true` after a successful change.
 class MobileChangePasscodeScreen extends ConsumerStatefulWidget {
   const MobileChangePasscodeScreen({super.key});
 
@@ -215,58 +210,6 @@ class _MobileChangePasscodeScreenState
     _error = error;
   }
 
-  Future<void> _showForgotPasscodeSheet() async {
-    final confirmed = await showAppMobileSheet<bool>(
-      context: context,
-      builder: (sheetContext) => const ForgotPasscodeSheet(),
-    );
-    if (confirmed != true || !mounted) return;
-    final lastWarningConfirmed = await showAppMobileSheet<bool>(
-      context: context,
-      builder: (sheetContext) => const ForgotPasscodeLastWarningSheet(),
-    );
-    if (lastWarningConfirmed != true || !mounted) return;
-    await _resetWallet();
-  }
-
-  Future<void> _resetWallet() async {
-    setState(() => _submitting = true);
-    final router = GoRouter.of(context);
-    try {
-      final didReset = await resetWalletForForgottenPasscode(ref);
-      if (!mounted) return;
-      if (!didReset) {
-        setState(() {
-          _submitting = false;
-          _entry = '';
-          _error = null;
-        });
-        return;
-      }
-    } on DeviceOwnerAuthException catch (e, st) {
-      log('MobileChangePasscode._resetWallet auth failed: $e\n$st');
-      if (!mounted) return;
-      setState(() {
-        _submitting = false;
-        _entry = '';
-        _error = e.kind == DeviceOwnerAuthErrorKind.unavailable
-            ? kWalletResetDeviceAuthRequiredMessage
-            : kWalletResetDeviceAuthFailedMessage;
-      });
-      return;
-    } catch (e, st) {
-      log('MobileChangePasscode._resetWallet: ERROR: $e\n$st');
-      if (!mounted) return;
-      setState(() {
-        _submitting = false;
-        _entry = '';
-        _error = "Couldn't reset the app. Please try again.";
-      });
-      return;
-    }
-    router.go('/welcome');
-  }
-
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
@@ -334,9 +277,6 @@ class _MobileChangePasscodeScreenState
                       onDigit: _onDigit,
                       onBackspace: _onBackspace,
                       canDelete: _entry.isNotEmpty,
-                      onHelp: _phase == _Phase.verify && !_submitting
-                          ? _showForgotPasscodeSheet
-                          : null,
                       enabled: !_submitting,
                     ),
                     const SizedBox(height: AppSpacing.md),

--- a/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
@@ -23,13 +23,10 @@ import '../../../../core/widgets/mobile/mobile_surface_card.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/app_security_provider.dart';
 import '../../../../providers/biometric_unlock_provider.dart';
-import '../../../../providers/device_owner_auth_provider.dart';
 import '../../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../../services/biometric_unlock.dart';
-import '../../../../services/device_owner_auth.dart';
-import '../../../onboarding/mobile/forgot_passcode_sheet.dart';
 import '../../../onboarding/mobile/mobile_passcode_screen.dart'
     show kMobilePasscodeLength;
 import '../../../onboarding/mobile/passcode_widgets.dart';
@@ -232,58 +229,6 @@ class _MobileSeedPhraseScreenState
         _gateError = "Couldn't verify the passcode. Try again.";
       });
     }
-  }
-
-  Future<void> _showForgotPasscodeSheet() async {
-    final confirmed = await showAppMobileSheet<bool>(
-      context: context,
-      builder: (sheetContext) => const ForgotPasscodeSheet(),
-    );
-    if (confirmed != true || !mounted) return;
-    final lastWarningConfirmed = await showAppMobileSheet<bool>(
-      context: context,
-      builder: (sheetContext) => const ForgotPasscodeLastWarningSheet(),
-    );
-    if (lastWarningConfirmed != true || !mounted) return;
-    await _resetWallet();
-  }
-
-  Future<void> _resetWallet() async {
-    setState(() => _checking = true);
-    final router = GoRouter.of(context);
-    try {
-      final didReset = await resetWalletForForgottenPasscode(ref);
-      if (!mounted) return;
-      if (!didReset) {
-        setState(() {
-          _checking = false;
-          _entry = '';
-          _gateError = null;
-        });
-        return;
-      }
-    } on DeviceOwnerAuthException catch (e, st) {
-      log('MobileSeedPhrase._resetWallet auth failed: $e\n$st');
-      if (!mounted) return;
-      setState(() {
-        _checking = false;
-        _entry = '';
-        _gateError = e.kind == DeviceOwnerAuthErrorKind.unavailable
-            ? kWalletResetDeviceAuthRequiredMessage
-            : kWalletResetDeviceAuthFailedMessage;
-      });
-      return;
-    } catch (e, st) {
-      log('MobileSeedPhrase._resetWallet: ERROR: $e\n$st');
-      if (!mounted) return;
-      setState(() {
-        _checking = false;
-        _entry = '';
-        _gateError = "Couldn't reset the app. Please try again.";
-      });
-      return;
-    }
-    router.go('/welcome');
   }
 
   // ── Reveal ─────────────────────────────────────────────────────────
@@ -586,7 +531,6 @@ class _MobileSeedPhraseScreenState
           onDigit: _onDigit,
           onBackspace: _onBackspace,
           canDelete: _entry.isNotEmpty,
-          onHelp: _checking ? null : _showForgotPasscodeSheet,
           enabled: !_checking,
         ),
         if (showBiometric) ...[

--- a/lib/src/features/settings/screens/mobile/mobile_viewing_key_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_viewing_key_screen.dart
@@ -7,7 +7,6 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../../main.dart' show log;
 import '../../../../core/clipboard/sensitive_clipboard.dart';
-import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../../core/storage/wallet_paths.dart';
@@ -19,12 +18,9 @@ import '../../../../core/widgets/mobile/mobile_surface_card.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/app_security_provider.dart';
 import '../../../../providers/biometric_unlock_provider.dart';
-import '../../../../providers/device_owner_auth_provider.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
 import '../../../../rust/api/wallet.dart' as rust_wallet;
 import '../../../../services/biometric_unlock.dart';
-import '../../../../services/device_owner_auth.dart';
-import '../../../onboarding/mobile/forgot_passcode_sheet.dart';
 import '../../../onboarding/mobile/mobile_passcode_screen.dart'
     show kMobilePasscodeLength;
 import '../../../onboarding/mobile/passcode_widgets.dart';
@@ -230,58 +226,6 @@ class _MobileViewingKeyScreenState
     }
   }
 
-  Future<void> _showForgotPasscodeSheet() async {
-    final confirmed = await showAppMobileSheet<bool>(
-      context: context,
-      builder: (sheetContext) => const ForgotPasscodeSheet(),
-    );
-    if (confirmed != true || !mounted) return;
-    final lastWarningConfirmed = await showAppMobileSheet<bool>(
-      context: context,
-      builder: (sheetContext) => const ForgotPasscodeLastWarningSheet(),
-    );
-    if (lastWarningConfirmed != true || !mounted) return;
-    await _resetWallet();
-  }
-
-  Future<void> _resetWallet() async {
-    setState(() => _checking = true);
-    final router = GoRouter.of(context);
-    try {
-      final didReset = await resetWalletForForgottenPasscode(ref);
-      if (!mounted) return;
-      if (!didReset) {
-        setState(() {
-          _checking = false;
-          _entry = '';
-          _gateError = null;
-        });
-        return;
-      }
-    } on DeviceOwnerAuthException catch (e, st) {
-      log('MobileViewingKey._resetWallet auth failed: $e\n$st');
-      if (!mounted) return;
-      setState(() {
-        _checking = false;
-        _entry = '';
-        _gateError = e.kind == DeviceOwnerAuthErrorKind.unavailable
-            ? kWalletResetDeviceAuthRequiredMessage
-            : kWalletResetDeviceAuthFailedMessage;
-      });
-      return;
-    } catch (e, st) {
-      log('MobileViewingKey._resetWallet: ERROR: $e\n$st');
-      if (!mounted) return;
-      setState(() {
-        _checking = false;
-        _entry = '';
-        _gateError = "Couldn't reset the app. Please try again.";
-      });
-      return;
-    }
-    router.go('/welcome');
-  }
-
   // ── Reveal ─────────────────────────────────────────────────────────
 
   AccountInfo? _targetAccount(AccountState? accountState) {
@@ -462,7 +406,6 @@ class _MobileViewingKeyScreenState
           onDigit: _onDigit,
           onBackspace: _onBackspace,
           canDelete: _entry.isNotEmpty,
-          onHelp: _checking ? null : _showForgotPasscodeSheet,
           enabled: !_checking,
         ),
         if (showBiometric) ...[

--- a/test/features/settings/mobile_change_passcode_screen_test.dart
+++ b/test/features/settings/mobile_change_passcode_screen_test.dart
@@ -172,13 +172,7 @@ void main() {
     expect(find.text('Confirm your access'), findsOneWidget);
     final verifyTitle = tester.widget<Text>(find.text('Enter Passcode'));
     expect(verifyTitle.style?.fontSize, AppTypography.displayLarge.fontSize);
-    expect(find.bySemanticsLabel('Passcode help'), findsOneWidget);
-
-    await tester.tap(find.bySemanticsLabel('Passcode help'));
-    await tester.pumpAndSettle();
-    expect(find.text('Forgot Passcode?'), findsOneWidget);
-    await tester.tap(find.text('Cancel'));
-    await tester.pumpAndSettle();
+    expect(find.bySemanticsLabel('Passcode help'), findsNothing);
 
     await _enterPasscode(tester, '111111');
     expect(find.text('Incorrect Passcode'), findsOneWidget);
@@ -193,7 +187,7 @@ void main() {
     await tester.pumpWidget(_app(security, popResult: popResult));
     await open(tester);
 
-    expect(find.bySemanticsLabel('Passcode help'), findsOneWidget);
+    expect(find.bySemanticsLabel('Passcode help'), findsNothing);
     await _enterPasscode(tester, '111111');
     expect(find.text('Set New Passcode'), findsOneWidget);
     expect(find.text('6 digits length'), findsOneWidget);

--- a/test/features/settings/mobile_seed_phrase_screen_test.dart
+++ b/test/features/settings/mobile_seed_phrase_screen_test.dart
@@ -218,17 +218,7 @@ void main() {
     final title = tester.widget<Text>(find.text('Enter Passcode'));
     expect(title.style?.fontSize, AppTypography.displayLarge.fontSize);
     expect(find.byType(PasscodeNumpad), findsOneWidget);
-    expect(find.bySemanticsLabel('Passcode help'), findsOneWidget);
-
-    await tester.tap(find.bySemanticsLabel('Passcode help'));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Forgot Passcode?'), findsOneWidget);
-    expect(find.text('Continue to reset Vizor'), findsOneWidget);
-
-    await tester.tap(find.text('Cancel'));
-    await tester.pumpAndSettle();
-    expect(find.text('Forgot Passcode?'), findsNothing);
+    expect(find.bySemanticsLabel('Passcode help'), findsNothing);
   });
 
   testWidgets('reveals the requested account without making it active', (

--- a/test/features/settings/mobile_viewing_key_screen_test.dart
+++ b/test/features/settings/mobile_viewing_key_screen_test.dart
@@ -127,6 +127,7 @@ void main() {
     expect(find.text('Enter Passcode'), findsOneWidget);
     expect(find.text('Confirm your access'), findsOneWidget);
     expect(find.byType(PasscodeNumpad), findsOneWidget);
+    expect(find.bySemanticsLabel('Passcode help'), findsNothing);
   });
 
   testWidgets(


### PR DESCRIPTION
## Summary

- keep the wallet-reset `?` action only on the app-start mobile `/unlock` screen
- remove the reset entry point from in-app passcode confirmation screens
- document the keypad visibility invariant in `AGENTS.md`
- update widget tests to cover the hidden help action

## Why

The help icon opens the forgotten-passcode wallet reset flow. In-app passcode gates are only reachable after the wallet has already been unlocked, so exposing a destructive reset entry point there is unnecessary and misleading.

## Impact

Mobile users still have access to wallet reset when they cannot unlock the app, while passcode confirmation screens now show only the controls relevant to re-authentication.

## Validation

- `fvm flutter analyze` on the changed Dart files and tests
- mobile widget tests for unlock, passcode change, secret phrase, and viewing key screens (34 tests passed)