### PR TITLE
Honor helper health during share submission

### DIFF
--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1690,8 +1690,15 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required BigInt submitAt,
   }) async {
     final acceptedServers = <String>[];
-    for (final serverUrl in candidateServers) {
-      if (acceptedServers.length >= targetCount) break;
+    final remainingServers = LinkedHashSet<String>.of(candidateServers);
+    while (remainingServers.isNotEmpty &&
+        acceptedServers.length < targetCount) {
+      // Re-evaluate health before every attempt so failures observed by
+      // concurrent submissions can move a degraded helper behind healthy
+      // alternatives. The tracker still returns every helper when all are
+      // degraded, preserving the liveness fallback.
+      final serverUrl = helperHealth.candidateServers(remainingServers).first;
+      remainingServers.remove(serverUrl);
       try {
         debugPrint(
           '[zcash] Voting: submitting share '

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -4613,6 +4613,155 @@ void main() {
     },
   );
 
+  test('share submission deprioritizes a degraded planner target', () async {
+    const helperA = 'https://helper-a.example';
+    const helperB = 'https://helper-b.example';
+    final http = FakeVotingHttpClient(
+      responses: votingHttpResponses(
+        dynamicConfig: dynamicConfigJson(
+          voteServers: const [
+            {'url': helperA, 'label': 'helper-a'},
+            {'url': helperB, 'label': 'helper-b'},
+          ],
+        ),
+      ),
+    );
+    final rust = FakeVotingRustApi(emitCommitments: true);
+    final helperHealth = VotingHelperHealthTracker(
+      failureThreshold: 1,
+      cooldown: const Duration(hours: 1),
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 1,
+        delegationTxHashes: [
+          rust_frb_types.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.submittedDelegation,
+            txHash: 'delegation-0',
+            vanLeafPosition: null,
+          ),
+        ],
+        votes: [vote(bundleIndex: 0, proposalId: 7)],
+      ),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+      helperHealthTracker: helperHealth,
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    helperHealth.recordFailure(helperA);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(
+          draftVotes: [
+            rust_wire.DraftVote(
+              proposalId: 7,
+              choice: 1,
+              numOptions: 2,
+              vcTreePosition: BigInt.zero,
+              singleShare: false,
+            ),
+          ],
+        );
+
+    final sharePostHosts = http.requests
+        .where(
+          (request) =>
+              request.method == 'POST' &&
+              request.uri.path == '/shielded-vote/v1/shares',
+        )
+        .map((request) => request.uri.host)
+        .toList(growable: false);
+    expect(sharePostHosts, ['helper-b.example']);
+    expect(rust.recordedShares.single.sentToUrls, [helperB]);
+  });
+
+  test(
+    'share submission reorders remaining helpers after a concurrent failure',
+    () async {
+      const helperA = 'https://helper-a.example';
+      const helperB = 'https://helper-b.example';
+      const helperC = 'https://helper-c.example';
+      final http = _GatedSharePostVotingHttpClient(
+        expectedShareCount: 1,
+        gatedShareIndexes: const {0},
+        responses: votingHttpResponses(
+          dynamicConfig: dynamicConfigJson(
+            voteServers: const [
+              {'url': helperA, 'label': 'helper-a'},
+              {'url': helperB, 'label': 'helper-b'},
+              {'url': helperC, 'label': 'helper-c'},
+            ],
+          ),
+        ),
+      );
+      final rust = FakeVotingRustApi(emitCommitments: true);
+      final helperHealth = VotingHelperHealthTracker(
+        failureThreshold: 1,
+        cooldown: const Duration(hours: 1),
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 1,
+          delegationTxHashes: [
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: 0,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-0',
+              vanLeafPosition: null,
+            ),
+          ],
+          votes: [vote(bundleIndex: 0, proposalId: 7)],
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+        helperHealthTracker: helperHealth,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final cast = container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+
+      await http.allSharePostsStarted.future.timeout(
+        const Duration(seconds: 1),
+      );
+      helperHealth.recordFailure(helperB);
+      http.releaseSharePosts.complete();
+      await cast;
+
+      final sharePostHosts = http.requests
+          .where(
+            (request) =>
+                request.method == 'POST' &&
+                request.uri.path == '/shielded-vote/v1/shares',
+          )
+          .map((request) => request.uri.host)
+          .toList(growable: false);
+      expect(sharePostHosts, ['helper-a.example', 'helper-c.example']);
+      expect(rust.recordedShares.single.sentToUrls, [helperA, helperC]);
+    },
+  );
+
   test('vote commitment validates all shares before submission', () async {
     final http = FakeVotingHttpClient(responses: votingHttpResponses());
     final rust = FakeVotingRustApi(


### PR DESCRIPTION
## Summary
- re-evaluate helper health before each share submission attempt
- deprioritize helpers degraded by concurrent submissions while retaining the all-degraded liveness fallback
- add regression coverage for planner-selected and mid-flight health changes

## Motivation / Why
Initial candidate lists could become stale while concurrent share submissions updated helper health. This allowed a newly degraded helper to remain ahead of healthy alternatives, including when Rust's planner originally placed it first.

## Tests
- `fvm dart format --output=none --set-exit-if-changed lib/src/providers/voting/voting_session_provider.dart test/providers/voting/voting_providers_test.dart`
- `fvm flutter analyze`
- `fvm flutter test`