### PR TITLE
Page Keystone voting bundle memos

### DIFF
--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -8,6 +8,7 @@ import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
 import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_submission_job_provider.dart';
 import '../../../providers/voting/voting_state.dart';
@@ -846,6 +847,7 @@ class _KeystoneSigningPanelState extends State<_KeystoneSigningPanel> {
   static const _transitionCueDuration = Duration(milliseconds: 1300);
 
   bool _showTransitionCue = false;
+  int _memoIndex = 0;
   int _cueGeneration = 0;
   Timer? _cueTimer;
 
@@ -853,6 +855,7 @@ class _KeystoneSigningPanelState extends State<_KeystoneSigningPanel> {
   void didUpdateWidget(covariant _KeystoneSigningPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.bundleIndex != widget.bundleIndex) {
+      _memoIndex = 0;
       _triggerTransitionCue();
     }
   }
@@ -891,6 +894,8 @@ class _KeystoneSigningPanelState extends State<_KeystoneSigningPanel> {
     final canSkipRemainingBundles = widget.canSkipRemainingBundles;
     final onSkipRemainingBundles = widget.onSkipRemainingBundles;
     final onScan = widget.onScan;
+    final memoIndex = _memoIndex < batchMemos.length ? _memoIndex : 0;
+    final selectedMemo = batchMemos.isEmpty ? null : batchMemos[memoIndex];
     final qrPhase = qrError != null
         ? KeystonePcztQrStagePhase.failed
         : urParts.isEmpty
@@ -1006,16 +1011,25 @@ class _KeystoneSigningPanelState extends State<_KeystoneSigningPanel> {
                 ),
               ),
             ],
-            if (batchMemos.isNotEmpty) ...[
+            if (selectedMemo != null) ...[
               const SizedBox(height: AppSpacing.sm),
-              for (var index = 0; index < batchMemos.length; index++) ...[
-                if (index > 0) const SizedBox(height: AppSpacing.xs),
-                _KeystoneSigningMemo(
-                  label:
-                      'Bundle ${batchMemos[index].bundleIndex + 1} of ${batchMemos[index].bundleCount} memo',
-                  displayMemo: batchMemos[index].displayMemo,
-                ),
-              ],
+              _KeystoneSigningMemo(
+                key: ValueKey<int>(selectedMemo.bundleIndex),
+                label:
+                    'Bundle ${selectedMemo.bundleIndex + 1} of ${selectedMemo.bundleCount} memo',
+                displayMemo: selectedMemo.displayMemo,
+                showNavigation: batchMemos.length > 1,
+                onPrevious: memoIndex > 0
+                    ? () => setState(() {
+                        _memoIndex = memoIndex - 1;
+                      })
+                    : null,
+                onNext: memoIndex + 1 < batchMemos.length
+                    ? () => setState(() {
+                        _memoIndex = memoIndex + 1;
+                      })
+                    : null,
+              ),
             ],
             const SizedBox(height: AppSpacing.sm),
             KeystoneScanHelpOverlay(
@@ -1053,10 +1067,20 @@ class _KeystoneSigningPanelState extends State<_KeystoneSigningPanel> {
 }
 
 class _KeystoneSigningMemo extends StatelessWidget {
-  const _KeystoneSigningMemo({required this.label, required this.displayMemo});
+  const _KeystoneSigningMemo({
+    required this.label,
+    required this.displayMemo,
+    required this.showNavigation,
+    required this.onPrevious,
+    required this.onNext,
+    super.key,
+  });
 
   final String label;
   final String displayMemo;
+  final bool showNavigation;
+  final VoidCallback? onPrevious;
+  final VoidCallback? onNext;
 
   @override
   Widget build(BuildContext context) {
@@ -1074,11 +1098,32 @@ class _KeystoneSigningMemo extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                label,
-                style: AppTypography.labelSmall.copyWith(
-                  color: colors.text.secondary,
-                ),
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      label,
+                      style: AppTypography.labelSmall.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                  ),
+                  if (showNavigation) ...[
+                    _KeystoneMemoNavigationButton(
+                      key: const ValueKey('keystone_memo_previous'),
+                      tooltip: 'Previous bundle memo',
+                      iconName: AppIcons.chevronBackward,
+                      onPressed: onPrevious,
+                    ),
+                    const SizedBox(width: AppSpacing.xxs),
+                    _KeystoneMemoNavigationButton(
+                      key: const ValueKey('keystone_memo_next'),
+                      tooltip: 'Next bundle memo',
+                      iconName: AppIcons.chevronForward,
+                      onPressed: onNext,
+                    ),
+                  ],
+                ],
               ),
               const SizedBox(height: AppSpacing.xxs),
               SelectableText(
@@ -1093,6 +1138,34 @@ class _KeystoneSigningMemo extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _KeystoneMemoNavigationButton extends StatelessWidget {
+  const _KeystoneMemoNavigationButton({
+    required this.tooltip,
+    required this.iconName,
+    required this.onPressed,
+    super.key,
+  });
+
+  final String tooltip;
+  final String iconName;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return IconButton(
+      onPressed: onPressed,
+      tooltip: tooltip,
+      iconSize: 16,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints.tightFor(width: 28, height: 28),
+      color: colors.button.ghost.label,
+      disabledColor: colors.icon.disabled,
+      icon: AppIcon(iconName, size: 16),
     );
   }
 }

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -3224,7 +3224,7 @@ void main() {
     expect(recoveryApi.ballotIntents, ['1:2:false:0', '2:3:true:null']);
   });
 
