### PR TITLE
Benchmark active-account and multi-account Ironwood trial decryption

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -87,6 +87,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambassador"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b27ba24e4d8a188489d5a03c7fabc167a60809a383cdb4d15feb37479cd2a48"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "amplify"
 version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +542,21 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin-private"
@@ -2666,6 +2693,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
  "either",
+ "proptest",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "incrementalmerkletree-testing"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad20fb6cf815e76ce9b9eca74f347740ab99059fe4b5e4a002403d0441a02983"
+dependencies = [
+ "incrementalmerkletree",
+ "proptest",
 ]
 
 [[package]]
@@ -3369,6 +3409,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "pasta_curves",
+ "proptest",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "reddsa",
@@ -3965,6 +4006,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4082,6 +4143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4186,6 +4253,15 @@ dependencies = [
  "libc",
  "rand_core 0.9.5",
  "winapi",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4448,6 +4524,7 @@ dependencies = [
  "bip0039",
  "bls12_381",
  "bytes",
+ "criterion",
  "ff",
  "flutter_rust_bridge",
  "futures",
@@ -4467,6 +4544,7 @@ dependencies = [
  "pczt",
  "prost 0.14.3",
  "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "redb",
  "rusqlite",
@@ -4597,6 +4675,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "safelog"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4650,6 +4740,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "memuse",
+ "proptest",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "redjubjub",
@@ -6761,6 +6852,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6993,6 +7090,65 @@ dependencies = [
  "pasta_curves",
  "rand 0.8.6",
  "sinsemilla",
+]
+
+[[package]]
+name = "wagyu-zcash-parameters"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c904628658374e651288f000934c33ef738b2d8b3e65d4100b70b395dbe2bb"
+dependencies = [
+ "wagyu-zcash-parameters-1",
+ "wagyu-zcash-parameters-2",
+ "wagyu-zcash-parameters-3",
+ "wagyu-zcash-parameters-4",
+ "wagyu-zcash-parameters-5",
+ "wagyu-zcash-parameters-6",
+]
+
+[[package]]
+name = "wagyu-zcash-parameters-1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bf2e21bb027d3f8428c60d6a720b54a08bf6ce4e6f834ef8e0d38bb5695da8"
+
+[[package]]
+name = "wagyu-zcash-parameters-2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a616ab2e51e74cc48995d476e94de810fb16fc73815f390bf2941b046cc9ba2c"
+
+[[package]]
+name = "wagyu-zcash-parameters-3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14da1e2e958ff93c0830ee68e91884069253bf3462a67831b02b367be75d6147"
+
+[[package]]
+name = "wagyu-zcash-parameters-4"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f058aeef03a2070e8666ffb5d1057d8bb10313b204a254a6e6103eb958e9a6d6"
+
+[[package]]
+name = "wagyu-zcash-parameters-5"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffe916b30e608c032ae1b734f02574a3e12ec19ab5cc5562208d679efe4969d"
+
+[[package]]
+name = "wagyu-zcash-parameters-6"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b6d5a78adc3e8f198e9cd730f219a695431467f7ec29dcfc63ade885feebe1"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7684,7 +7840,9 @@ version = "0.24.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49636f1d22b0511b2a117548cc9dcf569440a3589b06bf6df422c6b738f6231"
 dependencies = [
+ "ambassador",
  "arti-client",
+ "assert_matches",
  "async-trait",
  "base64",
  "bech32",
@@ -7704,6 +7862,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "incrementalmerkletree",
+ "jubjub",
  "memuse",
  "nonempty",
  "orchard",
@@ -7711,8 +7870,10 @@ dependencies = [
  "pczt",
  "percent-encoding",
  "postcard",
+ "proptest",
  "prost 0.14.3",
  "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
  "rust_decimal",
@@ -7740,6 +7901,7 @@ dependencies = [
  "zcash_keys",
  "zcash_note_encryption",
  "zcash_primitives",
+ "zcash_proofs",
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
@@ -7825,6 +7987,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "orchard",
+ "proptest",
  "rand_core 0.6.4",
  "sapling-crypto",
  "secrecy",
@@ -7890,6 +8053,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "orchard",
+ "proptest",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -7920,6 +8084,7 @@ dependencies = [
  "redjubjub",
  "sapling-crypto",
  "tracing",
+ "wagyu-zcash-parameters",
  "xdg",
  "zcash_primitives",
 ]
@@ -7933,7 +8098,10 @@ dependencies = [
  "corez",
  "document-features",
  "hex",
+ "incrementalmerkletree",
+ "incrementalmerkletree-testing",
  "memuse",
+ "proptest",
  "zcash_encoding",
 ]
 
@@ -7976,6 +8144,7 @@ dependencies = [
  "getset",
  "hex",
  "nonempty",
+ "proptest",
  "ripemd 0.1.3",
  "secp256k1",
  "sha2 0.10.9",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust_lib_zcash_wallet"
 version = "0.1.0"
 edition = "2021"
+autobenches = false
 
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]
@@ -145,11 +146,14 @@ features = ["std"]
 security-framework = { version = "3.7", features = ["OSX_10_15"] }
 
 [dev-dependencies]
+criterion = "0.7"
+rand_chacha = "0.3"
 tempfile = "3"
 hex = "0.4"
 # Integration tests inject/inspect scan_queue rows directly to exercise the
 # VZR-89 rescue path. Keep this version aligned with the [dependencies] entry.
 rusqlite = "0.37"
+zcash_client_backend = { version = "0.24.0-rc.7", features = ["test-dependencies"] }
 # Used only by the sigs-only byte-identity test to recover the spendable note
 # from a freshly built Orchard bundle (matches pczt's own end-to-end test).
 # Already in the dependency graph via zcash_client_backend.
@@ -157,6 +161,10 @@ zcash_note_encryption = "0.4"
 
 [dev-dependencies.vote-commitment-tree]
 version = "=0.4.0-rc.2"
+
+[[bench]]
+name = "ironwood_trial_decryption"
+harness = false
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)', 'cfg(ironwood_masquerade)'] }

--- a/rust/benches/ironwood_trial_decryption.rs
+++ b/rust/benches/ironwood_trial_decryption.rs
@@ -1,0 +1,174 @@
+//! Benchmarks the production Ironwood compact trial-decryption seam.
+//!
+//! [`zcash_client_backend::data_api::chain::scan_cached_blocks`] collects
+//! compact outputs using a 100-output flush threshold. It dispatches them via
+//! [`zcash_note_encryption::batch::try_compact_note_decryption`]. Benchmarking
+//! that function directly isolates the crypto work while preserving its batch
+//! shape. The public per-block scanner is deliberately not measured here: it
+//! uses an inline, per-transaction path and includes unrelated pool work.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use orchard::{
+    keys::{FullViewingKey, PreparedIncomingViewingKey},
+    note_encryption::{CompactAction, IronwoodDomain},
+};
+use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+use zcash_client_backend::{
+    data_api::testing::{AddressType, IronwoodFvk, TestFvk},
+    proto::compact_formats::CompactTx,
+};
+use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_note_encryption::batch;
+use zcash_protocol::{
+    consensus::{BlockHeight, Network, NetworkUpgrade, Parameters},
+    value::Zatoshis,
+};
+use zip32::{AccountId, Scope};
+
+const ACTION_COUNT: usize = 100;
+const BACKGROUND_ACCOUNT_COUNTS: [usize; 3] = [2, 4, 8];
+const ACTIVE_ACCOUNT_SEED_TAG: u8 = 7;
+const BACKGROUND_ACCOUNT_SEED_TAGS: [u8; 8] = [13, 17, 23, 29, 31, 37, 41, 43];
+const RECIPIENT_SEED_TAG: u8 = 113;
+const NOTE_VALUE: Zatoshis = Zatoshis::const_from_u64(1);
+const RNG_SEED: [u8; 32] = [19; 32];
+
+type CompactOutput = (IronwoodDomain, CompactAction);
+
+fn ironwood_height() -> BlockHeight {
+    Network::TestNetwork
+        .activation_height(NetworkUpgrade::Nu6_3)
+        .expect("testnet has an Ironwood activation height")
+}
+
+fn account(seed_tag: u8) -> FullViewingKey {
+    UnifiedSpendingKey::from_seed(&Network::TestNetwork, &[seed_tag; 32], AccountId::ZERO)
+        .expect("valid benchmark seed")
+        .to_unified_full_viewing_key()
+        .orchard()
+        .expect("benchmark account has an Orchard component")
+        .clone()
+}
+
+fn external_ivk(fvk: &FullViewingKey) -> PreparedIncomingViewingKey {
+    PreparedIncomingViewingKey::new(&fvk.to_ivk(Scope::External))
+}
+
+fn unrelated_outputs(recipient: &FullViewingKey) -> Vec<CompactOutput> {
+    let recipient = IronwoodFvk(recipient.clone());
+    let mut tx = CompactTx::default();
+    let mut rng = ChaCha20Rng::from_seed(RNG_SEED);
+
+    for _ in 0..ACTION_COUNT {
+        recipient.add_output(
+            &mut tx,
+            &Network::TestNetwork,
+            ironwood_height(),
+            None,
+            AddressType::DefaultExternal,
+            NOTE_VALUE,
+            0,
+            &mut rng,
+        );
+    }
+
+    assert_eq!(tx.ironwood_actions.len(), ACTION_COUNT);
+    tx.ironwood_actions
+        .iter()
+        .map(|action| {
+            let action = CompactAction::try_from(action)
+                .expect("generated Ironwood compact action is valid");
+            (IronwoodDomain::for_compact_action(&action), action)
+        })
+        .collect()
+}
+
+fn trial_decrypt(ivks: &[PreparedIncomingViewingKey], outputs: &[CompactOutput]) -> usize {
+    batch::try_compact_note_decryption(ivks, outputs)
+        .into_iter()
+        .filter(Option::is_some)
+        .count()
+}
+
+fn validate_fixture(
+    intended_recipient: &PreparedIncomingViewingKey,
+    foreground_ivks: &[PreparedIncomingViewingKey],
+    background_ivks: &[PreparedIncomingViewingKey],
+    outputs: &[CompactOutput],
+) {
+    let intended_results =
+        batch::try_compact_note_decryption(std::slice::from_ref(intended_recipient), outputs);
+    assert_eq!(intended_results.len(), ACTION_COUNT);
+    assert!(intended_results
+        .iter()
+        .all(|result| result.as_ref().map(|(_, index)| *index) == Some(0)));
+
+    assert_eq!(trial_decrypt(foreground_ivks, outputs), 0);
+    assert_eq!(trial_decrypt(background_ivks, outputs), 0);
+}
+
+fn benchmark_ironwood_trial_decryption(c: &mut Criterion) {
+    let recipient = account(RECIPIENT_SEED_TAG);
+    let outputs = unrelated_outputs(&recipient);
+    let intended_recipient = external_ivk(&recipient);
+
+    // Foreground sync prioritizes the active account and uses one scope. The
+    // common unrelated-action case therefore performs one trial per action.
+    let foreground_ivks = [external_ivk(&account(ACTIVE_ACCOUNT_SEED_TAG))];
+
+    // Background sync handles the remaining accounts after the active account
+    // result is available. Each key belongs to a distinct account and uses one
+    // scope, so this measures account scaling without doubling every account
+    // into external and internal keys.
+    let background_ivks: Vec<_> = BACKGROUND_ACCOUNT_SEED_TAGS
+        .iter()
+        .map(|seed_tag| external_ivk(&account(*seed_tag)))
+        .collect();
+
+    validate_fixture(
+        &intended_recipient,
+        &foreground_ivks,
+        &background_ivks,
+        &outputs,
+    );
+
+    let mut foreground = c.benchmark_group("ironwood_unrelated_trial_decryption/foreground");
+    foreground.throughput(Throughput::Elements(ACTION_COUNT as u64));
+    foreground.bench_function("active_account_1_ivk_x_100_actions", |bencher| {
+        bencher.iter(|| {
+            black_box(trial_decrypt(
+                black_box(&foreground_ivks),
+                black_box(&outputs),
+            ))
+        });
+    });
+    foreground.finish();
+
+    let mut background = c.benchmark_group("ironwood_unrelated_trial_decryption/background");
+    for account_count in BACKGROUND_ACCOUNT_COUNTS {
+        let ivks = &background_ivks[..account_count];
+        // Criterion's element throughput is the number of (IVK, action)
+        // trial pairs. All pairs are evaluated before note plaintext checks.
+        background.throughput(Throughput::Elements((account_count * ACTION_COUNT) as u64));
+        background.bench_with_input(
+            BenchmarkId::new("other_accounts_x_100_actions", account_count),
+            ivks,
+            |bencher, ivks| {
+                bencher.iter(|| black_box(trial_decrypt(black_box(ivks), black_box(&outputs))));
+            },
+        );
+    }
+    background.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(30)
+        .warm_up_time(core::time::Duration::from_secs(2))
+        .measurement_time(core::time::Duration::from_secs(5));
+    targets = benchmark_ironwood_trial_decryption
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Adds a deterministic Criterion benchmark around the exact batched compact
trial-decryption function used by `scan_cached_blocks` for Ironwood outputs.

It measures the two intended sync lanes over a production-sized batch of 100
unrelated Ironwood actions:

- foreground: one IVK for the active account, minimizing time to its result;
- background: 2, 4, and 8 IVKs belonging to other accounts, with one scope per
  account.

An earlier revision benchmarked `scan_block`; it has been replaced. That public
helper uses inline, per-transaction trial decryption and includes unrelated
empty-pool bookkeeping, so it did not represent the production batch runner or
provide a clean optimization signal.

## Expected impact

This PR does not change production behavior.

It establishes two independent optimization criteria:

1. active-account latency for one IVK over 100 unrelated actions;
2. sustained multi-account background throughput as additional IVKs are
   applied to the same prepared action batch.

This distinction lets us optimize the foreground ECDH path without obscuring
the separate opportunity to reuse per-action preparation across background
accounts.

A representative baseline measured approximately 5.74 ms for one IVK,
8.58 ms for two IVKs, 17.30 ms for four IVKs, and 34.56 ms for eight IVKs.
Absolute timings are machine-dependent. Optimization PRs should use
counterbalanced A/B/B/A runs and reject rounds disturbed by system load.

The benchmark is not a full-wallet sync wall-clock claim. It intentionally
excludes database writes, commitment-tree updates, and other shielded pools so
changes in Ironwood trial decryption have a direct, attributable signal.

## Benchmark design

- Uses `zcash_note_encryption::batch::try_compact_note_decryption`, the
  function dispatched by the production compact-scan batch runner.
- Uses exactly 100 version-3 Ironwood compact actions.
- Uses deterministic account seeds and RNG state.
- Keeps fixture construction outside the measured closure.
- Verifies all 100 actions decrypt with the intended recipient IVK.
- Verifies none decrypt with any foreground or background benchmark IVK.
- Uses one external-scope IVK from each distinct account.
- Excludes the active account from the background account sets.
- Reports foreground throughput in actions and background throughput in
  `(IVK, action)` trial pairs.
- Uses 30 samples, a two-second warmup, and a five-second measurement window.

A full `scan_cached_blocks` benchmark was considered. It would require wallet
database initialization, account state, block-source and chain-state plumbing,
commitment trees, two block traversals, and persistence. That scaffolding would
mix database and tree costs into this crypto-focused measurement, so it is
better treated as a separate end-to-end benchmark.

Run with:

```sh
cd rust
cargo bench --locked --offline --bench ironwood_trial_decryption
```

## Validation

- `cargo check --locked --offline --bench ironwood_trial_decryption`
- `cargo bench --locked --offline --bench ironwood_trial_decryption -- --test`
- full Criterion measurement of all four cases
- `rustfmt --edition 2021 --check benches/ironwood_trial_decryption.rs`
- `git diff --check`

## API surface

No Rust, FRB, C FFI, wire, schema, or production dependency API changes.

The developer-facing Cargo benchmark target is renamed from `ironwood_scan` to
`ironwood_trial_decryption`.
