### PR TITLE
Submit vote shares concurrently

### DIFF
--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1590,10 +1590,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
       }
 
+      final submissions = <Future<_InitialShareSubmissionResult>>[];
       for (var payloadIndex = 0; payloadIndex < shares.length; payloadIndex++) {
         final share = shares[payloadIndex];
         final plan = plans[payloadIndex];
-        final acceptedServers = <String>[];
         final targetCount = plan.targetCount
             .clamp(1, serverUrls.length)
             .toInt();
@@ -1617,60 +1617,95 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           totalQuestions: totalQuestions,
           voteSubmissionProgress: voteSubmissionProgress,
         );
-        for (final serverUrl in candidateServers) {
-          if (acceptedServers.length >= targetCount) break;
-          try {
-            debugPrint(
-              '[zcash] Voting: submitting share '
-              'proposal=${share.proposalId} share=${share.shareIndex} '
-              'server=$serverUrl treePosition=${body['tree_position']} '
-              'submitAt=${plan.submitAt} target=$targetCount',
-            );
-            await api.submitShare(serverUrl: Uri.parse(serverUrl), share: body);
-            helperHealth.recordSuccess(serverUrl);
-            acceptedServers.add(serverUrl);
-            debugPrint(
-              '[zcash] Voting: share accepted '
-              'proposal=${share.proposalId} share=${share.shareIndex} '
-              'server=$serverUrl accepted=${acceptedServers.length}/$targetCount',
-            );
-          } catch (e) {
-            debugPrint(
-              '[zcash] Voting: share rejected '
-              'proposal=${share.proposalId} share=${share.shareIndex} '
-              'server=$serverUrl error=$e',
-            );
-            helperHealth.recordFailure(serverUrl);
-            // Recovery retries helpers that did not accept this share.
-          }
-        }
-        if (acceptedServers.isEmpty) {
-          throw StateError(
-            'No vote server accepted share ${share.shareIndex} '
-            'for proposal ${share.proposalId}.',
-          );
-        }
-        if (acceptedServers.length < targetCount) {
-          debugPrint(
-            '[zcash] Voting: share accepted by fewer helpers than planned '
-            'proposal=${share.proposalId} '
-            'share=${share.shareIndex} '
-            'accepted=${acceptedServers.length}/$targetCount',
-          );
-        }
+        submissions.add(
+          _submitInitialShareToHelpers(
+            api: api,
+            helperHealth: helperHealth,
+            share: share,
+            body: body,
+            candidateServers: candidateServers,
+            targetCount: targetCount,
+            submitAt: plan.submitAt,
+          ),
+        );
+      }
 
+      final results = await Future.wait(submissions);
+      _InitialShareSubmissionResult? failedResult;
+      for (final result in results) {
+        if (result.acceptedServers.isEmpty) {
+          failedResult ??= result;
+          continue;
+        }
         await rust.recordShareDelegation(
           dbPath: context.dbPath,
           accountUuid: context.accountUuid,
           roundId: context.round.roundId,
           bundleIndex: commitments.bundleIndex,
-          proposalId: share.proposalId,
-          shareIndex: share.shareIndex,
-          sentToUrls: acceptedServers,
-          submitAt: plan.submitAt,
+          proposalId: result.share.proposalId,
+          shareIndex: result.share.shareIndex,
+          sentToUrls: result.acceptedServers,
+          submitAt: result.submitAt,
+        );
+      }
+      if (failedResult != null) {
+        throw StateError(
+          'No vote server accepted share ${failedResult.share.shareIndex} '
+          'for proposal ${failedResult.share.proposalId}.',
         );
       }
     }
