### PR TITLE
Reduce cold-start bootstrap latency

### DIFF
--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart' show kDebugMode, visibleForTesting;
@@ -210,13 +211,28 @@ class AppSyncSnapshot {
   );
 }
 
-Future<AppBootstrapState> loadAppBootstrap() async {
-  final storage = AppSecureStore.instance;
+Future<AppBootstrapState> loadAppBootstrap() {
+  return _loadAppBootstrap(
+    storage: AppSecureStore.instance,
+    getDbPath: _getDbPath,
+  );
+}
 
+@visibleForTesting
+Future<AppBootstrapState> loadAppBootstrapForTesting({
+  required AppSecureStore storage,
+  required Future<String> Function() getDbPath,
+}) {
+  return _loadAppBootstrap(storage: storage, getDbPath: getDbPath);
+}
+
+Future<AppBootstrapState> _loadAppBootstrap({
+  required AppSecureStore storage,
+  required Future<String> Function() getDbPath,
+}) async {
   try {
     log('bootstrap: loading startup snapshot');
     await ensureIosSecureStoreAccessibilityMigrated();
-    await storage.ensureWalletDbName();
     await _applyE2eBootstrapOverrides(storage);
     var passwordRotationRecoveryFailed = false;
     try {
@@ -231,29 +247,117 @@ Future<AppBootstrapState> loadAppBootstrap() async {
     } catch (e) {
       log('bootstrap: failed to recover password rotation: $e');
     }
-    final network = resolveStoredOrDefaultZcashNetworkName(
-      await storage.readString(_networkKey),
+
+    final networkFuture = storage
+        .readString(_networkKey)
+        .then(resolveStoredOrDefaultZcashNetworkName);
+    final networkRead = _captureBootstrapRead(networkFuture);
+    final rpcEndpointConfigFuture = networkFuture.then(
+      (network) => _readRpcEndpointConfig(storage, network),
     );
-    final rpcEndpointConfig = await _readRpcEndpointConfig(storage, network);
-    final themeMode = await _readThemeMode(storage);
-    final privacyModeEnabled = await _readPrivacyModeEnabled(storage);
-    final swapEnabledOverrideCachedForRelease =
-        await _readSwapEnabledOverrideCachedForRelease();
-    final biometricUnlockEnabled = await _readBiometricUnlockEnabled(storage);
-    final syncKeepAwakeEnabled = await _readPlainBool(
-      storage,
-      key: kSyncKeepAwakeEnabledKey,
-      label: 'sync keep-awake enabled flag',
+    final rpcEndpointConfigRead = _captureBootstrapRead(
+      rpcEndpointConfigFuture,
     );
-    final syncKeepAwakePromptSeen = await _readPlainBool(
-      storage,
-      key: kSyncKeepAwakePromptSeenKey,
-      label: 'sync keep-awake prompt seen flag',
+    final themeModeRead = _captureBootstrapRead(_readThemeMode(storage));
+    final privacyModeEnabledRead = _captureBootstrapRead(
+      _readPrivacyModeEnabled(storage),
     );
-    final isPasswordConfigured = await storage.isPasswordConfigured();
+    final swapEnabledOverrideCachedForReleaseRead = _captureBootstrapRead(
+      _readSwapEnabledOverrideCachedForRelease(),
+    );
+    final biometricUnlockEnabledRead = _captureBootstrapRead(
+      _readBiometricUnlockEnabled(storage),
+    );
+    final syncKeepAwakeEnabledRead = _captureBootstrapRead(
+      _readPlainBool(
+        storage,
+        key: kSyncKeepAwakeEnabledKey,
+        label: 'sync keep-awake enabled flag',
+      ),
+    );
+    final syncKeepAwakePromptSeenRead = _captureBootstrapRead(
+      _readPlainBool(
+        storage,
+        key: kSyncKeepAwakePromptSeenKey,
+        label: 'sync keep-awake prompt seen flag',
+      ),
+    );
+    final isPasswordConfiguredRead = _captureBootstrapRead(
+      storage.isPasswordConfigured(),
+    );
+    final storedAccountsRead = _captureBootstrapRead(
+      _readStoredAccounts(storage),
+    );
+    final storedActiveUuidRead = _captureBootstrapRead(
+      storage.readString(_activeAccountKey),
+    );
+    final settingsResultsFuture = (
+      rpcEndpointConfigRead,
+      themeModeRead,
+      privacyModeEnabledRead,
+      swapEnabledOverrideCachedForReleaseRead,
+      biometricUnlockEnabledRead,
+      syncKeepAwakeEnabledRead,
+      syncKeepAwakePromptSeenRead,
+    ).wait;
+    final walletStateResultsFuture = (
+      isPasswordConfiguredRead,
+      storedAccountsRead,
+      storedActiveUuidRead,
+    ).wait;
+    final dbPathRead = _captureBootstrapRead(getDbPath());
+    final (
+      networkResult,
+      settingsResults,
+      walletStateResults,
+      dbPathResult,
+    ) = await (
+      networkRead,
+      settingsResultsFuture,
+      walletStateResultsFuture,
+      dbPathRead,
+    ).wait;
+    final (
+      rpcEndpointConfigResult,
+      themeModeResult,
+      privacyModeEnabledResult,
+      swapEnabledOverrideCachedForReleaseResult,
+      biometricUnlockEnabledResult,
+      syncKeepAwakeEnabledResult,
+      syncKeepAwakePromptSeenResult,
+    ) = settingsResults;
+    final (
+      isPasswordConfiguredResult,
+      storedAccountsResult,
+      storedActiveUuidResult,
+    ) = walletStateResults;
+    // Unwrap in the legacy serial order so concurrent failures retain the
+    // same startup classification and database migrations never mask an
+    // earlier secure-storage failure.
+    final network = _unwrapBootstrapRead(networkResult);
+    final rpcEndpointConfig = _unwrapBootstrapRead(rpcEndpointConfigResult);
+    final themeMode = _unwrapBootstrapRead(themeModeResult);
+    final privacyModeEnabled = _unwrapBootstrapRead(privacyModeEnabledResult);
+    final swapEnabledOverrideCachedForRelease = _unwrapBootstrapRead(
+      swapEnabledOverrideCachedForReleaseResult,
+    );
+    final biometricUnlockEnabled = _unwrapBootstrapRead(
+      biometricUnlockEnabledResult,
+    );
+    final syncKeepAwakeEnabled = _unwrapBootstrapRead(
+      syncKeepAwakeEnabledResult,
+    );
+    final syncKeepAwakePromptSeen = _unwrapBootstrapRead(
+      syncKeepAwakePromptSeenResult,
+    );
+    final isPasswordConfigured = _unwrapBootstrapRead(
+      isPasswordConfiguredResult,
+    );
     final isUnlocked = storage.hasSessionPassword;
-    final dbPath = await _getDbPath();
-    if (rust_wallet.walletExists(dbPath: dbPath)) {
+    final dbPath = _unwrapBootstrapRead(dbPathResult);
+
+    final walletExists = rust_wallet.walletExists(dbPath: dbPath);
+    if (walletExists) {
       try {
         log('bootstrap: ensuring wallet DB migrations before startup snapshot');
         await rust_wallet.ensureWalletDbMigrated(
@@ -268,15 +372,15 @@ Future<AppBootstrapState> loadAppBootstrap() async {
         );
       }
     }
-    final storedAccounts = await _readStoredAccounts(storage);
+    final storedAccounts = _unwrapBootstrapRead(storedAccountsResult);
+    final storedActiveUuid = _unwrapBootstrapRead(storedActiveUuidResult);
     final storedAccountsByUuid = {
       for (final account in storedAccounts) account.uuid: account,
     };
-    final storedActiveUuid = await storage.readString(_activeAccountKey);
 
     var rustAccounts = <AccountInfo>[];
     final rustAddressesByUuid = <String, String>{};
-    if (rust_wallet.walletExists(dbPath: dbPath)) {
+    if (walletExists) {
       try {
         final listed = await rust_wallet.listAccounts(
           dbPath: dbPath,
@@ -312,10 +416,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
     final hasWallet = accounts.isNotEmpty;
     var initialSyncSnapshot = AppSyncSnapshot.empty;
 
-    if (isUnlocked &&
-        hasWallet &&
-        activeAccountUuid != null &&
-        rust_wallet.walletExists(dbPath: dbPath)) {
+    if (isUnlocked && hasWallet && activeAccountUuid != null && walletExists) {
       initialSyncSnapshot = await _loadInitialSyncSnapshot(
         dbPath: dbPath,
         network: network,
@@ -368,6 +469,24 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       failureMessage: 'Vizor could not load its startup state.',
     );
   }
+}
+
+typedef _BootstrapRead<T> = ({T? value, Object? error, StackTrace? stackTrace});
+
+Future<_BootstrapRead<T>> _captureBootstrapRead<T>(Future<T> future) async {
+  try {
+    return (value: await future, error: null, stackTrace: null);
+  } catch (error, stackTrace) {
+    return (value: null, error: error, stackTrace: stackTrace);
+  }
+}
+
+T _unwrapBootstrapRead<T>(_BootstrapRead<T> result) {
+  final error = result.error;
+  if (error != null) {
+    Error.throwWithStackTrace(error, result.stackTrace!);
+  }
+  return result.value as T;
 }
 
 String _walletDbMigrationFailureMessage(Object error) {
@@ -434,8 +553,12 @@ Future<RpcEndpointConfig> _readRpcEndpointConfig(
   String network,
 ) async {
   try {
-    final storedUrl = await storage.readString(kRpcEndpointUrlKey);
-    final storedPreset = await storage.readString(kRpcEndpointPresetKey);
+    final storedEndpoint = await Future.wait<String?>([
+      storage.readString(kRpcEndpointUrlKey),
+      storage.readString(kRpcEndpointPresetKey),
+    ]);
+    final storedUrl = storedEndpoint[0];
+    final storedPreset = storedEndpoint[1];
     return resolveStoredRpcEndpointConfig(
       networkName: zcashNetworkFromName(network).name,
       storedUrl: storedUrl,
@@ -547,27 +670,26 @@ Future<AppSyncSnapshot> _loadInitialSyncSnapshot({
   required String accountUuid,
 }) async {
   try {
-    final syncStatus = await rust_sync.getSyncStatus(
-      dbPath: dbPath,
-      network: network,
-    );
-    final balance = await rust_sync.getBalance(
-      dbPath: dbPath,
-      network: network,
-      accountUuid: accountUuid,
-    );
+    final (syncStatus, balance, recentTransactions) = await (
+      rust_sync.getSyncStatus(dbPath: dbPath, network: network),
+      rust_sync.getBalance(
+        dbPath: dbPath,
+        network: network,
+        accountUuid: accountUuid,
+      ),
+      rust_sync.getTransactionHistory(
+        dbPath: dbPath,
+        network: network,
+        limit: 10,
+        accountUuid: accountUuid,
+      ),
+    ).wait;
     if (balance.availability != rust_sync.WalletBalanceAvailability.available) {
       throw StateError(
         'Wallet balance unavailable during bootstrap: '
         '${balance.availability.name}',
       );
     }
-    final recentTransactions = await rust_sync.getTransactionHistory(
-      dbPath: dbPath,
-      network: network,
-      limit: 10,
-      accountUuid: accountUuid,
-    );
     var canShieldTransparentBalance = false;
     var shieldTransparentFee = BigInt.zero;
     var shieldTransparentAmount = BigInt.zero;

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -143,6 +143,8 @@ class AppSecureStore {
   final FlutterSecureStorage _storage;
   final FlutterSecureStorage _mnemonicStorage;
   final _secretMutationLock = _AsyncLock();
+  final _walletDbNameLock = _AsyncLock();
+  Future<String>? _walletDbNameFuture;
   String? _sessionPassword;
 
   bool get hasSessionPassword => _sessionPassword != null;
@@ -155,7 +157,25 @@ class AppSecureStore {
     return password;
   }
 
-  Future<String> ensureWalletDbName() async {
+  Future<String> ensureWalletDbName() {
+    final cached = _walletDbNameFuture;
+    if (cached != null) return cached;
+
+    late final Future<String> pending;
+    pending = _walletDbNameLock.run(_loadOrCreateWalletDbName).onError((
+      error,
+      stackTrace,
+    ) {
+      if (identical(_walletDbNameFuture, pending)) {
+        _walletDbNameFuture = null;
+      }
+      Error.throwWithStackTrace(error!, stackTrace);
+    });
+    _walletDbNameFuture = pending;
+    return pending;
+  }
+
+  Future<String> _loadOrCreateWalletDbName() async {
     final existing = await readPlain(kWalletDbNameKey);
     if (existing != null && existing.isNotEmpty) {
       return existing;
@@ -404,15 +424,20 @@ class AppSecureStore {
   }
 
   Future<void> deleteAll() {
-    return _secretMutationLock.run(() async {
-      await _runStorageOperation('delete all', _storage.deleteAll);
-      if (!identical(_mnemonicStorage, _storage)) {
-        await _runStorageOperation(
-          'delete all account mnemonics',
-          _mnemonicStorage.deleteAll,
-        );
-      }
-      _sessionPassword = null;
+    // Invalidate synchronously before queueing the reset. A concurrent lookup
+    // will then queue behind this delete instead of returning the old name.
+    _walletDbNameFuture = null;
+    return _walletDbNameLock.run(() {
+      return _secretMutationLock.run(() async {
+        await _runStorageOperation('delete all', _storage.deleteAll);
+        if (!identical(_mnemonicStorage, _storage)) {
+          await _runStorageOperation(
+            'delete all account mnemonics',
+            _mnemonicStorage.deleteAll,
+          );
+        }
+        _sessionPassword = null;
+      });
     });
   }
 
@@ -447,8 +472,12 @@ class AppSecureStore {
   }
 
   Future<bool> isPasswordConfigured() async {
-    final verifier = await readPlain(_passwordVerifierKey);
-    final salt = await readPlain(_passwordVerifierSaltKey);
+    final passwordConfiguration = await Future.wait<String?>([
+      readPlain(_passwordVerifierKey),
+      readPlain(_passwordVerifierSaltKey),
+    ]);
+    final verifier = passwordConfiguration[0];
+    final salt = passwordConfiguration[1];
     return verifier != null &&
         verifier.isNotEmpty &&
         salt != null &&

--- a/lib/src/core/storage/wallet_paths.dart
+++ b/lib/src/core/storage/wallet_paths.dart
@@ -1,13 +1,37 @@
+import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path_provider/path_provider.dart';
 
 import 'app_secure_store.dart';
 
-Future<Directory> getWalletSupportDirectory() async {
+Future<Directory>? _walletSupportDirectoryFuture;
+
+Future<Directory> getWalletSupportDirectory() {
+  final cached = _walletSupportDirectoryFuture;
+  if (cached != null) return cached;
+
+  late final Future<Directory> pending;
+  pending = _resolveWalletSupportDirectory().onError((error, stackTrace) {
+    if (identical(_walletSupportDirectoryFuture, pending)) {
+      _walletSupportDirectoryFuture = null;
+    }
+    Error.throwWithStackTrace(error!, stackTrace);
+  });
+  _walletSupportDirectoryFuture = pending;
+  return pending;
+}
+
+Future<Directory> _resolveWalletSupportDirectory() async {
   final dir = await getApplicationSupportDirectory();
   await dir.create(recursive: true);
   return dir;
+}
+
+@visibleForTesting
+void resetWalletSupportDirectoryCacheForTesting() {
+  _walletSupportDirectoryFuture = null;
 }
 
 Future<String> getWalletDbName() async {
@@ -15,8 +39,12 @@ Future<String> getWalletDbName() async {
 }
 
 Future<String> getWalletDbPath() async {
-  final dir = await getWalletSupportDirectory();
-  final dbName = await getWalletDbName();
+  final pathParts = await Future.wait<Object>([
+    getWalletSupportDirectory(),
+    getWalletDbName(),
+  ]);
+  final dir = pathParts[0] as Directory;
+  final dbName = pathParts[1] as String;
   return '${dir.path}${Platform.pathSeparator}$dbName';
 }
 

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -1,8 +1,55 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
+
+const _activeAccountKey = 'zcash_active_account';
+const _accountsKey = 'zcash_accounts';
+const _biometricUnlockEnabledKey = 'zcash_biometric_unlock_enabled';
+const _networkKey = 'zcash_wallet_network';
+const _passwordVerifierKey = 'zcash_password_verifier';
+const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
+
+const _firstWaveBootstrapKeys = <String>{
+  _networkKey,
+  kThemeModeKey,
+  kPrivacyModeEnabledKey,
+  _biometricUnlockEnabledKey,
+  kSyncKeepAwakeEnabledKey,
+  kSyncKeepAwakePromptSeenKey,
+  _passwordVerifierKey,
+  _passwordVerifierSaltKey,
+  _accountsKey,
+  _activeAccountKey,
+};
+
+const _dependentRpcKeys = <String>{kRpcEndpointUrlKey, kRpcEndpointPresetKey};
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late _RustBootstrapApiFake rustApi;
+
+  setUpAll(() {
+    rustApi = _RustBootstrapApiFake();
+    RustLib.initMock(api: rustApi);
+  });
+
+  tearDownAll(RustLib.dispose);
+
+  setUp(() {
+    rustApi.reset();
+    SharedPreferences.setMockInitialValues({});
+  });
+
   test('AccountInfo.fromJson normalizes legacy profile picture ids', () {
     final account = AccountInfo.fromJson({
       'uuid': 'account-1',
@@ -143,4 +190,403 @@ void main() {
       expect(AppBootstrapState.empty.syncKeepAwakePromptSeen, isFalse);
     },
   );
+
+  test('bootstrap launches independent reads before awaiting them', () async {
+    final storage = _ControlledReadStorage(
+      values: {
+        _networkKey: 'test',
+        kRpcEndpointUrlKey: 'https://custom.example:443',
+        kRpcEndpointPresetKey: 'custom',
+        kThemeModeKey: 'dark',
+        kPrivacyModeEnabledKey: 'true',
+        _biometricUnlockEnabledKey: 'true',
+        kSyncKeepAwakeEnabledKey: 'true',
+        kSyncKeepAwakePromptSeenKey: 'true',
+        _passwordVerifierKey: 'verifier',
+        _passwordVerifierSaltKey: 'salt',
+        _accountsKey: jsonEncode([
+          {'uuid': 'account-1', 'name': 'Stored account', 'order': 0},
+        ]),
+        _activeAccountKey: 'account-1',
+      },
+      blockedKeys: {..._firstWaveBootstrapKeys, ..._dependentRpcKeys},
+    );
+    final store = AppSecureStore.testing(storage: storage);
+    final dbPath = Completer<String>();
+    var dbPathStarted = false;
+
+    final bootstrap = loadAppBootstrapForTesting(
+      storage: store,
+      getDbPath: () {
+        dbPathStarted = true;
+        return dbPath.future;
+      },
+    );
+
+    await _waitUntil(
+      () => storage.startedKeys.containsAll(_firstWaveBootstrapKeys),
+    );
+    expect(dbPathStarted, isTrue);
+    expect(storage.startedKeys, isNot(containsAll(_dependentRpcKeys)));
+
+    storage.complete(_networkKey);
+    await _waitUntil(() => storage.startedKeys.containsAll(_dependentRpcKeys));
+
+    for (final key in <String>{
+      ..._firstWaveBootstrapKeys,
+      ..._dependentRpcKeys,
+    }.toList().reversed) {
+      storage.complete(key);
+    }
+    dbPath.complete('/tmp/vizor-bootstrap-no-wallet.db');
+
+    final result = await bootstrap;
+
+    expect(result.hasBlockingFailure, isFalse);
+    expect(result.initialLocation, '/unlock');
+    expect(result.network, 'test');
+    expect(
+      result.rpcEndpointConfig.lightwalletdUrl,
+      'https://custom.example:443',
+    );
+    expect(result.rpcEndpointConfig.presetId, 'custom');
+    expect(result.themeMode.name, 'dark');
+    expect(result.privacyModeEnabled, isTrue);
+    expect(result.biometricUnlockEnabled, isTrue);
+    expect(result.syncKeepAwakeEnabled, isTrue);
+    expect(result.syncKeepAwakePromptSeen, isTrue);
+    expect(result.isPasswordConfigured, isTrue);
+    expect(result.initialAccountState.activeAccountUuid, 'account-1');
+    expect(result.initialAccountState.accounts.single.name, 'Stored account');
+  });
+
+  test(
+    'bootstrap preserves storage failure precedence over a path failure',
+    () async {
+      final blockedKeys = <String>{
+        ..._firstWaveBootstrapKeys,
+        ..._dependentRpcKeys,
+      };
+      final storage = _ControlledReadStorage(
+        values: const {_networkKey: 'main'},
+        blockedKeys: blockedKeys,
+      );
+      final store = AppSecureStore.testing(storage: storage);
+      final dbPath = Completer<String>();
+      var bootstrapCompleted = false;
+
+      final bootstrap = loadAppBootstrapForTesting(
+        storage: store,
+        getDbPath: () => dbPath.future,
+      );
+      unawaited(
+        bootstrap.then((_) {
+          bootstrapCompleted = true;
+        }),
+      );
+
+      await _waitUntil(
+        () => storage.startedKeys.containsAll(_firstWaveBootstrapKeys),
+      );
+      storage.complete(_networkKey);
+      await _waitUntil(
+        () => storage.startedKeys.containsAll(_dependentRpcKeys),
+      );
+      dbPath.completeError(StateError('forced path failure'));
+      storage.fail(
+        kThemeModeKey,
+        PlatformException(code: 'keychain_unavailable'),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(bootstrapCompleted, isFalse);
+
+      for (final key in blockedKeys) {
+        storage.complete(key);
+      }
+      final result = await bootstrap;
+
+      expect(result.initialLocation, '/storage-unavailable');
+      expect(
+        result.failureKind,
+        AppBootstrapFailureKind.secureStorageUnavailable,
+      );
+      expect(
+        result.failureMessage,
+        'Vizor needs access to secure storage before it can open your wallet.',
+      );
+    },
+  );
+
+  test(
+    'bootstrap loads independent Rust snapshot reads concurrently',
+    () async {
+      rustApi.prepareWalletSnapshot();
+      final store = _unlockedBootstrapStore();
+      var bootstrapCompleted = false;
+
+      final bootstrap = loadAppBootstrapForTesting(
+        storage: store,
+        getDbPath: () async => '/tmp/vizor-bootstrap-wallet.db',
+      );
+      unawaited(
+        bootstrap.then((_) {
+          bootstrapCompleted = true;
+        }),
+      );
+
+      await _waitUntil(
+        () => rustApi.snapshotReadsStarted.containsAll(const {
+          'sync status',
+          'balance',
+          'transaction history',
+        }),
+      );
+      expect(bootstrapCompleted, isFalse);
+
+      rustApi.completeTransactionHistory();
+      rustApi.completeBalance();
+      rustApi.completeSyncStatus();
+      final result = await bootstrap;
+
+      expect(result.initialLocation, '/home');
+      expect(result.initialAccountState.activeAddress, 'u-test-account-1');
+      expect(result.initialSyncSnapshot.accountUuid, 'account-1');
+      expect(result.initialSyncSnapshot.hasAccountScopedData, isTrue);
+      expect(result.initialSyncSnapshot.scannedHeight, 75);
+      expect(result.initialSyncSnapshot.chainTipHeight, 100);
+      expect(result.initialSyncSnapshot.percentage, 0.75);
+      expect(result.initialSyncSnapshot.orchardBalance, BigInt.from(30));
+      expect(result.initialSyncSnapshot.totalBalance, BigInt.from(30));
+    },
+  );
+
+  test('bootstrap keeps the empty snapshot fallback on Rust failure', () async {
+    rustApi.prepareWalletSnapshot();
+    final store = _unlockedBootstrapStore();
+    var bootstrapCompleted = false;
+
+    final bootstrap = loadAppBootstrapForTesting(
+      storage: store,
+      getDbPath: () async => '/tmp/vizor-bootstrap-wallet.db',
+    );
+    unawaited(
+      bootstrap.then((_) {
+        bootstrapCompleted = true;
+      }),
+    );
+
+    await _waitUntil(
+      () => rustApi.snapshotReadsStarted.containsAll(const {
+        'sync status',
+        'balance',
+        'transaction history',
+      }),
+    );
+    rustApi.failBalance();
+    await Future<void>.delayed(Duration.zero);
+    expect(bootstrapCompleted, isFalse);
+
+    rustApi.completeTransactionHistory();
+    rustApi.completeSyncStatus();
+    final result = await bootstrap;
+
+    expect(result.initialLocation, '/home');
+    expect(result.initialSyncSnapshot.accountUuid, 'account-1');
+    expect(result.initialSyncSnapshot.hasAccountScopedData, isFalse);
+    expect(result.initialSyncSnapshot.totalBalance, BigInt.zero);
+    expect(result.initialSyncSnapshot.recentTransactions, isEmpty);
+  });
+}
+
+AppSecureStore _unlockedBootstrapStore() {
+  final storage = _ControlledReadStorage(
+    values: {
+      _networkKey: 'test',
+      _passwordVerifierKey: 'verifier',
+      _passwordVerifierSaltKey: 'salt',
+      _accountsKey: jsonEncode([
+        {'uuid': 'account-1', 'name': 'Stored account', 'order': 0},
+      ]),
+      _activeAccountKey: 'account-1',
+    },
+    blockedKeys: const {},
+  );
+  return AppSecureStore.testing(storage: storage)..setSessionPassword('test');
+}
+
+Future<void> _waitUntil(bool Function() condition) async {
+  for (var attempt = 0; attempt < 20 && !condition(); attempt += 1) {
+    await Future<void>.delayed(Duration.zero);
+  }
+  expect(condition(), isTrue, reason: 'Expected asynchronous work to start.');
+}
+
+class _ControlledReadStorage extends FlutterSecureStorage {
+  _ControlledReadStorage({
+    required this.values,
+    required Set<String> blockedKeys,
+  }) : _blockedKeys = blockedKeys;
+
+  final Map<String, String?> values;
+  final Set<String> _blockedKeys;
+  final Set<String> startedKeys = {};
+  final Map<String, Completer<String?>> _pendingReads = {};
+
+  void complete(String key) {
+    final pending = _pendingReads[key];
+    if (pending != null && !pending.isCompleted) {
+      pending.complete(values[key]);
+    }
+  }
+
+  void fail(String key, Object error) {
+    final pending = _pendingReads[key];
+    if (pending != null && !pending.isCompleted) {
+      pending.completeError(error, StackTrace.current);
+    }
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) {
+    startedKeys.add(key);
+    if (!_blockedKeys.contains(key)) {
+      return Future.value(values[key]);
+    }
+    return _pendingReads.putIfAbsent(key, Completer<String?>.new).future;
+  }
+}
+
+class _RustBootstrapApiFake implements RustLibApi {
+  bool _walletExists = false;
+  final Set<String> snapshotReadsStarted = {};
+  Completer<rust_sync.SyncProgress>? _syncStatus;
+  Completer<rust_sync.WalletBalance>? _balance;
+  Completer<List<rust_sync.TransactionInfo>>? _transactionHistory;
+
+  void reset() {
+    _walletExists = false;
+    snapshotReadsStarted.clear();
+    _syncStatus = null;
+    _balance = null;
+    _transactionHistory = null;
+  }
+
+  void prepareWalletSnapshot() {
+    _walletExists = true;
+    _syncStatus = Completer<rust_sync.SyncProgress>();
+    _balance = Completer<rust_sync.WalletBalance>();
+    _transactionHistory = Completer<List<rust_sync.TransactionInfo>>();
+  }
+
+  void completeSyncStatus() {
+    _syncStatus!.complete(
+      rust_sync.SyncProgress(
+        scannedHeight: BigInt.from(75),
+        chainTipHeight: BigInt.from(100),
+        isSyncing: false,
+        isComplete: false,
+      ),
+    );
+  }
+
+  void completeBalance() {
+    _balance!.complete(
+      rust_sync.WalletBalance(
+        availability: rust_sync.WalletBalanceAvailability.available,
+        transparent: BigInt.zero,
+        sapling: BigInt.zero,
+        orchard: BigInt.from(30),
+        ironwood: BigInt.zero,
+        transparentLocked: BigInt.zero,
+        saplingLocked: BigInt.zero,
+        orchardLocked: BigInt.zero,
+        ironwoodLocked: BigInt.zero,
+        transparentPending: BigInt.zero,
+        saplingPending: BigInt.zero,
+        orchardPending: BigInt.zero,
+        ironwoodPending: BigInt.zero,
+        changePendingConfirmation: BigInt.zero,
+        valuePendingSpendability: BigInt.zero,
+        uneconomicValue: BigInt.zero,
+        spendable: BigInt.from(30),
+        locked: BigInt.zero,
+        total: BigInt.from(30),
+      ),
+    );
+  }
+
+  void failBalance() {
+    _balance!.completeError(StateError('forced balance failure'));
+  }
+
+  void completeTransactionHistory() {
+    _transactionHistory!.complete(const []);
+  }
+
+  @override
+  Future<void> crateApiWalletEnsureWalletDbMigrated({
+    required String dbPath,
+    required String network,
+  }) async {}
+
+  @override
+  Future<List<rust_wallet.AccountInfo>> crateApiWalletListAccounts({
+    required String dbPath,
+    required String network,
+  }) async {
+    return const [
+      rust_wallet.AccountInfo(
+        uuid: 'account-1',
+        name: 'Rust account',
+        unifiedAddress: 'u-test-account-1',
+        isSeedAnchor: true,
+        isHardware: false,
+      ),
+    ];
+  }
+
+  @override
+  Future<rust_sync.SyncProgress> crateApiSyncGetSyncStatus({
+    required String dbPath,
+    required String network,
+  }) {
+    snapshotReadsStarted.add('sync status');
+    return _syncStatus!.future;
+  }
+
+  @override
+  Future<rust_sync.WalletBalance> crateApiSyncGetBalance({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+  }) {
+    snapshotReadsStarted.add('balance');
+    return _balance!.future;
+  }
+
+  @override
+  Future<List<rust_sync.TransactionInfo>> crateApiSyncGetTransactionHistory({
+    required String dbPath,
+    required String network,
+    int? limit,
+    required String accountUuid,
+  }) {
+    snapshotReadsStarted.add('transaction history');
+    return _transactionHistory!.future;
+  }
+
+  @override
+  bool crateApiWalletWalletExists({required String dbPath}) => _walletExists;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -320,6 +320,119 @@ void main() {
     );
   });
 
+  test(
+    'parallel password configuration reads preserve storage failure type',
+    () async {
+      store = AppSecureStore.testing(storage: _PlatformFailingReadStorage());
+
+      await expectLater(
+        store.isPasswordConfigured(),
+        throwsA(isA<SecureStorageUnavailableException>()),
+      );
+    },
+  );
+
+  test(
+    'wallet DB name lookups share one in-flight storage operation',
+    () async {
+      final storage = _MapStorage('primary');
+      store = AppSecureStore.testing(storage: storage);
+
+      final names = await Future.wait([
+        store.ensureWalletDbName(),
+        store.ensureWalletDbName(),
+        store.ensureWalletDbName(),
+      ]);
+      final cachedName = await store.ensureWalletDbName();
+
+      expect(names.toSet(), hasLength(1));
+      expect(cachedName, names.first);
+      expect(
+        storage.operations.where(
+          (operation) => operation == 'primary.read $kWalletDbNameKey',
+        ),
+        hasLength(1),
+      );
+      expect(
+        storage.operations.where(
+          (operation) => operation == 'primary.write $kWalletDbNameKey',
+        ),
+        hasLength(1),
+      );
+    },
+  );
+
+  test('deleteAll invalidates the cached wallet DB name', () async {
+    final storage = _MapStorage('primary');
+    store = AppSecureStore.testing(storage: storage);
+
+    final firstName = await store.ensureWalletDbName();
+    await store.deleteAll();
+    final secondName = await store.ensureWalletDbName();
+
+    expect(secondName, isNot(firstName));
+    expect(
+      storage.operations.where(
+        (operation) => operation == 'primary.read $kWalletDbNameKey',
+      ),
+      hasLength(2),
+    );
+    expect(
+      storage.operations.where(
+        (operation) => operation == 'primary.write $kWalletDbNameKey',
+      ),
+      hasLength(2),
+    );
+  });
+
+  test('wallet DB name lookup queues behind an in-flight deleteAll', () async {
+    final storage = _BlockingWriteStorage(blockKey: kWalletDbNameKey)
+      ..blockNextWrite = true;
+    addTearDown(storage.release);
+    store = AppSecureStore.testing(storage: storage);
+
+    final firstLookup = store.ensureWalletDbName();
+    await storage.writeStarted.future;
+
+    final reset = store.deleteAll();
+    final lookupAfterReset = store.ensureWalletDbName();
+    var lookupAfterResetCompleted = false;
+    unawaited(
+      lookupAfterReset.then((_) {
+        lookupAfterResetCompleted = true;
+      }),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(lookupAfterResetCompleted, isFalse);
+
+    storage.release();
+    final firstName = await firstLookup;
+    await reset;
+    final secondName = await lookupAfterReset;
+
+    expect(secondName, isNot(firstName));
+    expect(await store.readPlain(kWalletDbNameKey), secondName);
+  });
+
+  test('wallet DB name lookup retries after a storage failure', () async {
+    final storage = _FailingMapStorage('primary')
+      ..failNextWriteFor(kWalletDbNameKey);
+    store = AppSecureStore.testing(storage: storage);
+
+    await expectLater(store.ensureWalletDbName(), throwsStateError);
+    final name = await store.ensureWalletDbName();
+
+    expect(name, startsWith('zcash_wallet_'));
+    expect(await store.ensureWalletDbName(), name);
+    expect(
+      storage.operations.where(
+        (operation) => operation == 'primary.read $kWalletDbNameKey',
+      ),
+      hasLength(2),
+    );
+  });
+
   test('changePassword journal stores only roll-forward data', () async {
     final blockingStorage = _BlockingDeleteStorage(
       blockKey: _rotationInProgressKey,

--- a/test/core/storage/wallet_paths_test.dart
+++ b/test/core/storage/wallet_paths_test.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+// path_provider exposes its platform interface through this transitive package.
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+
+void main() {
+  test('concurrent support directory callers share one resolution', () async {
+    final originalPlatform = PathProviderPlatform.instance;
+    final tempRoot = await Directory.systemTemp.createTemp(
+      'vizor-wallet-paths-concurrent-test-',
+    );
+    final supportPath = [
+      tempRoot.path,
+      'application-support',
+    ].join(Platform.pathSeparator);
+    final platform = _BlockingPathProviderPlatform();
+    PathProviderPlatform.instance = platform;
+
+    try {
+      final first = getWalletSupportDirectory();
+      final second = getWalletSupportDirectory();
+
+      expect(platform.applicationSupportCalls, 1);
+      platform.complete(supportPath);
+      final directories = await Future.wait([first, second]);
+
+      expect(identical(directories[0], directories[1]), isTrue);
+      expect(await directories.first.exists(), isTrue);
+      expect(platform.applicationSupportCalls, 1);
+    } finally {
+      resetWalletSupportDirectoryCacheForTesting();
+      platform.complete(supportPath);
+      PathProviderPlatform.instance = originalPlatform;
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    }
+  });
+
+  test(
+    'support directory resolution is cached and retries after failure',
+    () async {
+      final originalPlatform = PathProviderPlatform.instance;
+      final tempRoot = await Directory.systemTemp.createTemp(
+        'vizor-wallet-paths-test-',
+      );
+      final supportPath = [
+        tempRoot.path,
+        'application-support',
+      ].join(Platform.pathSeparator);
+      final platform = _RetryingPathProviderPlatform(supportPath);
+      PathProviderPlatform.instance = platform;
+
+      try {
+        await expectLater(getWalletSupportDirectory(), throwsStateError);
+
+        final first = await getWalletSupportDirectory();
+        final second = await getWalletSupportDirectory();
+
+        expect(first.path, supportPath);
+        expect(identical(first, second), isTrue);
+        expect(await first.exists(), isTrue);
+        expect(platform.applicationSupportCalls, 2);
+      } finally {
+        resetWalletSupportDirectoryCacheForTesting();
+        PathProviderPlatform.instance = originalPlatform;
+        if (await tempRoot.exists()) {
+          await tempRoot.delete(recursive: true);
+        }
+      }
+    },
+  );
+}
+
+class _BlockingPathProviderPlatform extends PathProviderPlatform {
+  final Completer<String?> _path = Completer<String?>();
+  var applicationSupportCalls = 0;
+
+  void complete(String value) {
+    if (!_path.isCompleted) _path.complete(value);
+  }
+
+  @override
+  Future<String?> getApplicationSupportPath() {
+    applicationSupportCalls += 1;
+    return _path.future;
+  }
+}
+
+class _RetryingPathProviderPlatform extends PathProviderPlatform {
+  _RetryingPathProviderPlatform(this.applicationSupportPath);
+
+  final String applicationSupportPath;
+  var applicationSupportCalls = 0;
+
+  @override
+  Future<String?> getApplicationSupportPath() async {
+    applicationSupportCalls += 1;
+    if (applicationSupportCalls == 1) {
+      throw StateError('forced path resolution failure');
+    }
+    return applicationSupportPath;
+  }
+}


### PR DESCRIPTION
Split from #512. This is the independent startup/bootstrap portion; it has no Rust sync-engine dependency.

## What changes

- Starts independent secure-storage, path-provider, and startup-state reads together after the required iOS keychain migration, E2E override, and password-rotation recovery barriers.
- Loads sync status, the active account balance, and recent transaction history concurrently for an unlocked wallet.
- Memoizes the application-support directory and randomized wallet DB name for the process lifetime.
- Invalidates the cached DB name synchronously during wallet reset and serializes the next lookup behind deletion.

## Expected impact

Cold startup currently pays the cumulative latency of several unrelated keychain, filesystem platform-channel, and Rust FFI calls. After this change, those independent operations overlap, so that part of the startup critical path is closer to the slowest operation than to the sum of all operations.

The improvement should be most visible on devices where secure storage, path-provider, or initial SQLite reads have meaningful latency. Repeated DB-path consumers also avoid additional platform-channel and secure-storage round trips after the first successful resolution.

For an unlocked wallet, the first home frame should retain the existing account, balance, and recent-history snapshot without waiting for those three Rust reads serially. Locked-wallet behavior is unchanged: address, balance, and history are not hydrated before unlock.

This PR intentionally makes no benchmark claim and does not change shielded-sync throughput after startup.

## Correctness and tradeoffs

- Required migrations and password-recovery work remain ordering barriers.
- Concurrent results are unwrapped in the legacy serial order, preserving existing error classification when more than one operation fails.
- Failed cache resolutions are evicted and retried; only successful process-lifetime values remain memoized.
- Wallet reset clears the DB-name cache before deletion begins, so a concurrent lookup cannot return the deleted wallet's name.
- `walletExists` is sampled once for the bootstrap snapshot instead of repeatedly.
- The support-directory cache assumes the OS application-support directory remains valid for the process lifetime.

## Automated validation

- `fvm flutter test test/app_bootstrap_test.dart test/core/storage/app_secure_store_test.dart test/core/storage/wallet_paths_test.dart` — 54 passed.
- Focused `fvm flutter analyze` over all six changed files — no issues.
- `git diff --check` — passed.

The tests prove independent reads start before any one completes; endpoint settings begin after their network dependency; reverse completion order preserves field mapping; secure-storage failures retain precedence; Rust snapshot reads overlap and preserve empty-snapshot fallback; DB-name callers share one in-flight lookup, retry failures, and cannot race reset; and support-directory resolution is shared and retryable.

## Validation criteria before merge

- Compare at least 10 cold launches of locked and unlocked wallets against `main`, recording process start to the first usable welcome/unlock/home frame.
- Confirm unlocked startup paints the existing account, balance, and recent history without an empty-state flash.
- Confirm locked startup does not hydrate address, balance, or history.
- Reset a wallet while DB-path consumers are active, then create/import again; verify a new randomized DB filename is used and the deleted path is never reused.
- Verify unavailable secure storage still routes to `/storage-unavailable`.

## Review focus

1. Cache invalidation and lock ordering in `AppSecureStore`.
2. Bootstrap dependency ordering and preserved failure precedence.
3. Safety of concurrent read-only Rust snapshot calls on an unlocked wallet.

## API surface

Adds two Dart-only `@visibleForTesting` seams: `loadAppBootstrapForTesting` and `resetWalletSupportDirectoryCacheForTesting`. `getWalletSupportDirectory()` now has process-lifetime memoization. There are no Rust, FRB, C FFI, wire, schema, or user-facing copy changes.