### PR TITLE
Harden Windows secure storage writes

### DIFF
--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -743,6 +743,13 @@ class AppSecureStore {
         SecureStorageUnavailableException(operation: operation, cause: error),
         stackTrace,
       );
+    } on Exception catch (error, stackTrace) {
+      // FFI-backed platforms can surface native and file-system exceptions
+      // directly instead of wrapping them in PlatformException.
+      Error.throwWithStackTrace(
+        SecureStorageUnavailableException(operation: operation, cause: error),
+        stackTrace,
+      );
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -341,13 +341,12 @@ packages:
     source: hosted
     version: "2.1.0"
   flutter_secure_storage_windows:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: flutter_secure_storage_windows
-      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.0"
+      path: "third_party/flutter_secure_storage_windows"
+      relative: true
+    source: path
+    version: "4.1.0+vizor.1"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,6 +89,8 @@ dependency_overrides:
   freezed: ^3.2.5
   build_runner: ^2.13.1
   freezed_annotation: ^3.1.0
+  flutter_secure_storage_windows:
+    path: third_party/flutter_secure_storage_windows
   json_annotation: ^4.11.0
   json_serializable: ^6.13.1
 

--- a/scripts/windows-single-instance-smoke.ps1
+++ b/scripts/windows-single-instance-smoke.ps1
@@ -1,0 +1,80 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ExecutablePath,
+
+  [int]$StartupTimeoutSeconds = 30,
+  [int]$SecondaryExitTimeoutSeconds = 5,
+  [switch]$ConfirmIsolatedStorage
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $ConfirmIsolatedStorage) {
+  throw "This smoke test forcibly terminates Vizor. Run it only against a build with an isolated VIZOR_WINDOWS_STORAGE_PREFIX, then pass -ConfirmIsolatedStorage."
+}
+
+function Wait-ForMainWindow {
+  param(
+    [System.Diagnostics.Process]$Process,
+    [int]$TimeoutSeconds
+  )
+
+  $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+  while ([DateTime]::UtcNow -lt $deadline) {
+    if ($Process.HasExited) {
+      throw "Vizor exited before creating its main window (exit code $($Process.ExitCode))."
+    }
+    $Process.Refresh()
+    if ($Process.MainWindowHandle -ne [IntPtr]::Zero) {
+      return
+    }
+    Start-Sleep -Milliseconds 100
+  }
+  throw "Vizor did not create a main window within $TimeoutSeconds seconds."
+}
+
+function Stop-OwnedProcess {
+  param([System.Diagnostics.Process]$Process)
+
+  if ($null -eq $Process -or $Process.HasExited) {
+    return
+  }
+  Stop-Process -Id $Process.Id -Force
+  $Process.WaitForExit(5000) | Out-Null
+}
+
+$resolvedExecutable = (Resolve-Path -LiteralPath $ExecutablePath).Path
+$primary = $null
+$secondary = $null
+$replacement = $null
+
+try {
+  Write-Host "Starting primary: $resolvedExecutable"
+  $primary = Start-Process -FilePath $resolvedExecutable -PassThru
+  Wait-ForMainWindow -Process $primary -TimeoutSeconds $StartupTimeoutSeconds
+
+  Write-Host "Starting secondary"
+  $secondary = Start-Process -FilePath $resolvedExecutable -PassThru
+  if (-not $secondary.WaitForExit($SecondaryExitTimeoutSeconds * 1000)) {
+    throw "Secondary Vizor process did not exit within $SecondaryExitTimeoutSeconds seconds."
+  }
+  if ($secondary.ExitCode -ne 0) {
+    throw "Secondary Vizor process exited with code $($secondary.ExitCode)."
+  }
+  if ($primary.HasExited) {
+    throw "Primary Vizor process exited while the secondary was starting."
+  }
+
+  Write-Host "Forcibly terminating primary to verify OS lock recovery"
+  Stop-OwnedProcess -Process $primary
+  $primary = $null
+
+  $replacement = Start-Process -FilePath $resolvedExecutable -PassThru
+  Wait-ForMainWindow -Process $replacement -TimeoutSeconds $StartupTimeoutSeconds
+
+  Write-Host "PASS: secondary execution was blocked and the lock recovered after termination."
+} finally {
+  Stop-OwnedProcess -Process $secondary
+  Stop-OwnedProcess -Process $primary
+  Stop-OwnedProcess -Process $replacement
+}

