### PR TITLE
Add background vote share recovery

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -96,6 +96,7 @@ import 'src/providers/linux_update_provider.dart';
 import 'src/providers/network_privacy_provider.dart';
 import 'src/providers/rpc_endpoint_failover_provider.dart';
 import 'src/providers/router_refresh_provider.dart';
+import 'src/providers/voting/voting_share_tracking_restorer_provider.dart';
 import 'src/providers/wallet_provider.dart';
 import 'src/providers/windows_update_provider.dart';
 import 'src/rust/api/sync.dart' as rust_sync;
@@ -1119,6 +1120,7 @@ class ZcashWalletApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(votingShareTrackingRestorerProvider);
     final appRouter = ref.watch(_routerProvider);
     final router = appRouter.router;
     final themeMode = ref.watch(themeModeProvider);

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -27,6 +27,7 @@ import 'app_security_provider.dart';
 import 'network_privacy_provider.dart';
 import 'rpc_endpoint_failover_provider.dart';
 import 'rpc_endpoint_provider.dart';
+import 'voting/voting_share_tracking_registry_provider.dart';
 import 'voting/voting_submission_guard_provider.dart';
 
 export 'account_models.dart';
@@ -542,6 +543,22 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       throw ArgumentError.value(uuid, 'uuid', 'Unknown account UUID');
     }
 
