### PR TITLE
Make receive QR codes scannable at any rotation

### DIFF
--- a/lib/src/features/receive/widgets/receive_address_widgets.dart
+++ b/lib/src/features/receive/widgets/receive_address_widgets.dart
@@ -354,7 +354,11 @@ class _CachedQrBitmapState extends State<_CachedQrBitmap> {
       final image = await qrImage.toImage(
         size: _CachedQrBitmap._bitmapSize,
         decoration: PrettyQrDecoration(
-          quietZone: PrettyQrQuietZone.zero,
+          // QR decoders require four clear modules on every side. The
+          // receive card's 16x24px padding is less than four modules
+          // horizontally for dense addresses, which made detection depend on
+          // the camera's orientation.
+          quietZone: const PrettyQrQuietZone.modules(4),
           image: PrettyQrDecorationImage(
             image: AssetImage(widget.embeddedImageAsset),
             scale: widget.embeddedImageScale,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1308,6 +1308,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  zxing2:
+    dependency: "direct dev"
+    description:
+      name: zxing2
+      sha256: "2677c49a3b9ca9457cb1d294fd4bd5041cac6aab8cdb07b216ba4e98945c684f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.4"
 sdks:
   dart: ">=3.11.4 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
+  zxing2: ^0.2.4
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/features/receive/receive_qr_scannability_test.dart
+++ b/test/features/receive/receive_qr_scannability_test.dart
@@ -1,0 +1,124 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/receive/widgets/receive_address_widgets.dart';
+import 'package:zxing2/qrcode.dart';
+
+// An independently generated mainnet Orchard + Sapling Unified Address.
+// This is the longest address shape Vizor normally renders, so it exercises a
+// denser QR grid than an Orchard-only Keystone or transparent address.
+const _softwareUnifiedAddress =
+    'u1flce76a85e0zvdtrqaqj59mdk2mv35d074lafaeej5s09qjm4vflc9gndayyxt'
+    '37v6tekfgram4p9209ygugkz7es438hc9gsujwmcm0trr7zt5lcz8xmpfg9rqyfyzn'
+    'c83ax697lc5ur3nem8wwyen732wemtxcg6lxr4n2agm437m2';
+
+void main() {
+  testWidgets('receive QR decodes at every quarter-turn rotation', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: const Center(
+            child: ReceiveQrSurface(
+              address: _softwareUnifiedAddress,
+              size: 260,
+              paddingX: 16,
+              paddingY: 24,
+              type: ReceiveAddressType.shielded,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final renderedQr = tester.widget<RawImage>(find.byType(RawImage)).image!;
+    final rgba = await renderedQr.toByteData(format: ui.ImageByteFormat.rawRgba);
+    expect(rgba, isNotNull);
+
+    // The shielded QR is white-on-black. Composite its potentially transparent
+    // quiet-zone pixels onto the same black backing used by the receive card.
+    final uprightPixels = _rgbPixelsOnBlack(
+      rgba!,
+      renderedQr.width,
+      renderedQr.height,
+    );
+
+    for (var quarterTurns = 0; quarterTurns < 4; quarterTurns++) {
+      final pixels = _rotateSquare(
+        uprightPixels,
+        renderedQr.width,
+        quarterTurns,
+      );
+      final decoded = _decodeQr(pixels, renderedQr.width);
+
+      expect(
+        decoded,
+        _softwareUnifiedAddress,
+        reason: 'QR failed to decode at ${quarterTurns * 90} degrees',
+      );
+    }
+  });
+}
+
+Int32List _rgbPixelsOnBlack(ByteData rgba, int width, int height) {
+  final bytes = rgba.buffer.asUint8List(rgba.offsetInBytes, rgba.lengthInBytes);
+  final pixels = Int32List(width * height);
+
+  for (var i = 0; i < pixels.length; i++) {
+    final offset = i * 4;
+    final alpha = bytes[offset + 3];
+    final red = bytes[offset] * alpha ~/ 255;
+    final green = bytes[offset + 1] * alpha ~/ 255;
+    final blue = bytes[offset + 2] * alpha ~/ 255;
+    pixels[i] = (red << 16) | (green << 8) | blue;
+  }
+
+  return pixels;
+}
+
+Int32List _rotateSquare(Int32List source, int size, int quarterTurns) {
+  if (quarterTurns == 0) {
+    return source;
+  }
+
+  final rotated = Int32List(source.length);
+  for (var y = 0; y < size; y++) {
+    for (var x = 0; x < size; x++) {
+      final (rotatedX, rotatedY) = switch (quarterTurns) {
+        1 => (size - 1 - y, x),
+        2 => (size - 1 - x, size - 1 - y),
+        3 => (y, size - 1 - x),
+        _ => throw ArgumentError.value(quarterTurns, 'quarterTurns'),
+      };
+      rotated[rotatedY * size + rotatedX] = source[y * size + x];
+    }
+  }
+
+  return rotated;
+}
+
+String _decodeQr(Int32List pixels, int size) {
+  final source = RGBLuminanceSource(size, size, pixels);
+  final hints = DecodeHints()..put(DecodeHintType.tryHarder);
+  ReaderException? lastError;
+
+  // Vizor's shielded QR is inverted (light modules on a dark surface), but
+  // trying both polarities keeps this test valid if its colors change later.
+  for (final candidate in [source, source.invert()]) {
+    try {
+      return QRCodeReader()
+          .decode(BinaryBitmap(HybridBinarizer(candidate)), hints: hints)
+          .text;
+    } on ReaderException catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError ?? StateError('QR decoder returned no result');
+}


### PR DESCRIPTION
## What changed

- Render receive-address QR codes with the QR-standard four-module quiet zone.
- Apply the change in the shared renderer, covering desktop/mobile and shielded/transparent addresses.
- Add a behavioral regression test that renders Vizor's real decorated QR bitmap, rotates its pixels through 0°, 90°, 180°, and 270°, and independently decodes every result with ZXing.

## Why

The bitmap previously removed its quiet zone and relied on the card's 16x24px UI padding. Dense address codes need more than 16px for four full modules, leaving less clearance on the horizontal sides than the vertical sides. That put detection near the scanner's threshold and could make a quarter-turn scan fail even though QR data itself is rotation-independent.

Keeping the required clearance inside the bitmap makes all four sides symmetric and independent of the surrounding layout.

The regression fixture is an independently generated software-wallet Unified Address containing both Orchard and Sapling receivers, the densest normal shielded address Vizor renders. Keystone's Orchard-only address is shorter.

## Validation

- `git diff --check`
- The regression test uses an independent decoder rather than asserting implementation constants.
- Local Flutter execution is pending because `fvm` is unavailable in the execution environment.