+  }
+
+  Future<_InitialShareSubmissionResult> _submitInitialShareToHelpers({
+    required VotingApiClient api,
+    required VotingHelperHealthTracker helperHealth,
+    required rust_wire.VoteShareWire share,
+    required Map<String, dynamic> body,
+    required List<String> candidateServers,
+    required int targetCount,
+    required BigInt submitAt,
+  }) async {
+    final acceptedServers = <String>[];
+    for (final serverUrl in candidateServers) {
+      if (acceptedServers.length >= targetCount) break;
+      try {
+        debugPrint(
+          '[zcash] Voting: submitting share '
+          'proposal=${share.proposalId} share=${share.shareIndex} '
+          'server=$serverUrl treePosition=${body['tree_position']} '
+          'submitAt=$submitAt target=$targetCount',
+        );
+        await api.submitShare(serverUrl: Uri.parse(serverUrl), share: body);
+        helperHealth.recordSuccess(serverUrl);
+        acceptedServers.add(serverUrl);
+        debugPrint(
+          '[zcash] Voting: share accepted '
+          'proposal=${share.proposalId} share=${share.shareIndex} '
+          'server=$serverUrl accepted=${acceptedServers.length}/$targetCount',
+        );
+      } catch (e) {
+        debugPrint(
+          '[zcash] Voting: share rejected '
+          'proposal=${share.proposalId} share=${share.shareIndex} '
+          'server=$serverUrl error=$e',
+        );
+        helperHealth.recordFailure(serverUrl);
+        // Recovery retries helpers that did not accept this share.
+      }
+    }
+    if (acceptedServers.length < targetCount && acceptedServers.isNotEmpty) {
+      debugPrint(
+        '[zcash] Voting: share accepted by fewer helpers than planned '
+        'proposal=${share.proposalId} share=${share.shareIndex} '
+        'accepted=${acceptedServers.length}/$targetCount',
+      );
+    }
+    return _InitialShareSubmissionResult(
+      share: share,
+      submitAt: submitAt,
+      acceptedServers: acceptedServers,
+    );
   }
 
   Future<int> _syncVoteTreeWithFailover({
@@ -3752,6 +3787,18 @@ class VotingSubmissionSessionNotifier extends VotingSessionNotifier {
     }
     await _refreshVotingEligibilityState(current: current, context: context);
   }
+}
+
+class _InitialShareSubmissionResult {
+  const _InitialShareSubmissionResult({
+    required this.share,
+    required this.submitAt,
+    required this.acceptedServers,
+  });
+
+  final rust_wire.VoteShareWire share;
+  final BigInt submitAt;
+  final List<String> acceptedServers;
 }
 
 final votingSessionProvider =

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1590,7 +1590,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
       }
 
-      final submissions = <Future<_InitialShareSubmissionResult>>[];
+      // Validate every body before starting helper requests. Otherwise a later
+      // serialization failure could abandon already accepted submissions.
+      final preparedSubmissions = <_PreparedInitialShareSubmission>[];
       for (var payloadIndex = 0; payloadIndex < shares.length; payloadIndex++) {
         final share = shares[payloadIndex];
         final plan = plans[payloadIndex];
@@ -1617,10 +1619,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           totalQuestions: totalQuestions,
           voteSubmissionProgress: voteSubmissionProgress,
         );