+    final shareTracking = ref.read(votingShareTrackingRegistryProvider);
+    await shareTracking.quiesceAndDrain(accountUuid: uuid);
+    try {
+      await _removeAccountWithShareTrackingStopped(uuid);
+    } finally {
+      shareTracking.resume(accountUuid: uuid);
+    }
+  }
+
+  Future<void> _removeAccountWithShareTrackingStopped(String uuid) async {
+    final prev = state.value ?? const AccountState();
+    final targetIndex = prev.accounts.indexWhere((a) => a.uuid == uuid);
+    if (targetIndex < 0) {
+      throw ArgumentError.value(uuid, 'uuid', 'Unknown account UUID');
+    }
+
     final target = prev.accounts[targetIndex];
     final remaining = [
       for (final account in prev.accounts)
@@ -675,6 +692,16 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   Future<void> resetWallet() async {
     ref.read(votingSubmissionGuardProvider.notifier).throwIfActive();
 
+    final shareTracking = ref.read(votingShareTrackingRegistryProvider);
+    await shareTracking.quiesceAndDrain();
+    try {
+      await _resetWalletWithShareTrackingStopped();
+    } finally {
+      shareTracking.resume();
+    }
+  }
+
+  Future<void> _resetWalletWithShareTrackingStopped() async {
     Object? firstError;
     StackTrace? firstStackTrace;
     void recordError(String step, Object e, StackTrace st) {

--- a/lib/src/providers/voting/voting_config_provider.dart
+++ b/lib/src/providers/voting/voting_config_provider.dart
@@ -176,9 +176,11 @@ class VotingConfigNotifier extends AsyncNotifier<ResolvedVotingConfig> {
   /// - shared transport/client + PIR resolver caches via [_invalidateEndpointState];
   /// - the poll list ([votingRoundsProvider]) and the interactive session
   ///   ([votingSessionProvider]) so status polls and session setup rerun;
-  /// - the submission-session family ([votingSubmissionSessionProvider]) so a
-  ///   subsequent submission re-resolves its endpoints. Active submission guards
-  ///   keep existing sessions alive until their jobs release process-local state.
+  ///
+  /// Submission sessions stay alive because each action reloads this provider.
+  /// Recreating one during an ambiguous helper POST could duplicate a retry.
+  /// Active submission guards defer interactive-session invalidation until the
+  /// job releases process-local state.
   void _applySwitch(ConfigSwitchKind kind, {required bool sourceChanged}) {
     if (sourceChanged) {
       _invalidateConfigDependentState();
@@ -221,7 +223,6 @@ class VotingConfigNotifier extends AsyncNotifier<ResolvedVotingConfig> {
 
   void _invalidateVotingSessionState() {
     ref.invalidate(votingSessionProvider);
-    ref.invalidate(votingSubmissionSessionProvider);
   }
 
   void _invalidateEndpointState() {

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -59,6 +59,11 @@ final votingHelperRequestTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 5);
 });
 
+/// Delay before retrying a failed automatic helper-share tracking pass.
+final votingShareTrackingFailureRetryDelayProvider = Provider<Duration>((ref) {
+  return const Duration(seconds: 15);
+});
+
 /// Timeout for PIR `/root` probe requests.
 final votingPirProbeTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 10);
@@ -503,6 +508,11 @@ abstract interface class VotingRustApi {
     required bool singleShare,
   });
 
+  Future<List<String>> shareResubmissionServerOrder({
+    required List<String> configuredServerUrls,
+    required List<String> sentToUrls,
+  });
+
   BigInt? lastMomentBufferSeconds({
     required BigInt ceremonyStartSeconds,
     required BigInt voteEndTimeSeconds,
@@ -903,6 +913,17 @@ class FrbVotingRustApi implements VotingRustApi {
       voteEndTimeSeconds: voteEndTimeSeconds,
       lastMomentBufferSeconds: lastMomentBufferSeconds,
       singleShare: singleShare,
+    );
+  }
+
+  @override
+  Future<List<String>> shareResubmissionServerOrder({
+    required List<String> configuredServerUrls,
+    required List<String> sentToUrls,
+  }) {
+    return rust_api.shareResubmissionServerOrder(
+      configuredServerUrls: configuredServerUrls,
+      sentToUrls: sentToUrls,
     );
   }
 

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -20,8 +20,10 @@ import '../../services/voting/resolved_voting_config_extensions.dart';
 import '../../services/voting/voting_api_client.dart';
 import '../../services/voting/voting_helper_health_tracker.dart';
 import '../../services/voting/voting_models.dart';
+import '../app_security_provider.dart';
 import 'voting_config_provider.dart';
 import 'voting_service_providers.dart';
+import 'voting_share_tracking_registry_provider.dart';
 import 'voting_state.dart';
 import 'voting_submission_guard_provider.dart';
 
@@ -33,6 +35,20 @@ final _minimumVotingBundleWeightZatoshi = BigInt.from(12500000);
 /// account's Orchard key, but the action remains in the PCZT's Ironwood bundle.
 const _ironwoodPcztPool = 1;
 
+bool shouldTrackPendingVotingShares(VotingRoundDetails round, {DateTime? now}) {
+  final status = round.status.trim().toLowerCase();
+  if (!const {
+    'active',
+    'open',
+    '1',
+    'session_status_active',
+  }.contains(status)) {
+    return false;
+  }
+  final voteEnd = round.voteEndTime;
+  return voteEnd != null && (now ?? DateTime.now()).isBefore(voteEnd);
+}
+
 /// Orchestrates one round's voting lifecycle for the UI.
 ///
 /// The notifier is intentionally recovery-first: every public action reloads
@@ -42,11 +58,19 @@ const _ironwoodPcztPool = 1;
 class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   VotingSessionNotifier(this._roundId);
 
+  bool get _ownsAutomaticShareTracking => false;
+
+  bool _retainAutomaticShareTracking() => true;
+
+  void _releaseAutomaticShareTracking() {}
+
   Future<void> _operation = Future.value();
   final String _roundId;
   final Map<String, Future<void>> _delegationPirPrecomputes = {};
   final Map<String, Future<List<int>>> _hotkeyEnsures = {};
   Timer? _shareTrackingTimer;
+  Future<void>? _shareTrackingPass;
+  bool _automaticShareTrackingStopped = false;
   String? _sessionAccountUuid;
   bool? _sessionIsHardwareAccount;
   _VotingSessionContext? _currentContext;
@@ -122,6 +146,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       _delegationPirPrecomputes.clear();
       _hotkeyEnsures.clear();
       _shareTrackingTimer?.cancel();
+      _releaseAutomaticShareTracking();
       if (context == null) return;
       if (_activeSubmissionOwnsContext(context)) {
         debugPrint(
@@ -2011,13 +2036,41 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   }
 
   Future<void> submitPendingShares() {
-    return _enqueue(() async {
+    if (_automaticShareTrackingStopped) return Future.value();
+    final inFlight = _shareTrackingPass;
+    if (inFlight != null) return inFlight;
+
+    late final Future<void> pass;
+    pass = _startPendingSharePass().whenComplete(() {
+      if (identical(_shareTrackingPass, pass)) _shareTrackingPass = null;
+    });
+    _shareTrackingPass = pass;
+    return pass;
+  }
+
+  Future<void> _startPendingSharePass() {
+    return _enqueueShareTracking(() async {
       _shareTrackingTimer?.cancel();
       _shareTrackingTimer = null;
-      var current = await future;
-      var context = await _loadContext(_roundId);
+      if (_automaticShareTrackingStopped) return;
+      final current = await future;
+      final context = await _loadContext(_roundId);
+      _currentContext = context;
       var plan = await _loadResumePlan(context);
       var roundPlan = await _loadRoundPlan(context);
+      if (ref.read(appSecurityProvider).requiresUnlock ||
+          !shouldTrackPendingVotingShares(context.round)) {
+        _setStateForContext(
+          context,
+          current.copyWith(
+            phase: _phaseForPlans(roundPlan),
+            resumePlan: plan,
+            roundPlan: roundPlan,
+          ),
+        );
+        _releaseAutomaticShareTracking();
+        return;
+      }
       _setStateForContext(
         context,
         current.copyWith(
@@ -2033,15 +2086,16 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       final configuredServerUrls = context.config.voteServers
           .map((endpoint) => endpoint.url.toString())
           .toList(growable: false);
+      final configuredServerUrlSet = configuredServerUrls.toSet();
       final nowSeconds = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
       final voteEnd = context.round.voteEndTime;
       final voteEndSeconds = voteEnd == null
           ? null
           : voteEnd.millisecondsSinceEpoch ~/ 1000;
       for (final share in plan.unconfirmedShareDelegations) {
-        // A share is recoverable once any helper accepted it, but every
-        // configured helper should eventually receive it for redundancy.
-        final acceptedUrls = LinkedHashSet<String>.of(share.sentToUrls);
+        final acceptedUrls = LinkedHashSet<String>.of(
+          share.sentToUrls.where(configuredServerUrlSet.contains),
+        );
         final trackingFlags = await rust.shareTrackingFlags(
           share: share,
           nowSeconds: BigInt.from(nowSeconds),
@@ -2059,6 +2113,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           // helper is enough to advance the local workflow for this share.
           final confirmed = await _shareConfirmedByAnyHelper(
             api: api,
+            context: context,
             helperHealth: helperHealth,
             share: share,
             serverUrls: acceptedUrls,
@@ -2076,27 +2131,24 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           }
         }
 
-        final missingUrls = configuredServerUrls
-            .where((serverUrl) => !acceptedUrls.contains(serverUrl))
-            .toList(growable: false);
-        if (overdueForRetry && missingUrls.isNotEmpty) {
-          final newUrls = await _resubmitShareToMissingHelpers(
+        if (overdueForRetry) {
+          final retryServer = await _resubmitShare(
             api: api,
             context: context,
             plan: plan,
             share: share,
-            serverUrls: missingUrls,
+            configuredServerUrls: configuredServerUrls,
+            sentToUrls: acceptedUrls,
           );
-          if (newUrls.isNotEmpty) {
+          if (retryServer != null && acceptedUrls.add(retryServer)) {
             await ref
                 .read(votingRecoveryServiceProvider)
                 .addSentServersForShare(
                   dbPath: context.dbPath,
                   accountUuid: context.accountUuid,
                   share: share,
-                  newUrls: newUrls,
+                  newUrls: [retryServer],
                 );
-            acceptedUrls.addAll(newUrls);
           }
         }
       }
@@ -2119,14 +2171,27 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     });
   }
 
-  /// Retries an already-generated share against helpers missing from
-  /// `sent_to_urls` and returns only the helpers that accepted the retry.
-  Future<List<String>> _resubmitShareToMissingHelpers({
+  Future<void> stopAndDrainShareTracking() async {
+    _automaticShareTrackingStopped = true;
+    _shareTrackingTimer?.cancel();
+    _shareTrackingTimer = null;
+    _advanceSessionGeneration();
+    final pass = _shareTrackingPass;
+    if (pass != null) await pass;
+    _releaseAutomaticShareTracking();
+  }
+
+  void resumeShareTracking() {
+    _automaticShareTrackingStopped = false;
+  }
+
+  Future<String?> _resubmitShare({
     required VotingApiClient api,
     required _VotingSessionContext context,
     required VotingResumePlan plan,
     required rust_wire.ShareDelegationRecordView share,
-    required List<String> serverUrls,
+    required List<String> configuredServerUrls,
+    required Set<String> sentToUrls,
   }) async {
     final rust = ref.read(votingRustApiProvider);
     final key = VotingVoteKey(
@@ -2140,7 +2205,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         'round=${share.roundId} bundle=${share.bundleIndex} '
         'proposal=${share.proposalId} share=${share.shareIndex}',
       );
-      return const [];
+      return null;
     }
     final Map<String, dynamic> body;
     try {
@@ -2159,26 +2224,38 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         'round=${share.roundId} bundle=${share.bundleIndex} '
         'proposal=${share.proposalId} share=${share.shareIndex} error=$e',
       );
-      return const [];
+      return null;
     }
+
+    final retryOrder = await rust.shareResubmissionServerOrder(
+      configuredServerUrls: configuredServerUrls,
+      sentToUrls: sentToUrls.toList(growable: false),
+    );
     final shareId = bytesToHex(share.nullifier);
-    final acceptedUrls = <String>[];
     final helperHealth = ref.read(votingHelperHealthTrackerProvider);
-    for (final serverUrl in helperHealth.candidateServers(serverUrls)) {
+    for (final serverUrl in retryOrder) {
+      if (_automaticShareTrackingStopped ||
+          !_isCurrentContext(context) ||
+          ref.read(appSecurityProvider).requiresUnlock ||
+          !shouldTrackPendingVotingShares(context.round)) {
+        return null;
+      }
       try {
         await api.resubmitShare(
           serverUrl: Uri.parse(serverUrl),
           shareId: shareId,
           share: body,
         );
+        // Preserve a known acceptance even if a stop arrived during the POST;
+        // forgetting it could resend the same share after unlock.
         helperHealth.recordSuccess(serverUrl);
-        acceptedUrls.add(serverUrl);
         debugPrint(
           '[zcash] Voting: share resubmitted '
           'round=${share.roundId} bundle=${share.bundleIndex} '
           'proposal=${share.proposalId} share=${share.shareIndex} '
           'server=$serverUrl',
         );
+        return serverUrl;
       } catch (e) {
         debugPrint(
           '[zcash] Voting: share resubmit failed '
@@ -2189,17 +2266,31 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         helperHealth.recordFailure(serverUrl);
       }
     }
-    return acceptedUrls;
+    return null;
   }
 
   Future<void> _scheduleShareTracking(
     _VotingSessionContext context,
     VotingResumePlan plan,
   ) async {
+    if (!_ownsAutomaticShareTracking) {
+      _shareTrackingTimer?.cancel();
+      _shareTrackingTimer = null;
+      return;
+    }
+    if (_automaticShareTrackingStopped ||
+        plan.unconfirmedShareDelegations.isEmpty ||
+        !shouldTrackPendingVotingShares(context.round) ||
+        ref.read(appSecurityProvider).requiresUnlock) {
+      _shareTrackingTimer?.cancel();
+      _shareTrackingTimer = null;
+      _releaseAutomaticShareTracking();
+      return;
+    }
     if (!_isCurrentContext(context)) return;
+    if (!_retainAutomaticShareTracking()) return;
     _shareTrackingTimer?.cancel();
     _shareTrackingTimer = null;
-    if (plan.unconfirmedShareDelegations.isEmpty) return;
 
     final delaySeconds = await ref
         .read(votingRustApiProvider)
@@ -2209,34 +2300,94 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000,
           ),
         );
-    if (delaySeconds == null) return;
+    if (delaySeconds == null) {
+      _releaseAutomaticShareTracking();
+      return;
+    }
     if (!_isCurrentContext(context)) return;
     final delay = Duration(seconds: delaySeconds.toInt());
+    _armShareTrackingTimer(context, _delayCappedAtVoteEnd(context, delay));
+  }
 
-    // Keep the timer asynchronous so build/state updates settle before
-    // recovery polling re-enters the serialized operation queue.
-    final scheduledDelay = delay;
-    _shareTrackingTimer = Timer(scheduledDelay, () {
+  void _scheduleShareTrackingFailureRetry() {
+    if (_isDisposed ||
+        !_ownsAutomaticShareTracking ||
+        _automaticShareTrackingStopped ||
+        ref.read(appSecurityProvider).requiresUnlock) {
+      _releaseAutomaticShareTracking();
+      return;
+    }
+    final config = ref.read(votingConfigProvider).value;
+    if (config != null && !config.isRoundAuthenticated(_roundId)) {
+      _releaseAutomaticShareTracking();
+      return;
+    }
+    final context = _currentContext;
+    if (context == null ||
+        !_isCurrentContext(context) ||
+        !shouldTrackPendingVotingShares(context.round) ||
+        !_retainAutomaticShareTracking()) {
+      _releaseAutomaticShareTracking();
+      return;
+    }
+    final configuredDelay = ref.read(
+      votingShareTrackingFailureRetryDelayProvider,
+    );
+    final delay = configuredDelay.isNegative ? Duration.zero : configuredDelay;
+    _armShareTrackingTimer(context, _delayCappedAtVoteEnd(context, delay));
+  }
+
+  Duration _delayCappedAtVoteEnd(
+    _VotingSessionContext context,
+    Duration delay,
+  ) {
+    final remaining = context.round.voteEndTime!.difference(DateTime.now());
+    if (remaining.isNegative) return Duration.zero;
+    return delay < remaining ? delay : remaining;
+  }
+
+  void _armShareTrackingTimer(_VotingSessionContext context, Duration delay) {
+    _shareTrackingTimer?.cancel();
+    _shareTrackingTimer = Timer(delay, () {
       _shareTrackingTimer = null;
       if (!_isCurrentContext(context)) return;
+      if (!shouldTrackPendingVotingShares(context.round)) {
+        _releaseAutomaticShareTracking();
+        return;
+      }
       unawaited(submitPendingShares());
     });
   }
 
   Future<bool> _shareConfirmedByAnyHelper({
     required VotingApiClient api,
+    required _VotingSessionContext context,
     required VotingHelperHealthTracker helperHealth,
     required rust_wire.ShareDelegationRecordView share,
     required Iterable<String> serverUrls,
   }) async {
     final shareId = bytesToHex(share.nullifier);
     for (final serverUrl in helperHealth.candidateServers(serverUrls)) {
+      if (_automaticShareTrackingStopped ||
+          !_isCurrentContext(context) ||
+          ref.read(appSecurityProvider).requiresUnlock ||
+          !shouldTrackPendingVotingShares(context.round)) {
+        return false;
+      }
       try {
         final status = await api.getShareStatus(
           roundId: share.roundId,
           serverUrl: Uri.parse(serverUrl),
           shareId: shareId,
+          isCancelled: () =>
+              _automaticShareTrackingStopped ||
+              !_isCurrentContext(context) ||
+              ref.read(appSecurityProvider).requiresUnlock ||
+              !shouldTrackPendingVotingShares(context.round),
         );
+        if (_automaticShareTrackingStopped || !_isCurrentContext(context)) {
+          return false;
+        }
         helperHealth.recordSuccess(serverUrl);
         if (status.status == 'confirmed') return true;
       } catch (e) {
@@ -2428,7 +2579,12 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         '$height$statusCode$message';
   }
 
-  Future<void> _enqueue(Future<void> Function() action) {
+  Future<void> _enqueue(
+    Future<void> Function() action, {
+    void Function()? onError,
+    bool cleanupProcessStateOnError = true,
+    bool publishError = true,
+  }) {
     final actionGeneration = _sessionGeneration;
     final next = _operation.then((_) async {
       if (!_isCurrentGeneration(actionGeneration)) {
@@ -2443,14 +2599,26 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         _logStaleSessionUpdate('action');
       } catch (e, st) {
         debugPrint('[zcash] Voting: session action failed: $e\n$st');
-        await _cleanupCurrentSessionState(reason: 'action-failed');
-        _setError(_actionErrorMessage(e), cause: e);
+        if (cleanupProcessStateOnError) {
+          await _cleanupCurrentSessionState(reason: 'action-failed');
+        }
+        if (publishError) _setError(_actionErrorMessage(e), cause: e);
+        onError?.call();
       } finally {
         _runningActionGeneration = previousActionGeneration;
       }
     });
     _operation = next.catchError((_) {});
     return next;
+  }
+
+  Future<void> _enqueueShareTracking(Future<void> Function() action) {
+    return _enqueue(
+      action,
+      onError: _scheduleShareTrackingFailureRetry,
+      cleanupProcessStateOnError: false,
+      publishError: false,
+    );
   }
 
   static String _actionErrorMessage(Object error) {
@@ -3471,6 +3639,38 @@ class VotingSubmissionSessionNotifier extends VotingSessionNotifier {
   VotingSubmissionSessionNotifier(this._key) : super(_key.roundId);
 
   final VotingSessionKey _key;
+  VotingShareTrackingRegistry? _shareTrackingRegistry;
+  void Function()? _closeShareTrackingKeepAlive;
+
+  @override
+  bool get _ownsAutomaticShareTracking => true;
+
+  @override
+  bool _retainAutomaticShareTracking() {
+    if (_closeShareTrackingKeepAlive != null) return true;
+    final registry = ref.read(votingShareTrackingRegistryProvider);
+    final keepAlive = ref.keepAlive();
+    if (!registry.register(
+      key: _key,
+      owner: this,
+      stopAndDrain: stopAndDrainShareTracking,
+    )) {
+      keepAlive.close();
+      return false;
+    }
+    _shareTrackingRegistry = registry;
+    _closeShareTrackingKeepAlive = keepAlive.close;
+    return true;
+  }
+
+  @override
+  void _releaseAutomaticShareTracking() {
+    _shareTrackingRegistry?.unregister(key: _key, owner: this);
+    _shareTrackingRegistry = null;
+    final close = _closeShareTrackingKeepAlive;
+    _closeShareTrackingKeepAlive = null;
+    close?.call();
+  }
 
   // This subclass must remain in this library because it overrides private
   // hooks to pin background submissions to their original account.

--- a/lib/src/providers/voting/voting_share_tracking_registry_provider.dart
+++ b/lib/src/providers/voting/voting_share_tracking_registry_provider.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../features/voting/voting_flow_models.dart';
+
+typedef VotingShareTrackingStopper = Future<void> Function();
+
+class VotingShareTrackingRegistry {
+  final Map<VotingSessionKey, _VotingShareTrackingRegistration> _sessions = {};
+  final Set<String> _quiescedAccounts = {};
+  bool _allQuiesced = false;
+
+  bool register({
+    required VotingSessionKey key,
+    required Object owner,
+    required VotingShareTrackingStopper stopAndDrain,
+  }) {
+    if (isQuiesced(key.accountUuid)) return false;
+    _sessions[key] = _VotingShareTrackingRegistration(
+      owner: owner,
+      stopAndDrain: stopAndDrain,
+    );
+    return true;
+  }
+
+  void unregister({required VotingSessionKey key, required Object owner}) {
+    if (identical(_sessions[key]?.owner, owner)) _sessions.remove(key);
+  }
+
+  bool isQuiesced(String accountUuid) {
+    return _allQuiesced || _quiescedAccounts.contains(accountUuid);
+  }
+
+  Future<void> quiesceAndDrain({String? accountUuid}) async {
+    if (accountUuid == null) {
+      _allQuiesced = true;
+    } else {
+      _quiescedAccounts.add(accountUuid);
+    }
+    final sessions = [
+      for (final entry in _sessions.entries)
+        if (accountUuid == null || entry.key.accountUuid == accountUuid) entry,
+    ];
+    await Future.wait(sessions.map((entry) => entry.value.stopAndDrain()));
+    for (final entry in sessions) {
+      unregister(key: entry.key, owner: entry.value.owner);
+    }
+  }
+
+  void resume({String? accountUuid}) {
+    if (accountUuid == null) {
+      _allQuiesced = false;
+    } else {
+      _quiescedAccounts.remove(accountUuid);
+    }
+  }
+
+  @visibleForTesting
+  Set<VotingSessionKey> get registeredKeys => Set.unmodifiable(_sessions.keys);
+}
+
+class _VotingShareTrackingRegistration {
+  const _VotingShareTrackingRegistration({
+    required this.owner,
+    required this.stopAndDrain,
+  });
+
+  final Object owner;
+  final VotingShareTrackingStopper stopAndDrain;
+}
+
+final votingShareTrackingRegistryProvider = Provider((ref) {
+  return VotingShareTrackingRegistry();
+});

--- a/lib/src/providers/voting/voting_share_tracking_restorer_provider.dart
+++ b/lib/src/providers/voting/voting_share_tracking_restorer_provider.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../features/voting/voting_flow_models.dart';
+import '../../rust/api/voting.dart' as rust_api;
+import '../../services/voting/resolved_voting_config_extensions.dart';
+import '../account_provider.dart';
+import '../app_security_provider.dart';
+import 'voting_config_provider.dart';
+import 'voting_service_providers.dart';
+import 'voting_session_provider.dart';
+import 'voting_share_tracking_registry_provider.dart';
+import 'voting_state.dart';
+
+typedef VotingPendingShareRoundLoader =
+    Future<List<rust_api.ApiPendingShareRound>> Function({
+      required String dbPath,
+      required List<String> accountUuids,
+    });
+
+@visibleForTesting
+final votingPendingShareRoundLoaderProvider =
+    Provider<VotingPendingShareRoundLoader>((ref) {
+      return ({required dbPath, required accountUuids}) {
+        return rust_api.listPendingShareRounds(
+          dbPath: dbPath,
+          accountUuids: accountUuids,
+        );
+      };
+    });
+
+@visibleForTesting
+final votingPendingShareRestoreRetryDelayProvider = Provider((ref) {
+  return const Duration(seconds: 15);
+});
+
+class VotingShareTrackingRestorer {
+  VotingShareTrackingRestorer(this._ref);
+
+  final Ref _ref;
+  Future<void>? _restoreInFlight;
+  Future<void> _pauseInFlight = Future.value();
+  Timer? _retryTimer;
+
+  Future<void> restore() {
+    final inFlight = _restoreInFlight;
+    if (inFlight != null) return inFlight;
+    late final Future<void> restore;
+    restore = _restoreOnce().whenComplete(() {
+      if (identical(_restoreInFlight, restore)) _restoreInFlight = null;
+    });
+    _restoreInFlight = restore;
+    return restore;
+  }
+
+  Future<void> pause() {
+    _cancelRetry();
+    return _pauseInFlight = _ref
+        .read(votingShareTrackingRegistryProvider)
+        .quiesceAndDrain();
+  }
+
+  Future<void> resume() async {
+    await _pauseInFlight;
+    _ref.read(votingShareTrackingRegistryProvider).resume();
+    await _restoreInFlight;
+    await restore();
+  }
+
+  Future<void> _restoreOnce() async {
+    _cancelRetry();
+    if (_ref.read(appSecurityProvider).requiresUnlock) return;
+    var failed = false;
+    try {
+      final registry = _ref.read(votingShareTrackingRegistryProvider);
+      final accounts = (await _ref.read(accountProvider.future)).accounts;
+      final accountUuids = accounts
+          .map((account) => account.uuid)
+          .toList(growable: false);
+      if (accountUuids.isEmpty) return;
+      final dbPath = await _ref.read(votingWalletDbPathProvider).call();
+      final pending = await _ref
+          .read(votingPendingShareRoundLoaderProvider)
+          .call(dbPath: dbPath, accountUuids: accountUuids);
+      if (pending.isEmpty) return;
+
+      final accountSet = accountUuids.toSet();
+      final now = DateTime.now().toUtc();
+      final candidates = pending
+          .where((round) {
+            final voteEnd = votingSessionVoteEndTime(round.sessionJson);
+            return accountSet.contains(round.accountUuid) &&
+                !registry.isQuiesced(round.accountUuid) &&
+                voteEnd != null &&
+                now.isBefore(voteEnd);
+          })
+          .toList(growable: false);
+      if (candidates.isEmpty) return;
+
+      if (_ref.exists(votingConfigProvider)) {
+        await _ref.read(votingConfigProvider.notifier).refresh();
+      }
+      if (_ref.read(appSecurityProvider).requiresUnlock) return;
+      final config = await _ref.read(votingConfigProvider.future);
+      for (final round in candidates) {
+        if (!config.isRoundAuthenticated(round.roundId) ||
+            registry.isQuiesced(round.accountUuid)) {
+          continue;
+        }
+        final key = VotingSessionKey(
+          accountUuid: round.accountUuid,
+          roundId: round.roundId,
+        );
+        final provider = votingSubmissionSessionProvider(key);
+        try {
+          await _ref.read(provider.future);
+          if (_ref.read(appSecurityProvider).requiresUnlock) break;
+          if (registry.isQuiesced(round.accountUuid)) continue;
+          final notifier = _ref.read(provider.notifier);
+          notifier.resumeShareTracking();
+          await notifier.submitPendingShares();
+        } catch (error, stackTrace) {
+          failed = true;
+          debugPrint(
+            '[zcash] Voting: pending share restore failed '
+            'round=${round.roundId} account=${round.accountUuid} '
+            'error=$error\n$stackTrace',
+          );
+        }
+      }
+    } catch (error, stackTrace) {
+      failed = true;
+      debugPrint(
+        '[zcash] Voting: pending share discovery failed: $error\n$stackTrace',
+      );
+    }
+    if (failed && !_ref.read(appSecurityProvider).requiresUnlock) {
+      _scheduleRetry();
+    }
+  }
+
+  void _scheduleRetry() {
+    if (_retryTimer?.isActive ?? false) return;
+    final configured = _ref.read(votingPendingShareRestoreRetryDelayProvider);
+    final delay = configured.isNegative ? Duration.zero : configured;
+    _retryTimer = Timer(delay, () {
+      _retryTimer = null;
+      unawaited(restore());
+    });
+  }
+
+  void _cancelRetry() {
+    _retryTimer?.cancel();
+    _retryTimer = null;
+  }
+}
+
+final votingShareTrackingRestorerProvider = Provider((ref) {
+  final restorer = VotingShareTrackingRestorer(ref);
+  ref.listen<AppSecurityState>(appSecurityProvider, (previous, next) {
+    if (next.requiresUnlock) {
+      unawaited(restorer.pause());
+    } else if (previous?.requiresUnlock == true) {
+      unawaited(restorer.resume());
+    }
+  });
+  unawaited(restorer.restore());
+  final lifecycleListener = AppLifecycleListener(
+    onResume: () => unawaited(restorer.restore()),
+  );
+  ref.onDispose(() {
+    lifecycleListener.dispose();
+    restorer._cancelRetry();
+  });
+  return restorer;
+});

--- a/lib/src/providers/voting/voting_state.dart
+++ b/lib/src/providers/voting/voting_state.dart
@@ -167,6 +167,17 @@ class VotingRoundDetails {
   DateTime? get ceremonyStart => _dateFromJson(rawJson, 'ceremony_phase_start');
 }
 
+DateTime? votingSessionVoteEndTime(String? sessionJson) {
+  if (sessionJson == null) return null;
+  try {
+    final decoded = jsonDecode(sessionJson);
+    if (decoded is! Map<String, dynamic>) return null;
+    return _dateFromJson(decoded, 'vote_end_time');
+  } on FormatException {
+    return null;
+  }
+}
+
 /// One compact Keystone signature correlated to a pending voting bundle.
 class VotingKeystoneBatchSignature {
   final int bundleIndex;

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -14,7 +14,7 @@ import '../third_party/zcash_voting/wire.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `build_vote_commitments_result`, `catch`, `emit_signed_delegation_result`, `emit_signed_vote_result`, `log_sink_closed`, `parse_tx_events_json`, `require_len`, `share_record`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`
 
 /// Return the shared last-moment helper-share buffer, in Unix seconds.
 BigInt? lastMomentBufferSeconds({
@@ -90,6 +90,15 @@ Future<List<ShareSubmissionPlan>> planShareSubmissions({
   singleShare: singleShare,
 );
 
+/// Return the crate-owned randomized helper order for one share retry.
+Future<List<String>> shareResubmissionServerOrder({
+  required List<String> configuredServerUrls,
+  required List<String> sentToUrls,
+}) => RustLib.instance.api.crateApiVotingShareResubmissionServerOrder(
+  configuredServerUrls: configuredServerUrls,
+  sentToUrls: sentToUrls,
+);
+
 /// Build round params from server metadata while binding trusted `ea_pk`.
 ///
 /// Trust model for the per-round parameters:
@@ -156,7 +165,7 @@ Future<BigInt?> nextShareTrackingDelaySeconds({
 /// Extract and validate one helper-share payload from stored recovery JSON.
 ///
 /// The stored recovery blob is hex-encoded and also contains local-only
-/// recovery material. This helper emits only the public base64 wire shape that
+/// recovery material. This helper emits only the public wire fields that
 /// helper servers accept.
 Future<String> recoveredVoteShareWireJson({
   required String commitmentBundleJson,
@@ -510,6 +519,18 @@ Future<int> deleteVotingAccountState({
   accountUuid: accountUuid,
 );
 
+/// Lists account/round pairs with durable unconfirmed helper shares.
+///
+/// The opaque session JSON is returned for caller-owned deadline checks. The
+/// sidecar is not created when the wallet has never persisted voting state.
+Future<List<ApiPendingShareRound>> listPendingShareRounds({
+  required String dbPath,
+  required List<String> accountUuids,
+}) => RustLib.instance.api.crateApiVotingListPendingShareRounds(
+  dbPath: dbPath,
+  accountUuids: accountUuids,
+);
+
 /// Recover a committed but unsubmitted vote from persisted local recovery data.
 ///
 /// # Errors
@@ -847,6 +868,32 @@ class ApiKeystoneSignatureInput {
           sig == other.sig &&
           sighash == other.sighash &&
           rk == other.rk;
+}
+
+/// One account and round with durable unconfirmed helper shares.
+class ApiPendingShareRound {
+  final String accountUuid;
+  final String roundId;
+  final String? sessionJson;
+
+  const ApiPendingShareRound({
+    required this.accountUuid,
+    required this.roundId,
+    this.sessionJson,
+  });
+
+  @override
+  int get hashCode =>
+      accountUuid.hashCode ^ roundId.hashCode ^ sessionJson.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ApiPendingShareRound &&
+          runtimeType == other.runtimeType &&
+          accountUuid == other.accountUuid &&
+          roundId == other.roundId &&
+          sessionJson == other.sessionJson;
 }
 
 /// Progress event emitted while building ZKP2 vote commitments.

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -81,7 +81,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1626111918;
+  int get rustContentHash => -1596187728;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -764,6 +764,11 @@ abstract class RustLibApi extends BaseApi {
     required String network,
   });
 
+  Future<List<ApiPendingShareRound>> crateApiVotingListPendingShareRounds({
+    required String dbPath,
+    required List<String> accountUuids,
+  });
+
   Future<void> crateApiVotingMarkDelegationSubmitted({
     required String dbPath,
     required String accountUuid,
@@ -1065,6 +1070,11 @@ abstract class RustLibApi extends BaseApi {
 
   Future<BundleLayout> crateApiVotingSetupDelegationBundles({
     required ApiVotingRoundContext ctx,
+  });
+
+  Future<List<String>> crateApiVotingShareResubmissionServerOrder({
+    required List<String> configuredServerUrls,
+    required List<String> sentToUrls,
   });
 
   Future<int> crateApiVotingShareTrackingFlags({
@@ -5678,6 +5688,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<List<ApiPendingShareRound>> crateApiVotingListPendingShareRounds({
+    required String dbPath,
+    required List<String> accountUuids,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_list_String(accountUuids, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 109,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_api_pending_share_round,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiVotingListPendingShareRoundsConstMeta,
+        argValues: [dbPath, accountUuids],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVotingListPendingShareRoundsConstMeta =>
+      const TaskConstMeta(
+        debugName: "list_pending_share_rounds",
+        argNames: ["dbPath", "accountUuids"],
+      );
+
+  @override
   Future<void> crateApiVotingMarkDelegationSubmitted({
     required String dbPath,
     required String accountUuid,
@@ -5697,7 +5742,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5740,7 +5785,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5797,7 +5842,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5863,7 +5908,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5933,7 +5978,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
             port: port_,
           );
         },
@@ -6004,7 +6049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -6054,7 +6099,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
           )!;
         },
         codec: SseCodec(
@@ -6085,7 +6130,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
             port: port_,
           );
         },
@@ -6118,7 +6163,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
             port: port_,
           );
         },
@@ -6161,7 +6206,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 119,
             port: port_,
           );
         },
@@ -6215,7 +6260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 120,
             port: port_,
           );
         },
@@ -6253,7 +6298,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 121,
             port: port_,
           );
         },
@@ -6298,7 +6343,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 122,
             port: port_,
           );
         },
@@ -6358,7 +6403,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 123,
             port: port_,
           );
         },
@@ -6418,7 +6463,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 124,
             port: port_,
           );
         },
@@ -6477,7 +6522,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 125,
             port: port_,
           );
         },
@@ -6530,7 +6575,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6589,7 +6634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6651,7 +6696,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6699,7 +6744,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6758,7 +6803,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6828,7 +6873,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6887,7 +6932,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6934,7 +6979,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6979,7 +7024,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 134,
             port: port_,
           );
         },
@@ -7009,7 +7054,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 135,
           )!;
         },
         codec: SseCodec(
@@ -7042,7 +7087,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 136,
             port: port_,
           );
         },
@@ -7079,7 +7124,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 137,
             port: port_,
           );
         },
@@ -7114,7 +7159,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 138,
             port: port_,
           );
         },
@@ -7156,7 +7201,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7191,7 +7236,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7232,7 +7277,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7281,7 +7326,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7319,7 +7364,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7374,7 +7419,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 144,
             port: port_,
           );
         },
@@ -7444,7 +7489,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7491,7 +7536,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
           )!;
         },
         codec: SseCodec(
@@ -7521,7 +7566,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
           )!;
         },
         codec: SseCodec(
@@ -7556,7 +7601,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
             port: port_,
           );
         },
@@ -7589,7 +7634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7611,6 +7656,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<List<String>> crateApiVotingShareResubmissionServerOrder({
+    required List<String> configuredServerUrls,
+    required List<String> sentToUrls,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_list_String(configuredServerUrls, serializer);
+          sse_encode_list_String(sentToUrls, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 150,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_String,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiVotingShareResubmissionServerOrderConstMeta,
+        argValues: [configuredServerUrls, sentToUrls],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVotingShareResubmissionServerOrderConstMeta =>
+      const TaskConstMeta(
+        debugName: "share_resubmission_server_order",
+        argNames: ["configuredServerUrls", "sentToUrls"],
+      );
+
+  @override
   Future<int> crateApiVotingShareTrackingFlags({
     required ShareDelegationRecordView share,
     required BigInt nowSeconds,
@@ -7629,7 +7709,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 151,
             port: port_,
           );
         },
@@ -7670,7 +7750,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7724,7 +7804,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7774,7 +7854,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 152,
+              funcId: 154,
               port: port_,
             );
           },
@@ -7815,7 +7895,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 153,
+              funcId: 155,
               port: port_,
             );
           },
@@ -7847,7 +7927,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7874,7 +7954,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 157,
           )!;
         },
         codec: SseCodec(
@@ -7900,7 +7980,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7942,7 +8022,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 159,
             port: port_,
           );
         },