--- a/scripts/windows-single-instance-smoke.ps1
+++ b/scripts/windows-single-instance-smoke.ps1
@@ -1,3 +1,20 @@
+<#
+Build an isolated executable before running this destructive smoke test:
+
+  powershell.exe -NoProfile -ExecutionPolicy Bypass `
+    -File scripts/package-windows-velopack.ps1 `
+    -Network mainnet `
+    -PackId com.keplr.vizor.single-instance-smoke `
+    -PackTitle "Vizor Single Instance Smoke" `
+    -Channel win-x64-single-instance-smoke `
+    -OutputDir build\velopack\single-instance-smoke
+
+The PackTitle sets the executable's VERSIONINFO ProductName, which determines
+the Windows application-support directory used by the wallet database and
+flutter_secure_storage. Changing only VIZOR_WINDOWS_STORAGE_PREFIX does not
+isolate those files.
+#>
+
 param(
   [Parameter(Mandatory = $true)]
   [string]$ExecutablePath,
@@ -8,10 +25,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-
-if (-not $ConfirmIsolatedStorage) {
-  throw "This smoke test forcibly terminates Vizor. Run it only against a build with an isolated VIZOR_WINDOWS_STORAGE_PREFIX, then pass -ConfirmIsolatedStorage."
-}
+$requiredProductName = "Vizor Single Instance Smoke"
 
 function Wait-ForMainWindow {
   param(
@@ -44,6 +58,28 @@ function Stop-OwnedProcess {
 }
 
 $resolvedExecutable = (Resolve-Path -LiteralPath $ExecutablePath).Path
+$versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($resolvedExecutable)
+$actualProductName = $versionInfo.ProductName
+$productionProductNames = @("Vizor", "Vizor Testnet")
+
+if ([string]::IsNullOrWhiteSpace($actualProductName)) {
+  throw "The executable has no VERSIONINFO ProductName and cannot be verified as storage-isolated: $resolvedExecutable"
+}
+if ($productionProductNames -contains $actualProductName) {
+  throw "Refusing to run the destructive smoke test against production ProductName '$actualProductName'. Build with -PackTitle '$requiredProductName'."
+}
+if (-not [string]::Equals(
+    $actualProductName,
+    $requiredProductName,
+    [System.StringComparison]::Ordinal)) {
+  throw "Executable ProductName '$actualProductName' does not match required smoke ProductName '$requiredProductName'."
+}
+if (-not $ConfirmIsolatedStorage) {
+  throw "This smoke test forcibly terminates Vizor. ProductName '$actualProductName' is storage-isolated; pass -ConfirmIsolatedStorage to continue."
+}
+
+Write-Host "Verified isolated ProductName: $actualProductName"
+
 $primary = $null
 $secondary = $null
 $replacement = $null

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -303,6 +303,23 @@ void main() {
     );
   });
 
+  test('direct storage exceptions surface as storage unavailable', () async {
+    store = AppSecureStore.testing(storage: _DirectFailingReadStorage());
+
+    await expectLater(
+      () => store.readString('zcash_accounts'),
+      throwsA(
+        isA<SecureStorageUnavailableException>()
+            .having(
+              (error) => error.operation,
+              'operation',
+              'read "zcash_accounts"',
+            )
+            .having((error) => error.cause, 'cause', isA<FormatException>()),
+      ),
+    );
+  });
+
   test('changePassword journal stores only roll-forward data', () async {
     final blockingStorage = _BlockingDeleteStorage(
       blockKey: _rotationInProgressKey,
@@ -951,6 +968,21 @@ class _PlatformFailingReadStorage extends FlutterSecureStorage {
       code: 'Libsecret error',
       message: 'Failed to unlock the keyring',
     );
+  }
+}
+
+class _DirectFailingReadStorage extends FlutterSecureStorage {
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    throw const FormatException('Encrypted storage is malformed.');
   }
 }
 

--- a/third_party/flutter_secure_storage_windows/CHANGELOG.md
+++ b/third_party/flutter_secure_storage_windows/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Vizor fork
+
+* Serialize complete read-modify-write transactions across instances and
+  Windows processes.
+* Commit encrypted storage with atomic file replacement and retain a validated
+  backup of the latest committed primary.
+* Recover from a validated backup without deleting unreadable primary data.
+
+## 4.1.0
+Upgrades deprecated member usage of win32.
+
+## 4.0.0
+- This plugin requires a minimum dart sdk of 3.3.0 or higher and a minimum flutter version of 3.19.0.
+- Migrated to new analyzer and clean-up code.
+- Migrates to `win32` version 5.5.4 to support Dart 3.4 / Flutter 3.22.0.
+
+## 3.1.2
+Reverts onCupertinoProtectedDataAvailabilityChanged and isCupertinoProtectedDataAvailable.
+
+## 3.1.1
+Updated flutter_secure_storage_platform_interface to latest version.
+
+## 3.1.0
+Fixed CompanyName and CompanyProduct on Windows are ignored when the lang-charset in the Runner.rc file is not 040904e4
+
+## 3.0.0
+- Migrated to win32 package replacing C.
+- Changed PathNotFoundException to FileSystemException to be backwards compatible with Flutter SDK 2.12.0
+- Applied lint suggestions
+
+## 2.1.1
+Revert changes made in version 2.1.0 due to breaking changes.
+These changes will be republished under a new major version number 3.0.0.
+
+## 2.1.0
+- Changed PathNotFoundException to FileSystemException to be backwards compatible with Flutter SDK 2.12.0
+- Applied lint suggestions
+
+## 2.0.0
+Write encrypted data to files instead of the windows credential system.
+
+## 1.1.3
+Updated flutter_secure_storage_platform_interface to latest version.
+
+## 1.1.2
+- Silently ignore errors when deleting keys that don't exist
+
+## 1.1.1
+- Fix application crash when key doesn't exists.
+
+## 1.1.0
+Features
+- Add readAll, deleteAll and containsKey functions.
+
+Bugfixes
+- Fix implementation of delete operation to allow null value.
+
+## 1.0.0
+- Initial Windows implementation

--- a/third_party/flutter_secure_storage_windows/LICENSE
+++ b/third_party/flutter_secure_storage_windows/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright 2017 German Saprykin
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/flutter_secure_storage_windows/README.md
+++ b/third_party/flutter_secure_storage_windows/README.md
@@ -1,0 +1,23 @@
+# flutter_secure_storage_windows
+
+This is the platform-specific implementation of `flutter_secure_storage` for Windows.
+
+## Features
+
+In the Windows implementation of the flutter_secure_storage plugin, sensitive data is securely stored using a combination of local file storage and the Windows Credential Manager. The storage mechanism ensures both confidentiality and integrity through encryption and controlled access.
+
+When a key-value pair is stored, the value is encrypted using the AES-GCM (Galois/Counter Mode) encryption algorithm. The plugin generates a unique encryption key, securely managed and stored in the Windows Credential Manager. This key is used to encrypt the value, and the resulting encrypted data is saved to a file in the application's support directory. Each file is named after the key (with a .secure extension) and contains the encrypted value along with a nonce (used for AES-GCM encryption) and an authentication tag to verify the integrity of the data during decryption.
+
+The directory for storing these files is dynamically determined based on the application's context, ensuring isolation and protection against unauthorized access. Additionally, for backward compatibility, the plugin can store and retrieve data directly from the Windows Credential Manager if needed. This hybrid approach leverages the security of encrypted local storage and the reliability of the Credential Manager, ensuring robust data protection for Flutter applications running on Windows.
+
+## Installation
+
+Ensure the required C++ ATL libraries are installed alongside Visual Studio Build Tools.
+
+## Usage
+
+Refer to the main [flutter_secure_storage README](../README.md) for common usage instructions.
+
+## License
+
+This project is licensed under the BSD 3 License. See the [LICENSE](../LICENSE) file for details.

--- a/third_party/flutter_secure_storage_windows/README.md
+++ b/third_party/flutter_secure_storage_windows/README.md
@@ -4,11 +4,21 @@ This is the platform-specific implementation of `flutter_secure_storage` for Win
 
 ## Features
 
-In the Windows implementation of the flutter_secure_storage plugin, sensitive data is securely stored using a combination of local file storage and the Windows Credential Manager. The storage mechanism ensures both confidentiality and integrity through encryption and controlled access.
+This implementation serializes all key-value pairs into one JSON object and
+protects the complete payload with Windows Data Protection API (DPAPI). The
+encrypted payload is stored as `flutter_secure_storage.dat` in the
+application-support directory. DPAPI binds decryption to the Windows user
+account that encrypted the data; this implementation does not create or store
+a separate AES key in Windows Credential Manager.
 
-When a key-value pair is stored, the value is encrypted using the AES-GCM (Galois/Counter Mode) encryption algorithm. The plugin generates a unique encryption key, securely managed and stored in the Windows Credential Manager. This key is used to encrypt the value, and the resulting encrypted data is saved to a file in the application's support directory. Each file is named after the key (with a .secure extension) and contains the encrypted value along with a nonce (used for AES-GCM encryption) and an authentication tag to verify the integrity of the data during decryption.
+Windows Credential Manager is accessed only by the optional backward-
+compatibility path for reading, migrating, and removing entries written by an
+older implementation.
 
-The directory for storing these files is dynamically determined based on the application's context, ensuring isolation and protection against unauthorized access. Additionally, for backward compatibility, the plugin can store and retrieve data directly from the Windows Credential Manager if needed. This hybrid approach leverages the security of encrypted local storage and the reliability of the Credential Manager, ensuring robust data protection for Flutter applications running on Windows.
+Vizor vendors this package with atomic replacement, inter-process locking, and
+validated backup recovery. See [VIZOR_FORK.md](VIZOR_FORK.md) for the temporary,
+backup, recovery-marker, and lock sidecars that accompany the primary data
+file.
 
 ## Installation
 

--- a/third_party/flutter_secure_storage_windows/VIZOR_FORK.md
+++ b/third_party/flutter_secure_storage_windows/VIZOR_FORK.md
@@ -1,0 +1,31 @@
+# Vizor Windows secure-storage fork
+
+This directory vendors `flutter_secure_storage_windows` 4.1.0. The root
+`pubspec.yaml` selects it with a path override because the upstream Windows
+implementation writes its DPAPI-encrypted JSON file in place.
+
+Vizor-specific guarantees:
+
+- All public storage operations share one process-wide asynchronous lock.
+- A sidecar `.lock` file serializes the complete read-modify-write transaction
+  across Windows processes.
+- Writes go to a same-directory temporary file, are flushed, and are committed
+  with `ReplaceFileW` or `MoveFileExW` instead of overwriting the primary file.
+- Successful replacements refresh a validated `.bak` snapshot to the latest
+  committed primary, so recovery does not normally resurrect a deleted key.
+- A `.bak.invalid` marker prevents a stale backup from being restored if its
+  refresh is interrupted after the primary commit. A later successful read
+  repairs that backup without turning the committed write into an API failure.
+- If `ReplaceFileW` partially fails after moving the old primary to the backup
+  path, that validated previous primary is restored before the write error is
+  returned. A `.bak.restore` marker makes a transiently failed restoration
+  retryable on the next load without treating an unvalidated stale backup as
+  recoverable. Every new save must remove any older restore marker before it
+  can commit, so restore authorization cannot outlive the backup it validated.
+- A primary is recovered only after a DPAPI decryption or payload-format
+  failure, and only from a backup that decrypts and parses successfully.
+  Transient file-access and other native errors are returned to the caller.
+  Unreadable files are never automatically deleted.
+
+Keep changes to the Dart FFI implementation and its tests focused so this fork
+can be removed after equivalent behavior ships upstream.

--- a/third_party/flutter_secure_storage_windows/lib/flutter_secure_storage_windows.dart
+++ b/third_party/flutter_secure_storage_windows/lib/flutter_secure_storage_windows.dart
@@ -1,0 +1,3 @@
+export 'src/flutter_secure_storage_windows_stub.dart'
+    if (dart.library.ffi) 'src/flutter_secure_storage_windows_ffi.dart'
+    show FlutterSecureStorageWindows;

--- a/third_party/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_ffi.dart
+++ b/third_party/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_ffi.dart
@@ -1,0 +1,887 @@
+// Storage operations are intentionally asynchronous to avoid blocking Flutter.
+// ignore_for_file: avoid_slow_async_io
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+import 'package:win32/win32.dart';
+
+/// An extension on `Map<String, String>` to add support for specific
+/// configuration options related to backward compatibility.
+@visibleForTesting
+extension OptionsExtension on Map<String, String> {
+  /// Checks whether the `useBackwardCompatibility` flag is enabled in the map.
+  ///
+  /// Returns:
+  /// - `true` if the value associated with the `useBackwardCompatibility` key
+  ///   is not `'false'`.
+  /// - `false` otherwise.
+  bool get useBackwardCompatibility =>
+      this['useBackwardCompatibility'] != 'false';
+}
+
+/// Serializes asynchronous critical sections without adding another package.
+class _AsyncLock {
+  Future<void> _tail = Future<void>.value();
+
+  Future<T> run<T>(Future<T> Function() action) {
+    final previous = _tail;
+    final completer = Completer<void>();
+    _tail = completer.future;
+
+    return previous.then((_) => action()).whenComplete(completer.complete);
+  }
+}
+
+/// The `FlutterSecureStorageWindows` class provides a Windows-specific
+/// implementation of the `FlutterSecureStoragePlatform` interface.
+///
+/// This implementation uses a combination of a backward-compatible storage
+/// mechanism and a platform-specific storage backend.
+class FlutterSecureStorageWindows extends FlutterSecureStoragePlatform {
+  /// Creates an instance of `FlutterSecureStorageWindows` with default
+  /// configurations for both backward compatibility and platform-specific
+  /// storage.
+  FlutterSecureStorageWindows()
+      : this._(MethodChannelFlutterSecureStorage(), DpapiJsonFileMapStorage());
+
+  /// Internal constructor to initialize `FlutterSecureStorageWindows` with
+  /// custom implementations for backward compatibility and platform-specific
+  /// storage.
+  ///
+  /// Parameters:
+  /// - [_backwardCompatible]: The storage mechanism used for backward
+  ///   compatibility.
+  /// - [_storage]: The platform-specific storage backend for Windows.
+  FlutterSecureStorageWindows._(this._backwardCompatible, this._storage);
+
+  /// The storage implementation used for backward compatibility.
+  final FlutterSecureStoragePlatform _backwardCompatible;
+
+  /// The platform-specific storage implementation for Windows, using DPAPI.
+  final MapStorage _storage;
+
+  // FlutterSecureStorage can be instantiated more than once. This must be
+  // shared so every instance participates in the same read-modify-write lock.
+  static final _processLock = _AsyncLock();
+
+  Future<T> _runStorageTransaction<T>(Future<T> Function() action) {
+    return _processLock.run(() {
+      final storage = _storage;
+      if (storage is TransactionalMapStorage) {
+        return storage.runTransaction(action);
+      }
+      return action();
+    });
+  }
+
+  /// Registers this plugin.
+  static void registerWith() {
+    FlutterSecureStoragePlatform.instance = FlutterSecureStorageWindows();
+  }
+
+  @override
+  Future<bool> containsKey({
+    required String key,
+    required Map<String, String> options,
+  }) =>
+      _runStorageTransaction(() async {
+        final map = await _storage.load(options);
+        if (map.containsKey(key)) {
+          return true;
+        }
+
+        if (options.useBackwardCompatibility) {
+          return _backwardCompatible.containsKey(key: key, options: options);
+        }
+
+        return false;
+      });
+
+  @override
+  Future<void> delete({
+    required String key,
+    required Map<String, String> options,
+  }) =>
+      _runStorageTransaction(() async {
+        final map = await _storage.load(options);
+        final initialSize = map.length;
+        map.remove(key);
+        if (map.length != initialSize) {
+          await _storage.save(map, options);
+        }
+
+        if (options.useBackwardCompatibility) {
+          await _backwardCompatible.delete(key: key, options: options);
+        }
+      });
+
+  @override
+  Future<void> deleteAll({required Map<String, String> options}) =>
+      _runStorageTransaction(() async {
+        await _storage.clear(options);
+
+        if (options.useBackwardCompatibility) {
+          await _backwardCompatible.deleteAll(options: options);
+        }
+      });
+
+  @override
+  Future<String?> read({
+    required String key,
+    required Map<String, String> options,
+  }) =>
+      _runStorageTransaction(() async {
+        final map = await _storage.load(options);
+
+        var result = map[key];
+        if (options.useBackwardCompatibility) {
+          if (result == null) {
+            final compatible = await _backwardCompatible.read(
+              key: key,
+              options: options,
+            );
+            if (compatible != null) {
+              // Write back now, so the value should be retrieved from JSON
+              // next.
+              result = map[key] = compatible;
+              await _storage.save(map, options);
+            }
+          }
+
+          // Clear old entry.
+          await _backwardCompatible.delete(key: key, options: options);
+        }
+
+        return result;
+      });
+
+  @override
+  Future<Map<String, String>> readAll({required Map<String, String> options}) =>
+      _runStorageTransaction(() async {
+        final map = await _storage.load(options);
+        if (!options.useBackwardCompatibility) {
+          // Just return a map.
+          return map;
+        }
+
+        final compatible = await _backwardCompatible.readAll(options: options);
+
+        if (compatible.isEmpty) {
+          return map;
+        }
+
+        for (final entry in compatible.entries) {
+          map.putIfAbsent(entry.key, () => entry.value);
+        }
+
+        // Write back now, so the value should be retrieved from JSON next.
+        await _storage.save(map, options);
+
+        // Clear old entries.
+        await _backwardCompatible.deleteAll(options: options);
+
+        return map;
+      });
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) =>
+      _runStorageTransaction(() async {
+        final map = await _storage.load(options);
+        map[key] = value;
+        await _storage.save(map, options);
+
+        if (options.useBackwardCompatibility) {
+          // Clear old entry.
+          await _backwardCompatible.delete(key: key, options: options);
+        }
+      });
+}
+
+/// Creates a custom instance of `FlutterSecureStorageWindows` for testing.
+///
+/// This factory function is annotated with `@visibleForTesting` to indicate
+/// its intended use in testing scenarios. It allows specifying custom
+/// implementations for backward compatibility and platform-specific storage.
+///
+/// Parameters:
+/// - [backwardCompatible]: A custom implementation of
+///   `FlutterSecureStoragePlatform` for backward-compatible storage behavior.
+/// - [mapStorage]: A custom implementation of `MapStorage` for Windows secure
+///   storage functionality.
+///
+/// Returns:
+/// - An instance of `FlutterSecureStorageWindows` configured with the given
+///   `backwardCompatible` and `mapStorage` implementations.
+@visibleForTesting
+FlutterSecureStorageWindows createFlutterSecureStorageWindows(
+  FlutterSecureStoragePlatform backwardCompatible,
+  MapStorage mapStorage,
+) =>
+    FlutterSecureStorageWindows._(backwardCompatible, mapStorage);
+
+@visibleForTesting
+
+/// An abstract class that defines the interface for map-based storage
+/// implementations.
+abstract class MapStorage {
+  /// Loads a map of key-value pairs from the storage medium.
+  ///
+  /// Parameters:
+  /// - [options]: A map of options to customize the load operation.
+  FutureOr<Map<String, String>> load(Map<String, String> options);
+
+  /// Saves a map of key-value pairs to the storage medium.
+  ///
+  /// Parameters:
+  /// - [data]: A map containing the data to save.
+  /// - [options]: A map of options to customize the save operation.
+  FutureOr<void> save(Map<String, String> data, Map<String, String> options);
+
+  /// Clears all key-value pairs from the storage medium.
+  ///
+  /// Parameters:
+  /// - [options]: A map of options to customize the clear operation.
+  FutureOr<void> clear(Map<String, String> options);
+}
+
+/// A map storage that can guard a complete load-modify-save transaction.
+abstract class TransactionalMapStorage implements MapStorage {
+  /// Runs [action] while holding the storage's inter-process transaction lock.
+  Future<T> runTransaction<T>(Future<T> Function() action);
+}
+
+/// The file name used to store encrypted JSON data.
+///
+/// This constant is exposed for testing purposes.
+@visibleForTesting
+const String encryptedJsonFileName = 'flutter_secure_storage.dat';
+
+const _backupSuffix = '.bak';
+const _invalidBackupSuffix = '.invalid';
+const _restorePendingSuffix = '.restore';
+const _lockSuffix = '.lock';
+const _temporarySuffix = '.tmp';
+const _transactionLockTimeout = Duration(seconds: 10);
+const _retryDelay = Duration(milliseconds: 25);
+
+// FFI signatures need named native and Dart function types.
+// ignore: avoid_private_typedef_functions
+typedef _ReplaceFileNative = Int32 Function(
+  Pointer<Utf16> replacedFileName,
+  Pointer<Utf16> replacementFileName,
+  Pointer<Utf16> backupFileName,
+  Uint32 replaceFlags,
+  Pointer<Void> exclude,
+  Pointer<Void> reserved,
+);
+// FFI signatures need named native and Dart function types.
+// ignore: avoid_private_typedef_functions
+typedef _ReplaceFileDart = int Function(
+  Pointer<Utf16> replacedFileName,
+  Pointer<Utf16> replacementFileName,
+  Pointer<Utf16> backupFileName,
+  int replaceFlags,
+  Pointer<Void> exclude,
+  Pointer<Void> reserved,
+);
+
+final _replaceFile = DynamicLibrary.open(
+  'kernel32.dll',
+).lookupFunction<_ReplaceFileNative, _ReplaceFileDart>('ReplaceFileW');
+
+class _SecureStorageCorruptionException implements Exception {
+  const _SecureStorageCorruptionException(this.cause);
+
+  final Object cause;
+
+  @override
+  String toString() => 'Secure storage is corrupt: $cause';
+}
+
+/// A `MapStorage` implementation that uses DPAPI (Data Protection API) for
+/// encryption and stores data in a JSON file on disk.
+///
+/// This implementation is specific to Windows platforms.
+@visibleForTesting
+class DpapiJsonFileMapStorage extends TransactionalMapStorage {
+  /// Creates an instance of `DpapiJsonFileMapStorage`.
+  DpapiJsonFileMapStorage({
+    @visibleForTesting Future<void> Function(File primary)? refreshBackup,
+    @visibleForTesting
+    Future<void> Function(File temporary, File destination, File? backup)?
+        commitTemporaryFile,
+  })  : _refreshBackupOverride = refreshBackup,
+        _commitTemporaryFileOverride = commitTemporaryFile;
+
+  final Future<void> Function(File primary)? _refreshBackupOverride;
+  final Future<void> Function(File temporary, File destination, File? backup)?
+      _commitTemporaryFileOverride;
+
+  /// Retrieves the canonical path to the encrypted JSON file used for storage.
+  ///
+  /// This method constructs the file path based on the application's support
+  /// directory.
+  ///
+  /// Returns:
+  /// - A [FutureOr] resolving to the canonical file path as a string.
+  FutureOr<String> _getJsonFilePath() async {
+    final appDataDirectory = await getApplicationSupportDirectory();
+
+    return path.canonicalize(
+      path.join(appDataDirectory.path, encryptedJsonFileName),
+    );
+  }
+
+  @override
+  Future<T> runTransaction<T>(Future<T> Function() action) async {
+    final storagePath = await _getJsonFilePath();
+    final lockFile = File('$storagePath$_lockSuffix');
+    await lockFile.parent.create(recursive: true);
+
+    final handle = await lockFile.open(mode: FileMode.append);
+    var locked = false;
+    try {
+      final deadline = DateTime.now().add(_transactionLockTimeout);
+      while (!locked) {
+        try {
+          await handle.lock(FileLock.exclusive, 0, 1);
+          locked = true;
+        } on FileSystemException catch (error) {
+          final errorCode = error.osError?.errorCode;
+          final isContended = errorCode == ERROR_SHARING_VIOLATION ||
+              errorCode == ERROR_LOCK_VIOLATION;
+          if (!isContended || DateTime.now().isAfter(deadline)) {
+            if (isContended) {
+              throw FileSystemException(
+                'Timed out waiting for the secure-storage transaction lock.',
+                lockFile.path,
+                error.osError,
+              );
+            }
+            rethrow;
+          }
+          await Future<void>.delayed(_retryDelay);
+        }
+      }
+
+      await _deleteStaleTemporaryFiles(File(storagePath));
+      return await action();
+    } finally {
+      if (locked) {
+        await handle.unlock(0, 1);
+      }
+      await handle.close();
+    }
+  }
+
+  Future<void> _deleteStaleTemporaryFiles(File destination) async {
+    if (!await destination.parent.exists()) {
+      return;
+    }
+    await for (final entity in destination.parent.list(followLinks: false)) {
+      if (entity is! File ||
+          !entity.path.startsWith('${destination.path}.') ||
+          !entity.path.endsWith(_temporarySuffix)) {
+        continue;
+      }
+      try {
+        await entity.delete();
+      } on FileSystemException catch (error) {
+        debugPrint(
+          'Could not remove stale secure-storage temporary file '
+          '${entity.path}: $error',
+        );
+      }
+    }
+  }
+
+  @override
+  FutureOr<Map<String, String>> load(Map<String, String> options) async {
+    final file = File(await _getJsonFilePath());
+    final backup = File('${file.path}$_backupSuffix');
+    final invalidBackup = File('${backup.path}$_invalidBackupSuffix');
+    final restorePending = File('${backup.path}$_restorePendingSuffix');
+
+    if (!await file.exists()) {
+      if (!await backup.exists()) {
+        return {};
+      }
+      if (await restorePending.exists()) {
+        final recovered = await _loadFile(backup);
+        await _restoreBackup(file, backup);
+        await _deleteRecoveryMarker(invalidBackup);
+        await _deleteRecoveryMarker(restorePending);
+        return recovered;
+      }
+      if (await invalidBackup.exists()) {
+        throw FileSystemException(
+          'The secure-storage primary is missing and its backup was '
+          'invalidated by an interrupted backup refresh.',
+          file.path,
+        );
+      }
+      final recovered = await _loadFile(backup);
+      await _restoreBackup(file, backup);
+      return recovered;
+    }
+
+    try {
+      final loaded = await _loadFile(file);
+      if (await invalidBackup.exists()) {
+        await _repairInvalidatedBackup(file, invalidBackup);
+      }
+      await _deleteRecoveryMarker(restorePending);
+      return loaded;
+    } on _SecureStorageCorruptionException catch (primaryError, primaryStackTrace) {
+      if (!await invalidBackup.exists() && await backup.exists()) {
+        try {
+          final recovered = await _loadFile(backup);
+          await _restoreBackup(file, backup);
+          debugPrint(
+            'Recovered Windows secure storage from ${backup.path} after '
+            'failing to read ${file.path}: $primaryError',
+          );
+          return recovered;
+        } on Exception catch (backupError) {
+          debugPrint(
+            'Windows secure-storage primary and backup are unreadable. '
+            'Primary: $primaryError Backup: $backupError',
+          );
+        }
+      }
+
+      Error.throwWithStackTrace(primaryError, primaryStackTrace);
+    }
+  }
+
+  Future<Map<String, String>> _loadFile(File file) async {
+    final encryptedText = await file.readAsBytes();
+    try {
+      final plainText = using((alloc) {
+        final pEncryptedText = alloc<Uint8>(encryptedText.length);
+        pEncryptedText.asTypedList(encryptedText.length).setAll(
+              0,
+              encryptedText,
+            );
+
+        // Specify size of the struct explicitly.
+        final encryptedTextBlob = alloc.allocate<CRYPT_INTEGER_BLOB>(
+          sizeOf<CRYPT_INTEGER_BLOB>(),
+        );
+        encryptedTextBlob.ref.cbData = encryptedText.length;
+        encryptedTextBlob.ref.pbData = pEncryptedText;
+
+        // Specify size of the struct explicitly.
+        final plainTextBlob = alloc.allocate<CRYPT_INTEGER_BLOB>(
+          sizeOf<CRYPT_INTEGER_BLOB>(),
+        );
+        if (CryptUnprotectData(
+              encryptedTextBlob,
+              nullptr,
+              nullptr,
+              nullptr,
+              nullptr,
+              0,
+              plainTextBlob,
+            ) ==
+            0) {
+          throw WindowsException(
+            GetLastError(),
+            message: 'Failure on CryptUnprotectData()',
+          );
+        }
+
+        if (plainTextBlob.ref.pbData.address == NULL) {
+          throw WindowsException(
+            ERROR_OUTOFMEMORY,
+            message: 'Failure on CryptUnprotectData()',
+          );
+        }
+
+        try {
+          return utf8.decoder.convert(
+            plainTextBlob.ref.pbData.asTypedList(plainTextBlob.ref.cbData),
+          );
+        } finally {
+          if (plainTextBlob.ref.pbData.address != NULL) {
+            if (LocalFree(plainTextBlob.ref.pbData).address != NULL) {
+              debugPrint(
+                'load: Failed to LocalFree with: '
+                '0x${GetLastError().toHexString(32)}',
+              );
+            }
+          }
+        }
+      });
+
+      final decoded = jsonDecode(plainText);
+
+      if (decoded is! Map ||
+          decoded.entries.any((entry) {
+            return entry.key is! String || entry.value is! String;
+          })) {
+        throw const FormatException(
+          'Secure-storage JSON is not a string-to-string object.',
+        );
+      }
+
+      return {
+        for (final entry in decoded.entries)
+          entry.key as String: entry.value as String,
+      };
+    } on FormatException catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        _SecureStorageCorruptionException(error),
+        stackTrace,
+      );
+    } on WindowsException catch (error, stackTrace) {
+      if (error.hr == ERROR_OUTOFMEMORY) {
+        rethrow;
+      }
+      Error.throwWithStackTrace(
+        _SecureStorageCorruptionException(error),
+        stackTrace,
+      );
+    }
+  }
+
+  Future<void> _restoreBackup(File file, File backup) async {
+    final temporary = await _createTemporaryFile(file);
+    try {
+      final handle = await temporary.open(mode: FileMode.write);
+      try {
+        await handle.writeFrom(await backup.readAsBytes());
+        await handle.flush();
+      } finally {
+        await handle.close();
+      }
+      await _loadFile(temporary);
+      await _commitTemporaryFile(temporary, file, backup: null);
+    } finally {
+      if (await temporary.exists()) {
+        await temporary.delete();
+      }
+    }
+  }
+
+  @override
+  FutureOr<void> save(
+    Map<String, String> data,
+    Map<String, String> options,
+  ) async {
+    final file = File(await _getJsonFilePath());
+    final restorePending = File(
+      '${file.path}$_backupSuffix$_restorePendingSuffix',
+    );
+    // A restore marker authorizes recovery of one previously validated backup.
+    // It must not survive into a new commit where that backup can become stale.
+    await _deleteRecoveryMarkerStrict(restorePending);
+    final json = jsonEncode(data);
+    final plainText = utf8.encode(json);
+
+    await using<FutureOr<void>>((alloc) async {
+      final pPlainText = alloc<Uint8>(plainText.length);
+      pPlainText.asTypedList(plainText.length).setAll(0, plainText);
+
+      // Specify size of the struct explicitly.
+      final plainTextBlob = alloc.allocate<CRYPT_INTEGER_BLOB>(
+        sizeOf<CRYPT_INTEGER_BLOB>(),
+      );
+      plainTextBlob.ref.cbData = plainText.length;
+      plainTextBlob.ref.pbData = pPlainText;
+
+      // Specify size of the struct explicitly.
+      final encryptedTextBlob = alloc.allocate<CRYPT_INTEGER_BLOB>(
+        sizeOf<CRYPT_INTEGER_BLOB>(),
+      );
+      if (CryptProtectData(
+            plainTextBlob,
+            nullptr,
+            nullptr,
+            nullptr,
+            nullptr,
+            0,
+            encryptedTextBlob,
+          ) ==
+          0) {
+        throw WindowsException(
+          GetLastError(),
+          message: 'Failure on CryptProtectData()',
+        );
+      }
+
+      if (encryptedTextBlob.ref.pbData.address == NULL) {
+        throw WindowsException(
+          ERROR_OUTOFMEMORY,
+          message: 'Failure on CryptProtectData()',
+        );
+      }
+
+      try {
+        final encryptedText = Uint8List.fromList(
+          encryptedTextBlob.ref.pbData.asTypedList(
+            encryptedTextBlob.ref.cbData,
+          ),
+        );
+        final temporary = await _createTemporaryFile(file);
+        try {
+          final handle = await temporary.open(mode: FileMode.write);
+          try {
+            await handle.writeFrom(encryptedText);
+            await handle.flush();
+          } finally {
+            await handle.close();
+          }
+          final verified = await _loadFile(temporary);
+          final contentsMatch = verified.length == data.length &&
+              data.entries.every((entry) => verified[entry.key] == entry.value);
+          if (!contentsMatch) {
+            throw const FormatException(
+              'Secure-storage temporary file failed verification.',
+            );
+          }
+          final invalidBackup = File(
+            '${file.path}$_backupSuffix$_invalidBackupSuffix',
+          );
+          final backup = File('${file.path}$_backupSuffix');
+          await invalidBackup.writeAsString('invalid', flush: true);
+          try {
+            await _commitTemporaryFile(temporary, file, backup: backup);
+          } catch (error, stackTrace) {
+            await _recoverAfterFailedPrimaryCommit(
+              primary: file,
+              backup: backup,
+              invalidBackup: invalidBackup,
+              commitError: error,
+              commitStackTrace: stackTrace,
+            );
+          }
+          try {
+            await _refreshBackup(file);
+            await _deleteRecoveryMarker(invalidBackup);
+          } on Exception catch (error) {
+            // The primary commit has completed. Keep the invalidation marker
+            // and report success so callers never roll back a committed write.
+            debugPrint(
+              'Could not refresh the Windows secure-storage backup after '
+              'committing ${file.path}: $error',
+            );
+          }
+        } finally {
+          if (await temporary.exists()) {
+            await temporary.delete();
+          }
+        }
+      } finally {
+        if (encryptedTextBlob.ref.pbData.address != NULL) {
+          if (LocalFree(encryptedTextBlob.ref.pbData).address != NULL) {
+            debugPrint(
+              'save: Failed to LocalFree with: '
+              '0x${GetLastError().toHexString(32)}',
+            );
+          }
+        }
+      }
+    });
+  }
+
+  Future<void> _refreshBackup(File primary) async {
+    final override = _refreshBackupOverride;
+    if (override != null) {
+      await override(primary);
+      return;
+    }
+    final backup = File('${primary.path}$_backupSuffix');
+    final temporary = await _createTemporaryFile(backup);
+    try {
+      final handle = await temporary.open(mode: FileMode.write);
+      try {
+        await handle.writeFrom(await primary.readAsBytes());
+        await handle.flush();
+      } finally {
+        await handle.close();
+      }
+      await _loadFile(temporary);
+      await _commitTemporaryFile(temporary, backup, backup: null);
+    } finally {
+      if (await temporary.exists()) {
+        await temporary.delete();
+      }
+    }
+  }
+
+  Future<void> _repairInvalidatedBackup(
+    File primary,
+    File invalidBackup,
+  ) async {
+    try {
+      await _refreshBackup(primary);
+      await _deleteRecoveryMarker(invalidBackup);
+    } on Exception catch (error) {
+      debugPrint(
+        'Could not repair the invalidated Windows secure-storage backup for '
+        '${primary.path}: $error',
+      );
+    }
+  }
+
+  Future<Never> _recoverAfterFailedPrimaryCommit({
+    required File primary,
+    required File backup,
+    required File invalidBackup,
+    required Object commitError,
+    required StackTrace commitStackTrace,
+  }) async {
+    final restorePending = File('${backup.path}$_restorePendingSuffix');
+    try {
+      if (!await primary.exists() && await backup.exists()) {
+        await _loadFile(backup);
+        await restorePending.writeAsString('restore', flush: true);
+        await _deleteRecoveryMarker(invalidBackup);
+        await _restoreBackup(primary, backup);
+      }
+      await _deleteRecoveryMarker(invalidBackup);
+      await _deleteRecoveryMarker(restorePending);
+    } catch (recoveryError, recoveryStackTrace) {
+      Error.throwWithStackTrace(
+        FileSystemException(
+          'Could not restore secure storage after a failed atomic replace. '
+          'Commit error: $commitError Recovery error: $recoveryError',
+          primary.path,
+        ),
+        recoveryStackTrace,
+      );
+    }
+    Error.throwWithStackTrace(commitError, commitStackTrace);
+  }
+
+  Future<void> _deleteRecoveryMarker(File marker) async {
+    try {
+      if (await marker.exists()) {
+        await marker.delete();
+      }
+    } on FileSystemException catch (error) {
+      debugPrint(
+        'Could not remove Windows secure-storage recovery marker '
+        '${marker.path}: $error',
+      );
+    }
+  }
+
+  Future<void> _deleteRecoveryMarkerStrict(File marker) async {
+    if (await marker.exists()) {
+      await marker.delete();
+    }
+  }
+
+  Future<File> _createTemporaryFile(File destination) async {
+    await destination.parent.create(recursive: true);
+    for (var attempt = 0; attempt < 100; attempt++) {
+      final temporary = File(
+        '${destination.path}.$pid.'
+        '${DateTime.now().microsecondsSinceEpoch}.$attempt$_temporarySuffix',
+      );
+      try {
+        return await temporary.create(exclusive: true);
+      } on PathExistsException {
+        // Retry with a distinct attempt suffix.
+      }
+    }
+    throw FileSystemException(
+      'Could not allocate a secure-storage temporary file.',
+      destination.path,
+    );
+  }
+
+  Future<void> _commitTemporaryFile(
+    File temporary,
+    File destination, {
+    required File? backup,
+  }) async {
+    final override = _commitTemporaryFileOverride;
+    if (override != null) {
+      await override(temporary, destination, backup);
+      return;
+    }
+    final deadline = DateTime.now().add(const Duration(seconds: 2));
+    while (true) {
+      final succeeded = using((alloc) {
+        final temporaryPath = temporary.path.toNativeUtf16(allocator: alloc);
+        final destinationPath = destination.path.toNativeUtf16(
+          allocator: alloc,
+        );
+
+        if (!destination.existsSync()) {
+          return MoveFileEx(
+                temporaryPath,
+                destinationPath,
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+              ) !=
+              0;
+        }
+
+        final backupPath = backup == null
+            ? nullptr.cast<Utf16>()
+            : backup.path.toNativeUtf16(allocator: alloc);
+        return _replaceFile(
+              destinationPath,
+              temporaryPath,
+              backupPath,
+              0,
+              nullptr,
+              nullptr,
+            ) !=
+            0;
+      });
+      if (succeeded) {
+        return;
+      }
+
+      final errorCode = GetLastError();
+      final isRetriable = errorCode == ERROR_SHARING_VIOLATION ||
+          errorCode == ERROR_LOCK_VIOLATION ||
+          errorCode == ERROR_FILE_NOT_FOUND;
+      if (!isRetriable || DateTime.now().isAfter(deadline)) {
+        throw WindowsException(
+          errorCode,
+          message: 'Could not atomically replace Windows secure storage.',
+        );
+      }
+      await Future<void>.delayed(_retryDelay);
+    }
+  }
+
+  @override
+  FutureOr<void> clear(Map<String, String> options) async {
+    final file = File(await _getJsonFilePath());
+    final backup = File('${file.path}$_backupSuffix');
+    final invalidBackup = File('${backup.path}$_invalidBackupSuffix');
+    final restorePending = File('${backup.path}$_restorePendingSuffix');
+
+    // Delete the backup first so an interrupted clear sees the old primary or
+    // an empty store, never a missing primary that resurrects from backup.
+    if (await backup.exists()) {
+      await backup.delete();
+    }
+    if (await file.exists()) {
+      await file.delete();
+    }
+    await _deleteRecoveryMarker(invalidBackup);
+    await _deleteRecoveryMarker(restorePending);
+
+    await _deleteStaleTemporaryFiles(file);
+  }
+}