-        submissions.add(
-          _submitInitialShareToHelpers(
-            api: api,
-            helperHealth: helperHealth,
+        preparedSubmissions.add(
+          _PreparedInitialShareSubmission(
             share: share,
             body: body,
             candidateServers: candidateServers,
@@ -1630,23 +1630,46 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
       }
 
-      final results = await Future.wait(submissions);
+      final submissions = [
+        for (final prepared in preparedSubmissions)
+          _submitInitialShareToHelpers(
+            api: api,
+            helperHealth: helperHealth,
+            share: prepared.share,
+            body: prepared.body,
+            candidateServers: prepared.candidateServers,
+            targetCount: prepared.targetCount,
+            submitAt: prepared.submitAt,
+          ),
+      ];
       _InitialShareSubmissionResult? failedResult;
-      for (final result in results) {
+      Object? persistenceError;
+      StackTrace? persistenceStackTrace;
+      // Persist in completion order so accepted shares become durable promptly
+      // while Rust DB writes remain sequential.
+      await for (final result in Stream.fromFutures(submissions)) {
         if (result.acceptedServers.isEmpty) {
           failedResult ??= result;
           continue;
         }
-        await rust.recordShareDelegation(
-          dbPath: context.dbPath,
-          accountUuid: context.accountUuid,
-          roundId: context.round.roundId,
-          bundleIndex: commitments.bundleIndex,
-          proposalId: result.share.proposalId,
-          shareIndex: result.share.shareIndex,
-          sentToUrls: result.acceptedServers,
-          submitAt: result.submitAt,
-        );
+        try {
+          await rust.recordShareDelegation(
+            dbPath: context.dbPath,
+            accountUuid: context.accountUuid,
+            roundId: context.round.roundId,
+            bundleIndex: commitments.bundleIndex,
+            proposalId: result.share.proposalId,
+            shareIndex: result.share.shareIndex,
+            sentToUrls: result.acceptedServers,
+            submitAt: result.submitAt,
+          );
+        } catch (error, stackTrace) {
+          persistenceError ??= error;
+          persistenceStackTrace ??= stackTrace;
+        }
+      }
+      if (persistenceError != null) {
+        Error.throwWithStackTrace(persistenceError, persistenceStackTrace!);
       }
       if (failedResult != null) {
         throw StateError(
@@ -3787,6 +3810,22 @@ class VotingSubmissionSessionNotifier extends VotingSessionNotifier {
     }
     await _refreshVotingEligibilityState(current: current, context: context);
   }
+}
+
+class _PreparedInitialShareSubmission {
+  const _PreparedInitialShareSubmission({
+    required this.share,
+    required this.body,
+    required this.candidateServers,
+    required this.targetCount,
+    required this.submitAt,
+  });
+
+  final rust_wire.VoteShareWire share;
+  final Map<String, dynamic> body;
+  final List<String> candidateServers;
+  final int targetCount;
+  final BigInt submitAt;
 }
 
 class _InitialShareSubmissionResult {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -4544,14 +4544,81 @@ void main() {
     expect(rust.storedCommitmentBundles, ['0:7:2']);
   });
 
-  test('vote commitment submits all encrypted shares concurrently', () async {
-    final http = _GatedSharePostVotingHttpClient(
-      expectedShareCount: 3,
-      responses: votingHttpResponses(),
-    );
+  test(
+    'vote commitment submits shares concurrently and persists completions',
+    () async {
+      final http = _GatedSharePostVotingHttpClient(
+        expectedShareCount: 3,
+        gatedShareIndexes: const {2},
+        responses: votingHttpResponses(),
+      );
+      final rust = FakeVotingRustApi(
+        emitCommitments: true,
+        commitmentShareCount: 3,
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 1,
+          delegationTxHashes: [
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: 0,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-0',
+              vanLeafPosition: null,
+            ),
+          ],
+          votes: [vote(bundleIndex: 0, proposalId: 7)],
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final cast = container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+
+      await http.allSharePostsStarted.future.timeout(
+        const Duration(seconds: 1),
+      );
+      expect(http.startedShareIndexes, {0, 1, 2});
+      await _waitForRecordedShareCount(rust, 2);
+      expect(rust.recordedShares.map((share) => share.shareIndex).toSet(), {
+        0,
+        1,
+      });
+
+      http.releaseSharePosts.complete();
+      await cast;
+
+      expect(rust.recordedShares, hasLength(3));
+      expect(
+        rust.recordedShares.map((share) => share.shareIndex),
+        unorderedEquals([0, 1, 2]),
+      );
+    },
+  );
+
+  test('vote commitment validates all shares before submission', () async {
+    final http = FakeVotingHttpClient(responses: votingHttpResponses());
     final rust = FakeVotingRustApi(
       emitCommitments: true,
       commitmentShareCount: 3,
+      failingVoteShareWireIndexes: const {2},
     );
     final recoveryApi = FakeVotingRecoveryApi(
       state: recoveryState(
@@ -4575,7 +4642,7 @@ void main() {
     addTearDown(container.dispose);
 
     await container.read(votingSessionProvider(kRoundId).future);
-    final cast = container
+    await container
         .read(votingSessionProvider(kRoundId).notifier)
         .castVotes(
           draftVotes: [
@@ -4589,14 +4656,16 @@ void main() {
           ],
         );
 
-    await http.allSharePostsStarted.future;
-    expect(http.startedShareIndexes, {0, 1, 2});
+    final sharePosts = http.requests.where(
+      (request) =>
+          request.method == 'POST' &&
+          request.uri.path == '/shielded-vote/v1/shares',
+    );
+    expect(sharePosts, isEmpty);
     expect(rust.recordedShares, isEmpty);
-
-    http.releaseSharePosts.complete();
-    await cast;
-
-    expect(rust.recordedShares.map((share) => share.shareIndex), [0, 1, 2]);
+    final state = container.read(votingSessionProvider(kRoundId)).value!;
+    expect(state.phase, VotingSessionPhase.error);
+    expect(state.error?.message, contains('invalid vote share 2'));
   });
 
   test('ballot intent write failure aborts before vote submission', () async {
@@ -5990,10 +6059,12 @@ class _YieldingFakeVotingHttpClient extends FakeVotingHttpClient {
 class _GatedSharePostVotingHttpClient extends FakeVotingHttpClient {
   _GatedSharePostVotingHttpClient({
     required this.expectedShareCount,
+    required this.gatedShareIndexes,
     super.responses,
   });
 
   final int expectedShareCount;
+  final Set<int> gatedShareIndexes;
   final Set<int> startedShareIndexes = {};
   final Completer<void> allSharePostsStarted = Completer<void>();
   final Completer<void> releaseSharePosts = Completer<void>();
@@ -6005,12 +6076,15 @@ class _GatedSharePostVotingHttpClient extends FakeVotingHttpClient {
     Duration? timeout,
   }) async {
     if (uri.path == '/shielded-vote/v1/shares') {
-      startedShareIndexes.add(body['share_index'] as int);
+      final shareIndex = body['share_index'] as int;
+      startedShareIndexes.add(shareIndex);
       if (startedShareIndexes.length == expectedShareCount &&
           !allSharePostsStarted.isCompleted) {
         allSharePostsStarted.complete();
       }
-      await releaseSharePosts.future;
+      if (gatedShareIndexes.contains(shareIndex)) {
+        await releaseSharePosts.future;
+      }
     }
     return super.postJson(uri, body, timeout: timeout);
   }
@@ -6347,6 +6421,20 @@ Future<void> _waitForConfirmedShare(
   fail(
     'Timed out waiting for confirmed share $expectedShare. '
     'Saw ${rust.confirmedShares}.',
+  );
+}
+
+Future<void> _waitForRecordedShareCount(
+  FakeVotingRustApi rust,
+  int expectedCount,
+) async {
+  for (var i = 0; i < 100; i++) {
+    if (rust.recordedShares.length >= expectedCount) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail(
+    'Timed out waiting for $expectedCount recorded shares. '
+    'Saw ${rust.recordedShares.length}.',
   );
 }
 
@@ -7342,6 +7430,7 @@ class FakeVotingRustApi implements VotingRustApi {
     this.keystoneSignatureBatchFailuresRemaining = 0,
     this.shareResubmissionError,
     this.nextShareTrackingDelayGate,
+    this.failingVoteShareWireIndexes = const {},
   });
 
   final Duration setupDelay;
@@ -7367,6 +7456,7 @@ class FakeVotingRustApi implements VotingRustApi {
   int keystoneSignatureBatchFailuresRemaining;
   final Object? shareResubmissionError;
   final Completer<void>? nextShareTrackingDelayGate;
+  final Set<int> failingVoteShareWireIndexes;
   int setupCalls = 0;
   int _activeSetups = 0;
   int maxConcurrentSetups = 0;
@@ -7937,6 +8027,9 @@ class FakeVotingRustApi implements VotingRustApi {
     BigInt? vcTreePosition,
     required BigInt submitAt,
   }) async {
+    if (failingVoteShareWireIndexes.contains(share.shareIndex)) {
+      throw FormatException('invalid vote share ${share.shareIndex}');
+    }
     return jsonEncode({
       'vote_round_id': share.voteRoundId,
       'shares_hash': share.sharesHash,

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -4544,6 +4544,61 @@ void main() {
     expect(rust.storedCommitmentBundles, ['0:7:2']);
   });
 
+  test('vote commitment submits all encrypted shares concurrently', () async {
+    final http = _GatedSharePostVotingHttpClient(
+      expectedShareCount: 3,
+      responses: votingHttpResponses(),
+    );
+    final rust = FakeVotingRustApi(
+      emitCommitments: true,
+      commitmentShareCount: 3,
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 1,
+        delegationTxHashes: [
+          rust_frb_types.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.submittedDelegation,
+            txHash: 'delegation-0',
+            vanLeafPosition: null,
+          ),
+        ],
+        votes: [vote(bundleIndex: 0, proposalId: 7)],
+      ),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final cast = container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(
+          draftVotes: [
+            rust_wire.DraftVote(
+              proposalId: 7,
+              choice: 1,
+              numOptions: 2,
+              vcTreePosition: BigInt.zero,
+              singleShare: false,
+            ),
+          ],
+        );
+
+    await http.allSharePostsStarted.future;
+    expect(http.startedShareIndexes, {0, 1, 2});
+    expect(rust.recordedShares, isEmpty);
+
+    http.releaseSharePosts.complete();
+    await cast;
+
+    expect(rust.recordedShares.map((share) => share.shareIndex), [0, 1, 2]);
+  });
+
   test('ballot intent write failure aborts before vote submission', () async {
     final rust = FakeVotingRustApi(emitCommitments: true);
     final recoveryApi = FakeVotingRecoveryApi(
@@ -5929,6 +5984,35 @@ class _YieldingFakeVotingHttpClient extends FakeVotingHttpClient {
   }) async {
     await Future<void>.delayed(Duration.zero);
     return super.get(uri, headers: headers, timeout: timeout);
+  }
+}
+
+class _GatedSharePostVotingHttpClient extends FakeVotingHttpClient {
+  _GatedSharePostVotingHttpClient({
+    required this.expectedShareCount,
+    super.responses,
+  });
+
+  final int expectedShareCount;
+  final Set<int> startedShareIndexes = {};
+  final Completer<void> allSharePostsStarted = Completer<void>();
+  final Completer<void> releaseSharePosts = Completer<void>();
+
+  @override
+  Future<VotingHttpResponse> postJson(
+    Uri uri,
+    Map<String, dynamic> body, {
+    Duration? timeout,
+  }) async {
+    if (uri.path == '/shielded-vote/v1/shares') {
+      startedShareIndexes.add(body['share_index'] as int);
+      if (startedShareIndexes.length == expectedShareCount &&
+          !allSharePostsStarted.isCompleted) {
+        allSharePostsStarted.complete();
+      }
+      await releaseSharePosts.future;
+    }
+    return super.postJson(uri, body, timeout: timeout);
   }
 }
 


### PR DESCRIPTION
## Summary

- submit all encrypted vote shares concurrently
- retain ordered helper failover and three retries within each share submission
- persist successful delegation records sequentially after network submissions complete
- preserve successful sibling shares when another share is rejected by every helper

This removes the multiplicative delay where each share waited through the same unavailable helper retry window before the next share could start.

## Validation

- focused concurrent share-submission test
- all 129 voting provider tests
- full Flutter test suite: 2,388 passed, 76 skipped
- Flutter analysis on the changed provider and test
- git diff --check

## API surface

No public or pub(crate) API changes.