@@ -7998,7 +8078,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8033,7 +8113,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 161,
             port: port_,
           );
         },
@@ -8072,7 +8152,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8108,7 +8188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8143,7 +8223,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8180,7 +8260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8224,7 +8304,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 166,
             port: port_,
           );
         },
@@ -8274,7 +8354,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8306,7 +8386,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8334,7 +8414,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 169,
           )!;
         },
         codec: SseCodec(
@@ -8366,7 +8446,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8403,7 +8483,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 171,
             port: port_,
           );
         },
@@ -8434,7 +8514,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 172,
           )!;
         },
         codec: SseCodec(
@@ -8465,7 +8545,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 173,
             port: port_,
           );
         },
@@ -8502,7 +8582,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 174,
             port: port_,
           );
         },
@@ -8669,6 +8749,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       txidHex: dco_decode_String(arr[0]),
       accountUuids: dco_decode_list_String(arr[1]),
       matched: dco_decode_bool(arr[2]),
+    );
+  }
+
+  @protected
+  ApiPendingShareRound dco_decode_api_pending_share_round(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return ApiPendingShareRound(
+      accountUuid: dco_decode_String(arr[0]),
+      roundId: dco_decode_String(arr[1]),
+      sessionJson: dco_decode_opt_String(arr[2]),
     );
   }
 