--- a/third_party/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_stub.dart
+++ b/third_party/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_stub.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+
+/// A stub implementation to avoid extra transitive dependencies
+/// on non-Windows platforms including web.
+class FlutterSecureStorageWindows extends FlutterSecureStoragePlatform {
+  /// Cannot be instantiated.
+  FlutterSecureStorageWindows()
+      : assert(false, 'Cannot instantiate this class.');
+
+  /// Registers this plugin.
+  static void registerWith() {
+    FlutterSecureStoragePlatform.instance = FlutterSecureStorageWindows();
+  }
+
+  @override
+  Future<bool> containsKey({
+    required String key,
+    required Map<String, String> options,
+  }) =>
+      Future.value(false);
+
+  @override
+  Future<void> delete({
+    required String key,
+    required Map<String, String> options,
+  }) =>
+      Future.value();
+
+  @override
+  Future<void> deleteAll({required Map<String, String> options}) =>
+      Future.value();
+
+  @override
+  Future<String?> read({
+    required String key,
+    required Map<String, String> options,
+  }) =>
+      Future.value();
+
+  @override
+  Future<Map<String, String>> readAll({required Map<String, String> options}) =>
+      Future.value({});
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) =>
+      Future.value();
+
+  // @override
+  // Future<bool> isCupertinoProtectedDataAvailable() => Future.value(true);
+  //
+  // @override
+  // Stream<bool> get onCupertinoProtectedDataAvailabilityChanged =>
+  //     Stream.value(true);
+}

--- a/third_party/flutter_secure_storage_windows/pubspec.yaml
+++ b/third_party/flutter_secure_storage_windows/pubspec.yaml
@@ -1,0 +1,32 @@
+name: flutter_secure_storage_windows
+description: Windows implementation of flutter_secure_storage. Please use flutter_secure_storage instead of this package.
+repository: https://github.com/mogol/flutter_secure_storage
+version: 4.1.0+vizor.1
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: '>=3.19.0'
+
+dependencies:
+  ffi: ^2.0.0
+  flutter:
+    sdk: flutter
+  flutter_secure_storage_platform_interface: ^2.0.0
+  path: ^1.8.0
+  path_provider: ^2.0.0
+  win32: ^5.5.4
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  path_provider_platform_interface: ^2.1.2
+  path_provider_windows: ^2.2.1
+  very_good_analysis: ^7.0.0
+
+flutter:
+  plugin:
+    implements: flutter_secure_storage
+    platforms:
+      windows:
+        pluginClass: FlutterSecureStorageWindowsPlugin
+        dartPluginClass: FlutterSecureStorageWindows