-  testWidgets('hardware status screen shows each memo in a short window', (
+  testWidgets('hardware status screen pages one memo for a large batch', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(1152, 768));
@@ -3233,7 +3233,7 @@ void main() {
     });
 
     final recoveryApi = _MutableVotingRecoveryApi()
-      ..state = _recoveryState(bundleCount: 4);
+      ..state = _recoveryState(bundleCount: 50);
     final container = _statusContainer(
       accountOverride: _HardwareAccountNotifier.new,
       activeAccountUuid: () async => 'hardware-1',
@@ -3242,12 +3242,11 @@ void main() {
       recoveryApi: recoveryApi,
       rust: _VotingStatusRustApi(
         recoveryApi,
-        bundleCount: 4,
+        bundleCount: 50,
         keystoneMemoZecByBundle: const {
           0: '0.00000100',
           1: '0.00000200',
-          2: '0.00000300',
-          3: '0.00000400',
+          39: '0.00004000',
         },
       ),
       hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
@@ -3267,20 +3266,48 @@ void main() {
     await tester.pumpWidget(
       UncontrolledProviderScope(container: container, child: _statusHarness()),
     );
-    await _pumpUntilFound(tester, find.text('Sign 4 voting bundles'));
+    await _pumpUntilFound(tester, find.text('Sign 40 voting bundles'));
 
     expect(tester.takeException(), isNull);
     expect(find.byType(SingleChildScrollView), findsOneWidget);
-    expect(find.text('Sign 4 voting bundles'), findsOneWidget);
-    expect(find.text('One Keystone approval'), findsOneWidget);
-    expect(_RustApiFake.lastEncodedBatchMessageCount, 4);
-    for (var bundle = 1; bundle <= 4; bundle++) {
-      expect(find.text('Bundle $bundle of 4 memo'), findsOneWidget);
-      expect(
-        find.textContaining('Amount: 0.00000${bundle}00 ZEC'),
-        findsOneWidget,
-      );
+    expect(find.text('Sign 40 voting bundles'), findsOneWidget);
+    expect(
+      find.text('This QR signs 40 of 50 remaining bundles'),
+      findsOneWidget,
+    );
+    expect(find.text('One Keystone approval'), findsNothing);
+    expect(_RustApiFake.lastEncodedBatchMessageCount, 40);
+    expect(find.text('Bundle 1 of 50 memo'), findsOneWidget);
+    expect(find.text('Bundle 2 of 50 memo'), findsNothing);
+    expect(find.textContaining('Amount: 0.00000100 ZEC'), findsOneWidget);
+    expect(find.textContaining('Amount: 0.00000200 ZEC'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('keystone_memo_previous')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('keystone_memo_next')), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('keystone_memo_previous')));
+    await tester.pump();
+    expect(find.text('Bundle 1 of 50 memo'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('keystone_memo_next')));
+    await tester.pump();
+    expect(find.text('Bundle 1 of 50 memo'), findsNothing);
+    expect(find.text('Bundle 2 of 50 memo'), findsOneWidget);
+    expect(find.textContaining('Amount: 0.00000100 ZEC'), findsNothing);
+    expect(find.textContaining('Amount: 0.00000200 ZEC'), findsOneWidget);
+
+    for (var index = 2; index < 40; index++) {
+      await tester.tap(find.byKey(const ValueKey('keystone_memo_next')));
+      await tester.pump();
     }
+    expect(find.text('Bundle 40 of 50 memo'), findsOneWidget);
+    expect(find.textContaining('Amount: 0.00004000 ZEC'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('keystone_memo_next')));
+    await tester.pump();
+    expect(find.text('Bundle 40 of 50 memo'), findsOneWidget);
   });
 
   testWidgets('hardware status screen shows retry when Keystone QR fails', (


### PR DESCRIPTION
Show one Keystone voting bundle memo at a time with Previous and Next controls instead of stacking every memo above the signing QR. This keeps large signing batches usable while preserving the full batch QR and resets the pager when the signing batch advances.

Validated with `fvm flutter test test/features/voting/voting_status_screen_test.dart` and targeted Flutter analysis.