### PR TITLE
Improve transparent UTXO refresh and sync progress

### DIFF
--- a/lib/src/providers/sync_display_progress_provider.dart
+++ b/lib/src/providers/sync_display_progress_provider.dart
@@ -5,8 +5,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'sync_provider.dart';
 
-const _displayBlockDuration = Duration(milliseconds: 20);
-const _maxIncompleteDisplayPercentage = 0.999;
+const _displayTickDuration = Duration(milliseconds: 20);
+const _preparationCeiling = 0.05;
+const _scanCeiling = 0.99;
+const _timeEstimateShare = 0.85;
+const _timeEstimateSettleFactor = 6.0;
 
 typedef _SyncDisplayTarget = ({
   bool isSyncing,
@@ -14,13 +17,34 @@ typedef _SyncDisplayTarget = ({
   double percentage,
   double targetPercentage,
   int targetBlocks,
+  int phaseCompletedUnits,
+  int phaseTotalUnits,
+  String phase,
+  DateTime? startedAt,
 });
+
+_SyncDisplayTarget _displayTarget(AsyncValue<SyncState> value) {
+  final sync = value.asData?.value ?? SyncState();
+  return (
+    isSyncing: sync.isSyncing,
+    isSyncComplete: sync.isSyncComplete,
+    percentage: sync.percentage,
+    targetPercentage: sync.displayTargetPercentage,
+    targetBlocks: sync.displayTargetBlocks,
+    phaseCompletedUnits: sync.phaseCompletedUnits,
+    phaseTotalUnits: sync.phaseTotalUnits,
+    phase: sync.phase,
+    startedAt: sync.lastSyncStartedAt,
+  );
+}
 
 /// UI-only sync progress interpolated between authoritative Rust events.
 ///
-/// Keeping the timer outside [SyncState] means its 20 ms updates reach only
-/// widgets that explicitly render smooth progress. Wallet data, Home content,
-/// and other sync consumers continue to update at Rust event boundaries.
+/// Preparation occupies a bounded 0-5% display range. Measurable preparation
+/// work (currently active-account transparent UTXO batches) advances from real
+/// committed work units, while indeterminate waits approach—but never reach—
+/// their phase ceiling over time. Authoritative block progress is then mapped
+/// into 5-99%; only a real completion event can produce 100%.
 final syncDisplayPercentageProvider =
     NotifierProvider.autoDispose<SyncDisplayPercentageNotifier, double>(
       SyncDisplayPercentageNotifier.new,
@@ -29,63 +53,207 @@ final syncDisplayPercentageProvider =
 /// Whole percentage for labels that do not need frame-level progress.
 final syncDisplayWholePercentageProvider = Provider.autoDispose<int>((ref) {
   final progress = ref.watch(syncDisplayPercentageProvider);
-  return (progress.clamp(0.0, 0.99) * 100).round();
+  return (progress.clamp(0.0, _scanCeiling) * 100).round();
 });
 
 class SyncDisplayPercentageNotifier extends Notifier<double> {
   Timer? _timer;
+  _SyncDisplayTarget? _target;
+  DateTime? _sessionStartedAt;
+  String _phase = '';
+  Stopwatch? _phaseStopwatch;
+  double _displayValue = 0;
 
   @override
   double build() {
-    final target = ref.watch(
-      syncProvider.select((value) {
-        final sync = value.asData?.value ?? SyncState();
-        return (
-          isSyncing: sync.isSyncing,
-          isSyncComplete: sync.isSyncComplete,
-          percentage: sync.percentage,
-          targetPercentage: sync.displayTargetPercentage,
-          targetBlocks: sync.displayTargetBlocks,
-        );
-      }),
-    );
-
-    _stopTimer();
+    final input = ref.watch(syncProvider.select(_displayTarget));
+    final isNewSession =
+        input.isSyncing &&
+        input.startedAt != null &&
+        input.startedAt != _sessionStartedAt;
+    if (isNewSession) {
+      _stopTimer();
+      _displayValue = 0;
+      _phase = '';
+      _phaseStopwatch = null;
+    }
+    _target = input;
+    _sessionStartedAt = input.startedAt;
     ref.onDispose(_stopTimer);
-    return _startInterpolation(target);
+    Future<void>.microtask(() {
+      if (ref.mounted && identical(_target, input)) _applyTarget(input);
+    });
+    final next = _initialValue(input);
+    _displayValue = isNewSession ? next : math.max(_displayValue, next);
+    return _displayValue;
   }
 
-  double _startInterpolation(_SyncDisplayTarget input) {
-    final base = input.isSyncComplete
-        ? 1.0
-        : input.percentage
-              .clamp(0.0, _maxIncompleteDisplayPercentage)
-              .toDouble();
-    final target = input.isSyncing
-        ? input.targetPercentage
-              .clamp(base, _maxIncompleteDisplayPercentage)
-              .toDouble()
-        : base;
-    if (input.targetBlocks <= 0 || target <= base) return base;
+  double _initialValue(_SyncDisplayTarget input) {
+    if (input.isSyncComplete) return 1;
+    if (!input.isSyncing) {
+      return input.percentage.clamp(0.0, _scanCeiling).toDouble();
+    }
+    if (isSyncPreparationPhase(input.phase)) {
+      final range = _preparationRange(input.phase);
+      return math.max(range.floor, _measuredPreparation(input, range));
+    }
+    return _mappedScanPercentage(input.percentage, input.phase);
+  }
 
-    _timer = Timer.periodic(_displayBlockDuration, (timer) {
+  void _applyTarget(_SyncDisplayTarget input) {
+    final isNewSession =
+        input.isSyncing &&
+        input.startedAt != null &&
+        input.startedAt != _sessionStartedAt;
+    if (isNewSession) {
+      _stopTimer();
+      _publish(0);
+      _phase = '';
+      _phaseStopwatch = null;
+      _sessionStartedAt = input.startedAt;
+    }
+    _target = input;
+
+    if (input.isSyncComplete) {
+      _stopTimer();
+      _publish(1);
+      return;
+    }
+    if (!input.isSyncing) {
+      _stopTimer();
+      _publish(input.percentage.clamp(0.0, _scanCeiling).toDouble());
+      return;
+    }
+
+    if (isSyncPreparationPhase(input.phase)) {
+      _applyPreparationTarget(input);
+    } else {
+      _applyScanTarget(input);
+    }
+  }
+
+  void _applyPreparationTarget(_SyncDisplayTarget input) {
+    final range = _preparationRange(input.phase);
+    if (_phase != input.phase) {
+      _stopTimer();
+      _phase = input.phase;
+      _phaseStopwatch = Stopwatch()..start();
+    }
+    final measured = _measuredPreparation(input, range);
+    _publish(math.max(_displayValue, math.max(range.floor, measured)));
+    final elapsedMs = _phaseStopwatch?.elapsedMilliseconds.toDouble() ?? 0;
+    if (_timer == null &&
+        _displayValue < range.ceiling &&
+        !_timeEstimateHasSettled(elapsedMs, range)) {
+      _timer = Timer.periodic(_displayTickDuration, (_) {
+        final current = _target;
+        if (!ref.mounted ||
+            current == null ||
+            !current.isSyncing ||
+            current.phase != _phase) {
+          _stopTimer();
+          return;
+        }
+        final currentRange = _preparationRange(_phase);
+        final elapsedMs = _phaseStopwatch?.elapsedMilliseconds.toDouble() ?? 0;
+        final timeFraction =
+            _timeEstimateShare *
+            (1 - math.exp(-elapsedMs / currentRange.timeConstantMs));
+        final temporal =
+            currentRange.floor +
+            (currentRange.ceiling - currentRange.floor) * timeFraction;
+        final actual = _measuredPreparation(current, currentRange);
+        final next = math.min(
+          currentRange.ceiling,
+          math.max(_displayValue, math.max(temporal, actual)),
+        );
+        if (next > _displayValue) _publish(next);
+        if (_timeEstimateHasSettled(elapsedMs, currentRange)) {
+          _stopTimer();
+        }
+      });
+    }
+  }
+
+  void _applyScanTarget(_SyncDisplayTarget input) {
+    _stopTimer();
+    _phase = input.phase;
+    _phaseStopwatch = null;
+    final base = _mappedScanPercentage(input.percentage, input.phase);
+    final target = _mappedScanPercentage(
+      input.targetPercentage,
+      input.phase,
+    ).clamp(base, _scanCeiling).toDouble();
+    _publish(math.max(_displayValue, base));
+    if (input.targetBlocks <= 0 || target <= _displayValue) return;
+
+    final start = _displayValue;
+    _timer = Timer.periodic(_displayTickDuration, (timer) {
       if (!ref.mounted) {
         timer.cancel();
         return;
       }
       final virtualBlocks = math.min(timer.tick, input.targetBlocks);
       final next =
-          base + ((target - base) * virtualBlocks / input.targetBlocks);
-      if (next > state) state = next;
+          start + ((target - start) * virtualBlocks / input.targetBlocks);
+      if (next > _displayValue) _publish(next);
       if (virtualBlocks >= input.targetBlocks || next >= target) {
         _stopTimer();
       }
     });
-    return base;
   }
+
+  double _mappedScanPercentage(double raw, String phase) {
+    final clamped = raw.clamp(0.0, 1.0).toDouble();
+    if (phase != 'download' && phase != 'scan') {
+      return clamped.clamp(0.0, _scanCeiling).toDouble();
+    }
+    return (_preparationCeiling +
+            (_scanCeiling - _preparationCeiling) * clamped)
+        .clamp(_preparationCeiling, _scanCeiling)
+        .toDouble();
+  }
+
+  double _measuredPreparation(
+    _SyncDisplayTarget input,
+    _PreparationRange range,
+  ) {
+    if (input.phaseTotalUnits <= 0) return range.floor;
+    final fraction = (input.phaseCompletedUnits / input.phaseTotalUnits).clamp(
+      0.0,
+      1.0,
+    );
+    return range.floor + (range.ceiling - range.floor) * fraction;
+  }
+
+  _PreparationRange _preparationRange(String phase) {
+    return switch (phase) {
+      kSyncPhasePreflight => const _PreparationRange(0, 0.01, 400),
+      kSyncPhaseSetup => const _PreparationRange(0.01, 0.02, 800),
+      kSyncPhaseActiveUtxo => const _PreparationRange(0.02, 0.04, 1500),
+      kSyncPhaseChainPrepare => const _PreparationRange(0.04, 0.05, 1000),
+      _ => const _PreparationRange(0, 0, 1000),
+    };
+  }
+
+  bool _timeEstimateHasSettled(double elapsedMs, _PreparationRange range) =>
+      elapsedMs >= range.timeConstantMs * _timeEstimateSettleFactor;
 
   void _stopTimer() {
     _timer?.cancel();
     _timer = null;
   }
+
+  void _publish(double next) {
+    _displayValue = next;
+    state = next;
+  }
+}
+
+class _PreparationRange {
+  final double floor;
+  final double ceiling;
+  final double timeConstantMs;
+
+  const _PreparationRange(this.floor, this.ceiling, this.timeConstantMs);
 }

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -801,6 +801,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       final prevAccountUuid = prev?.value?.activeAccountUuid;
       final nextAccountUuid = next.value?.activeAccountUuid;
       if (prevAccountUuid != nextAccountUuid) {
+        // This only changes the order of transparent refreshes that Rust has
+        // not started yet. The current bounded request group keeps running.
+        rust_sync.setActiveSyncAccount(accountUuid: nextAccountUuid);
         _clearAccountScopedStateFor(nextAccountUuid);
       }
       if (nextCount > prevCount) {
@@ -1120,15 +1123,14 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
           // on a separate tokio runtime, so it can accept events while
           // the scan loop is still catching up on old blocks.
           _startMempoolObserver(dbPath, endpoint);
+          // Seed the shared priority synchronously before the asynchronous Rust
+          // sync task starts. Later account switches update the same target.
+          rust_sync.setActiveSyncAccount(accountUuid: _getActiveAccountUuid());
           final stream = rust_sync.startFullSync(
             dbPath: dbPath,
             lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
             network: endpoint.networkName,
             mode: 1,
-            // Endpoint preflight is asynchronous. Re-read the account here so
-            // a switch during preflight prioritizes the account the user is
-            // actually viewing when Rust starts.
-            activeAccountUuid: _getActiveAccountUuid(),
           );
           _syncSub = stream.listen(
             (event) {

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -1125,6 +1125,10 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
             lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
             network: endpoint.networkName,
             mode: 1,
+            // Endpoint preflight is asynchronous. Re-read the account here so
+            // a switch during preflight prioritizes the account the user is
+            // actually viewing when Rust starts.
+            activeAccountUuid: _getActiveAccountUuid(),
           );
           _syncSub = stream.listen(
             (event) {

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -17,6 +17,17 @@ import 'chain_upgrade_provider.dart';
 import 'rpc_endpoint_failover_provider.dart';
 import 'sync_failure.dart';
 
+const kSyncPhasePreflight = 'preflight';
+const kSyncPhaseSetup = 'setup';
+const kSyncPhaseActiveUtxo = 'active_utxo';
+const kSyncPhaseChainPrepare = 'chain_prepare';
+
+bool isSyncPreparationPhase(String phase) =>
+    phase == kSyncPhasePreflight ||
+    phase == kSyncPhaseSetup ||
+    phase == kSyncPhaseActiveUtxo ||
+    phase == kSyncPhaseChainPrepare;
+
 class SyncProgressEvent {
   final int scannedHeight;
   final int chainTipHeight;
@@ -26,9 +37,10 @@ class SyncProgressEvent {
   final bool isSyncing;
   final bool isComplete;
   final bool hasNewTx;
+  final int phaseCompletedUnits;
+  final int phaseTotalUnits;
 
-  /// Current sync phase from Rust: `"download"`, `"scan"`,
-  /// `"enhance"`, or `""` (unspecified / completion).
+  /// Current sync phase from Rust, including preparation phases.
   final String phase;
 
   const SyncProgressEvent({
@@ -40,6 +52,8 @@ class SyncProgressEvent {
     required this.isSyncing,
     required this.isComplete,
     required this.hasNewTx,
+    this.phaseCompletedUnits = 0,
+    this.phaseTotalUnits = 0,
     this.phase = '',
   });
 }
@@ -71,6 +85,8 @@ class SyncState {
   final double percentage;
   final double displayTargetPercentage;
   final int displayTargetBlocks;
+  final int phaseCompletedUnits;
+  final int phaseTotalUnits;
   final int scannedHeight;
   final int chainTipHeight;
   final BigInt transparentBalance;
@@ -141,9 +157,8 @@ class SyncState {
   final DateTime? lastSyncCompletedAt;
   final DateTime? lastSyncFailedAt;
 
-  /// Current sync phase: `"download"`, `"scan"`, `"enhance"`, or
-  /// empty. Widgets can use this to show e.g. "Downloading..."
-  /// instead of a bare percentage.
+  /// Current preparation, download, or scan phase. The Sidebar keeps its
+  /// existing percentage copy and uses this only to estimate display progress.
   final String phase;
 
   /// Amount waiting for confirmations (e.g. change from a recently sent tx).
@@ -324,6 +339,8 @@ class SyncState {
     this.percentage = 0,
     double? displayTargetPercentage,
     this.displayTargetBlocks = 0,
+    this.phaseCompletedUnits = 0,
+    this.phaseTotalUnits = 0,
     this.scannedHeight = 0,
     this.chainTipHeight = 0,
     BigInt? transparentBalance,
@@ -408,6 +425,8 @@ class SyncState {
     double? percentage,
     double? displayTargetPercentage,
     int? displayTargetBlocks,
+    int? phaseCompletedUnits,
+    int? phaseTotalUnits,
     int? scannedHeight,
     int? chainTipHeight,
     BigInt? transparentBalance,
@@ -458,6 +477,8 @@ class SyncState {
       displayTargetPercentage:
           displayTargetPercentage ?? this.displayTargetPercentage,
       displayTargetBlocks: displayTargetBlocks ?? this.displayTargetBlocks,
+      phaseCompletedUnits: phaseCompletedUnits ?? this.phaseCompletedUnits,
+      phaseTotalUnits: phaseTotalUnits ?? this.phaseTotalUnits,
       scannedHeight: scannedHeight ?? this.scannedHeight,
       chainTipHeight: chainTipHeight ?? this.chainTipHeight,
       transparentBalance: transparentBalance ?? this.transparentBalance,
@@ -540,6 +561,8 @@ class SyncState {
       percentage: current.percentage,
       displayTargetPercentage: current.displayTargetPercentage,
       displayTargetBlocks: current.displayTargetBlocks,
+      phaseCompletedUnits: current.phaseCompletedUnits,
+      phaseTotalUnits: current.phaseTotalUnits,
       scannedHeight: current.scannedHeight,
       chainTipHeight: current.chainTipHeight,
       failure: current.failure,
@@ -564,6 +587,8 @@ class SyncState {
       percentage: percentage,
       displayTargetPercentage: displayTargetPercentage,
       displayTargetBlocks: displayTargetBlocks,
+      phaseCompletedUnits: phaseCompletedUnits,
+      phaseTotalUnits: phaseTotalUnits,
       scannedHeight: scannedHeight,
       chainTipHeight: chainTipHeight,
       failure: failure,
@@ -1094,7 +1119,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         lastSyncStartedAt: startedAt,
         lastSyncCompletedAt: prev?.lastSyncCompletedAt,
         lastSyncFailedAt: prev?.lastSyncFailedAt,
-        phase: '',
+        phase: kSyncPhasePreflight,
       ),
     );
 
@@ -1118,6 +1143,16 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
           final endpoint = _endpointConfig;
           log('Sync: starting foreground sync via ${endpoint.hostPort}');
+          final readyState = state.value;
+          if (readyState != null && gen == _syncGen) {
+            state = AsyncData(
+              readyState.copyWith(
+                phase: kSyncPhaseSetup,
+                phaseCompletedUnits: 0,
+                phaseTotalUnits: 0,
+              ),
+            );
+          }
           // Fire up the mempool observer alongside the scan loop.
           // It has its own Rust cancel flag (MEMPOOL_CANCEL) and runs
           // on a separate tokio runtime, so it can accept events while
@@ -1144,6 +1179,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
                 isSyncing: event.isSyncing,
                 isComplete: event.isComplete,
                 hasNewTx: event.hasNewTx,
+                phaseCompletedUnits: event.phaseCompletedUnits.toInt(),
+                phaseTotalUnits: event.phaseTotalUnits.toInt(),
                 phase: event.phase,
               );
               _lastForegroundSyncProgress = progress;
@@ -2108,7 +2145,17 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     final syncCompletedAt = event.isComplete
         ? DateTime.now()
         : prev?.lastSyncCompletedAt;
-    final actualPercentage = _clampProgress(event.percentage);
+    final isPreparationEvent = isSyncPreparationPhase(event.phase);
+    final eventPercentage = _clampProgress(event.percentage);
+    final actualPercentage = isPreparationEvent
+        ? math.max(currentState?.percentage ?? 0, eventPercentage)
+        : eventPercentage;
+    final nextScannedHeight = isPreparationEvent
+        ? currentState?.scannedHeight ?? event.scannedHeight
+        : event.scannedHeight;
+    final nextChainTipHeight = isPreparationEvent
+        ? math.max(currentState?.chainTipHeight ?? 0, event.chainTipHeight)
+        : event.chainTipHeight;
     final nextSpendableBalance = useFetchedBalance
         ? spendable ?? stateScopedPrev?.spendableBalance ?? BigInt.zero
         : stateScopedPrev?.spendableBalance ?? BigInt.zero;
@@ -2131,10 +2178,16 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         isBackgroundMode: false,
         isSyncComplete: event.isComplete,
         percentage: actualPercentage,
-        displayTargetPercentage: event.displayTargetPercentage,
-        displayTargetBlocks: event.displayTargetBlocks,
-        scannedHeight: event.scannedHeight,
-        chainTipHeight: event.chainTipHeight,
+        displayTargetPercentage: isPreparationEvent
+            ? currentState?.displayTargetPercentage ?? actualPercentage
+            : event.displayTargetPercentage,
+        displayTargetBlocks: isPreparationEvent
+            ? currentState?.displayTargetBlocks ?? 0
+            : event.displayTargetBlocks,
+        phaseCompletedUnits: event.phaseCompletedUnits,
+        phaseTotalUnits: event.phaseTotalUnits,
+        scannedHeight: nextScannedHeight,
+        chainTipHeight: nextChainTipHeight,
         transparentBalance: useFetchedBalance
             ? transparent
             : stateScopedPrev?.transparentBalance,
@@ -2688,6 +2741,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         displayTargetPercentage:
             current?.displayTargetPercentage ?? current?.percentage ?? 0.0,
         displayTargetBlocks: current?.displayTargetBlocks ?? 0,
+        phaseCompletedUnits: current?.phaseCompletedUnits ?? 0,
+        phaseTotalUnits: current?.phaseTotalUnits ?? 0,
         scannedHeight: current?.scannedHeight ?? 0,
         chainTipHeight: current?.chainTipHeight ?? 0,
         transparentBalance: transparent ?? accountFallback?.transparentBalance,

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -25,11 +25,13 @@ Stream<ApiSyncProgressEvent> startFullSync({
   required String lightwalletdUrl,
   required String network,
   required int mode,
+  String? activeAccountUuid,
 }) => RustLib.instance.api.crateApiSyncStartFullSync(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
   network: network,
   mode: mode,
+  activeAccountUuid: activeAccountUuid,
 );
 
 /// Blocking sync entrypoint that uses the same API-layer network parsing,

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -1049,16 +1049,20 @@ class ApiSyncProgressEvent {
   final BigInt chainTipHeight;
   final double percentage;
 
-  /// UI-only smoothed progress target. Dart increments toward this
-  /// assuming one virtual block per 500ms, capped at the next batch.
+  /// UI-only smoothed progress target. Dart chooses the display tick and
+  /// advances at most `display_target_blocks` virtual blocks to this target.
   final double displayTargetPercentage;
   final BigInt displayTargetBlocks;
   final bool isSyncing;
   final bool isComplete;
   final bool hasNewTx;
 
-  /// Current sync phase: `"download"`, `"scan"`, `"enhance"`, or
-  /// `""` (completion / unspecified).
+  /// Completed and total work units for measurable preparation phases.
+  final BigInt phaseCompletedUnits;
+  final BigInt phaseTotalUnits;
+
+  /// Current sync phase. Preparation adds `"active_utxo"` and
+  /// `"chain_prepare"` before the existing download/scan phases.
   final String phase;
 
   const ApiSyncProgressEvent({
@@ -1070,6 +1074,8 @@ class ApiSyncProgressEvent {
     required this.isSyncing,
     required this.isComplete,
     required this.hasNewTx,
+    required this.phaseCompletedUnits,
+    required this.phaseTotalUnits,
     required this.phase,
   });
 
@@ -1083,6 +1089,8 @@ class ApiSyncProgressEvent {
       isSyncing.hashCode ^
       isComplete.hashCode ^
       hasNewTx.hashCode ^
+      phaseCompletedUnits.hashCode ^
+      phaseTotalUnits.hashCode ^
       phase.hashCode;
 
   @override
@@ -1098,6 +1106,8 @@ class ApiSyncProgressEvent {
           isSyncing == other.isSyncing &&
           isComplete == other.isComplete &&
           hasNewTx == other.hasNewTx &&
+          phaseCompletedUnits == other.phaseCompletedUnits &&
+          phaseTotalUnits == other.phaseTotalUnits &&
           phase == other.phase;
 }
 

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -18,6 +18,11 @@ void setSyncMode({required int mode}) =>
 /// Get the current desired sync mode.
 int getSyncMode() => RustLib.instance.api.crateApiSyncGetSyncMode();
 
+/// Update the foreground sync account whose pending transparent refreshes
+/// should be scheduled first. Requests already in flight are not interrupted.
+void setActiveSyncAccount({String? accountUuid}) => RustLib.instance.api
+    .crateApiSyncSetActiveSyncAccount(accountUuid: accountUuid);
+
 /// Start a full sync. Streams progress events to Dart via StreamSink.
 /// mode: 1=foreground, 2=background. Sync exits if desired mode changes.
 Stream<ApiSyncProgressEvent> startFullSync({
@@ -25,13 +30,11 @@ Stream<ApiSyncProgressEvent> startFullSync({
   required String lightwalletdUrl,
   required String network,
   required int mode,
-  String? activeAccountUuid,
 }) => RustLib.instance.api.crateApiSyncStartFullSync(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
   network: network,
   mode: mode,
-  activeAccountUuid: activeAccountUuid,
 );
 
 /// Blocking sync entrypoint that uses the same API-layer network parsing,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -1095,6 +1095,7 @@ abstract class RustLibApi extends BaseApi {
     required String lightwalletdUrl,
     required String network,
     required int mode,
+    String? activeAccountUuid,
   });
 
   Stream<ApiMempoolTxEvent> crateApiSyncStartMempoolObserver({
@@ -7759,6 +7760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String lightwalletdUrl,
     required String network,
     required int mode,
+    String? activeAccountUuid,
   }) {
     final sink = RustStreamSink<ApiSyncProgressEvent>();
     unawaited(
@@ -7770,6 +7772,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_String(lightwalletdUrl, serializer);
             sse_encode_String(network, serializer);
             sse_encode_u_8(mode, serializer);
+            sse_encode_opt_String(activeAccountUuid, serializer);
             sse_encode_StreamSink_api_sync_progress_event_Sse(sink, serializer);
             pdeCallFfi(
               generalizedFrbRustBinding,
@@ -7783,7 +7786,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             decodeErrorData: sse_decode_String,
           ),
           constMeta: kCrateApiSyncStartFullSyncConstMeta,
-          argValues: [dbPath, lightwalletdUrl, network, mode, sink],
+          argValues: [
+            dbPath,
+            lightwalletdUrl,
+            network,
+            mode,
+            activeAccountUuid,
+            sink,
+          ],
           apiImpl: this,
         ),
       ),
@@ -7793,7 +7803,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiSyncStartFullSyncConstMeta => const TaskConstMeta(
     debugName: "start_full_sync",
-    argNames: ["dbPath", "lightwalletdUrl", "network", "mode", "sink"],
+    argNames: [
+      "dbPath",
+      "lightwalletdUrl",
+      "network",
+      "mode",
+      "activeAccountUuid",
+      "sink",
+    ],
   );
 
   @override

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -8708,8 +8708,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ApiSyncProgressEvent dco_decode_api_sync_progress_event(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 9)
-      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    if (arr.length != 11)
+      throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return ApiSyncProgressEvent(
       scannedHeight: dco_decode_u_64(arr[0]),
       chainTipHeight: dco_decode_u_64(arr[1]),
@@ -8719,7 +8719,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       isSyncing: dco_decode_bool(arr[5]),
       isComplete: dco_decode_bool(arr[6]),
       hasNewTx: dco_decode_bool(arr[7]),
-      phase: dco_decode_String(arr[8]),
+      phaseCompletedUnits: dco_decode_u_64(arr[8]),
+      phaseTotalUnits: dco_decode_u_64(arr[9]),
+      phase: dco_decode_String(arr[10]),
     );
   }
 
@@ -11141,6 +11143,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_isSyncing = sse_decode_bool(deserializer);
     var var_isComplete = sse_decode_bool(deserializer);
     var var_hasNewTx = sse_decode_bool(deserializer);
+    var var_phaseCompletedUnits = sse_decode_u_64(deserializer);
+    var var_phaseTotalUnits = sse_decode_u_64(deserializer);
     var var_phase = sse_decode_String(deserializer);
     return ApiSyncProgressEvent(
       scannedHeight: var_scannedHeight,
@@ -11151,6 +11155,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       isSyncing: var_isSyncing,
       isComplete: var_isComplete,
       hasNewTx: var_hasNewTx,
+      phaseCompletedUnits: var_phaseCompletedUnits,
+      phaseTotalUnits: var_phaseTotalUnits,
       phase: var_phase,
     );
   }
@@ -14312,6 +14318,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self.isSyncing, serializer);
     sse_encode_bool(self.isComplete, serializer);
     sse_encode_bool(self.hasNewTx, serializer);
+    sse_encode_u_64(self.phaseCompletedUnits, serializer);
+    sse_encode_u_64(self.phaseTotalUnits, serializer);
     sse_encode_String(self.phase, serializer);
   }
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -81,7 +81,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1626111918;
+  int get rustContentHash => -1104268301;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -1042,6 +1042,8 @@ abstract class RustLibApi extends BaseApi {
     required BigInt limit,
   });
 
+  void crateApiSyncSetActiveSyncAccount({String? accountUuid});
+
   Future<void> crateApiVotingSetBallotIntent({
     required String dbPath,
     required String accountUuid,
@@ -1095,7 +1097,6 @@ abstract class RustLibApi extends BaseApi {
     required String lightwalletdUrl,
     required String network,
     required int mode,
-    String? activeAccountUuid,
   });
 
   Stream<ApiMempoolTxEvent> crateApiSyncStartMempoolObserver({
@@ -7422,6 +7423,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  void crateApiSyncSetActiveSyncAccount({String? accountUuid}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_opt_String(accountUuid, serializer);
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 144,
+          )!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiSyncSetActiveSyncAccountConstMeta,
+        argValues: [accountUuid],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncSetActiveSyncAccountConstMeta =>
+      const TaskConstMeta(
+        debugName: "set_active_sync_account",
+        argNames: ["accountUuid"],
+      );
+
+  @override
   Future<void> crateApiVotingSetBallotIntent({
     required String dbPath,
     required String accountUuid,
@@ -7445,7 +7476,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7492,7 +7523,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
           )!;
         },
         codec: SseCodec(
@@ -7522,7 +7553,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
           )!;
         },
         codec: SseCodec(
@@ -7557,7 +7588,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
             port: port_,
           );
         },
@@ -7590,7 +7621,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7630,7 +7661,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7671,7 +7702,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
             port: port_,
           );
         },
@@ -7725,7 +7756,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7760,7 +7791,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String lightwalletdUrl,
     required String network,
     required int mode,
-    String? activeAccountUuid,
   }) {
     final sink = RustStreamSink<ApiSyncProgressEvent>();
     unawaited(
@@ -7772,12 +7802,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_String(lightwalletdUrl, serializer);
             sse_encode_String(network, serializer);
             sse_encode_u_8(mode, serializer);
-            sse_encode_opt_String(activeAccountUuid, serializer);
             sse_encode_StreamSink_api_sync_progress_event_Sse(sink, serializer);
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 152,
+              funcId: 153,
               port: port_,
             );
           },
@@ -7786,14 +7815,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             decodeErrorData: sse_decode_String,
           ),
           constMeta: kCrateApiSyncStartFullSyncConstMeta,
-          argValues: [
-            dbPath,
-            lightwalletdUrl,
-            network,
-            mode,
-            activeAccountUuid,
-            sink,
-          ],
+          argValues: [dbPath, lightwalletdUrl, network, mode, sink],
           apiImpl: this,
         ),
       ),
@@ -7803,14 +7825,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiSyncStartFullSyncConstMeta => const TaskConstMeta(
     debugName: "start_full_sync",
-    argNames: [
-      "dbPath",
-      "lightwalletdUrl",
-      "network",
-      "mode",
-      "activeAccountUuid",
-      "sink",
-    ],
+    argNames: ["dbPath", "lightwalletdUrl", "network", "mode", "sink"],
   );
 
   @override
@@ -7832,7 +7847,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 153,
+              funcId: 154,
               port: port_,
             );
           },
@@ -7864,7 +7879,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
             port: port_,
           );
         },
@@ -7891,7 +7906,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 156,
           )!;
         },
         codec: SseCodec(
@@ -7917,7 +7932,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 157,
             port: port_,
           );
         },
@@ -7959,7 +7974,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 158,
             port: port_,
           );
         },