@@ -9336,6 +9429,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>)
         .map(dco_decode_api_keystone_signature_input)
+        .toList();
+  }
+
+  @protected
+  List<ApiPendingShareRound> dco_decode_list_api_pending_share_round(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_api_pending_share_round)
         .toList();
   }
 
@@ -11097,6 +11200,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ApiPendingShareRound sse_decode_api_pending_share_round(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_accountUuid = sse_decode_String(deserializer);
+    var var_roundId = sse_decode_String(deserializer);
+    var var_sessionJson = sse_decode_opt_String(deserializer);
+    return ApiPendingShareRound(
+      accountUuid: var_accountUuid,
+      roundId: var_roundId,
+      sessionJson: var_sessionJson,
+    );
+  }
+
+  @protected
   ApiSyncProgressEvent sse_decode_api_sync_progress_event(
     SseDeserializer deserializer,
   ) {
@@ -11876,6 +11994,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var ans_ = <ApiKeystoneSignatureInput>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_api_keystone_signature_input(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<ApiPendingShareRound> sse_decode_list_api_pending_share_round(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <ApiPendingShareRound>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_api_pending_share_round(deserializer));
     }
     return ans_;
   }
@@ -14267,6 +14399,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_api_pending_share_round(
+    ApiPendingShareRound self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.accountUuid, serializer);
+    sse_encode_String(self.roundId, serializer);
+    sse_encode_opt_String(self.sessionJson, serializer);
+  }
+
+  @protected
   void sse_encode_api_sync_progress_event(
     ApiSyncProgressEvent self,
     SseSerializer serializer,
@@ -14887,6 +15030,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
       sse_encode_api_keystone_signature_input(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_api_pending_share_round(
+    List<ApiPendingShareRound> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_api_pending_share_round(item, serializer);
     }
   }
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -83,6 +83,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ApiMempoolTxEvent dco_decode_api_mempool_tx_event(dynamic raw);
 
   @protected
+  ApiPendingShareRound dco_decode_api_pending_share_round(dynamic raw);
+
+  @protected
   ApiSyncProgressEvent dco_decode_api_sync_progress_event(dynamic raw);
 
   @protected
@@ -286,6 +289,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<ApiKeystoneSignatureInput> dco_decode_list_api_keystone_signature_input(
+    dynamic raw,
+  );
+
+  @protected
+  List<ApiPendingShareRound> dco_decode_list_api_pending_share_round(
     dynamic raw,
   );
 
@@ -849,6 +857,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ApiPendingShareRound sse_decode_api_pending_share_round(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   ApiSyncProgressEvent sse_decode_api_sync_progress_event(
     SseDeserializer deserializer,
   );
@@ -1110,6 +1123,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<ApiKeystoneSignatureInput> sse_decode_list_api_keystone_signature_input(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  List<ApiPendingShareRound> sse_decode_list_api_pending_share_round(
     SseDeserializer deserializer,
   );
 
@@ -1812,6 +1830,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_api_pending_share_round(
+    ApiPendingShareRound self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_api_sync_progress_event(
     ApiSyncProgressEvent self,
     SseSerializer serializer,
@@ -2126,6 +2150,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_list_api_keystone_signature_input(
     List<ApiKeystoneSignatureInput> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_api_pending_share_round(
+    List<ApiPendingShareRound> self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -85,6 +85,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ApiMempoolTxEvent dco_decode_api_mempool_tx_event(dynamic raw);
 
   @protected
+  ApiPendingShareRound dco_decode_api_pending_share_round(dynamic raw);
+
+  @protected
   ApiSyncProgressEvent dco_decode_api_sync_progress_event(dynamic raw);
 
   @protected
@@ -288,6 +291,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<ApiKeystoneSignatureInput> dco_decode_list_api_keystone_signature_input(
+    dynamic raw,
+  );
+
+  @protected
+  List<ApiPendingShareRound> dco_decode_list_api_pending_share_round(
     dynamic raw,
   );
 
@@ -851,6 +859,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ApiPendingShareRound sse_decode_api_pending_share_round(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   ApiSyncProgressEvent sse_decode_api_sync_progress_event(
     SseDeserializer deserializer,
   );
@@ -1112,6 +1125,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<ApiKeystoneSignatureInput> sse_decode_list_api_keystone_signature_input(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  List<ApiPendingShareRound> sse_decode_list_api_pending_share_round(
     SseDeserializer deserializer,
   );
 
@@ -1814,6 +1832,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_api_pending_share_round(
+    ApiPendingShareRound self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_api_sync_progress_event(
     ApiSyncProgressEvent self,
     SseSerializer serializer,
@@ -2128,6 +2152,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_list_api_keystone_signature_input(
     List<ApiKeystoneSignatureInput> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_api_pending_share_round(
+    List<ApiPendingShareRound> self,
     SseSerializer serializer,
   );
 

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -266,10 +266,14 @@ class VotingApiClient {
   }
 
   /// Checks whether a helper has confirmed a share identified by its nullifier.
+  ///
+  /// [isCancelled] is checked before each retry so lifecycle-owned polling can
+  /// stop without starting another request.
   Future<VotingShareStatus> getShareStatus({
     required String roundId,
     required Uri serverUrl,
     required String shareId,
+    bool Function()? isCancelled,
   }) async {
     final decoded = await _getJson(
       _endpoint([
@@ -279,6 +283,7 @@ class VotingApiClient {
       ], baseUrl: serverUrl),
       timeout: _helperTimeout,
       retryPolicy: _helperRetryPolicy,
+      isCancelled: isCancelled,
     );
     return VotingShareStatus.fromJson(_objectFromValue(decoded));
   }
@@ -287,7 +292,8 @@ class VotingApiClient {
   ///
   /// [shareId] is retained in the signature so call sites can keep the recovery
   /// key nearby, but the current helper endpoint accepts the same body as the
-  /// initial submission.
+  /// initial submission. This makes one transport attempt because a timeout is
+  /// ambiguous; the caller decides whether to try another helper or wait.
   Future<VotingShareSubmissionResult> resubmitShare({
     required Uri serverUrl,
     required String shareId,
@@ -297,7 +303,6 @@ class VotingApiClient {
       _endpoint(['shares'], baseUrl: serverUrl),
       share,
       timeout: _helperTimeout,
-      retryPolicy: _helperRetryPolicy,
     );
     return VotingShareSubmissionResult.fromJson(_objectFromValue(decoded));
   }
@@ -321,9 +326,11 @@ class VotingApiClient {
     Uri uri, {
     Duration? timeout,
     VotingRetryPolicy? retryPolicy,
+    bool Function()? isCancelled,
   }) async {
     final response = await _runRequestWithRetry(
       retryPolicy: retryPolicy,
+      isCancelled: isCancelled,
       operation: () async {
         final response = await _get(uri, timeout: timeout ?? _timeout);
         _throwIfNotSuccess(uri, response);
@@ -366,6 +373,7 @@ class VotingApiClient {
   Future<T> _runRequestWithRetry<T>({
     required Future<T> Function() operation,
     VotingRetryPolicy? retryPolicy,
+    bool Function()? isCancelled,
   }) {
     if (retryPolicy == null) {
       return operation();
@@ -374,6 +382,7 @@ class VotingApiClient {
       policy: retryPolicy,
       operation: operation,
       delay: _delay,
+      isCancelled: isCancelled,
     );
   }
 

--- a/lib/src/services/voting/voting_retry.dart
+++ b/lib/src/services/voting/voting_retry.dart
@@ -32,6 +32,7 @@ Future<T> withVotingRetry<T>({
   required VotingRetryPolicy policy,
   required Future<T> Function() operation,
   Future<void> Function(Duration delay)? delay,
+  bool Function()? isCancelled,
 }) async {
   final wait = delay ?? Future<void>.delayed;
   Object? lastError;
@@ -40,10 +41,13 @@ Future<T> withVotingRetry<T>({
       return await operation();
     } catch (error) {
       lastError = error;
-      if (attempt == policy.delays.length || !policy.shouldRetry(error)) {
+      if (attempt == policy.delays.length ||
+          !policy.shouldRetry(error) ||
+          (isCancelled?.call() ?? false)) {
         rethrow;
       }
       await wait(policy.delays[attempt]);
+      if (isCancelled?.call() ?? false) rethrow;
     }
   }
   throw StateError('${policy.name} retry exited unexpectedly: $lastError');

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6944,8 +6944,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d1048977b2b16cd9ec141fd4521266565a970d41df67d446a6d2dbefe329bd"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=7986b9cddf987c69e4a8ea23d3bb55c89e054910#7986b9cddf987c69e4a8ea23d3bb55c89e054910"
 dependencies = [
  "anyhow",
  "ff",
@@ -6961,8 +6960,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e818193fc3f7755ccd8d4ea713804a12f9743804737a4ef50a69dc26150b49e8"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=7986b9cddf987c69e4a8ea23d3bb55c89e054910#7986b9cddf987c69e4a8ea23d3bb55c89e054910"
 dependencies = [
  "base64",
  "ff",
@@ -7991,8 +7989,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c184a75b485d9d9d2c37dbf098306de7a33b4705d82ad0ca2b57361443966ab"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=7986b9cddf987c69e4a8ea23d3bb55c89e054910#7986b9cddf987c69e4a8ea23d3bb55c89e054910"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -158,6 +158,12 @@ zcash_note_encryption = "0.4"
 [dev-dependencies.vote-commitment-tree]
 version = "=0.5.0"
 
+# Temporary pending-share discovery API until the next zcash_voting release.
+[patch.crates-io]
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7986b9cddf987c69e4a8ea23d3bb55c89e054910" }
+vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7986b9cddf987c69e4a8ea23d3bb55c89e054910" }
+vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7986b9cddf987c69e4a8ea23d3bb55c89e054910" }
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)', 'cfg(ironwood_masquerade)'] }
 

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1,4 +1,4 @@
-use std::{panic, sync::Arc};
+use std::{panic, path::Path, sync::Arc};
 
 #[cfg(test)]
 use super::voting_helpers::bundle_policy;
@@ -145,6 +145,14 @@ pub struct ApiKeystoneSignatureBatchResult {
     pub already_present: u32,
 }
 
+/// One account and round with durable unconfirmed helper shares.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ApiPendingShareRound {
+    pub account_uuid: String,
+    pub round_id: String,
+    pub session_json: Option<String>,
+}
+
 /// Returns the vote-chain delegation submission body as validated wire JSON.
 ///
 /// Binary fields are base64-encoded here so Dart does not duplicate protocol
@@ -240,6 +248,29 @@ pub fn plan_share_submissions(
         .map_err(|e| e.to_string())?;
 
         Ok(plans)
+    })
+}
+
+/// Return the crate-owned randomized helper order for one share retry.
+pub fn share_resubmission_server_order(
+    configured_server_urls: Vec<String>,
+    sent_to_urls: Vec<String>,
+) -> Result<Vec<String>, String> {
+    catch(|| {
+        let required = zcash_voting::share_policy::resubmission_server_order_random_bytes_required(
+            &configured_server_urls,
+            &sent_to_urls,
+        );
+        let mut random_bytes = vec![0u8; required];
+        OsRng
+            .try_fill_bytes(&mut random_bytes)
+            .map_err(|e| format!("failed to draw share-resubmission entropy: {e}"))?;
+        zcash_voting::share_policy::resubmission_server_order(
+            &configured_server_urls,
+            &sent_to_urls,
+            &random_bytes,
+        )
+        .map_err(|e| e.to_string())
     })
 }
 
@@ -1290,6 +1321,44 @@ pub fn delete_voting_account_state(db_path: String, account_uuid: String) -> Res
     })
 }
 
+/// Lists account/round pairs with durable unconfirmed helper shares.
+///
+/// The opaque session JSON is returned for caller-owned deadline checks. The
+/// sidecar is not created when the wallet has never persisted voting state.
+pub fn list_pending_share_rounds(
+    db_path: String,
+    mut account_uuids: Vec<String>,
+) -> Result<Vec<ApiPendingShareRound>, String> {
+    catch(|| {
+        let sidecar_path =
+            zcash_voting::storage::VotingDb::wallet_sidecar_path(Path::new(&db_path));
+        if !sidecar_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        account_uuids.retain(|account_uuid| !account_uuid.is_empty());
+        account_uuids.sort();
+        account_uuids.dedup();
+        let mut pending = Vec::new();
+        for account_uuid in account_uuids {
+            let db = db::open_voting_db(&db_path, &account_uuid)?;
+            for round in zcash_voting::share::pending_rounds(&db)
+                .map_err(|e| format!("list pending voting share rounds failed: {e}"))?
+            {
+                pending.push(ApiPendingShareRound {
+                    account_uuid: account_uuid.clone(),
+                    round_id: round.round_id,
+                    session_json: round.session_json,
+                });
+            }
+        }
+        pending.sort_by(|left, right| {
+            (&left.account_uuid, &left.round_id).cmp(&(&right.account_uuid, &right.round_id))
+        });
+        Ok(pending)
+    })
+}
+
 /// Recover a committed but unsubmitted vote from persisted local recovery data.
 ///
 /// # Errors
@@ -2197,6 +2266,25 @@ mod tests {
     }
 
     #[test]
+    fn share_resubmission_order_uses_crate_policy() {
+        let configured = vec![
+            "https://helper-a.example".to_string(),
+            "https://helper-b.example".to_string(),
+            "https://helper-c.example".to_string(),
+        ];
+        let sent = vec!["https://helper-a.example".to_string()];
+        let order = share_resubmission_server_order(configured.clone(), sent.clone()).unwrap();
+
+        let mut sorted_order = order.clone();
+        sorted_order.sort();
+        let mut sorted_configured = configured;
+        sorted_configured.sort();
+        assert_eq!(sorted_order, sorted_configured);
+        assert!(!sent.contains(&order[0]));
+        assert_eq!(order.last(), sent.first());
+    }
+
+    #[test]
     fn api_van_witness_preserves_core_fields() {
         let mut witness = vec![vec![0u8; 32]; zcash_voting::vote::VAN_AUTH_PATH_LEN];
         witness[0] = vec![1; 32];
@@ -2802,6 +2890,56 @@ mod tests {
         assert!(target_db.list_rounds().unwrap().is_empty());
         assert_eq!(other_db.list_rounds().unwrap().len(), 1);
         assert_eq!(other_db.get_bundle_count(ROUND_ID).unwrap(), 1);
+    }
+
+    #[test]
+    fn list_pending_share_rounds_preserves_session_context() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let sidecar_path = zcash_voting::storage::VotingDb::wallet_sidecar_path(&db_path);
+        assert!(list_pending_share_rounds(
+            db_path.to_str().unwrap().to_string(),
+            vec![TEST_ACCOUNT_UUID.to_string()],
+        )
+        .unwrap()
+        .is_empty());
+        assert!(!sidecar_path.exists());
+
+        let session_json = r#"{"vote_end_time":4102444800}"#;
+        let db = db::open_voting_db(db_path.to_str().unwrap(), TEST_ACCOUNT_UUID).unwrap();
+        db.init_round(
+            zcash_voting::Network::Regtest,
+            &test_api_round_params(),
+            Some(session_json),
+        )
+        .unwrap();
+        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        seed_recovery_vote(&db, TEST_ACCOUNT_UUID, 0, 7, 1, 88);
+        drop(db);
+        record_share_delegation(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+            0,
+            7,
+            0,
+            vec!["https://helper.example".to_string()],
+            123,
+        )
+        .unwrap();
+
+        assert_eq!(
+            list_pending_share_rounds(
+                db_path.to_str().unwrap().to_string(),
+                vec![TEST_ACCOUNT_UUID.to_string(), TEST_ACCOUNT_UUID.to_string()],
+            )
+            .unwrap(),
+            vec![ApiPendingShareRound {
+                account_uuid: TEST_ACCOUNT_UUID.to_string(),
+                round_id: ROUND_ID.to_string(),
+                session_json: Some(session_json.to_string()),
+            }]
+        );
     }
 
     #[test]

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1626111918;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1596187728;
 
 // Section: executor
 
@@ -4253,6 +4253,43 @@ fn wire__crate__api__wallet__list_accounts_impl(
         },
     )
 }
+fn wire__crate__api__voting__list_pending_share_rounds_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "list_pending_share_rounds",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuids = <Vec<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::list_pending_share_rounds(
+                        api_db_path,
+                        api_account_uuids,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__voting__mark_delegation_submitted_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -5946,6 +5983,43 @@ fn wire__crate__api__voting__setup_delegation_bundles_impl(
         },
     )
 }
+fn wire__crate__api__voting__share_resubmission_server_order_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "share_resubmission_server_order",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_configured_server_urls = <Vec<String>>::sse_decode(&mut deserializer);
+            let api_sent_to_urls = <Vec<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::share_resubmission_server_order(
+                        api_configured_server_urls,
+                        api_sent_to_urls,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__voting__share_tracking_flags_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -7389,6 +7463,20 @@ impl SseDecode for crate::api::sync::ApiMempoolTxEvent {
     }
 }
 
+impl SseDecode for crate::api::voting::ApiPendingShareRound {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_accountUuid = <String>::sse_decode(deserializer);
+        let mut var_roundId = <String>::sse_decode(deserializer);
+        let mut var_sessionJson = <Option<String>>::sse_decode(deserializer);
+        return crate::api::voting::ApiPendingShareRound {
+            account_uuid: var_accountUuid,
+            round_id: var_roundId,
+            session_json: var_sessionJson,
+        };
+    }
+}
+
 impl SseDecode for crate::api::sync::ApiSyncProgressEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -8039,6 +8127,20 @@ impl SseDecode for Vec<crate::api::voting::ApiKeystoneSignatureInput> {
         let mut ans_ = vec![];
         for idx_ in 0..len_ {
             ans_.push(<crate::api::voting::ApiKeystoneSignatureInput>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<crate::api::voting::ApiPendingShareRound> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::voting::ApiPendingShareRound>::sse_decode(
                 deserializer,
             ));
         }
@@ -10313,63 +10415,65 @@ fn pde_ffi_dispatcher_primary_impl(
 102 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
 106 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
 108 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-116 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-117 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
-119 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-135 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-172 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+117 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+118 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+136 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+148 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+174 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10407,17 +10511,17 @@ fn pde_ffi_dispatcher_sync_impl(
         107 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        115 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        134 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        145 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        116 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        135 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        146 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        146 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        155 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        167 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        170 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        147 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        157 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        169 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        172 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -10597,6 +10701,28 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ApiMempoolTxEvent>
     for crate::api::sync::ApiMempoolTxEvent
 {
     fn into_into_dart(self) -> crate::api::sync::ApiMempoolTxEvent {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::voting::ApiPendingShareRound {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.account_uuid.into_into_dart().into_dart(),
+            self.round_id.into_into_dart().into_dart(),
+            self.session_json.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::voting::ApiPendingShareRound
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::voting::ApiPendingShareRound>
+    for crate::api::voting::ApiPendingShareRound
+{
+    fn into_into_dart(self) -> crate::api::voting::ApiPendingShareRound {
         self
     }
 }
@@ -13253,6 +13379,15 @@ impl SseEncode for crate::api::sync::ApiMempoolTxEvent {
     }
 }
 
+impl SseEncode for crate::api::voting::ApiPendingShareRound {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.account_uuid, serializer);
+        <String>::sse_encode(self.round_id, serializer);
+        <Option<String>>::sse_encode(self.session_json, serializer);
+    }
+}
+
 impl SseEncode for crate::api::sync::ApiSyncProgressEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -13693,6 +13828,16 @@ impl SseEncode for Vec<crate::api::voting::ApiKeystoneSignatureInput> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <crate::api::voting::ApiKeystoneSignatureInput>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<crate::api::voting::ApiPendingShareRound> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::voting::ApiPendingShareRound>::sse_encode(item, serializer);
         }
     }
 }

--- a/rust/src/wallet/voting/README.md
+++ b/rust/src/wallet/voting/README.md
@@ -162,6 +162,16 @@ submission. The canonical scheduling/retry/polling policy lives in the crate's
 `share_tracking_flags`, and `next_share_tracking_delay_seconds` helpers exposed
 through `api/voting.rs`.
 
+Accepted shares remain tracked after the vote screen closes. On launch, unlock,
+and resume, Vizor asks `zcash_voting::share::pending_rounds` for durable
+unconfirmed rounds and rejects expired or unauthenticated entries before
+restoring a session. A restored session checks only helpers still present in
+the current config and retains itself while work remains. Overdue shares use
+the crate's randomized resubmission order and stop after the first helper
+accepts; an ambiguous POST timeout is not repeated automatically. Lock, account
+deletion, and wallet reset stop and drain active checks before protected state
+changes.
+
 ## Wire Types And FRB Scanning
 
 `zcash_voting::wire` is the canonical owner of protocol wire JSON and wallet view

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart' show ProviderListenable;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/security/software_wallet_secret.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_submission_guard_provider.dart';
@@ -20,6 +21,8 @@ import 'package:zcash_wallet/src/providers/voting/voting_config_source_provider.
 import 'package:zcash_wallet/src/providers/voting/voting_rounds_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_service_providers.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_session_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_share_tracking_registry_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_share_tracking_restorer_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_state.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_tree_sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/voting.dart' as rust_api;
@@ -599,58 +602,62 @@ void main() {
     },
   );
 
-  test('config switch defers session invalidation during submission', () async {
-    var refreshCount = 0;
-    final roundProvider = votingSessionProvider(kRoundId);
-    const submissionKey = VotingSessionKey(
-      roundId: kRoundId,
-      accountUuid: 'account-1',
-    );
-    final submissionProvider = votingSubmissionSessionProvider(submissionKey);
-    final roundObserver = _ProviderDisposalObserver(roundProvider);
-    final submissionObserver = _ProviderDisposalObserver(submissionProvider);
-    final container = _sessionContainer(
-      observers: [roundObserver, submissionObserver],
-      configSwitchKind: (previous) => refreshCount++ == 0
-          ? rust_config.ConfigSwitchKind.initialLoad
-          : rust_config.ConfigSwitchKind.newChainOrRound,
-    );
-    addTearDown(container.dispose);
+  test(
+    'config switch defers interactive session invalidation during submission',
+    () async {
+      var refreshCount = 0;
+      final roundProvider = votingSessionProvider(kRoundId);
+      const submissionKey = VotingSessionKey(
+        roundId: kRoundId,
+        accountUuid: 'account-1',
+      );
+      final submissionProvider = votingSubmissionSessionProvider(submissionKey);
+      final roundObserver = _ProviderDisposalObserver(roundProvider);
+      final submissionObserver = _ProviderDisposalObserver(submissionProvider);
+      final container = _sessionContainer(
+        observers: [roundObserver, submissionObserver],
+        configSwitchKind: (previous) => refreshCount++ == 0
+            ? rust_config.ConfigSwitchKind.initialLoad
+            : rust_config.ConfigSwitchKind.newChainOrRound,
+      );
+      addTearDown(container.dispose);
 
-    final guard = container
-        .read(votingSubmissionGuardProvider.notifier)
-        .acquire(accountUuid: 'account-1', roundId: kRoundId);
-    addTearDown(() {
+      final guard = container
+          .read(votingSubmissionGuardProvider.notifier)
+          .acquire(accountUuid: 'account-1', roundId: kRoundId);
+      addTearDown(() {
+        container.read(votingSubmissionGuardProvider.notifier).release(guard);
+      });
+      final roundSubscription = container
+          .listen<AsyncValue<VotingSessionState>>(
+            roundProvider,
+            (_, _) {},
+            fireImmediately: true,
+          );
+      addTearDown(roundSubscription.close);
+      final submissionSubscription = container
+          .listen<AsyncValue<VotingSessionState>>(
+            submissionProvider,
+            (_, _) {},
+            fireImmediately: true,
+          );
+      addTearDown(submissionSubscription.close);
+      await container.read(roundProvider.future);
+      await container.read(submissionProvider.future);
+
+      await container.read(votingConfigProvider.notifier).refresh();
+      await container.pump();
+
+      expect(roundObserver.disposed, isFalse);
+      expect(submissionObserver.disposed, isFalse);
+
       container.read(votingSubmissionGuardProvider.notifier).release(guard);
-    });
-    final roundSubscription = container.listen<AsyncValue<VotingSessionState>>(
-      roundProvider,
-      (_, _) {},
-      fireImmediately: true,
-    );
-    addTearDown(roundSubscription.close);
-    final submissionSubscription = container
-        .listen<AsyncValue<VotingSessionState>>(
-          submissionProvider,
-          (_, _) {},
-          fireImmediately: true,
-        );
-    addTearDown(submissionSubscription.close);
-    await container.read(roundProvider.future);
-    await container.read(submissionProvider.future);
+      await container.pump();
 
-    await container.read(votingConfigProvider.notifier).refresh();
-    await container.pump();
-
-    expect(roundObserver.disposed, isFalse);
-    expect(submissionObserver.disposed, isFalse);
-
-    container.read(votingSubmissionGuardProvider.notifier).release(guard);
-    await container.pump();
-
-    expect(roundObserver.disposed, isTrue);
-    expect(submissionObserver.disposed, isTrue);
-  });
+      expect(roundObserver.disposed, isTrue);
+      expect(submissionObserver.disposed, isFalse);
+    },
+  );
 
   test('config switch unchanged keeps rounds provider cache', () async {
     final http = FakeVotingHttpClient(
@@ -2973,6 +2980,7 @@ void main() {
   test(
     'submitted delegation recovery continues pending share recovery',
     () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       final shareNullifier = Uint8List.fromList(List.filled(32, 1));
       final shareId = _hexFromBytes(shareNullifier);
       final acceptedShare = rust_frb_types.ShareDelegationRecordView(
@@ -2991,6 +2999,10 @@ void main() {
       final http = FakeVotingHttpClient(
         responses:
             votingHttpResponses(
+              roundStatus: roundStatusJson(
+                roundId: kRoundId,
+                voteEnd: nowSeconds + 1000,
+              ),
               dynamicConfig: dynamicConfigJson(
                 voteServers: const [
                   {'url': 'https://helper-a.example', 'label': 'helper-a'},
@@ -4637,7 +4649,145 @@ void main() {
     },
   );
 
+  test(
+    'expired persisted shares stop before config or round requests',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final http = FakeVotingHttpClient();
+      final container = _sessionContainer(
+        http: http,
+        pendingShareRoundLoader:
+            ({required dbPath, required accountUuids}) async {
+              return [
+                rust_api.ApiPendingShareRound(
+                  accountUuid: 'account-1',
+                  roundId: kRoundId,
+                  sessionJson: jsonEncode({'vote_end_time': nowSeconds - 1}),
+                ),
+              ];
+            },
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingShareTrackingRestorerProvider).restore();
+
+      expect(http.requests, isEmpty);
+    },
+  );
+
+  test('restores persisted share tracking without opening the vote', () async {
+    final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    const unknownRoundId =
+        'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+    final pendingShare = rust_wire.ShareDelegationRecordView(
+      roundId: kRoundId,
+      bundleIndex: 0,
+      proposalId: 7,
+      shareIndex: 0,
+      sentToUrls: const ['https://helper-a.example'],
+      nullifier: Uint8List.fromList(List.filled(32, 2)),
+      phase: VotingWorkflowPhase.submittedShare,
+      confirmed: false,
+      submitAt: BigInt.zero,
+      createdAt: BigInt.from(nowSeconds - 1000),
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        delegationTxHashes: [
+          const rust_wire.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.submittedDelegation,
+            txHash: 'delegation-0',
+            vanLeafPosition: null,
+          ),
+        ],
+        commitmentBundles: [
+          rust_wire.RecoverableCommitmentBundle(
+            bundleIndex: 0,
+            proposalId: 7,
+            commitmentBundleJson: commitmentBundleRecoveryJson(),
+            vcTreePosition: BigInt.from(42),
+          ),
+        ],
+        shareDelegations: [pendingShare],
+        unconfirmedShareDelegations: [pendingShare],
+      ),
+    );
+    final shareId = _hexFromBytes(pendingShare.nullifier);
+    final http = FakeVotingHttpClient(
+      responses:
+          votingHttpResponses(
+            roundStatus: roundStatusJson(
+              roundId: kRoundId,
+              voteEnd: nowSeconds + 1000,
+            ),
+            dynamicConfig: dynamicConfigJson(
+              voteServers: const [
+                {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                {'url': 'https://helper-b.example', 'label': 'helper-b'},
+              ],
+            ),
+          )..addAll({
+            'https://helper-a.example/shielded-vote/v1/share-status/$kRoundId/$shareId':
+                {'status': 'pending'},
+          }),
+    );
+    final container = _sessionContainer(
+      http: http,
+      recoveryApi: recoveryApi,
+      pendingShareRoundLoader:
+          ({required dbPath, required accountUuids}) async {
+            return [
+              rust_api.ApiPendingShareRound(
+                accountUuid: 'account-1',
+                roundId: kRoundId,
+                sessionJson: jsonEncode({'vote_end_time': nowSeconds + 1000}),
+              ),
+              rust_api.ApiPendingShareRound(
+                accountUuid: 'account-1',
+                roundId: kOtherRoundId,
+                sessionJson: jsonEncode({'vote_end_time': nowSeconds - 1}),
+              ),
+              rust_api.ApiPendingShareRound(
+                accountUuid: 'account-1',
+                roundId: unknownRoundId,
+                sessionJson: jsonEncode({'vote_end_time': nowSeconds + 1000}),
+              ),
+            ];
+          },
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingShareTrackingRestorerProvider).restore();
+
+    expect(
+      http.requests.where(
+        (request) =>
+            request.method == 'POST' &&
+            request.uri.host == 'helper-b.example' &&
+            request.uri.path == '/shielded-vote/v1/shares',
+      ),
+      hasLength(1),
+    );
+    final roundRequests = http.requests.where(
+      (request) => request.uri.path.contains('/shielded-vote/v1/round/'),
+    );
+    expect(roundRequests, isNotEmpty);
+    expect(
+      roundRequests.every((request) => request.uri.path.endsWith(kRoundId)),
+      isTrue,
+    );
+    final registry = container.read(votingShareTrackingRegistryProvider);
+    expect(registry.registeredKeys, {
+      const VotingSessionKey(accountUuid: 'account-1', roundId: kRoundId),
+    });
+
+    await registry.quiesceAndDrain();
+    expect(registry.registeredKeys, isEmpty);
+  });
+
   test('accepted unconfirmed shares confirm from any accepted helper', () async {
+    final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final shareNullifier = Uint8List.fromList(List.filled(32, 1));
     final shareId = _hexFromBytes(shareNullifier);
     final acceptedShare = rust_frb_types.ShareDelegationRecordView(
@@ -4646,6 +4796,7 @@ void main() {
       proposalId: 7,
       shareIndex: 0,
       sentToUrls: const [
+        'https://removed-helper.example',
         'https://helper-a.example',
         'https://helper-b.example',
       ],
@@ -4671,23 +4822,30 @@ void main() {
       ),
     );
     final rust = FakeVotingRustApi();
+    final http = FakeVotingHttpClient(
+      responses:
+          votingHttpResponses(
+            roundStatus: roundStatusJson(
+              roundId: kRoundId,
+              voteEnd: nowSeconds + 1000,
+            ),
+            dynamicConfig: dynamicConfigJson(
+              voteServers: const [
+                {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                {'url': 'https://helper-b.example', 'label': 'helper-b'},
+              ],
+            ),
+          )..addAll({
+            'https://removed-helper.example/shielded-vote/v1/share-status/$kRoundId/$shareId':
+                {'status': 'confirmed'},
+            'https://helper-a.example/shielded-vote/v1/share-status/$kRoundId/$shareId':
+                {'status': 'pending'},
+            'https://helper-b.example/shielded-vote/v1/share-status/$kRoundId/$shareId':
+                {'status': 'confirmed'},
+          }),
+    );
     final container = _sessionContainer(
-      http: FakeVotingHttpClient(
-        responses:
-            votingHttpResponses(
-              dynamicConfig: dynamicConfigJson(
-                voteServers: const [
-                  {'url': 'https://helper-a.example', 'label': 'helper-a'},
-                  {'url': 'https://helper-b.example', 'label': 'helper-b'},
-                ],
-              ),
-            )..addAll({
-              'https://helper-a.example/shielded-vote/v1/share-status/$kRoundId/$shareId':
-                  {'status': 'pending'},
-              'https://helper-b.example/shielded-vote/v1/share-status/$kRoundId/$shareId':
-                  {'status': 'confirmed'},
-            }),
-      ),
+      http: http,
       rust: rust,
       recoveryApi: recoveryApi,
     );
@@ -4702,6 +4860,12 @@ void main() {
     expect(state.phase, VotingSessionPhase.done);
     expect(state.resumePlan?.unconfirmedShareDelegations, [acceptedShare]);
     expect(rust.confirmedShares, ['0:7:0']);
+    expect(
+      http.requests.where(
+        (request) => request.uri.host == 'removed-helper.example',
+      ),
+      isEmpty,
+    );
   });
 
   test(
@@ -4738,6 +4902,10 @@ void main() {
       );
       final http = FakeVotingHttpClient(
         responses: votingHttpResponses(
+          roundStatus: roundStatusJson(
+            roundId: kRoundId,
+            voteEnd: nowSeconds + 1000,
+          ),
           dynamicConfig: dynamicConfigJson(
             voteServers: const [
               {'url': 'https://helper-a.example', 'label': 'helper-a'},
@@ -5217,6 +5385,7 @@ ProviderContainer _sessionContainer({
   VotingWalletSyncReadinessChecker? walletSyncReadinessChecker,
   void Function()? walletSyncStarter,
   Duration? walletSyncPollInterval,
+  VotingPendingShareRoundLoader? pendingShareRoundLoader,
   List<String> authenticatedRoundIds = const [kRoundId, kOtherRoundId],
   Map<String, Uint8List>? authenticatedRoundEaPks,
   List<String> skippedRoundIds = const [],
@@ -5230,6 +5399,7 @@ ProviderContainer _sessionContainer({
   return ProviderContainer(
     observers: observers,
     overrides: [
+      appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
       votingConfigSourceStoreProvider.overrideWithValue(
         FakeVotingConfigSourceStore(),
       ),
@@ -5256,6 +5426,10 @@ ProviderContainer _sessionContainer({
         ),
       ),
       votingWalletDbPathProvider.overrideWithValue(() async => 'wallet.db'),
+      if (pendingShareRoundLoader != null)
+        votingPendingShareRoundLoaderProvider.overrideWithValue(
+          pendingShareRoundLoader,
+        ),
       votingActiveAccountUuidProvider.overrideWith((ref) {
         final activeAccountUuidFromProvider =
             activeAccountUuidListenable == null
@@ -7091,6 +7265,18 @@ class FakeVotingRustApi implements VotingRustApi {
           targetCount: targetCount,
           targetServers: serverUrls.take(targetCount).toList(growable: false),
         ),
+    ];
+  }
+
+  @override
+  Future<List<String>> shareResubmissionServerOrder({
+    required List<String> configuredServerUrls,
+    required List<String> sentToUrls,
+  }) async {
+    final sent = sentToUrls.toSet();
+    return [
+      ...configuredServerUrls.where((url) => !sent.contains(url)),
+      ...configuredServerUrls.where(sent.contains),
     ];
   }
 

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -823,6 +823,40 @@ void main() {
     expect(delays, const [Duration(milliseconds: 2)]);
   });
 
+  test('does not repeat a resubmission after an ambiguous timeout', () async {
+    final delays = <Duration>[];
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://helper.example/shielded-vote/v1/shares':
+            SequentialVotingHttpResponses([
+              timeoutResponse(),
+              {'status': 'queued'},
+            ]),
+      },
+    );
+    final client = VotingApiClient(
+      baseUrl: Uri.parse('https://voting.valargroup.org'),
+      httpClient: http,
+      helperRetryPolicy: VotingRetryPolicy.transientHttp(
+        name: 'test-helper-retry',
+        delays: const [Duration(milliseconds: 2)],
+      ),
+      delay: (delay) async => delays.add(delay),
+    );
+
+    await expectLater(
+      client.resubmitShare(
+        serverUrl: Uri.parse('https://helper.example'),
+        shareId: 'share-1',
+        share: {'share_index': 0, 'vote_round_id': hexRoundId},
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+
+    expect(http.requests, hasLength(1));
+    expect(delays, isEmpty);
+  });
+
   test('helper responses require known status values', () async {
     final acceptedClient = VotingApiClient(
       baseUrl: Uri.parse('https://voting.valargroup.org'),

--- a/test/services/voting/voting_retry_test.dart
+++ b/test/services/voting/voting_retry_test.dart
@@ -83,4 +83,27 @@ void main() {
     );
     expect(attempts, 1);
   });
+
+  test('does not start another attempt after cancellation', () async {
+    var attempts = 0;
+    var cancelled = false;
+
+    await expectLater(
+      withVotingRetry<void>(
+        policy: VotingRetryPolicy.transientHttp(
+          name: 'cancelled',
+          delays: const [Duration(milliseconds: 1)],
+        ),
+        operation: () async {
+          attempts++;
+          throw TimeoutException('timed out');
+        },
+        delay: (_) async => cancelled = true,
+        isCancelled: () => cancelled,
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+
+    expect(attempts, 1);
+  });
 }


### PR DESCRIPTION
Vizor keeps accepted helper-share checks alive after the vote screen closes and restores pending rounds from durable zcash_voting state on launch, unlock, and resume. Expired or unauthenticated rounds stop before helper requests; lock, account deletion, and wallet reset drain active checks.

Retries use zcash_voting timing and randomized helper ordering, check only helpers still in the current config, stop after the first accepted retry, and do not repeat an ambiguous POST. The branch temporarily pins the coherent 3.0 crate family to the pending-round API revision.

Targeted Flutter and full Rust suites cover restart discovery, ended-round filtering, one-helper retry, config changes, and lifecycle draining. The unchanged helper/chain path was also exercised on a disposable localnet through one committed reveal and a clean restart.