### PR TITLE
Use Zakura voting stack and consolidation-aware note selection

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -172,9 +172,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayref"
@@ -1302,7 +1302,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1323,7 +1322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck 0.5.0",
- "indexmap 2.14.0",
+ "indexmap 1.9.3",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -1449,7 +1448,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1657,7 +1656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2136,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2637,16 +2636,15 @@ dependencies = [
 
 [[package]]
 name = "imt-tree"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aad3e3ab5a46f4a08d00f5525b86cd0d5204cba64ba68f46e20a590e1808aec"
+checksum = "e76a0e9767d86505105a2bf6756ff73ab13c9fa0342de743dff470c39b6515fd"
 dependencies = [
  "anyhow",
  "ff",
- "halo2_gadgets",
  "hex",
- "pasta_curves",
  "rayon",
+ "voting-crypto-deps",
 ]
 
 [[package]]
@@ -2816,7 +2814,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3178,7 +3176,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3708,9 +3706,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pir-client"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350efadb12ec2d11c8966cd376d9677c9e0038e3bb4aa2acfc69a8edc25700c9"
+checksum = "b7bb3a0dc7dbe1d1f6ed5e9b14324f94cd79911a993d41a62acd8c2b4c5cc25d"
 dependencies = [
  "anyhow",
  "ff",
@@ -3718,24 +3716,24 @@ dependencies = [
  "hex",
  "imt-tree",
  "log",
- "pasta_curves",
  "pir-types",
  "serde_json",
  "tokio",
  "valar-ypir",
+ "voting-crypto-deps",
 ]
 
 [[package]]
 name = "pir-types"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635f27cfabeca929f821a0f1c934a15f27fd2922a61c487ecf1daa43b20dfd3e"
+checksum = "54a2da79e15134d11243b0899a62ba70641c178244bb0a780dc81bee83a9a634"
 dependencies = [
  "anyhow",
  "ff",
  "imt-tree",
- "pasta_curves",
  "serde",
+ "voting-crypto-deps",
 ]
 
 [[package]]
@@ -4451,17 +4449,13 @@ dependencies = [
  "log",
  "minicbor",
  "nonempty",
- "orchard",
- "pasta_curves",
  "pbkdf2",
- "pczt",
  "prost 0.14.3",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "redb",
  "rusqlite",
  "rustls",
- "sapling-crypto",
  "secrecy",
  "security-framework",
  "serde",
@@ -4478,13 +4472,17 @@ dependencies = [
  "url",
  "uuid",
  "vote-commitment-tree",
+ "zakura-client-backend",
+ "zakura-client-sqlite",
+ "zakura-keys",
+ "zakura-orchard",
+ "zakura-pasta-curves",
+ "zakura-pczt",
+ "zakura-primitives",
+ "zakura-proofs",
+ "zakura-sapling-crypto",
  "zcash_address",
- "zcash_client_backend",
- "zcash_client_sqlite",
- "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_proofs",
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
@@ -4540,7 +4538,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5062,7 +5060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5246,7 +5244,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5329,12 +5327,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5344,15 +5341,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6933,54 +6930,64 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.5.0"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=7986b9cddf987c69e4a8ea23d3bb55c89e054910#7986b9cddf987c69e4a8ea23d3bb55c89e054910"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b341759f23454409a432b51d127e62df1ea0c5c2e2e14420d40fd506be00462b"
 dependencies = [
  "anyhow",
  "ff",
- "halo2_gadgets",
  "imt-tree",
  "incrementalmerkletree",
  "lazy_static",
  "libc",
- "pasta_curves",
  "shardtree",
+ "voting-crypto-deps",
 ]
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.7.0"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=7986b9cddf987c69e4a8ea23d3bb55c89e054910#7986b9cddf987c69e4a8ea23d3bb55c89e054910"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "211c6a63a87e0063b6af575657fef1d7e2f1ba520591c389bd0bb4d78980ffd3"
 dependencies = [
  "base64",
  "ff",
  "hex",
- "pasta_curves",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "vote-commitment-tree",
+ "voting-crypto-deps",
 ]
 
 [[package]]
 name = "voting-circuits"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014def2d1738ecc42253d0cd0f6e74847bc51ccde55ad992abadede7fade76d5"
+checksum = "3e5eaba983e549c7d466bda1a96cccc7c56c1e4c53aee18b8f5d545d6972536c"
 dependencies = [
  "blake2b_simd",
  "ff",
  "group",
- "halo2_gadgets",
- "halo2_poseidon",
- "halo2_proofs",
  "incrementalmerkletree",
  "itertools 0.14.0",
  "lazy_static",
- "orchard",
- "pasta_curves",
  "rand 0.8.6",
- "sinsemilla",
+ "voting-crypto-deps",
+]
+
+[[package]]
+name = "voting-crypto-deps"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4a58c1a77abf2198fd5a377da53b8ac39233bd62d66d655f6830875234fc30"
+dependencies = [
+ "zakura-halo2-gadgets",
+ "zakura-halo2-poseidon",
+ "zakura-halo2-proofs",
+ "zakura-orchard",
+ "zakura-pasta-curves",
+ "zakura-sinsemilla",
 ]
 
 [[package]]
@@ -7193,7 +7200,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7653,24 +7660,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_address"
-version = "0.13.0"
+name = "zakura-client-backend"
+version = "0.1.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
-dependencies = [
- "bech32",
- "bs58",
- "corez",
- "f4jumble",
- "zcash_encoding",
- "zcash_protocol",
-]
-
-[[package]]
-name = "zcash_client_backend"
-version = "0.24.0-rc.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49636f1d22b0511b2a117548cc9dcf569440a3589b06bf6df422c6b738f6231"
+checksum = "e446cc7bbd3ca1d859b6df7e46dcd9845018119551940debc385330220faf4ee"
 dependencies = [
  "arti-client",
  "async-trait",
@@ -7694,9 +7687,6 @@ dependencies = [
  "incrementalmerkletree",
  "memuse",
  "nonempty",
- "orchard",
- "pasta_curves",
- "pczt",
  "percent-encoding",
  "postcard",
  "prost 0.14.3",
@@ -7704,7 +7694,6 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "rust_decimal",
- "sapling-crypto",
  "secp256k1",
  "secrecy",
  "serde",
@@ -7722,6 +7711,429 @@ dependencies = [
  "tracing",
  "trait-variant",
  "webpki-roots",
+ "which 8.0.2",
+ "zakura-keys",
+ "zakura-orchard",
+ "zakura-pasta-curves",
+ "zakura-pczt",
+ "zakura-primitives",
+ "zakura-sapling-crypto",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_note_encryption",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
+ "zip32",
+ "zip321",
+]
+
+[[package]]
+name = "zakura-client-sqlite"
+version = "0.1.0-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "935fb2970f0612b5f8f390fe07b4357335d82c8a07a85cfed208d83aec04048e"
+dependencies = [
+ "bip32",
+ "bitflags",
+ "bs58",
+ "byteorder",
+ "document-features",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "maybe-rayon",
+ "nonempty",
+ "prost 0.14.3",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "rand_distr",
+ "regex",
+ "rusqlite",
+ "schemerz",
+ "schemerz-rusqlite",
+ "secp256k1",
+ "secrecy",
+ "serde",
+ "shardtree",
+ "static_assertions",
+ "subtle",
+ "time",
+ "tracing",
+ "uuid",
+ "zakura-client-backend",
+ "zakura-keys",
+ "zakura-orchard",
+ "zakura-pczt",
+ "zakura-primitives",
+ "zakura-sapling-crypto",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
+ "zip32",
+]
+
+[[package]]
+name = "zakura-halo2-gadgets"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea4f65916f14036420da6f487db68eca9f6cd69ff187e2ba6ba5fe467dba1b6"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand 0.8.6",
+ "subtle",
+ "uint",
+ "zakura-halo2-poseidon",
+ "zakura-halo2-proofs",
+ "zakura-pasta-curves",
+ "zakura-sinsemilla",
+]
+
+[[package]]
+name = "zakura-halo2-legacy-pdqsort"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7dc9de3579d54ea35e9d1982ce47e96901e7d7f2f3c2040dcd591952d6eeaa3"
+
+[[package]]
+name = "zakura-halo2-poseidon"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb66e808e2f7b83333051be6691c679d3a32eb43fbea58be59595f5f36fa4e1"
+dependencies = [
+ "bitvec",
+ "ff",
+ "group",
+ "zakura-pasta-curves",
+]
+
+[[package]]
+name = "zakura-halo2-proofs"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b0e307f5bc2c888bd82682ca468672b3896713ac8553f8107a3d1664326c90"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "indexmap 1.9.3",
+ "maybe-rayon",
+ "rand_core 0.6.4",
+ "tracing",
+ "zakura-halo2-legacy-pdqsort",
+ "zakura-pasta-curves",
+]
+
+[[package]]
+name = "zakura-keys"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3f2b37a4ebbdb0ed5020711a9bdefc08d42c885bb1549aabe32036eb0793166"
+dependencies = [
+ "bech32",
+ "bip32",
+ "blake2b_simd",
+ "bls12_381",
+ "bs58",
+ "byteorder",
+ "corez",
+ "document-features",
+ "group",
+ "memuse",
+ "nonempty",
+ "rand_core 0.6.4",
+ "secrecy",
+ "subtle",
+ "tracing",
+ "zakura-orchard",
+ "zakura-sapling-crypto",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_protocol",
+ "zcash_transparent",
+ "zip32",
+]
+
+[[package]]
+name = "zakura-orchard"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc54f01c582fc174c74bc05bbd7b25718a98c360b7e62541969e7ffecf8215b"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "corez",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
+ "tracing",
+ "visibility",
+ "zakura-halo2-gadgets",
+ "zakura-halo2-poseidon",
+ "zakura-halo2-proofs",
+ "zakura-pasta-curves",
+ "zakura-reddsa",
+ "zakura-sinsemilla",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zakura-pasta-curves"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb522ddc5c66ec58632313e31f8863d0c221c76e65d6ab6a32a3e3295cc21b3"
+dependencies = [
+ "blake2b_simd",
+ "cc",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand 0.8.6",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "zakura-pczt"
+version = "0.1.0-rc0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f3ca7e1b5785b709ba0c8a25f1efa4bf98a0b115be16042faa998ac30f016e"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "postcard",
+ "rand_core 0.6.4",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zakura-orchard",
+ "zakura-pasta-curves",
+ "zakura-primitives",
+ "zakura-redjubjub",
+ "zakura-sapling-crypto",
+ "zcash_note_encryption",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
+]
+
+[[package]]
+name = "zakura-primitives"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155bc30ce20ea60b953acd39b437df24c8a31a6d656df57f628d639443b7f34a"
+dependencies = [
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "corez",
+ "crypto-common 0.2.0-rc.1",
+ "document-features",
+ "equihash",
+ "ff",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "rand_core 0.6.4",
+ "secp256k1",
+ "sha2 0.10.9",
+ "zakura-orchard",
+ "zakura-redjubjub",
+ "zakura-sapling-crypto",
+ "zcash_encoding",
+ "zcash_note_encryption",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
+]
+
+[[package]]
+name = "zakura-proofs"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15debcada7148cf5e91a2b41bf94a43499c8ec2c45e448d97e8d39310e5ae93"
+dependencies = [
+ "bellman",
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "group",
+ "home",
+ "jubjub",
+ "known-folders",
+ "rand_core 0.6.4",
+ "tracing",
+ "xdg",
+ "zakura-primitives",
+ "zakura-redjubjub",
+ "zakura-sapling-crypto",
+]
+
+[[package]]
+name = "zakura-reddsa"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a474f689e9394925e16e5c896fcdee8b7375c0bdab9ebfee4d41728ab0df20b7"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "frost-rerandomized",
+ "group",
+ "hex",
+ "jubjub",
+ "rand_core 0.6.4",
+ "serde",
+ "thiserror 2.0.18",
+ "zakura-pasta-curves",
+ "zeroize",
+]
+
+[[package]]
+name = "zakura-redjubjub"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41c898072d6bf762423dd05f0193a486dae6684602a673e59847aa2487cfef81"
+dependencies = [
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
+ "zakura-reddsa",
+ "zeroize",
+]
+
+[[package]]
+name = "zakura-sapling-crypto"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799ccbf7446c09e97e82c5e385f36cf0f076cf6297ba624df170e696307993fc"
+dependencies = [
+ "aes",
+ "bellman",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "bls12_381",
+ "corez",
+ "document-features",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "lazy_static",
+ "memuse",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "subtle",
+ "tracing",
+ "zakura-redjubjub",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zakura-sinsemilla"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2514ff447516a189656567de0d571018d9dcc265da6f931be56fa324db94d681"
+dependencies = [
+ "group",
+ "lazy_static",
+ "subtle",
+ "zakura-pasta-curves",
+]
+
+[[package]]
+name = "zakura-wallet-lib"
+version = "0.1.0-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148371355bc6f83546a0304914a0aa832b843b57ae0dfcbcf400525a9665716c"
+dependencies = [
+ "zakura-client-backend",
+ "zakura-client-sqlite",
+ "zakura-keys",
+ "zakura-orchard",
+ "zakura-pczt",
+ "zakura-primitives",
+ "zcash_client_backend",
+ "zcash_client_sqlite",
+ "zcash_keys",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+dependencies = [
+ "bech32",
+ "bs58",
+ "corez",
+ "f4jumble",
+ "zcash_encoding",
+ "zcash_protocol",
+]
+
+[[package]]
+name = "zcash_client_backend"
+version = "0.24.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49636f1d22b0511b2a117548cc9dcf569440a3589b06bf6df422c6b738f6231"
+dependencies = [
+ "base64",
+ "bech32",
+ "bls12_381",
+ "bs58",
+ "byteorder",
+ "document-features",
+ "flume",
+ "getset",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "percent-encoding",
+ "prost 0.14.3",
+ "rand_core 0.6.4",
+ "rayon",
+ "sapling-crypto",
+ "secrecy",
+ "shardtree",
+ "subtle",
+ "time",
+ "tonic-prost-build",
+ "tracing",
  "which 8.0.2",
  "zcash_address",
  "zcash_encoding",
@@ -7741,7 +8153,6 @@ version = "0.22.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7a9511b23d123fabf23b797e9d750dabe69bd31ebcfd2de9423e0f5c0a3c73"
 dependencies = [
- "bip32",
  "bitflags",
  "bs58",
  "byteorder",
@@ -7763,9 +8174,7 @@ dependencies = [
  "sapling-crypto",
  "schemerz",
  "schemerz-rusqlite",
- "secp256k1",
  "secrecy",
- "serde",
  "shardtree",
  "static_assertions",
  "subtle",
@@ -7802,11 +8211,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
 dependencies = [
  "bech32",
- "bip32",
  "blake2b_simd",
  "bls12_381",
  "bs58",
- "byteorder",
  "corez",
  "document-features",
  "group",
@@ -7881,35 +8288,12 @@ dependencies = [
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
- "secp256k1",
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
-]
-
-[[package]]
-name = "zcash_proofs"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
-dependencies = [
- "bellman",
- "blake2b_simd",
- "bls12_381",
- "document-features",
- "group",
- "home",
- "jubjub",
- "known-folders",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "tracing",
- "xdg",
- "zcash_primitives",
 ]
 
 [[package]]
@@ -7978,8 +8362,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "3.0.0"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=7986b9cddf987c69e4a8ea23d3bb55c89e054910#7986b9cddf987c69e4a8ea23d3bb55c89e054910"
+version = "3.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "448504462b6f5e818d51582de7aa80f5014731a9131a5ac650b3491a383937b3"
 dependencies = [
  "anyhow",
  "base64",
@@ -7988,8 +8373,6 @@ dependencies = [
  "ed25519-dalek",
  "ff",
  "group",
- "halo2_gadgets",
- "halo2_proofs",
  "hex",
  "http",
  "http-body-util",
@@ -7999,9 +8382,6 @@ dependencies = [
  "imt-tree",
  "incrementalmerkletree",
  "nonempty",
- "orchard",
- "pasta_curves",
- "pczt",
  "pir-client",
  "pir-types",
  "prost 0.14.3",
@@ -8011,7 +8391,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "sinsemilla",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
@@ -8022,10 +8401,14 @@ dependencies = [
  "vote-commitment-tree",
  "vote-commitment-tree-client",
  "voting-circuits",
- "zcash_client_backend",
- "zcash_client_sqlite",
- "zcash_keys",
- "zcash_primitives",
+ "voting-crypto-deps",
+ "zakura-client-backend",
+ "zakura-client-sqlite",
+ "zakura-keys",
+ "zakura-orchard",
+ "zakura-pczt",
+ "zakura-primitives",
+ "zakura-wallet-lib",
  "zcash_protocol",
  "zeroize",
  "zip32",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,10 +10,10 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 flutter_rust_bridge = "=2.11.1"
 
 zcash_script = "0.4.3"
-sapling-crypto = { version = "0.7", default-features = false, features = ["circuit"] }
+sapling-crypto = { package = "zakura-sapling-crypto", version = "1.0.0-rc.1", default-features = false, features = ["circuit"] }
 uuid = "1.1"
 zip32 = "0.2"
-pasta_curves = "0.5"
+pasta_curves = { package = "zakura-pasta-curves", version = "1.0.0-rc.1" }
 ff = "0.13"
 # Required by no-op Sapling prover trait impls
 jubjub = "0.10"
@@ -75,15 +75,18 @@ ur = { git = "https://github.com/KeystoneHQ/ur-rs", tag = "0.3.3" }
 serde_json = "1"
 url = "2.5.8"
 
-# Zcash core
+# Zcash core. Package names are the Zakura forks; lib names stay upstream so
+# `use orchard` / `use zcash_client_backend` keep working.
 [dependencies.zcash_primitives]
-version = "0.30.0"
+package = "zakura-primitives"
+version = "1.0.0-rc.1"
 
 [dependencies.zcash_address]
 version = "0.13.0"
 
 [dependencies.zcash_keys]
-version = "0.16.1"
+package = "zakura-keys"
+version = "1.0.0-rc.1"
 features = ["orchard"]
 
 [dependencies.zcash_protocol]
@@ -94,7 +97,8 @@ package = "zcash_transparent"
 version = "0.10.0"
 
 [dependencies.zcash_client_backend]
-version = "0.24.0-rc.7"
+package = "zakura-client-backend"
+version = "0.1.0-rc1"
 features = [
     "orchard",
     "transparent-inputs",
@@ -106,24 +110,26 @@ features = [
 ]
 
 [dependencies.zcash_client_sqlite]
-version = "0.22.0-rc.7"
+package = "zakura-client-sqlite"
+version = "0.1.0-rc1"
 features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
-# Voting clients need PIR lookup support and vote-commitment-tree sync.
 [dependencies.zcash_voting]
-version = "=3.0.0"
+version = "=3.1.0-rc.1"
+default-features = false
+features = ["zakura"]
 
-# Keep Orchard aligned with the released librustzcash and zcash_voting family
-# to avoid type conflicts.
 [dependencies.orchard]
-version = "0.15.4"
+package = "zakura-orchard"
+version = "1.0.0-rc.1"
 
-# Proofs
 [dependencies.zcash_proofs]
-version = "0.30.0"
+package = "zakura-proofs"
+version = "1.0.0-rc.1"
 
 [dependencies.pczt]
-version = "0.9.2"
+package = "zakura-pczt"
+version = "0.1.0-rc0"
 features = [
     "orchard",
     "io-finalizer",
@@ -156,13 +162,9 @@ rusqlite = "0.37"
 zcash_note_encryption = "0.4"
 
 [dev-dependencies.vote-commitment-tree]
-version = "=0.5.0"
-
-# Temporary pending-share discovery API until the next zcash_voting release.
-[patch.crates-io]
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7986b9cddf987c69e4a8ea23d3bb55c89e054910" }
-vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7986b9cddf987c69e4a8ea23d3bb55c89e054910" }
-vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7986b9cddf987c69e4a8ea23d3bb55c89e054910" }
+version = "=0.5.1"
+default-features = false
+features = ["zakura"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)', 'cfg(ironwood_masquerade)'] }
@@ -177,3 +179,4 @@ opt-level = 3
 
 [profile.dev.package."*"]
 opt-level = 3
+

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -53,7 +53,7 @@ use shardtree::{
 use tonic::Code;
 use transparent::{address::TransparentAddress, bundle::OutPoint, keys::TransparentKeyScope};
 use zcash_client_backend::data_api::wallet::input_selection::{
-    GreedyInputSelector, InputSelector, LockFilter, LockedInputPolicy, SpendPolicy,
+    GreedyInputSelector, InputSelector, LockFilter, LockedInputPolicy, NoteSelection, SpendPolicy,
 };
 use zcash_client_backend::{
     data_api::{
@@ -3391,6 +3391,7 @@ fn ordinary_send_spend_pools(orchard_reserved_for_migration: bool) -> Vec<Shield
 
 fn ordinary_send_spend_policy(orchard_reserved_for_migration: bool) -> SpendPolicy {
     SpendPolicy::shielded_pools(ordinary_send_spend_pools(orchard_reserved_for_migration))
+        .with_note_selection(NoteSelection::PreferConsolidation)
 }
 
 pub(super) fn proposal_input_refs(

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -847,6 +847,7 @@ fn active_migration_restricts_ordinary_sends_to_ironwood() {
     assert!(!policy.permits_shielded(ShieldedPool::Sapling));
     assert!(!policy.permits_shielded(ShieldedPool::Orchard));
     assert!(policy.permits_shielded(ShieldedPool::Ironwood));
+    assert_eq!(policy.note_selection(), NoteSelection::PreferConsolidation);
     assert_eq!(
         ordinary_send_spend_pools(true),
         vec![ShieldedPool::Ironwood]
@@ -860,6 +861,7 @@ fn ordinary_send_policy_keeps_all_shielded_pools_without_migration() {
     assert!(policy.permits_shielded(ShieldedPool::Sapling));
     assert!(policy.permits_shielded(ShieldedPool::Orchard));
     assert!(policy.permits_shielded(ShieldedPool::Ironwood));
+    assert_eq!(policy.note_selection(), NoteSelection::PreferConsolidation);
 }
 
 fn migration_test_stage(


### PR DESCRIPTION
## Summary
- update `zcash_voting` to `3.1.0-rc.1` and select its non-default `zakura` feature
- move the compatible wallet, proving, PCZT, Orchard, Sapling, and voting dependency graph onto the published Zakura release candidates
- opt ordinary sends and fee estimates into `NoteSelection::PreferConsolidation`
- preserve migration pool restrictions while allowing bounded note cleanup within the selected pool

## Motivation / Why
The updated voting release can use Zakura's matching cryptography and wallet stack, including its optimized proving backend. Keeping the complete public-type graph on compatible Zakura packages avoids mixed upstream/fork types.

The new consolidation-aware policy reduces fragmented shielded balances without changing transaction fees or observable shape. It first chooses a small necessary funding set, then opportunistically adds bounded cleanup inputs only when they fit within already-observable shielded action capacity.

Send-max, shielding, and migration-specific proposal flows remain unchanged because they either consume all available funds or have specialized input-selection constraints. Ordinary sends still honor migration locks and restrict selection to Ironwood while Orchard inputs are reserved for an active migration.

## Implications
- transaction construction changes only for ordinary fixed-amount sends and matching fee estimates
- no Rust FFI surface, database schema, serialized format, or secure-storage change
- behavior applies across platforms through the shared Rust wallet core
- the selection policy preserves pool preferences, lock tiers, fees, output counts, and observable bundle shape

## Tests
- `cd rust && rustfmt --edition 2021 --check src/wallet/sync/send.rs src/wallet/sync/send/tests.rs`
- `cd rust && cargo check --locked`
- `cd rust && cargo test --locked wallet::voting --lib` (9 passed)
- `cd rust && cargo test --locked ordinary_send --lib` (2 passed)

Not run: regtest and Flutter suites; this change is confined to Rust dependency selection and wallet input-selection policy, with no FFI or Dart changes.