### PR TITLE
Skip empty transaction resubmission work

### DIFF
--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -108,6 +108,13 @@ pub(crate) use transactions::{
     WalletBalanceAvailability,
 };
 
+pub(super) fn has_pending_raw_transaction(
+    conn: &rusqlite::Connection,
+    chain_tip_height: u32,
+) -> Result<bool, String> {
+    transactions::has_pending_raw_transaction(conn, chain_tip_height)
+}
+
 pub(super) fn open_wallet_db(
     db_path: &str,
     network: WalletNetwork,

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -1849,8 +1849,35 @@ pub(crate) struct ResubmittableTx {
     pub expiry_height: u32,
 }
 
+/// Returns whether the wallet has any unmined raw transaction that could still
+/// be resubmitted after `chain_tip_height`.
+///
+/// This deliberately checks only the small `transactions` table. The
+/// account-level outbound predicate lives in [`get_resubmittable_txs`] and is
+/// evaluated only after the caller has refreshed the chain tip. A `true`
+/// result may therefore over-select, but `false` must not exclude a transaction
+/// that the full query would return at the same height.
+pub(super) fn has_pending_raw_transaction(
+    conn: &rusqlite::Connection,
+    chain_tip_height: u32,
+) -> Result<bool, String> {
+    let mut stmt = conn
+        .prepare_cached(
+            "SELECT EXISTS ( \
+             SELECT 1 \
+             FROM transactions \
+             WHERE mined_height IS NULL \
+               AND (expiry_height = 0 OR expiry_height > ?1) \
+               AND raw IS NOT NULL \
+         )",
+        )
+        .map_err(|e| format!("SQL error: {e}"))?;
+    stmt.query_row([chain_tip_height], |row| row.get(0))
+        .map_err(|e| format!("Query error: {e}"))
+}
+
 /// Return every wallet transaction that is eligible for automatic
-/// resubmit at `current_height`.
+/// resubmit after `chain_tip_height`.
 ///
 /// Mirrors zcash-android-wallet-sdk's `SELECTION_TRX_RESUBMISSION`
 /// predicate — see the Phase 3 design notes for why we follow the
@@ -1858,11 +1885,11 @@ pub(crate) struct ResubmittableTx {
 ///
 ///   * `mined_height IS NULL` — the transaction has not yet been
 ///     confirmed in a block.
-///   * `expiry_height = 0 OR expiry_height > ?current_height` — the
-///     transaction is still valid to relay. A zero expiry height means
-///     no expiry; otherwise, once the current tip passes
-///     `expiry_height`, the network will drop it and there is nothing
-///     we can do by resubmitting.
+///   * `expiry_height = 0 OR expiry_height > ?chain_tip_height` — the
+///     transaction can still be mined in the block after the current tip. A
+///     zero expiry height means no expiry; otherwise, when the current tip
+///     reaches `expiry_height`, the next block is already too late and there is
+///     nothing we can do by resubmitting.
 ///   * `account_balance_delta < 0` — the net balance change for the
 ///     account is negative, i.e. this is an outbound transaction
 ///     the wallet originated. Inbound transactions the sync loop
@@ -1871,30 +1898,36 @@ pub(crate) struct ResubmittableTx {
 ///   * `raw IS NOT NULL` — we actually have the serialized bytes to
 ///     broadcast. Defense-in-depth on top of the delta filter.
 ///
-/// A transaction that touches more than one of the wallet's own
-/// accounts shows up as more than one row in `v_transactions`; we
-/// `SELECT DISTINCT` on `(txid, raw, expiry_height)` to collapse
-/// that into a single broadcast instead of double-sending the same
-/// bytes.
+/// A transaction that touches more than one of the wallet's own accounts shows
+/// up as more than one row in `v_transactions`. The unique `transactions` row
+/// is therefore the outer query, and the account-level outbound test is an
+/// `EXISTS` predicate. Starting from `transactions` also avoids evaluating the
+/// comparatively expensive wallet view when there are no unmined raw
+/// transactions, which is the normal case for automatic sync.
 pub(crate) fn get_resubmittable_txs(
     db_path: &str,
-    current_height: u32,
+    chain_tip_height: u32,
 ) -> Result<Vec<ResubmittableTx>, String> {
     let conn = open_readonly_conn(db_path)?;
 
     let mut stmt = conn
         .prepare(
-            "SELECT DISTINCT txid, raw, expiry_height \
-             FROM v_transactions \
-             WHERE mined_height IS NULL \
-               AND (expiry_height = 0 OR expiry_height > ?1) \
-               AND account_balance_delta < 0 \
-               AND raw IS NOT NULL",
+            "SELECT t.txid, t.raw, t.expiry_height \
+             FROM transactions t \
+             WHERE t.mined_height IS NULL \
+               AND (t.expiry_height = 0 OR t.expiry_height > ?1) \
+               AND t.raw IS NOT NULL \
+               AND EXISTS ( \
+                   SELECT 1 \
+                   FROM v_transactions vt \
+                   WHERE vt.txid = t.txid \
+                     AND vt.account_balance_delta < 0 \
+               )",
         )
         .map_err(|e| format!("SQL error: {e}"))?;
 
     let rows = stmt
-        .query_map([current_height], |row| {
+        .query_map([chain_tip_height], |row| {
             let txid_bytes: Vec<u8> = row.get(0)?;
             let raw_tx: Vec<u8> = row.get(1)?;
             // The WHERE clause rejects NULL expiry heights but still
@@ -1919,11 +1952,11 @@ pub(crate) fn get_resubmittable_txs(
 /// loading raw transaction bytes.
 pub(crate) fn get_resubmittable_txs_excluding(
     db_path: &str,
-    current_height: u32,
+    chain_tip_height: u32,
     excluded_txids: &HashSet<Vec<u8>>,
 ) -> Result<Vec<ResubmittableTx>, String> {
     if excluded_txids.is_empty() {
-        return get_resubmittable_txs(db_path, current_height);
+        return get_resubmittable_txs(db_path, chain_tip_height);
     }
 
     let conn = open_readonly_conn(db_path)?;
@@ -1939,7 +1972,7 @@ pub(crate) fn get_resubmittable_txs_excluding(
             )
             .map_err(|e| format!("SQL error: {e}"))?;
         let rows = stmt
-            .query_map([current_height], |row| {
+            .query_map([chain_tip_height], |row| {
                 let txid_bytes: Vec<u8> = row.get(0)?;
                 let expiry_height = row
                     .get::<_, Option<i64>>(1)?
@@ -1975,23 +2008,21 @@ pub(crate) fn get_resubmittable_txs_excluding(
 mod tests {
     //! SQL-predicate regression tests for `get_resubmittable_txs`.
     //!
-    //! `get_resubmittable_txs` is a thin wrapper around a `v_transactions`
-    //! SELECT, but the SELECT is the entire contract: it's the piece that
-    //! encodes the four resubmit invariants we copied from
+    //! `get_resubmittable_txs` is a thin wrapper around a `transactions` query
+    //! with a `v_transactions` existence check. The SELECT is the entire
+    //! contract: it encodes the four resubmit invariants copied from
     //! `zcash-android-wallet-sdk`'s `SELECTION_TRX_RESUBMISSION`.
     //!
-    //! We test against a stand-in schema: a real SQLite DB with a plain
-    //! `v_transactions` table mirroring the columns the production view
-    //! exposes. That's enough for the WHERE clause to exercise each
-    //! filter independently without standing up the whole
+    //! We test against a stand-in schema: a real SQLite DB with a minimal
+    //! `transactions` table and a plain `v_transactions` table mirroring the
+    //! columns the production view exposes. That's enough for the predicates
+    //! to exercise each filter independently without standing up the whole
     //! `zcash_client_sqlite` migration stack.
     //!
-    //! If the production `v_transactions` view ever gains (or loses)
-    //! one of the columns we query here (`txid`, `raw`, `mined_height`,
-    //! `expiry_height`, `account_balance_delta`), the real build breaks
-    //! loudly at the first real query — but these unit tests still
-    //! exercise the logic, so a regression in the SQL text shows up here
-    //! first.
+    //! If the production `v_transactions` view ever loses `txid` or
+    //! `account_balance_delta`, the real query breaks loudly. The base-table
+    //! columns are represented separately here so these tests also catch a
+    //! regression in either side of the existence predicate.
     use super::*;
     use tempfile::NamedTempFile;
 
@@ -2015,17 +2046,18 @@ mod tests {
         }
     }
 
-    /// Build a throwaway SQLite database with a minimal
-    /// `v_transactions` table and return its `NamedTempFile`
-    /// handle. Tests keep the handle alive for the duration of the
-    /// test so the file isn't auto-deleted under them.
+    /// Build a throwaway SQLite database with minimal transaction tables and
+    /// return its `NamedTempFile` handle. Tests keep the handle alive for the
+    /// duration of the test so the file isn't auto-deleted.
     fn fresh_db() -> NamedTempFile {
         let file = NamedTempFile::new().unwrap();
         let conn = rusqlite::Connection::open(file.path()).unwrap();
         conn.execute_batch(
             "CREATE TABLE transactions (
                  txid BLOB PRIMARY KEY,
-                 raw BLOB
+                 raw BLOB,
+                 mined_height INTEGER,
+                 expiry_height INTEGER
              );
              CREATE TABLE v_transactions (
                  txid BLOB NOT NULL,
@@ -2067,7 +2099,7 @@ mod tests {
         file
     }
 
-    /// Insert one synthetic row into `v_transactions`.
+    /// Insert one synthetic base row and its account-level view row.
     fn insert_row(
         db: &NamedTempFile,
         txid: &[u8],
@@ -2078,9 +2110,10 @@ mod tests {
     ) {
         let conn = rusqlite::Connection::open(db.path()).unwrap();
         conn.execute(
-            "INSERT INTO transactions (txid, raw) VALUES (?1, ?2)
-             ON CONFLICT(txid) DO UPDATE SET raw = excluded.raw",
-            rusqlite::params![txid, raw],
+            "INSERT OR IGNORE INTO transactions
+                 (txid, raw, mined_height, expiry_height)
+             VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![txid, raw, mined_height, expiry_height],
         )
         .unwrap();
         conn.execute(
@@ -2089,6 +2122,76 @@ mod tests {
             rusqlite::params![txid, raw, mined_height, expiry_height, account_balance_delta],
         )
         .unwrap();
+    }
+
+    fn insert_base_row(
+        db: &NamedTempFile,
+        txid: &[u8],
+        raw: Option<&[u8]>,
+        mined_height: Option<i64>,
+        expiry_height: Option<i64>,
+    ) {
+        rusqlite::Connection::open(db.path())
+            .unwrap()
+            .execute(
+                "INSERT INTO transactions
+                     (txid, raw, mined_height, expiry_height)
+                 VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![txid, raw, mined_height, expiry_height],
+            )
+            .unwrap();
+    }
+
+    /// Runs the exact query replaced by [`get_resubmittable_txs`].
+    type ResubmittableRow = (Vec<u8>, Vec<u8>, u32);
+
+    fn legacy_resubmittable_rows(
+        db: &NamedTempFile,
+        chain_tip_height: u32,
+    ) -> Vec<ResubmittableRow> {
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT DISTINCT txid, raw, expiry_height
+                 FROM v_transactions
+                 WHERE mined_height IS NULL
+                   AND (expiry_height = 0 OR expiry_height > ?1)
+                   AND account_balance_delta < 0
+                   AND raw IS NOT NULL",
+            )
+            .unwrap();
+        let mut rows = stmt
+            .query_map([chain_tip_height], |row| {
+                let expiry_height = row
+                    .get::<_, Option<i64>>(2)?
+                    .map(|height| {
+                        u32::try_from(height.max(0)).expect("test expiry height must fit in a u32")
+                    })
+                    .unwrap_or(0);
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    expiry_height,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        rows.sort_by(|left, right| left.0.cmp(&right.0));
+        rows
+    }
+
+    fn rewritten_resubmittable_rows(
+        db: &NamedTempFile,
+        chain_tip_height: u32,
+    ) -> Vec<ResubmittableRow> {
+        let mut rows = get_resubmittable_txs(db.path().to_str().unwrap(), chain_tip_height)
+            .unwrap()
+            .into_iter()
+            .map(|tx| (tx.txid_bytes, tx.raw_tx, tx.expiry_height))
+            .collect::<Vec<_>>();
+        rows.sort_by(|left, right| left.0.cmp(&right.0));
+        rows
     }
 
     fn fake_txid(byte: u8) -> [u8; 32] {
@@ -5618,9 +5721,8 @@ mod tests {
     #[test]
     fn resubmit_dedupes_multi_account_rows() {
         // A tx that touches two of the wallet's own accounts shows up as
-        // two rows in `v_transactions`. `SELECT DISTINCT txid, raw,
-        // expiry_height` should collapse that to one broadcast — double-
-        // sending identical bytes would be a regression.
+        // two rows in `v_transactions`. Selecting from the unique base-table
+        // row with an `EXISTS` predicate must still produce one broadcast.
         let db = fresh_db();
         let txid = fake_txid(0x06);
         let raw = fake_raw();
@@ -5636,6 +5738,283 @@ mod tests {
             got.len(),
             1,
             "multi-account rows with same (txid, raw, expiry) must dedupe",
+        );
+    }
+
+    #[test]
+    fn pending_raw_preflight_has_no_false_negatives() {
+        struct Case {
+            name: &'static str,
+            raw: bool,
+            mined_height: Option<i64>,
+            expiry_height: Option<i64>,
+            account_delta: i64,
+            include_view_row: bool,
+            expected_preflight: bool,
+            expected_full_candidate: bool,
+        }
+
+        let cases = [
+            Case {
+                name: "eligible outbound",
+                raw: true,
+                mined_height: None,
+                expiry_height: Some(1_000_001),
+                account_delta: -1,
+                include_view_row: true,
+                expected_preflight: true,
+                expected_full_candidate: true,
+            },
+            Case {
+                name: "no expiry",
+                raw: true,
+                mined_height: None,
+                expiry_height: Some(0),
+                account_delta: -1,
+                include_view_row: true,
+                expected_preflight: true,
+                expected_full_candidate: true,
+            },
+            Case {
+                name: "expiry equals tip",
+                raw: true,
+                mined_height: None,
+                expiry_height: Some(1_000_000),
+                account_delta: -1,
+                include_view_row: true,
+                expected_preflight: false,
+                expected_full_candidate: false,
+            },
+            Case {
+                name: "expiry below tip",
+                raw: true,
+                mined_height: None,
+                expiry_height: Some(999_999),
+                account_delta: -1,
+                include_view_row: true,
+                expected_preflight: false,
+                expected_full_candidate: false,
+            },
+            Case {
+                name: "null expiry",
+                raw: true,
+                mined_height: None,
+                expiry_height: None,
+                account_delta: -1,
+                include_view_row: true,
+                expected_preflight: false,
+                expected_full_candidate: false,
+            },
+            Case {
+                name: "mined",
+                raw: true,
+                mined_height: Some(999_999),
+                expiry_height: Some(1_000_001),
+                account_delta: -1,
+                include_view_row: true,
+                expected_preflight: false,
+                expected_full_candidate: false,
+            },
+            Case {
+                name: "raw null",
+                raw: false,
+                mined_height: None,
+                expiry_height: Some(1_000_001),
+                account_delta: -1,
+                include_view_row: true,
+                expected_preflight: false,
+                expected_full_candidate: false,
+            },
+            Case {
+                name: "inbound false positive",
+                raw: true,
+                mined_height: None,
+                expiry_height: Some(1_000_001),
+                account_delta: 1,
+                include_view_row: true,
+                expected_preflight: true,
+                expected_full_candidate: false,
+            },
+            Case {
+                name: "zero-delta false positive",
+                raw: true,
+                mined_height: None,
+                expiry_height: Some(1_000_001),
+                account_delta: 0,
+                include_view_row: true,
+                expected_preflight: true,
+                expected_full_candidate: false,
+            },
+            Case {
+                name: "base-only false positive",
+                raw: true,
+                mined_height: None,
+                expiry_height: Some(1_000_001),
+                account_delta: -1,
+                include_view_row: false,
+                expected_preflight: true,
+                expected_full_candidate: false,
+            },
+        ];
+
+        let raw = fake_raw();
+        for (index, case) in cases.into_iter().enumerate() {
+            let db = fresh_db();
+            let txid =
+                fake_txid(0x20 + u8::try_from(index).expect("test case count must fit in a u8"));
+            let raw = case.raw.then_some(raw.as_slice());
+            if case.include_view_row {
+                insert_row(
+                    &db,
+                    &txid,
+                    raw,
+                    case.mined_height,
+                    case.expiry_height,
+                    case.account_delta,
+                );
+            } else {
+                insert_base_row(&db, &txid, raw, case.mined_height, case.expiry_height);
+            }
+
+            let conn = rusqlite::Connection::open(db.path()).unwrap();
+            let preflight = has_pending_raw_transaction(&conn, 1_000_000).unwrap();
+            let full = get_resubmittable_txs(db.path().to_str().unwrap(), 1_000_000).unwrap();
+
+            assert_eq!(preflight, case.expected_preflight, "{}", case.name);
+            assert_eq!(
+                !full.is_empty(),
+                case.expected_full_candidate,
+                "{}",
+                case.name,
+            );
+            assert!(
+                full.is_empty() || preflight,
+                "{} produced a preflight false negative",
+                case.name,
+            );
+        }
+    }
+
+    #[test]
+    fn pending_raw_preflight_reports_schema_errors() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        assert!(has_pending_raw_transaction(&conn, 1_000_000).is_err());
+    }
+
+    #[test]
+    fn rewritten_resubmit_query_matches_the_legacy_query() {
+        let db = fresh_db();
+        let raw = fake_raw();
+        for (byte, raw_value, mined_height, expiry_height, account_delta) in [
+            (0x40, Some(raw.as_slice()), None, Some(1_000_001), -1),
+            (0x41, Some(raw.as_slice()), None, Some(0), -1),
+            (0x42, Some(raw.as_slice()), None, Some(1_000_000), -1),
+            (0x43, Some(raw.as_slice()), None, Some(999_999), -1),
+            (0x44, Some(raw.as_slice()), None, None, -1),
+            (
+                0x45,
+                Some(raw.as_slice()),
+                Some(999_999),
+                Some(1_000_001),
+                -1,
+            ),
+            (0x46, None, None, Some(1_000_001), -1),
+            (0x47, Some(raw.as_slice()), None, Some(1_000_001), 1),
+            (0x48, Some(raw.as_slice()), None, Some(1_000_001), 0),
+        ] {
+            insert_row(
+                &db,
+                &fake_txid(byte),
+                raw_value,
+                mined_height,
+                expiry_height,
+                account_delta,
+            );
+        }
+
+        let multi_account_txid = fake_txid(0x49);
+        insert_row(
+            &db,
+            &multi_account_txid,
+            Some(&raw),
+            None,
+            Some(1_000_001),
+            1,
+        );
+        insert_row(
+            &db,
+            &multi_account_txid,
+            Some(&raw),
+            None,
+            Some(1_000_001),
+            -1,
+        );
+        insert_base_row(&db, &fake_txid(0x4a), Some(&raw), None, Some(1_000_001));
+
+        for chain_tip_height in [999_999, 1_000_000, 1_000_001] {
+            assert_eq!(
+                rewritten_resubmittable_rows(&db, chain_tip_height),
+                legacy_resubmittable_rows(&db, chain_tip_height),
+                "query mismatch at chain tip {chain_tip_height}",
+            );
+        }
+    }
+
+    #[test]
+    fn persistent_wal_reader_observes_committed_candidate_changes() {
+        let db = fresh_db();
+        let setup = rusqlite::Connection::open(db.path()).unwrap();
+        setup.pragma_update(None, "journal_mode", "WAL").unwrap();
+        drop(setup);
+
+        let reader = open_readonly_conn(db.path().to_str().unwrap()).unwrap();
+        assert!(!has_pending_raw_transaction(&reader, 1_000_000).unwrap());
+
+        let txid = fake_txid(0x50);
+        let raw = fake_raw();
+        let mut writer = rusqlite::Connection::open(db.path()).unwrap();
+        let tx = writer.transaction().unwrap();
+        tx.execute(
+            "INSERT INTO transactions
+                 (txid, raw, mined_height, expiry_height)
+             VALUES (?1, ?2, NULL, ?3)",
+            rusqlite::params![txid, raw, 1_000_001],
+        )
+        .unwrap();
+        tx.execute(
+            "INSERT INTO v_transactions
+                 (txid, raw, mined_height, expiry_height, account_balance_delta)
+             VALUES (?1, ?2, NULL, ?3, -1)",
+            rusqlite::params![txid, fake_raw(), 1_000_001],
+        )
+        .unwrap();
+        assert!(!has_pending_raw_transaction(&reader, 1_000_000).unwrap());
+        tx.commit().unwrap();
+
+        assert!(has_pending_raw_transaction(&reader, 1_000_000).unwrap());
+        writer
+            .execute(
+                "UPDATE transactions SET mined_height = ?1 WHERE txid = ?2",
+                rusqlite::params![1_000_000, txid],
+            )
+            .unwrap();
+        assert!(!has_pending_raw_transaction(&reader, 1_000_000).unwrap());
+    }
+
+    #[test]
+    fn pending_preflight_does_not_bypass_recovery_exclusions() {
+        let db = fresh_db();
+        let txid = fake_txid(0x51);
+        let raw = fake_raw();
+        insert_row(&db, &txid, Some(&raw), None, Some(1_000_001), -1);
+
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        assert!(has_pending_raw_transaction(&conn, 1_000_000).unwrap());
+        let excluded = HashSet::from([txid.to_vec()]);
+        assert!(
+            get_resubmittable_txs_excluding(db.path().to_str().unwrap(), 1_000_000, &excluded,)
+                .unwrap()
+                .is_empty()
         );
     }
 

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -379,6 +379,25 @@ fn is_pending_scan_range(range: &ScanRange) -> bool {
     range.priority() != ScanPriority::Ignored && range.priority() != ScanPriority::Scanned
 }
 
+/// Returns whether a resubmit pass should run after its cheap preflight.
+///
+/// Missing connections and query failures deliberately fail open so an
+/// optimization failure cannot suppress a valid transaction. Cancellation or
+/// a mode change always wins, including when it arrives while SQLite is
+/// waiting on its busy timeout.
+fn should_attempt_resubmit(
+    allow_resubmit: bool,
+    should_exit: bool,
+    preflight: Option<&Result<bool, String>>,
+) -> bool {
+    allow_resubmit
+        && !should_exit
+        && match preflight {
+            Some(Ok(candidate)) => *candidate,
+            Some(Err(_)) | None => true,
+        }
+}
+
 fn recovery_resubmit_exclusions(
     db_path: &str,
     ranges: &[ScanRange],
@@ -1848,6 +1867,23 @@ async fn run_sync_impl(
     // Open DB once — reused for the entire sync
     let mut db =
         with_wallet_db_write_lock("sync_engine.open_db", || open_db(db_data_path, network))?;
+    // Keep one read connection so the small resubmit preflight can reuse its
+    // prepared statement across batches. Opening or querying it is only an
+    // optimization: either failure falls back to the existing full path.
+    let resubmit_preflight_conn = if allow_resubmit {
+        match crate::wallet::sync::open_readonly_conn(db_data_path) {
+            Ok(conn) => Some(conn),
+            Err(e) => {
+                log::warn!(
+                    "[{}] sync: resubmit preflight connection unavailable: {e}",
+                    elapsed(),
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
     // The main-phase rewind budget also covers a reorg detected by the
     // initial tip response, before the scan queue has been created.
     let mut main_rewinds_this_run: u32 = 0;
@@ -1975,7 +2011,7 @@ async fn run_sync_impl(
     //
     // We reuse the same `client` instead of opening a fresh channel.
     //
-    // Pre-flight cancel/mode check: `update_chain_tip` and
+    // Preflight cancel/mode check: `update_chain_tip` and
     // `open_lwd_channel` can take a couple of seconds under a
     // slow connection, which is long enough for the user to hit
     // stop. Skip the whole pass in that case instead of sending
@@ -1989,23 +2025,43 @@ async fn run_sync_impl(
             elapsed(),
         );
     } else {
-        let startup_ranges = db
-            .suggest_scan_ranges()
-            .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?;
-        let startup_resubmit_exclusions =
-            recovery_resubmit_exclusions(db_data_path, &startup_ranges)?;
-        let _ = crate::wallet::sync::resubmit_pending_transactions(
-            db_data_path,
-            lightwalletd_url,
-            &mut client,
-            u32::from(tip_height),
-            &startup_resubmit_exclusions,
-            || {
-                cancel.load(Ordering::Relaxed)
-                    || desired_mode.load(Ordering::SeqCst) != running_mode
-            },
-        )
-        .await;
+        let preflight = resubmit_preflight_conn.as_ref().map(|conn| {
+            crate::wallet::sync::has_pending_raw_transaction(conn, u32::from(tip_height))
+        });
+        if let Some(Err(e)) = preflight.as_ref() {
+            log::warn!(
+                "[{}] sync: startup resubmit preflight failed: {e}",
+                elapsed(),
+            );
+        }
+        let exit_after_preflight = should_exit();
+        if exit_after_preflight {
+            log::info!(
+                "[{}] sync: cancel/mode observed after startup resubmit preflight",
+                elapsed(),
+            );
+            return Ok(());
+        }
+
+        if should_attempt_resubmit(true, exit_after_preflight, preflight.as_ref()) {
+            let startup_ranges = db
+                .suggest_scan_ranges()
+                .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?;
+            let startup_resubmit_exclusions =
+                recovery_resubmit_exclusions(db_data_path, &startup_ranges)?;
+            let _ = crate::wallet::sync::resubmit_pending_transactions(
+                db_data_path,
+                lightwalletd_url,
+                &mut client,
+                u32::from(tip_height),
+                &startup_resubmit_exclusions,
+                || {
+                    cancel.load(Ordering::Relaxed)
+                        || desired_mode.load(Ordering::SeqCst) != running_mode
+                },
+            )
+            .await;
+        }
     }
 
     // 3. Download subtree roots (incremental)
@@ -2871,36 +2927,20 @@ async fn run_sync_impl(
             return Ok(());
         }
 
-        // Truncation can temporarily clear a transaction's mined height while
-        // retaining note positions that prove compact scanning found it mined.
-        // Exclude those transactions from recovery resubmission while scanning
-        // can still restore their mined heights.
-        let post_scan_ranges = db
-            .suggest_scan_ranges()
-            .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?;
-        let resubmit_exclusions = recovery_resubmit_exclusions(db_data_path, &post_scan_ranges)?;
-
         // Enhancement
         run_enhancement(&mut client, &mut db, db_data_path, network).await?;
 
-        // Post-batch tip reconciliation and auto-resubmit. The resubmit calls
-        // match zcash-android-wallet-sdk's lines 593/701 call sites (end of a
-        // verify batch / end of a regular batch).
+        // Post-batch auto-resubmit. First query the small base transaction
+        // table. Most wallets have no pending raw transaction, so this avoids
+        // one candidate-triggered tip RPC and the account-level transaction
+        // view after every scan batch. The independent queue-drain check still
+        // validates tip identity before completion.
         //
-        // We deliberately re-fetch the chain tip via
-        // `get_latest_block` before each pass instead of reusing
-        // `tip.height` captured once at the top of `run_sync_impl`.
-        // `get_resubmittable_txs` decides "still inside expiry
-        // window" with `expiry_height > current_height`; using the
-        // stale top-of-sync tip meant a long catch-up session
-        // (several thousand blocks) could keep rebroadcasting txs
-        // whose expiry had already passed against the real chain
-        // tip. Refreshing here is one extra unary gRPC per batch,
-        // which is cheap compared to the batch download itself and
-        // closes the "resubmit expired tx forever" regression
-        // caught by Codex 2nd-round review finding 2.
+        // A possible candidate gets a fresh tip immediately before filtering
+        // and broadcasting. This keeps the expiry test tied to current chain
+        // state instead of the tip captured at sync startup.
         //
-        // Pre-flight guard matches the one at the startup resubmit
+        // Preflight guard matches the one at the startup resubmit
         // call site — if cancel or mode-change landed during
         // `run_enhancement` (which can spend a second or two on a
         // transparent-address scan), bail before opening a single
@@ -2909,11 +2949,9 @@ async fn run_sync_impl(
         // a cancel arriving mid-pass stops initiating further
         // broadcasts.
         //
-        // Best-effort: helper swallows per-tx failures, we ignore
-        // the return value, and if the tip refresh itself fails we
-        // log and skip the pass rather than falling back to the
-        // stale height (the whole point of the refresh is to avoid
-        // rebroadcasting against a stale expiry window).
+        // Best-effort: a failed preflight falls back to the old path so a
+        // local optimization failure cannot suppress resubmission. A failed
+        // tip refresh skips the pass instead of using a stale expiry window.
         if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode {
             log::info!(
                 "[{}] sync: cancel/mode observed before post-batch resubmit, exiting",
@@ -2921,14 +2959,48 @@ async fn run_sync_impl(
             );
             return Ok(());
         }
-        let fresh_tip_result = get_latest_block(&mut client).await;
-        let Some(fresh_tip_result) = tip_rpc_result_unless_exiting(fresh_tip_result, should_exit())
-        else {
-            log::info!("[{}] sync: exiting after post-batch tip fetch", elapsed());
+        let resubmit_tip_height = u32::from(block_height_from_u64(
+            current_tip_height,
+            "resubmit lightwalletd chain tip",
+        )?);
+        let preflight = if allow_resubmit {
+            resubmit_preflight_conn.as_ref().map(|conn| {
+                crate::wallet::sync::has_pending_raw_transaction(conn, resubmit_tip_height)
+            })
+        } else {
+            None
+        };
+        if let Some(Err(e)) = preflight.as_ref() {
+            log::warn!(
+                "[{}] sync: post-batch resubmit preflight failed: {e}",
+                elapsed(),
+            );
+        }
+        let exit_after_preflight = should_exit();
+        if exit_after_preflight {
+            log::info!(
+                "[{}] sync: cancel/mode observed after post-batch resubmit preflight",
+                elapsed(),
+            );
             return Ok(());
+        }
+        let should_resubmit =
+            should_attempt_resubmit(allow_resubmit, exit_after_preflight, preflight.as_ref());
+
+        let fresh_tip_result = if should_resubmit {
+            let fresh_tip_result = get_latest_block(&mut client).await;
+            let Some(fresh_tip_result) =
+                tip_rpc_result_unless_exiting(fresh_tip_result, should_exit())
+            else {
+                log::info!("[{}] sync: exiting after post-batch tip fetch", elapsed());
+                return Ok(());
+            };
+            Some(fresh_tip_result)
+        } else {
+            None
         };
         match fresh_tip_result {
-            Ok(fresh_tip) => {
+            Some(Ok(fresh_tip)) => {
                 let fresh_tip_height =
                     block_height_from_u64(fresh_tip.height, "post-batch lightwalletd chain tip")?;
 
@@ -3020,28 +3092,42 @@ async fn run_sync_impl(
                 // filter. The authoritative progress tip was promoted
                 // above only when its DB update succeeded; lower or
                 // divergent responses cannot reach this broadcast path.
-                if allow_resubmit {
-                    let _ = crate::wallet::sync::resubmit_pending_transactions(
-                        db_data_path,
-                        lightwalletd_url,
-                        &mut client,
-                        u32::from(fresh_tip_height),
-                        &resubmit_exclusions,
-                        || {
-                            cancel.load(Ordering::Relaxed)
-                                || desired_mode.load(Ordering::SeqCst) != running_mode
-                        },
-                    )
-                    .await;
-                }
+                // Truncation can temporarily clear a transaction's mined
+                // height while retaining note positions that prove compact
+                // scanning found it mined. Exclude those transactions while
+                // pending ranges can still restore their mined heights.
+                let post_scan_ranges = db
+                    .suggest_scan_ranges()
+                    .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?;
+                let resubmit_exclusions =
+                    recovery_resubmit_exclusions(db_data_path, &post_scan_ranges)?;
+                let _ = crate::wallet::sync::resubmit_pending_transactions(
+                    db_data_path,
+                    lightwalletd_url,
+                    &mut client,
+                    u32::from(fresh_tip_height),
+                    &resubmit_exclusions,
+                    || {
+                        cancel.load(Ordering::Relaxed)
+                            || desired_mode.load(Ordering::SeqCst) != running_mode
+                    },
+                )
+                .await;
             }
-            Err(e) => {
+            Some(Err(e)) => {
                 completion_tip_validation_required = true;
                 log::warn!(
                     "[{}] sync: post-batch tip refresh failed; skipping \
                      tip promotion and resubmit pass: {e}",
                     elapsed(),
                 );
+            }
+            None => {
+                // Suppressing the per-batch RPC must not suppress the chain-tip
+                // identity guarantee. Force one queue-drain validation even
+                // when the last successful check is still inside its normal
+                // grace period.
+                completion_tip_validation_required = true;
             }
         }
         if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode {
@@ -3366,6 +3452,35 @@ mod tests {
             (actual - expected).abs() < 0.000_001,
             "expected {expected}, got {actual}"
         );
+    }
+
+    #[test]
+    fn resubmit_preflight_fails_open_but_cancel_and_policy_win() {
+        let candidate = Ok(true);
+        let empty = Ok(false);
+        let failed = Err("synthetic preflight failure".to_owned());
+
+        assert!(should_attempt_resubmit(true, false, Some(&candidate)));
+        assert!(!should_attempt_resubmit(true, false, Some(&empty)));
+        assert!(should_attempt_resubmit(true, false, Some(&failed)));
+        assert!(should_attempt_resubmit(true, false, None));
+
+        assert!(!should_attempt_resubmit(true, true, Some(&candidate)));
+        assert!(!should_attempt_resubmit(true, true, Some(&failed)));
+        assert!(!should_attempt_resubmit(true, true, None));
+        assert!(!should_attempt_resubmit(false, false, Some(&candidate)));
+        assert!(!should_attempt_resubmit(false, false, Some(&failed)));
+        assert!(!should_attempt_resubmit(false, false, None));
+    }
+
+    #[test]
+    fn empty_resubmit_preflight_avoids_candidate_tip_refreshes_across_batches() {
+        let empty = Ok(false);
+        let candidate_tip_refreshes = (0..100)
+            .filter(|_| should_attempt_resubmit(true, false, Some(&empty)))
+            .count();
+
+        assert_eq!(candidate_tip_refreshes, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Stack

This PR is stacked on #517. Review and merge #517 first; GitHub will then show
only this PR's transaction-resubmission changes against `main`.

## Summary

- Keep one read-only SQLite connection for resubmission preflight checks.
- Use a cached `SELECT EXISTS` against the base `transactions` table before
  entering the full resubmission path.
- Skip candidate-triggered tip RPCs, recovery exclusions, transaction-view
  selection, and broadcast work when no raw pending transaction can qualify.
- Preserve #517's periodic and queue-drain tip-identity validation.
- Rewrite the main no-exclusions selection around the unique base transaction
  row plus an outbound `EXISTS` predicate, with direct equivalence tests
  against the previous query. The recovery-exclusions variant is unchanged.

## Expected impact

Most wallets do not have a locally stored, unmined raw transaction during
normal sync. Previously, every completed scan batch still performed a
dedicated latest-tip RPC, computed recovery exclusions, and evaluated the
account-level transaction view for resubmission.

In the common no-candidate case, those network and full-view operations no
longer scale with the number of scan batches. Each batch performs only the
small prepared base-table preflight, while #517's scheduled and final
chain-tip validation remains independent. As an illustrative upper bound, a
340,000-block recovery at 100 blocks per batch previously entered roughly
3,400 candidate-triggered tip/query cycles; this change can avoid those cycles
when no pending raw transaction exists.

This should reduce lightwalletd traffic, SQLite CPU, battery use, and wall
time during long catch-up or recovery scans. No percentage speedup is claimed
without an end-to-end benchmark. A wallet with a possible candidate pays one
additional small base-table query and then follows the existing authoritative
path.

## Safety model and trade-offs

The preflight is deliberately a superset. It checks mined height, expiry, and
raw bytes, but leaves the account-level outbound predicate to the
authoritative query. It may return a false positive, which only invokes the
old work; it must never return a false negative that suppresses a relayable
transaction.

- Connection-open and query failures fail open into the previous path.
- Candidate-present behavior still refreshes and classifies the tip, preserves
  reorg/server-behind handling, computes recovery exclusions, selects
  authoritative outbound candidates, and only then broadcasts.
- Cancellation and sync-mode handoff are rechecked after the potentially
  blocking preflight and take precedence over subsequent RPC or broadcast
  work.
- Skipping a post-batch RPC explicitly requires queue-drain identity
  validation, preserving #517's exact completion guarantee.
- One read-only SQLite connection remains open for the sync attempt, and one
  small preflight query remains per resubmission gate.

## Validation criteria

- [x] Eligible outbound, no-expiry, expiry-boundary, mined, raw-null,
  null-expiry, inbound, zero-delta, base-only, duplicate, and multi-account
  cases preserve the no-false-negative invariant.
- [x] The old and rewritten no-exclusions queries return identical rows across
  the eligibility matrix and multiple chain tips.
- [x] A persistent WAL reader observes a committed candidate insertion and a
  later mining update without reopening.
- [x] Recovery exclusions still suppress otherwise eligible candidates.
- [x] Preflight connection and query failures fail open.
- [x] Cancellation or mode change after preflight prevents later RPC and
  broadcast work.
- [x] A no-candidate decision skips candidate-triggered work and forces final
  identity validation.
- [x] #517's unchanged, unverified, advanced, server-behind, and reorg state
  transitions remain covered.
- [x] Transaction tests: 55 passed, 2 environment-gated tests ignored.
- [x] Sync-engine tests: 35 passed.
- [x] `cargo check --locked --offline`, scoped rustfmt, and diff checks pass.
- [ ] Before merge, count lightwalletd calls during a multi-batch
  no-candidate sync and smoke-test the migrated production wallet view.

## API surface

Adds two narrowly scoped `pub(super)` helpers: the transaction-module
preflight is visible only to its parent, and the sync-module wrapper is
visible only within `wallet`. There are no `pub`, `pub(crate)`, FRB, Dart,
schema, dependency, or migration changes.
