### PR TITLE
perf: isolate interpolated sync display progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,6 +362,12 @@ SyncProvider (sync_provider.dart)
   ├── Polling pauses on app background (onHide), resumes on foreground (onResume)
   ├── refreshAfterSend() called after account switch for immediate update
   └── refreshAfterUnlock() refreshes balances/history before foreground sync recovery
+
+SyncDisplayPercentageProvider (sync_display_progress_provider.dart)
+  ├── Owns the 20 ms UI-only interpolation timer between Rust progress events
+  ├── Watches only authoritative progress targets from SyncProvider
+  ├── Exposes raw interpolated progress only to smooth progress indicators
+  └── Exposes whole percentages to labels so unrelated UI does not rebuild per tick
 ```
 
 ### App Bootstrap

--- a/lib/src/core/formatting/sync_status_label.dart
+++ b/lib/src/core/formatting/sync_status_label.dart
@@ -16,7 +16,7 @@ class SyncStatusLabel {
   final String label;
   final String semanticsLabel;
 
-  factory SyncStatusLabel.from(SyncState sync) {
+  factory SyncStatusLabel.from(SyncState sync, {int? displayWholePercentage}) {
     final failure = sync.failure;
     if (failure != null) {
       final reason = _syncFailureReason(failure.kind);
@@ -33,7 +33,9 @@ class SyncStatusLabel {
             (sync.chainTipHeight > 0 &&
                 sync.scannedHeight >= sync.chainTipHeight));
     if (!complete && (sync.isSyncing || sync.isBackgroundMode)) {
-      final pct = formatSyncStatusPercentage(sync.displayPercentage);
+      final pct =
+          displayWholePercentage?.clamp(0, 99).toString() ??
+          formatSyncStatusPercentage(sync.percentage);
       return SyncStatusLabel(
         kind: SyncStatusKind.syncing,
         label: '$pct% Syncing...',

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -12,6 +12,7 @@ import '../../providers/account_provider.dart';
 import '../../providers/app_security_provider.dart';
 import '../../providers/privacy_mode_provider.dart';
 import '../../providers/receive_address_provider.dart';
+import '../../providers/sync_display_progress_provider.dart';
 import '../../providers/sync_provider.dart';
 import '../../providers/voting/voting_rounds_provider.dart';
 import '../../providers/voting/voting_submission_guard_provider.dart';
@@ -1479,16 +1480,16 @@ class _SidebarPopoverHoverTargetState
 /// added. (The mobile top-nav has the same effect with its own colors; the
 /// small shimmer/motion helpers are intentionally duplicated rather than
 /// shared so the two surfaces ship as independent changes.)
-class _SidebarSyncStatus extends StatefulWidget {
+class _SidebarSyncStatus extends ConsumerStatefulWidget {
   const _SidebarSyncStatus({required this.sync});
 
   final SyncState sync;
 
   @override
-  State<_SidebarSyncStatus> createState() => _SidebarSyncStatusState();
+  ConsumerState<_SidebarSyncStatus> createState() => _SidebarSyncStatusState();
 }
 
-class _SidebarSyncStatusState extends State<_SidebarSyncStatus>
+class _SidebarSyncStatusState extends ConsumerState<_SidebarSyncStatus>
     with SingleTickerProviderStateMixin {
   static const _height = 32.0;
   static const _indicatorWidth = 5.0;
@@ -1551,7 +1552,10 @@ class _SidebarSyncStatusState extends State<_SidebarSyncStatus>
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final status = SyncStatusLabel.from(widget.sync);
+    final status = SyncStatusLabel.from(
+      widget.sync,
+      displayWholePercentage: ref.watch(syncDisplayWholePercentageProvider),
+    );
     final syncedHeight =
         status.kind == SyncStatusKind.synced &&
             widget.sync.isSyncComplete &&

--- a/lib/src/core/layout/mobile/mobile_top_nav_account.dart
+++ b/lib/src/core/layout/mobile/mobile_top_nav_account.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../providers/account_provider.dart';
+import '../../../providers/sync_display_progress_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../formatting/sync_status_label.dart';
 import '../../profile_pictures.dart';
@@ -29,7 +30,10 @@ class MobileTopNavAccount extends ConsumerWidget {
     final colors = context.colors;
     final account = ref.watch(accountProvider).value?.activeAccount;
     final sync = ref.watch(syncProvider).value ?? SyncState();
-    final status = SyncStatusLabel.from(sync);
+    final status = SyncStatusLabel.from(
+      sync,
+      displayWholePercentage: ref.watch(syncDisplayWholePercentageProvider),
+    );
 
     final isSyncing = status.kind == SyncStatusKind.syncing;
     // Synced reads fully green: label `sync.text` (GreenPrimitives.p900) +

--- a/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
@@ -9,8 +9,8 @@ import '../../../features/onboarding/mobile/passcode_widgets.dart';
 import '../../../features/onboarding/shared/onboarding_welcome_art.dart';
 import '../../../providers/app_security_provider.dart';
 import '../../../providers/biometric_unlock_provider.dart';
+import '../../../providers/sync_display_progress_provider.dart';
 import '../../../providers/sync_keep_awake_provider.dart';
-import '../../../providers/sync_provider.dart';
 import '../../../services/biometric_unlock.dart';
 import '../../feedback/app_haptics.dart';
 import '../../formatting/sync_status_label.dart';
@@ -360,15 +360,9 @@ class _SyncKeepAwakeStatusScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.colors;
-    final done = mode == SyncKeepAwakePrivacyLockMode.done;
-    final interrupted = mode == SyncKeepAwakePrivacyLockMode.interrupted;
-    final sync = done || interrupted
-        ? null
-        : ref.watch(syncProvider).asData?.value;
     final biometric =
         ref.watch(biometricUnlockProvider).value ??
         BiometricUnlockState.initial;
-    final progress = sync?.displayPercentage ?? sync?.percentage ?? 0.0;
     final main = switch (mode) {
       SyncKeepAwakePrivacyLockMode.done => const _SyncKeepAwakeStatusLockup(
         iconName: AppIcons.checkCircle,
@@ -386,9 +380,8 @@ class _SyncKeepAwakeStatusScreen extends ConsumerWidget {
           success: false,
         ),
       SyncKeepAwakePrivacyLockMode.hidden ||
-      SyncKeepAwakePrivacyLockMode.syncing => _SyncKeepAwakeProgressLockup(
-        progress: progress,
-      ),
+      SyncKeepAwakePrivacyLockMode.syncing =>
+        const _SyncKeepAwakeDisplayProgressLockup(),
     };
     final semanticsLabel = switch (mode) {
       SyncKeepAwakePrivacyLockMode.done => 'Vizor is synced',
@@ -493,6 +486,17 @@ class _SyncKeepAwakeStatusScreen extends ConsumerWidget {
   }
 }
 
+class _SyncKeepAwakeDisplayProgressLockup extends ConsumerWidget {
+  const _SyncKeepAwakeDisplayProgressLockup();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return _SyncKeepAwakeProgressLockup(
+      progress: ref.watch(syncDisplayPercentageProvider),
+    );
+  }
+}
+
 class _SyncKeepAwakeLayoutSpec {
   const _SyncKeepAwakeLayoutSpec({
     required this.logoToMainGap,
@@ -576,7 +580,7 @@ class _SyncKeepAwakeVerticalLayout {
   final double mainToButtonGap;
 }
 
-class _SyncKeepAwakePasscodeConfirmScreen extends ConsumerWidget {
+class _SyncKeepAwakePasscodeConfirmScreen extends StatelessWidget {
   const _SyncKeepAwakePasscodeConfirmScreen({
     required this.mode,
     required this.entryLength,
@@ -598,10 +602,8 @@ class _SyncKeepAwakePasscodeConfirmScreen extends ConsumerWidget {
   static const _topNavHeight = 74.0;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final colors = context.colors;
-    final sync = ref.watch(syncProvider).asData?.value;
-    final progress = sync?.displayPercentage ?? sync?.percentage ?? 0.0;
     return Material(
       key: const ValueKey('sync_keep_awake_privacy_passcode_screen'),
       color: colors.background.window,
@@ -613,13 +615,17 @@ class _SyncKeepAwakePasscodeConfirmScreen extends ConsumerWidget {
         child: SafeArea(
           child: Column(
             children: [
-              MobileTopNav.back(
-                title: _titleForMode(progress),
-                titleStyle: AppTypography.bodyMediumStrong.copyWith(
-                  color: colors.text.accent,
+              Consumer(
+                builder: (context, ref, _) => MobileTopNav.back(
+                  title: _titleForMode(
+                    ref.watch(syncDisplayWholePercentageProvider),
+                  ),
+                  titleStyle: AppTypography.bodyMediumStrong.copyWith(
+                    color: colors.text.accent,
+                  ),
+                  height: _topNavHeight,
+                  onBack: submitting ? null : onBack,
                 ),
-                height: _topNavHeight,
-                onBack: submitting ? null : onBack,
               ),
               Expanded(
                 child: LayoutBuilder(
@@ -685,13 +691,13 @@ class _SyncKeepAwakePasscodeConfirmScreen extends ConsumerWidget {
     );
   }
 
-  String _titleForMode(double progress) {
+  String _titleForMode(int displayWholePercentage) {
     return switch (mode) {
       SyncKeepAwakePrivacyLockMode.done => 'Synced',
       SyncKeepAwakePrivacyLockMode.interrupted => 'Sync paused',
       SyncKeepAwakePrivacyLockMode.hidden ||
       SyncKeepAwakePrivacyLockMode.syncing =>
-        '${formatSyncStatusPercentage(progress)}% Syncing...',
+        '$displayWholePercentage% Syncing...',
     };
   }
 

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -30,6 +30,7 @@ import '../../../providers/zec_price_change_provider.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/privacy_mode_provider.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../providers/sync_display_progress_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
@@ -626,7 +627,6 @@ class _HomePaneState extends ConsumerState<_HomePane> {
 
     return _HomeDesktopPane(
       isImporting: isImporting,
-      importProgress: widget.sync.displayPercentage,
       importingAccountName: activeAccountName,
       hasBalance: hasBalance,
       showsIronwoodOnlyBalance: widget.showsIronwoodOnlyBalance,
@@ -1118,7 +1118,6 @@ Offset _positionShieldErrorTooltip(TooltipPositionContext context) {
 class _HomeDesktopPane extends StatelessWidget {
   const _HomeDesktopPane({
     required this.isImporting,
-    required this.importProgress,
     required this.importingAccountName,
     required this.hasBalance,
     required this.showsIronwoodOnlyBalance,
@@ -1147,7 +1146,6 @@ class _HomeDesktopPane extends StatelessWidget {
   });
 
   final bool isImporting;
-  final double importProgress;
   final String? importingAccountName;
   final bool hasBalance;
   final bool showsIronwoodOnlyBalance;
@@ -1285,9 +1283,11 @@ class _HomeDesktopPane extends StatelessWidget {
                       horizontal: AppSpacing.s,
                       vertical: AppSpacing.sm,
                     ),
-                    child: _HomeImportingContent(
-                      progress: importProgress,
-                      accountName: importingAccountName,
+                    child: Consumer(
+                      builder: (context, ref, _) => _HomeImportingContent(
+                        progress: ref.watch(syncDisplayPercentageProvider),
+                        accountName: importingAccountName,
+                      ),
                     ),
                   ),
                 ),

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -26,6 +26,7 @@ import '../../../../providers/account_provider.dart';
 import '../../../../providers/privacy_mode_provider.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
 import '../../../../providers/sync_keep_awake_provider.dart';
+import '../../../../providers/sync_display_progress_provider.dart';
 import '../../../../providers/sync_provider.dart';
 import '../../../../providers/zec_price_change_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
@@ -98,7 +99,7 @@ class MobileHomeScreen extends ConsumerWidget {
                   // with a soft eased fade instead of a hard clip line.
                   child: MobileTopScrollFade(
                     child: isImporting
-                        ? _ImportingView(progress: sync.displayPercentage)
+                        ? const _MobileHomeImportingProgress()
                         : _HomeContent(
                             sync: sync,
                             activeAccountUuid: activeAccountUuid,
@@ -781,6 +782,15 @@ class _ImportingBackground extends StatelessWidget {
         alignment: Alignment.topCenter,
       ),
     );
+  }
+}
+
+class _MobileHomeImportingProgress extends ConsumerWidget {
+  const _MobileHomeImportingProgress();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return _ImportingView(progress: ref.watch(syncDisplayPercentageProvider));
   }
 }
 

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
@@ -26,6 +26,7 @@ import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/app_profile_picture.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/network_privacy_provider.dart';
+import '../../../../providers/sync_display_progress_provider.dart';
 import '../../../../providers/sync_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../models/ironwood_migration_presentation.dart';

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_status_scaffold.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_status_scaffold.dart
@@ -23,19 +23,25 @@ class _MobileMigrationStatusScaffold extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.colors;
     final sync = ref.watch(syncProvider).value ?? SyncState();
-    final syncLabel = SyncStatusLabel.from(sync).label;
     return Scaffold(
       backgroundColor: colors.background.window,
       body: SafeArea(
         child: Column(
           children: [
             if (showAccountNav) ...[
-              MobileTopNav.account(
-                accountName: data.accountName,
-                syncLabel: syncLabel,
-                avatar: AppProfilePicture(
-                  profilePictureId: data.profilePictureId,
-                  size: AppProfilePictureSize.navLarge,
+              Consumer(
+                builder: (context, ref, _) => MobileTopNav.account(
+                  accountName: data.accountName,
+                  syncLabel: SyncStatusLabel.from(
+                    sync,
+                    displayWholePercentage: ref.watch(
+                      syncDisplayWholePercentageProvider,
+                    ),
+                  ).label,
+                  avatar: AppProfilePicture(
+                    profilePictureId: data.profilePictureId,
+                    size: AppProfilePictureSize.navLarge,
+                  ),
                 ),
               ),
             ],

--- a/lib/src/providers/sync_display_progress_provider.dart
+++ b/lib/src/providers/sync_display_progress_provider.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'sync_provider.dart';
+
+const _displayBlockDuration = Duration(milliseconds: 20);
+const _maxIncompleteDisplayPercentage = 0.999;
+
+typedef _SyncDisplayTarget = ({
+  bool isSyncing,
+  bool isSyncComplete,
+  double percentage,
+  double targetPercentage,
+  int targetBlocks,
+});
+
+/// UI-only sync progress interpolated between authoritative Rust events.
+///
+/// Keeping the timer outside [SyncState] means its 20 ms updates reach only
+/// widgets that explicitly render smooth progress. Wallet data, Home content,
+/// and other sync consumers continue to update at Rust event boundaries.
+final syncDisplayPercentageProvider =
+    NotifierProvider.autoDispose<SyncDisplayPercentageNotifier, double>(
+      SyncDisplayPercentageNotifier.new,
+    );
+
+/// Whole percentage for labels that do not need frame-level progress.
+final syncDisplayWholePercentageProvider = Provider.autoDispose<int>((ref) {
+  final progress = ref.watch(syncDisplayPercentageProvider);
+  return (progress.clamp(0.0, 0.99) * 100).round();
+});
+
+class SyncDisplayPercentageNotifier extends Notifier<double> {
+  Timer? _timer;
+
+  @override
+  double build() {
+    final target = ref.watch(
+      syncProvider.select((value) {
+        final sync = value.asData?.value ?? SyncState();
+        return (
+          isSyncing: sync.isSyncing,
+          isSyncComplete: sync.isSyncComplete,
+          percentage: sync.percentage,
+          targetPercentage: sync.displayTargetPercentage,
+          targetBlocks: sync.displayTargetBlocks,
+        );
+      }),
+    );
+
+    _stopTimer();
+    ref.onDispose(_stopTimer);
+    return _startInterpolation(target);
+  }
+
+  double _startInterpolation(_SyncDisplayTarget input) {
+    final base = input.isSyncComplete
+        ? 1.0
+        : input.percentage
+              .clamp(0.0, _maxIncompleteDisplayPercentage)
+              .toDouble();
+    final target = input.isSyncing
+        ? input.targetPercentage
+              .clamp(base, _maxIncompleteDisplayPercentage)
+              .toDouble()
+        : base;
+    if (input.targetBlocks <= 0 || target <= base) return base;
+
+    _timer = Timer.periodic(_displayBlockDuration, (timer) {
+      if (!ref.mounted) {
+        timer.cancel();
+        return;
+      }
+      final virtualBlocks = math.min(timer.tick, input.targetBlocks);
+      final next =
+          base + ((target - base) * virtualBlocks / input.targetBlocks);
+      if (next > state) state = next;
+      if (virtualBlocks >= input.targetBlocks || next >= target) {
+        _stopTimer();
+      }
+    });
+    return base;
+  }
+
+  void _stopTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+}

--- a/lib/src/providers/sync_keep_awake_provider.dart
+++ b/lib/src/providers/sync_keep_awake_provider.dart
@@ -255,7 +255,7 @@ bool isSyncKeepAwakeActiveSync(SyncState sync) {
 
 bool isSyncKeepAwakeCompletedSync(SyncState sync) {
   if (sync.isSyncing || sync.isBackgroundMode) return false;
-  if (sync.percentage >= 1 || sync.displayPercentage >= 1) return true;
+  if (sync.isSyncComplete || sync.percentage >= 1) return true;
   return sync.chainTipHeight > 0 && sync.scannedHeight >= sync.chainTipHeight;
 }
 

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -69,7 +69,6 @@ class SyncState {
   /// this cannot be set by the final non-complete scan progress event.
   final bool isSyncComplete;
   final double percentage;
-  final double displayPercentage;
   final double displayTargetPercentage;
   final int displayTargetBlocks;
   final int scannedHeight;
@@ -323,7 +322,6 @@ class SyncState {
     this.isBackgroundMode = false,
     this.isSyncComplete = false,
     this.percentage = 0,
-    double? displayPercentage,
     double? displayTargetPercentage,
     this.displayTargetBlocks = 0,
     this.scannedHeight = 0,
@@ -361,7 +359,6 @@ class SyncState {
   }) : hasBalanceData = hasBalanceData ?? hasAccountScopedData,
        hasRecentTransactionsData =
            hasRecentTransactionsData ?? hasAccountScopedData,
-       displayPercentage = displayPercentage ?? percentage,
        displayTargetPercentage = displayTargetPercentage ?? percentage,
        transparentBalance = transparentBalance ?? BigInt.zero,
        saplingBalance = saplingBalance ?? BigInt.zero,
@@ -409,7 +406,6 @@ class SyncState {
     bool? isBackgroundMode,
     bool? isSyncComplete,
     double? percentage,
-    double? displayPercentage,
     double? displayTargetPercentage,
     int? displayTargetBlocks,
     int? scannedHeight,
@@ -459,7 +455,6 @@ class SyncState {
       isBackgroundMode: isBackgroundMode ?? this.isBackgroundMode,
       isSyncComplete: isSyncComplete ?? this.isSyncComplete,
       percentage: percentage ?? this.percentage,
-      displayPercentage: displayPercentage ?? this.displayPercentage,
       displayTargetPercentage:
           displayTargetPercentage ?? this.displayTargetPercentage,
       displayTargetBlocks: displayTargetBlocks ?? this.displayTargetBlocks,
@@ -543,7 +538,6 @@ class SyncState {
       isBackgroundMode: current.isBackgroundMode,
       isSyncComplete: current.isSyncComplete,
       percentage: current.percentage,
-      displayPercentage: current.displayPercentage,
       displayTargetPercentage: current.displayTargetPercentage,
       displayTargetBlocks: current.displayTargetBlocks,
       scannedHeight: current.scannedHeight,
@@ -568,7 +562,6 @@ class SyncState {
       isBackgroundMode: isBackgroundMode,
       isSyncComplete: isSyncComplete,
       percentage: percentage,
-      displayPercentage: displayPercentage,
       displayTargetPercentage: displayTargetPercentage,
       displayTargetBlocks: displayTargetBlocks,
       scannedHeight: scannedHeight,
@@ -632,8 +625,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   SyncNotifier({Future<String> Function()? walletDbPathResolver})
     : _walletDbPathResolver = walletDbPathResolver ?? getWalletDbPath;
 
-  static const _displayBlockDuration = Duration(milliseconds: 20);
-  static const _maxIncompleteDisplayPercentage = 0.999;
   static const _authoritativeBalanceRecoveryDelays = <Duration>[
     Duration.zero,
     Duration(milliseconds: 250),
@@ -655,7 +646,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   int _syncGen = 0; // incremented by stopSync to invalidate pending startSync
   String? _cachedDbPath;
   StreamSubscription? _syncSub;
-  Timer? _displayProgressTimer;
   AppLifecycleListener? _lifecycleListener;
   Timer? _pollTimer;
   bool _pollCheckInFlight = false;
@@ -786,7 +776,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       _deferredSyncLatestTipHeight = null;
       rust_sync.cancelFullSync();
       _syncSub?.cancel();
-      _displayProgressTimer?.cancel();
       _mempoolSub?.cancel();
       // Cancel the Rust-side observer too; cancelling the Dart
       // subscription alone leaves the tonic stream task alive
@@ -1025,7 +1014,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _lastLoggedHeight = 0;
     _lastForegroundSyncProgress = null;
     _lastForegroundProgressHandling = null;
-    _stopDisplayProgressTimer();
     final gen = ++_syncGen;
     final prev = state.value;
     final accountUuid = _getActiveAccountUuid();
@@ -1121,7 +1109,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
             if (gen != _syncGen) return;
             log('Sync: endpoint preflight failed: $e');
             _isSyncing = false;
-            _stopDisplayProgressTimer();
             _recordSyncFailure(e);
             return;
           }
@@ -1194,7 +1181,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
                 }
                 ++_progressEventVersion;
                 _isSyncing = false;
-                _stopDisplayProgressTimer();
                 log(
                   'Sync: stream ended without applied isComplete, cleaning up',
                 );
@@ -1210,7 +1196,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               log('Sync: stream error: $e');
               ++_progressEventVersion;
               _isSyncing = false;
-              _stopDisplayProgressTimer();
               // Sync died mid-stream: tear the mempool observer down
               // at the same time so a failed sync session can't leak
               // a lightwalletd stream that keeps firing
@@ -1231,7 +1216,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
           log('SyncNotifier: ERROR: $e\n$st');
           ++_progressEventVersion;
           _isSyncing = false;
-          _stopDisplayProgressTimer();
           // Sync setup threw before the stream was ever attached.
           // We may have already started the mempool observer
           // (happens on the main success path just before
@@ -1493,7 +1477,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     // holds.
     _stopMempoolObserver();
     _isSyncing = false;
-    _stopDisplayProgressTimer();
     _stopPolling();
     final prev = state.value;
     final accountUuid = _getActiveAccountUuid();
@@ -1509,7 +1492,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         isBackgroundMode: false,
         isSyncComplete: prev?.isSyncComplete ?? false,
         percentage: prev?.percentage ?? 0.0,
-        displayPercentage: prev?.displayPercentage ?? prev?.percentage ?? 0.0,
         scannedHeight: prev?.scannedHeight ?? 0,
         chainTipHeight: prev?.chainTipHeight ?? 0,
         transparentBalance: scopedPrev?.transparentBalance,
@@ -1579,7 +1561,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     await onStoppingSync?.call();
     log('SyncNotifier: pausing sync for wallet DB mutation');
     _isSyncing = false;
-    _stopDisplayProgressTimer();
     rust_sync.setSyncMode(mode: 0);
     rust_sync.cancelFullSync();
     _stopMempoolObserver();
@@ -1628,7 +1609,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     ++_progressEventVersion;
     ++_balanceReadVersion;
     _isSyncing = false;
-    _stopDisplayProgressTimer();
     _stopPolling();
     _syncSub?.cancel();
     _syncSub = null;
@@ -1954,57 +1934,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
   double _clampProgress(double value) => value.clamp(0.0, 1.0).toDouble();
 
-  void _stopDisplayProgressTimer() {
-    _displayProgressTimer?.cancel();
-    _displayProgressTimer = null;
-  }
-
-  void _startDisplayProgressSmoothing({
-    required double basePercentage,
-    required double targetPercentage,
-    required int targetBlocks,
-  }) {
-    _stopDisplayProgressTimer();
-
-    final base = math.min(
-      _clampProgress(basePercentage),
-      _maxIncompleteDisplayPercentage,
-    );
-    final target = math.min(
-      _clampProgress(targetPercentage),
-      _maxIncompleteDisplayPercentage,
-    );
-    if (targetBlocks <= 0 || target <= base) {
-      return;
-    }
-
-    _displayProgressTimer = Timer.periodic(_displayBlockDuration, (timer) {
-      if (!ref.mounted) {
-        timer.cancel();
-        return;
-      }
-      final current = state.value;
-      if (current == null || !current.isSyncing) {
-        _stopDisplayProgressTimer();
-        return;
-      }
-
-      final virtualBlocks = math.min(timer.tick, targetBlocks);
-      final next = _clampProgress(
-        math.min(
-          target,
-          base + ((target - base) * virtualBlocks / targetBlocks),
-        ),
-      );
-      if (next > current.displayPercentage) {
-        state = AsyncData(current.copyWith(displayPercentage: next));
-      }
-      if (virtualBlocks >= targetBlocks || next >= target) {
-        _stopDisplayProgressTimer();
-      }
-    });
-  }
-
   // ======================== Progress Handling ========================
 
   Future<void> _onSyncProgress(SyncProgressEvent event) async {
@@ -2174,12 +2103,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         ? DateTime.now()
         : prev?.lastSyncCompletedAt;
     final actualPercentage = _clampProgress(event.percentage);
-    final maxDisplayPercentage = event.isComplete
-        ? 1.0
-        : _maxIncompleteDisplayPercentage;
-    final displayPercentage = event.isComplete
-        ? 1.0
-        : math.min(actualPercentage, maxDisplayPercentage);
     final nextSpendableBalance = useFetchedBalance
         ? spendable ?? stateScopedPrev?.spendableBalance ?? BigInt.zero
         : stateScopedPrev?.spendableBalance ?? BigInt.zero;
@@ -2202,7 +2125,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         isBackgroundMode: false,
         isSyncComplete: event.isComplete,
         percentage: actualPercentage,
-        displayPercentage: displayPercentage,
         displayTargetPercentage: event.displayTargetPercentage,
         displayTargetBlocks: event.displayTargetBlocks,
         scannedHeight: event.scannedHeight,
@@ -2299,16 +2221,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         phase: event.phase,
       ),
     );
-
-    if (event.isComplete || !event.isSyncing) {
-      _stopDisplayProgressTimer();
-    } else {
-      _startDisplayProgressSmoothing(
-        basePercentage: displayPercentage,
-        targetPercentage: event.displayTargetPercentage,
-        targetBlocks: event.displayTargetBlocks,
-      );
-    }
 
     // Handle sync completion here (not in onDone) to avoid race with async state update.
     if (event.isComplete) {
@@ -2585,7 +2497,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     bool clearRestoredSnapshotIfUnavailable = false,
   }) async {
     if (_requiresUnlock) {
-      _stopDisplayProgressTimer();
       state = AsyncData(SyncState());
       return;
     }
@@ -2768,8 +2679,6 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         isBackgroundMode: current?.isBackgroundMode ?? false,
         isSyncComplete: current?.isSyncComplete ?? false,
         percentage: current?.percentage ?? 0.0,
-        displayPercentage:
-            current?.displayPercentage ?? current?.percentage ?? 0.0,
         displayTargetPercentage:
             current?.displayTargetPercentage ?? current?.percentage ?? 0.0,
         displayTargetBlocks: current?.displayTargetBlocks ?? 0,

--- a/lib/widgetbook/receive_use_cases.dart
+++ b/lib/widgetbook/receive_use_cases.dart
@@ -194,7 +194,6 @@ class _WidgetbookSyncNotifier extends SyncNotifier {
     accountUuid: _mobileAccountState.activeAccountUuid,
     hasAccountScopedData: true,
     percentage: 1,
-    displayPercentage: 1,
   );
 }
 

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -1023,7 +1023,6 @@ Widget buildMobileHomeImportingUseCase(BuildContext context) {
       accountUuid: _accountsDesignState.activeAccountUuid,
       isSyncing: true,
       percentage: 0.34,
-      displayPercentage: 0.34,
     ),
   );
 }
@@ -1035,7 +1034,6 @@ Widget buildMobileHomeImportingResponsiveUseCase(BuildContext context) {
       accountUuid: _accountsDesignState.activeAccountUuid,
       isSyncing: true,
       percentage: 0.34,
-      displayPercentage: 0.34,
     ),
     constrainToPreviewFrame: false,
   );
@@ -1969,7 +1967,6 @@ Widget _buildIronwoodMigrationUseCase({
             hasAccountScopedData: true,
             isSyncing: true,
             percentage: 0.34,
-            displayPercentage: 0.34,
             displayTargetPercentage: 0.34,
             scannedHeight: 3_000_000,
             chainTipHeight: 3_000_000,
@@ -3532,7 +3529,6 @@ SyncState _homeSyncedState({
     hasAccountScopedData: true,
     isSyncComplete: true,
     percentage: 1,
-    displayPercentage: 1,
     scannedHeight: 3_428_143,
     chainTipHeight: 3_428_143,
     orchardBalance: resolvedOrchardBalance,
@@ -4489,7 +4485,6 @@ class _PreviewSyncNotifier extends SyncNotifier {
         hasAccountScopedData: activeAccountUuid != null,
         isSyncing: true,
         percentage: 0.34,
-        displayPercentage: 0.34,
         totalBalance: BigInt.from(14223000000),
       );
 

--- a/lib/widgetbook/send_use_cases.dart
+++ b/lib/widgetbook/send_use_cases.dart
@@ -572,7 +572,6 @@ class _WidgetbookSendSyncNotifier extends SyncNotifier {
     spendableBalance: BigInt.from(14312120000),
     totalBalance: BigInt.from(14312120000),
     percentage: 1,
-    displayPercentage: 1,
   );
 }
 

--- a/test/app_main_sidebar_test.dart
+++ b/test/app_main_sidebar_test.dart
@@ -45,9 +45,7 @@ void main() {
 
   testWidgets('sidebar shows in-progress sync percentage', (tester) async {
     await tester.pumpWidget(
-      _sidebarHarness(
-        SyncState(isSyncing: true, percentage: 1, displayPercentage: 1),
-      ),
+      _sidebarHarness(SyncState(isSyncing: true, percentage: 1)),
     );
     await tester.pump();
 
@@ -677,7 +675,7 @@ void main() {
           accountUuid: 'account-1',
           hasAccountScopedData: false,
           isSyncing: true,
-          displayPercentage: 0.32,
+          percentage: 0.32,
         ),
       ),
     );
@@ -813,7 +811,7 @@ void main() {
     tester,
   ) async {
     await tester.pumpWidget(
-      _sidebarHarness(SyncState(isSyncing: true, displayPercentage: 0.34)),
+      _sidebarHarness(SyncState(isSyncing: true, percentage: 0.34)),
     );
     await tester.pump();
 
@@ -838,7 +836,7 @@ void main() {
   ) async {
     await tester.pumpWidget(
       _sidebarHarness(
-        SyncState(isSyncing: true, displayPercentage: 0.34),
+        SyncState(isSyncing: true, percentage: 0.34),
         disableAnimations: false,
       ),
     );
@@ -869,7 +867,6 @@ void main() {
         SyncState(
           isSyncComplete: true,
           percentage: 1,
-          displayPercentage: 1,
           scannedHeight: 3_428_143,
           chainTipHeight: 3_428_143,
         ),
@@ -902,7 +899,6 @@ void main() {
       _sidebarHarness(
         SyncState(
           percentage: 1,
-          displayPercentage: 1,
           scannedHeight: 3_428_143,
           chainTipHeight: 3_428_143,
         ),
@@ -923,7 +919,6 @@ void main() {
         SyncState(
           isBackgroundMode: true,
           percentage: 1,
-          displayPercentage: 1,
           scannedHeight: 100,
           chainTipHeight: 100,
         ),
@@ -1028,7 +1023,7 @@ void main() {
   ) async {
     await tester.pumpWidget(
       _sidebarHarness(
-        SyncState(isSyncing: true, displayPercentage: 0.34),
+        SyncState(isSyncing: true, percentage: 0.34),
         sidebarWidth: 180,
       ),
     );
@@ -1152,7 +1147,6 @@ final _syncedSyncState = SyncState(
   hasAccountScopedData: true,
   isSyncComplete: true,
   percentage: 1,
-  displayPercentage: 1,
   scannedHeight: 3_428_143,
   chainTipHeight: 3_428_143,
 );

--- a/test/core/formatting/sync_status_label_test.dart
+++ b/test/core/formatting/sync_status_label_test.dart
@@ -14,7 +14,8 @@ void main() {
 
   test('syncing state carries whole-percent progress capped below 100', () {
     final status = SyncStatusLabel.from(
-      SyncState(isSyncing: true, percentage: 0.5, displayPercentage: 0.997),
+      SyncState(isSyncing: true, percentage: 0.5),
+      displayWholePercentage: 99,
     );
     expect(status.kind, SyncStatusKind.syncing);
     expect(status.label, '99% Syncing...');

--- a/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
@@ -507,7 +507,6 @@ void main() {
       _sync(
         isSyncing: false,
         percentage: 1,
-        displayPercentage: 1,
         scannedHeight: 200,
         chainTipHeight: 200,
         lastSyncStartedAt: DateTime(2026, 7, 9, 12),
@@ -554,7 +553,6 @@ void main() {
       _sync(
         isSyncing: false,
         percentage: 1,
-        displayPercentage: 1,
         scannedHeight: 200,
         chainTipHeight: 200,
         lastSyncStartedAt: DateTime(2026, 7, 9, 12),
@@ -567,7 +565,6 @@ void main() {
     syncNotifier.emit(
       _sync(
         percentage: 0,
-        displayPercentage: 0,
         scannedHeight: 200,
         chainTipHeight: 202,
         lastSyncStartedAt: DateTime(2026, 7, 9, 12, 2),
@@ -588,7 +585,6 @@ void main() {
       _sync(
         isSyncing: false,
         percentage: 1,
-        displayPercentage: 1,
         scannedHeight: 202,
         chainTipHeight: 202,
         lastSyncStartedAt: DateTime(2026, 7, 9, 12, 2),
@@ -633,7 +629,6 @@ void main() {
         _sync(
           isSyncing: false,
           percentage: 0.5,
-          displayPercentage: 0.5,
           scannedHeight: 150,
           chainTipHeight: 200,
           lastSyncStartedAt: DateTime(2026, 7, 9, 12),
@@ -722,11 +717,7 @@ void main() {
   testWidgets('animates display sync percentage changes', (tester) async {
     _setMobileViewport(tester);
     final syncNotifier = FakeSyncNotifier(
-      _sync(
-        percentage: 0.05,
-        displayPercentage: 0.05,
-        lastSyncStartedAt: DateTime(2026, 7, 9, 12),
-      ),
+      _sync(percentage: 0.05, lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
     );
 
     await tester.pumpWidget(
@@ -750,11 +741,7 @@ void main() {
     expect(find.text('5%'), findsOneWidget);
 
     syncNotifier.emit(
-      _sync(
-        percentage: 0.10,
-        displayPercentage: 0.10,
-        lastSyncStartedAt: DateTime(2026, 7, 9, 12),
-      ),
+      _sync(percentage: 0.10, lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
     );
     await tester.pump();
 
@@ -968,7 +955,6 @@ SyncState _sync({
   bool isSyncing = true,
   bool isBackgroundMode = false,
   double percentage = 0.25,
-  double? displayPercentage,
   int scannedHeight = 100,
   int chainTipHeight = 200,
   DateTime? lastSyncStartedAt,
@@ -977,7 +963,6 @@ SyncState _sync({
     isSyncing: isSyncing,
     isBackgroundMode: isBackgroundMode,
     percentage: percentage,
-    displayPercentage: displayPercentage,
     scannedHeight: scannedHeight,
     chainTipHeight: chainTipHeight,
     lastSyncStartedAt: lastSyncStartedAt,

--- a/test/features/activity/activity_transaction_status_screen_test.dart
+++ b/test/features/activity/activity_transaction_status_screen_test.dart
@@ -725,7 +725,6 @@ Future<void> _pumpScreen(
               accountUuid: 'account-1',
               hasAccountScopedData: true,
               percentage: 1,
-              displayPercentage: 1,
             ),
           ),
         ),

--- a/test/features/home/home_desktop_screen_test.dart
+++ b/test/features/home/home_desktop_screen_test.dart
@@ -1216,6 +1216,56 @@ void main() {
 
     expect(scrollableState.position.pixels, greaterThan(0));
   });
+
+  testWidgets('display progress ticks do not rebuild desktop Home content', (
+    tester,
+  ) async {
+    final initial = SyncState(
+      accountUuid: 'account-1',
+      hasAccountScopedData: true,
+      percentage: 1,
+      orchardBalance: BigInt.from(100000000),
+      spendableBalance: BigInt.from(100000000),
+      totalBalance: BigInt.from(100000000),
+      recentTransactions: [
+        _receivedZecTx(
+          txidHex: 'display-progress-home-row',
+          amountZatoshi: 100000000,
+          blockTime: 1800000000,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(_appHarness('/home', syncState: initial));
+    await tester.pumpAndSettle();
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ZcashWalletApp)),
+    );
+    (container.read(syncProvider.notifier) as FakeSyncNotifier).emit(
+      initial.copyWith(
+        isSyncing: true,
+        percentage: 0.4,
+        displayTargetPercentage: 0.5,
+        displayTargetBlocks: 10,
+      ),
+    );
+    await tester.pump();
+
+    final balanceFinder = find.byKey(
+      const ValueKey('home_desktop_balance_amount_text'),
+    );
+    final activityFinder = find.byKey(
+      const ValueKey('home_desktop_activity_row_0'),
+    );
+    final balanceBeforeTicks = tester.widget(balanceFinder);
+    final activityBeforeTicks = tester.widget(activityFinder);
+
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(tester.widget(balanceFinder), same(balanceBeforeTicks));
+    expect(tester.widget(activityFinder), same(activityBeforeTicks));
+  });
 }
 
 SwapIntentRecord _swapActivityRecord({

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -362,7 +362,6 @@ SyncState _syncedState({
   accountUuid: 'account-1',
   hasAccountScopedData: true,
   percentage: 1.0,
-  displayPercentage: 1.0,
   orchardBalance: orchardBalance ?? BigInt.zero,
   orchardLockedBalance: orchardLockedBalance ?? BigInt.zero,
   ironwoodBalance: ironwoodBalance ?? BigInt.zero,
@@ -591,7 +590,6 @@ void main() {
           hasAccountScopedData: true,
           isSyncing: true,
           percentage: 0.25,
-          displayPercentage: 0.25,
           scannedHeight: 50,
           chainTipHeight: 200,
           lastSyncStartedAt: DateTime.now().subtract(
@@ -640,11 +638,7 @@ void main() {
 
     await tester.pumpWidget(
       _app(
-        SyncState(
-          accountUuid: 'account-1',
-          isSyncing: true,
-          displayPercentage: 0.32,
-        ),
+        SyncState(accountUuid: 'account-1', isSyncing: true, percentage: 0.32),
       ),
     );
     await tester.pump();
@@ -2424,5 +2418,41 @@ void main() {
       seeAllText.style?.color,
       AppThemeData.dark.colors.button.ghost.label,
     );
+  });
+
+  testWidgets('display progress ticks do not rebuild mobile Home content', (
+    tester,
+  ) async {
+    final initial = _syncedState(
+      orchardBalance: BigInt.from(100000000),
+    ).copyWith(recentTransactions: [_tx(1)]);
+    final notifier = FakeSyncNotifier(initial);
+
+    await tester.pumpWidget(_app(initial, syncNotifier: notifier));
+    await tester.pumpAndSettle();
+
+    notifier.emit(
+      initial.copyWith(
+        isSyncing: true,
+        percentage: 0.4,
+        displayTargetPercentage: 0.5,
+        displayTargetBlocks: 10,
+      ),
+    );
+    await tester.pump();
+
+    final balanceFinder = find.byKey(
+      const ValueKey('mobile_home_shielded_balance'),
+    );
+    final activityFinder = find.byKey(
+      const ValueKey('mobile_home_activity_row_0'),
+    );
+    final balanceBeforeTicks = tester.widget(balanceFinder);
+    final activityBeforeTicks = tester.widget(activityFinder);
+
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(tester.widget(balanceFinder), same(balanceBeforeTicks));
+    expect(tester.widget(activityFinder), same(activityBeforeTicks));
   });
 }

--- a/test/features/migration/ironwood_migration_announcement_provider_test.dart
+++ b/test/features/migration/ironwood_migration_announcement_provider_test.dart
@@ -765,7 +765,6 @@ void main() {
     syncNotifier.emit(
       syncState.copyWith(
         percentage: 0.35,
-        displayPercentage: 0.35,
         displayTargetPercentage: 0.36,
         displayTargetBlocks: 25,
         scannedHeight: 3_499_800,
@@ -838,7 +837,6 @@ void main() {
           hasAccountScopedData: true,
           isSyncComplete: false,
           percentage: 0.99,
-          displayPercentage: 0.99,
           scannedHeight: 3_499_990,
           chainTipHeight: 3_500_000,
           totalBalance: BigInt.zero,
@@ -1021,7 +1019,6 @@ void main() {
     syncNotifier.emit(
       syncState.copyWith(
         percentage: 0.35,
-        displayPercentage: 0.35,
         displayTargetPercentage: 0.36,
         displayTargetBlocks: 25,
         scannedHeight: 3_499_800,
@@ -1209,7 +1206,6 @@ SyncState _syncingReadyState() {
     hasAccountScopedData: true,
     isSyncing: true,
     percentage: 0.34,
-    displayPercentage: 0.34,
     displayTargetPercentage: 0.34,
     scannedHeight: 3_499_700,
     chainTipHeight: 3_500_000,

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -660,7 +660,6 @@ SyncState _syncedStateFor(AccountState accountState) {
     accountUuid: accountState.activeAccountUuid,
     hasAccountScopedData: true,
     percentage: 1,
-    displayPercentage: 1,
   );
 }
 

--- a/test/providers/sync_display_progress_provider_test.dart
+++ b/test/providers/sync_display_progress_provider_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/providers/sync_display_progress_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import '../fakes/fake_sync_notifier.dart';
+
+void main() {
+  test('interpolates without republishing SyncState', () async {
+    final initial = SyncState(
+      isSyncing: true,
+      percentage: 0.2,
+      displayTargetPercentage: 0.3,
+      displayTargetBlocks: 10,
+    );
+    late FakeSyncNotifier syncNotifier;
+    final container = ProviderContainer(
+      overrides: [
+        syncProvider.overrideWith(
+          () => syncNotifier = FakeSyncNotifier(initial),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final displaySubscription = container.listen(
+      syncDisplayPercentageProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(displaySubscription.close);
+    await container.read(syncProvider.future);
+    await Future<void>.delayed(Duration.zero);
+
+    var syncUpdates = 0;
+    final syncSubscription = container.listen(syncProvider, (_, _) {
+      syncUpdates += 1;
+    });
+    addTearDown(syncSubscription.close);
+
+    expect(container.read(syncDisplayPercentageProvider), 0.2);
+    await Future<void>.delayed(const Duration(milliseconds: 110));
+
+    expect(container.read(syncDisplayPercentageProvider), closeTo(0.25, 0.011));
+    expect(container.read(syncProvider).requireValue.percentage, 0.2);
+    expect(syncUpdates, 0);
+
+    syncNotifier.emit(
+      initial.copyWith(
+        isSyncing: false,
+        isSyncComplete: true,
+        percentage: 1,
+        displayTargetPercentage: 1,
+        displayTargetBlocks: 0,
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(syncDisplayPercentageProvider), 1);
+  });
+
+  test('whole percentage notifies only when its label changes', () async {
+    final initial = SyncState(
+      isSyncing: true,
+      percentage: 0.2,
+      displayTargetPercentage: 0.3,
+      displayTargetBlocks: 100,
+    );
+    final container = ProviderContainer(
+      overrides: [syncProvider.overrideWith(() => FakeSyncNotifier(initial))],
+    );
+    addTearDown(container.dispose);
+    var updates = 0;
+    final subscription = container.listen(
+      syncDisplayWholePercentageProvider,
+      (_, _) => updates += 1,
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+    await container.read(syncProvider.future);
+    await Future<void>.delayed(Duration.zero);
+    final initialUpdates = updates;
+
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+
+    expect(container.read(syncDisplayWholePercentageProvider), 20);
+    expect(updates, initialUpdates);
+  });
+}

--- a/test/providers/sync_provider_test.dart
+++ b/test/providers/sync_provider_test.dart
@@ -186,6 +186,42 @@ void main() {
     await expectLater(handling, completes);
   });
 
+  test('batch progress publishes one authoritative state', () async {
+    late _LifecycleTestSyncNotifier notifier;
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+        accountProvider.overrideWith(_ExistingAccountNotifier.new),
+        syncProvider.overrideWith(
+          () => notifier = _LifecycleTestSyncNotifier(() async => 'wallet.db'),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.listen(syncProvider, (_, _) {});
+    await container.read(syncProvider.future);
+    var updates = 0;
+    container.listen(syncProvider, (_, _) => updates++);
+
+    await notifier.handleSyncProgressForTesting(
+      const SyncProgressEvent(
+        scannedHeight: 10,
+        chainTipHeight: 100,
+        percentage: 0.1,
+        displayTargetPercentage: 0.2,
+        displayTargetBlocks: 100,
+        isSyncing: true,
+        isComplete: false,
+        hasNewTx: false,
+      ),
+    );
+    expect(updates, 1);
+
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    expect(updates, 1);
+    expect(container.read(syncProvider).requireValue.percentage, 0.1);
+  });
+
   test('in-flight progress cannot replace a newer sync failure', () async {
     final resolverStarted = Completer<void>();
     final dbPath = Completer<String>();

--- a/test/sync_state_test.dart
+++ b/test/sync_state_test.dart
@@ -448,32 +448,6 @@ void main() {
     },
   );
 
-  test('displayPercentage defaults to actual percentage', () {
-    final state = SyncState(percentage: 0.25);
-
-    expect(state.percentage, 0.25);
-    expect(state.displayPercentage, 0.25);
-  });
-
-  test(
-    'displayPercentage can advance independently from actual percentage',
-    () {
-      final state = SyncState(percentage: 0.25);
-      final displayed = state.copyWith(displayPercentage: 0.30);
-
-      expect(displayed.percentage, 0.25);
-      expect(displayed.displayPercentage, 0.30);
-    },
-  );
-
-  test('displayPercentage can be reset below a previous display value', () {
-    final state = SyncState(percentage: 0.30, displayPercentage: 0.50);
-    final reset = state.copyWith(percentage: 0.25, displayPercentage: 0.25);
-
-    expect(reset.percentage, 0.25);
-    expect(reset.displayPercentage, 0.25);
-  });
-
   test('display target defaults to actual percentage', () {
     final state = SyncState(percentage: 0.25);
 
@@ -525,7 +499,6 @@ void main() {
       hasAccountScopedData: true,
       isSyncing: true,
       percentage: 0.75,
-      displayPercentage: 0.50,
       displayTargetPercentage: 0.80,
       displayTargetBlocks: 120,
       scannedHeight: 10,
@@ -546,7 +519,6 @@ void main() {
     expect(scoped.recentTransactions, isEmpty);
     expect(scoped.isSyncing, isTrue);
     expect(scoped.percentage, 0.75);
-    expect(scoped.displayPercentage, 0.50);
     expect(scoped.displayTargetPercentage, 0.80);
     expect(scoped.displayTargetBlocks, 120);
     expect(scoped.scannedHeight, 10);


### PR DESCRIPTION
## Summary

- move the 20 ms interpolated sync-display timer out of the authoritative `SyncState`
- publish smooth progress only to widgets that explicitly render it
- keep Home content, wallet data consumers, sidebar labels, migration UI, and keep-awake UI from rebuilding at frame-level frequency
- add regression coverage for provider isolation and desktop/mobile Home rebuild behavior

## Why

The sync progress interpolation timer previously republished the full authoritative sync state every 20 ms. That caused broad Riverpod consumers—including Home content and wallet-data views—to rebuild even when only the displayed percentage changed.

This keeps Rust sync events authoritative while isolating the UI-only interpolation in an auto-disposed display provider.

## User impact

Sync progress remains smooth, while unrelated Home and wallet content avoids unnecessary rebuilds during synchronization.

## Validation

- `fvm flutter test test/providers/sync_display_progress_provider_test.dart test/providers/sync_provider_test.dart test/app_main_sidebar_test.dart test/core/formatting/sync_status_label_test.dart test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart test/features/home/home_desktop_screen_test.dart` — 97 passed, 1 mobile-tagged suite skipped in the desktop lane
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/home/mobile_home_screen_test.dart test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart` — 73 passed
- `fvm flutter analyze` — no branch-specific findings; reports the same 23 pre-existing unused-declaration warnings as `main`
