### PR TITLE
Hide test rounds by default

### DIFF
--- a/lib/src/features/voting/widgets/voting_config_settings_panel.dart
+++ b/lib/src/features/voting/widgets/voting_config_settings_panel.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/services.dart'
-    show SystemMouseCursors, TextInputAction, TextInputType;
+    show LogicalKeyboardKey, SystemMouseCursors, TextInputAction, TextInputType;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -12,6 +12,7 @@ import '../../../core/widgets/app_text_field.dart';
 import '../../swap/models/swap_address_formatting.dart';
 import '../../../providers/voting/voting_config_provider.dart';
 import '../../../providers/voting/voting_config_source_provider.dart';
+import '../../../providers/voting/voting_round_visibility_provider.dart';
 import '../../../providers/voting/voting_rounds_provider.dart';
 import '../../../providers/voting/voting_service_providers.dart';
 import '../../../providers/voting/voting_submission_guard_provider.dart';
@@ -46,7 +47,9 @@ class _VotingConfigSettingsPanelState
   bool _showEditor = false;
   bool _isSubmitting = false;
   bool _isSavingSelection = false;
+  bool _isSavingTestRoundVisibility = false;
   String? _submitError;
+  String? _testRoundVisibilityError;
   String? _validationField;
   _ConfigSourceSelection? _pendingSelection;
 
@@ -375,10 +378,34 @@ class _VotingConfigSettingsPanelState
     return text.isEmpty ? "Couldn't update voting config." : text;
   }
 