--- a/third_party/flutter_secure_storage_windows/test/unit_test.dart
+++ b/third_party/flutter_secure_storage_windows/test/unit_test.dart
@@ -1,0 +1,1591 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_secure_storage_windows/src/flutter_secure_storage_windows_ffi.dart'
+    as ffi;
+import 'package:flutter_secure_storage_windows/src/flutter_secure_storage_windows_ffi.dart';
+import 'package:flutter_secure_storage_windows/src/flutter_secure_storage_windows_stub.dart'
+    as stub;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:path_provider_windows/path_provider_windows.dart';
+import 'package:win32/win32.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  PathProviderPlatform.instance = PathProviderWindows();
+
+  FutureOr<void> cleanUpFiles() async {
+    if (!Platform.isWindows) {
+      return;
+    }
+    // Clean up current & legacy files.
+    final directory = await getApplicationSupportDirectory();
+    if (directory.existsSync()) {
+      directory
+          .listSync(followLinks: false)
+          .whereType<File>()
+          .where(
+            (f) =>
+                path.basename(f.path).startsWith(encryptedJsonFileName) ||
+                f.path.endsWith('.secure'),
+          )
+          .forEach((f) => f.deleteSync());
+    }
+  }
+
+  setUpAll(() async {
+    await cleanUpFiles();
+  });
+
+  tearDown(() async {
+    await cleanUpFiles();
+  });
+
+  group('Transaction serialization', () {
+    Map<String, String> createOptions() =>
+        {'useBackwardCompatibility': 'false'};
+
+    test('serializes writes across plugin instances', () async {
+      final storage = _DelayedMapStorage();
+      final first = ffi.createFlutterSecureStorageWindows(
+        MethodChannelFlutterSecureStorage(),
+        storage,
+      );
+      final second = ffi.createFlutterSecureStorageWindows(
+        MethodChannelFlutterSecureStorage(),
+        storage,
+      );
+      final options = createOptions();
+
+      await Future.wait(
+        List.generate(100, (index) {
+          final target = index.isEven ? first : second;
+          return target.write(
+            key: 'key-$index',
+            value: 'value-$index',
+            options: options,
+          );
+        }),
+      );
+
+      expect(storage.values, hasLength(100));
+      for (var index = 0; index < 100; index++) {
+        expect(storage.values['key-$index'], 'value-$index');
+      }
+    });
+
+    test('wraps each public operation in one storage transaction', () async {
+      final storage = _TrackingTransactionalMapStorage();
+      final target = ffi.createFlutterSecureStorageWindows(
+        MethodChannelFlutterSecureStorage(),
+        storage,
+      );
+      final options = createOptions();
+
+      await target.write(key: 'key', value: 'value', options: options);
+      await target.read(key: 'key', options: options);
+      await target.readAll(options: options);
+      await target.containsKey(key: 'key', options: options);
+      await target.delete(key: 'key', options: options);
+      await target.deleteAll(options: options);
+
+      expect(storage.transactionCount, 6);
+      expect(storage.maximumConcurrentTransactions, 1);
+    });
+
+    test(
+      'sidecar file lock serializes separate storage objects',
+      () => withFfi(() async {
+        final firstStorage = ffi.DpapiJsonFileMapStorage();
+        final secondStorage = ffi.DpapiJsonFileMapStorage();
+        final firstEntered = Completer<void>();
+        final releaseFirst = Completer<void>();
+        var secondEntered = false;
+
+        final first = firstStorage.runTransaction(() async {
+          firstEntered.complete();
+          await releaseFirst.future;
+        });
+        await firstEntered.future;
+
+        final second = secondStorage.runTransaction(() async {
+          secondEntered = true;
+        });
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(secondEntered, isFalse);
+
+        releaseFirst.complete();
+        await Future.wait([first, second]);
+        expect(secondEntered, isTrue);
+      }),
+    );
+  });
+
+  group(
+    'Basic test cases',
+    () {
+      FlutterSecureStoragePlatform createTarget() {
+        TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+          (methodCall) async {
+            assert(false, 'MethodChanel is called.');
+            return null;
+          },
+        );
+        return ffi.FlutterSecureStorageWindows();
+      }
+
+      Map<String, String> createOptions() =>
+          {'useBackwardCompatibility': 'false'};
+
+      test(
+        'readAll - empty',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          final result = await target.readAll(options: options);
+          expect(result, isEmpty);
+        }),
+      );
+
+      test(
+        'readAll - 1 entries',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          const key = 'KEY';
+          const value = 'VALUE';
+          await target.write(key: key, value: value, options: options);
+          final result = await target.readAll(options: options);
+          expect(result.length, 1);
+          expect(result[key], value);
+        }),
+      );
+
+      test(
+        'readAll - 2 entries',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          const key1 = 'KEY1';
+          const value1 = 'VALUE1';
+          const key2 = 'KEY2';
+          const value2 = 'VALUE2';
+          await target.write(key: key1, value: value1, options: options);
+          await target.write(key: key2, value: value2, options: options);
+          final result = await target.readAll(options: options);
+          expect(result.length, 2);
+          expect(result[key1], value1);
+          expect(result[key2], value2);
+        }),
+      );
+
+      test(
+        'read - exists',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          const key = 'KEY';
+          const value = 'VALUE';
+          await target.write(key: key, value: value, options: options);
+          final result = await target.read(key: key, options: options);
+          expect(result, isNotNull);
+          expect(result, value);
+        }),
+      );
+
+      test(
+        'read - does not exist',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          const key = 'KEY';
+          final result = await target.read(key: key, options: options);
+          expect(result, isNull);
+        }),
+      );
+
+      test(
+        'containsKey - exists',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          const key = 'KEY';
+          const value = 'VALUE';
+          await target.write(key: key, value: value, options: options);
+          expect(
+            await target.containsKey(key: key, options: options),
+            isTrue,
+          );
+        }),
+      );
+
+      test(
+        'containsKey - does not exist',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          const key = 'KEY';
+          expect(
+            await target.containsKey(key: key, options: options),
+            isFalse,
+          );
+        }),
+      );
+
+      test(
+        'write - new',
+        () => withFfi(() async {
+          // Just checking file was created. Its contents should be tested via
+          // "read" test.
+
+          final target = createTarget();
+          final options = createOptions();
+          const key = 'KEY';
+          const value = 'VALUE';
+          await target.write(key: key, value: value, options: options);
+
+          final directory = await getApplicationSupportDirectory();
+          final file = File(path.join(directory.path, encryptedJsonFileName));
+          expect(file.existsSync(), isTrue);
+          expect(file.statSync().size, greaterThan(0));
+          // May be encrypted
+          final content = file.readAsBytesSync();
+          expect(
+            content,
+            isNot(
+              Uint8List.fromList(
+                utf8.encode('{"$key":"$value"}'),
+              ),
+            ),
+          );
+          try {
+            final map = jsonDecode(utf8.decode(content));
+            if (map is! Map || map[key] != value) {
+              throw const FormatException('might be encrypted');
+            }
+
+            fail('might not be encrypted');
+          } on FormatException catch (_) {
+            // OK
+          }
+        }),
+      );
+
+      test(
+        'write - overwrite',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          const key = 'KEY';
+          const value1 = 'VALUE1';
+          const value2 = 'VALUE2';
+          await target.write(key: key, value: value1, options: options);
+          await target.write(key: key, value: value2, options: options);
+
+          final result = await target.read(key: key, options: options);
+          expect(result, isNotNull);
+          expect(result, value2);
+
+          final results = await target.readAll(options: options);
+          expect(results.length, 1);
+          expect(results[key], value2);
+        }),
+      );
+
+      test(
+        'overwrite keeps a last-known-good backup',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          await target.write(key: 'key', value: 'old', options: options);
+          await target.write(key: 'key', value: 'new', options: options);
+
+          final directory = await getApplicationSupportDirectory();
+          final backup = File(
+            path.join(directory.path, '$encryptedJsonFileName.bak'),
+          );
+          expect(backup.existsSync(), isTrue);
+          expect(backup.statSync().size, greaterThan(0));
+          expect(
+            directory
+                .listSync(followLinks: false)
+                .whereType<File>()
+                .where((file) => file.path.endsWith('.tmp')),
+            isEmpty,
+          );
+        }),
+      );
+
+      test(
+        'a backup refresh failure does not fail an already committed write',
+        () => withFfi(() async {
+          final storage = ffi.DpapiJsonFileMapStorage(
+            refreshBackup: (_) async {
+              throw FileSystemException('forced backup refresh failure');
+            },
+          );
+          final target = ffi.createFlutterSecureStorageWindows(
+            MethodChannelFlutterSecureStorage(),
+            storage,
+          );
+          final options = createOptions();
+
+          await target.write(key: 'key', value: 'new', options: options);
+
+          final directory = await getApplicationSupportDirectory();
+          final invalidBackup = File(
+            path.join(
+              directory.path,
+              '$encryptedJsonFileName.bak.invalid',
+            ),
+          );
+          expect(invalidBackup.existsSync(), isTrue);
+          expect(await target.read(key: 'key', options: options), 'new');
+        }),
+      );
+
+      test(
+        'a new save clears stale restore authorization before committing',
+        () => withFfi(() async {
+          final options = createOptions();
+          final initialTarget = createTarget();
+          await initialTarget.write(key: 'key', value: 'old', options: options);
+
+          final directory = await getApplicationSupportDirectory();
+          final primary = File(
+            path.join(directory.path, encryptedJsonFileName),
+          );
+          final restorePending = File('${primary.path}.bak.restore');
+          await restorePending.writeAsString('restore', flush: true);
+
+          final storage = ffi.DpapiJsonFileMapStorage(
+            refreshBackup: (_) async {
+              throw FileSystemException('forced backup refresh failure');
+            },
+          );
+          await storage.save({'key': 'new'}, options);
+
+          expect(restorePending.existsSync(), isFalse);
+          expect(File('${primary.path}.bak.invalid').existsSync(), isTrue);
+        }),
+      );
+
+      test(
+        'restores the previous primary after a partially failed replacement',
+        () => withFfi(() async {
+          final options = createOptions();
+          final initialTarget = createTarget();
+          await initialTarget.write(key: 'key', value: 'old', options: options);
+
+          final storage = ffi.DpapiJsonFileMapStorage(
+            commitTemporaryFile: (temporary, destination, backup) async {
+              if (backup != null) {
+                if (await backup.exists()) {
+                  await backup.delete();
+                }
+                await destination.rename(backup.path);
+                throw WindowsException(
+                  ERROR_UNABLE_TO_MOVE_REPLACEMENT_2,
+                  message: 'forced partial replacement failure',
+                );
+              }
+              await temporary.rename(destination.path);
+            },
+          );
+          final failingTarget = ffi.createFlutterSecureStorageWindows(
+            MethodChannelFlutterSecureStorage(),
+            storage,
+          );
+
+          await expectLater(
+            failingTarget.write(key: 'key', value: 'new', options: options),
+            throwsA(isA<WindowsException>()),
+          );
+
+          final directory = await getApplicationSupportDirectory();
+          final primary = File(
+            path.join(directory.path, encryptedJsonFileName),
+          );
+          expect(File('${primary.path}.bak.invalid').existsSync(), isFalse);
+          expect(File('${primary.path}.bak.restore').existsSync(), isFalse);
+          expect(await initialTarget.read(key: 'key', options: options), 'old');
+        }),
+      );
+
+      test(
+        'retries a validated backup restore after a transient failure',
+        () => withFfi(() async {
+          final options = createOptions();
+          final initialTarget = createTarget();
+          await initialTarget.write(key: 'key', value: 'old', options: options);
+          var restoreAttempts = 0;
+
+          final storage = ffi.DpapiJsonFileMapStorage(
+            commitTemporaryFile: (temporary, destination, backup) async {
+              if (backup != null) {
+                if (await backup.exists()) {
+                  await backup.delete();
+                }
+                await destination.rename(backup.path);
+                throw WindowsException(
+                  ERROR_UNABLE_TO_MOVE_REPLACEMENT_2,
+                  message: 'forced partial replacement failure',
+                );
+              }
+              restoreAttempts++;
+              if (restoreAttempts == 1) {
+                throw FileSystemException('forced transient restore failure');
+              }
+              await temporary.rename(destination.path);
+            },
+          );
+          final target = ffi.createFlutterSecureStorageWindows(
+            MethodChannelFlutterSecureStorage(),
+            storage,
+          );
+
+          await expectLater(
+            target.write(key: 'key', value: 'new', options: options),
+            throwsA(isA<FileSystemException>()),
+          );
+
+          final directory = await getApplicationSupportDirectory();
+          final primary = File(
+            path.join(directory.path, encryptedJsonFileName),
+          );
+          expect(File('${primary.path}.bak.restore').existsSync(), isTrue);
+
+          expect(await target.read(key: 'key', options: options), 'old');
+          expect(restoreAttempts, 2);
+          expect(File('${primary.path}.bak.invalid').existsSync(), isFalse);
+          expect(File('${primary.path}.bak.restore').existsSync(), isFalse);
+        }),
+      );
+
+      test(
+        'recovers a corrupt primary from its backup',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          await target.write(key: 'key', value: 'old', options: options);
+          await target.write(key: 'key', value: 'new', options: options);
+
+          final directory = await getApplicationSupportDirectory();
+          final primary = File(
+            path.join(directory.path, encryptedJsonFileName),
+          );
+          await primary.writeAsBytes([1, 2, 3], flush: true);
+
+          expect(await target.read(key: 'key', options: options), 'new');
+          expect(await target.read(key: 'key', options: options), 'new');
+          expect(primary.existsSync(), isTrue);
+        }),
+      );
+
+      test(
+        'backup recovery does not resurrect a successfully deleted key',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          await target.write(key: 'deleted', value: 'secret', options: options);
+          await target.write(key: 'kept', value: 'value', options: options);
+          await target.delete(key: 'deleted', options: options);
+
+          final directory = await getApplicationSupportDirectory();
+          final primary = File(
+            path.join(directory.path, encryptedJsonFileName),
+          );
+          await primary.writeAsBytes([1, 2, 3], flush: true);
+
+          expect(await target.read(key: 'deleted', options: options), isNull);
+          expect(await target.read(key: 'kept', options: options), 'value');
+        }),
+      );
+
+      test(
+        'does not recover from a backup marked as stale',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          await target.write(key: 'key', value: 'old', options: options);
+          await target.write(key: 'key', value: 'new', options: options);
+
+          final directory = await getApplicationSupportDirectory();
+          final primary = File(
+            path.join(directory.path, encryptedJsonFileName),
+          );
+          final invalidBackup = File('${primary.path}.bak.invalid');
+          await invalidBackup.writeAsString('invalid', flush: true);
+          await primary.writeAsBytes([1, 2, 3], flush: true);
+
+          await expectLater(
+            target.read(key: 'key', options: options),
+            throwsA(anything),
+          );
+          expect(primary.readAsBytesSync(), [1, 2, 3]);
+        }),
+      );
+
+      test(
+        'repairs an invalidated backup from a readable primary',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          await target.write(key: 'key', value: 'new', options: options);
+
+          final directory = await getApplicationSupportDirectory();
+          final primary = File(
+            path.join(directory.path, encryptedJsonFileName),
+          );
+          final backup = File('${primary.path}.bak');
+          final invalidBackup = File('${backup.path}.invalid');
+          await backup.writeAsBytes([1, 2, 3], flush: true);
+          await invalidBackup.writeAsString('invalid', flush: true);
+
+          expect(await target.read(key: 'key', options: options), 'new');
+          expect(invalidBackup.existsSync(), isFalse);
+
+          await primary.writeAsBytes([1, 2, 3], flush: true);
+          expect(await target.read(key: 'key', options: options), 'new');
+        }),
+      );
+
+      test(
+        'does not delete a corrupt primary without a valid backup',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          await target.write(key: 'key', value: 'value', options: options);
+
+          final directory = await getApplicationSupportDirectory();
+          final primary = File(
+            path.join(directory.path, encryptedJsonFileName),
+          );
+          final backup = File('${primary.path}.bak');
+          await backup.delete();
+          await primary.writeAsBytes([1, 2, 3], flush: true);
+
+          await expectLater(
+            target.read(key: 'key', options: options),
+            throwsA(anything),
+          );
+          expect(primary.existsSync(), isTrue);
+          expect(primary.readAsBytesSync(), [1, 2, 3]);
+        }),
+      );
+
+      test(
+        'delete - exists',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          const key = 'KEY';
+          const value = 'VALUE';
+          await target.write(key: key, value: value, options: options);
+          expect(
+            await target.containsKey(key: key, options: options),
+            isTrue,
+          );
+
+          await target.delete(key: key, options: options);
+          expect(
+            await target.containsKey(key: key, options: options),
+            isFalse,
+          );
+        }),
+      );
+
+      test(
+        'delete - does not exist',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          const key = 'KEY';
+          expect(
+            await target.containsKey(key: key, options: options),
+            isFalse,
+          );
+
+          await target.delete(key: key, options: options);
+
+          expect(
+            await target.containsKey(key: key, options: options),
+            isFalse,
+          );
+        }),
+      );
+
+      test(
+        'deleteAll - empty',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          await target.deleteAll(options: options);
+          expect(
+            await target.readAll(options: options),
+            isEmpty,
+          );
+        }),
+      );
+
+      test(
+        'deleteAll - 1 entries',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          const key = 'KEY';
+          const value = 'VALUE';
+          await target.write(key: key, value: value, options: options);
+          await target.deleteAll(options: options);
+          expect(
+            await target.readAll(options: options),
+            isEmpty,
+          );
+        }),
+      );
+
+      test(
+        'deleteAll - 2 entries',
+        () => withFfi(() async {
+          final target = createTarget();
+          final options = createOptions();
+          const key1 = 'KEY1';
+          const value1 = 'VALUE1';
+          const key2 = 'KEY2';
+          const value2 = 'VALUE2';
+          await target.write(key: key1, value: value1, options: options);
+          await target.write(key: key2, value: value2, options: options);
+          await target.deleteAll(options: options);
+          expect(
+            await target.readAll(options: options),
+            isEmpty,
+          );
+        }),
+      );
+    },
+    skip: _windowsOnlySkipReason,
+  );
+
+  // These cases depend on 'Basic cases' are passed corrrectly.
+  // Just test backward compatibility logics.
+  group(
+    'Backwards compatibilty cases',
+    () {
+      FlutterSecureStoragePlatform createTarget(
+        Future<Object?> Function(MethodCall) handler,
+      ) {
+        TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+          handler,
+        );
+        return ffi.createFlutterSecureStorageWindows(
+          MethodChannelFlutterSecureStorage(),
+          ffi.DpapiJsonFileMapStorage(),
+        );
+      }
+
+      Map<String, String> createOptions() =>
+          {'useBackwardCompatibility': 'true'};
+
+      test(
+        'readAll - empty, empty',
+        () => withFfi(() async {
+          var readAllCalled = 0;
+          var deleteAllCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'readAll':
+                readAllCalled++;
+                return <String, String>{};
+              case 'deleteAll':
+                deleteAllCalled++;
+                return null;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+          final options = createOptions();
+          final result = await target.readAll(options: options);
+          expect(result, isEmpty);
+          expect(readAllCalled, 1);
+          expect(deleteAllCalled, 0);
+        }),
+      );
+      test(
+        'readAll - 1 entry, 1 entry, different keys',
+        () => withFfi(() async {
+          const newKey = 'KEY1';
+          const newValue = 'VALUE1';
+          const oldKey = 'KEY2';
+          const oldValue = 'VALUE2';
+
+          var readAllCalled = 0;
+          var deleteAllCalled = 0;
+          var onInit = true;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'readAll':
+                readAllCalled++;
+                return deleteAllCalled > 0 ? {} : {oldKey: oldValue};
+              case 'deleteAll':
+                deleteAllCalled++;
+                return null;
+              case 'delete':
+                if (onInit) {
+                  return null;
+                }
+            }
+            fail('Unexpected method call: ${call.method}');
+          });
+          final options = createOptions();
+          await target.write(key: newKey, value: newValue, options: options);
+          onInit = false;
+          final result1 = await target.readAll(options: options);
+          expect(result1.length, 2);
+          expect(result1[oldKey], oldValue);
+          expect(result1[newKey], newValue);
+          expect(readAllCalled, 1);
+          expect(deleteAllCalled, 1);
+
+          final result2 = await target.readAll(options: options);
+          expect(result2.length, 2);
+          expect(result2[oldKey], oldValue);
+          expect(result2[newKey], newValue);
+          expect(readAllCalled, 2);
+          expect(deleteAllCalled, 1);
+        }),
+      );
+
+      test(
+        'readAll - 1 entry, 1 entry, same keys',
+        () => withFfi(() async {
+          const newKey = 'KEY';
+          const newValue = 'VALUE1';
+          const oldKey = newKey;
+          const oldValue = 'VALUE2';
+
+          var readAllCalled = 0;
+          var deleteAllCalled = 0;
+          var onInit = true;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'readAll':
+                readAllCalled++;
+                return deleteAllCalled > 0 ? {} : {oldKey: oldValue};
+              case 'deleteAll':
+                deleteAllCalled++;
+                return null;
+              case 'delete':
+                if (onInit) {
+                  return null;
+                }
+            }
+            fail('Unexpected method call: ${call.method}');
+          });
+          final options = createOptions();
+          await target.write(key: newKey, value: newValue, options: options);
+          onInit = false;
+          final result1 = await target.readAll(options: options);
+          expect(result1.length, 1);
+          expect(result1[oldKey], newValue);
+          expect(result1[newKey], newValue);
+          expect(readAllCalled, 1);
+          expect(deleteAllCalled, 1);
+
+          final result2 = await target.readAll(options: options);
+          expect(result2.length, 1);
+          expect(result1[oldKey], newValue);
+          expect(result1[newKey], newValue);
+          expect(readAllCalled, 2);
+          expect(deleteAllCalled, 1);
+        }),
+      );
+
+      test(
+        'readAll - empty, 1entry',
+        () => withFfi(() async {
+          const oldKey = 'KEY';
+          const oldValue = 'VALUE2';
+
+          var readCalled = 0;
+          var readAllCalled = 0;
+          var deleteAllCalled = 0;
+          var deleteCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'read':
+                readCalled++;
+                return deleteAllCalled > 0
+                    ? null
+                    : (call.arguments as Map<String, dynamic>)['key'] == oldKey
+                        ? oldValue
+                        : null;
+              case 'readAll':
+                readAllCalled++;
+                return deleteAllCalled > 0 ? {} : {oldKey: oldValue};
+              case 'deleteAll':
+                deleteAllCalled++;
+                return null;
+              case 'delete':
+                deleteCalled++;
+                return null;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+
+          final options = createOptions();
+          final result1 = await target.readAll(options: options);
+          expect(result1.length, 1);
+          expect(result1[oldKey], oldValue);
+          expect(readCalled, 0);
+          expect(readAllCalled, 1);
+          expect(deleteAllCalled, 1);
+          expect(deleteCalled, 0);
+
+          final result2 = await target.readAll(options: options);
+          expect(result2.length, 1);
+          expect(result2[oldKey], oldValue);
+          expect(readCalled, 0);
+          expect(readAllCalled, 2);
+          expect(deleteAllCalled, 1);
+          expect(deleteCalled, 0);
+
+          final result3 = await target.read(key: oldKey, options: options);
+          expect(result3, oldValue);
+          // auto-migrated
+          expect(readCalled, 0);
+          expect(readAllCalled, 2);
+          expect(deleteAllCalled, 1);
+          expect(deleteCalled, 1);
+        }),
+      );
+
+      test(
+        'readAll - 1entry, empty',
+        () => withFfi(() async {
+          const newKey = 'KEY';
+          const newValue = 'VALUE1';
+
+          var readAllCalled = 0;
+          var deleteAllCalled = 0;
+          var onInit = true;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'readAll':
+                readAllCalled++;
+                return <String, String>{};
+              case 'deleteAll':
+                deleteAllCalled++;
+                return null;
+              case 'delete':
+                if (onInit) {
+                  return null;
+                }
+            }
+            fail('Unexpected method call: ${call.method}');
+          });
+          final options = createOptions();
+          await target.write(key: newKey, value: newValue, options: options);
+          onInit = false;
+          final result1 = await target.readAll(options: options);
+          expect(result1.length, 1);
+          expect(result1[newKey], newValue);
+          expect(readAllCalled, 1);
+          expect(deleteAllCalled, 0);
+
+          final result2 = await target.readAll(options: options);
+          expect(result2.length, 1);
+          expect(result1[newKey], newValue);
+          expect(readAllCalled, 2);
+          expect(deleteAllCalled, 0);
+        }),
+      );
+
+      test(
+        'readAll - 2 entries, 2 entries, same keys and diffrent keys',
+        () => withFfi(() async {
+          const newKey1 = 'KEY1';
+          const newValue1 = 'VALUE1';
+          const newKey2 = 'KEY2';
+          const newValue2 = 'VALUE2';
+          const oldKey1 = 'KEY3';
+          const oldValue1 = 'VALUE3';
+          const oldKey2 = newKey1;
+          const oldValue2 = 'VALUE4';
+
+          var readAllCalled = 0;
+          var deleteAllCalled = 0;
+          var onInit = true;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'readAll':
+                readAllCalled++;
+                return deleteAllCalled > 0
+                    ? {}
+                    : {oldKey1: oldValue1, oldKey2: oldValue2};
+              case 'deleteAll':
+                deleteAllCalled++;
+                return null;
+              case 'delete':
+                if (onInit) {
+                  return null;
+                }
+            }
+            fail('Unexpected method call: ${call.method}');
+          });
+          final options = createOptions();
+          await target.write(key: newKey1, value: newValue1, options: options);
+          await target.write(key: newKey2, value: newValue2, options: options);
+          onInit = false;
+          final result1 = await target.readAll(options: options);
+          expect(result1.length, 3);
+          expect(result1[newKey1], newValue1);
+          expect(result1[newKey2], newValue2);
+          expect(result1[oldKey1], oldValue1);
+          expect(result1[oldKey2], newValue1);
+          expect(readAllCalled, 1);
+          expect(deleteAllCalled, 1);
+
+          final result2 = await target.readAll(options: options);
+          expect(result2.length, 3);
+          expect(result1[newKey1], newValue1);
+          expect(result1[newKey2], newValue2);
+          expect(result1[oldKey1], oldValue1);
+          expect(result1[oldKey2], newValue1);
+          expect(readAllCalled, 2);
+          expect(deleteAllCalled, 1);
+        }),
+      );
+
+      test(
+        'read - exists, exists',
+        () => withFfi(() async {
+          const key = 'KEY';
+          const newValue = 'VALUE1';
+          const oldValue = 'VALUE2';
+
+          var readCalled = 0;
+          var deleteCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'read':
+                readCalled++;
+                return deleteCalled > 0 ? null : {key: oldValue};
+              case 'delete':
+                deleteCalled++;
+                return null;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+          final options = createOptions();
+          await target.write(key: key, value: newValue, options: options);
+          expect(deleteCalled, 1);
+          final result1 = await target.read(key: key, options: options);
+          expect(result1, newValue);
+          expect(readCalled, 0);
+          expect(deleteCalled, 2);
+
+          final result2 = await target.read(key: key, options: options);
+          expect(result2, newValue);
+          expect(readCalled, 0);
+          expect(deleteCalled, 3);
+        }),
+      );
+
+      test(
+        'read - does not exist, exists',
+        () => withFfi(() async {
+          const key = 'KEY';
+          const value = 'VALUE';
+
+          var readCalled = 0;
+          var deleteCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'read':
+                readCalled++;
+                return deleteCalled > 0 ? null : value;
+              case 'delete':
+                deleteCalled++;
+                return null;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+          final options = createOptions();
+          final result1 = await target.read(key: key, options: options);
+          expect(result1, value);
+          expect(readCalled, 1);
+          expect(deleteCalled, 1);
+
+          final result2 = await target.read(key: key, options: options);
+          expect(result2, value);
+          expect(readCalled, 1);
+          expect(deleteCalled, 2);
+        }),
+      );
+
+      test(
+        'read - exists, does not exist',
+        () => withFfi(() async {
+          const key = 'KEY';
+          const value = 'VALUE';
+
+          var readCalled = 0;
+          var deleteCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'read':
+                readCalled++;
+                return null;
+              case 'delete':
+                deleteCalled++;
+                return null;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+          final options = createOptions();
+          await target.write(key: key, value: value, options: options);
+          expect(deleteCalled, 1);
+
+          final result1 = await target.read(key: key, options: options);
+          expect(result1, value);
+          expect(readCalled, 0);
+          expect(deleteCalled, 2);
+
+          final result2 = await target.read(key: key, options: options);
+          expect(result2, value);
+          expect(readCalled, 0);
+          expect(deleteCalled, 3);
+        }),
+      );
+
+      test(
+        'read - does not exist, does not exist',
+        () => withFfi(() async {
+          const key = 'KEY';
+
+          var readCalled = 0;
+          var deleteCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'read':
+                readCalled++;
+                return null;
+              case 'delete':
+                deleteCalled++;
+                return null;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+          final options = createOptions();
+
+          final result1 = await target.read(key: key, options: options);
+          expect(result1, isNull);
+          expect(readCalled, 1);
+          expect(deleteCalled, 1);
+
+          final result2 = await target.read(key: key, options: options);
+          expect(result2, isNull);
+          expect(readCalled, 2);
+          expect(deleteCalled, 2);
+        }),
+      );
+
+      test(
+        'containsKey - exists, exists',
+        () => withFfi(() async {
+          const key = 'KEY';
+          const newValue = 'VALUE1';
+
+          var containsKeyCalled = 0;
+          var deleteCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'containsKey':
+                containsKeyCalled++;
+                return deleteCalled > 0 &&
+                    (call.arguments as Map<String, dynamic>)['key'] == key;
+              case 'delete':
+                deleteCalled++;
+                return null;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+          final options = createOptions();
+          await target.write(key: key, value: newValue, options: options);
+          expect(deleteCalled, 1);
+          expect(
+            await target.containsKey(key: key, options: options),
+            isTrue,
+          );
+          expect(containsKeyCalled, 0);
+          expect(deleteCalled, 1);
+
+          expect(
+            await target.containsKey(key: key, options: options),
+            isTrue,
+          );
+          expect(containsKeyCalled, 0);
+          expect(deleteCalled, 1);
+        }),
+      );
+
+      test(
+        'containsKey - does not exist, exists',
+        () => withFfi(() async {
+          const key = 'KEY';
+
+          var containsKeyCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'containsKey':
+                containsKeyCalled++;
+                return (call.arguments as Map<String, dynamic>)['key'] == key;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+          final options = createOptions();
+          expect(
+            await target.containsKey(key: key, options: options),
+            isTrue,
+          );
+          expect(containsKeyCalled, 1);
+
+          expect(
+            await target.containsKey(key: key, options: options),
+            isTrue,
+          );
+          expect(containsKeyCalled, 2);
+        }),
+      );
+
+      test(
+        'containsKey - exists, does not exist',
+        () => withFfi(() async {
+          const key = 'KEY';
+          const newValue = 'VALUE1';
+
+          var containsKeyCalled = 0;
+          var onInit = true;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'containsKey':
+                containsKeyCalled++;
+                return false;
+              case 'delete':
+                if (onInit) {
+                  return null;
+                }
+            }
+            fail('Unexpected method call: ${call.method}');
+          });
+          final options = createOptions();
+          await target.write(key: key, value: newValue, options: options);
+          onInit = false;
+          expect(
+            await target.containsKey(key: key, options: options),
+            isTrue,
+          );
+          expect(containsKeyCalled, 0);
+
+          expect(
+            await target.containsKey(key: key, options: options),
+            isTrue,
+          );
+          expect(containsKeyCalled, 0);
+        }),
+      );
+
+      test(
+        'containsKey - does not exist, does not exist',
+        () => withFfi(() async {
+          const key = 'KEY';
+
+          var containsKeyCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'containsKey':
+                containsKeyCalled++;
+                return false;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+          final options = createOptions();
+          expect(
+            await target.containsKey(key: key, options: options),
+            isFalse,
+          );
+          expect(containsKeyCalled, 1);
+
+          expect(
+            await target.containsKey(key: key, options: options),
+            isFalse,
+          );
+          expect(containsKeyCalled, 2);
+        }),
+      );
+
+      test(
+        'write - new',
+        () async {
+          const key = 'KEY';
+          const value = 'VALUE';
+
+          var deleteCalled = 0;
+          final target = createTarget((call) async {
+            if (call.method == 'delete') {
+              deleteCalled++;
+              return null;
+            }
+
+            fail('Unexpected method call: ${call.method}');
+          });
+          final options = createOptions();
+          await target.write(key: key, value: value, options: options);
+          expect(deleteCalled, 1);
+
+          final result = await target.read(key: key, options: options);
+          expect(result, value);
+          expect(deleteCalled, 2);
+        },
+      );
+
+      test(
+        'write - overwrite',
+        () async {
+          const key = 'KEY';
+          const value1 = 'VALUE1';
+          const value2 = 'VALUE2';
+
+          var deleteCalled = 0;
+          final target = createTarget((call) async {
+            if (call.method == 'delete') {
+              deleteCalled++;
+              return null;
+            }
+
+            fail('Unexpected method call: ${call.method}');
+          });
+          final options = createOptions();
+          await target.write(key: key, value: value1, options: options);
+          expect(deleteCalled, 1);
+          await target.write(key: key, value: value2, options: options);
+          expect(deleteCalled, 2);
+
+          final result = await target.read(key: key, options: options);
+          expect(result, value2);
+          expect(deleteCalled, 3);
+        },
+      );
+
+      test(
+        'delete - exists, any',
+        () => withFfi(() async {
+          const key = 'KEY';
+          const newValue = 'VALUE1';
+
+          var deleteCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'delete':
+                deleteCalled++;
+                return null;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+          final options = createOptions();
+          await target.write(key: key, value: newValue, options: options);
+          expect(deleteCalled, 1);
+          await target.delete(key: key, options: options);
+          expect(deleteCalled, 2);
+        }),
+      );
+
+      test(
+        'delete - does not exist, any',
+        () => withFfi(() async {
+          var deleteCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'delete':
+                deleteCalled++;
+                return null;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+          final options = createOptions();
+          await target.delete(key: 'KEY', options: options);
+          expect(deleteCalled, 1);
+        }),
+      );
+
+      test(
+        'deleteAll - empty, any',
+        () => withFfi(() async {
+          var deleteAllCalled = 0;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'deleteAll':
+                deleteAllCalled++;
+                return null;
+              default:
+                fail('Unexpected method call: ${call.method}');
+            }
+          });
+          final options = createOptions();
+          await target.deleteAll(options: options);
+          expect(deleteAllCalled, 1);
+        }),
+      );
+      test(
+        'deleteAll - 1 entry, any',
+        () => withFfi(() async {
+          const key = 'KEY';
+          const newValue = 'VALUE1';
+
+          var deleteAllCalled = 0;
+          var onInit = true;
+          final target = createTarget((call) async {
+            switch (call.method) {
+              case 'deleteAll':
+                deleteAllCalled++;
+                return null;
+              case 'delete':
+                if (onInit) {
+                  return null;
+                }
+            }
+            fail('Unexpected method call: ${call.method}');
+          });
+          final options = createOptions();
+          await target.write(key: key, value: newValue, options: options);
+          onInit = false;
+          await target.deleteAll(options: options);
+          expect(deleteAllCalled, 1);
+        }),
+      );
+    },
+    skip: _windowsOnlySkipReason,
+  );
+
+  group('Stub does not work at all', () {
+    test(
+      'constructor',
+      () async {
+        expect(
+          stub.FlutterSecureStorageWindows.new,
+          throwsAssertionError,
+        );
+      },
+    );
+  });
+
+  group(
+    'Special charactors handling',
+    () {
+      FlutterSecureStoragePlatform createTarget() {
+        TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+          (methodCall) async {
+            switch (methodCall.method) {
+              case 'read':
+                return null;
+              case 'readAll':
+                return <String, String>{};
+              case 'containsKey':
+                return false;
+              case 'write':
+                fail('write on MethodChanel causes error for special chars.');
+              case 'delete':
+              case 'deleteAll':
+                return null;
+              default:
+                fail('Unexpected method call: $methodCall');
+            }
+          },
+        );
+        return ffi.FlutterSecureStorageWindows();
+      }
+
+      Map<String, String> createOptions() =>
+          {'useBackwardCompatibility': 'true'};
+
+      Future<void> testSpecialCharactor(
+        String key, {
+        String? value,
+      }) async {
+        final target = createTarget();
+        final options = createOptions();
+
+        final realValue = value ?? DateTime.now().toIso8601String();
+
+        await target.write(key: key, value: realValue, options: options);
+
+        expect(await target.containsKey(key: key, options: options), isTrue);
+        expect(await target.read(key: key, options: options), realValue);
+        expect(await target.readAll(options: options), {key: realValue});
+        await target.delete(key: key, options: options);
+        expect(await target.containsKey(key: key, options: options), isFalse);
+        expect(await target.read(key: key, options: options), isNull);
+        expect(await target.readAll(options: options), isEmpty);
+
+        await target.write(key: '$key#1', value: realValue, options: options);
+        await target.write(key: '$key#2', value: realValue, options: options);
+
+        expect(
+          await target.containsKey(key: '$key#1', options: options),
+          isTrue,
+        );
+        expect(
+          await target.containsKey(key: '$key#2', options: options),
+          isTrue,
+        );
+        await target.deleteAll(options: options);
+
+        expect(
+          await target.containsKey(key: '$key#1', options: options),
+          isFalse,
+        );
+        expect(
+          await target.containsKey(key: '$key#2', options: options),
+          isFalse,
+        );
+      }
+
+      test('URL', () => testSpecialCharactor('http://example.com'));
+      test(
+        'Long key',
+        () => testSpecialCharactor(
+          String.fromCharCodes(Iterable.generate(256, (_) => 65 /* 'A' */)),
+        ),
+      );
+      test(
+        'Empty key & value',
+        () => testSpecialCharactor('', value: ''),
+      );
+
+      test('Only casing is differ', () async {
+        final target = createTarget();
+        final options = createOptions();
+        const key1 = 'KEY';
+        const key2 = 'key';
+        const value1 = 'Value1';
+        const value2 = 'Value2';
+
+        await target.write(key: key1, value: value1, options: options);
+        await target.write(key: key2, value: value2, options: options);
+        final results = await target.readAll(options: options);
+        expect(results.length, 2);
+        expect(results[key1], value1);
+        expect(results[key2], value2);
+
+        expect(await target.read(key: key1, options: options), value1);
+        expect(await target.read(key: key2, options: options), value2);
+        expect(await target.containsKey(key: key1, options: options), isTrue);
+        expect(await target.containsKey(key: key2, options: options), isTrue);
+
+        await target.delete(key: key1, options: options);
+        expect(await target.read(key: key1, options: options), isNull);
+        expect(await target.read(key: key2, options: options), value2);
+        expect(await target.containsKey(key: key1, options: options), isFalse);
+        expect(await target.containsKey(key: key2, options: options), isTrue);
+
+        await target.write(key: key2, value: value2, options: options);
+        await target.deleteAll(options: options);
+        expect(await target.read(key: key1, options: options), isNull);
+        expect(await target.read(key: key2, options: options), isNull);
+        expect(await target.containsKey(key: key1, options: options), isFalse);
+        expect(await target.containsKey(key: key2, options: options), isFalse);
+      });
+    },
+    skip: _windowsOnlySkipReason,
+  );
+}
+
+final String? _windowsOnlySkipReason =
+    Platform.isWindows ? null : 'This test must be run on Windows.';
+
+bool canTest() {
+  if (!Platform.isWindows) {
+    markTestSkipped('This test must be run on Windows.');
+    return false;
+  }
+
+  return true;
+}
+
+FutureOr<void> withFfi(
+  FutureOr<void> Function() test,
+) async {
+  if (!canTest()) {
+    return;
+  }
+
+  await test();
+}
+
+class _DelayedMapStorage extends ffi.MapStorage {
+  Map<String, String> values = {};
+
+  @override
+  Future<void> clear(Map<String, String> options) async {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+    values = {};
+  }
+
+  @override
+  Future<Map<String, String>> load(Map<String, String> options) async {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+    return Map.of(values);
+  }
+
+  @override
+  Future<void> save(
+    Map<String, String> data,
+    Map<String, String> options,
+  ) async {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+    values = Map.of(data);
+  }
+}
+
+class _TrackingTransactionalMapStorage extends _DelayedMapStorage
+    implements ffi.TransactionalMapStorage {
+  int transactionCount = 0;
+  var _concurrentTransactions = 0;
+  int maximumConcurrentTransactions = 0;
+
+  @override
+  Future<T> runTransaction<T>(Future<T> Function() action) async {
+    transactionCount++;
+    _concurrentTransactions++;
+    if (_concurrentTransactions > maximumConcurrentTransactions) {
+      maximumConcurrentTransactions = _concurrentTransactions;
+    }
+    try {
+      return await action();
+    } finally {
+      _concurrentTransactions--;
+    }
+  }
+}

