### PR TITLE
Use round-bound vote shares from zcash_voting 3.0.0-rc.3

### DIFF
--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1592,11 +1592,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
               'server=$serverUrl treePosition=${body['tree_position']} '
               'submitAt=${plan.submitAt} target=$targetCount',
             );
-            await api.submitShare(
-              roundId: context.round.roundId,
-              serverUrl: Uri.parse(serverUrl),
-              share: body,
-            );
+            await api.submitShare(serverUrl: Uri.parse(serverUrl), share: body);
             helperHealth.recordSuccess(serverUrl);
             acceptedServers.add(serverUrl);
             debugPrint(
@@ -2171,7 +2167,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     for (final serverUrl in helperHealth.candidateServers(serverUrls)) {
       try {
         await api.resubmitShare(
-          roundId: context.round.roundId,
           serverUrl: Uri.parse(serverUrl),
           shareId: shareId,
           share: body,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -10771,18 +10771,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   VoteShareWire dco_decode_vote_share_wire(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 9)
-      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    if (arr.length != 10)
+      throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
     return VoteShareWire(
-      sharesHash: dco_decode_String(arr[0]),
-      proposalId: dco_decode_u_32(arr[1]),
-      voteDecision: dco_decode_u_32(arr[2]),
-      encryptedShare: dco_decode_wire_encrypted_share(arr[3]),
-      shareIndex: dco_decode_u_32(arr[4]),
-      vcTreePosition: dco_decode_u_64(arr[5]),
-      shareComms: dco_decode_list_String(arr[6]),
-      primaryBlind: dco_decode_String(arr[7]),
-      submitAt: dco_decode_u_64(arr[8]),
+      voteRoundId: dco_decode_String(arr[0]),
+      sharesHash: dco_decode_String(arr[1]),
+      proposalId: dco_decode_u_32(arr[2]),
+      voteDecision: dco_decode_u_32(arr[3]),
+      encryptedShare: dco_decode_wire_encrypted_share(arr[4]),
+      shareIndex: dco_decode_u_32(arr[5]),
+      vcTreePosition: dco_decode_u_64(arr[6]),
+      shareComms: dco_decode_list_String(arr[7]),
+      primaryBlind: dco_decode_String(arr[8]),
+      submitAt: dco_decode_u_64(arr[9]),
     );
   }
 
@@ -13892,6 +13893,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   VoteShareWire sse_decode_vote_share_wire(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_voteRoundId = sse_decode_String(deserializer);
     var var_sharesHash = sse_decode_String(deserializer);
     var var_proposalId = sse_decode_u_32(deserializer);
     var var_voteDecision = sse_decode_u_32(deserializer);
@@ -13902,6 +13904,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_primaryBlind = sse_decode_String(deserializer);
     var var_submitAt = sse_decode_u_64(deserializer);
     return VoteShareWire(
+      voteRoundId: var_voteRoundId,
       sharesHash: var_sharesHash,
       proposalId: var_proposalId,
       voteDecision: var_voteDecision,
@@ -16477,6 +16480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.voteRoundId, serializer);
     sse_encode_String(self.sharesHash, serializer);
     sse_encode_u_32(self.proposalId, serializer);
     sse_encode_u_32(self.voteDecision, serializer);

--- a/lib/src/rust/third_party/zcash_voting/wire.dart
+++ b/lib/src/rust/third_party/zcash_voting/wire.dart
@@ -836,6 +836,8 @@ class VoteRecoveryWorkView {
 }
 
 class VoteShareWire {
+  /// Voting round ID as 32 bytes encoded in lowercase hex.
+  final String voteRoundId;
   final String sharesHash;
   final int proposalId;
   final int voteDecision;
@@ -847,6 +849,7 @@ class VoteShareWire {
   final BigInt submitAt;
 
   const VoteShareWire({
+    required this.voteRoundId,
     required this.sharesHash,
     required this.proposalId,
     required this.voteDecision,
@@ -860,6 +863,7 @@ class VoteShareWire {
 
   @override
   int get hashCode =>
+      voteRoundId.hashCode ^
       sharesHash.hashCode ^
       proposalId.hashCode ^
       voteDecision.hashCode ^
@@ -875,6 +879,7 @@ class VoteShareWire {
       identical(this, other) ||
       other is VoteShareWire &&
           runtimeType == other.runtimeType &&
+          voteRoundId == other.voteRoundId &&
           sharesHash == other.sharesHash &&
           proposalId == other.proposalId &&
           voteDecision == other.voteDecision &&

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -250,18 +250,15 @@ class VotingApiClient {
 
   /// Posts one encrypted share directly to a helper server.
   ///
-  /// The share map is expected to already use the service JSON field names
-  /// produced by the voting pipeline. We only add the round id required by the
-  /// helper API.
+  /// The share map is expected to be the complete service JSON body produced
+  /// by the voting pipeline.
   Future<VotingShareSubmissionResult> submitShare({
-    required String roundId,
     required Uri serverUrl,
     required Map<String, dynamic> share,
   }) async {
-    final body = {...share, 'vote_round_id': normalizeVotingRoundId(roundId)};
     final decoded = await _postJson(
       _endpoint(['shares'], baseUrl: serverUrl),
-      body,
+      share,
       timeout: _helperTimeout,
       retryPolicy: _helperRetryPolicy,
     );
@@ -292,15 +289,13 @@ class VotingApiClient {
   /// key nearby, but the current helper endpoint accepts the same body as the
   /// initial submission.
   Future<VotingShareSubmissionResult> resubmitShare({
-    required String roundId,
     required Uri serverUrl,
     required String shareId,
     required Map<String, dynamic> share,
   }) async {
-    final body = {...share, 'vote_round_id': normalizeVotingRoundId(roundId)};
     final decoded = await _postJson(
       _endpoint(['shares'], baseUrl: serverUrl),
-      body,
+      share,
       timeout: _helperTimeout,
       retryPolicy: _helperRetryPolicy,
     );

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6944,8 +6944,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.5.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fac7b20bee99168197ecdb760181d6d731ec7fb2428ff380a4772f2f1abfae9"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=199c6755041b099033c44fe1959b45158ad278af#199c6755041b099033c44fe1959b45158ad278af"
 dependencies = [
  "anyhow",
  "ff",
@@ -6961,8 +6960,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.7.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3a7fd4c1a40672a2f13c625999b8fefeb44d517230b4db1d4947c473d4e4a"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=199c6755041b099033c44fe1959b45158ad278af#199c6755041b099033c44fe1959b45158ad278af"
 dependencies = [
  "base64",
  "ff",
@@ -7991,8 +7989,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "3.0.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30dd82b84145d042cf8019804217fb3255a01ecfe92820463b9c276da99185ba"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=199c6755041b099033c44fe1959b45158ad278af#199c6755041b099033c44fe1959b45158ad278af"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6944,7 +6944,8 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.5.0-rc.1"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=199c6755041b099033c44fe1959b45158ad278af#199c6755041b099033c44fe1959b45158ad278af"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fac7b20bee99168197ecdb760181d6d731ec7fb2428ff380a4772f2f1abfae9"
 dependencies = [
  "anyhow",
  "ff",
@@ -6960,7 +6961,8 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.7.0-rc.1"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=199c6755041b099033c44fe1959b45158ad278af#199c6755041b099033c44fe1959b45158ad278af"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d3a7fd4c1a40672a2f13c625999b8fefeb44d517230b4db1d4947c473d4e4a"
 dependencies = [
  "base64",
  "ff",
@@ -7988,8 +7990,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "3.0.0-rc.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=199c6755041b099033c44fe1959b45158ad278af#199c6755041b099033c44fe1959b45158ad278af"
+version = "3.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbea3bf21e9185e6e49ec7632a1f2a4ada26542197a6e7cf9d35114eb999a70"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -158,6 +158,11 @@ zcash_note_encryption = "0.4"
 [dev-dependencies.vote-commitment-tree]
 version = "=0.5.0-rc.1"
 
+[patch.crates-io]
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "199c6755041b099033c44fe1959b45158ad278af" }
+vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "199c6755041b099033c44fe1959b45158ad278af" }
+vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "199c6755041b099033c44fe1959b45158ad278af" }
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)', 'cfg(ironwood_masquerade)'] }
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,7 +111,7 @@ features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 # Voting clients need PIR lookup support and vote-commitment-tree sync.
 [dependencies.zcash_voting]
-version = "=3.0.0-rc.2"
+version = "=3.0.0-rc.3"
 
 # Keep Orchard aligned with the released librustzcash and zcash_voting family
 # to avoid type conflicts.
@@ -157,11 +157,6 @@ zcash_note_encryption = "0.4"
 
 [dev-dependencies.vote-commitment-tree]
 version = "=0.5.0-rc.1"
-
-[patch.crates-io]
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "199c6755041b099033c44fe1959b45158ad278af" }
-vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "199c6755041b099033c44fe1959b45158ad278af" }
-vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "199c6755041b099033c44fe1959b45158ad278af" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)', 'cfg(ironwood_masquerade)'] }

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -357,7 +357,7 @@ pub fn next_share_tracking_delay_seconds(
 /// Extract and validate one helper-share payload from stored recovery JSON.
 ///
 /// The stored recovery blob is hex-encoded and also contains local-only
-/// recovery material. This helper emits only the public base64 wire shape that
+/// recovery material. This helper emits only the public wire fields that
 /// helper servers accept.
 pub fn recovered_vote_share_wire_json(
     commitment_bundle_json: String,
@@ -1986,6 +1986,7 @@ mod tests {
     fn share_wire_json_matches_helper_shape_for_live_and_recovery_payloads() {
         let live = vote_share_wire_json(
             zcash_voting::wire::VoteShareWire {
+                vote_round_id: "00".repeat(32),
                 shares_hash: "AQ==".to_string(),
                 proposal_id: 7,
                 vote_decision: 2,
@@ -2005,6 +2006,7 @@ mod tests {
         )
         .unwrap();
         let expected = serde_json::json!({
+            "vote_round_id":"00".repeat(32),
             "enc_share": {"c1":"Aw==","c2":"BA==","share_index":1},
             "primary_blind":"CQ==",
             "proposal_id":7,
@@ -2063,6 +2065,7 @@ mod tests {
         assert_eq!(recovered["share_index"], 1);
         assert_eq!(recovered["tree_position"], 99);
         assert_eq!(recovered["submit_at"], 0);
+        assert_eq!(recovered["vote_round_id"], "00".repeat(32));
         assert_eq!(recovered["enc_share"]["c1"], "Aw==");
         assert!(recovered.get("all_enc_shares").is_none());
         assert_eq!(
@@ -2086,29 +2089,35 @@ mod tests {
     }
 
     #[test]
-    fn share_wire_json_rejects_json_unsafe_integer_fields() {
-        let err = vote_share_wire_json(
-            zcash_voting::wire::VoteShareWire {
-                shares_hash: "AQ==".to_string(),
-                proposal_id: 7,
-                vote_decision: 2,
-                encrypted_share: zcash_voting::wire::WireEncryptedShare {
-                    c1: vec![3],
-                    c2: vec![4],
-                    share_index: 1,
-                },
+    fn share_wire_json_rejects_invalid_fields() {
+        let mut share = zcash_voting::wire::VoteShareWire {
+            vote_round_id: "00".repeat(32),
+            shares_hash: "AQ==".to_string(),
+            proposal_id: 7,
+            vote_decision: 2,
+            encrypted_share: zcash_voting::wire::WireEncryptedShare {
+                c1: vec![3],
+                c2: vec![4],
                 share_index: 1,
-                vc_tree_position: 0,
-                share_comms: vec![],
-                primary_blind: "CQ==".to_string(),
-                submit_at: 0,
             },
+            share_index: 1,
+            vc_tree_position: 0,
+            share_comms: vec![],
+            primary_blind: "CQ==".to_string(),
+            submit_at: 0,
+        };
+        let err = vote_share_wire_json(
+            share.clone(),
             // JSON numbers are constrained to the IEEE-754 safe-integer range.
             Some(MAX_SAFE_JSON_INTEGER + 1),
             123,
         )
         .unwrap_err();
         assert!(err.contains("tree_position"));
+
+        share.vote_round_id = "AA".repeat(32);
+        let err = vote_share_wire_json(share, Some(99), 123).unwrap_err();
+        assert!(err.contains("vote_round_id"));
     }
 
     #[test]
@@ -2306,6 +2315,7 @@ mod tests {
                         share_index: 0,
                     }],
                     share_payloads: vec![zcash_voting::SharePayload {
+                        vote_round_id: ROUND_ID.to_string(),
                         shares_hash: vec![7; 32],
                         proposal_id: 2,
                         vote_decision: 1,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -7179,6 +7179,7 @@ const _: fn() = || {
     }
     {
         let VoteShareWire = None::<zcash_voting::wire::VoteShareWire>.unwrap();
+        let _: String = VoteShareWire.vote_round_id;
         let _: String = VoteShareWire.shares_hash;
         let _: u32 = VoteShareWire.proposal_id;
         let _: u32 = VoteShareWire.vote_decision;
@@ -10005,6 +10006,7 @@ impl SseDecode for zcash_voting::wire::VoteRecoveryWorkView {
 impl SseDecode for zcash_voting::wire::VoteShareWire {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_voteRoundId = <String>::sse_decode(deserializer);
         let mut var_sharesHash = <String>::sse_decode(deserializer);
         let mut var_proposalId = <u32>::sse_decode(deserializer);
         let mut var_voteDecision = <u32>::sse_decode(deserializer);
@@ -10016,6 +10018,7 @@ impl SseDecode for zcash_voting::wire::VoteShareWire {
         let mut var_primaryBlind = <String>::sse_decode(deserializer);
         let mut var_submitAt = <u64>::sse_decode(deserializer);
         return zcash_voting::wire::VoteShareWire {
+            vote_round_id: var_voteRoundId,
             shares_hash: var_sharesHash,
             proposal_id: var_proposalId,
             vote_decision: var_voteDecision,
@@ -12847,6 +12850,7 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::VoteRecove
 impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::VoteShareWire> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
+            self.0.vote_round_id.into_into_dart().into_dart(),
             self.0.shares_hash.into_into_dart().into_dart(),
             self.0.proposal_id.into_into_dart().into_dart(),
             self.0.vote_decision.into_into_dart().into_dart(),
@@ -15102,6 +15106,7 @@ impl SseEncode for zcash_voting::wire::VoteRecoveryWorkView {
 impl SseEncode for zcash_voting::wire::VoteShareWire {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.vote_round_id, serializer);
         <String>::sse_encode(self.shares_hash, serializer);
         <u32>::sse_encode(self.proposal_id, serializer);
         <u32>::sse_encode(self.vote_decision, serializer);

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -4856,6 +4856,7 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
     required BigInt submitAt,
   }) async {
     return jsonEncode({
+      'vote_round_id': share.voteRoundId,
       'shares_hash': share.sharesHash,
       'proposal_id': share.proposalId,
       'vote_decision': share.voteDecision,
@@ -5178,6 +5179,7 @@ rust_wire.SignedVoteCommitmentsView _commitments({
         ),
         shares: [
           rust_wire.VoteShareWire(
+            voteRoundId: roundId,
             sharesHash: base64Encode(Uint8List.fromList(List.filled(32, 7))),
             proposalId: proposalId,
             voteDecision: choice,

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -5736,7 +5736,7 @@ const _delegationSubmissionWireGolden =
 const _voteCommitmentWireGolden =
     '{"van_nullifier":"$_bytes1x32Base64","vote_authority_note_new":"$_bytes2x32Base64","vote_commitment":"$_bytes3x32Base64","proposal_id":7,"proof":"BA==","vote_round_id":"$_roundIdBase64","vote_comm_tree_anchor_height":10,"r_vpk":"$_bytes13x32Base64","vote_auth_sig":"$_bytes12x64Base64"}';
 const _voteShareWireGolden =
-    '{"shares_hash":"$_bytes7x32Base64","proposal_id":7,"vote_decision":1,"enc_share":{"c1":"CA==","c2":"CQ==","share_index":0},"share_index":0,"tree_position":2,"share_comms":["$_bytes10x32Base64"],"primary_blind":"$_bytes11x32Base64","submit_at":0,"vote_round_id":"$kRoundId"}';
+    '{"vote_round_id":"$kRoundId","shares_hash":"$_bytes7x32Base64","proposal_id":7,"vote_decision":1,"enc_share":{"c1":"CA==","c2":"CQ==","share_index":0},"share_index":0,"tree_position":2,"share_comms":["$_bytes10x32Base64"],"primary_blind":"$_bytes11x32Base64","submit_at":0}';
 const _fastTxConfirmationPolling = VotingTxConfirmationPolling(
   attempts: 1,
   delay: Duration.zero,
@@ -6006,6 +6006,7 @@ rust_frb_types.VoteRecoveryView vote({
 String commitmentBundleRecoveryJson({int proposalId = 7, int shareIndex = 0}) {
   return jsonEncode({
     'format': 'vizor_vote_commitment_bundle_recovery_v1',
+    'vote_round_id': kRoundId,
     'share_payloads': [
       {
         'shares_hash': _hexFromBytes(List.filled(32, 7)),
@@ -7047,6 +7048,7 @@ class FakeVotingRustApi implements VotingRustApi {
     required BigInt submitAt,
   }) async {
     return jsonEncode({
+      'vote_round_id': share.voteRoundId,
       'shares_hash': share.sharesHash,
       'proposal_id': share.proposalId,
       'vote_decision': share.voteDecision,
@@ -7190,6 +7192,7 @@ class FakeVotingRustApi implements VotingRustApi {
     });
     final encShare = payload['enc_share'] as Map<String, dynamic>;
     return jsonEncode({
+      'vote_round_id': decoded['vote_round_id'],
       'shares_hash': base64Encode(
         _bytesFromHex(payload['shares_hash'] as String),
       ),
@@ -7343,6 +7346,7 @@ rust_wire.SignedVoteCommitmentsView _commitments({
   final shares = [
     for (final wireShare in wireShares)
       rust_wire.VoteShareWire(
+        voteRoundId: roundId,
         sharesHash: base64Encode(Uint8List.fromList(List.filled(32, 7))),
         proposalId: proposalId,
         voteDecision: choice,

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -51,9 +51,8 @@ void main() {
       submission: {'vote_round_id': encodedRoundId, 'proof': 'AQ=='},
     );
     await client.submitShare(
-      roundId: encodedRoundId,
       serverUrl: Uri.parse('https://helper.example'),
-      share: {'share_index': 0},
+      share: {'share_index': 0, 'vote_round_id': hexRoundId},
     );
     await client.getShareStatus(
       roundId: encodedRoundId,
@@ -61,10 +60,9 @@ void main() {
       shareId: 'share-1',
     );
     await client.resubmitShare(
-      roundId: encodedRoundId,
       serverUrl: Uri.parse('https://helper.example'),
       shareId: 'share-1',
-      share: {'share_index': 0},
+      share: {'share_index': 0, 'vote_round_id': hexRoundId},
     );
 
     expect(http.requests.map((request) => request.uri.path), [
@@ -770,7 +768,7 @@ void main() {
     },
   );
 
-  test('share request payloads preserve service JSON field names', () async {
+  test('share request payloads forward crate wire JSON unchanged', () async {
     final http = FakeVotingHttpClient(
       responses: {
         'https://helper.example/shielded-vote/v1/shares': {'status': 'queued'},
@@ -782,9 +780,8 @@ void main() {
     );
 
     final result = await client.submitShare(
-      roundId: encodedRoundId,
       serverUrl: Uri.parse('https://helper.example'),
-      share: {'share_index': 7, 'vote_round_id': 'bad-override'},
+      share: {'share_index': 7, 'vote_round_id': hexRoundId},
     );
 
     expect(result.status, 'queued');
@@ -817,9 +814,8 @@ void main() {
     );
 
     final result = await client.submitShare(
-      roundId: encodedRoundId,
       serverUrl: Uri.parse('https://helper.example'),
-      share: {'share_index': 0},
+      share: {'share_index': 0, 'vote_round_id': hexRoundId},
     );
 
     expect(result.status, 'queued');
@@ -842,9 +838,8 @@ void main() {
     );
 
     final submitted = await acceptedClient.submitShare(
-      roundId: hexRoundId,
       serverUrl: Uri.parse('https://helper.example'),
-      share: {'share_index': 0},
+      share: {'share_index': 0, 'vote_round_id': hexRoundId},
     );
     final status = await acceptedClient.getShareStatus(
       roundId: hexRoundId,
@@ -867,9 +862,8 @@ void main() {
     );
     await expectLater(
       rejectedSubmitClient.submitShare(
-        roundId: hexRoundId,
         serverUrl: Uri.parse('https://helper.example'),
-        share: {'share_index': 0},
+        share: {'share_index': 0, 'vote_round_id': hexRoundId},
       ),
       throwsA(isA<FormatException>()),
     );


### PR DESCRIPTION
Updates Vizor to the released `zcash_voting 3.0.0-rc.3`, whose helper-share wire JSON carries the authoritative lowercase-hex `vote_round_id` generated by Rust. Vizor forwards both live and recovered share JSON unchanged, removing the separate wallet round argument and its mismatch path.

This is stacked on the negotiated PIR layout change and will be merged into that branch so Vizor can review and merge the combined update as one PR.