### PR TITLE
Fix voting share submission and add real Ironwood regtest E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ rust/build/
 /coverage/
 .regtest/
 .regtest-logs/
+.regtest-voting/
 .ironwood-regtest/
 .ironwood-regtest-snapshots/
 

--- a/integration_test/regtest_voting_ironwood_setup_test.dart
+++ b/integration_test/regtest_voting_ironwood_setup_test.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/providers/chain_upgrade_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import 'support/desktop_regtest_flow.dart';
+
+const _driverUrl = String.fromEnvironment(
+  'ZCASH_E2E_DRIVER_URL',
+  defaultValue: 'http://127.0.0.1:39078',
+);
+const _lightwalletdUrl = String.fromEnvironment(
+  'ZCASH_E2E_LIGHTWALLETD_URL',
+  defaultValue: 'http://127.0.0.1:19067',
+);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(initializeZcashWalletRuntime);
+
+  testWidgets(
+    'prepares a confirmed Ironwood note for the voting E2E',
+    (tester) async {
+      await cleanupDesktopRegtestWallet();
+      final initialChain = await ironwoodDriverGet(_driverUrl, '/status');
+      expect(initialChain['ironwoodActive'], isFalse);
+
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+      await importDesktopRegtestWallet(tester);
+      await pumpUntil(
+        tester,
+        () =>
+            textForKey(
+              tester,
+              const ValueKey('home_desktop_balance_amount_text'),
+            ) ==
+            '0.13',
+        description: 'funded Orchard balance',
+        timeout: const Duration(minutes: 5),
+      );
+
+      final container = ProviderScope.containerOf(
+        tester.element(
+          find.byKey(const ValueKey('home_desktop_balance_amount_text')),
+        ),
+      );
+      await ironwoodDriverPost(_driverUrl, '/activate');
+      await pumpUntil(
+        tester,
+        () {
+          final chain = container.read(chainUpgradeStatusProvider).value;
+          final sync = container.read(syncProvider).value;
+          return chain?.ironwoodActiveAtTip == true &&
+              sync?.isSyncing == false &&
+              sync?.isSyncComplete == true &&
+              (sync?.scannedHeight ?? 0) >= 500;
+        },
+        description: 'wallet sync through NU6.3 activation',
+        timeout: const Duration(minutes: 5),
+      );
+
+      final account = (await desktopRegtestAccounts()).single;
+      final dbPath = await getWalletDbPath();
+      final plan = await rust_sync.getOrchardMigrationImmediatePlan(
+        dbPath: dbPath,
+        network: 'regtest',
+        accountUuid: account.uuid,
+      );
+      expect(plan, isNotNull);
+      final approved = plan!;
+      final result = await rust_sync.migrateOrchardToIronwoodImmediately(
+        dbPath: dbPath,
+        lightwalletdUrl: _lightwalletdUrl,
+        network: 'regtest',
+        accountUuid: account.uuid,
+        mnemonicBytes: utf8.encode(desktopRegtestMnemonic),
+        approvedTotalInputZatoshi: approved.totalInputZatoshi,
+        approvedFeeZatoshi: approved.feeZatoshi,
+        approvedMigratedZatoshi: approved.migratedZatoshi,
+        approvedInputNoteCount: approved.inputNoteCount,
+      );
+      expect(result.broadcastedCount, 1);
+
+      await ironwoodDriverPost(
+        _driverUrl,
+        '/mine',
+        payload: const {'blocks': 10},
+      );
+      await container.read(syncProvider.notifier).startSyncAnyway();
+      rust_sync.WalletBalance? balance;
+      final deadline = DateTime.now().add(const Duration(minutes: 5));
+      while (DateTime.now().isBefore(deadline)) {
+        await tester.pump(const Duration(seconds: 1));
+        balance = await rust_sync.getBalance(
+          dbPath: dbPath,
+          network: 'regtest',
+          accountUuid: account.uuid,
+        );
+        if (balance.ironwood > BigInt.zero) {
+          break;
+        }
+      }
+      expect(
+        balance?.ironwood,
+        greaterThan(BigInt.zero),
+        reason: 'immediate migration must create confirmed voting power',
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 15)),
+  );
+}

--- a/integration_test/regtest_voting_test.dart
+++ b/integration_test/regtest_voting_test.dart
@@ -1,0 +1,375 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart' show InkWell;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_session_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import 'support/desktop_onboarding_flow.dart';
+
+const _mnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon '
+    'abandon abandon about';
+const _bip39Passphrase = 'TREZOR';
+const _password = 'Vizor123!';
+const _roundId = String.fromEnvironment('ZCASH_E2E_VOTE_ROUND_ID');
+const _reuseMigratedWallet = bool.fromEnvironment(
+  'ZCASH_E2E_REUSE_MIGRATED_WALLET',
+);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(initializeZcashWalletRuntime);
+
+  testWidgets(
+    'imports an Ironwood wallet and completes a real regtest vote',
+    (tester) async {
+      if (_roundId.length != 64) {
+        fail('ZCASH_E2E_VOTE_ROUND_ID must be a 64-character round id.');
+      }
+      addTearDown(_cleanupE2eWalletState);
+      if (!_reuseMigratedWallet) {
+        await _cleanupE2eWalletState();
+      }
+
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+      if (_reuseMigratedWallet) {
+        _log('opening wallet preserved by the Orchard-to-Ironwood E2E');
+        await tester.pump(const Duration(milliseconds: 500));
+        if (tester.any(find.byKey(const ValueKey('unlock_password_field')))) {
+          await _enterText(
+            tester,
+            const ValueKey('unlock_password_field'),
+            _password,
+          );
+          await _tapButton(tester, const ValueKey('unlock_submit_button'));
+        }
+      } else {
+        _log('importing deterministic Ironwood-funded wallet');
+        await _tapButton(
+          tester,
+          const ValueKey('welcome_import_wallet_button'),
+        );
+        await _enterText(
+          tester,
+          const ValueKey('import_mnemonic_first_word_field'),
+          _mnemonic,
+        );
+        await _tapButton(tester, const ValueKey('bip39_passphrase_action'));
+        await _enterText(
+          tester,
+          const ValueKey('bip39_passphrase_field'),
+          _bip39Passphrase,
+        );
+        await _tapButton(
+          tester,
+          const ValueKey('bip39_passphrase_save_button'),
+        );
+        await _tapButton(tester, const ValueKey('import_secret_submit_button'));
+        await _tapButton(tester, const ValueKey('import_birthday_skip_button'));
+        await _tapButton(
+          tester,
+          const ValueKey('unknown_birthday_confirm_button'),
+        );
+        await _enterText(
+          tester,
+          const ValueKey('set_password_password_field'),
+          _password,
+        );
+        await _enterText(
+          tester,
+          const ValueKey('set_password_confirm_field'),
+          _password,
+        );
+        await _tapButton(tester, const ValueKey('set_password_submit_button'));
+        await finishDesktopAccountCustomisation(tester);
+      }
+
+      await _pumpUntil(
+        tester,
+        () => tester.any(
+          find.byKey(const ValueKey('home_desktop_balance_amount_text')),
+        ),
+        description: 'Ironwood balance to sync',
+        timeout: const Duration(minutes: 5),
+      );
+
+      _log('opening signed regtest voting round $_roundId');
+      await _tap(tester, const ValueKey('sidebar_voting_button'));
+      await _tapButton(
+        tester,
+        ValueKey('voting_poll_action_$_roundId'),
+        timeout: const Duration(minutes: 2),
+      );
+
+      final providerContainer = ProviderScope.containerOf(
+        tester.element(find.byKey(const ValueKey('sidebar_voting_button'))),
+      );
+      await _pumpUntil(
+        tester,
+        () {
+          final session = providerContainer.read(
+            votingSessionProvider(_roundId),
+          );
+          return session.hasError || session.value?.round != null;
+        },
+        description: 'voting session round to load',
+        timeout: const Duration(minutes: 2),
+      );
+      var session = providerContainer.read(votingSessionProvider(_roundId));
+      if (session.hasError) {
+        fail('Voting session failed to load: ${session.error}');
+      }
+      await _pumpUntil(
+        tester,
+        () {
+          session = providerContainer.read(votingSessionProvider(_roundId));
+          final value = session.value;
+          return session.hasError ||
+              value?.error != null ||
+              value?.hasConfirmedVotingEligibility == true;
+        },
+        description: 'Ironwood voting eligibility to confirm',
+        timeout: const Duration(minutes: 10),
+      );
+      if (session.hasError) {
+        fail('Voting eligibility failed: ${session.error}');
+      }
+      final eligibleSession = session.value!;
+      if (!eligibleSession.hasConfirmedVotingEligibility) {
+        fail(
+          'Voting eligibility was rejected: '
+          '${eligibleSession.error?.message ?? 'unknown error'}',
+        );
+      }
+      _log(
+        'eligibility confirmed at '
+        '${eligibleSession.eligibleWeightZatoshi} zatoshi',
+      );
+
+      final accountUuid = eligibleSession.accountUuid;
+      expect(accountUuid, isNotNull);
+      final draftKey = VotingSessionKey(
+        roundId: _roundId,
+        accountUuid: accountUuid!,
+      );
+
+      for (var proposalId = 1; proposalId <= 4; proposalId++) {
+        await _scrollUntilVisible(
+          tester,
+          ValueKey('voting_proposal_${proposalId}_option_0'),
+        );
+        await _tap(
+          tester,
+          ValueKey('voting_proposal_${proposalId}_option_0'),
+          timeout: const Duration(minutes: 10),
+        );
+        await _pumpUntil(
+          tester,
+          () =>
+              providerContainer
+                  .read(votingDraftProvider(draftKey))
+                  .choices[proposalId] ==
+              0,
+          description: 'proposal $proposalId selection to persist',
+        );
+        _log('selected proposal $proposalId');
+      }
+      expect(providerContainer.read(votingDraftProvider(draftKey)).choices, {
+        1: 0,
+        2: 0,
+        3: 0,
+        4: 0,
+      });
+      await _scrollUntilVisible(
+        tester,
+        const ValueKey('voting_review_answers_button'),
+      );
+      await _tapButton(tester, const ValueKey('voting_review_answers_button'));
+      await _tapButton(tester, const ValueKey('voting_confirm_submit_button'));
+
+      _log('waiting for real delegation, commitment, and share proofs');
+      await _pumpUntil(
+        tester,
+        () => tester.any(
+          find.byKey(const ValueKey('voting_submission_done_button')),
+        ),
+        description: 'confirmed voting receipt',
+        timeout: const Duration(minutes: 40),
+      );
+      final done = find.byKey(const ValueKey('voting_submission_done_button'));
+      final button = tester.widget<AppButton>(done);
+      expect(button.onPressed, isNotNull);
+      _log('vote completed and confirmation receipt is actionable');
+    },
+    timeout: const Timeout(Duration(minutes: 45)),
+  );
+}
+
+Future<void> _scrollUntilVisible(WidgetTester tester, Key key) async {
+  final finder = find.byKey(key);
+  if (tester.any(finder)) {
+    await tester.ensureVisible(finder);
+    return;
+  }
+  final scrollable = find.byType(Scrollable).last;
+  await _pumpUntil(
+    tester,
+    () => tester.any(scrollable),
+    description: 'poll list for $key',
+  );
+  await tester.scrollUntilVisible(
+    finder,
+    300,
+    scrollable: scrollable,
+    maxScrolls: 20,
+  );
+  await tester.pump(const Duration(milliseconds: 250));
+}
+
+Future<void> _cleanupE2eWalletState() async {
+  if (kZcashDefaultNetworkName != ZcashNetwork.regtest.name) {
+    throw StateError('Refusing cleanup outside regtest.');
+  }
+  rust_sync.setSyncMode(mode: 0);
+  rust_sync.cancelFullSync();
+  rust_sync.stopMempoolObserver();
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while ((rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+  final dbName = await getWalletDbName();
+  await AppSecureStore.instance.deleteAll();
+  final supportDir = await getWalletSupportDirectory();
+  if (!supportDir.existsSync()) return;
+  for (final name in [
+    dbName,
+    '$dbName-shm',
+    '$dbName-wal',
+    '$dbName.voting',
+    '$dbName.voting-journal',
+    '$dbName.voting-shm',
+    '$dbName.voting-wal',
+  ]) {
+    final file = File('${supportDir.path}${Platform.pathSeparator}$name');
+    if (file.existsSync()) file.deleteSync();
+  }
+}
+
+Future<void> _tapButton(
+  WidgetTester tester,
+  Key key, {
+  Duration timeout = const Duration(seconds: 30),
+}) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () {
+      if (!tester.any(finder)) return false;
+      final widget = tester.widget(finder);
+      return widget is! AppButton || widget.onPressed != null;
+    },
+    description: '$key button to enable',
+    timeout: timeout,
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  final inkWell = find.descendant(of: finder, matching: find.byType(InkWell));
+  final hitTestable = tester.any(inkWell)
+      ? inkWell.hitTestable()
+      : finder.hitTestable();
+  await _pumpUntil(
+    tester,
+    () => tester.any(hitTestable),
+    description: '$key button to become hit-testable',
+    timeout: timeout,
+  );
+  await tester.tap(hitTestable);
+  await tester.pump(const Duration(milliseconds: 250));
+}
+
+Future<void> _tap(
+  WidgetTester tester,
+  Key key, {
+  Duration timeout = const Duration(seconds: 30),
+}) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () => tester.any(finder),
+    description: '$key to appear',
+    timeout: timeout,
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  final inkWell = find.descendant(of: finder, matching: find.byType(InkWell));
+  if (tester.any(inkWell)) {
+    await _pumpUntil(
+      tester,
+      () => tester.widget<InkWell>(inkWell).onTap != null,
+      description: '$key InkWell to enable',
+      timeout: timeout,
+    );
+    final hitTestable = inkWell.hitTestable();
+    if (tester.any(hitTestable)) {
+      await tester.tap(hitTestable);
+    } else {
+      tester.widget<InkWell>(inkWell).onTap!.call();
+    }
+  } else {
+    final hitTestable = finder.hitTestable();
+    await _pumpUntil(
+      tester,
+      () => tester.any(hitTestable),
+      description: '$key to become hit-testable',
+      timeout: timeout,
+    );
+    await tester.tap(hitTestable);
+  }
+  await tester.pump(const Duration(milliseconds: 250));
+}
+
+Future<void> _enterText(WidgetTester tester, Key key, String text) async {
+  final editable = find.descendant(
+    of: find.byKey(key),
+    matching: find.byType(EditableText),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(editable),
+    description: '$key text field',
+  );
+  await tester.tap(editable);
+  await tester.enterText(editable, text);
+  await tester.pump(const Duration(milliseconds: 100));
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  required String description,
+  Duration timeout = const Duration(seconds: 30),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) return;
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+  fail('Timed out waiting for $description.');
+}
+
+void _log(String message) {
+  debugPrint('[voting-regtest-e2e] $message');
+}