--- a/third_party/flutter_secure_storage_windows/windows/CMakeLists.txt
+++ b/third_party/flutter_secure_storage_windows/windows/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.15)
+set(PROJECT_NAME "flutter_secure_storage_windows")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+# This value is used when generating builds using this plugin, so it must
+# not be changed
+set(PLUGIN_NAME "flutter_secure_storage_windows_plugin")
+
+add_library(${PLUGIN_NAME} SHARED
+  "flutter_secure_storage_windows_plugin.cpp"
+)
+apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+
+# List of absolute paths to libraries that should be bundled with the plugin
+set(flutter_secure_storage_bundled_libraries
+  ""
+  PARENT_SCOPE
+)
+if(NOT DEFINED STORAGE_PREFIX)
+  add_compile_definitions(SECURE_STORAGE_KEY_PREFIX="${BINARY_NAME}_VGhpcyBpcyB0aGUgcHJlZml4IGZv_")
+else()
+  add_compile_definitions(SECURE_STORAGE_KEY_PREFIX="${STORAGE_PREFIX}_VGhpcyBpcyB0aGUgcHJlZml4IGZv_")
+endif()

--- a/third_party/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
+++ b/third_party/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
@@ -1,0 +1,903 @@
+#include "include/flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h"
+
+// This must be included before many other Windows headers.
+#include <windows.h>
+#include <wincred.h>
+#include <atlstr.h>
+#include <ShlObj_core.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <direct.h>
+#include <bcrypt.h>
+
+// For getPlatformVersion; remove unless needed for your plugin implementation.
+#include <VersionHelpers.h>
+
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar_windows.h>
+#include <flutter/standard_method_codec.h>
+
+#include <map>
+#include <memory>
+#include <sstream>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <regex>
+
+#pragma comment(lib, "version.lib")
+#pragma comment(lib, "bcrypt.lib")
+
+namespace
+{
+
+  class FlutterSecureStorageWindowsPlugin : public flutter::Plugin
+  {
+  public:
+    static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
+
+    FlutterSecureStorageWindowsPlugin();
+
+    virtual ~FlutterSecureStorageWindowsPlugin();
+
+  private:
+    // Called when a method is called on this plugin's channel from Dart.
+    void HandleMethodCall(
+        const flutter::MethodCall<flutter::EncodableValue> &method_call,
+        std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+    // Retrieves the value passed to the given param.
+    std::optional<std::string> GetStringArg(
+        const std::string &param,
+        const flutter::EncodableMap *args);
+
+    // Derive the key for a value given a method argument map.
+    std::optional<std::string> FlutterSecureStorageWindowsPlugin::GetValueKey(const flutter::EncodableMap *args);
+
+    // Removes prefix of the given storage key.
+    //
+    // The prefix (defined by ELEMENT_PREFERENCES_KEY_PREFIX) is added automatically when writing to storage,
+    // to distinguish values that are written by this plugin from values that are not.
+    std::string RemoveKeyPrefix(const std::string &key);
+
+    // Gets the string name for the given int error code
+    std::string GetErrorString(const DWORD &error_code);
+    // Get string name of ntstatus
+    std::string NtStatusToString(const CHAR* operation, NTSTATUS status);
+
+    DWORD GetApplicationSupportPath(std::wstring& path);
+
+    std::wstring SanitizeDirString(std::wstring string);
+
+    bool PathExists(const std::wstring& path);
+
+    bool MakePath(const std::wstring& path);
+
+    PBYTE GetEncryptionKey();
+
+    // Stores the given value under the given key.
+    void Write(const std::string &key, const std::string &val);
+
+    std::optional<std::string> Read(const std::string &key);
+
+    flutter::EncodableMap ReadAll();
+
+    void Delete(const std::string &key);
+
+    void DeleteAll();
+
+    bool ContainsKey(const std::string &key);
+  };
+
+  const std::string ELEMENT_PREFERENCES_KEY_PREFIX = SECURE_STORAGE_KEY_PREFIX;
+  const int ELEMENT_PREFERENCES_KEY_PREFIX_LENGTH = (sizeof SECURE_STORAGE_KEY_PREFIX) - 1;
+
+  // this string is used to filter the credential storage so that only the values written
+  // by this plugin shows up.
+  const CA2W CREDENTIAL_FILTER((ELEMENT_PREFERENCES_KEY_PREFIX + '*').c_str());
+
+  static inline void rtrim(std::wstring& s) {
+      s.erase(std::find_if(s.rbegin(), s.rend(), [](wchar_t ch) {
+          return !std::isspace(ch);
+          }).base(), s.end());
+  }
+
+  // static
+  void FlutterSecureStorageWindowsPlugin::RegisterWithRegistrar(
+      flutter::PluginRegistrarWindows *registrar)
+  {
+    auto channel =
+        std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+            registrar->messenger(), "plugins.it_nomads.com/flutter_secure_storage",
+            &flutter::StandardMethodCodec::GetInstance());
+
+    auto plugin = std::make_unique<FlutterSecureStorageWindowsPlugin>();
+
+    channel->SetMethodCallHandler(
+        [plugin_pointer = plugin.get()](const auto &call, auto result)
+        {
+          plugin_pointer->HandleMethodCall(call, std::move(result));
+        });
+
+    registrar->AddPlugin(std::move(plugin));
+  }
+
+  FlutterSecureStorageWindowsPlugin::FlutterSecureStorageWindowsPlugin() {}
+
+  FlutterSecureStorageWindowsPlugin::~FlutterSecureStorageWindowsPlugin() {}
+
+  std::optional<std::string> FlutterSecureStorageWindowsPlugin::GetValueKey(const flutter::EncodableMap *args)
+  {
+    auto key = this->GetStringArg("key", args);
+    if (key.has_value())
+      return ELEMENT_PREFERENCES_KEY_PREFIX + key.value();
+    return std::nullopt;
+  }
+
+  std::string FlutterSecureStorageWindowsPlugin::RemoveKeyPrefix(const std::string& key)
+  {
+    return key.substr(ELEMENT_PREFERENCES_KEY_PREFIX_LENGTH);
+  }
+
+  std::optional<std::string> FlutterSecureStorageWindowsPlugin::GetStringArg(
+      const std::string &param,
+      const flutter::EncodableMap *args)
+  {
+    auto p = args->find(param);
+    if (p == args->end())
+      return std::nullopt;
+    return std::get<std::string>(p->second);
+  }
+
+  std::string FlutterSecureStorageWindowsPlugin::GetErrorString(const DWORD &error_code)
+  {
+    switch (error_code)
+    {
+    case ERROR_NO_SUCH_LOGON_SESSION:
+      return "ERROR_NO_SUCH_LOGIN_SESSION";
+    case ERROR_INVALID_FLAGS:
+      return "ERROR_INVALID_FLAGS";
+    case ERROR_BAD_USERNAME:
+      return "ERROR_BAD_USERNAME";
+    case SCARD_E_NO_READERS_AVAILABLE:
+      return "SCARD_E_NO_READERS_AVAILABLE";
+    case SCARD_E_NO_SMARTCARD:
+      return "SCARD_E_NO_SMARTCARD";
+    case SCARD_W_REMOVED_CARD:
+      return "SCARD_W_REMOVED_CARD";
+    case SCARD_W_WRONG_CHV:
+      return "SCARD_W_WRONG_CHV";
+    case ERROR_INVALID_PARAMETER:
+      return "ERROR_INVALID_PARAMETER";
+    default:
+      return "UNKNOWN_ERROR";
+    }
+  }
+
+  std::string FlutterSecureStorageWindowsPlugin::NtStatusToString(const CHAR* operation, NTSTATUS status)
+  {
+      std::ostringstream oss;
+      oss << operation << ", 0x" << std::hex << status;
+
+      switch (status)
+      {
+      case 0xc0000000:
+          oss << " (STATUS_SUCCESS)";
+          break;
+      case 0xC0000008:
+          oss << " (STATUS_INVALID_HANDLE)";
+          break;
+      case 0xc000000d:
+          oss << " (STATUS_INVALID_PARAMETER)";
+          break;
+      case 0xc00000bb:
+          oss << " (STATUS_NOT_SUPPORTED)";
+          break;
+      case 0xC0000225:
+          oss << " (STATUS_NOT_FOUND)";
+          break;
+      }
+      return oss.str();
+  }
+
+  DWORD FlutterSecureStorageWindowsPlugin::GetApplicationSupportPath(std::wstring &path)
+  {
+      std::wstring companyName;
+      std::wstring productName;
+      TCHAR nameBuffer[MAX_PATH + 1]{};
+      char* infoBuffer;
+      DWORD versionInfoSize;
+      DWORD resVal;
+      UINT queryLen;
+      LPVOID queryVal;
+      LPWSTR appdataPath;
+      std::wostringstream stream;
+
+      SHGetKnownFolderPath(FOLDERID_RoamingAppData,KF_FLAG_DEFAULT,NULL,&appdataPath);
+
+      if (nameBuffer == NULL) {
+          return ERROR_OUTOFMEMORY;
+      }
+
+      resVal = GetModuleFileName(NULL,nameBuffer,MAX_PATH);
+      if (resVal == 0) {
+          return GetLastError();
+      }
+
+      versionInfoSize = GetFileVersionInfoSize(nameBuffer, NULL);
+      if (versionInfoSize != 0) {
+          infoBuffer = (char*) calloc(versionInfoSize,sizeof(char));
+          if (infoBuffer == NULL) {
+              return ERROR_OUTOFMEMORY;
+          }
+          if (GetFileVersionInfo(nameBuffer, 0, versionInfoSize, infoBuffer) == 0) {
+              free(infoBuffer);
+              infoBuffer = NULL;
+          }
+          else {
+
+              if (VerQueryValue(infoBuffer, TEXT("\\StringFileInfo\\040904e4\\CompanyName"), &queryVal, &queryLen) != 0) {
+                  companyName = SanitizeDirString(std::wstring((const TCHAR*)queryVal));
+              }
+              else if (VerQueryValue(infoBuffer, TEXT("\\StringFileInfo\\040904b0\\CompanyName"), &queryVal, &queryLen) != 0) {
+                  companyName = SanitizeDirString(std::wstring((const TCHAR*)queryVal));
+              }
+              else {
+                  companyName = L"placeholder_company";
+              }
+              if (VerQueryValue(infoBuffer, TEXT("\\StringFileInfo\\040904e4\\ProductName"), &queryVal, &queryLen) != 0) {
+                  productName = SanitizeDirString(std::wstring((const TCHAR*)queryVal));
+              }
+              else if (VerQueryValue(infoBuffer, TEXT("\\StringFileInfo\\040904b0\\ProductName"), &queryVal, &queryLen) != 0) {
+                  productName = SanitizeDirString(std::wstring((const TCHAR*)queryVal));
+              }
+              else {
+                  productName = L"placeholder_product";
+              }
+          }
+          stream << appdataPath << "\\" << companyName << "\\" << productName;
+          path = stream.str();
+      }
+      else {
+          return GetLastError();
+      }
+      return ERROR_SUCCESS;
+
+  }
+
+  std::wstring FlutterSecureStorageWindowsPlugin::SanitizeDirString(std::wstring string)
+  {
+      std::wstring illegalChars = L"\\/:?\"<>|";
+      for (auto it = string.begin(); it < string.end(); ++it) {
+          if (illegalChars.find(*it) != std::wstring::npos) {
+              *it = L'_';
+          }
+      }
+      rtrim(string);
+      return string;
+  }
+
+  bool FlutterSecureStorageWindowsPlugin::PathExists(const std::wstring& path)
+  {
+      struct _stat info;
+      if (_wstat(path.c_str(), &info) != 0) {
+          return false;
+      }
+      return (info.st_mode & _S_IFDIR) != 0;
+  }
+
+  bool FlutterSecureStorageWindowsPlugin::MakePath(const std::wstring& path)
+  {
+      int ret = _wmkdir(path.c_str());
+      if (ret == 0) {
+          return true;
+      }
+      switch (errno) {
+      case ENOENT:
+        {
+          size_t pos = path.find_last_of('/');
+          if (pos == std::wstring::npos)
+              pos = path.find_last_of('\\');
+          if (pos == std::wstring::npos)
+              return false;
+          if (!MakePath(path.substr(0, pos)))
+              return false;
+        }
+        return 0 == _wmkdir(path.c_str());
+      case EEXIST:
+          return PathExists(path);
+      default:
+          return false;
+      }
+  }
+
+  PBYTE FlutterSecureStorageWindowsPlugin::GetEncryptionKey()
+  {
+      const size_t KEY_SIZE = 16;
+      DWORD credError = 0;
+      PBYTE AesKey;
+      PCREDENTIALW pcred;
+      CA2W target_name(("key_" + ELEMENT_PREFERENCES_KEY_PREFIX).c_str());
+
+      AesKey = (PBYTE)HeapAlloc(GetProcessHeap(), 0, KEY_SIZE);
+      if (NULL == AesKey) {
+          return NULL;
+      }
+
+      bool ok = CredReadW(target_name.m_psz, CRED_TYPE_GENERIC, 0, &pcred);
+      if (ok) {
+          if (pcred->CredentialBlobSize != KEY_SIZE) {
+              CredFree(pcred);
+              CredDeleteW(target_name.m_psz, CRED_TYPE_GENERIC, 0);
+              goto NewKey;
+          }
+          memcpy(AesKey, pcred->CredentialBlob, KEY_SIZE);
+          CredFree(pcred);
+          return AesKey;
+      }
+      credError = GetLastError();
+      if (credError != ERROR_NOT_FOUND) {
+          return NULL;
+      }
+  NewKey:
+      if (BCryptGenRandom(NULL, AesKey, KEY_SIZE, BCRYPT_USE_SYSTEM_PREFERRED_RNG) != ERROR_SUCCESS) {
+          return NULL;
+      }
+      CREDENTIALW cred = { 0 };
+      cred.Type = CRED_TYPE_GENERIC;
+      cred.TargetName = target_name.m_psz;
+      cred.CredentialBlobSize = KEY_SIZE;
+      cred.CredentialBlob = AesKey;
+      cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+
+      ok = CredWriteW(&cred, 0);
+      if (!ok) {
+          std::cerr << "Failed to write encryption key" << std::endl;
+          return NULL;
+      }
+      return AesKey;
+  }
+
+  void FlutterSecureStorageWindowsPlugin::HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue> &method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)
+  {
+    auto method = method_call.method_name();
+    const auto *args = std::get_if<flutter::EncodableMap>(method_call.arguments());
+    std::wstring path;
+    if (GetApplicationSupportPath(path) != ERROR_SUCCESS) {
+        result->Error("Exception occurred", "GetApplicationSupportPath");
+        return;
+    }
+    try
+    {
+      if (method == "write")
+      {
+        auto key = this->GetValueKey(args);
+        auto val = this->GetStringArg("value", args);
+        if (key.has_value())
+        {
+          if (val.has_value())
+            this->Write(key.value(), val.value());
+          else
+            this->Delete(key.value());
+          result->Success();
+        }
+        else
+        {
+          result->Error("Exception occurred", "write");
+        }
+      }
+      else if (method == "read")
+      {
+        auto key = this->GetValueKey(args);
+        if (key.has_value())
+        {
+          auto val = this->Read(key.value());
+          if (val.has_value())
+            result->Success(flutter::EncodableValue(val.value()));
+          else
+            result->Success();
+        }
+        else
+        {
+          result->Error("Exception occurred", "read");
+        }
+      }
+      else if (method == "readAll")
+      {
+        auto creds = this->ReadAll();
+        result->Success(flutter::EncodableValue(creds));
+      }
+      else if (method == "delete")
+      {
+        auto key = this->GetValueKey(args);
+        if (key.has_value())
+        {
+          this->Delete(key.value());
+          result->Success();
+        }
+        else
+        {
+          result->Error("Exception occurred", "delete");
+        }
+      }
+      else if (method == "deleteAll")
+      {
+        this->DeleteAll();
+        result->Success();
+      }
+      else if (method == "containsKey")
+      {
+        auto key = this->GetValueKey(args);
+        if (key.has_value())
+        {
+          auto contains_key = this->ContainsKey(key.value());
+          result->Success(flutter::EncodableValue(contains_key));
+        }
+        else
+        {
+          result->Error("Exception occurred", "containsKey");
+        }
+      }
+      else
+      {
+        result->NotImplemented();
+      }
+    }
+    catch (DWORD e)
+    {
+      auto str_code = this->GetErrorString(e);
+      result->Error("Exception encountered: " + str_code, method);
+    }
+  }
+
+  void FlutterSecureStorageWindowsPlugin::Write(const std::string &key, const std::string &val)
+  {
+      //The recommended size for AES-GCM IV is 12 bytes
+      const DWORD NONCE_SIZE = 12;
+      const DWORD KEY_SIZE = 16;
+
+      NTSTATUS status;
+      BCRYPT_ALG_HANDLE algo = NULL;
+      BCRYPT_KEY_HANDLE keyHandle = NULL;
+      DWORD bytesWritten = 0,
+          ciphertextSize = 0;
+      PBYTE ciphertext = NULL,
+          iv = (PBYTE)HeapAlloc(GetProcessHeap(), 0, NONCE_SIZE),
+          encryptionKey = GetEncryptionKey();
+      BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO authInfo{};
+      BCRYPT_AUTH_TAG_LENGTHS_STRUCT authTagLengths{};
+      std::basic_ofstream<BYTE> fs;
+      std::wstring appSupportPath;
+      std::string error;
+
+      if (iv == NULL) {
+          error = "IV HeapAlloc Failed";
+          goto err;
+      }
+      if (encryptionKey == NULL) {
+          error = "encryptionKey is NULL";
+          goto err;
+      }
+      status = BCryptOpenAlgorithmProvider(&algo, BCRYPT_AES_ALGORITHM, NULL, 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          error = NtStatusToString("BCryptOpenAlgorithmProvider", status);
+          goto err;
+      }
+      status = BCryptSetProperty(algo, BCRYPT_CHAINING_MODE, (PUCHAR)BCRYPT_CHAIN_MODE_GCM, sizeof(BCRYPT_CHAIN_MODE_GCM), 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          error = NtStatusToString("BCryptSetProperty", status);
+          goto err;
+      }
+      status = BCryptGetProperty(algo, BCRYPT_AUTH_TAG_LENGTH, (PBYTE)&authTagLengths, sizeof(BCRYPT_AUTH_TAG_LENGTHS_STRUCT), &bytesWritten, 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          error = NtStatusToString("BCryptGetProperty", status);
+          goto err;
+      }
+      BCRYPT_INIT_AUTH_MODE_INFO(authInfo);
+      authInfo.pbNonce = (PUCHAR)HeapAlloc(GetProcessHeap(), 0, NONCE_SIZE);
+      if (authInfo.pbNonce == NULL) {
+          error = "pbNonce HeapAlloc Failed";
+          goto err;
+      }
+      authInfo.cbNonce = NONCE_SIZE;
+      status = BCryptGenRandom(NULL, iv, authInfo.cbNonce, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+      if (!BCRYPT_SUCCESS(status)) {
+          error = NtStatusToString("BCryptGenRandom", status);
+          goto err;
+      }
+      //copy the original IV into the authInfo, we can't write the IV directly into the authInfo because it will change after calling BCryptEncrypt and we still need to write the IV to file
+      memcpy(authInfo.pbNonce, iv, authInfo.cbNonce);
+      //We do not use additional authenticated data
+      authInfo.pbAuthData = NULL;
+      authInfo.cbAuthData = 0;
+      //Make space for the authentication tag
+      authInfo.pbTag = (PUCHAR)HeapAlloc(GetProcessHeap(), 0, authTagLengths.dwMaxLength);
+      if (authInfo.pbTag == NULL) {
+          error = "pbTag HeapAlloc Failed";
+          goto err;
+      }
+      authInfo.cbTag = authTagLengths.dwMaxLength;
+      status = BCryptGenerateSymmetricKey(algo, &keyHandle, NULL, 0, encryptionKey, KEY_SIZE, 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          error = NtStatusToString("BCryptGenerateSymmetricKey", status);
+          goto err;
+      }
+      //First call to BCryptEncrypt to get size of ciphertext
+      status = BCryptEncrypt(keyHandle, (PUCHAR)val.c_str(), (ULONG)val.length() + 1, (PVOID)&authInfo, NULL, 0, NULL, 0, &bytesWritten, 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          error = NtStatusToString("BCryptEncrypt1", status);
+          goto err;
+      }
+      ciphertextSize = bytesWritten;
+      ciphertext = (PBYTE)HeapAlloc(GetProcessHeap(), 0, ciphertextSize);
+      if (ciphertext == NULL) {
+          error = "CipherText HeapAlloc failed";
+          goto err;
+      }
+      //Actual encryption
+      status = BCryptEncrypt(keyHandle, (PUCHAR)val.c_str(), (ULONG)val.length() + 1, (PVOID)&authInfo, NULL, 0, ciphertext, ciphertextSize, &bytesWritten, 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          error = NtStatusToString("BCryptEncrypt2", status);
+          goto err;
+      }
+      GetApplicationSupportPath(appSupportPath);
+      if (!PathExists(appSupportPath)) {
+          MakePath(appSupportPath);
+      }
+      fs = std::basic_ofstream<BYTE>(appSupportPath + L"\\" + std::wstring(key.begin(), key.end()) + L".secure", std::ios::binary | std::ios::trunc);
+      if (!fs) {
+          error = "Failed to open output stream";
+          goto err;
+      }
+      fs.write(iv, NONCE_SIZE);
+      fs.write(authInfo.pbTag, authInfo.cbTag);
+      fs.write(ciphertext, ciphertextSize);
+      fs.close();
+      HeapFree(GetProcessHeap(), 0, iv);
+      HeapFree(GetProcessHeap(), 0, encryptionKey);
+      HeapFree(GetProcessHeap(), 0, authInfo.pbNonce);
+      HeapFree(GetProcessHeap(), 0, authInfo.pbTag);
+      HeapFree(GetProcessHeap(), 0, ciphertext);
+      return;
+  err:
+      if (iv) {
+          HeapFree(GetProcessHeap(), 0, iv);
+      }
+      if (encryptionKey) {
+          HeapFree(GetProcessHeap(), 0, encryptionKey);
+      }
+      if (authInfo.pbNonce) {
+          HeapFree(GetProcessHeap(), 0, authInfo.pbNonce);
+      }
+      if (authInfo.pbTag) {
+          HeapFree(GetProcessHeap(), 0, authInfo.pbTag);
+      }
+      if (ciphertext) {
+          HeapFree(GetProcessHeap(), 0, ciphertext);
+      }
+      throw std::runtime_error(error);
+  }
+
+  std::optional<std::string> FlutterSecureStorageWindowsPlugin::Read(const std::string &key)
+  {
+      const DWORD NONCE_SIZE = 12;
+      const DWORD KEY_SIZE = 16;
+
+      NTSTATUS status;
+      BCRYPT_ALG_HANDLE algo = NULL;
+      BCRYPT_KEY_HANDLE keyHandle = NULL;
+      BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO authInfo{};
+      BCRYPT_AUTH_TAG_LENGTHS_STRUCT authTagLengths{};
+
+      PBYTE encryptionKey = GetEncryptionKey(),
+          ciphertext = NULL,
+          fileBuffer = NULL,
+          plaintext = NULL;
+      DWORD plaintextSize = 0,
+          bytesWritten = 0,
+          ciphertextSize = 0;
+      std::wstring appSupportPath;
+      std::basic_ifstream<BYTE> fs;
+      std::streampos fileSize;
+      std::optional<std::string> returnVal = std::nullopt;
+
+      if (encryptionKey == NULL) {
+          std::cerr << "encryptionKey is NULL" << std::endl;
+          goto cleanup;
+      }
+      GetApplicationSupportPath(appSupportPath);
+      if (!PathExists(appSupportPath)) {
+          MakePath(appSupportPath);
+      }
+      //Read full file into a buffer
+      fs = std::basic_ifstream<BYTE>(appSupportPath + L"\\" + std::wstring(key.begin(), key.end()) + L".secure", std::ios::binary);
+      if (!fs.good()) {
+          //Backwards comp.
+          PCREDENTIALW pcred;
+          CA2W target_name(key.c_str());
+          bool ok = CredReadW(target_name.m_psz, CRED_TYPE_GENERIC, 0, &pcred);
+          if (ok)
+          {
+              auto val = std::string((char*)pcred->CredentialBlob);
+              CredFree(pcred);
+              returnVal = val;
+          }
+          goto cleanup;
+      }
+      fs.unsetf(std::ios::skipws);
+      fs.seekg(0, std::ios::end);
+      fileSize = fs.tellg();
+      fs.seekg(0, std::ios::beg);
+      fileBuffer = (PBYTE)HeapAlloc(GetProcessHeap(), 0, fileSize);
+      if (NULL == fileBuffer) {
+          std::cerr << "fileBuffer HeapAlloc failed" << std::endl;
+          goto cleanup;
+      }
+      fs.read(fileBuffer, fileSize);
+      fs.close();
+
+      status = BCryptOpenAlgorithmProvider(&algo, BCRYPT_AES_ALGORITHM, NULL, 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          std::cerr << NtStatusToString("BCryptOpenAlgorithmProvider", status) << std::endl;
+          goto cleanup;
+      }
+      status = BCryptSetProperty(algo, BCRYPT_CHAINING_MODE, (PUCHAR)BCRYPT_CHAIN_MODE_GCM, sizeof(BCRYPT_CHAIN_MODE_GCM), 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          std::cerr << NtStatusToString("BCryptOpenAlgorithmProvider", status) << std::endl;
+          goto cleanup;
+      }
+      status = BCryptGetProperty(algo, BCRYPT_AUTH_TAG_LENGTH, (PBYTE)&authTagLengths, sizeof(BCRYPT_AUTH_TAG_LENGTHS_STRUCT), &bytesWritten, 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          std::cerr << NtStatusToString("BCryptGetProperty", status) << std::endl;
+          goto cleanup;
+      }
+
+      BCRYPT_INIT_AUTH_MODE_INFO(authInfo);
+      authInfo.pbNonce = (PUCHAR)HeapAlloc(GetProcessHeap(), 0, NONCE_SIZE);
+      if (authInfo.pbNonce == NULL) {
+          std::cerr << "pbNonce HeapAlloc Failed" << std::endl;
+          goto cleanup;
+      }
+      authInfo.cbNonce = NONCE_SIZE;
+      //Check if file is at least long enough for iv and authentication tag
+      if (fileSize <= static_cast<long long>(NONCE_SIZE) + authTagLengths.dwMaxLength) {
+          std::cerr << "File is too small" << std::endl;
+          goto cleanup;
+      }
+      authInfo.pbTag = (PUCHAR)HeapAlloc(GetProcessHeap(), 0, authTagLengths.dwMaxLength);
+      if (authInfo.pbTag == NULL) {
+          std::cerr << "pbTag HeapAlloc Failed" << std::endl;
+          goto cleanup;
+      }
+      ciphertextSize = (DWORD)fileSize - NONCE_SIZE - authTagLengths.dwMaxLength;
+      ciphertext = (PBYTE)HeapAlloc(GetProcessHeap(), 0, ciphertextSize);
+      if (ciphertext == NULL) {
+          std::cerr << "ciphertext HeapAlloc failed" << std::endl;
+          goto cleanup;
+      }
+      //Copy different parts needed for decryption from filebuffer
+#pragma warning(push)
+#pragma warning(disable:6385)
+      memcpy(authInfo.pbNonce, fileBuffer, NONCE_SIZE);
+#pragma warning(pop)
+      memcpy(authInfo.pbTag, &fileBuffer[NONCE_SIZE], authTagLengths.dwMaxLength);
+      memcpy(ciphertext, &fileBuffer[NONCE_SIZE + authTagLengths.dwMaxLength], ciphertextSize);
+      authInfo.cbTag = authTagLengths.dwMaxLength;
+
+      status = BCryptGenerateSymmetricKey(algo, &keyHandle, NULL, 0, encryptionKey, KEY_SIZE, 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          std::cerr << NtStatusToString("BCryptGenerateSymmetricKey", status) << std::endl;
+          goto cleanup;
+      }
+      //First call is to determine size of plaintext
+      status = BCryptDecrypt(keyHandle, ciphertext, ciphertextSize, (PVOID)&authInfo, NULL, 0, NULL, 0, &bytesWritten, 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          std::cerr << NtStatusToString("BCryptDecrypt1", status) << std::endl;
+          goto cleanup;
+      }
+      plaintextSize = bytesWritten;
+      plaintext = (PBYTE)HeapAlloc(GetProcessHeap(), 0, plaintextSize);
+      if (NULL == plaintext) {
+          std::cerr << "plaintext HeapAlloc failed" << std::endl;
+          goto cleanup;
+      }
+      //Actuual decryption
+      status = BCryptDecrypt(keyHandle, ciphertext, ciphertextSize, (PVOID)&authInfo, NULL, 0, plaintext, plaintextSize, &bytesWritten, 0);
+      if (!BCRYPT_SUCCESS(status)) {
+          std::cerr << NtStatusToString("BCryptDecrypt2", status) << std::endl;
+          goto cleanup;
+      }
+      returnVal = (char*)plaintext;
+  cleanup:
+      if (encryptionKey) {
+          HeapFree(GetProcessHeap(), 0, encryptionKey);
+      }
+      if (ciphertext) {
+          HeapFree(GetProcessHeap(), 0, ciphertext);
+      }
+      if (plaintext) {
+          HeapFree(GetProcessHeap(), 0, plaintext);
+      }
+      if (fileBuffer) {
+          HeapFree(GetProcessHeap(), 0, fileBuffer);
+      }
+      if (authInfo.pbNonce) {
+          HeapFree(GetProcessHeap(), 0, authInfo.pbNonce);
+      }
+      if (authInfo.pbTag) {
+          HeapFree(GetProcessHeap(), 0, authInfo.pbTag);
+      }
+      return returnVal;
+  }
+
+  flutter::EncodableMap FlutterSecureStorageWindowsPlugin::ReadAll()
+  {
+      WIN32_FIND_DATA searchRes;
+      HANDLE hFile;
+      std::wstring appSupportPath;
+
+      GetApplicationSupportPath(appSupportPath);
+      if (!PathExists(appSupportPath)) {
+          MakePath(appSupportPath);
+      }
+      hFile = FindFirstFile((appSupportPath + L"\\*.secure").c_str(), &searchRes);
+      if (hFile == INVALID_HANDLE_VALUE) {
+          return flutter::EncodableMap();
+      }
+
+      flutter::EncodableMap creds;
+
+      do {
+          std::wstring fileName(searchRes.cFileName);
+          size_t pos = fileName.find(L".secure");
+          fileName.erase(pos, 7);
+          char* out = new char[fileName.length() + 1];
+          size_t charsConverted = 0;
+          wcstombs_s(&charsConverted, out, fileName.length() + 1, fileName.c_str(), fileName.length() + 1);
+          std::optional<std::string> val = this->Read(out);
+          auto key = this->RemoveKeyPrefix(out);
+          if (val.has_value()) {
+              creds[key] = val.value();
+              continue;
+          }
+      } while (FindNextFile(hFile, &searchRes) != 0);
+
+    //Backwards comp.
+    PCREDENTIALW* pcreds;
+    DWORD cred_count = 0;
+
+    bool ok = CredEnumerateW(CREDENTIAL_FILTER.m_psz, 0, &cred_count, &pcreds);
+    if (!ok)
+    {
+        return creds;
+    }
+    for (DWORD i = 0; i < cred_count; i++)
+    {
+      auto pcred = pcreds[i];
+      std::string target_name = CW2A(pcred->TargetName);
+      auto val = std::string((char*)pcred->CredentialBlob);
+      auto key = this->RemoveKeyPrefix(target_name);
+      //If the key exists then data was already read from a file, which implies that the data read from the credential system is outdated
+      if (creds.find(key) == creds.end()) {
+          creds[key] = val;
+      }
+    }
+
+    CredFree(pcreds);
+
+    return creds;
+  }
+
+  void FlutterSecureStorageWindowsPlugin::Delete(const std::string &key)
+  {
+      std::wstring appSupportPath;
+      GetApplicationSupportPath(appSupportPath);
+      auto wstr = std::wstring(key.begin(), key.end());
+      BOOL ok = DeleteFile((appSupportPath + L"\\" + wstr + L".secure").c_str());
+      if (!ok) {
+          DWORD error = GetLastError();
+          if (error != ERROR_FILE_NOT_FOUND && error != ERROR_PATH_NOT_FOUND) {
+              throw error;
+          }
+      }
+
+    //Backwards comp.
+    ok = CredDeleteW(wstr.c_str(), CRED_TYPE_GENERIC, 0);
+    if (!ok)
+    {
+      auto error = GetLastError();
+
+      // Silently ignore if we try to delete a key that doesn't exist
+      if (error == ERROR_NOT_FOUND)
+        return;
+
+      throw error;
+    }
+  }
+
+  void FlutterSecureStorageWindowsPlugin::DeleteAll()
+  {
+
+      WIN32_FIND_DATA searchRes;
+      HANDLE hFile;
+      std::wstring appSupportPath;
+
+      GetApplicationSupportPath(appSupportPath);
+      if (!PathExists(appSupportPath)) {
+          MakePath(appSupportPath);
+      }
+      hFile = FindFirstFile((appSupportPath + L"\\*.secure").c_str(), &searchRes);
+      if (hFile == INVALID_HANDLE_VALUE) {
+          return;
+      }
+      do {
+          std::wstring fileName(searchRes.cFileName);
+          BOOL ok = DeleteFile((appSupportPath + L"\\" + fileName).c_str());
+          if (!ok) {
+              DWORD error = GetLastError();
+              if (error != ERROR_FILE_NOT_FOUND) {
+                  throw error;
+              }
+          }
+      } while (FindNextFile(hFile, &searchRes) != 0);
+
+    //Backwards comp.
+    PCREDENTIALW* pcreds;
+    DWORD cred_count = 0;
+
+    bool read_ok = CredEnumerateW(CREDENTIAL_FILTER.m_psz, 0, &cred_count, &pcreds);
+    if (!read_ok)
+    {
+      auto error = GetLastError();
+      if (error == ERROR_NOT_FOUND)
+        // No credentials to delete
+        return;
+      throw error;
+    }
+
+    for (DWORD i = 0; i < cred_count; i++)
+    {
+      auto pcred = pcreds[i];
+      auto target_name = pcred->TargetName;
+
+      bool delete_ok = CredDeleteW(target_name, CRED_TYPE_GENERIC, 0);
+      if (!delete_ok)
+      {
+        throw GetLastError();
+      }
+    }
+
+    CredFree(pcreds);
+  }
+
+  bool FlutterSecureStorageWindowsPlugin::ContainsKey(const std::string &key)
+  {
+      std::wstring appSupportPath;
+      GetApplicationSupportPath(appSupportPath);
+      std::wstring wstr = std::wstring(key.begin(), key.end());
+      if (INVALID_FILE_ATTRIBUTES == GetFileAttributes((appSupportPath + L"\\" + wstr + L".secure").c_str())) {
+          //Backwards comp.
+          PCREDENTIALW pcred;
+          CA2W target_name(key.c_str());
+
+          bool ok = CredReadW(target_name.m_psz, CRED_TYPE_GENERIC, 0, &pcred);
+          if (ok) return true;
+
+          auto error = GetLastError();
+          if (error == ERROR_NOT_FOUND)
+              return false;
+          throw error;
+      }
+      return true;
+  }
+} // namespace
+
+void FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar)
+{
+  FlutterSecureStorageWindowsPlugin::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
+}