@@ -8015,7 +8030,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 159,
             port: port_,
           );
         },
@@ -8050,7 +8065,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8089,7 +8104,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
             port: port_,
           );
         },
@@ -8125,7 +8140,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8160,7 +8175,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8197,7 +8212,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8241,7 +8256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8291,7 +8306,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
             port: port_,
           );
         },
@@ -8323,7 +8338,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8351,7 +8366,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 168,
           )!;
         },
         codec: SseCodec(
@@ -8383,7 +8398,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8420,7 +8435,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8451,7 +8466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 171,
           )!;
         },
         codec: SseCodec(
@@ -8482,7 +8497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8519,7 +8534,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 173,
             port: port_,
           );
         },

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -1,6 +1,6 @@
 use std::panic;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use flutter_rust_bridge::frb;
 use zeroize::Zeroizing;
@@ -11,6 +11,8 @@ use crate::wallet::{keys, network::WalletNetwork, secret_store, sync as wallet_s
 // ======================== Sync Mode ========================
 // 0 = None, 1 = Foreground, 2 = Background
 pub(crate) static DESIRED_SYNC_MODE: AtomicU8 = AtomicU8::new(0);
+static ACTIVE_SYNC_ACCOUNT: std::sync::LazyLock<sync_engine::ActiveSyncAccountTarget> =
+    std::sync::LazyLock::new(|| Arc::new(RwLock::new(None)));
 
 /// Set the desired sync mode. 0=none, 1=foreground, 2=background.
 /// The running sync loop checks this each batch and exits if mismatched.
@@ -23,6 +25,15 @@ pub fn set_sync_mode(mode: u8) {
 #[frb(sync)]
 pub fn get_sync_mode() -> u8 {
     DESIRED_SYNC_MODE.load(Ordering::SeqCst)
+}
+
+/// Update the foreground sync account whose pending transparent refreshes
+/// should be scheduled first. Requests already in flight are not interrupted.
+#[frb(sync)]
+pub fn set_active_sync_account(account_uuid: Option<String>) {
+    *ACTIVE_SYNC_ACCOUNT
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = account_uuid;
 }
 
 // ======================== Full Sync ========================
@@ -49,7 +60,7 @@ fn run_full_sync_internal<F>(
     lightwalletd_url: String,
     network: String,
     mode: u8,
-    active_account_uuid: Option<String>,
+    active_account_target: Option<sync_engine::ActiveSyncAccountTarget>,
     on_progress: F,
 ) -> Result<(), String>
 where
@@ -63,7 +74,6 @@ where
     }
 
     DESIRED_SYNC_MODE.store(mode, Ordering::SeqCst);
-
     let result = catch(panic::AssertUnwindSafe(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
         let cancel = SYNC_CANCEL.clone();
@@ -78,7 +88,7 @@ where
                 cancel,
                 mode,
                 &DESIRED_SYNC_MODE,
-                active_account_uuid.as_deref(),
+                active_account_target,
                 true,
                 |progress| on_progress(&progress),
             )
@@ -97,15 +107,15 @@ pub fn start_full_sync(
     lightwalletd_url: String,
     network: String,
     mode: u8,
-    active_account_uuid: Option<String>,
     sink: StreamSink<ApiSyncProgressEvent>,
 ) -> Result<(), String> {
+    let active_account_target = (mode == 1).then(|| ACTIVE_SYNC_ACCOUNT.clone());
     let result = run_full_sync_internal(
         db_path,
         lightwalletd_url,
         network,
         mode,
-        active_account_uuid,
+        active_account_target,
         |progress| {
             if sink
                 .add(ApiSyncProgressEvent {

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -49,6 +49,7 @@ fn run_full_sync_internal<F>(
     lightwalletd_url: String,
     network: String,
     mode: u8,
+    active_account_uuid: Option<String>,
     on_progress: F,
 ) -> Result<(), String>
 where
@@ -77,6 +78,7 @@ where
                 cancel,
                 mode,
                 &DESIRED_SYNC_MODE,
+                active_account_uuid.as_deref(),
                 true,
                 |progress| on_progress(&progress),
             )
@@ -95,29 +97,37 @@ pub fn start_full_sync(
     lightwalletd_url: String,
     network: String,
     mode: u8,
+    active_account_uuid: Option<String>,
     sink: StreamSink<ApiSyncProgressEvent>,
 ) -> Result<(), String> {
-    let result = run_full_sync_internal(db_path, lightwalletd_url, network, mode, |progress| {
-        if sink
-            .add(ApiSyncProgressEvent {
-                scanned_height: progress.scanned_height,
-                chain_tip_height: progress.chain_tip_height,
-                percentage: progress.percentage,
-                display_target_percentage: progress.display_target_percentage,
-                display_target_blocks: progress.display_target_blocks,
-                is_syncing: progress.is_syncing,
-                is_complete: progress.is_complete,
-                has_new_tx: progress.has_new_tx,
-                phase: progress.phase.clone(),
-            })
-            .is_err()
-        {
-            log::warn!(
-                "[{}] sync: StreamSink closed, progress not delivered",
-                sync_engine::elapsed(),
-            );
-        }
-    });
+    let result = run_full_sync_internal(
+        db_path,
+        lightwalletd_url,
+        network,
+        mode,
+        active_account_uuid,
+        |progress| {
+            if sink
+                .add(ApiSyncProgressEvent {
+                    scanned_height: progress.scanned_height,
+                    chain_tip_height: progress.chain_tip_height,
+                    percentage: progress.percentage,
+                    display_target_percentage: progress.display_target_percentage,
+                    display_target_blocks: progress.display_target_blocks,
+                    is_syncing: progress.is_syncing,
+                    is_complete: progress.is_complete,
+                    has_new_tx: progress.has_new_tx,
+                    phase: progress.phase.clone(),
+                })
+                .is_err()
+            {
+                log::warn!(
+                    "[{}] sync: StreamSink closed, progress not delivered",
+                    sync_engine::elapsed(),
+                );
+            }
+        },
+    );
 
     // Generated Dart exposes the sink stream, while the FRB task future is
     // detached. Forward terminal errors through the stream it actually reads.
@@ -143,7 +153,7 @@ pub fn run_full_sync_blocking(
     network: String,
     mode: u8,
 ) -> Result<(), String> {
-    run_full_sync_internal(db_path, lightwalletd_url, network, mode, |_| {})
+    run_full_sync_internal(db_path, lightwalletd_url, network, mode, None, |_| {})
 }
 
 /// Cancel a running full sync.

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -43,15 +43,18 @@ pub struct ApiSyncProgressEvent {
     pub scanned_height: u64,
     pub chain_tip_height: u64,
     pub percentage: f64,
-    /// UI-only smoothed progress target. Dart increments toward this
-    /// assuming one virtual block per 500ms, capped at the next batch.
+    /// UI-only smoothed progress target. Dart chooses the display tick and
+    /// advances at most `display_target_blocks` virtual blocks to this target.
     pub display_target_percentage: f64,
     pub display_target_blocks: u64,
     pub is_syncing: bool,
     pub is_complete: bool,
     pub has_new_tx: bool,
-    /// Current sync phase: `"download"`, `"scan"`, `"enhance"`, or
-    /// `""` (completion / unspecified).
+    /// Completed and total work units for measurable preparation phases.
+    pub phase_completed_units: u64,
+    pub phase_total_units: u64,
+    /// Current sync phase. Preparation adds `"active_utxo"` and
+    /// `"chain_prepare"` before the existing download/scan phases.
     pub phase: String,
 }
 
@@ -127,6 +130,8 @@ pub fn start_full_sync(
                     is_syncing: progress.is_syncing,
                     is_complete: progress.is_complete,
                     has_new_tx: progress.has_new_tx,
+                    phase_completed_units: progress.phase_completed_units,
+                    phase_total_units: progress.phase_total_units,
                     phase: progress.phase.clone(),
                 })
                 .is_err()

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -6099,6 +6099,7 @@ fn wire__crate__api__sync__start_full_sync_impl(
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_mode = <u8>::sse_decode(&mut deserializer);
+            let api_active_account_uuid = <Option<String>>::sse_decode(&mut deserializer);
             let api_sink = <StreamSink<
                 crate::api::sync::ApiSyncProgressEvent,
                 flutter_rust_bridge::for_generated::SseCodec,
@@ -6111,6 +6112,7 @@ fn wire__crate__api__sync__start_full_sync_impl(
                         api_lightwalletd_url,
                         api_network,
                         api_mode,
+                        api_active_account_uuid,
                         api_sink,
                     )?;
                     Ok(output_ok)

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1626111918;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1104268301;
 
 // Section: executor
 
@@ -5756,6 +5756,38 @@ fn wire__crate__api__sync__scan_blocks_impl(
         },
     )
 }
+fn wire__crate__api__sync__set_active_sync_account_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "set_active_sync_account",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_account_uuid = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::sync::set_active_sync_account(api_account_uuid);
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__voting__set_ballot_intent_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -6099,7 +6131,6 @@ fn wire__crate__api__sync__start_full_sync_impl(
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_mode = <u8>::sse_decode(&mut deserializer);
-            let api_active_account_uuid = <Option<String>>::sse_decode(&mut deserializer);
             let api_sink = <StreamSink<
                 crate::api::sync::ApiSyncProgressEvent,
                 flutter_rust_bridge::for_generated::SseCodec,
@@ -6112,7 +6143,6 @@ fn wire__crate__api__sync__start_full_sync_impl(
                         api_lightwalletd_url,
                         api_network,
                         api_mode,
-                        api_active_account_uuid,
                         api_sink,
                     )?;
                     Ok(output_ok)
@@ -10348,30 +10378,30 @@ fn pde_ffi_dispatcher_primary_impl(
 141 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
 142 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
 143 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-172 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+148 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10411,15 +10441,16 @@ fn pde_ffi_dispatcher_sync_impl(
         }
         115 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
         134 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        145 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        144 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
+        146 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        146 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        155 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        167 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        170 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        147 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        156 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        168 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        171 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -7432,6 +7432,8 @@ impl SseDecode for crate::api::sync::ApiSyncProgressEvent {
         let mut var_isSyncing = <bool>::sse_decode(deserializer);
         let mut var_isComplete = <bool>::sse_decode(deserializer);
         let mut var_hasNewTx = <bool>::sse_decode(deserializer);
+        let mut var_phaseCompletedUnits = <u64>::sse_decode(deserializer);
+        let mut var_phaseTotalUnits = <u64>::sse_decode(deserializer);
         let mut var_phase = <String>::sse_decode(deserializer);
         return crate::api::sync::ApiSyncProgressEvent {
             scanned_height: var_scannedHeight,
@@ -7442,6 +7444,8 @@ impl SseDecode for crate::api::sync::ApiSyncProgressEvent {
             is_syncing: var_isSyncing,
             is_complete: var_isComplete,
             has_new_tx: var_hasNewTx,
+            phase_completed_units: var_phaseCompletedUnits,
+            phase_total_units: var_phaseTotalUnits,
             phase: var_phase,
         };
     }
@@ -10645,6 +10649,8 @@ impl flutter_rust_bridge::IntoDart for crate::api::sync::ApiSyncProgressEvent {
             self.is_syncing.into_into_dart().into_dart(),
             self.is_complete.into_into_dart().into_dart(),
             self.has_new_tx.into_into_dart().into_dart(),
+            self.phase_completed_units.into_into_dart().into_dart(),
+            self.phase_total_units.into_into_dart().into_dart(),
             self.phase.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -13297,6 +13303,8 @@ impl SseEncode for crate::api::sync::ApiSyncProgressEvent {
         <bool>::sse_encode(self.is_syncing, serializer);
         <bool>::sse_encode(self.is_complete, serializer);
         <bool>::sse_encode(self.has_new_tx, serializer);
+        <u64>::sse_encode(self.phase_completed_units, serializer);
+        <u64>::sse_encode(self.phase_total_units, serializer);
         <String>::sse_encode(self.phase, serializer);
     }
 }

--- a/rust/src/migration_preparation.rs
+++ b/rust/src/migration_preparation.rs
@@ -211,6 +211,7 @@ pub fn run_sync(
             control.cancel.clone(),
             MIGRATION_PREPARATION_SYNC_MODE,
             &control.desired_sync_mode,
+            None,
             false,
             progress_callback,
         ))

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -87,6 +87,7 @@ const BATCH_SIZE_BACKGROUND: u32 = 300;
 const TRANSPARENT_UTXO_RECENT_EXTERNAL_LIMIT: usize = 20;
 const TRANSPARENT_UTXO_SWEEP_EXTERNAL_LIMIT: usize = 20;
 const MAX_CONCURRENT_TRANSPARENT_UTXO_STREAMS: usize = 4;
+const MAX_DEFERRED_TRANSPARENT_REFRESH_ATTEMPTS: u32 = 3;
 
 /// Sandblasting attack range (Zcash mainnet). Blocks in this range
 /// contain a very large number of outputs from a sustained spam
@@ -1172,23 +1173,52 @@ enum TransparentRefreshOutcome {
     Cancelled,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TransparentAccountSelection<'a> {
+    All,
+    Only(&'a str),
+    Except(&'a str),
+}
+
+impl TransparentAccountSelection<'_> {
+    fn includes(self, account_uuid: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::Only(selected) => account_uuid == selected,
+            Self::Except(selected) => account_uuid != selected,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct TransparentRefreshSummary {
+    matched_accounts: usize,
+}
+
 async fn refresh_utxos(
     client: &mut CompactTxStreamerClient<Channel>,
     db_data_path: &str,
     db: &mut WalletDatabase,
     network: WalletNetwork,
     tip_height: BlockHeight,
+    account_selection: TransparentAccountSelection<'_>,
+    received_outputs_seen: &mut bool,
     should_exit: &impl Fn() -> bool,
-) -> Result<(), SyncError> {
+) -> Result<TransparentRefreshSummary, SyncError> {
     let mut refreshes = Vec::new();
+    let mut summary = TransparentRefreshSummary::default();
     for account_id in db
         .get_account_ids()
         .map_err(|e| SyncError::db(format!("get_account_ids: {e}")))?
     {
         if should_exit() {
-            return Ok(());
+            return Ok(summary);
         }
         let account_uuid = account_id.expose_uuid().to_string();
+        if !account_selection.includes(&account_uuid) {
+            continue;
+        }
+        summary.matched_accounts += 1;
         let safety_start_height = db
             .utxo_query_height(account_id)
             .map_err(|e| SyncError::db(format!("utxo_query_height: {e}")))?;
@@ -1246,7 +1276,7 @@ async fn refresh_utxos(
 
         for (batch_index, batch) in external_batches.into_iter().enumerate() {
             if should_exit() {
-                return Ok(());
+                return Ok(summary);
             }
             let start_height = block_height_from_u64(
                 batch.start_height,
@@ -1298,6 +1328,7 @@ async fn refresh_utxos(
         refreshes,
         move |refresh| download_transparent_outputs(download_client.clone(), refresh, should_exit),
         |downloaded| {
+            let received_outputs = downloaded.iter().any(|batch| !batch.outputs.is_empty());
             store_then_mark_transparent_refreshes(
                 downloaded,
                 |downloaded| store_transparent_outputs(db, downloaded),
@@ -1309,7 +1340,9 @@ async fn refresh_utxos(
                         downloaded,
                     )
                 },
-            )
+            )?;
+            *received_outputs_seen |= received_outputs;
+            Ok(())
         },
         should_exit,
     )
@@ -1321,7 +1354,7 @@ async fn refresh_utxos(
         );
     }
 
-    Ok(())
+    Ok(summary)
 }
 
 fn update_transparent_refresh_cache_metadata(
@@ -1495,9 +1528,10 @@ async fn download_transparent_outputs(
     }
 
     log::info!(
-        "[{}] sync: refreshing {} from height {} ({} addresses)",
+        "[{}] sync: refreshing {} for account {} from height {} ({} addresses)",
         elapsed(),
         refresh.label,
+        refresh.account_uuid,
         u32::from(refresh.start_height),
         refresh.addresses.len(),
     );
@@ -1755,6 +1789,7 @@ pub async fn run_sync_inner(
     cancel: Arc<AtomicBool>,
     running_mode: u8,
     desired_mode: &AtomicU8,
+    active_account_uuid: Option<&str>,
     allow_resubmit: bool,
     progress_fn: impl Fn(SyncProgressEvent) + Send + Sync,
 ) -> Result<(), String> {
@@ -1795,6 +1830,7 @@ pub async fn run_sync_inner(
             cancel.clone(),
             running_mode,
             desired_mode,
+            active_account_uuid,
             allow_resubmit,
             &progress_fn,
         )
@@ -1852,6 +1888,7 @@ async fn run_sync_impl(
     cancel: Arc<AtomicBool>,
     running_mode: u8,
     desired_mode: &AtomicU8,
+    active_account_uuid: Option<&str>,
     allow_resubmit: bool,
     progress_fn: &(impl Fn(SyncProgressEvent) + Send + Sync),
 ) -> Result<(), SyncError> {
@@ -1924,15 +1961,61 @@ async fn run_sync_impl(
 
     let should_exit =
         || cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode;
-    refresh_utxos(
-        &mut client,
-        db_data_path,
-        &mut db,
-        network,
-        tip_height,
-        &should_exit,
-    )
-    .await?;
+    let defer_inactive_transparent_refresh = if let Some(active_account_uuid) = active_account_uuid
+    {
+        log::info!(
+            "[{}] sync: refreshing active-account transparent UTXOs before chain scan ({})",
+            elapsed(),
+            active_account_uuid,
+        );
+        let mut critical_received_outputs = false;
+        let active_summary = refresh_utxos(
+            &mut client,
+            db_data_path,
+            &mut db,
+            network,
+            tip_height,
+            TransparentAccountSelection::Only(active_account_uuid),
+            &mut critical_received_outputs,
+            &should_exit,
+        )
+        .await?;
+        if active_summary.matched_accounts == 0 {
+            log::warn!(
+                "[{}] sync: active account {} was absent from the wallet DB; refreshing all transparent UTXOs before chain scan",
+                elapsed(),
+                active_account_uuid,
+            );
+            refresh_utxos(
+                &mut client,
+                db_data_path,
+                &mut db,
+                network,
+                tip_height,
+                TransparentAccountSelection::All,
+                &mut critical_received_outputs,
+                &should_exit,
+            )
+            .await?;
+            false
+        } else {
+            true
+        }
+    } else {
+        let mut critical_received_outputs = false;
+        refresh_utxos(
+            &mut client,
+            db_data_path,
+            &mut db,
+            network,
+            tip_height,
+            TransparentAccountSelection::All,
+            &mut critical_received_outputs,
+            &should_exit,
+        )
+        .await?;
+        false
+    };
 
     if should_exit() {
         log::info!(
@@ -2911,6 +2994,102 @@ async fn run_sync_impl(
     };
     progress_fn(final_progress);
 
+    // Transparent receivers belonging to inactive accounts do not affect the
+    // account-scoped balance shown for this completed foreground sync. Keep
+    // the active account on the correctness-critical path, then refresh all
+    // remaining accounts after reporting chain-sync completion. The FRB
+    // stream stays open until this bounded follow-up finishes, so lock/reset
+    // cancellation and the global running guard still own its lifetime.
+    if defer_inactive_transparent_refresh && !should_exit() {
+        let active_account_uuid = active_account_uuid.expect("deferred refresh has active account");
+        log::info!(
+            "[{}] sync: starting deferred inactive-account transparent UTXO refresh",
+            elapsed(),
+        );
+        let mut deferred_attempt = 1;
+        let mut deferred_received_outputs = false;
+        let deferred_result = loop {
+            let result = refresh_utxos(
+                &mut client,
+                db_data_path,
+                &mut db,
+                network,
+                BlockHeight::from_u32(final_tip_height as u32),
+                TransparentAccountSelection::Except(active_account_uuid),
+                &mut deferred_received_outputs,
+                &should_exit,
+            )
+            .await;
+            match result {
+                Ok(summary) => break Ok(summary),
+                Err(error)
+                    if deferred_attempt < MAX_DEFERRED_TRANSPARENT_REFRESH_ATTEMPTS
+                        && !should_exit() =>
+                {
+                    let delay_secs = 1u64 << deferred_attempt;
+                    log::warn!(
+                        "[{}] sync: deferred transparent UTXO refresh attempt {}/{} failed; retrying in {}s: {}",
+                        elapsed(),
+                        deferred_attempt,
+                        MAX_DEFERRED_TRANSPARENT_REFRESH_ATTEMPTS,
+                        delay_secs,
+                        error,
+                    );
+                    let retry_delay =
+                        tokio::time::sleep(std::time::Duration::from_secs(delay_secs));
+                    tokio::pin!(retry_delay);
+                    tokio::select! {
+                        biased;
+                        _ = watch_for_exit(&should_exit) => break Err(error),
+                        _ = &mut retry_delay => {}
+                    }
+                    deferred_attempt += 1;
+                }
+                Err(error) => break Err(error),
+            }
+        };
+        match &deferred_result {
+            Ok(summary) => {
+                log::info!(
+                    "[{}] sync: deferred transparent UTXO refresh finished (accounts={}, received_outputs={})",
+                    elapsed(),
+                    summary.matched_accounts,
+                    deferred_received_outputs,
+                );
+            }
+            Err(error) => log::warn!(
+                "[{}] sync: deferred inactive-account transparent UTXO refresh failed after {} attempt(s); it will retry on a later sync: {}",
+                elapsed(),
+                deferred_attempt,
+                error,
+            ),
+        }
+        if deferred_received_outputs && !should_exit() {
+            if let Err(error) = run_enhancement(&mut client, &mut db, db_data_path, network).await {
+                log::warn!(
+                    "[{}] sync: deferred transparent transaction enhancement failed; it will retry on a later sync: {}",
+                    elapsed(),
+                    error,
+                );
+            }
+            // The user may have switched accounts while the deferred pass was
+            // running. Re-emit completion even after a terminal partial
+            // failure so Dart refreshes whichever account is active now from
+            // every output that was committed by an earlier successful group.
+            progress_fn(SyncProgressEvent {
+                scanned_height: final_scanned_height,
+                chain_tip_height: final_tip_height,
+                percentage: 1.0,
+                display_target_percentage: 1.0,
+                display_target_blocks: 0,
+                is_syncing: false,
+                is_complete: true,
+                has_new_tx: true,
+                phase: String::new(),
+            });
+        }
+    }
+
     Ok(())
 }
 
@@ -3252,6 +3431,16 @@ mod tests {
         .unwrap();
 
         assert_eq!(events.into_inner(), ["commit", "mark 1", "mark 2"]);
+    }
+
+    #[test]
+    fn transparent_account_selection_prioritizes_one_account() {
+        let selected = "active";
+        assert!(TransparentAccountSelection::All.includes(selected));
+        assert!(TransparentAccountSelection::Only(selected).includes(selected));
+        assert!(!TransparentAccountSelection::Only(selected).includes("inactive"));
+        assert!(!TransparentAccountSelection::Except(selected).includes(selected));
+        assert!(TransparentAccountSelection::Except(selected).includes("inactive"));
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -71,10 +71,16 @@ pub struct SyncProgressEvent {
     pub is_syncing: bool,
     pub is_complete: bool,
     pub has_new_tx: bool,
+    /// Completed and total work units for preparation phases. A zero total
+    /// means the phase has no measurable work and should be time-interpolated
+    /// by the UI instead.
+    pub phase_completed_units: u64,
+    pub phase_total_units: u64,
     /// Current sync phase for UI display. One of:
+    /// - `"active_utxo"` — refreshing the active account's transparent UTXOs
+    /// - `"chain_prepare"` — resubmission, subtree, and scan-range preparation
     /// - `"download"` — downloading compact blocks from lightwalletd
     /// - `"scan"` — running `scan_cached_blocks` (CPU-intensive)
-    /// - `"enhance"` — fetching full transaction data
     /// - `""` — completion event or unspecified
     pub phase: String,
 }
@@ -98,6 +104,27 @@ fn current_active_sync_account(target: Option<&ActiveSyncAccountTarget>) -> Opti
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone()
     })?
+}
+
+fn preparation_progress_event(
+    chain_tip_height: u64,
+    phase: &str,
+    phase_completed_units: u64,
+    phase_total_units: u64,
+) -> SyncProgressEvent {
+    SyncProgressEvent {
+        scanned_height: 0,
+        chain_tip_height,
+        percentage: 0.0,
+        display_target_percentage: 0.0,
+        display_target_blocks: 0,
+        is_syncing: true,
+        is_complete: false,
+        has_new_tx: false,
+        phase_completed_units,
+        phase_total_units,
+        phase: phase.into(),
+    }
 }
 
 /// Sandblasting attack range (Zcash mainnet). Blocks in this range
@@ -1215,6 +1242,7 @@ async fn refresh_utxos(
     account_selection: TransparentAccountSelection<'_>,
     priority_account_target: Option<&ActiveSyncAccountTarget>,
     received_outputs_seen: &mut bool,
+    progress: Option<&(dyn Fn(u64, u64) + Sync)>,
     should_exit: &impl Fn() -> bool,
 ) -> Result<TransparentRefreshSummary, SyncError> {
     let mut refreshes = Vec::new();
@@ -1335,11 +1363,17 @@ async fn refresh_utxos(
         }
     }
 
+    let total_refreshes = refreshes.len() as u64;
+    if let Some(progress) = progress {
+        progress(0, total_refreshes);
+    }
+    let mut completed_refreshes = 0u64;
     let download_client = client.clone();
     let outcome = process_bounded_transparent_refreshes(
         refreshes,
         move |refresh| download_transparent_outputs(download_client.clone(), refresh, should_exit),
         |downloaded| {
+            let downloaded_count = downloaded.len() as u64;
             let received_outputs = downloaded.iter().any(|batch| !batch.outputs.is_empty());
             store_then_mark_transparent_refreshes(
                 downloaded,
@@ -1354,6 +1388,10 @@ async fn refresh_utxos(
                 },
             )?;
             *received_outputs_seen |= received_outputs;
+            completed_refreshes = completed_refreshes.saturating_add(downloaded_count);
+            if let Some(progress) = progress {
+                progress(completed_refreshes, total_refreshes);
+            }
             Ok(())
         },
         |pending| prioritize_pending_transparent_refreshes(pending, priority_account_target),
@@ -2005,6 +2043,14 @@ async fn run_sync_impl(
 
     let should_exit =
         || cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode;
+    let active_utxo_progress = |completed, total| {
+        progress_fn(preparation_progress_event(
+            current_tip_height,
+            "active_utxo",
+            completed,
+            total,
+        ));
+    };
     let defer_inactive_transparent_refresh = if let Some(active_account_uuid) =
         active_account_uuid.as_deref()
     {
@@ -2023,6 +2069,7 @@ async fn run_sync_impl(
             TransparentAccountSelection::Only(active_account_uuid),
             None,
             &mut critical_received_outputs,
+            Some(&active_utxo_progress),
             &should_exit,
         )
         .await?;
@@ -2041,6 +2088,7 @@ async fn run_sync_impl(
                 TransparentAccountSelection::All,
                 None,
                 &mut critical_received_outputs,
+                Some(&active_utxo_progress),
                 &should_exit,
             )
             .await?;
@@ -2059,6 +2107,7 @@ async fn run_sync_impl(
             TransparentAccountSelection::All,
             None,
             &mut critical_received_outputs,
+            None,
             &should_exit,
         )
         .await?;
@@ -2071,6 +2120,15 @@ async fn run_sync_impl(
             elapsed(),
         );
         return Ok(());
+    }
+
+    if running_mode == 1 {
+        progress_fn(preparation_progress_event(
+            current_tip_height,
+            "chain_prepare",
+            0,
+            0,
+        ));
     }
 
     // 2.5. Resubmit eligible unmined wallet txs now that we know the
@@ -2401,6 +2459,8 @@ async fn run_sync_impl(
             is_syncing: true,
             is_complete: false,
             has_new_tx: false,
+            phase_completed_units: 0,
+            phase_total_units: 0,
             phase: "download".into(),
         });
         log::info!(
@@ -2960,6 +3020,8 @@ async fn run_sync_impl(
             is_syncing: true,
             is_complete: false,
             has_new_tx,
+            phase_completed_units: 0,
+            phase_total_units: 0,
             phase: "scan".into(),
         };
         last_progress_percentage = progress.percentage;
@@ -3038,6 +3100,8 @@ async fn run_sync_impl(
         is_syncing: false,
         is_complete: true,
         has_new_tx: false,
+        phase_completed_units: 0,
+        phase_total_units: 0,
         phase: String::new(),
     };
     progress_fn(final_progress);
@@ -3068,6 +3132,7 @@ async fn run_sync_impl(
                 TransparentAccountSelection::Except(active_account_uuid),
                 active_account_target,
                 &mut deferred_received_outputs,
+                None,
                 &should_exit,
             )
             .await;
@@ -3136,6 +3201,8 @@ async fn run_sync_impl(
                 is_syncing: false,
                 is_complete: true,
                 has_new_tx: true,
+                phase_completed_units: 0,
+                phase_total_units: 0,
                 phase: String::new(),
             });
         }

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 
+use futures::{stream, StreamExt, TryStreamExt};
 use nonempty::NonEmpty;
 use rusqlite::{params, OptionalExtension};
 use shardtree::error::{InsertionError, QueryError, ShardTreeError};
@@ -85,6 +86,7 @@ const BATCH_SIZE_FOREGROUND: u32 = 1000;
 const BATCH_SIZE_BACKGROUND: u32 = 300;
 const TRANSPARENT_UTXO_RECENT_EXTERNAL_LIMIT: usize = 20;
 const TRANSPARENT_UTXO_SWEEP_EXTERNAL_LIMIT: usize = 20;
+const MAX_CONCURRENT_TRANSPARENT_UTXO_STREAMS: usize = 4;
 
 /// Sandblasting attack range (Zcash mainnet). Blocks in this range
 /// contain a very large number of outputs from a sustained spam
@@ -1146,6 +1148,30 @@ fn transparent_address_for_query(
         .map_err(|e| format!("decode transparent address {address}: {e}"))
 }
 
+struct TransparentRefresh {
+    addresses: Vec<String>,
+    start_height: BlockHeight,
+    label: String,
+    account_uuid: String,
+    completion: Option<TransparentRefreshCompletion>,
+}
+
+struct TransparentRefreshCompletion {
+    child_indices: Vec<u32>,
+    next_sweep_offset: Option<usize>,
+}
+
+struct DownloadedTransparentRefresh {
+    refresh: TransparentRefresh,
+    outputs: Vec<WalletTransparentOutput<AccountUuid>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TransparentRefreshOutcome {
+    Completed,
+    Cancelled,
+}
+
 async fn refresh_utxos(
     client: &mut CompactTxStreamerClient<Channel>,
     db_data_path: &str,
@@ -1154,6 +1180,7 @@ async fn refresh_utxos(
     tip_height: BlockHeight,
     should_exit: &impl Fn() -> bool,
 ) -> Result<(), SyncError> {
+    let mut refreshes = Vec::new();
     for account_id in db
         .get_account_ids()
         .map_err(|e| SyncError::db(format!("get_account_ids: {e}")))?
@@ -1230,33 +1257,16 @@ async fn refresh_utxos(
             } else {
                 "transparent external UTXOs recent batch".to_string()
             };
-            refresh_transparent_addresses(
-                client,
-                db,
-                batch.addresses,
+            refreshes.push(TransparentRefresh {
+                addresses: batch.addresses,
                 start_height,
-                &label,
-                || mark_transparent_receive_cache_dirty(db_data_path, &account_uuid),
-                should_exit,
-            )
-            .await?;
-            if should_exit() {
-                return Ok(());
-            }
-            if let Err(e) = transparent_receive_cache::mark_utxo_refresh_batch_complete(
-                db_data_path,
-                network,
-                &account_uuid,
-                &batch.child_indices,
-                u64::from(u32::from(tip_height)) + 1,
-                batch.next_sweep_offset,
-            ) {
-                log::warn!(
-                    "transparent receive cache: failed to mark UTXO batch complete for account {}: {}",
-                    account_uuid,
-                    e
-                );
-            }
+                label,
+                account_uuid: account_uuid.clone(),
+                completion: Some(TransparentRefreshCompletion {
+                    child_indices: batch.child_indices,
+                    next_sweep_offset: batch.next_sweep_offset,
+                }),
+            });
         }
 
         let external_selected = external_addresses
@@ -1273,20 +1283,73 @@ async fn refresh_utxos(
             .collect();
 
         if !non_external_addresses.is_empty() {
-            refresh_transparent_addresses(
-                client,
-                db,
-                non_external_addresses,
-                safety_start_height,
-                "transparent non-external UTXOs",
-                || mark_transparent_receive_cache_dirty(db_data_path, &account_uuid),
-                should_exit,
-            )
-            .await?;
+            refreshes.push(TransparentRefresh {
+                addresses: non_external_addresses,
+                start_height: safety_start_height,
+                label: "transparent non-external UTXOs".to_string(),
+                account_uuid,
+                completion: None,
+            });
         }
     }
 
+    let download_client = client.clone();
+    let outcome = process_bounded_transparent_refreshes(
+        refreshes,
+        move |refresh| download_transparent_outputs(download_client.clone(), refresh, should_exit),
+        |downloaded| {
+            store_then_mark_transparent_refreshes(
+                downloaded,
+                |downloaded| store_transparent_outputs(db, downloaded),
+                |downloaded| {
+                    update_transparent_refresh_cache_metadata(
+                        db_data_path,
+                        network,
+                        tip_height,
+                        downloaded,
+                    )
+                },
+            )
+        },
+        should_exit,
+    )
+    .await?;
+    if outcome == TransparentRefreshOutcome::Cancelled {
+        log::info!(
+            "[{}] sync: exiting before transparent UTXO database update",
+            elapsed(),
+        );
+    }
+
     Ok(())
+}
+
+fn update_transparent_refresh_cache_metadata(
+    db_data_path: &str,
+    network: WalletNetwork,
+    tip_height: BlockHeight,
+    downloaded: &DownloadedTransparentRefresh,
+) {
+    if !downloaded.outputs.is_empty() {
+        mark_transparent_receive_cache_dirty(db_data_path, &downloaded.refresh.account_uuid);
+    }
+    if let Some(completion) = downloaded.refresh.completion.as_ref() {
+        if let Err(e) = transparent_receive_cache::mark_utxo_refresh_batch_complete(
+            db_data_path,
+            network,
+            &downloaded.refresh.account_uuid,
+            &completion.child_indices,
+            u64::from(u32::from(tip_height)) + 1,
+            completion.next_sweep_offset,
+        ) {
+            log::warn!(
+                "transparent receive cache: failed to mark UTXO batch complete for \
+                 account {}: {}",
+                downloaded.refresh.account_uuid,
+                e,
+            );
+        }
+    }
 }
 
 fn mark_transparent_receive_cache_dirty(db_data_path: &str, account_uuid: &str) {
@@ -1319,41 +1382,145 @@ fn block_height_from_u64(height: u64, label: &str) -> Result<BlockHeight, SyncEr
     Ok(BlockHeight::from_u32(height))
 }
 
-async fn refresh_transparent_addresses(
-    client: &mut CompactTxStreamerClient<Channel>,
+async fn process_bounded_transparent_refreshes<R, D, E, Download, DownloadFuture, Persist, Exit>(
+    refreshes: Vec<R>,
+    download: Download,
+    mut persist: Persist,
+    should_exit: &Exit,
+) -> Result<TransparentRefreshOutcome, E>
+where
+    Download: Fn(R) -> DownloadFuture,
+    DownloadFuture: Future<Output = Result<Option<D>, E>>,
+    Persist: FnMut(Vec<D>) -> Result<(), E>,
+    Exit: Fn() -> bool,
+{
+    let mut refreshes = refreshes.into_iter();
+    loop {
+        if should_exit() {
+            return Ok(TransparentRefreshOutcome::Cancelled);
+        }
+
+        let group = refreshes
+            .by_ref()
+            .take(MAX_CONCURRENT_TRANSPARENT_UTXO_STREAMS)
+            .collect::<Vec<_>>();
+        if group.is_empty() {
+            return Ok(TransparentRefreshOutcome::Completed);
+        }
+
+        let downloaded_result = download_transparent_refresh_group(group, &download).await;
+        // Cancellation and mode handoff win if they race a network error.
+        // No database or cache mutation is allowed after either signal.
+        if should_exit() {
+            return Ok(TransparentRefreshOutcome::Cancelled);
+        }
+        let downloaded = downloaded_result?;
+        let Some(downloaded) = downloaded.into_iter().collect::<Option<Vec<_>>>() else {
+            return Ok(TransparentRefreshOutcome::Cancelled);
+        };
+
+        persist(downloaded)?;
+    }
+}
+
+async fn download_transparent_refresh_group<R, D, E, Download, DownloadFuture>(
+    refreshes: Vec<R>,
+    download: &Download,
+) -> Result<Vec<Option<D>>, E>
+where
+    Download: Fn(R) -> DownloadFuture,
+    DownloadFuture: Future<Output = Result<Option<D>, E>>,
+{
+    let mut downloaded = stream::iter(refreshes.into_iter().enumerate())
+        .map(|(position, refresh)| {
+            let future = download(refresh);
+            async move { future.await.map(|downloaded| (position, downloaded)) }
+        })
+        .buffer_unordered(MAX_CONCURRENT_TRANSPARENT_UTXO_STREAMS)
+        .try_collect::<Vec<_>>()
+        .await?;
+    downloaded.sort_unstable_by_key(|(position, _)| *position);
+    Ok(downloaded
+        .into_iter()
+        .map(|(_, downloaded)| downloaded)
+        .collect())
+}
+
+fn store_then_mark_transparent_refreshes<T, E>(
+    downloaded: Vec<T>,
+    store: impl FnOnce(&[T]) -> Result<(), E>,
+    mut mark_cache_metadata: impl FnMut(&T),
+) -> Result<(), E> {
+    store(&downloaded)?;
+    for item in &downloaded {
+        mark_cache_metadata(item);
+    }
+    Ok(())
+}
+
+fn store_transparent_outputs(
     db: &mut WalletDatabase,
-    addresses: Vec<String>,
-    start_height: BlockHeight,
-    label: &str,
-    mut mark_cache_dirty: impl FnMut(),
+    downloaded: &[DownloadedTransparentRefresh],
+) -> Result<(), SyncError> {
+    if downloaded.iter().all(|batch| batch.outputs.is_empty()) {
+        return Ok(());
+    }
+
+    with_wallet_db_write_lock("sync_engine.put_received_transparent_utxos", || {
+        db.transactionally(|tx_db| -> Result<(), SqliteClientError> {
+            for batch in downloaded {
+                for output in &batch.outputs {
+                    tx_db.put_received_transparent_utxo(output)?;
+                }
+            }
+            Ok(())
+        })
+        .map_err(|e| SyncError::db(format!("put_received_transparent_utxos: {e}")))
+    })
+}
+
+async fn download_transparent_outputs(
+    mut client: CompactTxStreamerClient<Channel>,
+    mut refresh: TransparentRefresh,
     should_exit: &impl Fn() -> bool,
-) -> Result<bool, SyncError> {
-    if addresses.is_empty() || should_exit() {
-        return Ok(false);
+) -> Result<Option<DownloadedTransparentRefresh>, SyncError> {
+    if should_exit() {
+        return Ok(None);
+    }
+    if refresh.addresses.is_empty() {
+        return Ok(Some(DownloadedTransparentRefresh {
+            refresh,
+            outputs: Vec::new(),
+        }));
     }
 
     log::info!(
         "[{}] sync: refreshing {} from height {} ({} addresses)",
         elapsed(),
-        label,
-        u32::from(start_height),
-        addresses.len(),
+        refresh.label,
+        u32::from(refresh.start_height),
+        refresh.addresses.len(),
     );
 
+    let addresses = std::mem::take(&mut refresh.addresses);
     let mut stream = tokio::select! {
         biased;
         _ = watch_for_exit(should_exit) => {
             log::info!(
                 "[{}] sync: exiting during {} transparent UTXO stream start",
                 elapsed(),
-                label,
+                refresh.label,
             );
-            return Ok(false);
+            return Ok(None);
         }
-        result = get_address_utxos_stream(client, addresses, start_height) => result?,
+        result = get_address_utxos_stream(
+            &mut client,
+            addresses,
+            refresh.start_height,
+        ) => result?,
     };
 
-    let mut received_any = false;
+    let mut outputs = Vec::new();
     loop {
         let reply = tokio::select! {
             biased;
@@ -1361,9 +1528,9 @@ async fn refresh_transparent_addresses(
                 log::info!(
                     "[{}] sync: exiting during {} transparent UTXO refresh",
                     elapsed(),
-                    label,
+                    refresh.label,
                 );
-                return Ok(received_any);
+                return Ok(None);
             }
             result = next_stream_message(&mut stream, "get_address_utxos_stream") => result?,
         };
@@ -1387,29 +1554,22 @@ async fn refresh_transparent_addresses(
             ))
         })?;
 
-        let output = WalletTransparentOutput::from_parts(
-            OutPoint::new(txid, index),
-            TxOut::new(value, Script(script::Code(reply.script))),
-            Some(BlockHeight::from_u32(height)),
-            None,
-            None,
-            None,
-        )
-        .ok_or_else(|| {
-            SyncError::parse("transparent UTXO script did not decode to a wallet address")
-        })?;
-
-        with_wallet_db_write_lock("sync_engine.put_received_transparent_utxo", || {
-            db.put_received_transparent_utxo(&output)
-                .map_err(|e| SyncError::db(format!("put_received_transparent_utxo: {e}")))
-        })?;
-        if !received_any {
-            mark_cache_dirty();
-        }
-        received_any = true;
+        outputs.push(
+            WalletTransparentOutput::from_parts(
+                OutPoint::new(txid, index),
+                TxOut::new(value, Script(script::Code(reply.script))),
+                Some(BlockHeight::from_u32(height)),
+                None,
+                None,
+                None,
+            )
+            .ok_or_else(|| {
+                SyncError::parse("transparent UTXO script did not decode to a wallet address")
+            })?,
+        );
     }
 
-    Ok(received_any)
+    Ok(Some(DownloadedTransparentRefresh { refresh, outputs }))
 }
 
 async fn watch_for_exit(should_exit: &impl Fn() -> bool) {
@@ -2866,7 +3026,9 @@ fn should_use_empty_chain_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::{Cell, RefCell};
     use std::sync::atomic::AtomicUsize;
+    use std::sync::Mutex;
     use std::time::Duration;
     use tokio::sync::{Barrier, Notify};
     use zcash_client_backend::proto::compact_formats::CompactBlock;
@@ -2905,6 +3067,204 @@ mod tests {
         })
         .await
         .expect("prefetch task was not dropped");
+    }
+
+    #[tokio::test]
+    async fn transparent_refreshes_limit_concurrency_to_four() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let commit_count = Arc::new(AtomicUsize::new(0));
+
+        let download_active = active.clone();
+        let download_peak = peak.clone();
+        let persist_count = commit_count.clone();
+        let outcome = process_bounded_transparent_refreshes(
+            (0..12).collect(),
+            move |refresh| {
+                let active = download_active.clone();
+                let peak = download_peak.clone();
+                async move {
+                    let concurrent = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(concurrent, Ordering::SeqCst);
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    Ok::<_, &'static str>(Some(refresh))
+                }
+            },
+            move |group| {
+                assert!(group.len() <= MAX_CONCURRENT_TRANSPARENT_UTXO_STREAMS);
+                persist_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            &|| false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, TransparentRefreshOutcome::Completed);
+        assert_eq!(peak.load(Ordering::SeqCst), 4);
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+        assert_eq!(commit_count.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn transparent_refresh_downloads_actually_overlap() {
+        let barrier = Arc::new(tokio::sync::Barrier::new(4));
+        let started = Arc::new(AtomicUsize::new(0));
+
+        let download_barrier = barrier.clone();
+        let download_started = started.clone();
+        let refresh = process_bounded_transparent_refreshes(
+            (0..4).collect(),
+            move |refresh| {
+                let barrier = download_barrier.clone();
+                let started = download_started.clone();
+                async move {
+                    started.fetch_add(1, Ordering::SeqCst);
+                    barrier.wait().await;
+                    Ok::<_, &'static str>(Some(refresh))
+                }
+            },
+            |_| Ok(()),
+            &|| false,
+        );
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(1), refresh)
+            .await
+            .expect("four downloads did not overlap")
+            .unwrap();
+
+        assert_eq!(outcome, TransparentRefreshOutcome::Completed);
+        assert_eq!(started.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn transparent_refresh_cancellation_wins_over_racing_error() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let commits = Arc::new(AtomicUsize::new(0));
+        let download_cancelled = cancelled.clone();
+        let persist_commits = commits.clone();
+        let exit_cancelled = cancelled.clone();
+        let should_exit = move || exit_cancelled.load(Ordering::SeqCst);
+
+        let outcome = process_bounded_transparent_refreshes(
+            vec![0],
+            move |_| {
+                let cancelled = download_cancelled.clone();
+                async move {
+                    cancelled.store(true, Ordering::SeqCst);
+                    Err::<Option<usize>, _>("network error")
+                }
+            },
+            move |_| {
+                persist_commits.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            &should_exit,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, TransparentRefreshOutcome::Cancelled);
+        assert_eq!(commits.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn failed_transparent_stream_prevents_group_commit() {
+        let commits = Arc::new(AtomicUsize::new(0));
+        let persist_commits = commits.clone();
+        let result = process_bounded_transparent_refreshes(
+            (0..4).collect(),
+            |refresh| async move {
+                if refresh == 2 {
+                    Err("stream failed")
+                } else {
+                    tokio::task::yield_now().await;
+                    Ok(Some(refresh))
+                }
+            },
+            move |_| {
+                persist_commits.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            &|| false,
+        )
+        .await;
+
+        assert_eq!(result, Err("stream failed"));
+        assert_eq!(commits.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn cancelled_transparent_stream_prevents_group_commit() {
+        let commits = Arc::new(AtomicUsize::new(0));
+        let persist_commits = commits.clone();
+        let outcome = process_bounded_transparent_refreshes(
+            (0..4).collect(),
+            |refresh| async move { Ok::<_, &'static str>((refresh != 2).then_some(refresh)) },
+            move |_| {
+                persist_commits.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            &|| false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, TransparentRefreshOutcome::Cancelled);
+        assert_eq!(commits.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn transparent_refresh_groups_restore_request_order_before_commit() {
+        let commits = Arc::new(Mutex::new(Vec::new()));
+        let persist_commits = commits.clone();
+        let outcome = process_bounded_transparent_refreshes(
+            (0..6).collect(),
+            |refresh| async move {
+                let delay = 5 * (4 - (refresh % 4));
+                tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                Ok::<_, &'static str>(Some(refresh))
+            },
+            move |group| {
+                persist_commits.lock().unwrap().push(group);
+                Ok(())
+            },
+            &|| false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, TransparentRefreshOutcome::Completed);
+        assert_eq!(*commits.lock().unwrap(), vec![vec![0, 1, 2, 3], vec![4, 5]]);
+    }
+
+    #[test]
+    fn transparent_cache_metadata_is_marked_only_after_commit() {
+        let events = RefCell::new(Vec::new());
+        store_then_mark_transparent_refreshes(
+            vec![1, 2],
+            |_| {
+                events.borrow_mut().push("commit".to_string());
+                Ok::<_, &'static str>(())
+            },
+            |refresh| events.borrow_mut().push(format!("mark {refresh}")),
+        )
+        .unwrap();
+
+        assert_eq!(events.into_inner(), ["commit", "mark 1", "mark 2"]);
+    }
+
+    #[test]
+    fn failed_transparent_commit_does_not_advance_cache_metadata() {
+        let marked = Cell::new(0);
+        let result = store_then_mark_transparent_refreshes(
+            vec![1, 2],
+            |_| Err("commit failed"),
+            |_| marked.set(marked.get() + 1),
+        );
+
+        assert_eq!(result, Err("commit failed"));
+        assert_eq!(marked.get(), 0);
     }
 
     fn assert_pct(actual: f64, expected: f64) {

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -1,7 +1,7 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashSet, VecDeque};
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use futures::{stream, StreamExt, TryStreamExt};
 use nonempty::NonEmpty;
@@ -88,6 +88,17 @@ const TRANSPARENT_UTXO_RECENT_EXTERNAL_LIMIT: usize = 20;
 const TRANSPARENT_UTXO_SWEEP_EXTERNAL_LIMIT: usize = 20;
 const MAX_CONCURRENT_TRANSPARENT_UTXO_STREAMS: usize = 4;
 const MAX_DEFERRED_TRANSPARENT_REFRESH_ATTEMPTS: u32 = 3;
+
+pub(crate) type ActiveSyncAccountTarget = Arc<RwLock<Option<String>>>;
+
+fn current_active_sync_account(target: Option<&ActiveSyncAccountTarget>) -> Option<String> {
+    target.map(|target| {
+        target
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    })?
+}
 
 /// Sandblasting attack range (Zcash mainnet). Blocks in this range
 /// contain a very large number of outputs from a sustained spam
@@ -1202,6 +1213,7 @@ async fn refresh_utxos(
     network: WalletNetwork,
     tip_height: BlockHeight,
     account_selection: TransparentAccountSelection<'_>,
+    priority_account_target: Option<&ActiveSyncAccountTarget>,
     received_outputs_seen: &mut bool,
     should_exit: &impl Fn() -> bool,
 ) -> Result<TransparentRefreshSummary, SyncError> {
@@ -1344,6 +1356,7 @@ async fn refresh_utxos(
             *received_outputs_seen |= received_outputs;
             Ok(())
         },
+        |pending| prioritize_pending_transparent_refreshes(pending, priority_account_target),
         should_exit,
     )
     .await?;
@@ -1355,6 +1368,35 @@ async fn refresh_utxos(
     }
 
     Ok(summary)
+}
+
+fn prioritize_pending_transparent_refreshes(
+    pending: &mut VecDeque<TransparentRefresh>,
+    priority_account_target: Option<&ActiveSyncAccountTarget>,
+) {
+    let Some(active_account_uuid) = current_active_sync_account(priority_account_target) else {
+        return;
+    };
+    let Some(previous_position) = pending
+        .iter()
+        .position(|refresh| refresh.account_uuid == active_account_uuid)
+    else {
+        return;
+    };
+    // Stable sorting keeps every other account in its existing order. This is
+    // evaluated only between bounded groups, so requests already in flight are
+    // allowed to finish and commit normally.
+    pending
+        .make_contiguous()
+        .sort_by_key(|refresh| refresh.account_uuid != active_account_uuid);
+    if previous_position > 0 {
+        log::info!(
+            "[{}] sync: moved active account {} ahead of {} pending transparent refresh(es)",
+            elapsed(),
+            active_account_uuid,
+            previous_position,
+        );
+    }
 }
 
 fn update_transparent_refresh_cache_metadata(
@@ -1419,6 +1461,7 @@ async fn process_bounded_transparent_refreshes<R, D, E, Download, DownloadFuture
     refreshes: Vec<R>,
     download: Download,
     mut persist: Persist,
+    mut prioritize_pending: impl FnMut(&mut VecDeque<R>),
     should_exit: &Exit,
 ) -> Result<TransparentRefreshOutcome, E>
 where
@@ -1427,15 +1470,15 @@ where
     Persist: FnMut(Vec<D>) -> Result<(), E>,
     Exit: Fn() -> bool,
 {
-    let mut refreshes = refreshes.into_iter();
+    let mut refreshes = VecDeque::from(refreshes);
     loop {
         if should_exit() {
             return Ok(TransparentRefreshOutcome::Cancelled);
         }
 
-        let group = refreshes
-            .by_ref()
-            .take(MAX_CONCURRENT_TRANSPARENT_UTXO_STREAMS)
+        prioritize_pending(&mut refreshes);
+        let group = (0..MAX_CONCURRENT_TRANSPARENT_UTXO_STREAMS)
+            .filter_map(|_| refreshes.pop_front())
             .collect::<Vec<_>>();
         if group.is_empty() {
             return Ok(TransparentRefreshOutcome::Completed);
@@ -1789,7 +1832,7 @@ pub async fn run_sync_inner(
     cancel: Arc<AtomicBool>,
     running_mode: u8,
     desired_mode: &AtomicU8,
-    active_account_uuid: Option<&str>,
+    active_account_target: Option<ActiveSyncAccountTarget>,
     allow_resubmit: bool,
     progress_fn: impl Fn(SyncProgressEvent) + Send + Sync,
 ) -> Result<(), String> {
@@ -1830,7 +1873,7 @@ pub async fn run_sync_inner(
             cancel.clone(),
             running_mode,
             desired_mode,
-            active_account_uuid,
+            active_account_target.as_ref(),
             allow_resubmit,
             &progress_fn,
         )
@@ -1888,10 +1931,11 @@ async fn run_sync_impl(
     cancel: Arc<AtomicBool>,
     running_mode: u8,
     desired_mode: &AtomicU8,
-    active_account_uuid: Option<&str>,
+    active_account_target: Option<&ActiveSyncAccountTarget>,
     allow_resubmit: bool,
     progress_fn: &(impl Fn(SyncProgressEvent) + Send + Sync),
 ) -> Result<(), SyncError> {
+    let active_account_uuid = current_active_sync_account(active_account_target);
     let mut migration_anchor_retention_required =
         crate::wallet::sync::migration_anchor_retention_required(db_data_path, network)
             .map_err(SyncError::db)?;
@@ -1961,7 +2005,8 @@ async fn run_sync_impl(
 
     let should_exit =
         || cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode;
-    let defer_inactive_transparent_refresh = if let Some(active_account_uuid) = active_account_uuid
+    let defer_inactive_transparent_refresh = if let Some(active_account_uuid) =
+        active_account_uuid.as_deref()
     {
         log::info!(
             "[{}] sync: refreshing active-account transparent UTXOs before chain scan ({})",
@@ -1976,6 +2021,7 @@ async fn run_sync_impl(
             network,
             tip_height,
             TransparentAccountSelection::Only(active_account_uuid),
+            None,
             &mut critical_received_outputs,
             &should_exit,
         )
@@ -1993,6 +2039,7 @@ async fn run_sync_impl(
                 network,
                 tip_height,
                 TransparentAccountSelection::All,
+                None,
                 &mut critical_received_outputs,
                 &should_exit,
             )
@@ -2010,6 +2057,7 @@ async fn run_sync_impl(
             network,
             tip_height,
             TransparentAccountSelection::All,
+            None,
             &mut critical_received_outputs,
             &should_exit,
         )
@@ -3001,7 +3049,9 @@ async fn run_sync_impl(
     // stream stays open until this bounded follow-up finishes, so lock/reset
     // cancellation and the global running guard still own its lifetime.
     if defer_inactive_transparent_refresh && !should_exit() {
-        let active_account_uuid = active_account_uuid.expect("deferred refresh has active account");
+        let active_account_uuid = active_account_uuid
+            .as_deref()
+            .expect("deferred refresh has active account");
         log::info!(
             "[{}] sync: starting deferred inactive-account transparent UTXO refresh",
             elapsed(),
@@ -3016,6 +3066,7 @@ async fn run_sync_impl(
                 network,
                 BlockHeight::from_u32(final_tip_height as u32),
                 TransparentAccountSelection::Except(active_account_uuid),
+                active_account_target,
                 &mut deferred_received_outputs,
                 &should_exit,
             )
@@ -3209,7 +3260,7 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::sync::Mutex;
     use std::time::Duration;
-    use tokio::sync::{Barrier, Notify};
+    use tokio::sync::{Barrier, Notify, Semaphore};
     use zcash_client_backend::proto::compact_formats::CompactBlock;
 
     struct DropSignal {
@@ -3275,6 +3326,7 @@ mod tests {
                 persist_count.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             },
+            |_| {},
             &|| false,
         )
         .await
@@ -3305,6 +3357,7 @@ mod tests {
                 }
             },
             |_| Ok(()),
+            |_| {},
             &|| false,
         );
         let outcome = tokio::time::timeout(std::time::Duration::from_secs(1), refresh)
@@ -3338,6 +3391,7 @@ mod tests {
                 persist_commits.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             },
+            |_| {},
             &should_exit,
         )
         .await
@@ -3365,6 +3419,7 @@ mod tests {
                 persist_commits.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             },
+            |_| {},
             &|| false,
         )
         .await;
@@ -3384,6 +3439,7 @@ mod tests {
                 persist_commits.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             },
+            |_| {},
             &|| false,
         )
         .await
@@ -3408,6 +3464,7 @@ mod tests {
                 persist_commits.lock().unwrap().push(group);
                 Ok(())
             },
+            |_| {},
             &|| false,
         )
         .await
@@ -3415,6 +3472,88 @@ mod tests {
 
         assert_eq!(outcome, TransparentRefreshOutcome::Completed);
         assert_eq!(*commits.lock().unwrap(), vec![vec![0, 1, 2, 3], vec![4, 5]]);
+    }
+
+    #[tokio::test]
+    async fn transparent_refresh_reprioritizes_only_pending_groups() {
+        let priority = Arc::new(AtomicUsize::new(usize::MAX));
+        let commits = Arc::new(Mutex::new(Vec::new()));
+        let first_group_started = Arc::new(Barrier::new(5));
+        let release_first_group = Arc::new(Semaphore::new(0));
+
+        let run_priority = priority.clone();
+        let run_commits = commits.clone();
+        let run_started = first_group_started.clone();
+        let run_release = release_first_group.clone();
+        let run = tokio::spawn(async move {
+            process_bounded_transparent_refreshes(
+                (0..6).collect(),
+                move |refresh| {
+                    let started = run_started.clone();
+                    let release = run_release.clone();
+                    async move {
+                        if refresh < 4 {
+                            started.wait().await;
+                            release.acquire().await.unwrap().forget();
+                        }
+                        Ok::<_, &'static str>(Some(refresh))
+                    }
+                },
+                move |group| {
+                    run_commits.lock().unwrap().push(group);
+                    Ok(())
+                },
+                move |pending| {
+                    let priority = run_priority.load(Ordering::SeqCst);
+                    pending
+                        .make_contiguous()
+                        .sort_by_key(|refresh| *refresh != priority);
+                },
+                &|| false,
+            )
+            .await
+        });
+
+        first_group_started.wait().await;
+        priority.store(5, Ordering::SeqCst);
+        release_first_group.add_permits(4);
+        let outcome = run.await.unwrap().unwrap();
+
+        assert_eq!(outcome, TransparentRefreshOutcome::Completed);
+        assert_eq!(*commits.lock().unwrap(), vec![vec![0, 1, 2, 3], vec![5, 4]]);
+    }
+
+    #[test]
+    fn transparent_refresh_priority_moves_every_active_batch_stably() {
+        let refresh = |account_uuid: &str, label: &str| TransparentRefresh {
+            addresses: Vec::new(),
+            start_height: block_height(1),
+            label: label.to_string(),
+            account_uuid: account_uuid.to_string(),
+            completion: None,
+        };
+        let mut pending = VecDeque::from(vec![
+            refresh("active", "active recent"),
+            refresh("other", "other recent"),
+            refresh("active", "active sweep"),
+            refresh("other", "other sweep"),
+        ]);
+        let target = Arc::new(RwLock::new(Some("active".to_string())));
+
+        prioritize_pending_transparent_refreshes(&mut pending, Some(&target));
+
+        assert_eq!(
+            pending
+                .iter()
+                .map(|refresh| refresh.label.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "active recent",
+                "active sweep",
+                "other recent",
+                "other sweep",
+            ],
+        );
     }
 
     #[test]

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -5321,6 +5321,7 @@ class _RustApiFake implements RustLibApi {
     required String lightwalletdUrl,
     required String network,
     required int mode,
+    String? activeAccountUuid,
   }) {
     return const Stream.empty();
   }

--- a/test/providers/sync_display_progress_provider_test.dart
+++ b/test/providers/sync_display_progress_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/providers/sync_display_progress_provider.dart';
@@ -6,6 +8,209 @@ import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import '../fakes/fake_sync_notifier.dart';
 
 void main() {
+  test(
+    'time-interpolates preparation without reaching its phase cap',
+    () async {
+      final initial = SyncState(
+        isSyncing: true,
+        phase: kSyncPhasePreflight,
+        lastSyncStartedAt: DateTime.utc(2026, 8, 18),
+      );
+      final container = ProviderContainer(
+        overrides: [syncProvider.overrideWith(() => FakeSyncNotifier(initial))],
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        syncDisplayPercentageProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+
+      final progress = container.read(syncDisplayPercentageProvider);
+      expect(progress, greaterThan(0.005));
+      expect(progress, lessThan(0.01));
+    },
+  );
+
+  test(
+    'uses elapsed time when preparation timer delivery is delayed',
+    () async {
+      final initial = SyncState(
+        isSyncing: true,
+        phase: kSyncPhasePreflight,
+        lastSyncStartedAt: DateTime.utc(2026, 8, 18),
+      );
+      final container = ProviderContainer(
+        overrides: [syncProvider.overrideWith(() => FakeSyncNotifier(initial))],
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        syncDisplayPercentageProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+      await Future<void>.delayed(Duration.zero);
+
+      // Simulate a busy/throttled UI isolate. Only one periodic callback should
+      // be needed afterward because progress is based on real elapsed time.
+      sleep(const Duration(milliseconds: 500));
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(container.read(syncDisplayPercentageProvider), greaterThan(0.005));
+    },
+  );
+
+  test('uses committed UTXO work units inside the preparation range', () async {
+    final startedAt = DateTime.utc(2026, 8, 18);
+    final initial = SyncState(
+      isSyncing: true,
+      phase: kSyncPhaseActiveUtxo,
+      phaseTotalUnits: 4,
+      lastSyncStartedAt: startedAt,
+    );
+    late FakeSyncNotifier syncNotifier;
+    final container = ProviderContainer(
+      overrides: [
+        syncProvider.overrideWith(
+          () => syncNotifier = FakeSyncNotifier(initial),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      syncDisplayPercentageProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+    await container.read(syncProvider.future);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(syncDisplayPercentageProvider), closeTo(0.02, 0.001));
+    syncNotifier.emit(initial.copyWith(phaseCompletedUnits: 2));
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(syncDisplayPercentageProvider), closeTo(0.03, 0.001));
+
+    syncNotifier.emit(initial.copyWith(phaseCompletedUnits: 4));
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(syncDisplayPercentageProvider), closeTo(0.04, 0.001));
+  });
+
+  test(
+    'maps authoritative block progress into the 5-99 percent range',
+    () async {
+      final initial = SyncState(
+        isSyncing: true,
+        phase: 'scan',
+        percentage: 0.5,
+        displayTargetPercentage: 0.5,
+        lastSyncStartedAt: DateTime.utc(2026, 8, 18),
+      );
+      final container = ProviderContainer(
+        overrides: [syncProvider.overrideWith(() => FakeSyncNotifier(initial))],
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        syncDisplayPercentageProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.read(syncDisplayPercentageProvider),
+        closeTo(0.52, 0.001),
+      );
+    },
+  );
+
+  test('does not regress when a Rust retry returns to preparation', () async {
+    final startedAt = DateTime.utc(2026, 8, 18);
+    final initial = SyncState(
+      isSyncing: true,
+      phase: 'scan',
+      percentage: 0.5,
+      displayTargetPercentage: 0.5,
+      lastSyncStartedAt: startedAt,
+    );
+    late FakeSyncNotifier syncNotifier;
+    final container = ProviderContainer(
+      overrides: [
+        syncProvider.overrideWith(
+          () => syncNotifier = FakeSyncNotifier(initial),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      syncDisplayPercentageProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+    await container.read(syncProvider.future);
+    await Future<void>.delayed(Duration.zero);
+    final beforeRetry = container.read(syncDisplayPercentageProvider);
+
+    syncNotifier.emit(
+      initial.copyWith(
+        phase: kSyncPhaseActiveUtxo,
+        percentage: 0,
+        displayTargetPercentage: 0,
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+
+    expect(container.read(syncDisplayPercentageProvider), beforeRetry);
+  });
+
+  test('resets estimated progress when a new sync session starts', () async {
+    final firstStartedAt = DateTime.utc(2026, 8, 18);
+    final initial = SyncState(
+      isSyncing: true,
+      phase: 'scan',
+      percentage: 0.5,
+      displayTargetPercentage: 0.5,
+      lastSyncStartedAt: firstStartedAt,
+    );
+    late FakeSyncNotifier syncNotifier;
+    final container = ProviderContainer(
+      overrides: [
+        syncProvider.overrideWith(
+          () => syncNotifier = FakeSyncNotifier(initial),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      syncDisplayPercentageProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+    await container.read(syncProvider.future);
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(syncDisplayPercentageProvider), closeTo(0.52, 0.001));
+
+    syncNotifier.emit(
+      SyncState(
+        isSyncing: true,
+        phase: kSyncPhasePreflight,
+        lastSyncStartedAt: firstStartedAt.add(const Duration(minutes: 1)),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(syncDisplayPercentageProvider), 0);
+  });
+
   test('interpolates without republishing SyncState', () async {
     final initial = SyncState(
       isSyncing: true,

--- a/test/providers/sync_provider_test.dart
+++ b/test/providers/sync_provider_test.dart
@@ -222,6 +222,62 @@ void main() {
     expect(container.read(syncProvider).requireValue.percentage, 0.1);
   });
 
+  test(
+    'preparation progress preserves authoritative scan state on retry',
+    () async {
+      late _LifecycleTestSyncNotifier notifier;
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+          accountProvider.overrideWith(_ExistingAccountNotifier.new),
+          syncProvider.overrideWith(
+            () =>
+                notifier = _LifecycleTestSyncNotifier(() async => 'wallet.db'),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.listen(syncProvider, (_, _) {});
+      await container.read(syncProvider.future);
+      notifier.replaceState(
+        SyncState(
+          accountUuid: _accountUuid,
+          isSyncing: true,
+          percentage: 0.5,
+          displayTargetPercentage: 0.6,
+          displayTargetBlocks: 100,
+          scannedHeight: 50,
+          chainTipHeight: 100,
+        ),
+      );
+
+      await notifier.handleSyncProgressForTesting(
+        const SyncProgressEvent(
+          scannedHeight: 0,
+          chainTipHeight: 120,
+          percentage: 0,
+          displayTargetPercentage: 0,
+          displayTargetBlocks: 0,
+          isSyncing: true,
+          isComplete: false,
+          hasNewTx: false,
+          phaseCompletedUnits: 2,
+          phaseTotalUnits: 4,
+          phase: kSyncPhaseActiveUtxo,
+        ),
+      );
+
+      final current = container.read(syncProvider).requireValue;
+      expect(current.percentage, 0.5);
+      expect(current.displayTargetPercentage, 0.6);
+      expect(current.displayTargetBlocks, 100);
+      expect(current.scannedHeight, 50);
+      expect(current.chainTipHeight, 120);
+      expect(current.phaseCompletedUnits, 2);
+      expect(current.phaseTotalUnits, 4);
+    },
+  );
+
   test('in-flight progress cannot replace a newer sync failure', () async {
     final resolverStarted = Completer<void>();
     final dbPath = Completer<String>();


### PR DESCRIPTION
## What changed

- Parallelize transparent UTXO refresh downloads in bounded groups of four while preserving deterministic persistence order and transactional group commits.
- Keep the active account's transparent refresh on the sync-critical path and defer inactive-account refreshes until after the completed-sync event.
- Reprioritize only pending deferred refresh groups when the user switches accounts, without restarting sync or cancelling in-flight network requests.
- Add measurable preparation work to Rust progress events and a UI-only hybrid progress estimator for the existing percentage display.
- Map preparation into 0–5% and authoritative block scanning into 5–99%; only Rust completion produces 100%.

## Why

Transparent receiver discovery was serialized across accounts and could hold the sidebar at 0% before compact-block scanning began. Multi-account wallets paid the full sum of network round trips even though only the active account's result was immediately relevant to the visible balance and activity.

This change overlaps independent transparent queries, completes the active account first, moves inactive work behind the completion boundary, and makes the existing percentage display advance during otherwise unreported preparation without changing sidebar copy or layout.

## Behavior and correctness

- No sync restart or in-flight request cancellation occurs when the active account changes.
- A newly active account is moved ahead only among deferred groups that have not started; the current group completes normally.
- The completed-sync event remains gated by active-account transparent refresh, compact-block scan, enhancement, and final reconciliation.
- Deferred inactive refreshes run after 100% and update the wallet DB/cache when they complete.
- Network errors and cancellation discard an uncommitted concurrent group; metadata advances only after successful persistence.
- Display interpolation is monotonic within a sync session and never emits 100% without an authoritative completion event.

## Tradeoffs

- Up to four lightwalletd streams are active at once and up to one group of results is buffered before persistence.
- Inactive transparent balances may become current shortly after the sidebar reaches 100%; switching accounts reprioritizes pending work but does not interrupt already-running requests.
- The early percentage is deliberately an estimate bounded by real phase targets; it improves perceived progress but is not an ETA.

## Validation

- `cargo test --locked --offline wallet::sync_engine:: --lib` — 92 passed.
- `fvm flutter test test/providers/sync_display_progress_provider_test.dart test/providers/sync_provider_test.dart` — 23 passed.
- iOS Simulator debug build — passed.
- Mobile-focused test lane — 122 passed.
- Standalone migration screen tests — 159 passed.
- `git diff --check origin/main...HEAD` — passed.

Android validation was intentionally skipped after iOS and shared mobile/provider coverage passed because the Android build lane was taking disproportionately long.