--- a/integration_test/support/desktop_regtest_flow.dart
+++ b/integration_test/support/desktop_regtest_flow.dart
@@ -376,7 +376,15 @@ Future<void> cleanupDesktopRegtestWallet() async {
 
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
-  for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
+  for (final name in [
+    dbName,
+    '$dbName-shm',
+    '$dbName-wal',
+    '$dbName.voting',
+    '$dbName.voting-journal',
+    '$dbName.voting-shm',
+    '$dbName.voting-wal',
+  ]) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();
   }

--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -454,6 +454,7 @@ class _PollCard extends StatelessWidget {
             Align(
               alignment: Alignment.centerRight,
               child: AppButton(
+                key: ValueKey('voting_poll_action_${round.roundId}'),
                 onPressed: onAction,
                 variant: _actionButtonVariant(state),
                 size: AppButtonSize.medium,

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -498,6 +498,7 @@ class _ActivePollContentState extends State<_ActivePollContent> {
                           !widget.votingEligibilityConfirmed &&
                           widget.votingEligibilityErrorMessage != null;
                       return _ReviewAnswersButton(
+                        key: const ValueKey('voting_review_answers_button'),
                         enabled:
                             canRetryEligibility ||
                             isIneligible ||
@@ -809,6 +810,7 @@ class _PollSummary extends StatelessWidget {
 
 class _ReviewAnswersButton extends StatelessWidget {
   const _ReviewAnswersButton({
+    super.key,
     required this.enabled,
     required this.label,
     required this.onPressed,

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -248,6 +248,7 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                   ),
                   child: Center(
                     child: AppButton(
+                      key: const ValueKey('voting_confirm_submit_button'),
                       onPressed: onSubmit,
                       variant: AppButtonVariant.primary,
                       minWidth: 240,

--- a/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
+++ b/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
@@ -511,6 +511,9 @@ class _ConfirmationScaffold extends StatelessWidget {
                         SizedBox(
                           width: double.infinity,
                           child: AppButton(
+                            key: const ValueKey(
+                              'voting_submission_done_button',
+                            ),
                             onPressed: doneEnabled
                                 ? onDone ?? () => context.go('/voting')
                                 : null,

--- a/lib/src/features/voting/widgets/voting_metadata_widgets.dart
+++ b/lib/src/features/voting/widgets/voting_metadata_widgets.dart
@@ -255,6 +255,9 @@ class VotingProposalCard extends StatelessWidget {
           const SizedBox(height: AppSpacing.s),
           for (final option in proposal.options) ...[
             _VotingProposalOptionRow(
+              key: ValueKey(
+                'voting_proposal_${proposal.id}_option_${option.index}',
+              ),
               option: option,
               selected: selectedChoice == option.index,
               enabled: enabled,
@@ -289,6 +292,7 @@ class VotingProposalCard extends StatelessWidget {
 
 class _VotingProposalOptionRow extends StatelessWidget {
   const _VotingProposalOptionRow({
+    super.key,
     required this.option,
     required this.selected,
     required this.enabled,

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -21,16 +21,24 @@ import '../../services/voting/pir_snapshot_resolver.dart';
 import '../../services/voting/resolved_voting_config_extensions.dart';
 import '../../services/voting/voting_api_client.dart';
 import '../../services/voting/voting_config_loader.dart';
+import '../../services/voting/voting_endpoint_mapper.dart';
 import '../../services/voting/voting_helper_health_tracker.dart';
 import '../../services/voting/voting_http.dart';
 import '../../services/voting/voting_retry.dart';
 import 'voting_config_source_provider.dart';
 
 /// Transport shared by the voting service clients.
+final votingEndpointMapperProvider = Provider<VotingEndpointMapper>((ref) {
+  return VotingEndpointMapper.forBuild();
+});
+
 final votingHttpClientProvider = Provider<VotingHttpClient>((ref) {
-  final client = DartIoVotingHttpClient();
-  ref.onDispose(client.close);
-  return client;
+  final directClient = DartIoVotingHttpClient();
+  ref.onDispose(directClient.close);
+  return MappedVotingHttpClient(
+    directClient,
+    ref.watch(votingEndpointMapperProvider),
+  );
 });
 
 /// Loads the hash-pinned static config and dynamic voting config.

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -459,7 +459,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         await for (final event
             in rust.buildProveAndSignDelegationPayloadWithProgress(
               ctx: _apiRoundContext(context),
-              pirServerUrl: pirEndpoint!.toString(),
+              pirServerUrl: _transportUrl(pirEndpoint!),
               mnemonic: mnemonic!,
               storedHotkeySecret: storedHotkeySecret!,
               bundleIndex: bundleIndex,
@@ -853,7 +853,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             in rust
                 .buildProveDelegationPayloadWithKeystoneSignatureWithProgress(
                   ctx: _apiRoundContext(context),
-                  pirServerUrl: pirEndpoint!.toString(),
+                  pirServerUrl: _transportUrl(pirEndpoint!),
                   storedHotkeySecret: storedHotkeySecret!,
                   bundleIndex: bundleIndex,
                   keystoneSig: signature.sig,
@@ -1590,10 +1590,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
       }
 
+      final submissions = <Future<_InitialShareSubmissionResult>>[];
       for (var payloadIndex = 0; payloadIndex < shares.length; payloadIndex++) {
         final share = shares[payloadIndex];
         final plan = plans[payloadIndex];
-        final acceptedServers = <String>[];
         final targetCount = plan.targetCount
             .clamp(1, serverUrls.length)
             .toInt();
@@ -1617,60 +1617,95 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           totalQuestions: totalQuestions,
           voteSubmissionProgress: voteSubmissionProgress,
         );
-        for (final serverUrl in candidateServers) {
-          if (acceptedServers.length >= targetCount) break;
-          try {
-            debugPrint(
-              '[zcash] Voting: submitting share '
-              'proposal=${share.proposalId} share=${share.shareIndex} '
-              'server=$serverUrl treePosition=${body['tree_position']} '
-              'submitAt=${plan.submitAt} target=$targetCount',
-            );
-            await api.submitShare(serverUrl: Uri.parse(serverUrl), share: body);
-            helperHealth.recordSuccess(serverUrl);
-            acceptedServers.add(serverUrl);
-            debugPrint(
-              '[zcash] Voting: share accepted '
-              'proposal=${share.proposalId} share=${share.shareIndex} '
-              'server=$serverUrl accepted=${acceptedServers.length}/$targetCount',
-            );
-          } catch (e) {
-            debugPrint(
-              '[zcash] Voting: share rejected '
-              'proposal=${share.proposalId} share=${share.shareIndex} '
-              'server=$serverUrl error=$e',
-            );
-            helperHealth.recordFailure(serverUrl);
-            // Recovery retries helpers that did not accept this share.
-          }
-        }
-        if (acceptedServers.isEmpty) {
-          throw StateError(
-            'No vote server accepted share ${share.shareIndex} '
-            'for proposal ${share.proposalId}.',
-          );
-        }
-        if (acceptedServers.length < targetCount) {
-          debugPrint(
-            '[zcash] Voting: share accepted by fewer helpers than planned '
-            'proposal=${share.proposalId} '
-            'share=${share.shareIndex} '
-            'accepted=${acceptedServers.length}/$targetCount',
-          );
-        }
+        submissions.add(
+          _submitInitialShareToHelpers(
+            api: api,
+            helperHealth: helperHealth,
+            share: share,
+            body: body,
+            candidateServers: candidateServers,
+            targetCount: targetCount,
+            submitAt: plan.submitAt,
+          ),
+        );
+      }
 
+      final results = await Future.wait(submissions);
+      _InitialShareSubmissionResult? failedResult;
+      for (final result in results) {
+        if (result.acceptedServers.isEmpty) {
+          failedResult ??= result;
+          continue;
+        }
         await rust.recordShareDelegation(
           dbPath: context.dbPath,
           accountUuid: context.accountUuid,
           roundId: context.round.roundId,
           bundleIndex: commitments.bundleIndex,
-          proposalId: share.proposalId,
-          shareIndex: share.shareIndex,
-          sentToUrls: acceptedServers,
-          submitAt: plan.submitAt,
+          proposalId: result.share.proposalId,
+          shareIndex: result.share.shareIndex,
+          sentToUrls: result.acceptedServers,
+          submitAt: result.submitAt,
+        );
+      }
+      if (failedResult != null) {
+        throw StateError(
+          'No vote server accepted share ${failedResult.share.shareIndex} '
+          'for proposal ${failedResult.share.proposalId}.',
         );
       }
     }
+  }
+
+  Future<_InitialShareSubmissionResult> _submitInitialShareToHelpers({
+    required VotingApiClient api,
+    required VotingHelperHealthTracker helperHealth,
+    required rust_wire.VoteShareWire share,
+    required Map<String, dynamic> body,
+    required List<String> candidateServers,
+    required int targetCount,
+    required BigInt submitAt,
+  }) async {
+    final acceptedServers = <String>[];
+    for (final serverUrl in candidateServers) {
+      if (acceptedServers.length >= targetCount) break;
+      try {
+        debugPrint(
+          '[zcash] Voting: submitting share '
+          'proposal=${share.proposalId} share=${share.shareIndex} '
+          'server=$serverUrl treePosition=${body['tree_position']} '
+          'submitAt=$submitAt target=$targetCount',
+        );
+        await api.submitShare(serverUrl: Uri.parse(serverUrl), share: body);
+        helperHealth.recordSuccess(serverUrl);
+        acceptedServers.add(serverUrl);
+        debugPrint(
+          '[zcash] Voting: share accepted '
+          'proposal=${share.proposalId} share=${share.shareIndex} '
+          'server=$serverUrl accepted=${acceptedServers.length}/$targetCount',
+        );
+      } catch (e) {
+        debugPrint(
+          '[zcash] Voting: share rejected '
+          'proposal=${share.proposalId} share=${share.shareIndex} '
+          'server=$serverUrl error=$e',
+        );
+        helperHealth.recordFailure(serverUrl);
+        // Recovery retries helpers that did not accept this share.
+      }
+    }
+    if (acceptedServers.length < targetCount && acceptedServers.isNotEmpty) {
+      debugPrint(
+        '[zcash] Voting: share accepted by fewer helpers than planned '
+        'proposal=${share.proposalId} share=${share.shareIndex} '
+        'accepted=${acceptedServers.length}/$targetCount',
+      );
+    }
+    return _InitialShareSubmissionResult(
+      share: share,
+      submitAt: submitAt,
+      acceptedServers: acceptedServers,
+    );
   }
 
   Future<int> _syncVoteTreeWithFailover({
@@ -1688,7 +1723,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           dbPath: context.dbPath,
           accountUuid: context.accountUuid,
           roundId: context.round.roundId,
-          nodeUrl: nodeUrl.toString(),
+          nodeUrl: _transportUrl(nodeUrl),
         );
       } catch (error) {
         lastError = error;
@@ -2476,7 +2511,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           .read(votingRustApiProvider)
           .precomputeDelegationPir(
             ctx: _apiRoundContext(context),
-            pirServerUrl: pirEndpoint.toString(),
+            pirServerUrl: _transportUrl(pirEndpoint),
             storedHotkeySecret: storedHotkeySecret,
             bundleIndex: bundleIndex,
           );
@@ -2514,6 +2549,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       'round=${context.round.roundId} bundle=$bundleIndex',
     );
     await precompute;
+  }
+
+  String _transportUrl(Uri logicalUrl) {
+    return ref.read(votingEndpointMapperProvider).map(logicalUrl).toString();
   }
 
   static String _delegationPirPrecomputeKey(
@@ -3752,6 +3791,18 @@ class VotingSubmissionSessionNotifier extends VotingSessionNotifier {
     }
     await _refreshVotingEligibilityState(current: current, context: context);
   }
+}
+
+class _InitialShareSubmissionResult {
+  const _InitialShareSubmissionResult({
+    required this.share,
+    required this.submitAt,
+    required this.acceptedServers,
+  });
+
+  final rust_wire.VoteShareWire share;
+  final BigInt submitAt;
+  final List<String> acceptedServers;
 }
 
 final votingSessionProvider =

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1590,7 +1590,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
       }
 
-      final submissions = <Future<_InitialShareSubmissionResult>>[];
+      // Validate every body before starting helper requests. Otherwise a later
+      // serialization failure could abandon already accepted submissions.
+      final preparedSubmissions = <_PreparedInitialShareSubmission>[];
       for (var payloadIndex = 0; payloadIndex < shares.length; payloadIndex++) {
         final share = shares[payloadIndex];
         final plan = plans[payloadIndex];
@@ -1617,10 +1619,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           totalQuestions: totalQuestions,
           voteSubmissionProgress: voteSubmissionProgress,
         );
-        submissions.add(
-          _submitInitialShareToHelpers(
-            api: api,
-            helperHealth: helperHealth,
+        preparedSubmissions.add(
+          _PreparedInitialShareSubmission(
             share: share,
             body: body,
             candidateServers: candidateServers,
@@ -1630,23 +1630,46 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
       }
 
-      final results = await Future.wait(submissions);
+      final submissions = [
+        for (final prepared in preparedSubmissions)
+          _submitInitialShareToHelpers(
+            api: api,
+            helperHealth: helperHealth,
+            share: prepared.share,
+            body: prepared.body,
+            candidateServers: prepared.candidateServers,
+            targetCount: prepared.targetCount,
+            submitAt: prepared.submitAt,
+          ),
+      ];
       _InitialShareSubmissionResult? failedResult;
-      for (final result in results) {
+      Object? persistenceError;
+      StackTrace? persistenceStackTrace;
+      // Persist in completion order so accepted shares become durable promptly
+      // while Rust DB writes remain sequential.
+      await for (final result in Stream.fromFutures(submissions)) {
         if (result.acceptedServers.isEmpty) {
           failedResult ??= result;
           continue;
         }
-        await rust.recordShareDelegation(
-          dbPath: context.dbPath,
-          accountUuid: context.accountUuid,
-          roundId: context.round.roundId,
-          bundleIndex: commitments.bundleIndex,
-          proposalId: result.share.proposalId,
-          shareIndex: result.share.shareIndex,
-          sentToUrls: result.acceptedServers,
-          submitAt: result.submitAt,
-        );
+        try {
+          await rust.recordShareDelegation(
+            dbPath: context.dbPath,
+            accountUuid: context.accountUuid,
+            roundId: context.round.roundId,
+            bundleIndex: commitments.bundleIndex,
+            proposalId: result.share.proposalId,
+            shareIndex: result.share.shareIndex,
+            sentToUrls: result.acceptedServers,
+            submitAt: result.submitAt,
+          );
+        } catch (error, stackTrace) {
+          persistenceError ??= error;
+          persistenceStackTrace ??= stackTrace;
+        }
+      }
+      if (persistenceError != null) {
+        Error.throwWithStackTrace(persistenceError, persistenceStackTrace!);
       }
       if (failedResult != null) {
         throw StateError(
@@ -3791,6 +3814,22 @@ class VotingSubmissionSessionNotifier extends VotingSessionNotifier {
     }
     await _refreshVotingEligibilityState(current: current, context: context);
   }
+}
+
+class _PreparedInitialShareSubmission {
+  const _PreparedInitialShareSubmission({
+    required this.share,
+    required this.body,
+    required this.candidateServers,
+    required this.targetCount,
+    required this.submitAt,
+  });
+
+  final rust_wire.VoteShareWire share;
+  final Map<String, dynamic> body;
+  final List<String> candidateServers;
+  final int targetCount;
+  final BigInt submitAt;
 }
 
 class _InitialShareSubmissionResult {

--- a/lib/src/providers/voting/voting_tree_sync_provider.dart
+++ b/lib/src/providers/voting/voting_tree_sync_provider.dart
@@ -86,13 +86,16 @@ class VotingTreePreSyncService {
       for (var attempt = 0; attempt < nodeUrls.length; attempt++) {
         final nodeUrl = nodeUrls[attempt];
         try {
+          final transportUrl = _ref
+              .read(votingEndpointMapperProvider)
+              .map(nodeUrl);
           final height = await _ref
               .read(votingRustApiProvider)
               .syncVoteTree(
                 dbPath: dbPath,
                 accountUuid: accountUuid,
                 roundId: roundId,
-                nodeUrl: nodeUrl.toString(),
+                nodeUrl: transportUrl.toString(),
               );
           _completed.add(key);
           debugPrint(

--- a/lib/src/services/voting/voting_config_loader.dart
+++ b/lib/src/services/voting/voting_config_loader.dart
@@ -43,6 +43,15 @@ const kStageStaticVotingConfigMirror =
     'v2-static-voting-config.json'
     '?checksum=sha256:17484ebabab92225205a02a962add09f1659c9798c2e2e325bd8eac56ab3bf8f';
 
+/// Hash-pinned logical source injected by the desktop regtest voting harness.
+///
+/// It is ignored unless the app is also compiled for regtest. Transport to the
+/// local fixture is handled separately by `VotingEndpointMapper`.
+const kE2eStaticVotingConfigSourceEnvKey = 'ZCASH_E2E_VOTING_STATIC_CONFIG_URL';
+const kE2eStaticVotingConfigSource = String.fromEnvironment(
+  kE2eStaticVotingConfigSourceEnvKey,
+);
+
 /// Ordered production trust-anchor mirrors, canonical origin first.
 ///
 /// Every entry carries the same `?checksum=sha256:` pin, so whichever origin
@@ -60,12 +69,18 @@ const kStageStaticVotingConfigMirrors = <String>[
 ];
 
 /// Bundled voting config for the selected launch network.
-const kDefaultStaticVotingConfigSource = kZcashDefaultNetworkRaw == 'test'
+const kDefaultStaticVotingConfigSource =
+    kZcashDefaultNetworkRaw == 'regtest' && kE2eStaticVotingConfigSource != ''
+    ? kE2eStaticVotingConfigSource
+    : kZcashDefaultNetworkRaw == 'test'
     ? kStageStaticVotingConfigSource
     : kProductionStaticVotingConfigSource;
 
 /// Mirrors for the selected launch network's bundled trust anchor.
-const kDefaultStaticVotingConfigMirrors = kZcashDefaultNetworkRaw == 'test'
+const kDefaultStaticVotingConfigMirrors =
+    kZcashDefaultNetworkRaw == 'regtest' && kE2eStaticVotingConfigSource != ''
+    ? <String>[kE2eStaticVotingConfigSource]
+    : kZcashDefaultNetworkRaw == 'test'
     ? kStageStaticVotingConfigMirrors
     : kProductionStaticVotingConfigMirrors;
 

--- a/lib/src/services/voting/voting_endpoint_mapper.dart
+++ b/lib/src/services/voting/voting_endpoint_mapper.dart
@@ -1,0 +1,105 @@
+import '../../core/config/network_config.dart';
+import 'voting_http.dart';
+
+const kE2eVotingGatewayUrlEnvKey = 'ZCASH_E2E_VOTING_GATEWAY_URL';
+const kE2eVotingGatewayUrl = String.fromEnvironment(kE2eVotingGatewayUrlEnvKey);
+
+/// Reserved logical DNS suffix used by the regtest voting harness.
+///
+/// Signed voting config keeps HTTPS identities under this suffix. Only a
+/// regtest build with an explicit loopback gateway maps them to local HTTP.
+const kE2eVotingLogicalHostSuffix = '.vizor-vote.invalid';
+
+/// Maps authenticated logical voting endpoints onto a local regtest gateway.
+///
+/// Production and testnet builds always use identity mapping. The regtest
+/// mapping is intentionally narrow: the configured gateway must be loopback,
+/// and only HTTPS hosts below [kE2eVotingLogicalHostSuffix] are rewritten.
+class VotingEndpointMapper {
+  VotingEndpointMapper({required bool isRegtest, String gatewayUrl = ''})
+    : _gateway = _parseGateway(isRegtest: isRegtest, raw: gatewayUrl);
+
+  factory VotingEndpointMapper.forBuild() {
+    return VotingEndpointMapper(
+      isRegtest: kZcashDefaultNetworkRaw == 'regtest',
+      gatewayUrl: kE2eVotingGatewayUrl,
+    );
+  }
+
+  final Uri? _gateway;
+
+  bool get isEnabled => _gateway != null;
+
+  Uri map(Uri logicalUri) {
+    final gateway = _gateway;
+    if (gateway == null || !_isHarnessIdentity(logicalUri)) {
+      return logicalUri;
+    }
+
+    return gateway.replace(
+      pathSegments: [
+        ...gateway.pathSegments.where((segment) => segment.isNotEmpty),
+        logicalUri.host,
+        ...logicalUri.pathSegments.where((segment) => segment.isNotEmpty),
+      ],
+      query: logicalUri.hasQuery ? logicalUri.query : null,
+      fragment: null,
+    );
+  }
+
+  String mapUrl(String logicalUrl) => map(Uri.parse(logicalUrl)).toString();
+
+  static Uri? _parseGateway({required bool isRegtest, required String raw}) {
+    final trimmed = raw.trim();
+    if (!isRegtest || trimmed.isEmpty) return null;
+
+    final gateway = Uri.tryParse(trimmed);
+    if (gateway == null ||
+        gateway.scheme != 'http' ||
+        !_isLoopbackHost(gateway.host) ||
+        gateway.userInfo.isNotEmpty ||
+        gateway.hasQuery ||
+        gateway.hasFragment) {
+      throw StateError(
+        '$kE2eVotingGatewayUrlEnvKey must be a loopback HTTP URL in regtest.',
+      );
+    }
+    return gateway;
+  }
+
+  static bool _isHarnessIdentity(Uri uri) {
+    return uri.scheme == 'https' &&
+        uri.userInfo.isEmpty &&
+        uri.host.endsWith(kE2eVotingLogicalHostSuffix);
+  }
+
+  static bool _isLoopbackHost(String host) {
+    return host == 'localhost' || host == '127.0.0.1' || host == '::1';
+  }
+}
+
+/// Applies [VotingEndpointMapper] at the shared Dart HTTP boundary.
+class MappedVotingHttpClient implements VotingHttpClient {
+  const MappedVotingHttpClient(this._inner, this._mapper);
+
+  final VotingHttpClient _inner;
+  final VotingEndpointMapper _mapper;
+
+  @override
+  Future<VotingHttpResponse> get(
+    Uri uri, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) {
+    return _inner.get(_mapper.map(uri), headers: headers, timeout: timeout);
+  }
+
+  @override
+  Future<VotingHttpResponse> postJson(
+    Uri uri,
+    Map<String, dynamic> body, {
+    Duration? timeout,
+  }) {
+    return _inner.postJson(_mapper.map(uri), body, timeout: timeout);
+  }
+}

--- a/rust/src/wallet/voting/db.rs
+++ b/rust/src/wallet/voting/db.rs
@@ -12,11 +12,24 @@ pub fn open_voting_db(
     db_path: &str,
     account_uuid: &str,
 ) -> Result<zcash_voting::storage::VotingDb, String> {
-    zcash_voting::storage::VotingDb::open_wallet_sidecar(
-        std::path::Path::new(db_path),
-        account_uuid,
-    )
-    .map_err(|e| format!("Error opening voting database: {e}"))
+    const MAX_LOCK_RETRIES: u32 = 5;
+    let wallet_path = std::path::Path::new(db_path);
+    for attempt in 0..=MAX_LOCK_RETRIES {
+        match zcash_voting::storage::VotingDb::open_wallet_sidecar(wallet_path, account_uuid) {
+            Ok(db) => return Ok(db),
+            Err(error) => {
+                let message = error.to_string();
+                let locked = message.to_ascii_lowercase().contains("database is locked");
+                if !locked || attempt == MAX_LOCK_RETRIES {
+                    return Err(format!("Error opening voting database: {message}"));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(
+                    50 * u64::from(attempt + 1),
+                ));
+            }
+        }
+    }
+    unreachable!("the bounded voting database retry loop always returns")
 }
 
 #[cfg(test)]
@@ -47,5 +60,23 @@ mod tests {
             .pragma_query_value(None, "user_version", |row| row.get(0))
             .unwrap();
         assert_eq!(wallet_version, 8);
+    }
+
+    #[test]
+    fn open_voting_db_retries_a_transient_schema_lock() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("zcash_wallet.db");
+        let sidecar_path = zcash_voting::storage::VotingDb::wallet_sidecar_path(&db_path);
+        let lock = rusqlite::Connection::open(&sidecar_path).unwrap();
+        lock.execute_batch("BEGIN EXCLUSIVE").unwrap();
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(125));
+            lock.execute_batch("ROLLBACK").unwrap();
+        });
+
+        let db = open_voting_db(db_path.to_str().unwrap(), "wallet-1").unwrap();
+
+        release.join().unwrap();
+        assert!(db.list_rounds().unwrap().is_empty());
     }
 }

--- a/scripts/e2e/export-regtest-ironwood-nullifiers.py
+++ b/scripts/e2e/export-regtest-ironwood-nullifiers.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Export actual Ironwood nullifiers from a regtest lightwalletd snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import subprocess
+from pathlib import Path
+
+
+def decode_stream(raw: str) -> list[dict[str, object]]:
+    decoder = json.JSONDecoder()
+    values: list[dict[str, object]] = []
+    offset = 0
+    while offset < len(raw):
+        while offset < len(raw) and raw[offset].isspace():
+            offset += 1
+        if offset == len(raw):
+            break
+        value, offset = decoder.raw_decode(raw, offset)
+        if not isinstance(value, dict):
+            raise ValueError("grpcurl stream contained a non-object value")
+        values.append(value)
+    return values
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--grpcurl", default="grpcurl")
+    parser.add_argument("--proto-dir", type=Path, required=True)
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--activation-height", type=int, required=True)
+    parser.add_argument("--snapshot-height", type=int, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    if args.activation_height < 2 or args.snapshot_height < args.activation_height:
+        raise SystemExit("snapshot must be at or after activation height")
+
+    request = json.dumps(
+        {
+            "start": {"height": str(args.activation_height)},
+            "end": {"height": str(args.snapshot_height)},
+        }
+    )
+    command = [
+        args.grpcurl,
+        "-plaintext",
+        "-import-path",
+        str(args.proto_dir),
+        "-proto",
+        "service.proto",
+        "-d",
+        request,
+        args.endpoint,
+        "cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRange",
+    ]
+    completed = subprocess.run(command, capture_output=True, text=True)
+    if completed.returncode != 0:
+        raise SystemExit(f"grpcurl failed: {completed.stderr.strip()}")
+
+    nullifiers: list[bytes] = []
+    seen: set[bytes] = set()
+    for block in decode_stream(completed.stdout):
+        for transaction in block.get("vtx", []):
+            if not isinstance(transaction, dict):
+                raise ValueError("compact transaction is not an object")
+            for action in transaction.get("ironwoodActions", []):
+                if not isinstance(action, dict):
+                    raise ValueError("Ironwood action is not an object")
+                encoded = action.get("nullifier")
+                if not isinstance(encoded, str):
+                    raise ValueError("Ironwood action omitted its nullifier")
+                nullifier = base64.b64decode(encoded, validate=True)
+                if len(nullifier) != 32:
+                    raise ValueError(f"Ironwood nullifier has {len(nullifier)} bytes")
+                if nullifier in seen:
+                    raise ValueError("duplicate Ironwood nullifier in snapshot")
+                seen.add(nullifier)
+                nullifiers.append(nullifier)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(b"".join(nullifiers))
+    print(
+        json.dumps(
+            {
+                "activation_height": args.activation_height,
+                "snapshot_height": args.snapshot_height,
+                "nullifier_count": len(nullifiers),
+                "output": str(args.output),
+            },
+            separators=(",", ":"),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -27,41 +27,47 @@ require_cmd python3
 cd "$ROOT_DIR"
 
 # Keep this ordered from the narrowest smoke test to broader user flows.
-run_test "1/12 import funded wallet and sync balances" \
+run_test "1/14 import funded wallet and sync balances" \
   "scripts/e2e/flutter-macos-regtest-import-sync.sh"
 
-run_test "2/12 fallback from unavailable endpoint and sync balances" \
+run_test "2/14 fallback from unavailable endpoint and sync balances" \
   "scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh"
 
-run_test "3/12 keep custom endpoint failures private" \
+run_test "3/14 keep custom endpoint failures private" \
   "scripts/e2e/flutter-macos-regtest-custom-endpoint-no-fallback.sh"
 
-run_test "4/12 recover from a stalled startup stream" \
+run_test "4/14 recover from a stalled startup stream" \
   "scripts/e2e/flutter-macos-regtest-sync-startup-stall-recovery.sh"
 
-run_test "5/12 fallback from slow-height primary and recover" \
+run_test "5/14 fallback from slow-height primary and recover" \
   "scripts/e2e/flutter-macos-regtest-slow-height-fallback.sh"
 
-run_test "6/12 create wallet and shield transparent funds" \
+run_test "6/14 create wallet and shield transparent funds" \
   "scripts/e2e/flutter-macos-regtest-shield-transparent.sh"
 
-run_test "7/12 retry shield transparent broadcast failure" \
+run_test "7/14 retry shield transparent broadcast failure" \
   "scripts/e2e/flutter-macos-regtest-shield-transparent-retry.sh"
 
-run_test "8/12 import two accounts and send shielded funds" \
+run_test "8/14 import two accounts and send shielded funds" \
   "scripts/e2e/flutter-macos-regtest-multi-account-send.sh"
 
-run_test "9/12 send shielded funds to a TEX address" \
+run_test "9/14 send shielded funds to a TEX address" \
   "scripts/e2e/flutter-macos-regtest-tex-send.sh"
 
-run_test "10/12 show mempool receives in activity history" \
+run_test "10/14 show mempool receives in activity history" \
   "scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh"
 
-run_test "11/12 show mempool receives while sync is running" \
+run_test "11/14 show mempool receives while sync is running" \
   "scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh"
 
-run_test "12/12 expire unmined mempool receives" \
+run_test "12/14 expire unmined mempool receives" \
   "scripts/e2e/flutter-macos-regtest-mempool-expiry.sh"
+
+run_test "13/14 complete a real Ironwood vote" \
+  "scripts/e2e/flutter-macos-regtest-voting.sh"
+
+run_test "14/14 keep voting concurrent with a slow helper" \
+  "scripts/e2e/flutter-macos-regtest-voting-slow-helper.sh"
 
 echo
 echo "all macOS regtest E2E tests passed"

--- a/scripts/e2e/flutter-macos-regtest-voting-slow-helper.sh
+++ b/scripts/e2e/flutter-macos-regtest-voting-slow-helper.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Regression for the multi-minute stall reported when an unhealthy helper was
+# retried serially for every encrypted share. The gateway delays one logical
+# helper while forwarding to the real local helper, then the base E2E asserts
+# that multiple delayed share requests overlapped.
+E2E_SLOW_HELPER_MODE=1 \
+  exec "$ROOT_DIR/scripts/e2e/flutter-macos-regtest-voting.sh" "$@"

--- a/scripts/e2e/flutter-macos-regtest-voting.sh
+++ b/scripts/e2e/flutter-macos-regtest-voting.sh
@@ -261,7 +261,7 @@ fvm flutter test integration_test/regtest_voting_test.dart -d "$FLUTTER_DEVICE" 
 
 METRICS="$(curl -fsS "http://127.0.0.1:$GATEWAY_PORT/metrics")"
 if [[ "$SLOW_HELPER_MODE" == "1" ]]; then
-  jq -e '.slow_share_requests > 0 and .share_max_inflight > 1' \
+  jq -e '.slow_share_requests > 0 and .slow_share_max_inflight > 1' \
     <<<"$METRICS" >/dev/null || {
       echo "slow-helper E2E did not observe concurrent share submission: $METRICS" >&2
       exit 1

--- a/scripts/e2e/flutter-macos-regtest-voting.sh
+++ b/scripts/e2e/flutter-macos-regtest-voting.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+STATE_DIR="$ROOT_DIR/.regtest-voting"
+DEPS_DIR="$STATE_DIR/deps"
+LOG_DIR="$STATE_DIR/logs"
+CONFIG_DIR="$STATE_DIR/config"
+PIR_DATA_DIR="$STATE_DIR/pir-data"
+VOTE_HOME="$STATE_DIR/vote-home"
+SHIM_DIR="$STATE_DIR/shims"
+
+VOTE_SDK_URL="https://github.com/valargroup/vote-sdk.git"
+VOTE_SDK_REV="6a10c073baae3c2003ada402d7c5c513ee6b90ce"
+PIR_URL="https://github.com/valargroup/vote-nullifier-pir.git"
+PIR_REV="20356d14f61a825ef28726f38270c37d604cc268"
+VOTE_SDK_DIR="$DEPS_DIR/vote-sdk-$VOTE_SDK_REV"
+PIR_DIR="$DEPS_DIR/vote-nullifier-pir-$PIR_REV"
+
+ACTIVATION_HEIGHT=500
+LWD_PORT="${E2E_IRONWOOD_LIGHTWALLETD_PORT:-19067}"
+PIR_PORT="${E2E_PIR_PORT:-13000}"
+VOTE_PORT="${E2E_VOTE_PORT:-1317}"
+GATEWAY_PORT="${E2E_VOTING_GATEWAY_PORT:-18080}"
+SLOW_HELPER_DELAY="${E2E_SLOW_HELPER_DELAY:-2.0}"
+SLOW_HELPER_MODE="${E2E_SLOW_HELPER_MODE:-0}"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+# Deterministic secp256k1 scalar 1, used only by the disposable local chain.
+VOTE_MANAGER_PRIVATE_KEY="0000000000000000000000000000000000000000000000000000000000000001"
+
+pids=()
+cleanup() {
+  for pid in "${pids[@]:-}"; do
+    kill "$pid" >/dev/null 2>&1 || true
+  done
+  if [[ "${KEEP_VOTING_REGTEST:-0}" != "1" ]]; then
+    IRONWOOD_ACTIVATION_HEIGHT="$ACTIVATION_HEIGHT" \
+      IRONWOOD_LIGHTWALLETD_PORT="$LWD_PORT" \
+      "$ROOT_DIR/scripts/ironwood-regtest/down.sh" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required command: $1" >&2
+    exit 1
+  }
+}
+
+fetch_exact_revision() {
+  local url="$1" revision="$2" destination="$3"
+  if [[ -d "$destination/.git" ]] &&
+    [[ "$(git -C "$destination" rev-parse HEAD)" == "$revision" ]]; then
+    assert_clean_dependency_checkout "$destination"
+    return
+  fi
+  mkdir -p "$(dirname "$destination")"
+  if [[ ! -d "$destination/.git" ]]; then
+    git clone --filter=blob:none --no-checkout "$url" "$destination"
+  fi
+  git -C "$destination" fetch --depth 1 origin "$revision"
+  git -C "$destination" checkout --detach "$revision"
+  [[ "$(git -C "$destination" rev-parse HEAD)" == "$revision" ]]
+  assert_clean_dependency_checkout "$destination"
+}
+
+assert_clean_dependency_checkout() {
+  local destination="$1" dirty
+  # vote-sdk's build writes these binaries at the repository root. All other
+  # tracked or untracked changes would make the supposedly pinned build local.
+  dirty="$(git -C "$destination" status --porcelain --untracked-files=all |
+    grep -Ev '^\?\? (svoted|voting-config)$' || true)"
+  if [[ -n "$dirty" ]]; then
+    echo "cached dependency checkout is dirty: $destination" >&2
+    echo "$dirty" >&2
+    exit 1
+  fi
+}
+
+wait_http() {
+  local url="$1" label="$2"
+  for _ in $(seq 1 180); do
+    if curl -fsS "$url" >/dev/null 2>&1; then return; fi
+    sleep 1
+  done
+  echo "timed out waiting for $label at $url" >&2
+  exit 1
+}
+
+require_cmd cargo
+require_cmd curl
+require_cmd docker
+require_cmd fvm
+require_cmd git
+require_cmd grpcurl
+require_cmd jq
+require_cmd make
+require_cmd python3
+
+mkdir -p "$DEPS_DIR" "$LOG_DIR" "$CONFIG_DIR" "$SHIM_DIR"
+fetch_exact_revision "$VOTE_SDK_URL" "$VOTE_SDK_REV" "$VOTE_SDK_DIR"
+fetch_exact_revision "$PIR_URL" "$PIR_REV" "$PIR_DIR"
+
+echo "building pinned vote-sdk and PIR services"
+make -C "$VOTE_SDK_DIR" build-ffi build-voting-config
+cargo build --release --manifest-path "$PIR_DIR/Cargo.toml" \
+  -p pir-export --features cli -p nf-server --features serve
+
+echo "creating voting power through the real Orchard-to-Ironwood migration"
+IRONWOOD_ACTIVATION_HEIGHT="$ACTIVATION_HEIGHT" \
+  IRONWOOD_LIGHTWALLETD_PORT="$LWD_PORT" \
+  E2E_TEST_FILE=integration_test/regtest_voting_ironwood_setup_test.dart \
+  E2E_LIGHTWALLETD_URL="http://127.0.0.1:$LWD_PORT" \
+  E2E_ORCHARD_FUNDING_AMOUNT=0.13 \
+  E2E_ORCHARD_FUNDING_ZATOSHI=13000000 \
+  VIZOR_E2E_HIDDEN_WINDOW="${VIZOR_E2E_HIDDEN_WINDOW:-true}" \
+  "$ROOT_DIR/scripts/e2e/flutter-macos-ironwood-migration.sh"
+
+SNAPSHOT_HEIGHT="$(IRONWOOD_ACTIVATION_HEIGHT="$ACTIVATION_HEIGHT" \
+  IRONWOOD_LIGHTWALLETD_PORT="$LWD_PORT" \
+  "$ROOT_DIR/scripts/ironwood-regtest/rpc.sh" getblockcount)"
+rm -rf "$PIR_DATA_DIR"
+mkdir -p "$PIR_DATA_DIR"
+python3 "$ROOT_DIR/scripts/e2e/export-regtest-ironwood-nullifiers.py" \
+  --proto-dir "$ROOT_DIR/protos" \
+  --endpoint "127.0.0.1:$LWD_PORT" \
+  --activation-height "$ACTIVATION_HEIGHT" \
+  --snapshot-height "$SNAPSHOT_HEIGHT" \
+  --output "$PIR_DATA_DIR/nullifiers.bin" \
+  >"$LOG_DIR/nullifier-export.json"
+python3 - "$PIR_DATA_DIR" "$SNAPSHOT_HEIGHT" <<'PY'
+import json, pathlib, struct, sys
+directory = pathlib.Path(sys.argv[1])
+height = int(sys.argv[2])
+(directory / "nullifiers.dataset.json").write_text(json.dumps({
+    "zcash_network": "test", "nullifier_pool": "ironwood", "dataset_version": 2
+}, indent=2) + "\n")
+offset = (directory / "nullifiers.bin").stat().st_size
+(directory / "nullifiers.checkpoint").write_bytes(struct.pack("<QQ", height, offset))
+PY
+"$PIR_DIR/target/release/pir-export" \
+  --nullifiers "$PIR_DATA_DIR/nullifiers.bin" \
+  --checkpoint "$PIR_DATA_DIR/nullifiers.checkpoint" \
+  --output-dir "$PIR_DATA_DIR" 2>"$LOG_DIR/pir-export.log"
+
+SVOTE_PIR_CONFIG_URL='' SVOTE_PIR_PRECOMPUTED_BASE_URL='' \
+  "$PIR_DIR/target/release/nf-server" serve \
+  --zcash-network test --port "$PIR_PORT" \
+  --pir-data-dir "$PIR_DATA_DIR" --lwd-url "http://127.0.0.1:$LWD_PORT" \
+  --stale-threshold-secs 0 >"$LOG_DIR/pir-server.log" 2>&1 &
+pids+=("$!")
+wait_http "http://127.0.0.1:$PIR_PORT/ready" "PIR server"
+jq -e --argjson height "$SNAPSHOT_HEIGHT" \
+  '.height == $height and .nullifier_pool == "ironwood" and .dataset_version == 2' \
+  < <(curl -fsS "http://127.0.0.1:$PIR_PORT/root") >/dev/null
+
+echo "starting pinned single-validator vote chain and helper"
+rm -rf "$VOTE_HOME"
+PATH="$VOTE_SDK_DIR:$PATH" SVOTED_HOME="$VOTE_HOME" \
+  VM_PRIVKEYS="$VOTE_MANAGER_PRIVATE_KEY" \
+  SVOTE_ADMIN_DISABLE=true SVOTE_HELPER_EXPOSE_QUEUE_STATUS=true \
+  bash "$VOTE_SDK_DIR/scripts/init.sh" >"$LOG_DIR/vote-init.log" 2>&1
+"$VOTE_SDK_DIR/svoted" start --home "$VOTE_HOME" \
+  --api.address "tcp://127.0.0.1:$VOTE_PORT" \
+  >"$LOG_DIR/vote-server.log" 2>&1 &
+pids+=("$!")
+wait_http "http://127.0.0.1:$VOTE_PORT/shielded-vote/v1/rounds" "vote chain"
+
+REAL_GRPCURL="$(command -v grpcurl)"
+cat >"$SHIM_DIR/grpcurl" <<EOF
+#!/usr/bin/env bash
+exec "$REAL_GRPCURL" -plaintext -import-path "$ROOT_DIR/protos" -proto service.proto "\$@"
+EOF
+chmod +x "$SHIM_DIR/grpcurl"
+PATH="$SHIM_DIR:$VOTE_SDK_DIR:$PATH" \
+  VM_PRIVKEYS="$VOTE_MANAGER_PRIVATE_KEY" \
+  SVOTE_HOME="$VOTE_HOME" SVOTE_PALLAS_PK_PATH="$VOTE_HOME/pallas.pk" \
+  SVOTE_API_URL="http://127.0.0.1:$VOTE_PORT" \
+  ZASHI_LIGHTWALLETD="127.0.0.1:$LWD_PORT" \
+  ZASHI_PIR_URL="http://127.0.0.1:$PIR_PORT" \
+  ZASHI_SNAPSHOT_HEIGHT="$SNAPSHOT_HEIGHT" ZASHI_VOTE_WINDOW_SECS=7200 \
+  cargo test --manifest-path "$VOTE_SDK_DIR/e2e-tests/Cargo.toml" \
+  --test create_round_for_zashi create_round_for_zashi -- --ignored --nocapture \
+  >"$LOG_DIR/create-round.log" 2>&1
+
+ROUND_JSON="$(curl -fsS "http://127.0.0.1:$VOTE_PORT/shielded-vote/v1/rounds/active")"
+read -r ROUND_ID EA_PK < <(python3 -c '
+import base64, json, sys
+round_data = json.load(sys.stdin)["round"]
+print(
+    base64.b64decode(round_data["vote_round_id"], validate=True).hex(),
+    round_data["ea_pk"],
+)
+' <<<"$ROUND_JSON")
+
+KEY_OUTPUT="$("$VOTE_SDK_DIR/voting-config" keygen \
+  --signer-id vizor-regtest-e2e --out "$CONFIG_DIR/signing.seed" --force)"
+TRUSTED_KEY="$(sed -n 's/^trusted_keys_entry: //p' <<<"$KEY_OUTPUT")"
+cat >"$CONFIG_DIR/static-voting-config.json" <<EOF
+{
+  "static_config_version": 1,
+  "dynamic_config_url": "https://config.vizor-vote.invalid/dynamic-voting-config.json",
+  "trusted_keys": [$TRUSTED_KEY]
+}
+EOF
+if [[ "$SLOW_HELPER_MODE" == "1" ]]; then
+  VOTE_SERVERS='[
+    {"url":"https://slow.vizor-vote.invalid","label":"delayed regtest helper"},
+    {"url":"https://vote.vizor-vote.invalid","label":"healthy regtest helper"}
+  ]'
+else
+  VOTE_SERVERS='[
+    {"url":"https://vote.vizor-vote.invalid","label":"healthy regtest helper"}
+  ]'
+fi
+cat >"$CONFIG_DIR/dynamic-voting-config.json" <<EOF
+{
+  "config_version": 1,
+  "vote_servers": $VOTE_SERVERS,
+  "pir_endpoints": [
+    {"url":"https://pir.vizor-vote.invalid","label":"regtest PIR"}
+  ],
+  "pir_layout": {"pir_depth":19,"tier0_layers":12,"tier1_layers":7,"poly_len":4096},
+  "supported_versions": {"pir":["v0"],"vote_protocol":"v0","tally":"v0","vote_server":"v1"},
+  "rounds": {}
+}
+EOF
+"$VOTE_SDK_DIR/voting-config" sign --round-id "$ROUND_ID" --ea-pk "$EA_PK" \
+  --signer-id vizor-regtest-e2e --privkey-file "$CONFIG_DIR/signing.seed" \
+  --pir-depth 19 --tier0-layers 12 --tier1-layers 7 --poly-len 4096 \
+  --merge "$CONFIG_DIR/dynamic-voting-config.json"
+"$VOTE_SDK_DIR/voting-config" verify \
+  --config "$CONFIG_DIR/dynamic-voting-config.json" \
+  --static-config "$CONFIG_DIR/static-voting-config.json"
+
+python3 "$ROOT_DIR/scripts/e2e/voting-regtest-gateway.py" \
+  --port "$GATEWAY_PORT" --config-dir "$CONFIG_DIR" \
+  --pir-target "http://127.0.0.1:$PIR_PORT" \
+  --vote-target "http://127.0.0.1:$VOTE_PORT" \
+  --slow-helper-delay "$SLOW_HELPER_DELAY" \
+  >"$LOG_DIR/gateway.log" 2>&1 &
+pids+=("$!")
+wait_http "http://127.0.0.1:$GATEWAY_PORT/health" "voting gateway"
+
+STATIC_SHA="$(shasum -a 256 "$CONFIG_DIR/static-voting-config.json" | awk '{print $1}')"
+STATIC_URL="https://config.vizor-vote.invalid/static-voting-config.json?checksum=sha256:$STATIC_SHA"
+
+echo "running real-proof Flutter voting E2E for round $ROUND_ID"
+cd "$ROOT_DIR"
+fvm flutter test integration_test/regtest_voting_test.dart -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
+  --dart-define=ZCASH_REGTEST_IRONWOOD_ACTIVATION_HEIGHT="$ACTIVATION_HEIGHT" \
+  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="http://127.0.0.1:$LWD_PORT" \
+  --dart-define=ZCASH_E2E_VOTING_GATEWAY_URL="http://127.0.0.1:$GATEWAY_PORT" \
+  --dart-define=ZCASH_E2E_VOTING_STATIC_CONFIG_URL="$STATIC_URL" \
+  --dart-define=ZCASH_E2E_VOTE_ROUND_ID="$ROUND_ID" \
+  --dart-define=ZCASH_E2E_REUSE_MIGRATED_WALLET=true \
+  --dart-define=ZCASH_E2E_FIRST_UNLOCK_MNEMONIC_KEYCHAIN=true \
+  --dart-define=VIZOR_E2E_HIDDEN_WINDOW="${VIZOR_E2E_HIDDEN_WINDOW:-true}"
+
+METRICS="$(curl -fsS "http://127.0.0.1:$GATEWAY_PORT/metrics")"
+if [[ "$SLOW_HELPER_MODE" == "1" ]]; then
+  jq -e '.slow_share_requests > 0 and .share_max_inflight > 1' \
+    <<<"$METRICS" >/dev/null || {
+      echo "slow-helper E2E did not observe concurrent share submission: $METRICS" >&2
+      exit 1
+    }
+fi
+jq -e '.tree.next_index > 0' < <(curl -fsS \
+  "http://127.0.0.1:$VOTE_PORT/shielded-vote/v1/commitment-tree/$ROUND_ID/latest") \
+  >/dev/null
+echo "voting E2E passed; round=$ROUND_ID snapshot=$SNAPSHOT_HEIGHT metrics=$METRICS"

--- a/scripts/e2e/test_voting_regtest_tools.py
+++ b/scripts/e2e/test_voting_regtest_tools.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def load_script(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_DIR / filename)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {filename}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+exporter = load_script(
+    "export_regtest_ironwood_nullifiers",
+    "export-regtest-ironwood-nullifiers.py",
+)
+gateway = load_script("voting_regtest_gateway", "voting-regtest-gateway.py")
+
+
+class ExporterTests(unittest.TestCase):
+    def test_decodes_concatenated_grpcurl_stream(self) -> None:
+        self.assertEqual(
+            exporter.decode_stream('{"height":"1"}\n{"height":"2"}\n'),
+            [{"height": "1"}, {"height": "2"}],
+        )
+
+    def test_rejects_non_object_stream_item(self) -> None:
+        with self.assertRaisesRegex(ValueError, "non-object"):
+            exporter.decode_stream("[]")
+
+
+class GatewayTests(unittest.TestCase):
+    def test_accepts_only_loopback_http_origins(self) -> None:
+        self.assertEqual(gateway.parse_target("http://127.0.0.1:3000"), ("127.0.0.1", 3000))
+        with self.assertRaisesRegex(Exception, "loopback HTTP"):
+            gateway.parse_target("https://127.0.0.1:3000")
+        with self.assertRaisesRegex(Exception, "loopback HTTP"):
+            gateway.parse_target("http://example.com:3000")
+
+    def test_decodes_chunked_request_body(self) -> None:
+        stream = io.BytesIO(b"4\r\ntest\r\n6;ignored=yes\r\n-body!\r\n0\r\n\r\n")
+        self.assertEqual(
+            gateway.read_request_body(stream, {"Transfer-Encoding": "chunked"}),
+            b"test-body!",
+        )
+
+    def test_rejects_truncated_chunked_request_body(self) -> None:
+        with self.assertRaisesRegex(ValueError, "truncated"):
+            gateway.read_request_body(
+                io.BytesIO(b"4\r\nabc\r\n"),
+                {"Transfer-Encoding": "chunked"},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/e2e/voting-regtest-gateway.py
+++ b/scripts/e2e/voting-regtest-gateway.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Loopback gateway for signed logical voting E2E endpoints."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import mimetypes
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+CONFIG_HOST = "config.vizor-vote.invalid"
+PIR_HOST = "pir.vizor-vote.invalid"
+VOTE_HOST = "vote.vizor-vote.invalid"
+SLOW_VOTE_HOST = "slow.vizor-vote.invalid"
+HOP_BY_HOP = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+MAX_REQUEST_BODY = 128 * 1024 * 1024
+
+
+def read_request_body(stream, headers) -> bytes | None:
+    content_length = headers.get("Content-Length")
+    if content_length is not None:
+        length = int(content_length)
+        if length < 0 or length > MAX_REQUEST_BODY:
+            raise ValueError("request body is too large")
+        return stream.read(length) if length else None
+    if headers.get("Transfer-Encoding", "").lower() != "chunked":
+        return None
+
+    body = bytearray()
+    while True:
+        size_line = stream.readline()
+        if not size_line:
+            raise ValueError("unexpected EOF in chunked request body")
+        try:
+            size = int(size_line.split(b";", 1)[0].strip(), 16)
+        except ValueError as error:
+            raise ValueError("invalid chunk size") from error
+        if size < 0 or len(body) + size > MAX_REQUEST_BODY:
+            raise ValueError("request body is too large")
+        if size == 0:
+            while True:
+                trailer = stream.readline()
+                if trailer in {b"\r\n", b"\n"}:
+                    return bytes(body)
+                if not trailer:
+                    raise ValueError("unexpected EOF in chunked trailers")
+        chunk = stream.read(size)
+        if len(chunk) != size or stream.read(2) != b"\r\n":
+            raise ValueError("truncated chunked request body")
+        body.extend(chunk)
+
+
+class GatewayHandler(BaseHTTPRequestHandler):
+    config_dir: Path
+    pir_target: tuple[str, int]
+    vote_target: tuple[str, int]
+    slow_helper_delay: float
+    metrics_lock = threading.Lock()
+    slow_share_inflight = 0
+    slow_share_max_inflight = 0
+    slow_share_requests = 0
+    share_inflight = 0
+    share_max_inflight = 0
+    share_requests = 0
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._dispatch()
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._dispatch()
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        print(f"[voting-gateway] {self.address_string()} {fmt % args}", flush=True)
+
+    def _dispatch(self) -> None:
+        parsed = urlsplit(self.path)
+        if parsed.path == "/health":
+            self._json(200, {"status": "ok"})
+            return
+        if parsed.path == "/metrics":
+            with self.metrics_lock:
+                self._json(200, {
+                    "share_requests": type(self).share_requests,
+                    "share_max_inflight": type(self).share_max_inflight,
+                    "slow_share_requests": type(self).slow_share_requests,
+                    "slow_share_max_inflight": type(self).slow_share_max_inflight,
+                })
+            return
+
+        segments = [segment for segment in parsed.path.split("/") if segment]
+        if not segments:
+            self._json(404, {"error": "missing logical host"})
+            return
+        logical_host = segments[0]
+        upstream_path = "/" + "/".join(segments[1:])
+        if parsed.query:
+            upstream_path += "?" + parsed.query
+
+        if logical_host == CONFIG_HOST:
+            self._serve_config(segments[1:])
+        elif logical_host == PIR_HOST:
+            self._proxy(self.pir_target, upstream_path)
+        elif logical_host == VOTE_HOST:
+            self._vote(upstream_path, delayed=False)
+        elif logical_host == SLOW_VOTE_HOST:
+            self._vote(upstream_path, delayed=True)
+        else:
+            self._json(404, {"error": f"unknown logical host: {logical_host}"})
+
+    def _vote(self, upstream_path: str, *, delayed: bool) -> None:
+        if self.command != "POST" or upstream_path != "/shielded-vote/v1/shares":
+            self._proxy(self.vote_target, upstream_path)
+            return
+        handler = type(self)
+        with self.metrics_lock:
+            handler.share_requests += 1
+            handler.share_inflight += 1
+            handler.share_max_inflight = max(
+                handler.share_max_inflight, handler.share_inflight
+            )
+            if delayed:
+                handler.slow_share_requests += 1
+                handler.slow_share_inflight += 1
+                handler.slow_share_max_inflight = max(
+                    handler.slow_share_max_inflight,
+                    handler.slow_share_inflight,
+                )
+        try:
+            if delayed:
+                time.sleep(self.slow_helper_delay)
+            self._proxy(self.vote_target, upstream_path)
+        finally:
+            with self.metrics_lock:
+                handler.share_inflight -= 1
+                if delayed:
+                    handler.slow_share_inflight -= 1
+
+    def _serve_config(self, segments: list[str]) -> None:
+        if self.command != "GET" or len(segments) != 1:
+            self._json(404, {"error": "unknown config object"})
+            return
+        candidate = self.config_dir / segments[0]
+        if not candidate.is_file() or candidate.parent != self.config_dir:
+            self._json(404, {"error": "unknown config object"})
+            return
+        body = candidate.read_bytes()
+        content_type = mimetypes.guess_type(candidate.name)[0] or "application/octet-stream"
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _proxy(self, target: tuple[str, int], path: str) -> None:
+        try:
+            body = read_request_body(self.rfile, self.headers)
+        except (TypeError, ValueError) as error:
+            self._json(400, {"error": f"invalid request body: {error}"})
+            return
+        headers = {
+            key: value
+            for key, value in self.headers.items()
+            if key.lower() not in HOP_BY_HOP | {"host", "content-length"}
+        }
+        connection = http.client.HTTPConnection(*target, timeout=30)
+        try:
+            connection.request(self.command, path, body=body, headers=headers)
+            response = connection.getresponse()
+            response_body = response.read()
+            self.send_response(response.status)
+            for key, value in response.getheaders():
+                if key.lower() not in HOP_BY_HOP | {"content-length"}:
+                    self.send_header(key, value)
+            self.send_header("Content-Length", str(len(response_body)))
+            self.end_headers()
+            self.wfile.write(response_body)
+        except (OSError, http.client.HTTPException) as error:
+            self._json(502, {"error": f"upstream unavailable: {error}"})
+        finally:
+            connection.close()
+
+    def _json(self, status: int, value: object) -> None:
+        body = json.dumps(value, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def parse_target(raw: str) -> tuple[str, int]:
+    parsed = urlsplit(raw)
+    if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost"}:
+        raise argparse.ArgumentTypeError("target must be a loopback HTTP origin")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise argparse.ArgumentTypeError("target must not contain a path, query, or fragment")
+    return parsed.hostname, parsed.port or 80
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--config-dir", type=Path, required=True)
+    parser.add_argument("--pir-target", type=parse_target, required=True)
+    parser.add_argument("--vote-target", type=parse_target, required=True)
+    parser.add_argument("--slow-helper-delay", type=float, default=0.0)
+    args = parser.parse_args()
+
+    config_dir = args.config_dir.resolve(strict=True)
+    if not config_dir.is_dir():
+        raise SystemExit(f"config directory is not a directory: {config_dir}")
+
+    handler = type(
+        "ConfiguredGatewayHandler",
+        (GatewayHandler,),
+        {
+            "config_dir": config_dir,
+            "pir_target": args.pir_target,
+            "vote_target": args.vote_target,
+            "slow_helper_delay": max(0.0, args.slow_helper_delay),
+        },
+    )
+    server = ThreadingHTTPServer((args.host, args.port), handler)
+    print(f"[voting-gateway] listening on http://{args.host}:{args.port}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -4544,14 +4544,81 @@ void main() {
     expect(rust.storedCommitmentBundles, ['0:7:2']);
   });
 
-  test('vote commitment submits all encrypted shares concurrently', () async {
-    final http = _GatedSharePostVotingHttpClient(
-      expectedShareCount: 3,
-      responses: votingHttpResponses(),
-    );
+  test(
+    'vote commitment submits shares concurrently and persists completions',
+    () async {
+      final http = _GatedSharePostVotingHttpClient(
+        expectedShareCount: 3,
+        gatedShareIndexes: const {2},
+        responses: votingHttpResponses(),
+      );
+      final rust = FakeVotingRustApi(
+        emitCommitments: true,
+        commitmentShareCount: 3,
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 1,
+          delegationTxHashes: [
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: 0,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-0',
+              vanLeafPosition: null,
+            ),
+          ],
+          votes: [vote(bundleIndex: 0, proposalId: 7)],
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final cast = container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+
+      await http.allSharePostsStarted.future.timeout(
+        const Duration(seconds: 1),
+      );
+      expect(http.startedShareIndexes, {0, 1, 2});
+      await _waitForRecordedShareCount(rust, 2);
+      expect(rust.recordedShares.map((share) => share.shareIndex).toSet(), {
+        0,
+        1,
+      });
+
+      http.releaseSharePosts.complete();
+      await cast;
+
+      expect(rust.recordedShares, hasLength(3));
+      expect(
+        rust.recordedShares.map((share) => share.shareIndex),
+        unorderedEquals([0, 1, 2]),
+      );
+    },
+  );
+
+  test('vote commitment validates all shares before submission', () async {
+    final http = FakeVotingHttpClient(responses: votingHttpResponses());
     final rust = FakeVotingRustApi(
       emitCommitments: true,
       commitmentShareCount: 3,
+      failingVoteShareWireIndexes: const {2},
     );
     final recoveryApi = FakeVotingRecoveryApi(
       state: recoveryState(
@@ -4575,7 +4642,7 @@ void main() {
     addTearDown(container.dispose);
 
     await container.read(votingSessionProvider(kRoundId).future);
-    final cast = container
+    await container
         .read(votingSessionProvider(kRoundId).notifier)
         .castVotes(
           draftVotes: [
@@ -4589,15 +4656,73 @@ void main() {
           ],
         );
 
-    await http.allSharePostsStarted.future;
-    expect(http.startedShareIndexes, {0, 1, 2});
+    final sharePosts = http.requests.where(
+      (request) =>
+          request.method == 'POST' &&
+          request.uri.path == '/shielded-vote/v1/shares',
+    );
+    expect(sharePosts, isEmpty);
     expect(rust.recordedShares, isEmpty);
-
-    http.releaseSharePosts.complete();
-    await cast;
-
-    expect(rust.recordedShares.map((share) => share.shareIndex), [0, 1, 2]);
+    final state = container.read(votingSessionProvider(kRoundId)).value!;
+    expect(state.phase, VotingSessionPhase.error);
+    expect(state.error?.message, contains('invalid vote share 2'));
   });
+
+  test(
+    'vote commitment persists sibling shares after one persistence failure',
+    () async {
+      final http = FakeVotingHttpClient(responses: votingHttpResponses());
+      final rust = FakeVotingRustApi(
+        emitCommitments: true,
+        commitmentShareCount: 3,
+        failingRecordShareIndexes: const {1},
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 1,
+          delegationTxHashes: [
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: 0,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-0',
+              vanLeafPosition: null,
+            ),
+          ],
+          votes: [vote(bundleIndex: 0, proposalId: 7)],
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+
+      expect(rust.recordShareAttempts, unorderedEquals([0, 1, 2]));
+      expect(
+        rust.recordedShares.map((share) => share.shareIndex),
+        unorderedEquals([0, 2]),
+      );
+      final state = container.read(votingSessionProvider(kRoundId)).value!;
+      expect(state.phase, VotingSessionPhase.error);
+      expect(state.error?.message, contains('share persistence failed 1'));
+    },
+  );
 
   test('ballot intent write failure aborts before vote submission', () async {
     final rust = FakeVotingRustApi(emitCommitments: true);
@@ -5990,10 +6115,12 @@ class _YieldingFakeVotingHttpClient extends FakeVotingHttpClient {
 class _GatedSharePostVotingHttpClient extends FakeVotingHttpClient {
   _GatedSharePostVotingHttpClient({
     required this.expectedShareCount,
+    required this.gatedShareIndexes,
     super.responses,
   });
 
   final int expectedShareCount;
+  final Set<int> gatedShareIndexes;
   final Set<int> startedShareIndexes = {};
   final Completer<void> allSharePostsStarted = Completer<void>();
   final Completer<void> releaseSharePosts = Completer<void>();
@@ -6005,15 +6132,32 @@ class _GatedSharePostVotingHttpClient extends FakeVotingHttpClient {
     Duration? timeout,
   }) async {
     if (uri.path == '/shielded-vote/v1/shares') {
-      startedShareIndexes.add(body['share_index'] as int);
+      final shareIndex = body['share_index'] as int;
+      startedShareIndexes.add(shareIndex);
       if (startedShareIndexes.length == expectedShareCount &&
           !allSharePostsStarted.isCompleted) {
         allSharePostsStarted.complete();
       }
-      await releaseSharePosts.future;
+      if (gatedShareIndexes.contains(shareIndex)) {
+        await releaseSharePosts.future;
+      }
     }
     return super.postJson(uri, body, timeout: timeout);
   }
+}
+
+Future<void> _waitForRecordedShareCount(
+  FakeVotingRustApi rust,
+  int expectedCount,
+) async {
+  for (var i = 0; i < 100; i++) {
+    if (rust.recordedShares.length >= expectedCount) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail(
+    'Timed out waiting for $expectedCount recorded shares. '
+    'Saw ${rust.recordedShares.length}.',
+  );
 }
 
 class _CountingVotingRoundsNotifier extends VotingRoundsNotifier {
@@ -7342,6 +7486,8 @@ class FakeVotingRustApi implements VotingRustApi {
     this.keystoneSignatureBatchFailuresRemaining = 0,
     this.shareResubmissionError,
     this.nextShareTrackingDelayGate,
+    this.failingVoteShareWireIndexes = const {},
+    this.failingRecordShareIndexes = const {},
   });
 
   final Duration setupDelay;
@@ -7367,6 +7513,8 @@ class FakeVotingRustApi implements VotingRustApi {
   int keystoneSignatureBatchFailuresRemaining;
   final Object? shareResubmissionError;
   final Completer<void>? nextShareTrackingDelayGate;
+  final Set<int> failingVoteShareWireIndexes;
+  final Set<int> failingRecordShareIndexes;
   int setupCalls = 0;
   int _activeSetups = 0;
   int maxConcurrentSetups = 0;
@@ -7381,6 +7529,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final storedVanPositions = <String>[];
   final operationLog = <String>[];
   final recordedShares = <_RecordedShare>[];
+  final recordShareAttempts = <int>[];
   final syncedVoteTrees = <String>[];
   final syncedVoteTreeNodeUrls = <String>[];
   final precomputedDelegationPir = <int>[];
@@ -7937,6 +8086,9 @@ class FakeVotingRustApi implements VotingRustApi {
     BigInt? vcTreePosition,
     required BigInt submitAt,
   }) async {
+    if (failingVoteShareWireIndexes.contains(share.shareIndex)) {
+      throw FormatException('invalid vote share ${share.shareIndex}');
+    }
     return jsonEncode({
       'vote_round_id': share.voteRoundId,
       'shares_hash': share.sharesHash,
@@ -8195,6 +8347,10 @@ class FakeVotingRustApi implements VotingRustApi {
     required List<String> sentToUrls,
     required BigInt submitAt,
   }) async {
+    recordShareAttempts.add(shareIndex);
+    if (failingRecordShareIndexes.contains(shareIndex)) {
+      throw StateError('share persistence failed $shareIndex');
+    }
     operationLog.add('record_share:$bundleIndex:$proposalId:$shareIndex');
     recordedShares.add(
       _RecordedShare(

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -4544,6 +4544,61 @@ void main() {
     expect(rust.storedCommitmentBundles, ['0:7:2']);
   });
 
+  test('vote commitment submits all encrypted shares concurrently', () async {
+    final http = _GatedSharePostVotingHttpClient(
+      expectedShareCount: 3,
+      responses: votingHttpResponses(),
+    );
+    final rust = FakeVotingRustApi(
+      emitCommitments: true,
+      commitmentShareCount: 3,
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 1,
+        delegationTxHashes: [
+          rust_frb_types.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.submittedDelegation,
+            txHash: 'delegation-0',
+            vanLeafPosition: null,
+          ),
+        ],
+        votes: [vote(bundleIndex: 0, proposalId: 7)],
+      ),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final cast = container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(
+          draftVotes: [
+            rust_wire.DraftVote(
+              proposalId: 7,
+              choice: 1,
+              numOptions: 2,
+              vcTreePosition: BigInt.zero,
+              singleShare: false,
+            ),
+          ],
+        );
+
+    await http.allSharePostsStarted.future;
+    expect(http.startedShareIndexes, {0, 1, 2});
+    expect(rust.recordedShares, isEmpty);
+
+    http.releaseSharePosts.complete();
+    await cast;
+
+    expect(rust.recordedShares.map((share) => share.shareIndex), [0, 1, 2]);
+  });
+
   test('ballot intent write failure aborts before vote submission', () async {
     final rust = FakeVotingRustApi(emitCommitments: true);
     final recoveryApi = FakeVotingRecoveryApi(
@@ -5929,6 +5984,35 @@ class _YieldingFakeVotingHttpClient extends FakeVotingHttpClient {
   }) async {
     await Future<void>.delayed(Duration.zero);
     return super.get(uri, headers: headers, timeout: timeout);
+  }
+}
+
+class _GatedSharePostVotingHttpClient extends FakeVotingHttpClient {
+  _GatedSharePostVotingHttpClient({
+    required this.expectedShareCount,
+    super.responses,
+  });
+
+  final int expectedShareCount;
+  final Set<int> startedShareIndexes = {};
+  final Completer<void> allSharePostsStarted = Completer<void>();
+  final Completer<void> releaseSharePosts = Completer<void>();
+
+  @override
+  Future<VotingHttpResponse> postJson(
+    Uri uri,
+    Map<String, dynamic> body, {
+    Duration? timeout,
+  }) async {
+    if (uri.path == '/shielded-vote/v1/shares') {
+      startedShareIndexes.add(body['share_index'] as int);
+      if (startedShareIndexes.length == expectedShareCount &&
+          !allSharePostsStarted.isCompleted) {
+        allSharePostsStarted.complete();
+      }
+      await releaseSharePosts.future;
+    }
+    return super.postJson(uri, body, timeout: timeout);
   }
 }
 

--- a/test/services/voting/voting_endpoint_mapper_test.dart
+++ b/test/services/voting/voting_endpoint_mapper_test.dart
@@ -1,0 +1,113 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/services/voting/voting_endpoint_mapper.dart';
+import 'package:zcash_wallet/src/services/voting/voting_http.dart';
+
+void main() {
+  group('VotingEndpointMapper', () {
+    test('is identity outside regtest', () {
+      final mapper = VotingEndpointMapper(
+        isRegtest: false,
+        gatewayUrl: 'http://127.0.0.1:18080',
+      );
+      final logical = Uri.parse(
+        'https://vote.vizor-vote.invalid/shielded-vote/v1/rounds',
+      );
+
+      expect(mapper.isEnabled, isFalse);
+      expect(mapper.map(logical), logical);
+    });
+
+    test('maps only reserved HTTPS identities through loopback', () {
+      final mapper = VotingEndpointMapper(
+        isRegtest: true,
+        gatewayUrl: 'http://127.0.0.1:18080/gateway',
+      );
+
+      expect(
+        mapper.map(Uri.parse('https://pir.vizor-vote.invalid/root?height=42')),
+        Uri.parse(
+          'http://127.0.0.1:18080/gateway/'
+          'pir.vizor-vote.invalid/root?height=42',
+        ),
+      );
+      expect(
+        mapper.map(Uri.parse('https://example.com/root')),
+        Uri.parse('https://example.com/root'),
+      );
+      expect(
+        mapper.map(Uri.parse('http://pir.vizor-vote.invalid/root')),
+        Uri.parse('http://pir.vizor-vote.invalid/root'),
+      );
+    });
+
+    test('rejects non-loopback or HTTPS gateways', () {
+      expect(
+        () => VotingEndpointMapper(
+          isRegtest: true,
+          gatewayUrl: 'http://example.com:18080',
+        ),
+        throwsStateError,
+      );
+      expect(
+        () => VotingEndpointMapper(
+          isRegtest: true,
+          gatewayUrl: 'https://127.0.0.1:18080',
+        ),
+        throwsStateError,
+      );
+    });
+  });
+
+  test('MappedVotingHttpClient rewrites GET and POST destinations', () async {
+    final inner = _RecordingVotingHttpClient();
+    final client = MappedVotingHttpClient(
+      inner,
+      VotingEndpointMapper(
+        isRegtest: true,
+        gatewayUrl: 'http://localhost:18080',
+      ),
+    );
+
+    await client.get(Uri.parse('https://config.vizor-vote.invalid/static'));
+    await client.postJson(
+      Uri.parse('https://vote.vizor-vote.invalid/api'),
+      const {'vote': 1},
+    );
+
+    expect(
+      inner.getUris.single,
+      Uri.parse('http://localhost:18080/config.vizor-vote.invalid/static'),
+    );
+    expect(
+      inner.postUris.single,
+      Uri.parse('http://localhost:18080/vote.vizor-vote.invalid/api'),
+    );
+  });
+}
+
+class _RecordingVotingHttpClient implements VotingHttpClient {
+  final List<Uri> getUris = [];
+  final List<Uri> postUris = [];
+
+  @override
+  Future<VotingHttpResponse> get(
+    Uri uri, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
+    getUris.add(uri);
+    return VotingHttpResponse(statusCode: 200, bodyBytes: Uint8List(0));
+  }
+
+  @override
+  Future<VotingHttpResponse> postJson(
+    Uri uri,
+    Map<String, dynamic> body, {
+    Duration? timeout,
+  }) async {
+    postUris.add(uri);
+    return VotingHttpResponse(statusCode: 200, bodyBytes: Uint8List(0));
+  }
+}


### PR DESCRIPTION
## Summary

- parallelize encrypted share submissions within each proposal so unhealthy or slow helpers do not add serial retry delays across every share
- validate all share payloads before any helper request, persist successful shares in completion order, and continue persisting siblings after an individual DB write failure
- retry transient SQLite lock failures in the voting sidecar
- add a real desktop Ironwood regtest E2E with pinned vote-sdk, PIR, zcashd, and lightwalletd dependencies
- add a slow-helper regression lane that verifies share submissions overlap instead of accumulating minutes of delay

This supersedes and fully covers #538, including both of its commits. It also adds persistence-failure coverage and the full-chain regtest E2E.

## Mainnet and testnet impact

- share POSTs for one proposal now run concurrently; proposal processing and helper failover policy remain unchanged
- accepted shares become durable as soon as each request completes
- one share persistence failure no longer prevents other accepted shares from being recorded; the first persistence error is still surfaced
- transient voting sidecar SQLite locks are retried for up to 750 ms
- regtest endpoint rewriting and local HTTP transport are restricted to explicit regtest configuration and do not alter mainnet or testnet endpoints

## Bug fixed

Production configuration can contain multiple vote/helper servers. The client previously submitted encrypted shares serially, and each unhealthy helper could consume several timeout/retry attempts for every share. Across multiple questions this turned an expected seconds-long step into a multi-minute wait. The previous concurrent implementation also waited for the slowest share before persisting any result and could abandon sibling persistence after one DB error.

## Validation

- `fvm flutter analyze`
- `fvm flutter test test/providers/voting/voting_providers_test.dart` — 131 tests passed
- focused share serialization, completion-order persistence, and persistence-failure regression tests
- `scripts/e2e/flutter-macos-regtest-voting.sh` — 4 proposals, 64 real encrypted shares, max 10 in flight
- `scripts/e2e/flutter-macos-regtest-voting-slow-helper.sh` — 64 shares, 36 slow-helper requests, max 10 slow requests in flight, completed in about 38 seconds

The E2E uses the immediate Ironwood migration path.