--- a/third_party/flutter_secure_storage_windows/windows/include/flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h
+++ b/third_party/flutter_secure_storage_windows/windows/include/flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h
@@ -1,0 +1,23 @@
+#ifndef FLUTTER_PLUGIN_FLUTTER_SECURE_STORAGE_WINDOWS_PLUGIN_H_
+#define FLUTTER_PLUGIN_FLUTTER_SECURE_STORAGE_WINDOWS_PLUGIN_H_
+
+#include <flutter_plugin_registrar.h>
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllimport)
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+FLUTTER_PLUGIN_EXPORT void FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
+
+#endif  // FLUTTER_PLUGIN_FLUTTER_SECURE_STORAGE_WINDOWS_PLUGIN_H_

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -9,6 +9,7 @@ project(runner LANGUAGES CXX)
 add_executable(${BINARY_NAME} WIN32
   "flutter_window.cpp"
   "main.cpp"
+  "single_instance.cpp"
   "utils.cpp"
   "velopack_uninstall.cpp"
   "velopack_update.cpp"

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "flutter/generated_plugin_registrant.h"
+#include "single_instance.h"
 #include "utils.h"
 #include "velopack_update.h"
 
@@ -378,8 +379,9 @@ void VerifyDeviceOwner(
 
 }  // namespace
 
-FlutterWindow::FlutterWindow(const flutter::DartProject& project)
-    : project_(project) {}
+FlutterWindow::FlutterWindow(const flutter::DartProject& project,
+                             UINT activation_message)
+    : project_(project), activation_message_(activation_message) {}
 
 FlutterWindow::~FlutterWindow() {}
 
@@ -462,6 +464,24 @@ LRESULT
 FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
                               WPARAM const wparam,
                               LPARAM const lparam) noexcept {
+  if (activation_message_ != 0 && message == activation_message_) {
+    if (::IsIconic(hwnd)) {
+      ::ShowWindow(hwnd, SW_RESTORE);
+    } else {
+      ::ShowWindow(hwnd, SW_SHOW);
+    }
+    ::BringWindowToTop(hwnd);
+    if (::SetForegroundWindow(hwnd) == 0) {
+      FLASHWINFO flash_info = {};
+      flash_info.cbSize = sizeof(flash_info);
+      flash_info.hwnd = hwnd;
+      flash_info.dwFlags = FLASHW_TRAY | FLASHW_TIMERNOFG;
+      flash_info.uCount = 3;
+      ::FlashWindowEx(&flash_info);
+    }
+    return kSingleInstanceActivationAcknowledged;
+  }
+
   // Give Flutter, including plugins, an opportunity to handle window messages.
   if (flutter_controller_) {
     std::optional<LRESULT> result =

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -13,7 +13,7 @@
 class FlutterWindow : public Win32Window {
  public:
   // Creates a new FlutterWindow hosting a Flutter view running |project|.
-  explicit FlutterWindow(const flutter::DartProject& project);
+  FlutterWindow(const flutter::DartProject& project, UINT activation_message);
   virtual ~FlutterWindow();
 
  protected:
@@ -36,6 +36,10 @@ class FlutterWindow : public Win32Window {
       device_owner_auth_channel_;
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
       velopack_update_channel_;
+
+  // Registered Windows message used by a secondary process to restore this
+  // primary window. The message name is scoped to the storage prefix.
+  UINT activation_message_ = 0;
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -3,13 +3,38 @@
 #include <roapi.h>
 #include <windows.h>
 
+#include <string>
+
 #include "flutter_window.h"
+#include "single_instance.h"
 #include "utils.h"
 #include "velopack_uninstall.h"
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
   RunVelopackHooks();
+
+  SingleInstanceGuard single_instance;
+  const SingleInstanceAcquireResult instance_result = single_instance.Acquire();
+  if (instance_result == SingleInstanceAcquireResult::kSecondary) {
+    if (!ActivateExistingInstance(single_instance.activation_message())) {
+      ::MessageBoxW(
+          nullptr,
+          L"Vizor is already running. It may be starting, not responding, or "
+          L"running in another Windows session.",
+          L"Vizor", MB_OK | MB_ICONINFORMATION | MB_SETFOREGROUND);
+    }
+    return EXIT_SUCCESS;
+  }
+  if (instance_result == SingleInstanceAcquireResult::kError) {
+    const std::wstring error_message =
+        L"Vizor could not establish its single-instance lock and will close "
+        L"to protect wallet data.\n\nWindows error: " +
+        std::to_wstring(single_instance.last_error());
+    ::MessageBoxW(nullptr, error_message.c_str(), L"Vizor",
+                  MB_OK | MB_ICONERROR | MB_SETFOREGROUND);
+    return EXIT_FAILURE;
+  }
 
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
@@ -29,7 +54,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
 
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
-  FlutterWindow window(project);
+  FlutterWindow window(project, single_instance.activation_message());
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1095, 726);
   if (!window.Create(L"Vizor", origin, size)) {

--- a/windows/runner/runner.exe.manifest
+++ b/windows/runner/runner.exe.manifest
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>

--- a/windows/runner/single_instance.cpp
+++ b/windows/runner/single_instance.cpp
@@ -1,0 +1,206 @@
+#include "single_instance.h"
+
+#include <knownfolders.h>
+#include <shlobj.h>
+
+#include <cwchar>
+#include <cwctype>
+#include <filesystem>
+#include <string>
+#include <system_error>
+
+#include "resource_values.h"
+#include "utils.h"
+
+namespace {
+
+#ifndef VIZOR_WINDOWS_STORAGE_PREFIX
+#define VIZOR_WINDOWS_STORAGE_PREFIX "Vizor"
+#endif
+
+#define VIZOR_WIDEN2(value) L##value
+#define VIZOR_WIDEN(value) VIZOR_WIDEN2(value)
+
+constexpr wchar_t kLockDirectoryName[] = L"VizorInstanceLocks";
+constexpr DWORD kActivationRetryWindowMs = 2000;
+constexpr DWORD kActivationRetryDelayMs = 50;
+constexpr UINT kActivationMessageTimeoutMs = 100;
+
+std::wstring SanitizedFileName(std::wstring value) {
+  constexpr wchar_t kInvalidChars[] = L"<>:\"/\\|?*";
+  for (auto& ch : value) {
+    if (wcschr(kInvalidChars, ch) != nullptr || iswcntrl(ch)) {
+      ch = L'_';
+    }
+  }
+  while (!value.empty() &&
+         (iswspace(value.back()) || value.back() == L'.')) {
+    value.pop_back();
+  }
+  return value;
+}
+
+std::filesystem::path LocalAppDataPath() {
+  PWSTR raw_path = nullptr;
+  const HRESULT result = ::SHGetKnownFolderPath(
+      FOLDERID_LocalAppData, KF_FLAG_DEFAULT, nullptr, &raw_path);
+  if (FAILED(result) || raw_path == nullptr) {
+    if (raw_path != nullptr) {
+      ::CoTaskMemFree(raw_path);
+    }
+    return {};
+  }
+
+  std::filesystem::path path(raw_path);
+  ::CoTaskMemFree(raw_path);
+  return path;
+}
+
+std::filesystem::path LockFilePath(DWORD* error) {
+  const std::filesystem::path local_app_data = LocalAppDataPath();
+  if (local_app_data.empty()) {
+    *error = ERROR_PATH_NOT_FOUND;
+    return {};
+  }
+
+  std::wstring company_name = Utf16FromUtf8(VIZOR_WINDOWS_COMPANY_NAME);
+  if (company_name.empty()) {
+    company_name = L"com.keplr";
+  }
+  const std::wstring storage_prefix =
+      SanitizedFileName(VIZOR_WIDEN(VIZOR_WINDOWS_STORAGE_PREFIX));
+  if (storage_prefix.empty()) {
+    *error = ERROR_INVALID_NAME;
+    return {};
+  }
+
+  const std::filesystem::path lock_directory =
+      local_app_data / company_name / kLockDirectoryName;
+  std::error_code directory_error;
+  std::filesystem::create_directories(lock_directory, directory_error);
+  if (directory_error) {
+    *error = static_cast<DWORD>(directory_error.value());
+    return {};
+  }
+
+  *error = ERROR_SUCCESS;
+  return lock_directory / (storage_prefix + L".lock");
+}
+
+std::wstring ActivationMessageName() {
+  const std::wstring storage_prefix =
+      SanitizedFileName(VIZOR_WIDEN(VIZOR_WINDOWS_STORAGE_PREFIX));
+  if (storage_prefix.empty()) {
+    return {};
+  }
+  return L"com.keplr.vizor." + storage_prefix + L".activate";
+}
+
+struct ActivationContext {
+  UINT message = 0;
+  bool acknowledged = false;
+};
+
+BOOL CALLBACK SendActivationMessage(HWND window, LPARAM parameter) {
+  auto* context = reinterpret_cast<ActivationContext*>(parameter);
+  if (context == nullptr || context->message == 0) {
+    return FALSE;
+  }
+
+  DWORD_PTR response = 0;
+  if (::SendMessageTimeoutW(
+          window, context->message, 0, 0,
+          SMTO_ABORTIFHUNG | SMTO_BLOCK, kActivationMessageTimeoutMs,
+          &response) != 0 &&
+      response ==
+          static_cast<DWORD_PTR>(kSingleInstanceActivationAcknowledged)) {
+    context->acknowledged = true;
+    return FALSE;
+  }
+  return TRUE;
+}
+
+}  // namespace
+
+SingleInstanceGuard::SingleInstanceGuard() = default;
+
+SingleInstanceGuard::~SingleInstanceGuard() {
+  if (lock_held_ && lock_file_ != INVALID_HANDLE_VALUE) {
+    ::UnlockFileEx(lock_file_, 0, 1, 0, &lock_overlapped_);
+  }
+  if (lock_file_ != INVALID_HANDLE_VALUE) {
+    ::CloseHandle(lock_file_);
+  }
+}
+
+SingleInstanceAcquireResult SingleInstanceGuard::Acquire() {
+  if (acquire_attempted_) {
+    last_error_ = ERROR_ALREADY_INITIALIZED;
+    return SingleInstanceAcquireResult::kError;
+  }
+  acquire_attempted_ = true;
+
+  const std::wstring activation_name = ActivationMessageName();
+  if (activation_name.empty()) {
+    last_error_ = ERROR_INVALID_NAME;
+    return SingleInstanceAcquireResult::kError;
+  }
+  activation_message_ = ::RegisterWindowMessageW(activation_name.c_str());
+  if (activation_message_ == 0) {
+    last_error_ = ::GetLastError();
+    return SingleInstanceAcquireResult::kError;
+  }
+
+  DWORD path_error = ERROR_SUCCESS;
+  const std::filesystem::path lock_path = LockFilePath(&path_error);
+  if (lock_path.empty()) {
+    last_error_ = path_error;
+    return SingleInstanceAcquireResult::kError;
+  }
+
+  lock_file_ = ::CreateFileW(
+      lock_path.c_str(), GENERIC_READ | GENERIC_WRITE,
+      FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
+      FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED, nullptr);
+  if (lock_file_ == INVALID_HANDLE_VALUE) {
+    last_error_ = ::GetLastError();
+    return SingleInstanceAcquireResult::kError;
+  }
+
+  lock_overlapped_ = {};
+  if (::LockFileEx(lock_file_,
+                   LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, 1,
+                   0, &lock_overlapped_) != 0) {
+    lock_held_ = true;
+    last_error_ = ERROR_SUCCESS;
+    return SingleInstanceAcquireResult::kPrimary;
+  }
+
+  last_error_ = ::GetLastError();
+  ::CloseHandle(lock_file_);
+  lock_file_ = INVALID_HANDLE_VALUE;
+  if (last_error_ == ERROR_LOCK_VIOLATION ||
+      last_error_ == ERROR_SHARING_VIOLATION) {
+    return SingleInstanceAcquireResult::kSecondary;
+  }
+  return SingleInstanceAcquireResult::kError;
+}
+
+bool ActivateExistingInstance(UINT activation_message) {
+  if (activation_message == 0) {
+    return false;
+  }
+
+  const ULONGLONG deadline = ::GetTickCount64() + kActivationRetryWindowMs;
+  do {
+    ActivationContext context{activation_message, false};
+    ::EnumWindows(SendActivationMessage,
+                  reinterpret_cast<LPARAM>(&context));
+    if (context.acknowledged) {
+      return true;
+    }
+    ::Sleep(kActivationRetryDelayMs);
+  } while (::GetTickCount64() < deadline);
+
+  return false;
+}

--- a/windows/runner/single_instance.h
+++ b/windows/runner/single_instance.h
@@ -1,0 +1,49 @@
+#ifndef RUNNER_SINGLE_INSTANCE_H_
+#define RUNNER_SINGLE_INSTANCE_H_
+
+#include <windows.h>
+
+enum class SingleInstanceAcquireResult {
+  kPrimary,
+  kSecondary,
+  kError,
+};
+
+// Holds an OS file lock for the lifetime of the primary Vizor process.
+//
+// The lock lives in the current user's LocalAppData and is keyed by
+// VIZOR_WINDOWS_STORAGE_PREFIX, so processes that share wallet storage also
+// share the same instance boundary. The lock is released automatically when
+// the handle is closed, including after an abnormal process termination.
+class SingleInstanceGuard {
+ public:
+  SingleInstanceGuard();
+  ~SingleInstanceGuard();
+
+  SingleInstanceGuard(const SingleInstanceGuard&) = delete;
+  SingleInstanceGuard& operator=(const SingleInstanceGuard&) = delete;
+
+  SingleInstanceAcquireResult Acquire();
+
+  UINT activation_message() const { return activation_message_; }
+  DWORD last_error() const { return last_error_; }
+
+ private:
+  HANDLE lock_file_ = INVALID_HANDLE_VALUE;
+  OVERLAPPED lock_overlapped_{};
+  UINT activation_message_ = 0;
+  DWORD last_error_ = ERROR_SUCCESS;
+  bool acquire_attempted_ = false;
+  bool lock_held_ = false;
+};
+
+// Result returned by the matching primary window for an activation message.
+constexpr LRESULT kSingleInstanceActivationAcknowledged = 0x56495A4F;
+
+// Tries briefly to find the primary window in the current interactive session
+// and asks it to restore and activate itself. Returns false when the primary is
+// still starting, hung, elevated beyond the caller, or running in another
+// Windows session. Process exclusion remains enforced by the file lock.
+bool ActivateExistingInstance(UINT activation_message);
+
+#endif  // RUNNER_SINGLE_INSTANCE_H_


### PR DESCRIPTION
## Summary

- prevent multiple Windows Vizor processes from opening the same wallet storage concurrently
- vendor the existing `flutter_secure_storage_windows` 4.1.0 implementation as `4.1.0+vizor.1`
- serialize complete read-modify-write transactions across plugin instances and processes
- commit DPAPI-encrypted storage through flushed temporary files and atomic Windows file replacement
- retain and validate a last-known-good backup without deleting unreadable primary data
- surface native/file-system storage failures through Vizor's secure-storage unavailable error path
- document the actual DPAPI storage model and add a Windows single-instance smoke test

## Motivation

Issue [#490](https://github.com/chainapsis/vizor-wallet/issues/490) reports a Windows restart scenario where previously configured wallets were no longer visible. An interrupted or concurrent in-place rewrite of the Windows secure-storage file is one plausible contributor to that kind of symptom, so this PR hardens that path. This does not establish secure-storage corruption as the confirmed root cause of the report; it is a preventative reliability improvement for a credible failure mode.

## Compatibility

The fork is based on the exact Windows implementation already resolved by `flutter_secure_storage` 10.0.0. It keeps the same public API, application-support path, `flutter_secure_storage.dat` filename, JSON payload, and DPAPI encryption parameters. Existing 4.1.0 data remains readable. The additional lock, temporary, backup, and recovery-marker files are internal sidecars.

Downgrading to an unforked implementation and then returning to this fork is not treated as a supported storage transition without sidecar cleanup or migration.

## Validation

- `fvm flutter test test/core/storage/app_secure_store_test.dart` — 34 passed
- `fvm flutter test` in `third_party/flutter_secure_storage_windows` — platform-independent tests passed; Windows-only DPAPI/file-lock tests require a Windows host
- `fvm flutter analyze` in `third_party/flutter_secure_storage_windows` — no issues
- `git diff --check origin/main...HEAD`

The included Windows smoke script is intended for an isolated-storage Windows build because it forcibly terminates the test process while verifying lock recovery.