+  Future<void> _toggleTestRoundVisibility(bool currentlyShown) async {
+    if (_isSavingTestRoundVisibility) return;
+    setState(() {
+      _isSavingTestRoundVisibility = true;
+      _testRoundVisibilityError = null;
+    });
+    try {
+      await ref
+          .read(showTestVotingRoundsProvider.notifier)
+          .setShowTestRounds(!currentlyShown);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _testRoundVisibilityError =
+            "Couldn't update the test round visibility setting.";
+      });
+    } finally {
+      if (mounted) {
+        setState(() => _isSavingTestRoundVisibility = false);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
     final sourceState = ref.watch(votingConfigSourceProvider);
+    final showTestRoundsState = ref.watch(showTestVotingRoundsProvider);
     final submissionInProgress = ref
         .watch(votingSubmissionGuardProvider)
         .isNotEmpty;
@@ -428,6 +455,18 @@ class _VotingConfigSettingsPanelState
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
+                          _ShowTestRoundsCard(
+                            enabled: showTestRoundsState.value ?? false,
+                            error: _testRoundVisibilityError,
+                            onToggle:
+                                showTestRoundsState.hasValue &&
+                                    !_isSavingTestRoundVisibility
+                                ? () => _toggleTestRoundVisibility(
+                                    showTestRoundsState.requireValue,
+                                  )
+                                : null,
+                          ),
+                          const SizedBox(height: AppSpacing.sm),
                           _SourceCard(
                             title: 'Token holder voting',
                             sourceUrl: kDefaultStaticVotingConfigSource,
@@ -551,6 +590,161 @@ class _VotingConfigSettingsPanelState
                 ],
               );
             },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+const _toggleShortcuts = <ShortcutActivator, Intent>{
+  SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+  SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
+};
+
+class _ShowTestRoundsCard extends StatefulWidget {
+  const _ShowTestRoundsCard({
+    required this.enabled,
+    required this.error,
+    required this.onToggle,
+  });
+
+  final bool enabled;
+  final String? error;
+  final VoidCallback? onToggle;
+
+  @override
+  State<_ShowTestRoundsCard> createState() => _ShowTestRoundsCardState();
+}
+
+class _ShowTestRoundsCardState extends State<_ShowTestRoundsCard> {
+  bool _focused = false;
+
+  void _activate() => widget.onToggle?.call();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final interactive = widget.onToggle != null;
+    return Semantics(
+      container: true,
+      button: true,
+      enabled: interactive,
+      toggled: widget.enabled,
+      label: 'Show test rounds',
+      onTap: widget.onToggle,
+      excludeSemantics: true,
+      child: MouseRegion(
+        cursor: interactive
+            ? SystemMouseCursors.click
+            : SystemMouseCursors.basic,
+        child: FocusableActionDetector(
+          enabled: interactive,
+          mouseCursor: interactive
+              ? SystemMouseCursors.click
+              : SystemMouseCursors.basic,
+          onShowFocusHighlight: (focused) {
+            if (_focused == focused) return;
+            setState(() => _focused = focused);
+          },
+          shortcuts: _toggleShortcuts,
+          actions: <Type, Action<Intent>>{
+            ActivateIntent: CallbackAction<Intent>(
+              onInvoke: (_) {
+                _activate();
+                return null;
+              },
+            ),
+          },
+          child: GestureDetector(
+            key: const ValueKey('voting_show_test_rounds_toggle'),
+            behavior: HitTestBehavior.opaque,
+            onTap: widget.onToggle,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: colors.surface.card,
+                borderRadius: BorderRadius.circular(AppRadii.small),
+                border: Border.all(
+                  color: _focused
+                      ? colors.state.focusRing
+                      : colors.border.subtle,
+                  width: _focused ? 2 : 1,
+                ),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.sm),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Show test rounds',
+                            style: AppTypography.labelLarge.copyWith(
+                              color: colors.text.accent,
+                            ),
+                          ),
+                          const SizedBox(height: AppSpacing.xxs),
+                          Text(
+                            'Display authenticated rounds whose titles begin with [TEST].',
+                            style: AppTypography.labelMedium.copyWith(
+                              color: colors.text.secondary,
+                            ),
+                          ),
+                          if (widget.error != null) ...[
+                            const SizedBox(height: AppSpacing.xxs),
+                            Text(
+                              widget.error!,
+                              style: AppTypography.labelMedium.copyWith(
+                                color: colors.text.destructive,
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.sm),
+                    Opacity(
+                      opacity: interactive ? 1 : 0.65,
+                      child: AnimatedContainer(
+                        duration: const Duration(milliseconds: 140),
+                        curve: Curves.easeOut,
+                        width: 44,
+                        height: 20,
+                        padding: const EdgeInsets.all(2),
+                        decoration: BoxDecoration(
+                          color: widget.enabled
+                              ? colors.background.brandCrimsonStrong
+                              : colors.background.overlay,
+                          borderRadius: BorderRadius.circular(AppRadii.full),
+                        ),
+                        child: AnimatedAlign(
+                          duration: const Duration(milliseconds: 140),
+                          curve: Curves.easeOut,
+                          alignment: widget.enabled
+                              ? Alignment.centerRight
+                              : Alignment.centerLeft,
+                          child: DecoratedBox(
+                            key: const ValueKey(
+                              'voting_show_test_rounds_thumb',
+                            ),
+                            decoration: BoxDecoration(
+                              color: const Color(0xFFFFFFFF),
+                              borderRadius: BorderRadius.circular(
+                                AppRadii.full,
+                              ),
+                            ),
+                            child: const SizedBox(width: 28, height: 16),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/src/providers/voting/voting_round_visibility_provider.dart
+++ b/lib/src/providers/voting/voting_round_visibility_provider.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Install-local preference for showing authenticated test voting rounds.
+const votingShowTestRoundsStorageKey = 'vizor_voting_show_test_rounds';
+
+/// Persists whether test voting rounds should appear in the vote menu.
+abstract interface class VotingRoundVisibilityStore {
+  Future<bool> readShowTestRounds();
+
+  Future<void> writeShowTestRounds(bool show);
+}
+
+/// Shared preferences implementation of [VotingRoundVisibilityStore].
+class SharedPreferencesVotingRoundVisibilityStore
+    implements VotingRoundVisibilityStore {
+  const SharedPreferencesVotingRoundVisibilityStore();
+
+  @override
+  Future<bool> readShowTestRounds() async {
+    final preferences = await SharedPreferences.getInstance();
+    return preferences.getBool(votingShowTestRoundsStorageKey) ?? false;
+  }
+
+  @override
+  Future<void> writeShowTestRounds(bool show) async {
+    final preferences = await SharedPreferences.getInstance();
+    final saved = await preferences.setBool(
+      votingShowTestRoundsStorageKey,
+      show,
+    );
+    if (!saved) {
+      throw StateError('Could not save the test round visibility preference.');
+    }
+  }
+}
+
+/// Injectable persistence used by [showTestVotingRoundsProvider].
+final votingRoundVisibilityStoreProvider = Provider<VotingRoundVisibilityStore>(
+  (_) => const SharedPreferencesVotingRoundVisibilityStore(),
+);
+
+/// Loads and updates the test round visibility preference.
+class ShowTestVotingRoundsNotifier extends AsyncNotifier<bool> {
+  @override
+  Future<bool> build() async {
+    try {
+      return await ref
+          .watch(votingRoundVisibilityStoreProvider)
+          .readShowTestRounds();
+    } catch (error) {
+      debugPrint(
+        '[zcash] Voting: failed to load test round visibility: $error',
+      );
+      return false;
+    }
+  }
+
+  /// Persists [show] before publishing it to vote menu consumers.
+  Future<void> setShowTestRounds(bool show) async {
+    if (state.value == show) return;
+    await ref
+        .read(votingRoundVisibilityStoreProvider)
+        .writeShowTestRounds(show);
+    state = AsyncData(show);
+  }
+}
+
+/// Whether authenticated rounds whose titles start with `[TEST]` are visible.
+final showTestVotingRoundsProvider =
+    AsyncNotifierProvider<ShowTestVotingRoundsNotifier, bool>(
+      ShowTestVotingRoundsNotifier.new,
+    );

--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -12,6 +12,7 @@ import 'voting_service_providers.dart';
 import 'voting_state.dart';
 
 const kVotingPollListRecentRefreshWindow = Duration(seconds: 10);
+const _hiddenTestRoundTitlePrefix = '[TEST]';
 DateTime? _lastVotingPollListRefreshAt;
 
 class VotingPollListRefreshRequestNotifier extends Notifier<int> {
@@ -102,22 +103,32 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
     final authenticatedRoundIds = config.authenticatedRounds
         .map((round) => round.roundId)
         .toSet();
-    final filteredRounds = rounds
+    final authenticatedRounds = rounds
         .where((round) => authenticatedRoundIds.contains(round.roundId))
         .toList(growable: false);
-    if (filteredRounds.length != rounds.length) {
+    if (authenticatedRounds.length != rounds.length) {
       debugPrint(
         '[zcash] Voting: filtered rounds '
         '(unauthenticated) '
-        'shown=${filteredRounds.length} total=${rounds.length}',
+        'shown=${authenticatedRounds.length} total=${rounds.length}',
+      );
+    }
+    final visibleRounds = authenticatedRounds
+        .where((round) => !round.title.startsWith(_hiddenTestRoundTitlePrefix))
+        .toList(growable: false);
+    if (visibleRounds.length != authenticatedRounds.length) {
+      debugPrint(
+        '[zcash] Voting: filtered test rounds '
+        'shown=${visibleRounds.length} '
+        'authenticated=${authenticatedRounds.length}',
       );
     }
     final recoveryStates = await _roundListRecoveryStates(
-      filteredRounds,
+      visibleRounds,
       api: api,
     );
     return [
-      for (final round in filteredRounds)
+      for (final round in visibleRounds)
         VotingRoundView.fromSummary(
           round,
           voted: recoveryStates[round.roundId]?.voted ?? false,

--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -8,6 +8,7 @@ import '../../services/voting/voting_api_client.dart';
 import '../../services/voting/resolved_voting_config_extensions.dart';
 import '../../services/voting/voting_models.dart';
 import 'voting_config_provider.dart';
+import 'voting_round_visibility_provider.dart';
 import 'voting_service_providers.dart';
 import 'voting_state.dart';
 
@@ -68,7 +69,8 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
   @override
   Future<List<VotingRoundView>> build() async {
     ref.watch(votingActiveAccountUuidProvider);
-    return _load();
+    final showTestRounds = await ref.watch(showTestVotingRoundsProvider.future);
+    return _load(showTestRounds: showTestRounds);
   }
 
   Future<void> reload() async {
@@ -84,7 +86,12 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
       do {
         _reloadQueued = false;
         state = const AsyncLoading<List<VotingRoundView>>();
-        state = await AsyncValue.guard(_load);
+        state = await AsyncValue.guard(() async {
+          final showTestRounds = await ref.read(
+            showTestVotingRoundsProvider.future,
+          );
+          return _load(showTestRounds: showTestRounds);
+        });
       } while (_reloadQueued);
     }();
     _reloadFuture = run;
@@ -95,7 +102,7 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
     }
   }
 
-  Future<List<VotingRoundView>> _load() async {
+  Future<List<VotingRoundView>> _load({required bool showTestRounds}) async {
     final config = await ref.read(votingConfigProvider.future);
     final api = ref.read(votingApiClientProvider(config.apiServers));
 
@@ -113,9 +120,13 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
         'shown=${authenticatedRounds.length} total=${rounds.length}',
       );
     }
-    final visibleRounds = authenticatedRounds
-        .where((round) => !round.title.startsWith(_hiddenTestRoundTitlePrefix))
-        .toList(growable: false);
+    final visibleRounds = showTestRounds
+        ? authenticatedRounds
+        : authenticatedRounds
+              .where(
+                (round) => !round.title.startsWith(_hiddenTestRoundTitlePrefix),
+              )
+              .toList(growable: false);
     if (visibleRounds.length != authenticatedRounds.length) {
       debugPrint(
         '[zcash] Voting: filtered test rounds '

--- a/test/features/voting/voting_config_settings_panel_test.dart
+++ b/test/features/voting/voting_config_settings_panel_test.dart
@@ -10,6 +10,7 @@ import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/voting/widgets/voting_config_settings_panel.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_config_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_round_visibility_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_rounds_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_config_source_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_state.dart';
@@ -19,6 +20,43 @@ import 'package:zcash_wallet/src/providers/voting/voting_submission_guard_provid
 import 'package:zcash_wallet/src/services/voting/voting_config_loader.dart';
 
 void main() {
+  testWidgets('test round visibility setting persists both states', (
+    tester,
+  ) async {
+    final visibilityStore = _FakeVotingRoundVisibilityStore();
+    await tester.binding.setSurfaceSize(const Size(800, 720));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await _pumpPanel(
+      tester,
+      store: _FakeVotingConfigSourceStore(),
+      visibilityStore: visibilityStore,
+    );
+
+    expect(find.text('Show test rounds'), findsOneWidget);
+    expect(
+      find.text('Display authenticated rounds whose titles begin with [TEST].'),
+      findsOneWidget,
+    );
+    expect(visibilityStore.showTestRounds, isFalse);
+
+    await tester.tap(
+      find.byKey(const ValueKey('voting_show_test_rounds_toggle')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(visibilityStore.showTestRounds, isTrue);
+
+    await tester.tap(
+      find.byKey(const ValueKey('voting_show_test_rounds_toggle')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(visibilityStore.showTestRounds, isFalse);
+  });
+
   testWidgets('default source does not duplicate the current URL', (
     tester,
   ) async {
@@ -212,12 +250,16 @@ void main() {
 Future<void> _pumpPanel(
   WidgetTester tester, {
   required _FakeVotingConfigSourceStore store,
+  _FakeVotingRoundVisibilityStore? visibilityStore,
   bool guarded = false,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         votingConfigSourceStoreProvider.overrideWithValue(store),
+        votingRoundVisibilityStoreProvider.overrideWithValue(
+          visibilityStore ?? _FakeVotingRoundVisibilityStore(),
+        ),
         votingConfigProvider.overrideWith(_NoopVotingConfigNotifier.new),
         votingRoundsProvider.overrideWith(_NoopVotingRoundsNotifier.new),
         if (guarded)
@@ -332,5 +374,19 @@ class _FakeVotingConfigSourceStore implements VotingConfigSourceStore {
   @override
   Future<void> writeSavedSourcesJson(String savedSourcesJson) async {
     this.savedSourcesJson = savedSourcesJson;
+  }
+}
+
+class _FakeVotingRoundVisibilityStore implements VotingRoundVisibilityStore {
+  _FakeVotingRoundVisibilityStore();
+
+  bool showTestRounds = false;
+
+  @override
+  Future<bool> readShowTestRounds() async => showTestRounds;
+
+  @override
+  Future<void> writeShowTestRounds(bool show) async {
+    showTestRounds = show;
   }
 }

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -17,6 +17,7 @@ import 'package:zcash_wallet/src/features/voting/voting_recovery_service.dart';
 import 'package:zcash_wallet/src/features/voting/voting_resume_plan.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_config_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_config_source_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_round_visibility_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_rounds_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_service_providers.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_session_provider.dart';
@@ -890,6 +891,47 @@ void main() {
 
     final rounds = await container.read(votingRoundsProvider.future);
     expect(rounds.map((round) => round.roundId), [kOtherRoundId]);
+  });
+
+  test('rounds provider refreshes when test rounds are enabled', () async {
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://voting.example/static-voting-config.json': staticConfigJson(),
+        'https://voting.example/dynamic-voting-config.json':
+            dynamicConfigJson(),
+        '/shielded-vote/v1/rounds': {
+          'rounds': [
+            {
+              'vote_round_id': kRoundId,
+              'title': '[TEST] Opt-in poll',
+              'status': 'active',
+            },
+            {
+              'vote_round_id': kOtherRoundId,
+              'title': 'Visible poll',
+              'status': 'active',
+            },
+          ],
+        },
+      },
+    );
+    final visibilityStore = FakeVotingRoundVisibilityStore();
+    final container = _container(http: http, visibilityStore: visibilityStore);
+    addTearDown(container.dispose);
+
+    final hiddenRounds = await container.read(votingRoundsProvider.future);
+    expect(hiddenRounds.map((round) => round.roundId), [kOtherRoundId]);
+
+    await container
+        .read(showTestVotingRoundsProvider.notifier)
+        .setShowTestRounds(true);
+
+    final visibleRounds = await container.read(votingRoundsProvider.future);
+    expect(visibleRounds.map((round) => round.roundId), [
+      kRoundId,
+      kOtherRoundId,
+    ]);
+    expect(visibilityStore.showTestRounds, isTrue);
   });
 
   test(
@@ -5174,11 +5216,15 @@ void main() {
 ProviderContainer _container({
   required VotingHttpClient http,
   VotingConfigSourceStore? sourceStore,
+  VotingRoundVisibilityStore? visibilityStore,
 }) {
   return ProviderContainer(
     overrides: [
       votingConfigSourceStoreProvider.overrideWithValue(
         sourceStore ?? FakeVotingConfigSourceStore(),
+      ),
+      votingRoundVisibilityStoreProvider.overrideWithValue(
+        visibilityStore ?? FakeVotingRoundVisibilityStore(),
       ),
       votingHttpClientProvider.overrideWithValue(http),
       votingConfigLoaderProvider.overrideWithValue(
@@ -5202,6 +5248,20 @@ ProviderContainer _container({
       votingActiveAccountUuidProvider.overrideWithValue(() async => null),
     ],
   );
+}
+
+class FakeVotingRoundVisibilityStore implements VotingRoundVisibilityStore {
+  FakeVotingRoundVisibilityStore({this.showTestRounds = false});
+
+  bool showTestRounds;
+
+  @override
+  Future<bool> readShowTestRounds() async => showTestRounds;
+
+  @override
+  Future<void> writeShowTestRounds(bool show) async {
+    showTestRounds = show;
+  }
 }
 
 final class _ProviderDisposalObserver extends ProviderObserver {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -863,6 +863,35 @@ void main() {
     expect(rounds.map((round) => round.roundId), [kRoundId, kOtherRoundId]);
   });
 
+  test('rounds provider hides authenticated [TEST] title prefixes', () async {
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://voting.example/static-voting-config.json': staticConfigJson(),
+        'https://voting.example/dynamic-voting-config.json':
+            dynamicConfigJson(),
+        '/shielded-vote/v1/rounds': {
+          'rounds': [
+            {
+              'vote_round_id': kRoundId,
+              'title': '[TEST] Hidden poll',
+              'status': 'active',
+            },
+            {
+              'vote_round_id': kOtherRoundId,
+              'title': 'Visible poll [TEST]',
+              'status': 'active',
+            },
+          ],
+        },
+      },
+    );
+    final container = _container(http: http);
+    addTearDown(container.dispose);
+
+    final rounds = await container.read(votingRoundsProvider.future);
+    expect(rounds.map((round) => round.roundId), [kOtherRoundId]);
+  });
+
   test(
     'rounds provider marks locally completed active rounds as voted',
     () async {


### PR DESCRIPTION
Rounds whose title begins with the exact `[TEST]` marker are hidden from the vote menu by default after authentication. Users can opt in with **Show test rounds** in Voting config, and that choice is saved for later sessions.

The behavior applies to production and stage configurations. Enabling test rounds does not bypass config authentication or change explicit authenticated round flows.