### PR TITLE
Use six confirmations for external receives

### DIFF
--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -1496,7 +1496,7 @@ class _SendMaxBalanceControl extends StatelessWidget {
       'Your spendable balance may be lower than your total balance.';
   static const _tooltipBody =
       'Funds need confirmations before they can be spent: 3 for change from '
-      'your own wallet, 10 for funds received from others. Shielded notes also '
+      'your own wallet, 6 for funds received from others. Shielded notes also '
       "need to be fully scanned. They'll become available shortly.";
 
   final String spendableText;

--- a/rust/src/wallet/mod.rs
+++ b/rust/src/wallet/mod.rs
@@ -1,3 +1,7 @@
+use std::num::NonZeroU32;
+
+use zcash_client_backend::data_api::wallet::ConfirmationsPolicy;
+
 pub(crate) mod db;
 pub mod keys;
 pub mod keystone;
@@ -9,3 +13,53 @@ pub mod sync_engine;
 pub(crate) mod transparent_receive_cache;
 pub mod voting;
 pub(crate) mod wallet_summary_cache;
+
+const TRUSTED_CONFIRMATIONS: u32 = 3;
+// Vizor's product policy accepts externally received funds sooner than the
+// ZIP 315 default of 10 confirmations.
+const UNTRUSTED_CONFIRMATIONS: u32 = 6;
+const ALLOW_ZERO_CONFIRMATION_SHIELDING: bool = true;
+
+fn confirmations_policy() -> ConfirmationsPolicy {
+    ConfirmationsPolicy::new(
+        NonZeroU32::new(TRUSTED_CONFIRMATIONS).expect("trusted confirmations are nonzero"),
+        NonZeroU32::new(UNTRUSTED_CONFIRMATIONS).expect("untrusted confirmations are nonzero"),
+        ALLOW_ZERO_CONFIRMATION_SHIELDING,
+    )
+    .expect("trusted confirmations do not exceed untrusted confirmations")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zcash_client_backend::data_api::wallet::TargetHeight;
+    use zcash_protocol::{consensus::BlockHeight, PoolType, ShieldedPool};
+    use zip32::Scope;
+
+    #[test]
+    fn confirmation_policy_uses_six_confirmations_for_external_funds() {
+        let policy = confirmations_policy();
+
+        assert_eq!(u32::from(policy.trusted()), TRUSTED_CONFIRMATIONS);
+        assert_eq!(u32::from(policy.untrusted()), UNTRUSTED_CONFIRMATIONS);
+    }
+
+    #[test]
+    fn external_funds_become_spendable_after_six_confirmations() {
+        let policy = confirmations_policy();
+        let confirmations_remaining = |target_height| {
+            policy.confirmations_until_spendable(
+                TargetHeight::from(target_height),
+                PoolType::Shielded(ShieldedPool::Orchard),
+                Some(Scope::External),
+                Some(BlockHeight::from_u32(100)),
+                false,
+                None,
+                false,
+            )
+        };
+
+        assert_eq!(confirmations_remaining(105), 1);
+        assert_eq!(confirmations_remaining(106), 0);
+    }
+}

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -94,6 +94,7 @@ use zcash_protocol::{
     PoolType, ShieldedPool,
 };
 
+use crate::wallet::confirmations_policy;
 use crate::wallet::db::{
     open_wallet_db_readonly_with_timeout, open_wallet_raw_conn_with_timeout,
     with_wallet_db_write_lock, READ_DB_BUSY_TIMEOUT,
@@ -3344,7 +3345,7 @@ fn propose_send_with_reserved_notes(
     spend_policy: &SpendPolicy,
     proposed_tx_version: Option<TxVersion>,
 ) -> Result<Proposal<WalletFeeRule, ReceivedNoteId>, String> {
-    let confirmations_policy = ConfirmationsPolicy::default();
+    let confirmations_policy = confirmations_policy();
     let (target_height, anchor_height) = db
         .get_target_and_anchor_heights(confirmations_policy.trusted())
         .map_err(|e| format!("Read chain state for proposal: {e}"))?
@@ -3737,7 +3738,7 @@ fn build_send_max_proposal(
         to,
         memo_bytes,
         MaxSpendMode::MaxSpendable,
-        ConfirmationsPolicy::default(),
+        confirmations_policy(),
         &LockedInputPolicy::Exclude,
         None,
     )
@@ -3752,7 +3753,7 @@ fn proposed_tx_version_for_wallet_db(
     network: WalletNetwork,
     context: &str,
 ) -> Result<Option<TxVersion>, String> {
-    let confirmations_policy = ConfirmationsPolicy::default();
+    let confirmations_policy = confirmations_policy();
     let (target_height, _) = db
         .get_target_and_anchor_heights(confirmations_policy.trusted())
         .map_err(|e| format!("Read chain state for {context}: {e}"))?
@@ -3786,7 +3787,7 @@ fn build_transparent_recipient_send_max_proposal(
     fee_rule: WalletFeeRule,
     spend_pools: &[ShieldedPool],
 ) -> Result<Proposal<WalletFeeRule, <WalletDatabase as InputSource>::NoteRef>, String> {
-    let confirmations_policy = ConfirmationsPolicy::default();
+    let confirmations_policy = confirmations_policy();
     let (target_height, anchor_height) = db
         .get_target_and_anchor_heights(confirmations_policy.trusted())
         .map_err(|e| format!("Failed to read target height: {e}"))?
@@ -3891,7 +3892,7 @@ fn build_transparent_recipient_send_max_proposal_from_notes<NoteRef>(
         fee_rule,
         target_height,
         // Matches the flow's proposal policy (see zip317_helper callers).
-        ConfirmationsPolicy::default(),
+        confirmations_policy(),
         false,
         network.is_nu_active(
             zcash_protocol::consensus::NetworkUpgrade::Nu6_3,

--- a/rust/src/wallet/wallet_summary_cache.rs
+++ b/rust/src/wallet/wallet_summary_cache.rs
@@ -12,10 +12,11 @@ use std::{
     sync::{Arc, Mutex, OnceLock},
 };
 
-use zcash_client_backend::data_api::{wallet::ConfirmationsPolicy, WalletRead, WalletSummary};
+use zcash_client_backend::data_api::{WalletRead, WalletSummary};
 use zcash_client_sqlite::AccountUuid;
 
 use crate::wallet::{
+    confirmations_policy,
     db::{open_wallet_db_for_read_with_timeout, wallet_db_write_epoch, READ_DB_BUSY_TIMEOUT},
     network::WalletNetwork,
 };
@@ -68,14 +69,14 @@ pub(crate) fn evict_db(db_path: &str) {
     map.retain(|key, _| key.db_path != db_path);
 }
 
-/// Cached `get_wallet_summary` for the default confirmation policy.
+/// Cached `get_wallet_summary` for the wallet confirmation policy.
 pub(crate) fn get_wallet_summary_cached(
     db_path: &str,
     network: WalletNetwork,
 ) -> Result<CachedSummary, String> {
     get_or_load_with(db_path, network, || {
         let db = open_wallet_db_for_read_with_timeout(db_path, network, READ_DB_BUSY_TIMEOUT)?;
-        db.get_wallet_summary(ConfirmationsPolicy::default())
+        db.get_wallet_summary(confirmations_policy())
             .map_err(|e| format!("{e}"))
     })
 }
@@ -157,6 +158,7 @@ mod tests {
         thread,
         time::Duration,
     };
+    use zcash_client_backend::data_api::wallet::ConfirmationsPolicy;
 
     use zcash_client_backend::data_api::{Progress, Ratio, WalletSummary};
     use zcash_protocol::consensus::BlockHeight;

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -870,6 +870,31 @@ void main() {
     expect(find.text('Shielded → Transparent'), findsNothing);
     expect(rustApi.proposeSendCalls, 0);
   });
+
+  testWidgets('explains the external receive confirmation policy', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(_sendHarness());
+    await tester.pumpAndSettle();
+
+    final tooltip = tester.widget<Tooltip>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Tooltip &&
+            widget.richMessage?.toPlainText().contains(
+                  'Your spendable balance may be lower',
+                ) ==
+                true,
+      ),
+    );
+
+    expect(
+      tooltip.richMessage?.toPlainText(),
+      contains('6 for funds received from others'),
+    );
+  });
 }
 
 const _figmaModalSurfaceShadows = [


### PR DESCRIPTION
## Summary

- replace the ZIP 315 default confirmation policy with a private Vizor policy
  that keeps wallet-created change at 3 confirmations and makes externally
  received funds spendable after 6 confirmations
- thread the shared policy through the current wallet-summary cache and the
  ordinary/max send proposal paths
- update the spendable-balance tooltip and add Rust boundary plus Flutter
  widget coverage

## Why

Vizor currently requires 10 confirmations before externally received shielded
funds are spendable. This changes that product policy to 6 confirmations while
retaining the existing 3-confirmation treatment for wallet-created change and
zero-confirmation transparent shielding.

## Impact

Externally received shielded funds become spendable after 6 confirmations.
This intentionally diverges from the upstream ZIP 315 default, reducing reorg
protection and potentially making spending behavior distinguishable from
wallets that retain the default.

No Rust, `pub(crate)`, or FRB API surface changed.

## Validation

- `cargo test --manifest-path rust/Cargo.toml`: 623 passed; 21 ignored,
  including Docker regtests and opt-in benchmark/fixture tests
- `fvm flutter test test/features/send/send_screen_test.dart`: 25 passed
- changed Rust files pass `rustfmt --check`
- changed Dart files pass `dart format --set-exit-if-changed`
- rebased diff passes `git diff --check`

Latest `chainapsis/main` has unrelated baseline failures in this environment:

- full `fvm flutter test`: 2308 passed, 75 skipped, 30 failures in unrelated
  Widgetbook, Figma comparison, and Ironwood migration route/layout tests
- `fvm flutter analyze`: 23 unrelated unused-code warnings in migration UI
- repository-wide `cargo fmt --check`: unrelated formatting diffs in
  `rust/src/ffi.rs`, `rust/src/network_privacy.rs`, and
  `rust/src/wallet/sync_engine/mod.rs`
