### PR TITLE
Add mobile Gift Card creation UI states

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -6,6 +6,7 @@ import 'package:flutter/widgets.dart';
 import '../widgetbook/home_use_cases.dart';
 import '../widgetbook/mobile_pay_use_cases.dart';
 import '../widgetbook/pay_use_cases.dart';
+import '../widgetbook/payment_link_mobile_use_cases.dart';
 import '../widgetbook/payment_link_use_cases.dart';
 import '../widgetbook/carousel_use_cases.dart';
 import '../widgetbook/screen_use_cases.dart';
@@ -264,6 +265,62 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     id: 'payment-link-received-message',
     description: 'Desktop received Gift Card message preview',
     builder: buildPaymentLinkReceivedMessageUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-link-home-empty',
+    description: 'Mobile Gift Cards empty state',
+    builder: buildMobilePaymentLinkHomeEmptyUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-link-amount-empty',
+    description: 'Mobile Gift Card amount step without an amount',
+    builder: buildMobilePaymentLinkAmountEmptyUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-link-amount-filled',
+    description: 'Mobile Gift Card amount step with a ZEC value',
+    builder: buildMobilePaymentLinkAmountFilledUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-link-amount-focused',
+    description: 'Mobile Gift Card focused amount editor without OS keyboard',
+    builder: buildMobilePaymentLinkAmountFocusedUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-link-message-empty',
+    description: 'Mobile Gift Card optional-message step without a message',
+    builder: buildMobilePaymentLinkMessageEmptyUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-link-message-filled',
+    description: 'Mobile Gift Card optional-message step with a message',
+    builder: buildMobilePaymentLinkMessageFilledUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-link-message-focused',
+    description: 'Mobile Gift Card focused empty message editor',
+    builder: buildMobilePaymentLinkMessageFocusedUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-link-review',
+    description: 'Mobile Gift Card fee review fixture',
+    builder: buildMobilePaymentLinkReviewUseCase,
+    desktop: false,
+    mobile: true,
   ),
   FigmaCompareScenario(
     id: 'customise-account',

--- a/lib/src/features/payment_links/widgets/mobile/payment_link_mobile_views.dart
+++ b/lib/src/features/payment_links/widgets/mobile/payment_link_mobile_views.dart
@@ -1,0 +1,584 @@
+import 'package:flutter/widgets.dart';
+
+import '../../../../core/layout/mobile/mobile_top_nav.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_button.dart';
+import '../../../../core/widgets/app_icon.dart';
+import '../../../../core/widgets/app_tooltip.dart';
+
+const _referenceContentHeight = 773.0;
+const _topInset = 12.0;
+const _navHeight = 74.0;
+const _sideInset = 16.0;
+const _subtitleTop = 102.0;
+const _cardTop = 207.0;
+const _cardWidth = 361.0;
+const _cardHeight = 225.625;
+const _selectorTop = _cardTop + _cardHeight + AppSpacing.md;
+const _selectorHeight = 80.0;
+const _bottomInset = 12.0;
+const _buttonHeight = 50.0;
+
+/// Empty Gift Cards landing view for the mobile form factor.
+class PaymentLinksHomeMobileView extends StatelessWidget {
+  const PaymentLinksHomeMobileView({
+    required this.illustration,
+    required this.onBack,
+    required this.onShowHelp,
+    required this.onCreate,
+    required this.onRedeem,
+    this.screenTitle = 'Gift Cards',
+    this.title = 'No Gift Cards yet',
+    this.helpLabel = 'How the Gift Card works',
+    this.createLabel = 'Create a card',
+    this.redeemLabel = 'Redeem a card',
+    super.key,
+  });
+
+  final Widget illustration;
+  final VoidCallback onBack;
+  final VoidCallback onShowHelp;
+  final VoidCallback onCreate;
+  final VoidCallback onRedeem;
+  final String screenTitle;
+  final String title;
+  final String helpLabel;
+  final String createLabel;
+  final String redeemLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return _MobilePaymentLinkFrame(
+      title: screenTitle,
+      onBack: onBack,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          Positioned(
+            top: 207,
+            left: _sideInset,
+            right: _sideInset,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  width: 340,
+                  height: 220,
+                  child: Center(
+                    child: SizedBox(
+                      key: const ValueKey(
+                        'payment_links_mobile_empty_illustration',
+                      ),
+                      width: 300,
+                      height: 200,
+                      child: illustration,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.base),
+                Text(
+                  title,
+                  key: const ValueKey('payment_links_mobile_empty_title'),
+                  textAlign: TextAlign.center,
+                  style: AppTypography.headlineLarge.copyWith(
+                    color: context.colors.text.accent,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.s),
+                AppButton(
+                  key: const ValueKey('payment_links_mobile_help_action'),
+                  onPressed: onShowHelp,
+                  variant: AppButtonVariant.ghost,
+                  size: AppButtonSize.mediumLarge,
+                  height: 36,
+                  constrainContent: true,
+                  trailing: AppIcon(
+                    AppIcons.help,
+                    size: 16,
+                    color: context.colors.icon.regular,
+                  ),
+                  child: Text(
+                    helpLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            left: _sideInset,
+            right: _sideInset,
+            bottom: 0,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                AppButton(
+                  key: const ValueKey('payment_links_mobile_redeem_button'),
+                  onPressed: onRedeem,
+                  variant: AppButtonVariant.ghost,
+                  size: AppButtonSize.large,
+                  height: _buttonHeight,
+                  expand: true,
+                  child: Text(redeemLabel),
+                ),
+                const SizedBox(height: AppSpacing.s),
+                AppButton(
+                  key: const ValueKey('payment_links_mobile_create_button'),
+                  onPressed: onCreate,
+                  size: AppButtonSize.large,
+                  height: _buttonHeight,
+                  expand: true,
+                  leading: const AppIcon(
+                    AppIcons.giftCard,
+                    size: AppIconSize.medium,
+                  ),
+                  child: Text(createLabel),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Amount entry and artwork selection state from the completed mobile flow.
+class PaymentLinkAmountMobileView extends StatelessWidget {
+  const PaymentLinkAmountMobileView({
+    required this.card,
+    required this.cardSelector,
+    required this.onBack,
+    this.onContinue,
+    this.supportingText,
+    this.supportingTextIsError = false,
+    this.title = 'Create Gift Card',
+    this.subtitle = 'Enter amount & pick a design.',
+    this.continueLabel = 'Continue',
+    super.key,
+  });
+
+  final Widget card;
+  final Widget cardSelector;
+  final VoidCallback onBack;
+  final VoidCallback? onContinue;
+  final String? supportingText;
+  final bool supportingTextIsError;
+  final String title;
+  final String subtitle;
+  final String continueLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return _MobilePaymentLinkWizardFrame(
+      title: title,
+      subtitle: subtitle,
+      onBack: onBack,
+      card: card,
+      selector: cardSelector,
+      supportingText: supportingText,
+      supportingTextIsError: supportingTextIsError,
+      action: AppButton(
+        key: const ValueKey('payment_link_mobile_amount_continue_button'),
+        onPressed: onContinue,
+        size: AppButtonSize.large,
+        height: _buttonHeight,
+        expand: true,
+        child: Text(continueLabel),
+      ),
+    );
+  }
+}
+
+/// Optional encrypted memo state. The single CTA also handles an empty memo.
+class PaymentLinkMessageMobileView extends StatelessWidget {
+  const PaymentLinkMessageMobileView({
+    required this.card,
+    required this.onBack,
+    this.onContinue,
+    this.onSkip,
+    this.errorText,
+    this.title = 'Enter a message',
+    this.subtitle = 'Attach a short encrypted memo (optional).',
+    this.continueLabel = 'Continue',
+    super.key,
+  });
+
+  final Widget card;
+  final VoidCallback onBack;
+  final VoidCallback? onContinue;
+
+  /// Used by the same Continue CTA only when the caller models an empty memo
+  /// as a separate skip action. It never adds a second visible action.
+  final VoidCallback? onSkip;
+  final String? errorText;
+  final String title;
+  final String subtitle;
+  final String continueLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return _MobilePaymentLinkWizardFrame(
+      title: title,
+      subtitle: subtitle,
+      onBack: onBack,
+      card: card,
+      supportingText: errorText,
+      supportingTextIsError: errorText != null,
+      action: AppButton(
+        key: const ValueKey('payment_link_mobile_message_continue_button'),
+        onPressed: onContinue ?? onSkip,
+        size: AppButtonSize.large,
+        height: _buttonHeight,
+        expand: true,
+        child: Text(continueLabel),
+      ),
+    );
+  }
+}
+
+/// Mobile fee review state. Amounts are supplied by the transaction layer.
+class PaymentLinkReviewMobileView extends StatelessWidget {
+  const PaymentLinkReviewMobileView({
+    required this.card,
+    required this.onBack,
+    required this.cardAmountText,
+    required this.cardFeeText,
+    required this.totalAmountText,
+    this.onContinue,
+    this.onFeeHelp,
+    this.title = 'Review Gift Card',
+    this.subtitle = 'Review amount and fees.',
+    this.continueLabel = 'Create card',
+    super.key,
+  });
+
+  final Widget card;
+  final VoidCallback onBack;
+  final String cardAmountText;
+  final String cardFeeText;
+  final String totalAmountText;
+  final VoidCallback? onContinue;
+  final VoidCallback? onFeeHelp;
+  final String title;
+  final String subtitle;
+  final String continueLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return _MobilePaymentLinkFrame(
+      title: title,
+      onBack: onBack,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          Positioned(
+            top: _subtitleTop,
+            left: _sideInset,
+            right: _sideInset,
+            child: Text(
+              subtitle,
+              key: const ValueKey('payment_link_mobile_review_subtitle'),
+              textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: context.colors.text.secondary,
+              ),
+            ),
+          ),
+          Positioned(
+            top: _cardTop,
+            left: _sideInset,
+            right: _sideInset,
+            child: _MobileCardSlot(card: card),
+          ),
+          Positioned(
+            top: 456.625,
+            left: _sideInset,
+            right: _sideInset,
+            child: Container(
+              key: const ValueKey('payment_link_mobile_review_summary'),
+              width: double.infinity,
+              height: 193,
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.sm,
+                vertical: AppSpacing.base,
+              ),
+              decoration: BoxDecoration(
+                color: context.colors.background.ground,
+                borderRadius: BorderRadius.circular(AppRadii.large),
+              ),
+              child: Column(
+                children: [
+                  _MobileReviewRow(label: 'Card amount', value: cardAmountText),
+                  _MobileReviewRow(
+                    label: 'Card fee (deposit + redeem)',
+                    value: cardFeeText,
+                    onHelp: onFeeHelp,
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  SizedBox(
+                    key: const ValueKey('payment_link_mobile_review_divider'),
+                    width: double.infinity,
+                    height: 1,
+                    child: ColoredBox(color: context.colors.border.regular),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  _MobileReviewRow(
+                    label: 'Total amount deducted',
+                    value: totalAmountText,
+                    emphasized: true,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Positioned(
+            left: _sideInset,
+            right: _sideInset,
+            bottom: _bottomInset,
+            child: AppButton(
+              key: const ValueKey('payment_link_mobile_review_continue_button'),
+              onPressed: onContinue,
+              size: AppButtonSize.large,
+              height: _buttonHeight,
+              expand: true,
+              child: Text(continueLabel),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MobilePaymentLinkWizardFrame extends StatelessWidget {
+  const _MobilePaymentLinkWizardFrame({
+    required this.title,
+    required this.subtitle,
+    required this.onBack,
+    required this.card,
+    required this.action,
+    this.selector,
+    this.supportingText,
+    this.supportingTextIsError = false,
+  });
+
+  final String title;
+  final String subtitle;
+  final VoidCallback onBack;
+  final Widget card;
+  final Widget action;
+  final Widget? selector;
+  final String? supportingText;
+  final bool supportingTextIsError;
+
+  @override
+  Widget build(BuildContext context) {
+    return _MobilePaymentLinkFrame(
+      title: title,
+      onBack: onBack,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          Positioned(
+            top: _subtitleTop,
+            left: _sideInset,
+            right: _sideInset,
+            child: Text(
+              subtitle,
+              key: const ValueKey('payment_link_mobile_step_subtitle'),
+              textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: context.colors.text.secondary,
+              ),
+            ),
+          ),
+          Positioned(
+            top: _cardTop,
+            left: _sideInset,
+            right: _sideInset,
+            child: _MobileCardSlot(card: card),
+          ),
+          if (selector case final selector?)
+            Positioned(
+              top: _selectorTop,
+              left: 0,
+              right: 0,
+              height: _selectorHeight,
+              child: Center(child: selector),
+            ),
+          Positioned(
+            left: _sideInset,
+            right: _sideInset,
+            bottom: _bottomInset,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (supportingText case final message?) ...[
+                  Text(
+                    message,
+                    key: const ValueKey('payment_link_mobile_supporting_text'),
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodySmall.copyWith(
+                      color: supportingTextIsError
+                          ? context.colors.text.destructive
+                          : context.colors.text.secondary,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                ],
+                SizedBox(width: double.infinity, child: action),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MobilePaymentLinkFrame extends StatelessWidget {
+  const _MobilePaymentLinkFrame({
+    required this.title,
+    required this.onBack,
+    required this.body,
+  });
+
+  final String title;
+  final VoidCallback onBack;
+  final Widget body;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final height = constraints.hasBoundedHeight
+            ? constraints.maxHeight
+            : _referenceContentHeight;
+        return SizedBox(
+          key: const ValueKey('payment_link_mobile_view'),
+          width: double.infinity,
+          height: height,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              body,
+              Positioned(
+                top: _topInset,
+                left: 0,
+                right: 0,
+                height: _navHeight,
+                child: MobileTopNav.back(
+                  title: title,
+                  onBack: onBack,
+                  height: _navHeight,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _MobileCardSlot extends StatelessWidget {
+  const _MobileCardSlot({required this.card});
+
+  final Widget card;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox(
+        key: const ValueKey('payment_link_mobile_card_slot'),
+        width: _cardWidth,
+        height: _cardHeight,
+        child: card,
+      ),
+    );
+  }
+}
+
+class _MobileReviewRow extends StatelessWidget {
+  const _MobileReviewRow({
+    required this.label,
+    required this.value,
+    this.onHelp,
+    this.emphasized = false,
+  });
+
+  final String label;
+  final String value;
+  final VoidCallback? onHelp;
+  final bool emphasized;
+
+  @override
+  Widget build(BuildContext context) {
+    final labelStyle = emphasized
+        ? AppTypography.bodyMediumStrong
+        : AppTypography.bodyMedium;
+    final help = AppTooltip(
+      message:
+          'Includes the fee to fund the Gift Card and the fee reserved for '
+          'the recipient to claim it.',
+      preferBelow: true,
+      tapToShow: true,
+      child: Semantics(
+        label: 'About the Gift Card fee',
+        button: onHelp != null,
+        onTap: onHelp,
+        child: AppIcon(
+          AppIcons.help,
+          size: 16,
+          color: context.colors.icon.muted,
+        ),
+      ),
+    );
+
+    return SizedBox(
+      height: 32,
+      child: Row(
+        children: [
+          Expanded(
+            child: Row(
+              children: [
+                Flexible(
+                  child: Text(
+                    label,
+                    style: labelStyle.copyWith(
+                      color: context.colors.text.secondary,
+                    ),
+                  ),
+                ),
+                if (label.startsWith('Card fee')) ...[
+                  const SizedBox(width: AppSpacing.xxs),
+                  Listener(
+                    key: const ValueKey('payment_link_mobile_fee_help'),
+                    onPointerUp: onHelp == null ? null : (_) => onHelp!(),
+                    child: help,
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Text(
+            value,
+            key: ValueKey('payment_link_mobile_review_value_$label'),
+            textAlign: TextAlign.right,
+            style: AppTypography.bodyMediumStrong.copyWith(
+              color: context.colors.text.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/payment_links/widgets/payment_link_card_selector.dart
+++ b/lib/src/features/payment_links/widgets/payment_link_card_selector.dart
@@ -11,9 +11,17 @@ class PaymentLinkCardSelector extends StatelessWidget {
     required this.artwork,
     required this.selected,
     required this.onSelected,
+    this.itemWidth = width,
+    this.itemHeight = height,
+    this.artworkWidth = 60,
+    this.artworkHeight = 44,
+    this.selectionInset = const EdgeInsets.fromLTRB(1, 2, 0, 1),
     this.semanticLabel,
     super.key,
-  });
+  }) : assert(itemWidth > 0),
+       assert(itemHeight > 0),
+       assert(artworkWidth > 0 && artworkWidth <= itemWidth),
+       assert(artworkHeight > 0 && artworkHeight <= itemHeight);
 
   static const double width = 65;
   static const double height = 51;
@@ -21,6 +29,11 @@ class PaymentLinkCardSelector extends StatelessWidget {
   final PaymentLinkCardArtwork artwork;
   final bool selected;
   final VoidCallback onSelected;
+  final double itemWidth;
+  final double itemHeight;
+  final double artworkWidth;
+  final double artworkHeight;
+  final EdgeInsets selectionInset;
   final String? semanticLabel;
 
   @override
@@ -33,16 +46,18 @@ class PaymentLinkCardSelector extends StatelessWidget {
       builder: (context, hovered, focused) {
         final active = selected || focused;
         final opacity = selected || hovered || focused ? 1.0 : 0.5;
+        final artworkLeft = (itemWidth - artworkWidth) / 2;
+        final artworkTop = (itemHeight - artworkHeight) / 2;
         return SizedBox(
-          width: PaymentLinkCardSelector.width,
-          height: PaymentLinkCardSelector.height,
+          width: itemWidth,
+          height: itemHeight,
           child: Stack(
             children: [
               Positioned(
-                left: 3,
-                top: 4,
-                width: 60,
-                height: 44,
+                left: artworkLeft,
+                top: artworkTop,
+                width: artworkWidth,
+                height: artworkHeight,
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(AppRadii.xSmall),
                   child: AnimatedOpacity(
@@ -60,10 +75,10 @@ class PaymentLinkCardSelector extends StatelessWidget {
               ),
               if (active)
                 Positioned(
-                  left: 1,
-                  top: 2,
-                  width: 64,
-                  height: 48,
+                  left: selectionInset.left,
+                  top: selectionInset.top,
+                  right: selectionInset.right,
+                  bottom: selectionInset.bottom,
                   child: IgnorePointer(
                     child: DecoratedBox(
                       key: const ValueKey('payment_link_card_focus_ring'),

--- a/lib/src/features/payment_links/widgets/payment_link_card_selector_rail.dart
+++ b/lib/src/features/payment_links/widgets/payment_link_card_selector_rail.dart
@@ -16,12 +16,21 @@ class PaymentLinkCardSelectorRail extends StatefulWidget {
     required this.selected,
     required this.onSelected,
     this.width = defaultWidth,
+    this.itemWidth = PaymentLinkCardSelector.width,
+    this.itemHeight = PaymentLinkCardSelector.height,
+    this.artworkWidth = 60,
+    this.artworkHeight = 44,
+    this.itemGap = AppSpacing.xxs,
+    this.selectionInset = const EdgeInsets.fromLTRB(1, 2, 0, 1),
     super.key,
   }) : assert(artworks.length > 0),
        assert(
-         width >= PaymentLinkCardSelector.width + (AppSpacing.xxs * 2),
+         width >= itemWidth + (AppSpacing.xxs * 2),
          'width must leave room for the selector edge treatment.',
-       );
+       ),
+       assert(itemWidth > 0),
+       assert(itemHeight > 0),
+       assert(itemGap >= 0);
 
   static const double defaultWidth = 396;
 
@@ -32,6 +41,12 @@ class PaymentLinkCardSelectorRail extends StatefulWidget {
   final PaymentLinkCardArtwork selected;
   final ValueChanged<PaymentLinkCardArtwork> onSelected;
   final double width;
+  final double itemWidth;
+  final double itemHeight;
+  final double artworkWidth;
+  final double artworkHeight;
+  final double itemGap;
+  final EdgeInsets selectionInset;
 
   @override
   State<PaymentLinkCardSelectorRail> createState() =>
@@ -40,13 +55,13 @@ class PaymentLinkCardSelectorRail extends StatefulWidget {
 
 class _PaymentLinkCardSelectorRailState
     extends State<PaymentLinkCardSelectorRail> {
-  static const _itemGap = AppSpacing.xxs;
-  static const _itemStride = PaymentLinkCardSelector.width + _itemGap;
   static const _selectionDuration = Duration(milliseconds: 180);
 
   late final ScrollController _controller;
 
-  double get _sidePadding => (widget.width - PaymentLinkCardSelector.width) / 2;
+  double get _itemStride => widget.itemWidth + widget.itemGap;
+
+  double get _sidePadding => (widget.width - widget.itemWidth) / 2;
 
   @override
   void initState() {
@@ -122,7 +137,7 @@ class _PaymentLinkCardSelectorRailState
     return SizedBox(
       key: const ValueKey('payment_link_card_selector_rail'),
       width: widget.width,
-      height: PaymentLinkCardSelector.height,
+      height: widget.itemHeight,
       child: ClipRect(
         child: ShaderMask(
           key: const ValueKey('payment_link_card_selector_edge_fade'),
@@ -151,7 +166,7 @@ class _PaymentLinkCardSelectorRailState
               itemExtent: _itemStride,
               padding: EdgeInsets.only(
                 left: _sidePadding,
-                right: _sidePadding - _itemGap,
+                right: _sidePadding - widget.itemGap,
               ),
               itemCount: widget.artworks.length,
               itemBuilder: (context, index) {
@@ -163,6 +178,11 @@ class _PaymentLinkCardSelectorRailState
                     artwork: artwork,
                     selected: artwork == widget.selected,
                     onSelected: () => widget.onSelected(artwork),
+                    itemWidth: widget.itemWidth,
+                    itemHeight: widget.itemHeight,
+                    artworkWidth: widget.artworkWidth,
+                    artworkHeight: widget.artworkHeight,
+                    selectionInset: widget.selectionInset,
                   ),
                 );
               },

--- a/lib/src/features/payment_links/widgets/payment_link_gift_card.dart
+++ b/lib/src/features/payment_links/widgets/payment_link_gift_card.dart
@@ -1,7 +1,9 @@
-import 'package:flutter/material.dart' show InputDecoration, TextField;
+import 'package:flutter/material.dart'
+    show InputDecoration, Material, MaterialType, TextField;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import '../../../core/layout/app_form_factor.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
 import 'payment_link_action.dart';
@@ -54,6 +56,8 @@ enum PaymentLinkCardArtwork {
 class PaymentLinkGiftCard extends StatefulWidget {
   const PaymentLinkGiftCard({
     required this.artwork,
+    this.cardWidth = width,
+    this.cardHeight = height,
     this.amountText,
     this.amountController,
     this.amountFocusNode,
@@ -81,7 +85,9 @@ class PaymentLinkGiftCard extends StatefulWidget {
     this.onDeleteMessage,
     this.semanticLabel,
     super.key,
-  }) : assert(maxMessageLength > 0),
+  }) : assert(cardWidth > 0),
+       assert(cardHeight > 0),
+       assert(maxMessageLength > 0),
        assert(
          (amountController == null) == (amountFocusNode == null),
          'amountController and amountFocusNode must be supplied together.',
@@ -108,6 +114,8 @@ class PaymentLinkGiftCard extends StatefulWidget {
   static const double height = 200;
 
   final PaymentLinkCardArtwork artwork;
+  final double cardWidth;
+  final double cardHeight;
 
   /// Null is the default state; empty is active; non-empty is the value state.
   final String? amountText;
@@ -240,8 +248,8 @@ class _PaymentLinkGiftCardState extends State<PaymentLinkGiftCard> {
             ? 'Gift card message'
             : 'Gift card, ${widget.artwork.semanticLabel} design');
     final card = SizedBox(
-      width: PaymentLinkGiftCard.width,
-      height: PaymentLinkGiftCard.height,
+      width: widget.cardWidth,
+      height: widget.cardHeight,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(AppRadii.large),
         child: Stack(
@@ -285,6 +293,7 @@ class _PaymentLinkGiftCardState extends State<PaymentLinkGiftCard> {
                 semanticLabel: label,
                 showCaret: widget.showCaret,
                 motion: motion,
+                cardWidth: widget.cardWidth,
               ),
             const _PaymentLinkGiftCardBorder(),
           ],
@@ -428,6 +437,7 @@ class _PaymentLinkGiftCardFrontContent extends StatelessWidget {
     required this.semanticLabel,
     required this.showCaret,
     required this.motion,
+    required this.cardWidth,
   });
 
   final String? amountText;
@@ -445,6 +455,7 @@ class _PaymentLinkGiftCardFrontContent extends StatelessWidget {
   final String semanticLabel;
   final bool showCaret;
   final PaymentLinkCardMotionScope? motion;
+  final double cardWidth;
 
   @override
   Widget build(BuildContext context) {
@@ -487,6 +498,7 @@ class _PaymentLinkGiftCardFrontContent extends StatelessWidget {
               emptyAmountLabel: emptyAmountLabel,
               semanticLabel: semanticLabel,
               cardTextColor: cardTextColor,
+              availableWidth: cardWidth - (AppSpacing.md * 2),
             ),
           ] else ...[
             if (supportingLoading) ...[
@@ -571,6 +583,7 @@ class _PaymentLinkGiftCardFrontContent extends StatelessWidget {
                 emptyAmountLabel: emptyAmountLabel,
                 semanticLabel: semanticLabel,
                 cardTextColor: cardTextColor,
+                availableWidth: cardWidth - (AppSpacing.md * 2),
               )
             else
               _PaymentLinkStaticAmountRow(
@@ -658,6 +671,7 @@ class _PaymentLinkAmountTextField extends StatelessWidget {
     required this.emptyAmountLabel,
     required this.semanticLabel,
     required this.cardTextColor,
+    required this.availableWidth,
     super.key,
   });
 
@@ -670,6 +684,7 @@ class _PaymentLinkAmountTextField extends StatelessWidget {
   final String emptyAmountLabel;
   final String semanticLabel;
   final Color cardTextColor;
+  final double availableWidth;
 
   @override
   Widget build(BuildContext context) {
@@ -696,10 +711,9 @@ class _PaymentLinkAmountTextField extends StatelessWidget {
       textDirection: Directionality.of(context),
       textScaler: MediaQuery.textScalerOf(context),
     )..layout();
-    final contentWidth = PaymentLinkGiftCard.width - (AppSpacing.md * 2);
     final maxInputWidth = showCurrency
-        ? contentWidth - _amountElementGap - currencyPainter.width
-        : contentWidth;
+        ? availableWidth - _amountElementGap - currencyPainter.width
+        : availableWidth;
     final inputWidth =
         (painter.width + (focused ? cursorGap + _amountCaretWidth : 0)).clamp(
           2.0,
@@ -872,6 +886,13 @@ class _PaymentLinkGiftCardBackContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final cardTextColor = colors.text.homeCard;
+    final mobileMessageAction = kAppFormFactor == AppFormFactor.mobile;
+    final messageActionBackground = mobileMessageAction
+        ? colors.background.ground
+        : colors.background.homeCard;
+    final messageActionForeground = mobileMessageAction
+        ? colors.text.accent
+        : cardTextColor;
     final editing = messageController != null && messageFocusNode != null;
     final displayedMessage = editing ? messageController!.text : message;
     final usedCharacterCount = displayedMessage.characters.length.clamp(
@@ -937,14 +958,14 @@ class _PaymentLinkGiftCardBackContent extends StatelessWidget {
                     Positioned.fill(
                       child: DecoratedBox(
                         decoration: BoxDecoration(
-                          color: colors.background.homeCard,
+                          color: messageActionBackground,
                           shape: BoxShape.circle,
                         ),
                         child: Center(
                           child: AppIcon(
                             AppIcons.trash,
                             size: AppIconSize.medium,
-                            color: cardTextColor,
+                            color: messageActionForeground,
                           ),
                         ),
                       ),
@@ -1002,27 +1023,30 @@ class _PaymentLinkMessageTextField extends StatelessWidget {
       child: MergeSemantics(
         child: Semantics(
           label: semanticLabel,
-          child: TextField(
-            key: editorKey,
-            controller: controller,
-            focusNode: focusNode,
-            style: style,
-            cursorColor: cardTextColor,
-            cursorWidth: 2,
-            cursorRadius: const Radius.circular(AppRadii.full),
-            cursorOpacityAnimates: true,
-            mouseCursor: SystemMouseCursors.text,
-            keyboardType: TextInputType.multiline,
-            textInputAction: TextInputAction.newline,
-            inputFormatters: [
-              ...inputFormatters,
-              LengthLimitingTextInputFormatter(maxMessageLength),
-            ],
-            minLines: 1,
-            maxLines: 7,
-            textAlign: TextAlign.center,
-            decoration: const InputDecoration.collapsed(hintText: null),
-            onChanged: onChanged,
+          child: Material(
+            type: MaterialType.transparency,
+            child: TextField(
+              key: editorKey,
+              controller: controller,
+              focusNode: focusNode,
+              style: style,
+              cursorColor: cardTextColor,
+              cursorWidth: 2,
+              cursorRadius: const Radius.circular(AppRadii.full),
+              cursorOpacityAnimates: true,
+              mouseCursor: SystemMouseCursors.text,
+              keyboardType: TextInputType.multiline,
+              textInputAction: TextInputAction.newline,
+              inputFormatters: [
+                ...inputFormatters,
+                LengthLimitingTextInputFormatter(maxMessageLength),
+              ],
+              minLines: 1,
+              maxLines: 7,
+              textAlign: TextAlign.center,
+              decoration: const InputDecoration.collapsed(hintText: null),
+              onChanged: onChanged,
+            ),
           ),
         ),
       ),

--- a/lib/widgetbook/payment_link_mobile_use_cases.dart
+++ b/lib/widgetbook/payment_link_mobile_use_cases.dart
@@ -1,0 +1,504 @@
+// ignore_for_file: depend_on_referenced_packages
+// Widgetbook is dev-only. Every fixture in this file is isolated from wallet
+// storage, payment-link operations, network access, and Rust state.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../src/core/theme/app_theme.dart';
+import '../src/features/payment_links/models/vizor_payment_link.dart';
+import '../src/features/payment_links/widgets/mobile/payment_link_mobile_views.dart';
+import '../src/features/payment_links/widgets/payment_link_card_selector_rail.dart';
+import '../src/features/payment_links/widgets/payment_link_gift_card.dart';
+
+const _mobilePreviewSize = Size(393, 773);
+const _cardWidth = 361.0;
+const _cardHeight = 225.625;
+const _fixtureAmount = '4.45';
+const _fixtureFee = '0.04 ZEC';
+const _fixtureTotal = '4.49 ZEC';
+const _fixtureMessage = 'Hey there! Welcome to the Shielded World ;)';
+const _fixtureArtwork = PaymentLinkCardArtwork.chestLava;
+const kMobilePaymentLinkPreviewFiatDelay = Duration(milliseconds: 1200);
+
+Widget buildMobilePaymentLinkHomeEmptyUseCase(BuildContext context) {
+  return const _MobilePaymentLinkFrame(child: _PaymentLinkHomeFixture());
+}
+
+Widget buildMobilePaymentLinkAmountEmptyUseCase(BuildContext context) {
+  return _MobilePaymentLinkFrame(
+    child: PaymentLinkAmountMobileView(
+      card: const PaymentLinkGiftCard(
+        artwork: _fixtureArtwork,
+        cardWidth: _cardWidth,
+        cardHeight: _cardHeight,
+        emptyAmountLabel: 'Enter Amount',
+      ),
+      cardSelector: _artworkSelector(_fixtureArtwork),
+      onBack: _noop,
+    ),
+  );
+}
+
+Widget buildMobilePaymentLinkAmountFilledUseCase(BuildContext context) {
+  return _MobilePaymentLinkFrame(
+    child: PaymentLinkAmountMobileView(
+      card: const PaymentLinkGiftCard(
+        artwork: _fixtureArtwork,
+        cardWidth: _cardWidth,
+        cardHeight: _cardHeight,
+        amountText: _fixtureAmount,
+        showCaret: false,
+        supportingLoading: true,
+      ),
+      cardSelector: _artworkSelector(_fixtureArtwork),
+      onBack: _noop,
+      onContinue: _noop,
+    ),
+  );
+}
+
+Widget buildMobilePaymentLinkAmountFocusedUseCase(BuildContext context) {
+  return const _MobilePaymentLinkFrame(child: _FocusedAmountFixture());
+}
+
+Widget buildMobilePaymentLinkMessageEmptyUseCase(BuildContext context) {
+  return const _MobilePaymentLinkFrame(
+    child: PaymentLinkMessageMobileView(
+      card: PaymentLinkGiftCard(
+        artwork: _fixtureArtwork,
+        cardWidth: _cardWidth,
+        cardHeight: _cardHeight,
+        showBack: true,
+      ),
+      onBack: _noop,
+      onSkip: _noop,
+    ),
+  );
+}
+
+Widget buildMobilePaymentLinkMessageFilledUseCase(BuildContext context) {
+  return const _MobilePaymentLinkFrame(
+    child: PaymentLinkMessageMobileView(
+      card: PaymentLinkGiftCard(
+        artwork: _fixtureArtwork,
+        cardWidth: _cardWidth,
+        cardHeight: _cardHeight,
+        showBack: true,
+        message: _fixtureMessage,
+        onDeleteMessage: _noop,
+      ),
+      onBack: _noop,
+      onContinue: _noop,
+    ),
+  );
+}
+
+Widget buildMobilePaymentLinkMessageFocusedUseCase(BuildContext context) {
+  return const _MobilePaymentLinkFrame(child: _FocusedMessageFixture());
+}
+
+Widget buildMobilePaymentLinkReviewUseCase(BuildContext context) {
+  return const _MobilePaymentLinkFrame(
+    child: PaymentLinkReviewMobileView(
+      card: PaymentLinkGiftCard(
+        artwork: _fixtureArtwork,
+        cardWidth: _cardWidth,
+        cardHeight: _cardHeight,
+        amountText: _fixtureAmount,
+        showCaret: false,
+      ),
+      onBack: _noop,
+      cardAmountText: '$_fixtureAmount ZEC',
+      cardFeeText: _fixtureFee,
+      totalAmountText: _fixtureTotal,
+      onContinue: _noop,
+      onFeeHelp: _noop,
+    ),
+  );
+}
+
+Widget buildMobilePaymentLinkInteractiveUseCase(BuildContext context) {
+  return const _MobilePaymentLinkFrame(
+    child: _MobilePaymentLinkInteractivePreview(),
+  );
+}
+
+Widget _artworkSelector(PaymentLinkCardArtwork selected) {
+  return PaymentLinkCardSelectorRail(
+    artworks: PaymentLinkCardArtwork.values,
+    selected: selected,
+    width: _mobilePreviewSize.width,
+    itemWidth: 80,
+    itemHeight: 60,
+    artworkWidth: 76,
+    artworkHeight: 56,
+    itemGap: AppSpacing.xs,
+    selectionInset: EdgeInsets.zero,
+    onSelected: _ignoreArtwork,
+  );
+}
+
+class _PaymentLinkHomeFixture extends StatelessWidget {
+  const _PaymentLinkHomeFixture();
+
+  @override
+  Widget build(BuildContext context) {
+    return PaymentLinksHomeMobileView(
+      illustration: Image.asset(
+        'assets/illustrations/payment_links/payment_link_empty_card.png',
+        fit: BoxFit.contain,
+        excludeFromSemantics: true,
+      ),
+      onBack: _noop,
+      onShowHelp: _noop,
+      onCreate: _noop,
+      onRedeem: _noop,
+    );
+  }
+}
+
+class _FocusedAmountFixture extends StatefulWidget {
+  const _FocusedAmountFixture();
+
+  @override
+  State<_FocusedAmountFixture> createState() => _FocusedAmountFixtureState();
+}
+
+class _FocusedAmountFixtureState extends State<_FocusedAmountFixture> {
+  final _controller = TextEditingController(text: _fixtureAmount);
+  final _focusNode = FocusNode(debugLabel: 'MobilePaymentLinkAmountFixture');
+  var _renderVisualFocusFallback = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (_focusNode.canRequestFocus) {
+        _focusNode.requestFocus();
+      } else {
+        setState(() => _renderVisualFocusFallback = true);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PaymentLinkAmountMobileView(
+      card: _renderVisualFocusFallback
+          ? const PaymentLinkGiftCard(
+              key: ValueKey('mobile_payment_link_amount_focus_fallback'),
+              artwork: _fixtureArtwork,
+              cardWidth: _cardWidth,
+              cardHeight: _cardHeight,
+              amountText: _fixtureAmount,
+              supportingLoading: true,
+            )
+          : PaymentLinkGiftCard(
+              artwork: _fixtureArtwork,
+              cardWidth: _cardWidth,
+              cardHeight: _cardHeight,
+              amountController: _controller,
+              amountFocusNode: _focusNode,
+              amountEditorKey: const ValueKey(
+                'mobile_payment_link_focused_amount_editor',
+              ),
+              supportingLoading: true,
+              semanticLabel: 'Gift card amount input',
+            ),
+      cardSelector: _artworkSelector(_fixtureArtwork),
+      onBack: _noop,
+    );
+  }
+}
+
+class _FocusedMessageFixture extends StatefulWidget {
+  const _FocusedMessageFixture();
+
+  @override
+  State<_FocusedMessageFixture> createState() => _FocusedMessageFixtureState();
+}
+
+class _FocusedMessageFixtureState extends State<_FocusedMessageFixture> {
+  final _controller = TextEditingController();
+  final _focusNode = FocusNode(debugLabel: 'MobilePaymentLinkMessageFixture');
+  var _renderVisualFocusFallback = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (_focusNode.canRequestFocus) {
+        _focusNode.requestFocus();
+      } else {
+        setState(() => _renderVisualFocusFallback = true);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PaymentLinkMessageMobileView(
+      card: _renderVisualFocusFallback
+          ? const PaymentLinkGiftCard(
+              key: ValueKey('mobile_payment_link_message_focus_fallback'),
+              artwork: _fixtureArtwork,
+              cardWidth: _cardWidth,
+              cardHeight: _cardHeight,
+              showBack: true,
+              emptyMessageLabel: '|',
+            )
+          : PaymentLinkGiftCard(
+              artwork: _fixtureArtwork,
+              cardWidth: _cardWidth,
+              cardHeight: _cardHeight,
+              showBack: true,
+              messageController: _controller,
+              messageFocusNode: _focusNode,
+              messageEditorKey: const ValueKey(
+                'mobile_payment_link_focused_message_editor',
+              ),
+              semanticLabel: 'Gift card message input',
+            ),
+      onBack: _noop,
+      onSkip: _noop,
+    );
+  }
+}
+
+class _MobilePaymentLinkFrame extends StatelessWidget {
+  const _MobilePaymentLinkFrame({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox.fromSize(
+        key: const ValueKey('mobile_payment_link_preview_frame'),
+        size: _mobilePreviewSize,
+        child: MediaQuery(
+          data: MediaQuery.of(context).copyWith(size: _mobilePreviewSize),
+          child: ColoredBox(
+            color: context.colors.background.window,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+enum _MobilePaymentLinkStep { amount, message, review }
+
+class _MobilePaymentLinkInteractivePreview extends StatefulWidget {
+  const _MobilePaymentLinkInteractivePreview();
+
+  @override
+  State<_MobilePaymentLinkInteractivePreview> createState() =>
+      _MobilePaymentLinkInteractivePreviewState();
+}
+
+class _MobilePaymentLinkInteractivePreviewState
+    extends State<_MobilePaymentLinkInteractivePreview> {
+  static const _usdPerZec = 272.0;
+  static final _amountFormatter = TextInputFormatter.withFunction((
+    oldValue,
+    newValue,
+  ) {
+    final valid = RegExp(
+      r'^(?:\d+(?:\.\d{0,8})?|\.\d{0,8})?$',
+    ).hasMatch(newValue.text);
+    return valid ? newValue : oldValue;
+  });
+
+  final _amountController = TextEditingController();
+  final _amountFocusNode = FocusNode();
+  final _messageController = TextEditingController();
+  final _messageFocusNode = FocusNode();
+  Timer? _fiatTimer;
+  String? _fiatText;
+  var _fiatLoading = false;
+  var _step = _MobilePaymentLinkStep.amount;
+  var _artwork = _fixtureArtwork;
+
+  bool get _hasPositiveAmount {
+    final raw = _amountController.text;
+    final value = double.tryParse(raw.startsWith('.') ? '0$raw' : raw);
+    return value != null && value > 0;
+  }
+
+  bool get _messageFitsPayload =>
+      PaymentLinkPresentation.isMessageWithinUtf8ByteLimit(
+        _messageController.text,
+      );
+
+  @override
+  void dispose() {
+    _fiatTimer?.cancel();
+    _amountController.dispose();
+    _amountFocusNode.dispose();
+    _messageController.dispose();
+    _messageFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _showStep(_MobilePaymentLinkStep step) {
+    FocusManager.instance.primaryFocus?.unfocus();
+    setState(() => _step = step);
+  }
+
+  void _clearMessage() {
+    _messageController.clear();
+    setState(() {});
+  }
+
+  void _handleAmountChanged(String value) {
+    _fiatTimer?.cancel();
+    final amount = double.tryParse(value.startsWith('.') ? '0$value' : value);
+    if (amount == null || amount <= 0) {
+      setState(() {
+        _fiatLoading = false;
+        _fiatText = null;
+      });
+      return;
+    }
+
+    setState(() {
+      _fiatLoading = true;
+      _fiatText = null;
+    });
+    _fiatTimer = Timer(kMobilePaymentLinkPreviewFiatDelay, () {
+      if (!mounted || _amountController.text != value) return;
+      setState(() {
+        _fiatLoading = false;
+        _fiatText = _formatUsd(amount * _usdPerZec);
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (_step) {
+      _MobilePaymentLinkStep.amount => PaymentLinkAmountMobileView(
+        card: PaymentLinkGiftCard(
+          artwork: _artwork,
+          cardWidth: _cardWidth,
+          cardHeight: _cardHeight,
+          amountController: _amountController,
+          amountFocusNode: _amountFocusNode,
+          amountEditorKey: const ValueKey(
+            'mobile_payment_link_interactive_amount_editor',
+          ),
+          amountInputFormatters: [_amountFormatter],
+          onAmountChanged: _handleAmountChanged,
+          supportingText: _fiatText,
+          supportingLoading: _fiatLoading,
+          maxAmountText: '142.23',
+          onUseMax: () {
+            _amountController.text = _fixtureAmount;
+            _handleAmountChanged(_fixtureAmount);
+          },
+          emptyAmountLabel: 'Enter Amount',
+          semanticLabel: 'Gift card amount input',
+        ),
+        cardSelector: PaymentLinkCardSelectorRail(
+          artworks: PaymentLinkCardArtwork.values,
+          selected: _artwork,
+          width: _mobilePreviewSize.width,
+          itemWidth: 80,
+          itemHeight: 60,
+          artworkWidth: 76,
+          artworkHeight: 56,
+          itemGap: AppSpacing.xs,
+          selectionInset: EdgeInsets.zero,
+          onSelected: (artwork) => setState(() => _artwork = artwork),
+        ),
+        onBack: _noop,
+        onContinue: _hasPositiveAmount
+            ? () => _showStep(_MobilePaymentLinkStep.message)
+            : null,
+      ),
+      _MobilePaymentLinkStep.message => PaymentLinkMessageMobileView(
+        card: PaymentLinkGiftCard(
+          artwork: _artwork,
+          cardWidth: _cardWidth,
+          cardHeight: _cardHeight,
+          showBack: true,
+          messageController: _messageController,
+          messageFocusNode: _messageFocusNode,
+          messageEditorKey: const ValueKey(
+            'mobile_payment_link_interactive_message_editor',
+          ),
+          messageInputFormatters: [
+            LengthLimitingTextInputFormatter(
+              PaymentLinkPresentation.maxMessageCharacters,
+            ),
+          ],
+          onMessageChanged: (_) => setState(() {}),
+          onDeleteMessage: _messageController.text.isEmpty
+              ? null
+              : _clearMessage,
+          semanticLabel: 'Gift card message input',
+        ),
+        onBack: () => _showStep(_MobilePaymentLinkStep.amount),
+        onSkip: () => _showStep(_MobilePaymentLinkStep.review),
+        onContinue: _messageFitsPayload && _messageController.text.isNotEmpty
+            ? () => _showStep(_MobilePaymentLinkStep.review)
+            : null,
+        errorText: _messageFitsPayload
+            ? null
+            : 'This message is too large. Try using fewer complex emoji.',
+      ),
+      _MobilePaymentLinkStep.review => PaymentLinkReviewMobileView(
+        card: PaymentLinkGiftCard(
+          artwork: _artwork,
+          cardWidth: _cardWidth,
+          cardHeight: _cardHeight,
+          amountText: _amountController.text,
+          showCaret: false,
+        ),
+        onBack: () => _showStep(_MobilePaymentLinkStep.message),
+        cardAmountText: '${_amountController.text} ZEC',
+        cardFeeText: _fixtureFee,
+        totalAmountText: '${(_parsedAmount + 0.04).toStringAsFixed(2)} ZEC',
+        onFeeHelp: _noop,
+      ),
+    };
+  }
+
+  double get _parsedAmount {
+    final raw = _amountController.text;
+    return double.tryParse(raw.startsWith('.') ? '0$raw' : raw) ?? 0;
+  }
+
+  static String _formatUsd(double value) {
+    final parts = value.toStringAsFixed(2).split('.');
+    final whole = parts.first.replaceAllMapped(
+      RegExp(r'(\d)(?=(\d{3})+$)'),
+      (match) => '${match[1]},',
+    );
+    return '\$$whole.${parts.last}';
+  }
+}
+
+void _noop() {}
+void _ignoreArtwork(PaymentLinkCardArtwork _) {}

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -21,6 +21,7 @@ import 'home_use_cases.dart';
 import 'mobile_pay_use_cases.dart';
 import 'mobile_shell_use_cases.dart';
 import 'pay_use_cases.dart';
+import 'payment_link_mobile_use_cases.dart';
 import 'payment_link_use_cases.dart';
 import 'receive_use_cases.dart';
 import 'received_receipt_use_cases.dart';
@@ -893,6 +894,47 @@ class WidgetbookApp extends StatelessWidget {
             WidgetbookFolder(
               name: 'Gift Cards',
               children: [
+                WidgetbookComponent(
+                  name: 'Mobile',
+                  useCases: [
+                    WidgetbookUseCase(
+                      name: 'Home - Empty',
+                      builder: buildMobilePaymentLinkHomeEmptyUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Amount - Empty',
+                      builder: buildMobilePaymentLinkAmountEmptyUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Amount - Filled',
+                      builder: buildMobilePaymentLinkAmountFilledUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Amount - Focused',
+                      builder: buildMobilePaymentLinkAmountFocusedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Message - Empty',
+                      builder: buildMobilePaymentLinkMessageEmptyUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Message - Filled',
+                      builder: buildMobilePaymentLinkMessageFilledUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Message - Focused',
+                      builder: buildMobilePaymentLinkMessageFocusedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Review',
+                      builder: buildMobilePaymentLinkReviewUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Interactive simulator',
+                      builder: buildMobilePaymentLinkInteractiveUseCase,
+                    ),
+                  ],
+                ),
                 WidgetbookComponent(
                   name: 'Home',
                   useCases: [

--- a/test/features/payment_links/payment_link_gift_card_test.dart
+++ b/test/features/payment_links/payment_link_gift_card_test.dart
@@ -617,6 +617,25 @@ void main() {
     );
   });
 
+  testWidgets('selector rail accepts the mobile item gap', (tester) async {
+    await _pump(
+      tester,
+      PaymentLinkCardSelectorRail(
+        artworks: PaymentLinkCardArtwork.values,
+        selected: PaymentLinkCardArtwork.knight,
+        itemWidth: 80,
+        itemHeight: 60,
+        itemGap: AppSpacing.xs,
+        onSelected: (_) {},
+      ),
+    );
+
+    final list = tester.widget<ListView>(
+      find.byKey(const ValueKey('payment_link_card_selector_scroll')),
+    );
+    expect(list.itemExtent, 88);
+  });
+
   testWidgets('selector rail accepts mouse dragging', (tester) async {
     await _pump(
       tester,

--- a/test/features/payment_links/payment_link_mobile_views_test.dart
+++ b/test/features/payment_links/payment_link_mobile_views_test.dart
@@ -1,0 +1,156 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/payment_links/widgets/mobile/payment_link_mobile_views.dart';
+
+const _feeHelpText =
+    'Includes the fee to fund the Gift Card and the fee reserved for '
+    'the recipient to claim it.';
+
+void main() {
+  testWidgets('review defaults describe review and card creation', (
+    tester,
+  ) async {
+    await _pumpReview(tester);
+
+    expect(find.text('Review Gift Card'), findsOneWidget);
+    expect(find.text('Review amount and fees.'), findsOneWidget);
+    expect(find.text('Create card'), findsOneWidget);
+    expect(find.text('Enter a message'), findsNothing);
+  });
+
+  testWidgets('fee help tap shows its tooltip and forwards the callback', (
+    tester,
+  ) async {
+    var helpCalls = 0;
+    await _pumpReview(tester, onFeeHelp: () => helpCalls++);
+
+    expect(find.text(_feeHelpText), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey('payment_link_mobile_fee_help')),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(helpCalls, 1);
+    expect(find.text(_feeHelpText), findsOneWidget);
+  });
+
+  testWidgets('wizard and review subtitles are centered', (tester) async {
+    await _pumpAmount(tester);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('payment_link_mobile_step_subtitle')),
+          )
+          .textAlign,
+      TextAlign.center,
+    );
+
+    await _pumpReview(tester);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('payment_link_mobile_review_subtitle')),
+          )
+          .textAlign,
+      TextAlign.center,
+    );
+  });
+
+  testWidgets('review summary matches the mobile Figma surface geometry', (
+    tester,
+  ) async {
+    await _pumpReview(tester);
+
+    final summary = find.byKey(
+      const ValueKey('payment_link_mobile_review_summary'),
+    );
+    expect(tester.getSize(summary), const Size(361, 193));
+    expect(tester.getTopLeft(summary).dx, 16);
+    expect(tester.getTopLeft(summary).dy, closeTo(456.625, 0.01));
+
+    final container = tester.widget<Container>(summary);
+    expect(
+      container.padding,
+      const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: AppSpacing.base,
+      ),
+    );
+    final decoration = container.decoration! as BoxDecoration;
+    expect(decoration.color, AppThemeData.light.colors.background.ground);
+    expect(decoration.borderRadius, BorderRadius.circular(AppRadii.large));
+  });
+
+  testWidgets('amount selector strip uses the lowered mobile anchor', (
+    tester,
+  ) async {
+    await _pumpAmount(tester);
+
+    final selector = find.byKey(const ValueKey('mobile_selector_probe'));
+    expect(tester.getTopLeft(selector).dy, closeTo(466.625, 0.01));
+  });
+}
+
+Future<void> _pumpReview(WidgetTester tester, {VoidCallback? onFeeHelp}) async {
+  await tester.binding.setSurfaceSize(const Size(393, 773));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpWidget(
+    MaterialApp(
+      builder: (_, navigator) =>
+          AppTheme(data: AppThemeData.light, child: navigator!),
+      home: Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 393,
+          height: 773,
+          child: PaymentLinkReviewMobileView(
+            card: const SizedBox(width: 361, height: 225.625),
+            onBack: _noop,
+            cardAmountText: '4.45 ZEC',
+            cardFeeText: '0.04 ZEC',
+            totalAmountText: '4.49 ZEC',
+            onContinue: _noop,
+            onFeeHelp: onFeeHelp,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void _noop() {}
+
+Future<void> _pumpAmount(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(393, 773));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpWidget(
+    MaterialApp(
+      builder: (_, navigator) =>
+          AppTheme(data: AppThemeData.light, child: navigator!),
+      home: Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 393,
+          height: 773,
+          child: PaymentLinkAmountMobileView(
+            card: const SizedBox(width: 361, height: 225.625),
+            cardSelector: const SizedBox(
+              key: ValueKey('mobile_selector_probe'),
+              width: 361,
+              height: 60,
+            ),
+            onBack: _noop,
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/test/widgetbook/payment_link_mobile_use_cases_test.dart
+++ b/test/widgetbook/payment_link_mobile_use_cases_test.dart
@@ -1,0 +1,96 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/widgetbook/payment_link_mobile_use_cases.dart';
+
+void main() {
+  testWidgets('interactive preview accepts amount and message input', (
+    tester,
+  ) async {
+    await _pumpInteractivePreview(tester);
+
+    final amountEditor = find.byKey(
+      const ValueKey('mobile_payment_link_interactive_amount_editor'),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('payment_link_mobile_card_slot')),
+    );
+    await tester.pump();
+    expect(
+      tester.widget<EditableText>(amountEditor).focusNode.hasFocus,
+      isTrue,
+    );
+
+    await tester.enterText(amountEditor, '4.45');
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey('payment_link_fiat_loading_placeholder')),
+      findsOneWidget,
+    );
+    await tester.pump(kMobilePaymentLinkPreviewFiatDelay);
+    expect(find.text(r'$1,210.40'), findsOneWidget);
+
+    final amountContinue = find.byKey(
+      const ValueKey('payment_link_mobile_amount_continue_button'),
+    );
+    expect(tester.widget<AppButton>(amountContinue).onPressed, isNotNull);
+    await tester.tap(amountContinue);
+    await tester.pump();
+
+    expect(find.text('Enter a message'), findsOneWidget);
+    final messageEditor = find.byKey(
+      const ValueKey('mobile_payment_link_interactive_message_editor'),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('payment_link_mobile_card_slot')),
+    );
+    await tester.pump();
+    expect(tester.widget<TextField>(messageEditor).focusNode?.hasFocus, isTrue);
+    expect(find.text('Start typing...'), findsNothing);
+
+    await tester.enterText(messageEditor, 'Congratulations!');
+    await tester.pump();
+    final messageContinue = find.byKey(
+      const ValueKey('payment_link_mobile_message_continue_button'),
+    );
+    expect(tester.widget<AppButton>(messageContinue).onPressed, isNotNull);
+    await tester.tap(messageContinue);
+    await tester.pump();
+
+    expect(find.text('Review Gift Card'), findsOneWidget);
+    expect(find.text('Card amount'), findsOneWidget);
+    expect(find.text('4.49 ZEC'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpInteractivePreview(WidgetTester tester) async {
+  tester.view
+    ..physicalSize = const Size(393, 773)
+    ..devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () {
+            final primary = FocusManager.instance.primaryFocus;
+            if (primary != null && primary is! FocusScopeNode) {
+              primary.unfocus();
+            }
+          },
+          child: Builder(builder: buildMobilePaymentLinkInteractiveUseCase),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}


### PR DESCRIPTION
## Problem

The Payment Link stack has desktop UI coverage, but the completed mobile Figma states were not represented in code. This made the mobile amount, artwork, optional message, and fee-review flow difficult to review or validate without inventing screens that are still in progress.

## Solution

- Add mobile Gift Cards empty, amount/artwork, optional-message, and fee-review views.
- Preserve desktop defaults while allowing the Gift Card and artwork selector to use the mobile Figma dimensions.
- Align mobile subtitles, carousel spacing, review fee surface, fee-help interaction, and review copy with the reviewed design and product behavior.
- Register eight deterministic Figma comparison scenarios and an interactive Widgetbook simulator with local fiat-loading behavior.
- Add focused widget coverage for mobile geometry, input focus, message entry, fee tooltip behavior, and selector spacing.

## Scope

This PR is intentionally limited to the completed mobile Figma states. It does not add production navigation or wallet wiring for mobile claim/redeem, confirmation waiting, link-ready, or card-list flows.

## Verification

- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/payment_links/payment_link_mobile_views_test.dart test/widgetbook/payment_link_mobile_use_cases_test.dart`
- `fvm flutter test test/features/payment_links/payment_link_gift_card_test.dart`
- Targeted `fvm dart analyze` for the changed mobile views, shared Gift Card widgets, previews, and tests
- Deterministic mobile captures for amount, message, and review states in light and dark themes
- `git diff --check`

## Stack

Depends on #471. The base branch is `rowan/payment-links-desktop-ui`.