### PR TITLE
Parallelize voting proof work and warm proving caches

### DIFF
--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -555,13 +555,7 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
 
   bool _isCurrentStatusRoute(VotingSessionKey key) {
     if (!mounted) return false;
-    final currentPath = GoRouter.of(
-      context,
-    ).routerDelegate.currentConfiguration.uri.path;
-    final statusPath = Uri.parse(
-      votingStatusRoute(key.roundId, accountUuid: key.accountUuid),
-    ).path;
-    return currentPath == statusPath;
+    return ModalRoute.of(context)?.isCurrent ?? false;
   }
 }
 

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -555,7 +555,9 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
 
   bool _isCurrentStatusRoute(VotingSessionKey key) {
     if (!mounted) return false;
-    final currentPath = GoRouterState.of(context).uri.path;
+    final currentPath = GoRouter.of(
+      context,
+    ).routerDelegate.currentConfiguration.uri.path;
     final statusPath = Uri.parse(
       votingStatusRoute(key.roundId, accountUuid: key.accountUuid),
     ).path;

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -9,7 +9,6 @@ import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
-import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_submission_job_provider.dart';
 import '../../../providers/voting/voting_state.dart';
 import '../../../services/voting/pir_snapshot_resolver.dart';
@@ -534,21 +533,11 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
         }
         return;
       }
-      unawaited(_navigateToConfirmation(key));
+      _navigateToConfirmation(key);
     });
   }
 
-  Future<void> _navigateToConfirmation(VotingSessionKey key) async {
-    try {
-      await ref
-          .read(votingSubmissionSessionProvider(key).notifier)
-          .refreshEligibleWeight();
-    } catch (error) {
-      debugPrint(
-        '[zcash] Voting: pre-confirmation voting power refresh failed '
-        'round=${key.roundId} account=${key.accountUuid} error=$error',
-      );
-    }
+  void _navigateToConfirmation(VotingSessionKey key) {
     if (!mounted ||
         _selectedJobKey() != key ||
         !_canNavigateToConfirmation(key)) {
@@ -566,9 +555,7 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
 
   bool _isCurrentStatusRoute(VotingSessionKey key) {
     if (!mounted) return false;
-    final currentPath = GoRouter.of(
-      context,
-    ).routerDelegate.currentConfiguration.uri.path;
+    final currentPath = GoRouterState.of(context).uri.path;
     final statusPath = Uri.parse(
       votingStatusRoute(key.roundId, accountUuid: key.accountUuid),
     ).path;

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -11,7 +11,6 @@ import '../../main.dart' show log;
 import '../app_bootstrap.dart';
 import '../core/account_name_policy.dart';
 import '../core/config/network_config.dart';
-import '../core/layout/app_form_factor.dart';
 import '../core/profile_pictures.dart';
 import '../core/security/software_wallet_secret.dart';
 import '../core/storage/app_secure_store.dart';
@@ -533,20 +532,17 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   /// Remove an account from the wallet.
   ///
   /// Destructive account changes are blocked while any vote submission is in
-  /// progress. Once removal is allowed, process-local voting state is cleared
-  /// before the wallet delete. Durable voting rows, hotkeys, and other
-  /// account-scoped sidecars are cleared after the wallet account is deleted.
+  /// progress. Once removal is allowed, in-flight helper-share tracking is
+  /// quiesced and drained so it cannot keep reading or writing this account's
+  /// voting records. Process-local voting state is then cleared before the
+  /// wallet delete. Durable voting rows, hotkeys, and other account-scoped
+  /// sidecars are cleared after the wallet account is deleted.
   Future<void> removeAccount(String uuid) async {
     ref.read(votingSubmissionGuardProvider.notifier).throwIfActive();
     final prev = state.value ?? const AccountState();
     final targetIndex = prev.accounts.indexWhere((a) => a.uuid == uuid);
     if (targetIndex < 0) {
       throw ArgumentError.value(uuid, 'uuid', 'Unknown account UUID');
-    }
-
-    if (kAppFormFactor == AppFormFactor.mobile) {
-      await _removeAccountWithShareTrackingStopped(uuid);
-      return;
     }
 
     final shareTracking = ref.read(votingShareTrackingRegistryProvider);
@@ -687,8 +683,10 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
 
   /// Delete all wallet data (DB + keychain). Caller must stop sync first.
   ///
-  /// This also clears voting state held in this process for every account
-  /// before the wallet DB and voting sidecar DB are deleted.
+  /// In-flight helper-share tracking is quiesced and drained first so it
+  /// cannot keep reading or writing voting records during the wipe. This also
+  /// clears voting state held in this process for every account before the
+  /// wallet DB and voting sidecar DB are deleted.
   ///
   /// Migration work must first stop without deleting its credential. After
   /// that fail-closed preflight, the wipe is best-effort: deletion steps remain
@@ -698,11 +696,6 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   /// and its on-disk state is cleared too — see [clearTorPrivacyStateForReset].
   Future<void> resetWallet() async {
     ref.read(votingSubmissionGuardProvider.notifier).throwIfActive();
-
-    if (kAppFormFactor == AppFormFactor.mobile) {
-      await _resetWalletWithShareTrackingStopped();
-      return;
-    }
 
     final shareTracking = ref.read(votingShareTrackingRegistryProvider);
     var restoreAfterFailure = false;

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -371,6 +371,12 @@ abstract interface class VotingRustApi {
     required int bundleIndex,
   });
 
+  /// Fire-and-forget Halo2 proving-key warm-up for voting proofs.
+  void warmVotingProvingCaches();
+
+  /// Forwards a vote-pipeline timing line into Rust `frb_user` os_log.
+  void logVotingTiming({required String message});
+
   Stream<rust_api.ApiDelegationProofEvent>
   buildProveAndSignDelegationPayloadWithProgress({
     required rust_api.ApiVotingRoundContext ctx,
@@ -639,6 +645,16 @@ class FrbVotingRustApi implements VotingRustApi {
       storedHotkeySecret: storedHotkeySecret,
       bundleIndex: bundleIndex,
     );
+  }
+
+  @override
+  void warmVotingProvingCaches() {
+    rust_api.warmVotingProvingCaches();
+  }
+
+  @override
+  void logVotingTiming({required String message}) {
+    rust_api.logVotingTiming(message: message);
   }
 
   @override

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -380,9 +380,6 @@ abstract interface class VotingRustApi {
   /// Fire-and-forget Halo2 proving-key warm-up for voting proofs.
   void warmVotingProvingCaches();
 
-  /// Forwards a vote-pipeline timing line into Rust `frb_user` os_log.
-  void logVotingTiming({required String message});
-
   Stream<rust_api.ApiDelegationProofEvent>
   buildProveAndSignDelegationPayloadWithProgress({
     required rust_api.ApiVotingRoundContext ctx,
@@ -656,11 +653,6 @@ class FrbVotingRustApi implements VotingRustApi {
   @override
   void warmVotingProvingCaches() {
     rust_api.warmVotingProvingCaches();
-  }
-
-  @override
-  void logVotingTiming({required String message}) {
-    rust_api.logVotingTiming(message: message);
   }
 
   @override

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -61,9 +61,19 @@ final votingApiRequestTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 10);
 });
 
-/// Timeout for helper share endpoints.
+/// Total retry budget for an initial helper share submission.
 final votingHelperRequestTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 5);
+});
+
+/// Timeout for one helper readiness probe.
+final votingHelperPreflightTimeoutProvider = Provider<Duration>((ref) {
+  return const Duration(seconds: 2);
+});
+
+/// Short cache lifetime for helper readiness results shared by vote batches.
+final votingHelperPreflightTtlProvider = Provider<Duration>((ref) {
+  return const Duration(seconds: 10);
 });
 
 /// Delay before retrying a failed automatic helper-share tracking pass.
@@ -132,6 +142,8 @@ final votingApiClientProvider =
         httpClient: ref.watch(votingHttpClientProvider),
         timeout: ref.watch(votingApiRequestTimeoutProvider),
         helperTimeout: ref.watch(votingHelperRequestTimeoutProvider),
+        helperPreflightTimeout: ref.watch(votingHelperPreflightTimeoutProvider),
+        helperPreflightTtl: ref.watch(votingHelperPreflightTtlProvider),
         readRetryPolicy: ref.watch(votingApiReadRetryPolicyProvider),
         helperRetryPolicy: ref.watch(votingHelperRetryPolicyProvider),
         broadcastRetryPolicy: ref.watch(votingBroadcastRetryPolicyProvider),

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -61,7 +61,7 @@ final votingApiRequestTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 10);
 });
 
-/// Total retry budget for an initial helper share submission.
+/// Timeout for one helper share request.
 final votingHelperRequestTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 5);
 });
@@ -69,11 +69,6 @@ final votingHelperRequestTimeoutProvider = Provider<Duration>((ref) {
 /// Timeout for one helper readiness probe.
 final votingHelperPreflightTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 2);
-});
-
-/// Short cache lifetime for helper readiness results shared by vote batches.
-final votingHelperPreflightTtlProvider = Provider<Duration>((ref) {
-  return const Duration(seconds: 10);
 });
 
 /// Delay before retrying a failed automatic helper-share tracking pass.
@@ -143,7 +138,6 @@ final votingApiClientProvider =
         timeout: ref.watch(votingApiRequestTimeoutProvider),
         helperTimeout: ref.watch(votingHelperRequestTimeoutProvider),
         helperPreflightTimeout: ref.watch(votingHelperPreflightTimeoutProvider),
-        helperPreflightTtl: ref.watch(votingHelperPreflightTtlProvider),
         readRetryPolicy: ref.watch(votingApiReadRetryPolicyProvider),
         helperRetryPolicy: ref.watch(votingHelperRetryPolicyProvider),
         broadcastRetryPolicy: ref.watch(votingBroadcastRetryPolicyProvider),

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -2825,7 +2825,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       final current = await future;
       if (_isDisposed || !ref.mounted) return;
       final context = await _loadContext(_roundId);
-      if (_shareTrackingCancelled(context)) return;
+      if (_shareTrackingCancelled(context)) {
+        _releaseAutomaticShareTrackingIfRoundExpired(context);
+        return;
+      }
       _currentContext = context;
       var plan = await _loadResumePlan(context);
       var roundPlan = await _loadRoundPlan(context);
@@ -2874,7 +2877,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
               ? null
               : BigInt.from(voteEndSeconds),
         );
-        if (_shareTrackingCancelled(context)) return;
+        if (_shareTrackingCancelled(context)) {
+          _releaseAutomaticShareTrackingIfRoundExpired(context);
+          return;
+        }
         final readyForStatusCheck = (trackingFlags & 1) != 0;
         final overdueForRetry = (trackingFlags & 2) != 0;
 
@@ -2925,7 +2931,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         }
       }
 
-      if (_shareTrackingCancelled(context)) return;
+      if (_shareTrackingCancelled(context)) {
+        _releaseAutomaticShareTrackingIfRoundExpired(context);
+        return;
+      }
       final refreshedPlan = await _loadResumePlan(context);
       final refreshedRoundPlan = await _loadRoundPlan(context);
       final hasBlockingWork = hasBlockingRoundRecoveryWork(refreshedRoundPlan);
@@ -3194,6 +3203,14 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     return !_isCurrentContext(context) ||
         ref.read(appSecurityProvider).requiresUnlock ||
         !shouldTrackPendingVotingShares(context.round);
+  }
+
+  void _releaseAutomaticShareTrackingIfRoundExpired(
+    _VotingSessionContext context,
+  ) {
+    if (!shouldTrackPendingVotingShares(context.round)) {
+      _releaseAutomaticShareTracking();
+    }
   }
 
   Future<Uri?> _resolvePirEndpoint(_VotingSessionContext context) async {

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -35,6 +35,10 @@ final _minimumVotingBundleWeightZatoshi = BigInt.from(12500000);
 /// account's Orchard key, but the action remains in the PCZT's Ironwood bundle.
 const _ironwoodPcztPool = 1;
 
+/// Cap for independent voting work pools: delegation proofs, vote proofs,
+/// share submission, and recovery polling.
+const _votingWorkConcurrency = 3;
+
 /// Whether an authenticated round is still safe for automatic share recovery.
 bool shouldTrackPendingVotingShares(VotingRoundDetails round, {DateTime? now}) {
   final status = round.status.trim().toLowerCase();
@@ -378,8 +382,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
         return;
       }
-      var plan = current.resumePlan ?? context.resumePlan;
-      var roundPlan = current.roundPlan ?? context.roundPlan;
+      var plan = context.resumePlan;
+      var roundPlan = context.roundPlan;
       if (_needsFreshDelegationWork(plan, roundPlan) &&
           _needsDelegationPreparation(current)) {
         await _prepareDelegationUnlocked();
@@ -389,8 +393,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           return;
         }
         context = await _loadContext(_roundId);
-        plan = current.resumePlan ?? context.resumePlan;
-        roundPlan = current.roundPlan ?? context.roundPlan;
+        plan = context.resumePlan;
+        roundPlan = context.roundPlan;
       }
 
       final hasPendingBundles = plan.pendingDelegationBundleIndexes.isNotEmpty;
@@ -414,7 +418,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         final nextState = (state.value ?? current).copyWith(
           phase: VotingSessionPhase.delegating,
           resumePlan: plan,
-          currentBundleIndex: plan.pendingDelegationBundleIndexes.first,
+          clearCurrentBundleIndex: true,
           clearError: true,
         );
         _setStateForContext(context, nextState);
@@ -435,78 +439,58 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         progress: progress,
       );
       if (completedBundleIndexes == null) return;
-      for (final bundleIndex in plan.pendingDelegationBundleIndexes) {
-        await _awaitDelegationPirPrecomputeIfRunning(context, bundleIndex);
-        final bundleTimer = Stopwatch()..start();
-        debugPrint(
-          '[zcash] Voting: delegation bundle start '
-          'round=${context.round.roundId} bundle=$bundleIndex',
-        );
-        _setStateForContext(
-          context,
-          (state.value ?? current).copyWith(
-            phase: VotingSessionPhase.delegating,
-            currentBundleIndex: bundleIndex,
+      try {
+        completedBundleIndexes.addAll(
+          await _runDelegationBundleBatch(
+            context: context,
+            fallbackState: current,
+            bundleIndexes: plan.pendingDelegationBundleIndexes,
+            progress: progress,
+            logLabel: 'software',
+            prove: (bundleIndex, publishProgress) async {
+              await _awaitDelegationPirPrecomputeIfRunning(
+                context,
+                bundleIndex,
+              );
+              _throwIfContextStale(context, 'delegation-proof');
+              rust_wire.SignedDelegationPayloadView? signedPayload;
+              await for (final event
+                  in rust.buildProveAndSignDelegationPayloadWithProgress(
+                    ctx: _apiRoundContext(context),
+                    pirServerUrl: _transportUrl(pirEndpoint!),
+                    mnemonic: mnemonic!,
+                    storedHotkeySecret: storedHotkeySecret!,
+                    bundleIndex: bundleIndex,
+                  )) {
+                _throwIfContextStale(context, 'delegation-proof-progress');
+                signedPayload = event.signedDelegationPayload ?? signedPayload;
+                publishProgress(
+                  VotingSessionProgress(
+                    phase: event.phase,
+                    bundleIndex: bundleIndex,
+                    proofProgress: _monotonicProofProgress(
+                      progress[bundleIndex]?.proofProgress,
+                      event.proofProgress,
+                    ),
+                  ),
+                );
+              }
+              return signedPayload ??
+                  (throw StateError(
+                    'Delegation proof completed without submission payload.',
+                  ));
+            },
           ),
         );
-        rust_wire.SignedDelegationPayloadView? signedDelegationPayload;
-        await for (final event
-            in rust.buildProveAndSignDelegationPayloadWithProgress(
-              ctx: _apiRoundContext(context),
-              pirServerUrl: _transportUrl(pirEndpoint!),
-              mnemonic: mnemonic!,
-              storedHotkeySecret: storedHotkeySecret!,
-              bundleIndex: bundleIndex,
-            )) {
-          signedDelegationPayload =
-              event.signedDelegationPayload ?? signedDelegationPayload;
-          final proofProgress = _monotonicProofProgress(
-            progress[bundleIndex]?.proofProgress,
-            event.proofProgress,
-          );
-          progress[bundleIndex] = VotingSessionProgress(
-            phase: event.phase,
-            bundleIndex: bundleIndex,
-            proofProgress: proofProgress,
-            message: null,
-          );
-          _setStateForContext(
-            context,
-            (state.value ?? current).copyWith(delegationProgress: progress),
-          );
-        }
-        debugPrint(
-          '[zcash] Voting: delegation proof stream completed '
-          'round=${context.round.roundId} bundle=$bundleIndex '
-          'elapsed=${formatElapsedSeconds(bundleTimer.elapsed)}',
-        );
-        final submission = signedDelegationPayload;
-        if (submission == null) {
-          throw StateError(
-            'Delegation proof completed without submission payload.',
-          );
-        }
-        _throwIfContextStale(context, 'delegation-submit');
-        final result = await _submitAndConfirmDelegation(
+      } on _StaleVotingSessionAction {
+        rethrow;
+      } catch (error, stackTrace) {
+        await _refreshDelegationPlansAfterBatchFailure(
           context: context,
-          bundleIndex: bundleIndex,
-          submission: submission,
+          fallbackState: current,
+          progress: progress,
         );
-        debugPrint(
-          '[zcash] Voting: delegation bundle completed '
-          'round=${context.round.roundId} bundle=$bundleIndex '
-          'leafIndex=${result.leafIndex} total=${formatElapsedSeconds(bundleTimer.elapsed)}',
-        );
-        completedBundleIndexes.add(bundleIndex);
-        progress[bundleIndex] = VotingSessionProgress(
-          phase: 'submitted',
-          bundleIndex: bundleIndex,
-          message: result.txHash,
-        );
-        _setStateForContext(
-          context,
-          (state.value ?? current).copyWith(delegationProgress: progress),
-        );
+        Error.throwWithStackTrace(error, stackTrace);
       }
 
       final resumeTimer = Stopwatch()..start();
@@ -540,7 +524,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           clearCurrentBundleIndex: true,
         ),
       );
-    });
+    }, cleanupProcessStateOnError: false);
   }
 
   Future<void> prepareKeystoneSigning() {
@@ -770,8 +754,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
         return;
       }
-      var plan = current.resumePlan ?? context.resumePlan;
-      var roundPlan = current.roundPlan ?? context.roundPlan;
+      var plan = context.resumePlan;
+      var roundPlan = context.roundPlan;
       if (_needsFreshDelegationWork(plan, roundPlan) &&
           _needsDelegationPreparation(current)) {
         await _prepareDelegationUnlocked();
@@ -781,8 +765,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           return;
         }
         context = await _loadContext(_roundId);
-        plan = current.resumePlan ?? context.resumePlan;
-        roundPlan = current.roundPlan ?? context.roundPlan;
+        plan = context.resumePlan;
+        roundPlan = context.roundPlan;
       }
       final progress = Map<int, VotingSessionProgress>.from(
         current.delegationProgress,
@@ -824,89 +808,76 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           return;
         }
       }
-      for (final bundleIndex in plan.pendingDelegationBundleIndexes) {
-        final signature = signatures[bundleIndex]!;
-        final bundleTimer = Stopwatch()..start();
-        debugPrint(
-          '[zcash] Voting: Keystone delegation bundle start '
-          'round=${context.round.roundId} bundle=$bundleIndex',
-        );
-        _setStateForContext(
-          context,
-          (state.value ?? current).copyWith(
-            phase: VotingSessionPhase.delegating,
-            keystoneSignatures: signatures,
-            clearKeystoneSigningRequest: true,
-            clearKeystoneScanError: true,
-            currentBundleIndex: bundleIndex,
+      _setStateForContext(
+        context,
+        (state.value ?? current).copyWith(
+          phase: VotingSessionPhase.delegating,
+          keystoneSignatures: signatures,
+          clearKeystoneSigningRequest: true,
+          clearKeystoneScanError: true,
+          clearCurrentBundleIndex: true,
+        ),
+      );
+      try {
+        completedBundleIndexes.addAll(
+          await _runDelegationBundleBatch(
+            context: context,
+            fallbackState: current,
+            bundleIndexes: plan.pendingDelegationBundleIndexes,
+            progress: progress,
+            logLabel: 'Keystone',
+            prove: (bundleIndex, publishProgress) async {
+              final signature = signatures[bundleIndex]!;
+              rust_wire.SignedDelegationPayloadView? signedPayload;
+              await for (final event
+                  in rust
+                      .buildProveDelegationPayloadWithKeystoneSignatureWithProgress(
+                        ctx: _apiRoundContext(context),
+                        pirServerUrl: _transportUrl(pirEndpoint!),
+                        storedHotkeySecret: storedHotkeySecret!,
+                        bundleIndex: bundleIndex,
+                        keystoneSig: signature.sig,
+                        keystoneSighash: signature.sighash,
+                      )) {
+                _throwIfContextStale(
+                  context,
+                  'keystone-delegation-proof-progress',
+                );
+                signedPayload = event.signedDelegationPayload ?? signedPayload;
+                publishProgress(
+                  VotingSessionProgress(
+                    phase: event.phase,
+                    bundleIndex: bundleIndex,
+                    proofProgress: _monotonicProofProgress(
+                      progress[bundleIndex]?.proofProgress,
+                      event.proofProgress,
+                    ),
+                  ),
+                );
+              }
+              final submission =
+                  signedPayload ??
+                  (throw StateError(
+                    'Delegation proof completed without submission payload.',
+                  ));
+              _verifyKeystoneDelegationSignature(
+                submission: submission,
+                signature: signature,
+                bundleIndex: bundleIndex,
+              );
+              return submission;
+            },
           ),
         );
-
-        rust_wire.SignedDelegationPayloadView? signedDelegationPayload;
-        await for (final event
-            in rust
-                .buildProveDelegationPayloadWithKeystoneSignatureWithProgress(
-                  ctx: _apiRoundContext(context),
-                  pirServerUrl: _transportUrl(pirEndpoint!),
-                  storedHotkeySecret: storedHotkeySecret!,
-                  bundleIndex: bundleIndex,
-                  keystoneSig: signature.sig,
-                  keystoneSighash: signature.sighash,
-                )) {
-          signedDelegationPayload =
-              event.signedDelegationPayload ?? signedDelegationPayload;
-          final proofProgress = _monotonicProofProgress(
-            progress[bundleIndex]?.proofProgress,
-            event.proofProgress,
-          );
-          progress[bundleIndex] = VotingSessionProgress(
-            phase: event.phase,
-            bundleIndex: bundleIndex,
-            proofProgress: proofProgress,
-            message: null,
-          );
-          _setStateForContext(
-            context,
-            (state.value ?? current).copyWith(delegationProgress: progress),
-          );
-        }
-        debugPrint(
-          '[zcash] Voting: Keystone delegation proof stream completed '
-          'round=${context.round.roundId} bundle=$bundleIndex '
-          'elapsed=${formatElapsedSeconds(bundleTimer.elapsed)}',
-        );
-        final submission = signedDelegationPayload;
-        if (submission == null) {
-          throw StateError(
-            'Delegation proof completed without submission payload.',
-          );
-        }
-        _verifyKeystoneDelegationSignature(
-          submission: submission,
-          signature: signature,
-          bundleIndex: bundleIndex,
-        );
-        _throwIfContextStale(context, 'keystone-delegation-submit');
-        final result = await _submitAndConfirmDelegation(
+      } on _StaleVotingSessionAction {
+        rethrow;
+      } catch (error, stackTrace) {
+        await _refreshDelegationPlansAfterBatchFailure(
           context: context,
-          bundleIndex: bundleIndex,
-          submission: submission,
+          fallbackState: current,
+          progress: progress,
         );
-        debugPrint(
-          '[zcash] Voting: Keystone delegation bundle completed '
-          'round=${context.round.roundId} bundle=$bundleIndex '
-          'leafIndex=${result.leafIndex} total=${formatElapsedSeconds(bundleTimer.elapsed)}',
-        );
-        completedBundleIndexes.add(bundleIndex);
-        progress[bundleIndex] = VotingSessionProgress(
-          phase: 'submitted',
-          bundleIndex: bundleIndex,
-          message: result.txHash,
-        );
-        _setStateForContext(
-          context,
-          (state.value ?? current).copyWith(delegationProgress: progress),
-        );
+        Error.throwWithStackTrace(error, stackTrace);
       }
 
       final refreshedPlan = await _loadResumePlan(context);
@@ -930,7 +901,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           clearCurrentBundleIndex: true,
         ),
       );
-    });
+    }, cleanupProcessStateOnError: false);
   }
 
   Future<void> castVotes({
@@ -1797,6 +1768,13 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     return nextValue < previousValue ? previousValue : nextValue;
   }
 
+  /// Mirrors vote-pipeline timings into Rust os_log so Release `log show`
+  /// captures them (`subsystem == "frb_user"`, prefix `[VOTING_VOTE]`).
+  void _logVoteTiming(String message) {
+    debugPrint('[zcash] Voting: $message');
+    ref.read(votingRustApiProvider).logVotingTiming(message: message);
+  }
+
   List<String> _plannedShareServers({
     required List<String> plannedServers,
     required Iterable<String> fallbackServers,
@@ -1887,7 +1865,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         txHash: result.txHash,
       );
 
-      final confirmation = await _awaitTxConfirmation(api, result.txHash);
+      final confirmation = await _awaitTxConfirmation(
+        api,
+        result.txHash,
+        context: context,
+      );
       if (confirmation == null) {
         throw StateError(
           'Transaction ${result.txHash} was not confirmed in time.',
@@ -1962,7 +1944,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     for (final entry in submittedDelegationsByBundle.entries) {
       final bundleIndex = entry.key;
       final txHash = entry.value;
-      final confirmation = await _awaitTxConfirmation(api, txHash);
+      final confirmation = await _awaitTxConfirmation(
+        api,
+        txHash,
+        context: context,
+      );
       if (confirmation == null) {
         _setError(
           'Delegation transaction $txHash for bundle $bundleIndex is still '
@@ -1997,7 +1983,225 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     return completedBundleIndexes;
   }
 
-  Future<({String txHash, int leafIndex})> _submitAndConfirmDelegation({
+  Future<void> _refreshDelegationPlansAfterBatchFailure({
+    required _VotingSessionContext context,
+    required VotingSessionState fallbackState,
+    required Map<int, VotingSessionProgress> progress,
+  }) async {
+    try {
+      final refreshedPlan = await _loadResumePlan(context);
+      final refreshedRoundPlan = await _loadRoundPlan(context);
+      _throwIfContextStale(context, 'delegation-batch-failure-refresh');
+      _setStateForContext(
+        context,
+        (state.value ?? fallbackState).copyWith(
+          resumePlan: refreshedPlan,
+          roundPlan: refreshedRoundPlan,
+          delegationProgress: Map<int, VotingSessionProgress>.of(progress),
+          clearCurrentBundleIndex: true,
+        ),
+      );
+    } on _StaleVotingSessionAction {
+      rethrow;
+    } catch (error, stackTrace) {
+      // Preserve the original bundle failure for the user. A later retry still
+      // reloads context from durable recovery state before doing any work.
+      debugPrint(
+        '[zcash] Voting: delegation recovery refresh failed '
+        'round=${context.round.roundId} error=$error\n$stackTrace',
+      );
+    }
+  }
+
+  Future<Set<int>> _runDelegationBundleBatch({
+    required _VotingSessionContext context,
+    required VotingSessionState fallbackState,
+    required List<int> bundleIndexes,
+    required Map<int, VotingSessionProgress> progress,
+    required Future<rust_wire.SignedDelegationPayloadView> Function(
+      int bundleIndex,
+      void Function(VotingSessionProgress progress) publishProgress,
+    )
+    prove,
+    required String logLabel,
+  }) async {
+    final batchTimer = Stopwatch()..start();
+    final proofWallTimer = Stopwatch()..start();
+    final timers = <int, Stopwatch>{};
+    final proofElapsed = <int, Duration>{};
+
+    void publishProgress(VotingSessionProgress update) {
+      final bundleIndex = update.bundleIndex;
+      if (bundleIndex == null) return;
+      progress[bundleIndex] = update;
+      _setStateForContext(
+        context,
+        (state.value ?? fallbackState).copyWith(
+          phase: VotingSessionPhase.delegating,
+          delegationProgress: Map<int, VotingSessionProgress>.of(progress),
+          clearCurrentBundleIndex: true,
+        ),
+      );
+    }
+
+    final proofOutcomes = await _runBoundedBundleWork(
+      bundleIndexes,
+      concurrency: _votingWorkConcurrency,
+      work: (bundleIndex) async {
+        _throwIfContextStale(context, '$logLabel-proof-start');
+        final timer = Stopwatch()..start();
+        timers[bundleIndex] = timer;
+        debugPrint(
+          '[zcash] Voting: $logLabel delegation bundle start '
+          'round=${context.round.roundId} bundle=$bundleIndex',
+        );
+        try {
+          final submission = await prove(bundleIndex, publishProgress);
+          debugPrint(
+            '[zcash] Voting: $logLabel delegation proof stream completed '
+            'round=${context.round.roundId} bundle=$bundleIndex '
+            'elapsed=${formatElapsedSeconds(timer.elapsed)}',
+          );
+          return submission;
+        } finally {
+          proofElapsed[bundleIndex] = timer.elapsed;
+        }
+      },
+    );
+    final serialProofDuration = proofElapsed.values.fold<Duration>(
+      Duration.zero,
+      (total, elapsed) => total + elapsed,
+    );
+    debugPrint(
+      '[zcash] Voting: $logLabel delegation proof fan-in '
+      'round=${context.round.roundId} bundles=${bundleIndexes.length} '
+      'concurrency=$_votingWorkConcurrency '
+      'wall=${formatElapsedSeconds(proofWallTimer.elapsed)} '
+      'serialEquivalent=${formatElapsedSeconds(serialProofDuration)}',
+    );
+
+    _throwIfContextStale(context, '$logLabel-proof-fan-in');
+    final failures = <_DelegationBundleFailure>[];
+    final submittedTxHashes = <int, String>{};
+
+    // Broadcasts remain serial because the vote server API does not expose an
+    // idempotency key. Persist each returned hash before starting the next one.
+    for (final bundleIndex in bundleIndexes) {
+      final proof = proofOutcomes[bundleIndex]!;
+      if (proof.error != null) {
+        publishProgress(
+          VotingSessionProgress(
+            phase: 'failed',
+            bundleIndex: bundleIndex,
+            message: proof.error.toString(),
+          ),
+        );
+        failures.add(
+          _DelegationBundleFailure(
+            bundleIndex: bundleIndex,
+            stage: 'proof',
+            error: proof.error!,
+          ),
+        );
+        continue;
+      }
+      try {
+        _throwIfContextStale(context, '$logLabel-delegation-submit');
+        final txHash = await _submitDelegation(
+          context: context,
+          bundleIndex: bundleIndex,
+          submission: proof.value!,
+        );
+        submittedTxHashes[bundleIndex] = txHash;
+        publishProgress(
+          VotingSessionProgress(
+            phase: 'submitted',
+            bundleIndex: bundleIndex,
+            message: txHash,
+          ),
+        );
+      } catch (error) {
+        publishProgress(
+          VotingSessionProgress(
+            phase: 'failed',
+            bundleIndex: bundleIndex,
+            message: error.toString(),
+          ),
+        );
+        failures.add(
+          _DelegationBundleFailure(
+            bundleIndex: bundleIndex,
+            stage: 'submission',
+            error: error,
+          ),
+        );
+        if (error is _StaleVotingSessionAction) break;
+      }
+    }
+
+    final confirmationOutcomes = await _runBoundedBundleWork(
+      submittedTxHashes.keys.toList(growable: false),
+      concurrency: _votingWorkConcurrency,
+      work: (bundleIndex) => _confirmDelegation(
+        context: context,
+        bundleIndex: bundleIndex,
+        txHash: submittedTxHashes[bundleIndex]!,
+      ),
+    );
+    final completed = <int>{};
+    for (final bundleIndex in submittedTxHashes.keys) {
+      final confirmation = confirmationOutcomes[bundleIndex]!;
+      if (confirmation.error != null) {
+        publishProgress(
+          VotingSessionProgress(
+            phase: 'failed',
+            bundleIndex: bundleIndex,
+            message: confirmation.error.toString(),
+          ),
+        );
+        failures.add(
+          _DelegationBundleFailure(
+            bundleIndex: bundleIndex,
+            stage: 'confirmation',
+            error: confirmation.error!,
+          ),
+        );
+        continue;
+      }
+      final result = confirmation.value!;
+      completed.add(bundleIndex);
+      publishProgress(
+        VotingSessionProgress(
+          phase: 'confirmed',
+          bundleIndex: bundleIndex,
+          message: result.txHash,
+        ),
+      );
+      debugPrint(
+        '[zcash] Voting: $logLabel delegation bundle completed '
+        'round=${context.round.roundId} bundle=$bundleIndex '
+        'leafIndex=${result.leafIndex} '
+        'total=${formatElapsedSeconds(timers[bundleIndex]!.elapsed)}',
+      );
+    }
+
+    for (final failure in failures) {
+      if (failure.error is _StaleVotingSessionAction) {
+        throw failure.error;
+      }
+    }
+    if (failures.isNotEmpty) {
+      throw _DelegationBundleBatchException(failures);
+    }
+    debugPrint(
+      '[zcash] Voting: $logLabel delegation batch completed '
+      'round=${context.round.roundId} bundles=${bundleIndexes.length} '
+      'elapsed=${formatElapsedSeconds(batchTimer.elapsed)}',
+    );
+    return completed;
+  }
+
+  Future<String> _submitDelegation({
     required _VotingSessionContext context,
     required int bundleIndex,
     required rust_wire.SignedDelegationPayloadView submission,
@@ -2039,12 +2243,23 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       'round=${context.round.roundId} bundle=$bundleIndex '
       'txHash=${result.txHash}',
     );
+    return result.txHash;
+  }
 
-    final confirmation = await _awaitTxConfirmation(api, result.txHash);
+  Future<({String txHash, int leafIndex})> _confirmDelegation({
+    required _VotingSessionContext context,
+    required int bundleIndex,
+    required String txHash,
+  }) async {
+    final api = ref.read(votingApiClientProvider(context.config.apiServers));
+    final rust = ref.read(votingRustApiProvider);
+    final confirmation = await _awaitTxConfirmation(
+      api,
+      txHash,
+      context: context,
+    );
     if (confirmation == null) {
-      throw StateError(
-        'Transaction ${result.txHash} was not confirmed in time.',
-      );
+      throw StateError('Transaction $txHash was not confirmed in time.');
     }
     if (confirmation.code != 0) {
       throw StateError(
@@ -2058,29 +2273,29 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       accountUuid: context.accountUuid,
       roundId: context.round.roundId,
       bundleIndex: bundleIndex,
-      txHash: result.txHash,
+      txHash: txHash,
       eventsJson: confirmation.eventsJson,
     );
-    return (
-      txHash: result.txHash,
-      leafIndex: delegationConfirmation.vanLeafPosition,
-    );
+    return (txHash: txHash, leafIndex: delegationConfirmation.vanLeafPosition);
   }
 
   Future<VotingTxConfirmation?> _awaitTxConfirmation(
     VotingApiClient api,
-    String txHash,
-  ) async {
+    String txHash, {
+    _VotingSessionContext? context,
+  }) async {
     final polling = ref.read(votingTxConfirmationPollingProvider);
     final attempts = polling.attempts;
     final delay = polling.delay;
     final timer = Stopwatch()..start();
-    debugPrint('[zcash] Voting: tx confirmation wait start txHash=$txHash');
+    _logVoteTiming('tx confirmation wait start txHash=$txHash');
     for (var attempt = 0; attempt < attempts; attempt++) {
+      if (context != null) _throwIfContextStale(context, 'tx-confirmation');
       final confirmation = await api.getTxConfirmation(txHash);
+      if (context != null) _throwIfContextStale(context, 'tx-confirmation-response');
       if (confirmation != null) {
-        debugPrint(
-          '[zcash] Voting: tx confirmation found txHash=$txHash '
+        _logVoteTiming(
+          'tx confirmation found txHash=$txHash '
           'attempt=${attempt + 1} code=${confirmation.code} '
           'elapsed=${formatElapsedSeconds(timer.elapsed)}',
         );
@@ -2094,10 +2309,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           );
         }
         await Future<void>.delayed(delay);
+        if (context != null) _throwIfContextStale(context, 'tx-confirmation-delay');
       }
     }
-    debugPrint(
-      '[zcash] Voting: tx confirmation wait timed out txHash=$txHash '
+    _logVoteTiming(
+      'tx confirmation wait timed out txHash=$txHash '
       'elapsed=${formatElapsedSeconds(timer.elapsed)}',
     );
     return null;
@@ -3679,6 +3895,90 @@ class _RecoveredVoteWork {
       case _RecoveredVoteWorkKind.submitShares:
         return 'confirmed vote shares';
     }
+  }
+}
+
+Future<Map<int, _BundleWorkOutcome<T>>> _runBoundedBundleWork<T>(
+  List<int> bundleIndexes, {
+  required int concurrency,
+  required Future<T> Function(int bundleIndex) work,
+}) async {
+  if (bundleIndexes.isEmpty) return {};
+  final outcomes = <int, _BundleWorkOutcome<T>>{};
+  var nextIndex = 0;
+  final workerCount = concurrency < bundleIndexes.length
+      ? concurrency
+      : bundleIndexes.length;
+
+  Future<void> worker() async {
+    while (nextIndex < bundleIndexes.length) {
+      final bundleIndex = bundleIndexes[nextIndex++];
+      try {
+        outcomes[bundleIndex] = _BundleWorkOutcome.success(
+          await work(bundleIndex),
+        );
+      } catch (error, stackTrace) {
+        outcomes[bundleIndex] = _BundleWorkOutcome.failure(error, stackTrace);
+      }
+    }
+  }
+
+  await Future.wait(List.generate(workerCount, (_) => worker()));
+  return outcomes;
+}
+
+/// Serializes vote-tree syncs and batches concurrent requesters onto one call.
+///
+/// Two guarantees matter to callers:
+///
+/// * **Never concurrent.** `_syncVoteTreeWithFailover` resets round-global
+///   process state when it fails over to another node, so overlapping syncs
+///   could tear down state another bundle is mid-witness on.
+/// * **Never stale.** `fresh()` only resolves with the result of a sync that
+///   *started after* the call. A bundle that just recorded a vote confirmation
+///   therefore cannot be handed an anchor height from a sync that predates its
+///   new VAN leaf. Requests arriving while a sync runs are batched into the
+///   next one, so N bundles finishing a proposal together cost one round trip.
+
+class _BundleWorkOutcome<T> {
+  const _BundleWorkOutcome.success(this.value)
+    : error = null,
+      stackTrace = null;
+
+  const _BundleWorkOutcome.failure(this.error, this.stackTrace) : value = null;
+
+  final T? value;
+  final Object? error;
+  final StackTrace? stackTrace;
+}
+
+class _DelegationBundleFailure {
+  const _DelegationBundleFailure({
+    required this.bundleIndex,
+    required this.stage,
+    required this.error,
+  });
+
+  final int bundleIndex;
+  final String stage;
+  final Object error;
+}
+
+class _DelegationBundleBatchException implements Exception {
+  const _DelegationBundleBatchException(this.failures);
+
+  final List<_DelegationBundleFailure> failures;
+
+  @override
+  String toString() {
+    final details = failures
+        .map(
+          (failure) =>
+              'bundle ${failure.bundleIndex + 1} ${failure.stage}: '
+              '${failure.error}',
+        )
+        .join('; ');
+    return 'Delegation bundle processing failed: $details';
   }
 }
 

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1729,11 +1729,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     return nextValue < previousValue ? previousValue : nextValue;
   }
 
-  /// Mirrors vote-pipeline timings into Rust os_log so Release `log show`
-  /// captures them (`subsystem == "frb_user"`, prefix `[VOTING_VOTE]`).
   void _logVoteTiming(String message) {
     debugPrint('[zcash] Voting: $message');
-    ref.read(votingRustApiProvider).logVotingTiming(message: message);
   }
 
   List<String> _plannedShareServers({

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1687,7 +1687,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         if (attempt == nodeUrls.length - 1) {
           rethrow;
         }
-        await rust.resetVotingSessionState(
+        await rust.resetVoteTree(
           dbPath: context.dbPath,
           accountUuid: context.accountUuid,
           roundId: context.round.roundId,
@@ -1806,10 +1806,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   /// the next proposal of the same bundle is proved.
   ///
   /// Different bundles own independent VAN chains, so they never wait on each
-  /// other. Only the CPU-heavy witness+proof step is capped
-  /// ([_votingWorkConcurrency]); a bundle parked on a block confirmation
-  /// holds no proof permit. Share submission is dispatched off the chain
-  /// because the VAN advance is already durable by then.
+  /// other. Witness materialization stays inside the serialized tree handoff;
+  /// only the CPU-heavy proof step is capped ([_votingWorkConcurrency]). A
+  /// bundle parked on a block confirmation holds no proof permit. Share
+  /// submission is dispatched off the chain because the VAN advance is already
+  /// durable by then.
   ///
   /// Returns the number of bundle tasks that completed through share
   /// submission. Throws [_VoteWaveBatchException] if any task failed.
@@ -1977,12 +1978,20 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             // own previous confirmation, so the coalescer only hands back one
             // that started after it.
             final syncTimer = Stopwatch()..start();
-            final anchorHeight = await treeSync.fresh();
-            _logVoteTiming(
-              'bundle=$bundleIndex proposal=${draft.proposalId} '
-              'tree-sync elapsed=${formatElapsedSeconds(syncTimer.elapsed)} '
-              'anchorHeight=$anchorHeight',
-            );
+            final witness = await treeSync.freshAndUse((anchorHeight) async {
+              _logVoteTiming(
+                'bundle=$bundleIndex proposal=${draft.proposalId} '
+                'tree-sync elapsed=${formatElapsedSeconds(syncTimer.elapsed)} '
+                'anchorHeight=$anchorHeight',
+              );
+              return rust.generateVanWitness(
+                dbPath: context.dbPath,
+                accountUuid: context.accountUuid,
+                roundId: context.round.roundId,
+                bundleIndex: bundleIndex,
+                anchorHeight: anchorHeight,
+              );
+            });
             // Re-evaluated per step: a long round can cross into the last-moment
             // buffer part way through a bundle's chain.
             final timedDraft = _draftVoteForCurrentShareMode(context, draft);
@@ -1991,13 +2000,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
               _throwIfContextStale(context, 'vote-chain-proof-start');
               final timer = Stopwatch()..start();
               try {
-                final witness = await rust.generateVanWitness(
-                  dbPath: context.dbPath,
-                  accountUuid: context.accountUuid,
-                  roundId: context.round.roundId,
-                  bundleIndex: bundleIndex,
-                  anchorHeight: anchorHeight,
-                );
                 rust_wire.SignedVoteCommitmentsView? built;
                 await for (final event in rust.buildVoteCommitmentsWithProgress(
                   dbPath: context.dbPath,
@@ -4485,10 +4487,11 @@ Future<_BundleWorkOutcome<T>> _captureBundleWork<T>(
 ///
 /// Two guarantees matter to callers:
 ///
-/// * **Never concurrent.** `_syncVoteTreeWithFailover` resets round-global
-///   process state when it fails over to another node, so overlapping syncs
-///   could tear down state another bundle is mid-witness on.
-/// * **Never stale.** `fresh()` only resolves with the result of a sync that
+/// * **Protected handoff.** `_syncVoteTreeWithFailover` resets round-global
+///   process state when it fails over to another node, so the next sync cannot
+///   start until every caller served by the previous sync has materialized its
+///   witness.
+/// * **Never stale.** `freshAndUse()` only uses the result of a sync that
 ///   *started after* the call. A bundle that just recorded a vote confirmation
 ///   therefore cannot be handed an anchor height from a sync that predates its
 ///   new VAN leaf. Requests arriving while a sync runs are batched into the
@@ -4497,18 +4500,19 @@ class _VoteTreeSyncCoalescer {
   _VoteTreeSyncCoalescer(this._sync);
 
   final Future<int> Function() _sync;
-  final Queue<Completer<int>> _waiting = Queue<Completer<int>>();
+  final Queue<_VoteTreeSyncRequestBase> _waiting =
+      Queue<_VoteTreeSyncRequestBase>();
   bool _running = false;
 
-  Future<int> fresh() {
-    final waiter = Completer<int>();
-    _waiting.addLast(waiter);
+  Future<T> freshAndUse<T>(Future<T> Function(int anchorHeight) useTree) {
+    final request = _VoteTreeSyncRequest<T>(useTree);
+    _waiting.addLast(request);
     // Deferred so every requester in this turn joins the same sync — bundles
     // that finish a proposal together should cost one round trip, not N.
     // Delaying the start can only add requesters ahead of it, so the
     // "started after my call" guarantee still holds.
     scheduleMicrotask(_pump);
-    return waiter.future;
+    return request.future;
   }
 
   void _pump() {
@@ -4528,14 +4532,14 @@ class _VoteTreeSyncCoalescer {
     }
     attempt
         .then(
-          (anchorHeight) {
-            for (final waiter in batch) {
-              waiter.complete(anchorHeight);
-            }
+          (anchorHeight) async {
+            await Future.wait([
+              for (final request in batch) request.completeWith(anchorHeight),
+            ]);
           },
           onError: (Object error, StackTrace stackTrace) {
-            for (final waiter in batch) {
-              waiter.completeError(error, stackTrace);
+            for (final request in batch) {
+              request.completeError(error, stackTrace);
             }
           },
         )
@@ -4543,6 +4547,35 @@ class _VoteTreeSyncCoalescer {
           _running = false;
           scheduleMicrotask(_pump);
         });
+  }
+}
+
+abstract interface class _VoteTreeSyncRequestBase {
+  Future<void> completeWith(int anchorHeight);
+
+  void completeError(Object error, StackTrace stackTrace);
+}
+
+class _VoteTreeSyncRequest<T> implements _VoteTreeSyncRequestBase {
+  _VoteTreeSyncRequest(this._useTree);
+
+  final Future<T> Function(int anchorHeight) _useTree;
+  final Completer<T> _completer = Completer<T>();
+
+  Future<T> get future => _completer.future;
+
+  @override
+  Future<void> completeWith(int anchorHeight) async {
+    try {
+      _completer.complete(await _useTree(anchorHeight));
+    } catch (error, stackTrace) {
+      _completer.completeError(error, stackTrace);
+    }
+  }
+
+  @override
+  void completeError(Object error, StackTrace stackTrace) {
+    _completer.completeError(error, stackTrace);
   }
 }
 

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -139,13 +139,20 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     if (_disposeHandlerRegistered) return;
     _disposeHandlerRegistered = true;
     final rust = ref.read(votingRustApiProvider);
+    final guardNotifier = ref.read(votingSubmissionGuardProvider.notifier);
     ref.onDispose(() {
+      // Snapshot guards before listener teardown. Do not ref.read here:
+      // Riverpod forbids using this provider's Ref inside onDispose.
+      final context = _currentContext;
+      final ownsSubmission =
+          context != null &&
+          (_guardsOwnContext(_activeSubmissionGuards, context) ||
+              _guardsOwnContext(_guardNotifierState(guardNotifier), context));
       _disposeHandlerRegistered = false;
       _activeAccountListenerRegistered = false;
       _submissionGuardListenerRegistered = false;
       // Provider disposal is round-scoped: clear abandoned prepared PCZTs but
       // keep account-wide vote-tree sync state reusable across rounds.
-      final context = _currentContext;
       _isDisposed = true;
       _advanceSessionGeneration();
       _delegationPirPrecomputes.clear();
@@ -153,7 +160,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       _shareTrackingTimer?.cancel();
       _releaseAutomaticShareTracking();
       if (context == null) return;
-      if (_activeSubmissionOwnsContext(context)) {
+      if (ownsSubmission) {
         debugPrint(
           '[zcash] Voting: process-local state reset skipped '
           'round=${context.round.roundId} account=${context.accountUuid} '
@@ -2790,6 +2797,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     if (_automaticShareTrackingStopped) return Future.value();
     final inFlight = _shareTrackingPass;
     if (inFlight != null) return inFlight;
+    if (_ownsAutomaticShareTracking && !_retainAutomaticShareTracking()) {
+      return Future.value();
+    }
 
     late final Future<void> pass;
     pass = _startPendingSharePass().whenComplete(() {
@@ -2805,7 +2815,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       _shareTrackingTimer = null;
       if (_automaticShareTrackingStopped) return;
       final current = await future;
+      if (_isDisposed || !ref.mounted) return;
       final context = await _loadContext(_roundId);
+      if (_shareTrackingCancelled(context)) return;
       _currentContext = context;
       var plan = await _loadResumePlan(context);
       var roundPlan = await _loadRoundPlan(context);
@@ -2854,6 +2866,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
               ? null
               : BigInt.from(voteEndSeconds),
         );
+        if (_shareTrackingCancelled(context)) return;
         final readyForStatusCheck = (trackingFlags & 1) != 0;
         final overdueForRetry = (trackingFlags & 2) != 0;
 
@@ -2904,6 +2917,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         }
       }
 
+      if (_shareTrackingCancelled(context)) return;
       final refreshedPlan = await _loadResumePlan(context);
       final refreshedRoundPlan = await _loadRoundPlan(context);
       final hasBlockingWork = hasBlockingRoundRecoveryWork(refreshedRoundPlan);
@@ -2950,6 +2964,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required List<String> configuredServerUrls,
     required Set<String> sentToUrls,
   }) async {
+    if (!ref.mounted || !_isCurrentContext(context)) return null;
     final rust = ref.read(votingRustApiProvider);
     final key = VotingVoteKey(
       bundleIndex: share.bundleIndex,
@@ -3165,8 +3180,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   }
 
   bool _shareTrackingCancelled(_VotingSessionContext context) {
-    return _automaticShareTrackingStopped ||
-        !_isCurrentContext(context) ||
+    if (_automaticShareTrackingStopped || _isDisposed || !ref.mounted) {
+      return true;
+    }
+    return !_isCurrentContext(context) ||
         ref.read(appSecurityProvider).requiresUnlock ||
         !shouldTrackPendingVotingShares(context.round);
   }
@@ -4011,7 +4028,28 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   }
 
   bool _activeSubmissionOwnsContext(_VotingSessionContext context) {
-    for (final guard in _activeSubmissionGuards) {
+    return _guardsOwnContext(_activeSubmissionGuards, context) ||
+        _guardsOwnContext(
+          _guardNotifierState(ref.read(votingSubmissionGuardProvider.notifier)),
+          context,
+        );
+  }
+
+  static List<VotingSubmissionGuard> _guardNotifierState(
+    VotingSubmissionGuardNotifier notifier,
+  ) {
+    try {
+      return notifier.state;
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  static bool _guardsOwnContext(
+    List<VotingSubmissionGuard> guards,
+    _VotingSessionContext context,
+  ) {
+    for (final guard in guards) {
       if (guard.accountUuid == context.accountUuid &&
           guard.roundId == context.round.roundId) {
         return true;

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -963,40 +963,94 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       }
 
       var confirmedSubmittedVotes = false;
-      for (final work in _pendingVotePollingWork(roundPlan)) {
-        final key = VotingVoteKey(
-          bundleIndex: work.bundleIndex,
-          proposalId: work.proposalId,
-        );
-        final txHash = work.txHash;
-        if (txHash == null) continue;
-        final confirmation = await _awaitTxConfirmation(api, txHash);
-        if (confirmation == null) {
-          _setError(
-            'Vote commitment transaction $txHash for bundle '
-            '${key.bundleIndex}, proposal ${key.proposalId} is still '
-            'unconfirmed after repeated checks. Retry to resume confirmation '
-            'before continuing.',
+      final pendingVotePolling = _pendingVotePollingWork(roundPlan);
+      final pollingOutcomes = await _runBoundedBundleWork(
+        List<int>.generate(pendingVotePolling.length, (index) => index),
+        concurrency: _votingWorkConcurrency,
+        work: (index) async {
+          final work = pendingVotePolling[index];
+          final key = VotingVoteKey(
+            bundleIndex: work.bundleIndex,
+            proposalId: work.proposalId,
+          );
+          final txHash = work.txHash;
+          if (txHash == null) {
+            throw StateError(
+              'Missing submitted vote transaction hash for '
+              'bundle ${key.bundleIndex}, proposal ${key.proposalId}.',
+            );
+          }
+          final confirmation = await _awaitTxConfirmation(
+            api,
+            txHash,
             context: context,
           );
-          return;
-        }
-        if (confirmation.code != 0) {
-          throw StateError(
-            confirmation.log.isEmpty
-                ? 'Vote commitment transaction failed.'
-                : confirmation.log,
+          if (confirmation == null) {
+            throw _VoteConfirmationTimeout(key: key, txHash: txHash);
+          }
+          return _PolledVoteRecovery(
+            key: key,
+            txHash: txHash,
+            confirmation: confirmation,
           );
+        },
+      );
+      final voteRecoveryFailures = <_VoteWaveFailure>[];
+      for (var index = 0; index < pendingVotePolling.length; index++) {
+        final outcome = pollingOutcomes[index]!;
+        final error = outcome.error;
+        if (error != null) {
+          final work = pendingVotePolling[index];
+          voteRecoveryFailures.add(
+            _VoteWaveFailure(
+              bundleIndex: work.bundleIndex,
+              proposalId: work.proposalId,
+              stage: 'recovery confirmation polling',
+              error: error,
+            ),
+          );
+          continue;
         }
-        await rust.confirmVoteSubmission(
-          dbPath: context.dbPath,
-          accountUuid: context.accountUuid,
-          roundId: context.round.roundId,
-          bundleIndex: key.bundleIndex,
-          proposalId: key.proposalId,
-          txHash: txHash,
-          eventsJson: confirmation.eventsJson,
-        );
+        final polled = outcome.value!;
+        final key = polled.key;
+        final txHash = polled.txHash;
+        final confirmation = polled.confirmation;
+        if (confirmation.code != 0) {
+          voteRecoveryFailures.add(
+            _VoteWaveFailure(
+              bundleIndex: key.bundleIndex,
+              proposalId: key.proposalId,
+              stage: 'recovery confirmation',
+              error: StateError(
+                confirmation.log.isEmpty
+                    ? 'Vote commitment transaction failed.'
+                    : confirmation.log,
+              ),
+            ),
+          );
+          continue;
+        }
+        try {
+          await rust.confirmVoteSubmission(
+            dbPath: context.dbPath,
+            accountUuid: context.accountUuid,
+            roundId: context.round.roundId,
+            bundleIndex: key.bundleIndex,
+            proposalId: key.proposalId,
+            txHash: txHash,
+            eventsJson: confirmation.eventsJson,
+          );
+        } catch (error) {
+          voteRecoveryFailures.add(
+            _VoteWaveFailure(
+              bundleIndex: key.bundleIndex,
+              proposalId: key.proposalId,
+              stage: 'recovery confirmation persistence',
+              error: error,
+            ),
+          );
+          continue;
+        }
         progress[key] = VotingSessionProgress(
           phase: 'confirmed',
           bundleIndex: key.bundleIndex,
@@ -1016,6 +1070,23 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             voteProgress: progress,
           ),
         );
+      }
+      for (final failure in voteRecoveryFailures) {
+        if (failure.error is _StaleVotingSessionAction) throw failure.error;
+        final error = failure.error;
+        if (error is _VoteConfirmationTimeout) {
+          _setError(
+            'Vote commitment transaction ${error.txHash} for bundle '
+            '${error.key.bundleIndex}, proposal ${error.key.proposalId} is still '
+            'unconfirmed after repeated checks. Retry to resume confirmation '
+            'before continuing.',
+            context: context,
+          );
+          return;
+        }
+      }
+      if (voteRecoveryFailures.isNotEmpty) {
+        throw _VoteWaveBatchException(voteRecoveryFailures);
       }
       final recoveredVoteWork = _pendingRecoveredVoteWork(roundPlan);
       final recoveredVoteKeys = {
@@ -1070,8 +1141,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       var completedBundleTasks = 0;
       var completedQuestions = 0;
       final startTiming = _roundShareTiming(context, _nowSeconds());
-      debugPrint(
-        '[zcash] Voting: cast votes start '
+      _logVoteTiming(
+        'cast votes start '
         'round=${context.round.roundId} bundleTasks=$totalBundleTasks '
         'proposals=$totalQuestions '
         'lastMoment=${startTiming.isLastMoment}',
@@ -1186,193 +1257,44 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           'total=${formatElapsedSeconds(voteTimer.elapsed)}',
         );
       }
-      for (final work in voteWork) {
-        final draftVote = work.draftVote;
-        for (final bundleIndex in work.bundleIndexes) {
-          final voteTimer = Stopwatch()..start();
-          final key = VotingVoteKey(
-            bundleIndex: bundleIndex,
-            proposalId: draftVote.proposalId,
-          );
-          _setStateForContext(
-            context,
-            (state.value ?? current).copyWith(
-              phase: VotingSessionPhase.syncingVoteTree,
-              currentBundleIndex: bundleIndex,
-              currentVoteKey: key,
-              voteSubmissionCompletedCount: completedQuestions,
-              voteSubmissionTotalCount: totalQuestions,
-              voteSubmissionProgress: _voteSubmissionProgress(
-                completedBundleTasks: completedBundleTasks,
-                totalBundleTasks: totalBundleTasks,
-              ),
-            ),
-          );
-          debugPrint(
-            '[zcash] Voting: vote tree sync start '
-            'round=${context.round.roundId} bundle=$bundleIndex '
-            'proposal=${draftVote.proposalId}',
-          );
-          final syncTimer = Stopwatch()..start();
-          final anchorHeight = await _syncVoteTreeWithFailover(
+      if (voteWork.isNotEmpty) {
+        late final int chainCompleted;
+        try {
+          chainCompleted = await _runVoteRoundChains(
             context: context,
-            bundleIndex: bundleIndex,
-            proposalId: draftVote.proposalId,
+            fallbackState: current,
+            voteWork: voteWork,
+            storedHotkeySecret: storedHotkeySecret!,
+            progress: progress,
+            completedBundleTasks: completedBundleTasks,
+            totalBundleTasks: totalBundleTasks,
+            completedQuestions: completedQuestions,
+            totalQuestions: totalQuestions,
           );
-          debugPrint(
-            '[zcash] Voting: vote tree sync completed '
-            'round=${context.round.roundId} bundle=$bundleIndex '
-            'proposal=${draftVote.proposalId} anchorHeight=$anchorHeight '
-            'elapsed=${formatElapsedSeconds(syncTimer.elapsed)}',
-          );
-
-          final witnessTimer = Stopwatch()..start();
-          debugPrint(
-            '[zcash] Voting: VAN witness generation start '
-            'round=${context.round.roundId} bundle=$bundleIndex '
-            'proposal=${draftVote.proposalId} anchorHeight=$anchorHeight',
-          );
-          final witness = await ref
-              .read(votingRustApiProvider)
-              .generateVanWitness(
-                dbPath: context.dbPath,
-                accountUuid: context.accountUuid,
-                roundId: context.round.roundId,
-                bundleIndex: bundleIndex,
-                anchorHeight: anchorHeight,
-              );
-          debugPrint(
-            '[zcash] Voting: VAN witness generation completed '
-            'round=${context.round.roundId} bundle=$bundleIndex '
-            'proposal=${draftVote.proposalId} position=${witness.position} '
-            'elapsed=${formatElapsedSeconds(witnessTimer.elapsed)}',
-          );
+        } catch (_) {
+          plan = await _loadResumePlan(context);
+          roundPlan = await _loadRoundPlan(context);
           _setStateForContext(
             context,
             (state.value ?? current).copyWith(
-              phase: VotingSessionPhase.castingVotes,
-              currentBundleIndex: bundleIndex,
-              currentVoteKey: key,
-              voteSubmissionCompletedCount: completedQuestions,
-              voteSubmissionTotalCount: totalQuestions,
-              voteSubmissionProgress: _voteSubmissionProgress(
-                completedBundleTasks: completedBundleTasks,
-                totalBundleTasks: totalBundleTasks,
-              ),
-            ),
-          );
-          final timedDraftVote = _draftVoteForCurrentShareMode(
-            context,
-            draftVote,
-          );
-          debugPrint(
-            '[zcash] Voting: ZKP2 commitment stream start '
-            'round=${context.round.roundId} bundle=$bundleIndex '
-            'proposal=${draftVote.proposalId} '
-            'singleShare=${timedDraftVote.singleShare}',
-          );
-          await for (final event
-              in ref
-                  .read(votingRustApiProvider)
-                  .buildVoteCommitmentsWithProgress(
-                    dbPath: context.dbPath,
-                    accountUuid: context.accountUuid,
-                    network: context.network,
-                    roundId: context.round.roundId,
-                    bundleIndex: bundleIndex,
-                    storedHotkeySecret: storedHotkeySecret!,
-                    vanWitness: witness,
-                    draftVotes: [timedDraftVote],
-                  )) {
-            final proposalId = event.proposalId;
-            if (proposalId != null) {
-              final eventKey = VotingVoteKey(
-                bundleIndex: event.bundleIndex ?? bundleIndex,
-                proposalId: proposalId,
-              );
-              final proofProgress = _monotonicProofProgress(
-                progress[eventKey]?.proofProgress,
-                event.proofProgress,
-              );
-              progress[eventKey] = VotingSessionProgress(
-                phase: event.phase,
-                bundleIndex: eventKey.bundleIndex,
-                proposalId: proposalId,
-                proofProgress: proofProgress,
-              );
-              _setStateForContext(
-                context,
-                (state.value ?? current).copyWith(
-                  phase: VotingSessionPhase.castingVotes,
-                  voteProgress: progress,
-                  currentVoteKey: eventKey,
-                  voteSubmissionCompletedCount: completedQuestions,
-                  voteSubmissionTotalCount: totalQuestions,
-                  voteSubmissionProgress: _voteSubmissionProgress(
-                    completedBundleTasks: completedBundleTasks,
-                    totalBundleTasks: totalBundleTasks,
-                    currentBundleProgress: proofProgress,
-                  ),
-                ),
-              );
-            }
-            final commitments = event.commitments;
-            if (commitments != null) {
-              _throwIfContextStale(context, 'vote-commitment-submit');
-              final vcTreePositions = await _submitVoteCommitments(
-                context,
-                commitments,
-              );
-              await _submitCommitmentShares(
-                context,
-                commitments,
-                vcTreePositions: vcTreePositions,
-                singleShare: timedDraftVote.singleShare,
-                completedQuestions: completedQuestions,
-                totalQuestions: totalQuestions,
-                voteSubmissionProgress: _voteSubmissionProgress(
-                  completedBundleTasks: completedBundleTasks,
-                  totalBundleTasks: totalBundleTasks,
-                  currentBundleProgress: _monotonicProofProgress(
-                    progress[key]?.proofProgress,
-                    0.95,
-                  ),
-                ),
-              );
-            }
-          }
-          completedBundleTasks++;
-          progress[key] = VotingSessionProgress(
-            phase: 'completed',
-            bundleIndex: key.bundleIndex,
-            proposalId: key.proposalId,
-          );
-          _setStateForContext(
-            context,
-            (state.value ?? current).copyWith(
-              phase: VotingSessionPhase.castingVotes,
+              resumePlan: plan,
+              roundPlan: roundPlan,
               voteProgress: progress,
-              currentVoteKey: key,
-              voteSubmissionCompletedCount: completedQuestions,
-              voteSubmissionTotalCount: totalQuestions,
-              voteSubmissionProgress: _voteSubmissionProgress(
-                completedBundleTasks: completedBundleTasks,
-                totalBundleTasks: totalBundleTasks,
-              ),
             ),
           );
-          debugPrint(
-            '[zcash] Voting: vote flow completed '
-            'round=${context.round.roundId} bundle=$bundleIndex '
-            'proposal=${draftVote.proposalId} '
-            'total=${formatElapsedSeconds(voteTimer.elapsed)}',
-          );
+          await _scheduleShareTracking(context, plan);
+          rethrow;
         }
-        completedQuestions++;
+        completedBundleTasks += chainCompleted;
+        completedQuestions += voteWork.length;
+        plan = await _loadResumePlan(context);
+        roundPlan = await _loadRoundPlan(context);
         _setStateForContext(
           context,
           (state.value ?? current).copyWith(
             phase: VotingSessionPhase.castingVotes,
+            resumePlan: plan,
+            roundPlan: roundPlan,
             voteProgress: progress,
             voteSubmissionCompletedCount: completedQuestions,
             voteSubmissionTotalCount: totalQuestions,
@@ -1421,7 +1343,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         ),
       );
       await _scheduleShareTracking(context, refreshedPlan);
-    });
+    }, cleanupProcessStateOnError: false);
   }
 
   Future<List<int>?> _hotkeyForVoteCasting(
@@ -1511,6 +1433,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     rust_wire.SignedVoteCommitmentsView commitments, {
     Map<int, BigInt> vcTreePositions = const {},
     Set<int>? shareIndexFilter,
+    void Function(VotingSessionProgress progress)? publishProgress,
     required bool singleShare,
     required int completedQuestions,
     required int totalQuestions,
@@ -1575,15 +1498,26 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             submitAt: plan.submitAt,
           ),
         );
-        _setShareSubmissionProgress(
-          context: context,
-          bundleIndex: commitments.bundleIndex,
-          proposalId: share.proposalId,
-          message: bundleProgressMessage,
-          completedQuestions: completedQuestions,
-          totalQuestions: totalQuestions,
-          voteSubmissionProgress: voteSubmissionProgress,
-        );
+        if (publishProgress == null) {
+          _setShareSubmissionProgress(
+            context: context,
+            bundleIndex: commitments.bundleIndex,
+            proposalId: share.proposalId,
+            message: bundleProgressMessage,
+            completedQuestions: completedQuestions,
+            totalQuestions: totalQuestions,
+            voteSubmissionProgress: voteSubmissionProgress,
+          );
+        } else {
+          publishProgress(
+            VotingSessionProgress(
+              phase: 'submitting_shares',
+              bundleIndex: commitments.bundleIndex,
+              proposalId: share.proposalId,
+              message: bundleProgressMessage,
+            ),
+          );
+        }
         preparedSubmissions.add(
           _PreparedInitialShareSubmission(
             share: share,
@@ -1703,10 +1637,13 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     );
   }
 
+  /// Syncs the round's vote tree, failing over across configured API servers.
+  ///
+  /// Failover resets round-global process state, so callers must never run two
+  /// of these concurrently — go through [_VoteTreeSyncCoalescer].
   Future<int> _syncVoteTreeWithFailover({
     required _VotingSessionContext context,
-    required int bundleIndex,
-    required int proposalId,
+    required String label,
   }) async {
     final nodeUrls = context.config.apiServers.all;
     final rust = ref.read(votingRustApiProvider);
@@ -1732,8 +1669,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
         debugPrint(
           '[zcash] Voting: vote tree sync retrying failover '
-          'round=${context.round.roundId} bundle=$bundleIndex '
-          'proposal=$proposalId from=$nodeUrl error=$error',
+          '$label from=$nodeUrl error=$error',
         );
       }
     }
@@ -1810,17 +1746,548 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       proposalId: proposalId,
       message: message,
     );
+    final previousProgress = current.voteSubmissionProgress ?? 0;
+    final requestedProgress = voteSubmissionProgress ?? previousProgress;
+    final monotonicProgress = requestedProgress < previousProgress
+        ? previousProgress
+        : requestedProgress;
     _setStateForContext(
       context,
       current.copyWith(
         phase: VotingSessionPhase.castingVotes,
         voteProgress: progress,
-        currentVoteKey: key,
         voteSubmissionCompletedCount: completedQuestions,
         voteSubmissionTotalCount: totalQuestions,
-        voteSubmissionProgress: voteSubmissionProgress,
+        voteSubmissionProgress: monotonicProgress,
+        clearCurrentBundleIndex: true,
+        clearCurrentVoteKey: true,
       ),
     );
+  }
+
+  /// Casts every pending vote for the round, running one serial chain per
+  /// delegation bundle with all bundles in flight at once.
+  ///
+  /// The serialization inside a bundle is a protocol requirement, not a
+  /// throttle. A cast vote spends the bundle's vote authority note: the proof
+  /// binds the current VAN leaf position and the current proposal-authority
+  /// mask, submission clears that proposal's bit, and confirmation appends the
+  /// replacement VAN leaf and advances the stored position. Proving two
+  /// proposals of one bundle against the same state yields the same
+  /// `van_nullifier`, so the second cast-vote transaction is a double spend.
+  /// Each step therefore waits for `submit -> confirm -> tree re-sync` before
+  /// the next proposal of the same bundle is proved.
+  ///
+  /// Different bundles own independent VAN chains, so they never wait on each
+  /// other. Only the CPU-heavy witness+proof step is capped
+  /// ([_votingWorkConcurrency]); a bundle parked on a block confirmation
+  /// holds no proof permit. Share submission is dispatched off the chain
+  /// because the VAN advance is already durable by then.
+  ///
+  /// Returns the number of bundle tasks that completed through share
+  /// submission. Throws [_VoteWaveBatchException] if any task failed.
+  Future<int> _runVoteRoundChains({
+    required _VotingSessionContext context,
+    required VotingSessionState fallbackState,
+    required List<_DraftVoteWork> voteWork,
+    required List<int> storedHotkeySecret,
+    required Map<VotingVoteKey, VotingSessionProgress> progress,
+    required int completedBundleTasks,
+    required int totalBundleTasks,
+    required int completedQuestions,
+    required int totalQuestions,
+  }) async {
+    // Transpose proposal -> bundles into bundle -> proposals. Proposal order
+    // within a bundle follows the draft order so a restart resumes the same
+    // chain it left off.
+    final draftsByBundle = <int, List<rust_wire.DraftVote>>{};
+    final voteKeys = <VotingVoteKey>[];
+    for (final work in voteWork) {
+      for (final bundleIndex in work.bundleIndexes) {
+        draftsByBundle
+            .putIfAbsent(bundleIndex, () => <rust_wire.DraftVote>[])
+            .add(work.draftVote);
+        voteKeys.add(
+          VotingVoteKey(
+            bundleIndex: bundleIndex,
+            proposalId: work.draftVote.proposalId,
+          ),
+        );
+      }
+    }
+    if (voteKeys.isEmpty) return 0;
+
+    final rust = ref.read(votingRustApiProvider);
+    // Idempotent and non-blocking: kicked off before the first tree sync so
+    // Halo2 keygen overlaps the network round trip instead of landing cold on
+    // the first proof.
+    rust.warmVotingProvingCaches();
+    final roundTimer = Stopwatch()..start();
+    final proofWallTimer = Stopwatch()..start();
+    final proofElapsed = <VotingVoteKey, Duration>{};
+    final failures = <_VoteWaveFailure>[];
+    final proofPool = _AsyncPermitPool(_votingWorkConcurrency);
+    // Cast-vote broadcasts stay one-at-a-time across all bundles; only the
+    // confirmation wait that follows them overlaps.
+    final broadcastPool = _AsyncPermitPool(1);
+    final sharePool = _AsyncPermitPool(_votingWorkConcurrency);
+    final shareOutcomeFutures =
+        <VotingVoteKey, Future<_BundleWorkOutcome<void>>>{};
+    var syncCount = 0;
+    final treeSync = _VoteTreeSyncCoalescer(() {
+      syncCount++;
+      return _syncVoteTreeWithFailover(
+        context: context,
+        label:
+            'round=${context.round.roundId} bundles=${draftsByBundle.length}',
+      );
+    });
+    var lastAggregateProgress =
+        _voteSubmissionProgress(
+          completedBundleTasks: completedBundleTasks,
+          totalBundleTasks: totalBundleTasks,
+        ) ??
+        0;
+
+    double? aggregateProgress() => _aggregateVotePipelineProgress(
+      progress: progress,
+      voteKeys: voteKeys,
+      completedBundleTasks: completedBundleTasks,
+      totalBundleTasks: totalBundleTasks,
+    );
+
+    void publish(VotingSessionProgress update) {
+      final bundleIndex = update.bundleIndex;
+      final proposalId = update.proposalId;
+      if (bundleIndex == null || proposalId == null) return;
+      final key = VotingVoteKey(
+        bundleIndex: bundleIndex,
+        proposalId: proposalId,
+      );
+      progress[key] = update;
+      final updatedProgress = aggregateProgress() ?? lastAggregateProgress;
+      if (updatedProgress > lastAggregateProgress) {
+        lastAggregateProgress = updatedProgress;
+      }
+      // A question counts as done only once every bundle finished it, because
+      // bundles now advance through the proposal list independently.
+      final completedChainQuestions = voteWork.where((work) {
+        return work.bundleIndexes.every(
+          (bundleIndex) =>
+              progress[VotingVoteKey(
+                    bundleIndex: bundleIndex,
+                    proposalId: work.draftVote.proposalId,
+                  )]
+                  ?.phase ==
+              'completed',
+        );
+      }).length;
+      _setStateForContext(
+        context,
+        (state.value ?? fallbackState).copyWith(
+          phase: VotingSessionPhase.castingVotes,
+          voteProgress: Map<VotingVoteKey, VotingSessionProgress>.of(progress),
+          voteSubmissionCompletedCount:
+              completedQuestions + completedChainQuestions,
+          voteSubmissionTotalCount: totalQuestions,
+          voteSubmissionProgress: lastAggregateProgress,
+          clearCurrentBundleIndex: true,
+          clearCurrentVoteKey: true,
+        ),
+      );
+    }
+
+    void recordFailure({
+      required VotingVoteKey key,
+      required String stage,
+      required Object error,
+    }) {
+      failures.add(
+        _VoteWaveFailure(
+          bundleIndex: key.bundleIndex,
+          proposalId: key.proposalId,
+          stage: stage,
+          error: error,
+        ),
+      );
+      publish(
+        VotingSessionProgress(
+          phase: 'failed',
+          bundleIndex: key.bundleIndex,
+          proposalId: key.proposalId,
+          proofProgress: progress[key]?.proofProgress,
+          message: error.toString(),
+        ),
+      );
+    }
+
+    /// Runs one bundle's proposals in order. A failed step aborts the rest of
+    /// this bundle — the next proposal cannot be proved without the VAN
+    /// advance the failed step was supposed to produce — but leaves every other
+    /// bundle running.
+    Future<void> runBundleChain(
+      int bundleIndex,
+      List<rust_wire.DraftVote> drafts,
+    ) async {
+      // Attribute anything that escapes the per-stage handlers below.
+      // A swallowed error would leave `failures` empty and let the caller
+      // report a fully successful round.
+      VotingVoteKey? currentKey;
+      try {
+        for (final draft in drafts) {
+          final key = VotingVoteKey(
+            bundleIndex: bundleIndex,
+            proposalId: draft.proposalId,
+          );
+          currentKey = key;
+
+          final rust_wire.SignedVoteCommitmentsView commitments;
+          final bool singleShare;
+          try {
+            _throwIfContextStale(context, 'vote-chain-sync');
+            // A sync that started before this call could predate this bundle's
+            // own previous confirmation, so the coalescer only hands back one
+            // that started after it.
+            final syncTimer = Stopwatch()..start();
+            final anchorHeight = await treeSync.fresh();
+            _logVoteTiming(
+              'bundle=$bundleIndex proposal=${draft.proposalId} '
+              'tree-sync elapsed=${formatElapsedSeconds(syncTimer.elapsed)} '
+              'anchorHeight=$anchorHeight',
+            );
+            // Re-evaluated per step: a long round can cross into the last-moment
+            // buffer part way through a bundle's chain.
+            final timedDraft = _draftVoteForCurrentShareMode(context, draft);
+            singleShare = timedDraft.singleShare;
+            commitments = await proofPool.run(() async {
+              _throwIfContextStale(context, 'vote-chain-proof-start');
+              final timer = Stopwatch()..start();
+              try {
+                final witness = await rust.generateVanWitness(
+                  dbPath: context.dbPath,
+                  accountUuid: context.accountUuid,
+                  roundId: context.round.roundId,
+                  bundleIndex: bundleIndex,
+                  anchorHeight: anchorHeight,
+                );
+                rust_wire.SignedVoteCommitmentsView? built;
+                await for (final event in rust.buildVoteCommitmentsWithProgress(
+                  dbPath: context.dbPath,
+                  accountUuid: context.accountUuid,
+                  network: context.network,
+                  roundId: context.round.roundId,
+                  bundleIndex: bundleIndex,
+                  storedHotkeySecret: storedHotkeySecret,
+                  vanWitness: witness,
+                  draftVotes: [timedDraft],
+                )) {
+                  _throwIfContextStale(context, 'vote-chain-proof-progress');
+                  final eventKey = VotingVoteKey(
+                    bundleIndex: event.bundleIndex ?? bundleIndex,
+                    proposalId: event.proposalId ?? draft.proposalId,
+                  );
+                  publish(
+                    VotingSessionProgress(
+                      phase: event.phase,
+                      bundleIndex: eventKey.bundleIndex,
+                      proposalId: eventKey.proposalId,
+                      proofProgress: _monotonicProofProgress(
+                        progress[eventKey]?.proofProgress,
+                        event.proofProgress,
+                      ),
+                    ),
+                  );
+                  built = event.commitments ?? built;
+                }
+                return built ??
+                    (throw StateError(
+                      'Vote proof completed without commitment payload.',
+                    ));
+              } finally {
+                proofElapsed[key] = timer.elapsed;
+                _logVoteTiming(
+                  'bundle=$bundleIndex proposal=${draft.proposalId} '
+                  'prove elapsed=${formatElapsedSeconds(timer.elapsed)}',
+                );
+              }
+            });
+          } catch (error) {
+            recordFailure(key: key, stage: 'proof', error: error);
+            return;
+          }
+
+          final Map<int, String> txHashes;
+          try {
+            _throwIfContextStale(context, 'vote-chain-submit');
+            final submitTimer = Stopwatch()..start();
+            txHashes = await broadcastPool.run(
+              () => _submitVoteCommitmentsWithoutConfirmation(
+                context,
+                commitments,
+              ),
+            );
+            _logVoteTiming(
+              'bundle=$bundleIndex proposal=${key.proposalId} '
+              'submit elapsed=${formatElapsedSeconds(submitTimer.elapsed)}',
+            );
+            publish(
+              VotingSessionProgress(
+                phase: 'submitted',
+                bundleIndex: bundleIndex,
+                proposalId: key.proposalId,
+                proofProgress: 1,
+                message: txHashes[key.proposalId],
+              ),
+            );
+          } catch (error) {
+            recordFailure(key: key, stage: 'submission', error: error);
+            return;
+          }
+
+          final confirmations = <int, VotingTxConfirmation>{};
+          try {
+            final confirmTimer = Stopwatch()..start();
+            final api = ref.read(
+              votingApiClientProvider(context.config.apiServers),
+            );
+            for (final entry in txHashes.entries) {
+              final confirmation = await _awaitTxConfirmation(
+                api,
+                entry.value,
+                context: context,
+              );
+              if (confirmation == null) {
+                throw StateError(
+                  'Transaction ${entry.value} was not confirmed in time.',
+                );
+              }
+              if (confirmation.code != 0) {
+                throw StateError(
+                  confirmation.log.isEmpty
+                      ? 'Vote commitment transaction failed.'
+                      : confirmation.log,
+                );
+              }
+              confirmations[entry.key] = confirmation;
+            }
+            _logVoteTiming(
+              'bundle=$bundleIndex proposal=${key.proposalId} '
+              'confirm-wait elapsed=${formatElapsedSeconds(confirmTimer.elapsed)}',
+            );
+          } catch (error) {
+            recordFailure(key: key, stage: 'confirmation', error: error);
+            return;
+          }
+
+          final Map<int, BigInt> vcTreePositions;
+          try {
+            // Advances this bundle's stored VAN position, which is what unblocks
+            // the next proposal in this chain.
+            final persistTimer = Stopwatch()..start();
+            vcTreePositions = await _persistVoteConfirmations(
+              context,
+              bundleIndex: bundleIndex,
+              txHashes: txHashes,
+              confirmations: confirmations,
+            );
+            _logVoteTiming(
+              'bundle=$bundleIndex proposal=${key.proposalId} '
+              'confirm-persist elapsed=${formatElapsedSeconds(persistTimer.elapsed)}',
+            );
+            publish(
+              VotingSessionProgress(
+                phase: 'confirmed',
+                bundleIndex: bundleIndex,
+                proposalId: key.proposalId,
+                proofProgress: 1,
+                message: txHashes[key.proposalId],
+              ),
+            );
+          } catch (error) {
+            recordFailure(
+              key: key,
+              stage: 'confirmation persistence',
+              error: error,
+            );
+            return;
+          }
+
+          // Shares are off the chain: the VAN advance is durable, so the next
+          // proposal does not wait on helper-server delivery.
+          shareOutcomeFutures[key] = _captureBundleWork(
+            () => sharePool.run(() async {
+              final shareTimer = Stopwatch()..start();
+              await _submitCommitmentShares(
+                context,
+                commitments,
+                vcTreePositions: vcTreePositions,
+                publishProgress: publish,
+                singleShare: singleShare,
+                completedQuestions: completedQuestions,
+                totalQuestions: totalQuestions,
+                voteSubmissionProgress: aggregateProgress(),
+              );
+              _logVoteTiming(
+                'bundle=$bundleIndex proposal=${key.proposalId} '
+                'shares elapsed=${formatElapsedSeconds(shareTimer.elapsed)}',
+              );
+              publish(
+                VotingSessionProgress(
+                  phase: 'completed',
+                  bundleIndex: bundleIndex,
+                  proposalId: key.proposalId,
+                  proofProgress: 1,
+                ),
+              );
+            }),
+          );
+        }
+      } catch (error) {
+        failures.add(
+          _VoteWaveFailure(
+            bundleIndex: bundleIndex,
+            proposalId: currentKey?.proposalId ?? drafts.first.proposalId,
+            stage: 'chain',
+            error: error,
+          ),
+        );
+      }
+    }
+
+    await Future.wait([
+      for (final entry in draftsByBundle.entries)
+        _captureBundleWork(() => runBundleChain(entry.key, entry.value)),
+    ]);
+
+    final serialProofDuration = proofElapsed.values.fold<Duration>(
+      Duration.zero,
+      (total, elapsed) => total + elapsed,
+    );
+    _logVoteTiming(
+      'vote chains proof time '
+      'round=${context.round.roundId} proposals=${voteWork.length} '
+      'bundles=${draftsByBundle.length} tasks=${voteKeys.length} '
+      'treeSyncs=$syncCount concurrency=$_votingWorkConcurrency '
+      'wall=${formatElapsedSeconds(proofWallTimer.elapsed)} '
+      'serialEquivalent=${formatElapsedSeconds(serialProofDuration)}',
+    );
+
+    final shareOutcomes = <VotingVoteKey, _BundleWorkOutcome<void>>{};
+    await Future.wait(
+      shareOutcomeFutures.entries.map((entry) async {
+        shareOutcomes[entry.key] = await entry.value;
+      }),
+    );
+
+    var completed = 0;
+    for (final entry in shareOutcomes.entries) {
+      final outcome = entry.value;
+      if (outcome.error != null) {
+        recordFailure(key: entry.key, stage: 'shares', error: outcome.error!);
+        continue;
+      }
+      completed++;
+    }
+
+    if (failures.isNotEmpty) {
+      // A stale session is a control-flow signal, not a per-task failure; let
+      // it unwind on its own so the caller can drop the abandoned round.
+      for (final failure in failures) {
+        if (failure.error is _StaleVotingSessionAction) throw failure.error;
+      }
+      throw _VoteWaveBatchException(failures);
+    }
+    _logVoteTiming(
+      'vote chains completed '
+      'round=${context.round.roundId} proposals=${voteWork.length} '
+      'bundles=${draftsByBundle.length} tasks=$completed '
+      'elapsed=${formatElapsedSeconds(roundTimer.elapsed)}',
+    );
+    return completed;
+  }
+
+  double? _aggregateVotePipelineProgress({
+    required Map<VotingVoteKey, VotingSessionProgress> progress,
+    required List<VotingVoteKey> voteKeys,
+    required int completedBundleTasks,
+    required int totalBundleTasks,
+  }) {
+    if (totalBundleTasks <= 0) return null;
+    var pipelineProgress = 0.0;
+    for (final key in voteKeys) {
+      final item = progress[key];
+      pipelineProgress += switch (item?.phase) {
+        'completed' => 1,
+        'submitting_shares' => 0.95,
+        'confirmed' => 0.95,
+        'submitted' => 0.85,
+        'failed' => 0,
+        _ => (item?.proofProgress ?? 0).clamp(0.0, 1.0) * 0.8,
+      };
+    }
+    return ((completedBundleTasks + pipelineProgress) / totalBundleTasks)
+        .clamp(0.0, 1.0)
+        .toDouble();
+  }
+
+  Future<Map<int, String>> _submitVoteCommitmentsWithoutConfirmation(
+    _VotingSessionContext context,
+    rust_wire.SignedVoteCommitmentsView commitments,
+  ) async {
+    final api = ref.read(votingApiClientProvider(context.config.apiServers));
+    final rust = ref.read(votingRustApiProvider);
+    final txHashes = <int, String>{};
+    for (final commitment in commitments.commitments) {
+      final result = await api.submitVoteCommitment(
+        commitment: await _wireJsonMap(
+          rust.voteCommitmentWireJson(commitment: commitment.wire),
+        ),
+      );
+      if (result.code != 0) {
+        throw StateError(
+          result.log.isEmpty
+              ? 'Vote commitment transaction was rejected.'
+              : result.log,
+        );
+      }
+      if (result.txHash.isEmpty) {
+        throw StateError('Vote commitment response did not include tx_hash.');
+      }
+      await rust.markVoteSubmitted(
+        dbPath: context.dbPath,
+        accountUuid: context.accountUuid,
+        roundId: context.round.roundId,
+        bundleIndex: commitments.bundleIndex,
+        proposalId: commitment.proposalId,
+        txHash: result.txHash,
+      );
+      txHashes[commitment.proposalId] = result.txHash;
+    }
+    return txHashes;
+  }
+
+  Future<Map<int, BigInt>> _persistVoteConfirmations(
+    _VotingSessionContext context, {
+    required int bundleIndex,
+    required Map<int, String> txHashes,
+    required Map<int, VotingTxConfirmation> confirmations,
+  }) async {
+    final rust = ref.read(votingRustApiProvider);
+    final vcTreePositions = <int, BigInt>{};
+    for (final entry in txHashes.entries) {
+      final confirmation = confirmations[entry.key]!;
+      final result = await rust.confirmVoteSubmission(
+        dbPath: context.dbPath,
+        accountUuid: context.accountUuid,
+        roundId: context.round.roundId,
+        bundleIndex: bundleIndex,
+        proposalId: entry.key,
+        txHash: entry.value,
+        eventsJson: confirmation.eventsJson,
+      );
+      vcTreePositions[entry.key] = result.vcTreePosition;
+    }
+    return vcTreePositions;
   }
 
   Future<Map<int, BigInt>> _submitVoteCommitments(
@@ -2282,7 +2749,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   Future<VotingTxConfirmation?> _awaitTxConfirmation(
     VotingApiClient api,
     String txHash, {
-    _VotingSessionContext? context,
+    required _VotingSessionContext context,
   }) async {
     final polling = ref.read(votingTxConfirmationPollingProvider);
     final attempts = polling.attempts;
@@ -2290,9 +2757,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     final timer = Stopwatch()..start();
     _logVoteTiming('tx confirmation wait start txHash=$txHash');
     for (var attempt = 0; attempt < attempts; attempt++) {
-      if (context != null) _throwIfContextStale(context, 'tx-confirmation');
+      _throwIfContextStale(context, 'tx-confirmation');
       final confirmation = await api.getTxConfirmation(txHash);
-      if (context != null) _throwIfContextStale(context, 'tx-confirmation-response');
+      _throwIfContextStale(context, 'tx-confirmation-response');
       if (confirmation != null) {
         _logVoteTiming(
           'tx confirmation found txHash=$txHash '
@@ -2309,7 +2776,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           );
         }
         await Future<void>.delayed(delay);
-        if (context != null) _throwIfContextStale(context, 'tx-confirmation-delay');
+        _throwIfContextStale(context, 'tx-confirmation-delay');
       }
     }
     _logVoteTiming(
@@ -3927,6 +4394,16 @@ Future<Map<int, _BundleWorkOutcome<T>>> _runBoundedBundleWork<T>(
   return outcomes;
 }
 
+Future<_BundleWorkOutcome<T>> _captureBundleWork<T>(
+  Future<T> Function() work,
+) async {
+  try {
+    return _BundleWorkOutcome.success(await work());
+  } catch (error, stackTrace) {
+    return _BundleWorkOutcome.failure(error, stackTrace);
+  }
+}
+
 /// Serializes vote-tree syncs and batches concurrent requesters onto one call.
 ///
 /// Two guarantees matter to callers:
@@ -3939,6 +4416,94 @@ Future<Map<int, _BundleWorkOutcome<T>>> _runBoundedBundleWork<T>(
 ///   therefore cannot be handed an anchor height from a sync that predates its
 ///   new VAN leaf. Requests arriving while a sync runs are batched into the
 ///   next one, so N bundles finishing a proposal together cost one round trip.
+class _VoteTreeSyncCoalescer {
+  _VoteTreeSyncCoalescer(this._sync);
+
+  final Future<int> Function() _sync;
+  final Queue<Completer<int>> _waiting = Queue<Completer<int>>();
+  bool _running = false;
+
+  Future<int> fresh() {
+    final waiter = Completer<int>();
+    _waiting.addLast(waiter);
+    // Deferred so every requester in this turn joins the same sync — bundles
+    // that finish a proposal together should cost one round trip, not N.
+    // Delaying the start can only add requesters ahead of it, so the
+    // "started after my call" guarantee still holds.
+    scheduleMicrotask(_pump);
+    return waiter.future;
+  }
+
+  void _pump() {
+    if (_running || _waiting.isEmpty) return;
+    _running = true;
+    // Everyone registered *before* this sync starts is served by it; anyone who
+    // registers after this point waits for the following run.
+    final batch = _waiting.toList(growable: false);
+    _waiting.clear();
+    Future<int> attempt;
+    try {
+      attempt = _sync();
+    } catch (error, stackTrace) {
+      // A synchronous throw would otherwise leave `_running` latched and hang
+      // every later requester instead of failing them.
+      attempt = Future<int>.error(error, stackTrace);
+    }
+    attempt
+        .then(
+          (anchorHeight) {
+            for (final waiter in batch) {
+              waiter.complete(anchorHeight);
+            }
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            for (final waiter in batch) {
+              waiter.completeError(error, stackTrace);
+            }
+          },
+        )
+        .whenComplete(() {
+          _running = false;
+          scheduleMicrotask(_pump);
+        });
+  }
+}
+
+class _AsyncPermitPool {
+  _AsyncPermitPool(int concurrency)
+    : assert(concurrency > 0),
+      _availablePermits = concurrency;
+
+  int _availablePermits;
+  final Queue<Completer<void>> _waiters = Queue<Completer<void>>();
+
+  Future<T> run<T>(Future<T> Function() work) async {
+    await _acquire();
+    try {
+      return await work();
+    } finally {
+      _release();
+    }
+  }
+
+  Future<void> _acquire() {
+    if (_availablePermits > 0) {
+      _availablePermits--;
+      return Future<void>.value();
+    }
+    final waiter = Completer<void>();
+    _waiters.addLast(waiter);
+    return waiter.future;
+  }
+
+  void _release() {
+    if (_waiters.isNotEmpty) {
+      _waiters.removeFirst().complete();
+    } else {
+      _availablePermits++;
+    }
+  }
+}
 
 class _BundleWorkOutcome<T> {
   const _BundleWorkOutcome.success(this.value)
@@ -3980,6 +4545,58 @@ class _DelegationBundleBatchException implements Exception {
         .join('; ');
     return 'Delegation bundle processing failed: $details';
   }
+}
+
+class _VoteWaveFailure {
+  const _VoteWaveFailure({
+    required this.bundleIndex,
+    required this.proposalId,
+    required this.stage,
+    required this.error,
+  });
+
+  final int bundleIndex;
+  final int proposalId;
+  final String stage;
+  final Object error;
+}
+
+class _VoteWaveBatchException implements Exception {
+  const _VoteWaveBatchException(this.failures);
+
+  final List<_VoteWaveFailure> failures;
+
+  @override
+  String toString() {
+    final details = failures
+        .map(
+          (failure) =>
+              'bundle ${failure.bundleIndex + 1} '
+              'proposal ${failure.proposalId} ${failure.stage}: '
+              '${failure.error}',
+        )
+        .join('; ');
+    return 'Vote casting failed: $details';
+  }
+}
+
+class _PolledVoteRecovery {
+  const _PolledVoteRecovery({
+    required this.key,
+    required this.txHash,
+    required this.confirmation,
+  });
+
+  final VotingVoteKey key;
+  final String txHash;
+  final VotingTxConfirmation confirmation;
+}
+
+class _VoteConfirmationTimeout implements Exception {
+  const _VoteConfirmationTimeout({required this.key, required this.txHash});
+
+  final VotingVoteKey key;
+  final String txHash;
 }
 
 class _VotingSessionContext {

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1764,6 +1764,21 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     return [...responsive, ...unknown, ...unavailable];
   }
 
+  Future<void> _warmShareHelperPreflight({
+    required _VotingSessionContext context,
+    required VotingApiClient api,
+  }) async {
+    try {
+      await api.preflightHelpers(context.config.apiServers.all);
+    } catch (error) {
+      // Readiness is only an ordering hint. The just-in-time preflight and
+      // bounded share submission still provide the authoritative fallback.
+      debugPrint(
+        '[zcash] Voting: helper preflight warmup ignored error=$error',
+      );
+    }
+  }
+
   Future<Map<String, bool>> _preflightShareHelpers({
     required _VotingSessionContext context,
     required VotingApiClient api,
@@ -2319,6 +2334,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   ) async {
     final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
+    // Warm every configured helper while the commitment is broadcast and
+    // confirmed. The just-in-time preflight reuses this in-flight or cached
+    // result when it is still fresh, and refreshes it after the cache TTL.
+    unawaited(_warmShareHelperPreflight(context: context, api: api));
     final txHashes = <int, String>{};
     for (final commitment in commitments.commitments) {
       final result = await api.submitVoteCommitment(
@@ -2379,6 +2398,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   ) async {
     final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
+    unawaited(_warmShareHelperPreflight(context: context, api: api));
     final vcTreePositions = <int, BigInt>{};
     for (final commitment in commitments.commitments) {
       debugPrint(

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1153,6 +1153,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             0,
             (total, work) => total + work.bundleIndexes.length,
           );
+      final helperAvailability = totalBundleTasks == 0
+          ? Future.value(const <String, bool>{})
+          : ref
+                .read(votingApiClientProvider(context.config.apiServers))
+                .preflightHelpers(context.config.apiServers.all);
       var completedBundleTasks = 0;
       var completedQuestions = 0;
       final startTiming = _roundShareTiming(context, _nowSeconds());
@@ -1233,6 +1238,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         await _submitCommitmentShares(
           context,
           commitments,
+          helperAvailability: helperAvailability,
           vcTreePositions: vcTreePositions,
           singleShare: _commitmentsUseSingleShare(commitments),
           shareIndexFilter: shareIndexFilter,
@@ -1285,6 +1291,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             totalBundleTasks: totalBundleTasks,
             completedQuestions: completedQuestions,
             totalQuestions: totalQuestions,
+            helperAvailability: helperAvailability,
           );
         } catch (_) {
           plan = await _loadResumePlan(context);
@@ -1446,6 +1453,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   Future<void> _submitCommitmentShares(
     _VotingSessionContext context,
     rust_wire.SignedVoteCommitmentsView commitments, {
+    required Future<Map<String, bool>> helperAvailability,
     Map<int, BigInt> vcTreePositions = const {},
     Set<int>? shareIndexFilter,
     void Function(VotingSessionProgress progress)? publishProgress,
@@ -1463,6 +1471,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     if (serverUrls.isEmpty) {
       throw StateError('No vote servers configured for share submission.');
     }
+    final availableHelpers = await helperAvailability;
+    _throwIfContextStale(context, 'helper-preflight-finished');
 
     final timing = _roundShareTiming(context, _nowSeconds());
     final bundleProgressMessage = _bundleProgressMessage(
@@ -1492,16 +1502,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           '${shares.length} payload(s).',
         );
       }
-      final plannedServers = <String>{
-        for (final plan in plans) ...plan.targetServers,
-      };
-      final helperAvailability = await _preflightShareHelpers(
-        context: context,
-        api: api,
-        plannedServers: plannedServers,
-        configuredServers: serverUrls,
-      );
-
       // Validate every body before starting helper requests. Otherwise a later
       // serialization failure could abandon already accepted submissions.
       final preparedSubmissions = <_PreparedInitialShareSubmission>[];
@@ -1514,7 +1514,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         final candidateServers = _plannedShareServers(
           plannedServers: plan.targetServers,
           fallbackServers: helperHealth.candidateServers(serverUrls),
-          helperAvailability: helperAvailability,
+          helperAvailability: availableHelpers,
         );
         final body = await _wireJsonMap(
           rust.voteShareWireJson(
@@ -1748,79 +1748,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     for (final server in fallbackServers) {
       if (server.trim().isNotEmpty) ordered.add(server);
     }
-    final responsive = <String>[];
-    final unknown = <String>[];
-    final unavailable = <String>[];
-    for (final server in ordered) {
-      final isReady = helperAvailability[server];
-      if (isReady == true) {
-        responsive.add(server);
-      } else if (isReady == false) {
-        unavailable.add(server);
-      } else {
-        unknown.add(server);
-      }
-    }
-    return [...responsive, ...unknown, ...unavailable];
-  }
-
-  Future<void> _warmShareHelperPreflight({
-    required _VotingSessionContext context,
-    required VotingApiClient api,
-  }) async {
-    try {
-      await api.preflightHelpers(context.config.apiServers.all);
-    } catch (error) {
-      // Readiness is only an ordering hint. The just-in-time preflight and
-      // bounded share submission still provide the authoritative fallback.
-      debugPrint(
-        '[zcash] Voting: helper preflight warmup ignored error=$error',
-      );
-    }
-  }
-
-  Future<Map<String, bool>> _preflightShareHelpers({
-    required _VotingSessionContext context,
-    required VotingApiClient api,
-    required Iterable<String> plannedServers,
-    required List<String> configuredServers,
-  }) async {
-    _throwIfContextStale(context, 'helper-preflight-start');
-    final planned = plannedServers
-        .where((server) => server.trim().isNotEmpty)
-        .toSet();
-    if (planned.isEmpty) return const {};
-
-    final timer = Stopwatch()..start();
-    try {
-      final availability = <String, bool>{
-        ...await api.preflightHelpers(planned.map(Uri.parse)),
-      };
-      if (planned.any((server) => availability[server] == false)) {
-        final replacements = configuredServers.where(
-          (server) => !planned.contains(server),
-        );
-        availability.addAll(
-          await api.preflightHelpers(replacements.map(Uri.parse)),
-        );
-      }
-      _throwIfContextStale(context, 'helper-preflight-finished');
-      final readyCount = availability.values.where((ready) => ready).length;
-      final unavailableCount = availability.length - readyCount;
-      _logVoteTiming(
-        'helper preflight planned=${planned.length} '
-        'probed=${availability.length} ready=$readyCount '
-        'unavailable=$unavailableCount '
-        'elapsed=${formatElapsedSeconds(timer.elapsed)}',
-      );
-      return Map<String, bool>.unmodifiable(availability);
-    } on _StaleVotingSessionAction {
-      rethrow;
-    } catch (error) {
-      _throwIfContextStale(context, 'helper-preflight-failed');
-      debugPrint('[zcash] Voting: helper preflight ignored error=$error');
-      return const {};
-    }
+    return [
+      for (final readiness in const <bool?>[true, null, false])
+        for (final server in ordered)
+          if (helperAvailability[server] == readiness) server,
+    ];
   }
 
   void _setShareSubmissionProgress({
@@ -1894,6 +1826,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required int totalBundleTasks,
     required int completedQuestions,
     required int totalQuestions,
+    required Future<Map<String, bool>> helperAvailability,
   }) async {
     // Transpose proposal -> bundles into bundle -> proposals. Proposal order
     // within a bundle follows the draft order so a restart resumes the same
@@ -2218,6 +2151,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
               await _submitCommitmentShares(
                 context,
                 commitments,
+                helperAvailability: helperAvailability,
                 vcTreePositions: vcTreePositions,
                 publishProgress: publish,
                 singleShare: singleShare,
@@ -2334,10 +2268,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   ) async {
     final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
-    // Warm every configured helper while the commitment is broadcast and
-    // confirmed. The just-in-time preflight reuses this in-flight or cached
-    // result when it is still fresh, and refreshes it after the cache TTL.
-    unawaited(_warmShareHelperPreflight(context: context, api: api));
     final txHashes = <int, String>{};
     for (final commitment in commitments.commitments) {
       final result = await api.submitVoteCommitment(
@@ -2398,7 +2328,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   ) async {
     final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
-    unawaited(_warmShareHelperPreflight(context: context, api: api));
     final vcTreePositions = <int, BigInt>{};
     for (final commitment in commitments.commitments) {
       debugPrint(

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -2531,14 +2531,14 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       'round=${context.round.roundId} bundle=$bundleIndex',
     );
     try {
-      final result = await ref
-          .read(votingRustApiProvider)
-          .precomputeDelegationPir(
-            ctx: _apiRoundContext(context),
-            pirServerUrl: _transportUrl(pirEndpoint),
-            storedHotkeySecret: storedHotkeySecret,
-            bundleIndex: bundleIndex,
-          );
+      final rust = ref.read(votingRustApiProvider);
+      rust.warmVotingProvingCaches();
+      final result = await rust.precomputeDelegationPir(
+        ctx: _apiRoundContext(context),
+        pirServerUrl: _transportUrl(pirEndpoint),
+        storedHotkeySecret: storedHotkeySecret,
+        bundleIndex: bundleIndex,
+      );
       debugPrint(
         '[zcash] Voting: delegation PIR precompute completed '
         'round=${context.round.roundId} bundle=$bundleIndex '
@@ -2900,6 +2900,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   Future<void> _prepareDelegationUnlocked() async {
     final current = await future;
     final context = await _loadContext(_roundId);
+    ref.read(votingRustApiProvider).warmVotingProvingCaches();
     await _waitUntilWalletReadyForVoting(context);
     _setStateForContext(
       context,

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -69,6 +69,14 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
 
   void _releaseAutomaticShareTracking() {}
 
+  /// Pins automatic helper-share tracking before a submission job can drop its
+  /// destructive-operation guard.
+  ///
+  /// Returns false when the registry is quiesced and new tracking must not
+  /// start. Account delete/reset drain through the registry, so the job must
+  /// register first when accepted shares still need confirmation.
+  bool pinAutomaticShareTracking() => _retainAutomaticShareTracking();
+
   Future<void> _operation = Future.value();
   final String _roundId;
   final Map<String, Future<void>> _delegationPirPrecomputes = {};
@@ -4703,6 +4711,8 @@ class VotingSubmissionSessionNotifier extends VotingSessionNotifier {
     if (_closeShareTrackingKeepAlive != null) return true;
     final registry = ref.read(votingShareTrackingRegistryProvider);
     final keepAlive = ref.keepAlive();
+    // Register before the submission job drops its guard so account
+    // delete/reset can drain this pass through the registry.
     if (!registry.register(
       key: _key,
       owner: this,

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1492,6 +1492,15 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           '${shares.length} payload(s).',
         );
       }
+      final plannedServers = <String>{
+        for (final plan in plans) ...plan.targetServers,
+      };
+      final helperAvailability = await _preflightShareHelpers(
+        context: context,
+        api: api,
+        plannedServers: plannedServers,
+        configuredServers: serverUrls,
+      );
 
       // Validate every body before starting helper requests. Otherwise a later
       // serialization failure could abandon already accepted submissions.
@@ -1505,6 +1514,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         final candidateServers = _plannedShareServers(
           plannedServers: plan.targetServers,
           fallbackServers: helperHealth.candidateServers(serverUrls),
+          helperAvailability: helperAvailability,
         );
         final body = await _wireJsonMap(
           rust.voteShareWireJson(
@@ -1729,6 +1739,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   List<String> _plannedShareServers({
     required List<String> plannedServers,
     required Iterable<String> fallbackServers,
+    Map<String, bool> helperAvailability = const {},
   }) {
     final ordered = <String>{};
     for (final server in plannedServers) {
@@ -1737,7 +1748,64 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     for (final server in fallbackServers) {
       if (server.trim().isNotEmpty) ordered.add(server);
     }
-    return ordered.toList(growable: false);
+    final responsive = <String>[];
+    final unknown = <String>[];
+    final unavailable = <String>[];
+    for (final server in ordered) {
+      final isReady = helperAvailability[server];
+      if (isReady == true) {
+        responsive.add(server);
+      } else if (isReady == false) {
+        unavailable.add(server);
+      } else {
+        unknown.add(server);
+      }
+    }
+    return [...responsive, ...unknown, ...unavailable];
+  }
+
+  Future<Map<String, bool>> _preflightShareHelpers({
+    required _VotingSessionContext context,
+    required VotingApiClient api,
+    required Iterable<String> plannedServers,
+    required List<String> configuredServers,
+  }) async {
+    _throwIfContextStale(context, 'helper-preflight-start');
+    final planned = plannedServers
+        .where((server) => server.trim().isNotEmpty)
+        .toSet();
+    if (planned.isEmpty) return const {};
+
+    final timer = Stopwatch()..start();
+    try {
+      final availability = <String, bool>{
+        ...await api.preflightHelpers(planned.map(Uri.parse)),
+      };
+      if (planned.any((server) => availability[server] == false)) {
+        final replacements = configuredServers.where(
+          (server) => !planned.contains(server),
+        );
+        availability.addAll(
+          await api.preflightHelpers(replacements.map(Uri.parse)),
+        );
+      }
+      _throwIfContextStale(context, 'helper-preflight-finished');
+      final readyCount = availability.values.where((ready) => ready).length;
+      final unavailableCount = availability.length - readyCount;
+      _logVoteTiming(
+        'helper preflight planned=${planned.length} '
+        'probed=${availability.length} ready=$readyCount '
+        'unavailable=$unavailableCount '
+        'elapsed=${formatElapsedSeconds(timer.elapsed)}',
+      );
+      return Map<String, bool>.unmodifiable(availability);
+    } on _StaleVotingSessionAction {
+      rethrow;
+    } catch (error) {
+      _throwIfContextStale(context, 'helper-preflight-failed');
+      debugPrint('[zcash] Voting: helper preflight ignored error=$error');
+      return const {};
+    }
   }
 
   void _setShareSubmissionProgress({

--- a/lib/src/providers/voting/voting_state.dart
+++ b/lib/src/providers/voting/voting_state.dart
@@ -276,11 +276,21 @@ class VotingSessionState {
     this.voteSubmissionTotalCount = 0,
     this.voteSubmissionProgress,
     this.error,
-  }) : pirDiagnostics = UnmodifiableListView(pirDiagnostics),
-       delegationProgress = UnmodifiableMapView(delegationProgress),
-       voteProgress = UnmodifiableMapView(voteProgress),
-       keystoneSignatures = UnmodifiableMapView(keystoneSignatures),
-       keystoneSigningRequests = UnmodifiableListView(keystoneSigningRequests);
+  }) : pirDiagnostics = UnmodifiableListView(
+         List<PirSnapshotEndpointDiagnostic>.of(pirDiagnostics),
+       ),
+       delegationProgress = UnmodifiableMapView(
+         Map<int, VotingSessionProgress>.of(delegationProgress),
+       ),
+       voteProgress = UnmodifiableMapView(
+         Map<VotingVoteKey, VotingSessionProgress>.of(voteProgress),
+       ),
+       keystoneSignatures = UnmodifiableMapView(
+         Map<int, rust_wire.KeystoneSignatureRecord>.of(keystoneSignatures),
+       ),
+       keystoneSigningRequests = UnmodifiableListView(
+         List<rust_delegate.KeystoneSigningRequest>.of(keystoneSigningRequests),
+       );
 
   bool get hasError => phase == VotingSessionPhase.error;
 

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -935,14 +935,42 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       );
     }
     if (!_isCurrentJob(key: key, generation: generation)) return;
-    final afterVotes = _sessionForJob(key);
-    if (afterVotes?.phase == VotingSessionPhase.error) {
-      _failFromSession(key: key, generation: generation, session: afterVotes!);
+    var done = _sessionForJob(key);
+    if (done?.phase == VotingSessionPhase.error) {
+      _failFromSession(key: key, generation: generation, session: done!);
+      return;
+    }
+    if (done != null) {
+      final completedEligibilitySession =
+          await _ensureEligibilityForCompletedSession(
+            key: key,
+            generation: generation,
+            sessionNotifier: sessionNotifier,
+            session: done,
+          );
+      if (completedEligibilitySession == null) return;
+      done = completedEligibilitySession;
+    }
+    if (_canCompleteSubmission(done)) {
+      // Helper reveal is background work. Awaiting it here keeps the status
+      // screen on "Finalizing submission" for every accepted-but-unrevealed
+      // share.
+      unawaited(
+        sessionNotifier.submitPendingShares().catchError((
+          Object error,
+          StackTrace stack,
+        ) {
+          debugPrint(
+            '[zcash] Voting: background share tracking failed: $error\n$stack',
+          );
+        }),
+      );
+      _completeJob(key: key, generation: generation);
       return;
     }
     await sessionNotifier.submitPendingShares();
     if (!_isCurrentJob(key: key, generation: generation)) return;
-    var done = _sessionForJob(key);
+    done = _sessionForJob(key);
     if (done?.phase == VotingSessionPhase.error) {
       _failFromSession(key: key, generation: generation, session: done!);
       return;

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -952,19 +952,6 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       done = completedEligibilitySession;
     }
     if (_canCompleteSubmission(done)) {
-      // Helper reveal is background work. Awaiting it here keeps the status
-      // screen on "Finalizing submission" for every accepted-but-unrevealed
-      // share.
-      unawaited(
-        sessionNotifier.submitPendingShares().catchError((
-          Object error,
-          StackTrace stack,
-        ) {
-          debugPrint(
-            '[zcash] Voting: background share tracking failed: $error\n$stack',
-          );
-        }),
-      );
       _completeJob(key: key, generation: generation);
       return;
     }
@@ -1027,6 +1014,10 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
   void _completeJob({required VotingSessionKey key, required int generation}) {
     if (!_isCurrentJob(key: key, generation: generation)) return;
     _cancelCompletionPoll();
+    // Register live helper-share tracking before releasing the submission
+    // guard. Account delete/reset drain through the registry; they must not
+    // observe an unguarded in-flight pass.
+    _pinLiveShareTracking(key);
     _releaseGuard();
     _releaseSessionSubscription();
     ref.invalidate(votingSessionProvider(key.roundId));
@@ -1128,6 +1119,32 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     if (guard == null) return;
     _guard = null;
     ref.read(votingSubmissionGuardProvider.notifier).release(guard);
+  }
+
+  void _pinLiveShareTracking(VotingSessionKey key) {
+    final hasUnconfirmedShares =
+        _sessionForJob(
+          key,
+        )?.resumePlan?.unconfirmedShareDelegations.isNotEmpty ??
+        false;
+    if (!hasUnconfirmedShares) return;
+    final sessionNotifier = ref.read(
+      votingSubmissionSessionProvider(key).notifier,
+    );
+    sessionNotifier.pinAutomaticShareTracking();
+    // Helper reveal is background work. Awaiting it in the job keeps the
+    // status screen on "Finalizing submission" for accepted-but-unrevealed
+    // shares. The registry, not the job guard, is the drain barrier.
+    unawaited(
+      sessionNotifier.submitPendingShares().catchError((
+        Object error,
+        StackTrace stack,
+      ) {
+        debugPrint(
+          '[zcash] Voting: background share tracking failed: $error\n$stack',
+        );
+      }),
+    );
   }
 
   void _scheduleCompletionPoll({

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -236,6 +236,21 @@ Future<DelegationPirPrecomputeResultView> precomputeDelegationPir({
   bundleIndex: bundleIndex,
 );
 
+/// Kick off process-lifetime Halo2 proving-key warm-up for voting proofs.
+///
+/// Safe to call repeatedly; only the first call starts work. Returns
+/// immediately so Dart can overlap warm-up with PIR resolve / bundle setup.
+void warmVotingProvingCaches() =>
+    RustLib.instance.api.crateApiVotingWarmVotingProvingCaches();
+
+/// Forwards a Dart-side vote-pipeline timing line into `frb_user` os_log.
+///
+/// Release Flutter builds do not surface `debugPrint` through `log show`, so
+/// cast-vote wall clocks that live in Dart (HTTP submit, confirmation wait,
+/// share posts, per-bundle chain summaries) go through this helper.
+void logVotingTiming({required String message}) =>
+    RustLib.instance.api.crateApiVotingLogVotingTiming(message: message);
+
 /// Streaming variant of `build_prove_and_sign_delegation_payload`.
 ///
 /// Emits local preparation phase events while work progresses, then emits a

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -243,14 +243,6 @@ Future<DelegationPirPrecomputeResultView> precomputeDelegationPir({
 void warmVotingProvingCaches() =>
     RustLib.instance.api.crateApiVotingWarmVotingProvingCaches();
 
-/// Forwards a Dart-side vote-pipeline timing line into `frb_user` os_log.
-///
-/// Release Flutter builds do not surface `debugPrint` through `log show`, so
-/// cast-vote wall clocks that live in Dart (HTTP submit, confirmation wait,
-/// share posts, per-bundle chain summaries) go through this helper.
-void logVotingTiming({required String message}) =>
-    RustLib.instance.api.crateApiVotingLogVotingTiming(message: message);
-
 /// Streaming variant of `build_prove_and_sign_delegation_payload`.
 ///
 /// Emits local preparation phase events while work progresses, then emits a

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -80,7 +80,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -310653252;
+  int get rustContentHash => -1543264106;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -767,8 +767,6 @@ abstract class RustLibApi extends BaseApi {
     required String dbPath,
     required List<String> accountUuids,
   });
-
-  void crateApiVotingLogVotingTiming({required String message});
 
   Future<void> crateApiVotingMarkDelegationSubmitted({
     required String dbPath,
@@ -5728,36 +5726,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  void crateApiVotingLogVotingTiming({required String message}) {
-    return handler.executeSync(
-      SyncTask(
-        callFfi: () {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(message, serializer);
-          return pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 110,
-          )!;
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: null,
-        ),
-        constMeta: kCrateApiVotingLogVotingTimingConstMeta,
-        argValues: [message],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiVotingLogVotingTimingConstMeta =>
-      const TaskConstMeta(
-        debugName: "log_voting_timing",
-        argNames: ["message"],
-      );
-
-  @override
   Future<void> crateApiVotingMarkDelegationSubmitted({
     required String dbPath,
     required String accountUuid,
@@ -5777,7 +5745,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5820,7 +5788,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5877,7 +5845,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5943,7 +5911,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 113,
             port: port_,
           );
         },
@@ -6013,7 +5981,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 114,
             port: port_,
           );
         },
@@ -6084,7 +6052,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 115,
             port: port_,
           );
         },
@@ -6134,7 +6102,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 116,
           )!;
         },
         codec: SseCodec(
@@ -6165,7 +6133,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 117,
             port: port_,
           );
         },
@@ -6198,7 +6166,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 118,
             port: port_,
           );
         },
@@ -6241,7 +6209,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 119,
             port: port_,
           );
         },
@@ -6295,7 +6263,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 120,
             port: port_,
           );
         },
@@ -6333,7 +6301,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 121,
             port: port_,
           );
         },
@@ -6378,7 +6346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 122,
             port: port_,
           );
         },
@@ -6438,7 +6406,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 123,
             port: port_,
           );
         },
@@ -6498,7 +6466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 124,
             port: port_,
           );
         },
@@ -6557,7 +6525,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 125,
             port: port_,
           );
         },
@@ -6610,7 +6578,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6669,7 +6637,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6731,7 +6699,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6779,7 +6747,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6838,7 +6806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6908,7 +6876,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6967,7 +6935,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 132,
             port: port_,
           );
         },
@@ -7014,7 +6982,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 133,
             port: port_,
           );
         },
@@ -7059,7 +7027,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 134,
             port: port_,
           );
         },
@@ -7089,7 +7057,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 135,
           )!;
         },
         codec: SseCodec(
@@ -7122,7 +7090,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 136,
             port: port_,
           );
         },
@@ -7159,7 +7127,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 137,
             port: port_,
           );
         },
@@ -7194,7 +7162,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 138,
             port: port_,
           );
         },
@@ -7236,7 +7204,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7271,7 +7239,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7312,7 +7280,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7361,7 +7329,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7399,7 +7367,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7454,7 +7422,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 144,
             port: port_,
           );
         },
@@ -7510,7 +7478,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 145,
           )!;
         },
         codec: SseCodec(
@@ -7554,7 +7522,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 146,
             port: port_,
           );
         },
@@ -7601,7 +7569,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 147,
           )!;
         },
         codec: SseCodec(
@@ -7631,7 +7599,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 148,
           )!;
         },
         codec: SseCodec(
@@ -7666,7 +7634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7699,7 +7667,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7734,7 +7702,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 151,
             port: port_,
           );
         },
@@ -7774,7 +7742,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7815,7 +7783,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7869,7 +7837,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7919,7 +7887,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 156,
+              funcId: 155,
               port: port_,
             );
           },
@@ -7960,7 +7928,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 157,
+              funcId: 156,
               port: port_,
             );
           },
@@ -7992,7 +7960,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 157,
             port: port_,
           );
         },
@@ -8019,7 +7987,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 158,
           )!;
         },
         codec: SseCodec(
@@ -8045,7 +8013,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 159,
             port: port_,
           );
         },
@@ -8087,7 +8055,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8143,7 +8111,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 161,
             port: port_,
           );
         },
@@ -8178,7 +8146,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8217,7 +8185,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8253,7 +8221,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8288,7 +8256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8325,7 +8293,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 166,
             port: port_,
           );
         },
@@ -8369,7 +8337,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8419,7 +8387,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8451,7 +8419,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8479,7 +8447,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 170,
           )!;
         },
         codec: SseCodec(
@@ -8511,7 +8479,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 171,
             port: port_,
           );
         },
@@ -8548,7 +8516,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8579,7 +8547,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 173,
           )!;
         },
         codec: SseCodec(
@@ -8605,7 +8573,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 174,
           )!;
         },
         codec: SseCodec(
@@ -8639,7 +8607,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 175,
             port: port_,
           );
         },
@@ -8676,7 +8644,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 176,
             port: port_,
           );
         },

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -80,7 +80,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 582226879;
+  int get rustContentHash => -310653252;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -768,6 +768,8 @@ abstract class RustLibApi extends BaseApi {
     required List<String> accountUuids,
   });
 
+  void crateApiVotingLogVotingTiming({required String message});
+
   Future<void> crateApiVotingMarkDelegationSubmitted({
     required String dbPath,
     required String accountUuid,
@@ -1198,6 +1200,8 @@ abstract class RustLibApi extends BaseApi {
   });
 
   bool crateApiWalletWalletExists({required String dbPath});
+
+  void crateApiVotingWarmVotingProvingCaches();
 
   Future<void> crateApiSyncWriteBlockMetadata({
     required String cachePath,
@@ -5724,6 +5728,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  void crateApiVotingLogVotingTiming({required String message}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(message, serializer);
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 110,
+          )!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiVotingLogVotingTimingConstMeta,
+        argValues: [message],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVotingLogVotingTimingConstMeta =>
+      const TaskConstMeta(
+        debugName: "log_voting_timing",
+        argNames: ["message"],
+      );
+
+  @override
   Future<void> crateApiVotingMarkDelegationSubmitted({
     required String dbPath,
     required String accountUuid,
@@ -5743,7 +5777,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5786,7 +5820,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5843,7 +5877,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5909,7 +5943,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
             port: port_,
           );
         },
@@ -5979,7 +6013,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -6050,7 +6084,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
             port: port_,
           );
         },
@@ -6100,7 +6134,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
           )!;
         },
         codec: SseCodec(
@@ -6131,7 +6165,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
             port: port_,
           );
         },
@@ -6164,7 +6198,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 119,
             port: port_,
           );
         },
@@ -6207,7 +6241,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 120,
             port: port_,
           );
         },
@@ -6261,7 +6295,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 121,
             port: port_,
           );
         },
@@ -6299,7 +6333,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 122,
             port: port_,
           );
         },
@@ -6344,7 +6378,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 123,
             port: port_,
           );
         },
@@ -6404,7 +6438,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 124,
             port: port_,
           );
         },
@@ -6464,7 +6498,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 125,
             port: port_,
           );
         },
@@ -6523,7 +6557,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6576,7 +6610,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6635,7 +6669,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6697,7 +6731,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6745,7 +6779,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6804,7 +6838,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6874,7 +6908,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6933,7 +6967,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6980,7 +7014,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 134,
             port: port_,
           );
         },
@@ -7025,7 +7059,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 135,
             port: port_,
           );
         },
@@ -7055,7 +7089,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 136,
           )!;
         },
         codec: SseCodec(
@@ -7088,7 +7122,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 137,
             port: port_,
           );
         },
@@ -7125,7 +7159,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 138,
             port: port_,
           );
         },
@@ -7160,7 +7194,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7202,7 +7236,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7237,7 +7271,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7278,7 +7312,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7327,7 +7361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7365,7 +7399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 144,
             port: port_,
           );
         },
@@ -7420,7 +7454,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7476,7 +7510,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
           )!;
         },
         codec: SseCodec(
@@ -7520,7 +7554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7567,7 +7601,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
           )!;
         },
         codec: SseCodec(
@@ -7597,7 +7631,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
           )!;
         },
         codec: SseCodec(
@@ -7632,7 +7666,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7665,7 +7699,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
             port: port_,
           );
         },
@@ -7700,7 +7734,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7740,7 +7774,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7781,7 +7815,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7835,7 +7869,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
             port: port_,
           );
         },
@@ -7885,7 +7919,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 155,
+              funcId: 156,
               port: port_,
             );
           },
@@ -7926,7 +7960,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 156,
+              funcId: 157,
               port: port_,
             );
           },
@@ -7958,7 +7992,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7985,7 +8019,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 159,
           )!;
         },
         codec: SseCodec(
@@ -8011,7 +8045,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8053,7 +8087,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
             port: port_,
           );
         },
@@ -8109,7 +8143,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8144,7 +8178,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8183,7 +8217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8219,7 +8253,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8254,7 +8288,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
             port: port_,
           );
         },
@@ -8291,7 +8325,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8335,7 +8369,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8385,7 +8419,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8417,7 +8451,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8445,7 +8479,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 171,
           )!;
         },
         codec: SseCodec(
@@ -8477,7 +8511,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8514,7 +8548,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 173,
             port: port_,
           );
         },
@@ -8545,7 +8579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 174,
           )!;
         },
         codec: SseCodec(
@@ -8563,6 +8597,35 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "wallet_exists", argNames: ["dbPath"]);
 
   @override
+  void crateApiVotingWarmVotingProvingCaches() {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 175,
+          )!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiVotingWarmVotingProvingCachesConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVotingWarmVotingProvingCachesConstMeta =>
+      const TaskConstMeta(
+        debugName: "warm_voting_proving_caches",
+        argNames: [],
+      );
+
+  @override
   Future<void> crateApiSyncWriteBlockMetadata({
     required String cachePath,
     required List<BlockMetaInfo> blocks,
@@ -8576,7 +8639,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 176,
             port: port_,
           );
         },
@@ -8613,7 +8676,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 177,
             port: port_,
           );
         },

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -19,7 +19,6 @@ class VotingApiClient {
     Duration timeout = const Duration(seconds: 10),
     Duration helperTimeout = const Duration(seconds: 5),
     Duration helperPreflightTimeout = const Duration(seconds: 2),
-    Duration helperPreflightTtl = const Duration(seconds: 10),
     VotingRetryPolicy? readRetryPolicy,
     VotingRetryPolicy? helperRetryPolicy,
     VotingRetryPolicy? broadcastRetryPolicy,
@@ -30,7 +29,6 @@ class VotingApiClient {
        _timeout = timeout,
        _helperTimeout = helperTimeout,
        _helperPreflightTimeout = helperPreflightTimeout,
-       _helperPreflightTtl = helperPreflightTtl,
        _readRetryPolicy =
            readRetryPolicy ??
            VotingRetryPolicy.transientHttp(
@@ -60,13 +58,10 @@ class VotingApiClient {
   final Duration _timeout;
   final Duration _helperTimeout;
   final Duration _helperPreflightTimeout;
-  final Duration _helperPreflightTtl;
   final VotingRetryPolicy _readRetryPolicy;
   final VotingRetryPolicy _helperRetryPolicy;
   final VotingRetryPolicy _broadcastRetryPolicy;
   final Future<void> Function(Duration delay) _delay;
-  final Map<String, _CachedHelperPreflight> _helperPreflightCache = {};
-  final Map<String, Future<bool>> _helperPreflightInFlight = {};
 
   /// Lists rounds from the vote server.
   ///
@@ -257,19 +252,13 @@ class VotingApiClient {
   /// Checks helper readiness concurrently without failing the voting flow.
   ///
   /// A helper is ready only when its public status endpoint returns a
-  /// successful `{"status":"ok"}` response. Results are cached briefly so
-  /// concurrent share batches do not repeatedly probe the same helpers.
+  /// successful `{"status":"ok"}` response.
   Future<Map<String, bool>> preflightHelpers(Iterable<Uri> serverUrls) async {
-    final uniqueServers = <String, Uri>{};
-    for (final serverUrl in serverUrls) {
-      uniqueServers.putIfAbsent(serverUrl.toString(), () => serverUrl);
-    }
     final entries = await Future.wait([
-      for (final entry in uniqueServers.entries)
-        _preflightHelper(
-          entry.key,
-          entry.value,
-        ).then((isReady) => MapEntry(entry.key, isReady)),
+      for (final serverUrl in serverUrls)
+        _probeHelper(
+          serverUrl,
+        ).then((isReady) => MapEntry(serverUrl.toString(), isReady)),
     ]);
     return Map<String, bool>.unmodifiable(Map.fromEntries(entries));
   }
@@ -278,9 +267,8 @@ class VotingApiClient {
   ///
   /// The share map is expected to be the complete service JSON body produced
   /// by the voting pipeline. Fast transient failures retain the helper retry
-  /// policy, but every attempt and backoff shares one [_helperTimeout] budget.
-  /// An ambiguous timeout is never retried against the same helper so the
-  /// caller can promptly move to another candidate.
+  /// policy. An ambiguous timeout is never retried against the same helper so
+  /// the caller can promptly move to another candidate.
   Future<VotingShareSubmissionResult> submitShare({
     required Uri serverUrl,
     required Map<String, dynamic> share,
@@ -385,32 +373,6 @@ class VotingApiClient {
     return jsonDecode(response.bodyText);
   }
 
-  Future<bool> _preflightHelper(String key, Uri serverUrl) async {
-    final current = DateTime.now();
-    final cached = _helperPreflightCache[key];
-    if (cached != null && current.isBefore(cached.expiresAt)) {
-      return cached.isReady;
-    }
-
-    final existing = _helperPreflightInFlight[key];
-    if (existing != null) return existing;
-
-    final probe = _probeHelper(serverUrl);
-    _helperPreflightInFlight[key] = probe;
-    try {
-      final isReady = await probe;
-      _helperPreflightCache[key] = _CachedHelperPreflight(
-        isReady: isReady,
-        expiresAt: DateTime.now().add(_helperPreflightTtl),
-      );
-      return isReady;
-    } finally {
-      if (identical(_helperPreflightInFlight[key], probe)) {
-        _helperPreflightInFlight.remove(key);
-      }
-    }
-  }
-
   Future<bool> _probeHelper(Uri serverUrl) async {
     final uri = _endpoint(['status'], baseUrl: serverUrl);
     try {
@@ -430,51 +392,25 @@ class VotingApiClient {
     Uri uri,
     Map<String, dynamic> body,
   ) async {
-    final budget = Stopwatch()..start();
-    Object? lastError;
-    StackTrace? lastStackTrace;
-    for (
-      var attempt = 0;
-      attempt <= _helperRetryPolicy.delays.length;
-      attempt++
-    ) {
-      final remaining = attempt == 0
-          ? _helperTimeout
-          : _helperTimeout - budget.elapsed;
-      if (remaining <= Duration.zero) {
-        if (lastError != null && lastStackTrace != null) {
-          Error.throwWithStackTrace(lastError, lastStackTrace);
-        }
-        throw TimeoutException(
-          'Helper submission budget exhausted for $uri',
-          _helperTimeout,
-        );
-      }
-      try {
+    final retryPolicy = VotingRetryPolicy(
+      name: '${_helperRetryPolicy.name}-initial',
+      delays: _helperRetryPolicy.delays,
+      shouldRetry: (error) =>
+          error is! TimeoutException && _helperRetryPolicy.shouldRetry(error),
+    );
+    final response = await _runRequestWithRetry(
+      retryPolicy: retryPolicy,
+      operation: () async {
         final response = await _post(
           uri,
           body,
-          timeout: remaining,
-        ).timeout(remaining);
+          timeout: _helperTimeout,
+        ).timeout(_helperTimeout);
         _throwIfNotSuccess(uri, response);
-        return jsonDecode(response.bodyText);
-      } catch (error, stackTrace) {
-        lastError = error;
-        lastStackTrace = stackTrace;
-        if (error is TimeoutException ||
-            attempt == _helperRetryPolicy.delays.length ||
-            !_helperRetryPolicy.shouldRetry(error)) {
-          rethrow;
-        }
-        final retryDelay = _helperRetryPolicy.delays[attempt];
-        final remainingAfterAttempt = _helperTimeout - budget.elapsed;
-        if (remainingAfterAttempt <= retryDelay) rethrow;
-        await _delay(retryDelay).timeout(remainingAfterAttempt);
-      }
-    }
-    throw StateError(
-      '${_helperRetryPolicy.name} retry exited unexpectedly: $lastError',
+        return response;
+      },
     );
+    return jsonDecode(response.bodyText);
   }
 
   Future<VotingHttpResponse> _get(Uri uri, {required Duration timeout}) {
@@ -567,16 +503,6 @@ class VotingApiClient {
     }
     return List<Uri>.unmodifiable(deduped);
   }
-}
-
-class _CachedHelperPreflight {
-  const _CachedHelperPreflight({
-    required this.isReady,
-    required this.expiresAt,
-  });
-
-  final bool isReady;
-  final DateTime expiresAt;
 }
 
 Map<String, dynamic> _objectFromValue(Object? value) {

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -227,18 +227,16 @@ class VotingApiClient {
   Future<VotingTxConfirmation?> getTxConfirmation(String txHash) async {
     final response = await _withVoteServerFailover(
       policy: _readRetryPolicy,
-      operation: (baseUrl) {
+      operation: (baseUrl) async {
         final requestUri = _endpoint(['tx', txHash], baseUrl: baseUrl);
-        return _runRequestWithRetry(
-          retryPolicy: _readRetryPolicy,
-          operation: () async {
-            final response = await _get(requestUri, timeout: _timeout);
-            if (response.statusCode != 404 && response.statusCode != 422) {
-              _throwIfNotSuccess(requestUri, response);
-            }
-            return response;
-          },
-        );
+        // Confirmation polling retries the complete lookup. Trying each server
+        // once per pass keeps one offline fallback from consuming the request
+        // timeout repeatedly before the next server gets a chance to answer.
+        final response = await _get(requestUri, timeout: _timeout);
+        if (response.statusCode != 404 && response.statusCode != 422) {
+          _throwIfNotSuccess(requestUri, response);
+        }
+        return response;
       },
       shouldTryNextCandidate: (response) => response.statusCode == 404,
     );

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -18,6 +18,8 @@ class VotingApiClient {
     List<Uri> fallbackBaseUrls = const [],
     Duration timeout = const Duration(seconds: 10),
     Duration helperTimeout = const Duration(seconds: 5),
+    Duration helperPreflightTimeout = const Duration(seconds: 2),
+    Duration helperPreflightTtl = const Duration(seconds: 10),
     VotingRetryPolicy? readRetryPolicy,
     VotingRetryPolicy? helperRetryPolicy,
     VotingRetryPolicy? broadcastRetryPolicy,
@@ -27,6 +29,8 @@ class VotingApiClient {
        _fallbackBaseUrls = _dedupeBaseUrls(fallbackBaseUrls, baseUrl: baseUrl),
        _timeout = timeout,
        _helperTimeout = helperTimeout,
+       _helperPreflightTimeout = helperPreflightTimeout,
+       _helperPreflightTtl = helperPreflightTtl,
        _readRetryPolicy =
            readRetryPolicy ??
            VotingRetryPolicy.transientHttp(
@@ -55,10 +59,14 @@ class VotingApiClient {
   final VotingHttpClient _httpClient;
   final Duration _timeout;
   final Duration _helperTimeout;
+  final Duration _helperPreflightTimeout;
+  final Duration _helperPreflightTtl;
   final VotingRetryPolicy _readRetryPolicy;
   final VotingRetryPolicy _helperRetryPolicy;
   final VotingRetryPolicy _broadcastRetryPolicy;
   final Future<void> Function(Duration delay) _delay;
+  final Map<String, _CachedHelperPreflight> _helperPreflightCache = {};
+  final Map<String, Future<bool>> _helperPreflightInFlight = {};
 
   /// Lists rounds from the vote server.
   ///
@@ -246,21 +254,40 @@ class VotingApiClient {
     );
   }
 
+  /// Checks helper readiness concurrently without failing the voting flow.
+  ///
+  /// A helper is ready only when its public status endpoint returns a
+  /// successful `{"status":"ok"}` response. Results are cached briefly so
+  /// concurrent share batches do not repeatedly probe the same helpers.
+  Future<Map<String, bool>> preflightHelpers(Iterable<Uri> serverUrls) async {
+    final uniqueServers = <String, Uri>{};
+    for (final serverUrl in serverUrls) {
+      uniqueServers.putIfAbsent(serverUrl.toString(), () => serverUrl);
+    }
+    final entries = await Future.wait([
+      for (final entry in uniqueServers.entries)
+        _preflightHelper(
+          entry.key,
+          entry.value,
+        ).then((isReady) => MapEntry(entry.key, isReady)),
+    ]);
+    return Map<String, bool>.unmodifiable(Map.fromEntries(entries));
+  }
+
   /// Posts one encrypted share directly to a helper server.
   ///
   /// The share map is expected to be the complete service JSON body produced
-  /// by the voting pipeline. This makes one transport attempt because the
-  /// caller already walks the remaining helper candidates after a failure.
-  /// Retrying an unresponsive helper here would delay that failover and a
-  /// timeout is ambiguous because the helper may have accepted the payload.
+  /// by the voting pipeline. Fast transient failures retain the helper retry
+  /// policy, but every attempt and backoff shares one [_helperTimeout] budget.
+  /// An ambiguous timeout is never retried against the same helper so the
+  /// caller can promptly move to another candidate.
   Future<VotingShareSubmissionResult> submitShare({
     required Uri serverUrl,
     required Map<String, dynamic> share,
   }) async {
-    final decoded = await _postJson(
+    final decoded = await _postInitialShareJson(
       _endpoint(['shares'], baseUrl: serverUrl),
       share,
-      timeout: _helperTimeout,
     );
     return VotingShareSubmissionResult.fromJson(_objectFromValue(decoded));
   }
@@ -358,6 +385,98 @@ class VotingApiClient {
     return jsonDecode(response.bodyText);
   }
 
+  Future<bool> _preflightHelper(String key, Uri serverUrl) async {
+    final current = DateTime.now();
+    final cached = _helperPreflightCache[key];
+    if (cached != null && current.isBefore(cached.expiresAt)) {
+      return cached.isReady;
+    }
+
+    final existing = _helperPreflightInFlight[key];
+    if (existing != null) return existing;
+
+    final probe = _probeHelper(serverUrl);
+    _helperPreflightInFlight[key] = probe;
+    try {
+      final isReady = await probe;
+      _helperPreflightCache[key] = _CachedHelperPreflight(
+        isReady: isReady,
+        expiresAt: DateTime.now().add(_helperPreflightTtl),
+      );
+      return isReady;
+    } finally {
+      if (identical(_helperPreflightInFlight[key], probe)) {
+        _helperPreflightInFlight.remove(key);
+      }
+    }
+  }
+
+  Future<bool> _probeHelper(Uri serverUrl) async {
+    final uri = _endpoint(['status'], baseUrl: serverUrl);
+    try {
+      final response = await _get(
+        uri,
+        timeout: _helperPreflightTimeout,
+      ).timeout(_helperPreflightTimeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) return false;
+      final status = _objectFromValue(jsonDecode(response.bodyText))['status'];
+      return status?.toString().trim().toLowerCase() == 'ok';
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<Object?> _postInitialShareJson(
+    Uri uri,
+    Map<String, dynamic> body,
+  ) async {
+    final budget = Stopwatch()..start();
+    Object? lastError;
+    StackTrace? lastStackTrace;
+    for (
+      var attempt = 0;
+      attempt <= _helperRetryPolicy.delays.length;
+      attempt++
+    ) {
+      final remaining = attempt == 0
+          ? _helperTimeout
+          : _helperTimeout - budget.elapsed;
+      if (remaining <= Duration.zero) {
+        if (lastError != null && lastStackTrace != null) {
+          Error.throwWithStackTrace(lastError, lastStackTrace);
+        }
+        throw TimeoutException(
+          'Helper submission budget exhausted for $uri',
+          _helperTimeout,
+        );
+      }
+      try {
+        final response = await _post(
+          uri,
+          body,
+          timeout: remaining,
+        ).timeout(remaining);
+        _throwIfNotSuccess(uri, response);
+        return jsonDecode(response.bodyText);
+      } catch (error, stackTrace) {
+        lastError = error;
+        lastStackTrace = stackTrace;
+        if (error is TimeoutException ||
+            attempt == _helperRetryPolicy.delays.length ||
+            !_helperRetryPolicy.shouldRetry(error)) {
+          rethrow;
+        }
+        final retryDelay = _helperRetryPolicy.delays[attempt];
+        final remainingAfterAttempt = _helperTimeout - budget.elapsed;
+        if (remainingAfterAttempt <= retryDelay) rethrow;
+        await _delay(retryDelay).timeout(remainingAfterAttempt);
+      }
+    }
+    throw StateError(
+      '${_helperRetryPolicy.name} retry exited unexpectedly: $lastError',
+    );
+  }
+
   Future<VotingHttpResponse> _get(Uri uri, {required Duration timeout}) {
     return _httpClient.get(uri, timeout: timeout);
   }
@@ -448,6 +567,16 @@ class VotingApiClient {
     }
     return List<Uri>.unmodifiable(deduped);
   }
+}
+
+class _CachedHelperPreflight {
+  const _CachedHelperPreflight({
+    required this.isReady,
+    required this.expiresAt,
+  });
+
+  final bool isReady;
+  final DateTime expiresAt;
 }
 
 Map<String, dynamic> _objectFromValue(Object? value) {

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -249,7 +249,10 @@ class VotingApiClient {
   /// Posts one encrypted share directly to a helper server.
   ///
   /// The share map is expected to be the complete service JSON body produced
-  /// by the voting pipeline.
+  /// by the voting pipeline. This makes one transport attempt because the
+  /// caller already walks the remaining helper candidates after a failure.
+  /// Retrying an unresponsive helper here would delay that failover and a
+  /// timeout is ambiguous because the helper may have accepted the payload.
   Future<VotingShareSubmissionResult> submitShare({
     required Uri serverUrl,
     required Map<String, dynamic> share,
@@ -258,7 +261,6 @@ class VotingApiClient {
       _endpoint(['shares'], baseUrl: serverUrl),
       share,
       timeout: _helperTimeout,
-      retryPolicy: _helperRetryPolicy,
     );
     return VotingShareSubmissionResult.fromJson(_objectFromValue(decoded));
   }

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -228,21 +228,27 @@ class VotingApiClient {
   }
 
   Future<VotingTxConfirmation?> getTxConfirmation(String txHash) async {
-    final response = await _withVoteServerFailover(
-      policy: _readRetryPolicy,
-      operation: (baseUrl) async {
-        final requestUri = _endpoint(['tx', txHash], baseUrl: baseUrl);
-        // Confirmation polling retries the complete lookup. Trying each server
-        // once per pass keeps one offline fallback from consuming the request
-        // timeout repeatedly before the next server gets a chance to answer.
-        final response = await _get(requestUri, timeout: _timeout);
-        if (response.statusCode != 404 && response.statusCode != 422) {
-          _throwIfNotSuccess(requestUri, response);
-        }
-        return response;
-      },
-      shouldTryNextCandidate: (response) => response.statusCode == 404,
-    );
+    final VotingHttpResponse response;
+    try {
+      response = await _withVoteServerFailover(
+        policy: _readRetryPolicy,
+        operation: (baseUrl) async {
+          final requestUri = _endpoint(['tx', txHash], baseUrl: baseUrl);
+          // Confirmation polling retries the complete lookup. Trying each
+          // server once per pass keeps one offline fallback from consuming the
+          // request timeout repeatedly before the next server gets a chance.
+          final response = await _get(requestUri, timeout: _timeout);
+          if (response.statusCode != 404 && response.statusCode != 422) {
+            _throwIfNotSuccess(requestUri, response);
+          }
+          return response;
+        },
+        shouldTryNextCandidate: (response) => response.statusCode == 404,
+      );
+    } catch (error) {
+      if (_readRetryPolicy.shouldRetry(error)) return null;
+      rethrow;
+    }
     if (response.statusCode == 404) return null;
     return VotingTxConfirmation.fromJson(
       _objectFromValue(jsonDecode(response.bodyText)),

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8511,9 +8511,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "3.1.0-rc.6"
+version = "3.1.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bd14a025fd4b3c0d8b78e01fc987025ee511c2a3a5b6b0d5ccf35c58cbe0ce"
+checksum = "26f676b1c1577ddd33286b2732dfbd8a391638b8c88a80b16582b62ad87aaf1e"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -116,7 +116,7 @@ version = "0.1.0-rc2"
 features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 [dependencies.zcash_voting]
-version = "=3.1.0-rc.6"
+version = "=3.1.0-rc.7"
 default-features = false
 features = ["zakura"]
 

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -791,6 +791,25 @@ pub async fn precompute_delegation_pir(
     .map(zcash_voting::wire::DelegationPirPrecomputeResultView::from)
 }
 
+/// Kick off process-lifetime Halo2 proving-key warm-up for voting proofs.
+///
+/// Safe to call repeatedly; only the first call starts work. Returns
+/// immediately so Dart can overlap warm-up with PIR resolve / bundle setup.
+#[flutter_rust_bridge::frb(sync)]
+pub fn warm_voting_proving_caches() {
+    delegation::start_proving_cache_warmup();
+}
+
+/// Forwards a Dart-side vote-pipeline timing line into `frb_user` os_log.
+///
+/// Release Flutter builds do not surface `debugPrint` through `log show`, so
+/// cast-vote wall clocks that live in Dart (HTTP submit, confirmation wait,
+/// share posts, per-bundle chain summaries) go through this helper.
+#[flutter_rust_bridge::frb(sync)]
+pub fn log_voting_timing(message: String) {
+    let _ = message;
+}
+
 /// Streaming variant of `build_prove_and_sign_delegation_payload`.
 ///
 /// Emits local preparation phase events while work progresses, then emits a
@@ -1954,6 +1973,12 @@ mod tests {
         assert_eq!(hotkey_a.len(), 64);
         assert_eq!(hotkey_b.len(), 64);
         assert_ne!(hotkey_a, hotkey_b);
+    }
+
+    #[test]
+    fn warm_voting_proving_caches_is_idempotent() {
+        warm_voting_proving_caches();
+        warm_voting_proving_caches();
     }
 
     #[test]

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1,9 +1,4 @@
-use std::{
-    panic,
-    path::Path,
-    sync::{Arc, Mutex},
-    time::Instant,
-};
+use std::{panic, path::Path, sync::Arc, time::Instant};
 
 #[cfg(test)]
 use super::voting_helpers::bundle_policy;
@@ -40,7 +35,7 @@ const PHASE_BUILDING_SHARE_PAYLOADS: &str = "building_share_payloads";
 const PHASE_SIGNING: &str = "signing";
 const PHASE_VOTE_COMMIT_STAGE: &str = "vote_commit_stage";
 
-/// Prefix for Release-visible cast-vote timings (`log show` subsystem `frb_user`).
+/// Prefix for coarse cast-vote stage timings (`log show` subsystem `frb_user`).
 const VOTING_VOTE_LOG: &str = "[VOTING_VOTE]";
 
 /// Return the shared last-moment helper-share buffer, in Unix seconds.
@@ -209,10 +204,6 @@ pub fn vote_commitment_wire_json(
     commitment: zcash_voting::wire::VoteCommitmentWire,
 ) -> Result<String, String> {
     catch(|| {
-        log::info!(
-            "{VOTING_VOTE_LOG} submit-encode proposal={}",
-            commitment.proposal_id
-        );
         // Serialize validated cast-vote commitment into chain wire JSON.
         commitment.to_json().map_err(|e| e.to_string())
     })
@@ -225,11 +216,6 @@ pub fn vote_share_wire_json(
     submit_at: u64,
 ) -> Result<String, String> {
     catch(|| {
-        log::info!(
-            "{VOTING_VOTE_LOG} share-encode bundle-proposal={} share={}",
-            share.proposal_id,
-            share.share_index
-        );
         // Bind late fields before emitting helper wire JSON.
         share
             .with_late_bound(vc_tree_position, submit_at)
@@ -817,16 +803,6 @@ pub fn warm_voting_proving_caches() {
     delegation::start_proving_cache_warmup();
 }
 
-/// Forwards a Dart-side vote-pipeline timing line into `frb_user` os_log.
-///
-/// Release Flutter builds do not surface `debugPrint` through `log show`, so
-/// cast-vote wall clocks that live in Dart (HTTP submit, confirmation wait,
-/// share posts, per-bundle chain summaries) go through this helper.
-#[flutter_rust_bridge::frb(sync)]
-pub fn log_voting_timing(message: String) {
-    log::info!("{VOTING_VOTE_LOG} {message}");
-}
-
 /// Streaming variant of `build_prove_and_sign_delegation_payload`.
 ///
 /// Emits local preparation phase events while work progresses, then emits a
@@ -846,29 +822,12 @@ pub async fn build_prove_and_sign_delegation_payload_with_progress(
     bundle_index: u32,
     sink: StreamSink<ApiDelegationProofEvent>,
 ) -> Result<(), String> {
-    let total_started = Instant::now();
-    log::info!("[VOTING_PROVE] bundle={bundle_index} api-start");
     // Resolve static delegation inputs and validate the app-owned stored hotkey.
-    let static_inputs_started = Instant::now();
     let (voting_network, bundle_policy) =
         delegation_static_inputs(&ctx.network, ctx.max_real_notes_per_bundle)?;
-    log::info!(
-        "[VOTING_PROVE] bundle={bundle_index} static-inputs elapsed={:.3}s",
-        static_inputs_started.elapsed().as_secs_f64()
-    );
-    let seed_started = Instant::now();
     let seed = seed_from_mnemonic(mnemonic)?;
-    log::info!(
-        "[VOTING_PROVE] bundle={bundle_index} seed elapsed={:.3}s",
-        seed_started.elapsed().as_secs_f64()
-    );
-    let hotkey_started = Instant::now();
     let voting_hotkey =
         hotkey::voting_hotkey_from_stored_secret(stored_hotkey_secret, voting_network)?;
-    log::info!(
-        "[VOTING_PROVE] bundle={bundle_index} hotkey elapsed={:.3}s",
-        hotkey_started.elapsed().as_secs_f64()
-    );
 
     // Resolve lightwalletd inputs and assemble delegation prepare parameters.
     let lwd_started = Instant::now();
@@ -883,7 +842,6 @@ pub async fn build_prove_and_sign_delegation_payload_with_progress(
         "[VOTING_PROVE] bundle={bundle_index} lwd-inputs elapsed={:.3}s",
         lwd_started.elapsed().as_secs_f64()
     );
-    let prepare_params_started = Instant::now();
     let prepare_params = prepare_delegation_bundle_params(
         lwd,
         ctx.session_json.as_deref(),
@@ -892,16 +850,12 @@ pub async fn build_prove_and_sign_delegation_payload_with_progress(
         bundle_index,
         bundle_policy,
     );
-    log::info!(
-        "[VOTING_PROVE] bundle={bundle_index} prepare-params elapsed={:.3}s",
-        prepare_params_started.elapsed().as_secs_f64()
-    );
 
     // Stream local progress events and emit one final result/error event.
     let sink = Arc::new(sink);
     let progress_sink = sink.clone();
     let wallet_flow_started = Instant::now();
-    let delegation_result = delegation::build_prove_and_sign_delegation_payload(
+    let signed_result = delegation::build_prove_and_sign_delegation_payload(
         &ctx.db_path,
         &pir_server_url,
         ctx.pir_layout,
@@ -913,27 +867,15 @@ pub async fn build_prove_and_sign_delegation_payload_with_progress(
             }
         },
     )
-    .await;
+    .await
+    .and_then(|bundle| {
+        zcash_voting::wire::SignedDelegationPayloadView::try_from(bundle).map_err(|e| e.to_string())
+    });
     log::info!(
         "[VOTING_PROVE] bundle={bundle_index} wallet-prove-sign elapsed={:.3}s",
         wallet_flow_started.elapsed().as_secs_f64()
     );
-    let conversion_started = Instant::now();
-    let signed_result = delegation_result.and_then(|bundle| {
-        zcash_voting::wire::SignedDelegationPayloadView::try_from(bundle).map_err(|e| e.to_string())
-    });
-    log::info!(
-        "[VOTING_PROVE] bundle={bundle_index} wire-conversion elapsed={:.3}s",
-        conversion_started.elapsed().as_secs_f64()
-    );
-    let emit_started = Instant::now();
-    let result = emit_signed_delegation_result(sink.as_ref(), signed_result);
-    log::info!(
-        "[VOTING_PROVE] bundle={bundle_index} emit elapsed={:.3}s total={:.3}s",
-        emit_started.elapsed().as_secs_f64(),
-        total_started.elapsed().as_secs_f64()
-    );
-    result
+    emit_signed_delegation_result(sink.as_ref(), signed_result)
 }
 
 /// Build and redact voting PCZTs that Keystone can sign in one or more batches.
@@ -1294,9 +1236,8 @@ pub fn sync_vote_tree(
     node_url: String,
 ) -> Result<u32, String> {
     catch(|| {
-        let started = Instant::now();
-        log::info!("{VOTING_VOTE_LOG} sync-tree start round={round_id}");
         // Sync and cache vote tree state for this wallet/round.
+        let started = Instant::now();
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         let height = zcash_voting::precompute::sync_vote_tree(&db, &round_id, &node_url)
             .map_err(|e| format!("sync_vote_tree failed: {e}"))?;
@@ -1326,9 +1267,6 @@ pub fn generate_van_witness(
 ) -> Result<zcash_voting::wire::VanWitness, String> {
     catch(|| {
         let started = Instant::now();
-        log::info!(
-            "{VOTING_VOTE_LOG} van-witness start bundle={bundle_index} anchor={anchor_height}"
-        );
         let db = db::open_voting_db(&db_path, &account_uuid)?;
 
         // Validate bundle index against persisted bundle count first.
@@ -1509,26 +1447,14 @@ pub fn recover_vote_commitment(
     proposal_id: u32,
 ) -> Result<zcash_voting::wire::SignedVoteCommitmentsView, String> {
     catch(|| {
-        let started = Instant::now();
-        log::info!("{VOTING_VOTE_LOG} recover-start bundle={bundle_index} proposal={proposal_id}");
         // Recover persisted commitments and convert to public wire view.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
-        let commitments = zcash_voting::vote::recover_signed_commitments(
-            &db,
-            &round_id,
-            bundle_index,
-            proposal_id,
-        )
-        .map_err(|e| format!("vote commitment recovery failed: {e}"))
-        .and_then(|commitments| {
-            zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments)
-                .map_err(|e| e.to_string())
-        })?;
-        log::info!(
-            "{VOTING_VOTE_LOG} recover-complete bundle={bundle_index} proposal={proposal_id} elapsed={:.3}s",
-            started.elapsed().as_secs_f64()
-        );
-        Ok(commitments)
+        zcash_voting::vote::recover_signed_commitments(&db, &round_id, bundle_index, proposal_id)
+            .map_err(|e| format!("vote commitment recovery failed: {e}"))
+            .and_then(|commitments| {
+                zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments)
+                    .map_err(|e| e.to_string())
+            })
     })
 }
 
@@ -1558,74 +1484,15 @@ where
         .join(",");
     log::info!("{VOTING_VOTE_LOG} bundle={bundle_index} prove-start proposals=[{proposal_label}]");
 
-    let stage_last = Mutex::new(Instant::now());
-    let stage_total = Instant::now();
-    let logged_on_stage = move |stage: zcash_voting::vote::VoteCommitStage| {
-        let step_s = stage_last
-            .lock()
-            .map(|mut last| {
-                let step = last.elapsed().as_secs_f64();
-                *last = Instant::now();
-                step
-            })
-            .unwrap_or(0.0);
-        let total_s = stage_total.elapsed().as_secs_f64();
-        match &stage {
-            zcash_voting::vote::VoteCommitStage::ProofStarting {
-                proposal_id,
-                bundle_index,
-            } => log::info!(
-                "{VOTING_VOTE_LOG} bundle={bundle_index} proposal={proposal_id} event=ProofStarting step={step_s:.3}s total={total_s:.3}s"
-            ),
-            zcash_voting::vote::VoteCommitStage::ProofProgress {
-                proposal_id,
-                bundle_index,
-                progress,
-            } => log::info!(
-                "{VOTING_VOTE_LOG} bundle={bundle_index} proposal={proposal_id} event=ProofProgress({progress:.1}) step={step_s:.3}s total={total_s:.3}s"
-            ),
-            zcash_voting::vote::VoteCommitStage::SharePayloadsBuilding {
-                proposal_id,
-                bundle_index,
-            } => log::info!(
-                "{VOTING_VOTE_LOG} bundle={bundle_index} proposal={proposal_id} event=SharePayloadsBuilding step={step_s:.3}s total={total_s:.3}s"
-            ),
-            zcash_voting::vote::VoteCommitStage::Signing {
-                proposal_id,
-                bundle_index,
-            } => log::info!(
-                "{VOTING_VOTE_LOG} bundle={bundle_index} proposal={proposal_id} event=Signing step={step_s:.3}s total={total_s:.3}s"
-            ),
-            _ => log::info!(
-                "{VOTING_VOTE_LOG} bundle={bundle_index} event={stage:?} step={step_s:.3}s total={total_s:.3}s"
-            ),
-        }
-        on_stage(stage);
-    };
-
     // Commit/prove work is CPU-heavy; run it on a blocking worker thread.
     let commitment_result = tokio::task::spawn_blocking(move || {
-        log::info!(
-            "{VOTING_VOTE_LOG} bundle={bundle_index} worker-start queue_wait={:.3}s",
-            total_started.elapsed().as_secs_f64()
-        );
-        let reporter = zcash_voting::VoteCommitStageBridge::new(logged_on_stage);
-        let db_started = Instant::now();
+        let reporter = zcash_voting::VoteCommitStageBridge::new(on_stage);
         let voting_db = db::open_voting_db(&db_path, &account_uuid)?;
-        log::info!(
-            "{VOTING_VOTE_LOG} bundle={bundle_index} db-open elapsed={:.3}s",
-            db_started.elapsed().as_secs_f64()
-        );
-        let hotkey_started = Instant::now();
         let voting_hotkey = zcash_voting::VotingHotkey::from_stored_secret(
             stored_hotkey_secret.expose_secret(),
             voting_network(network),
         )
         .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
-        log::info!(
-            "{VOTING_VOTE_LOG} bundle={bundle_index} hotkey elapsed={:.3}s",
-            hotkey_started.elapsed().as_secs_f64()
-        );
 
         let prepare_started = Instant::now();
         let prepared = zcash_voting::vote::prepare_commit_batch(
@@ -1662,15 +1529,8 @@ where
     let commitments = commitment_result?;
 
     // Convert internal commitment type into the FRB wire view.
-    let wire_started = Instant::now();
-    let view = zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments)
-        .map_err(|e| e.to_string())?;
-    log::info!(
-        "{VOTING_VOTE_LOG} bundle={bundle_index} emit elapsed={:.3}s total={:.3}s",
-        wire_started.elapsed().as_secs_f64(),
-        total_started.elapsed().as_secs_f64()
-    );
-    Ok(view)
+    zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments)
+        .map_err(|e| e.to_string())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1744,18 +1604,12 @@ pub fn mark_vote_submitted(
     tx_hash: String,
 ) -> Result<(), String> {
     catch(|| {
-        let started = Instant::now();
         db::with_voting_sidecar_write_lock(&db_path, || {
             // Persist submission hash for this round/bundle/proposal key.
             let db = db::open_voting_db(&db_path, &account_uuid)?;
             db.mark_vote_submitted(&round_id, bundle_index, proposal_id, &tx_hash)
                 .map_err(|e| e.to_string())
-        })?;
-        log::info!(
-            "{VOTING_VOTE_LOG} mark-submitted bundle={bundle_index} proposal={proposal_id} elapsed={:.3}s",
-            started.elapsed().as_secs_f64()
-        );
-        Ok(())
+        })
     })
 }
 
@@ -1775,9 +1629,8 @@ pub fn confirm_vote_submission(
     events_json: String,
 ) -> Result<zcash_voting::wire::VoteConfirmation, String> {
     catch(|| {
-        let started = Instant::now();
         let events = parse_tx_events_json(&events_json)?;
-        let confirmation = db::with_voting_sidecar_write_lock(&db_path, || {
+        db::with_voting_sidecar_write_lock(&db_path, || {
             // Parse tx events and persist vote confirmation fields.
             let db = db::open_voting_db(&db_path, &account_uuid)?;
             zcash_voting::confirmation::confirm_vote_submission(
@@ -1789,12 +1642,7 @@ pub fn confirm_vote_submission(
                 &events,
             )
             .map_err(|e| e.to_string())
-        })?;
-        log::info!(
-            "{VOTING_VOTE_LOG} confirm-persist bundle={bundle_index} proposal={proposal_id} elapsed={:.3}s",
-            started.elapsed().as_secs_f64()
-        );
-        Ok(confirmation)
+        })
     })
 }
 
@@ -1822,7 +1670,6 @@ pub fn record_share_delegation(
     submit_at: u64,
 ) -> Result<(), String> {
     catch(|| {
-        let started = Instant::now();
         db::with_voting_sidecar_write_lock(&db_path, || {
             let db = db::open_voting_db(&db_path, &account_uuid)?;
             // Recover vote context first, then persist helper submission metadata.
@@ -1830,12 +1677,7 @@ pub fn record_share_delegation(
                 .map_err(|e| format!("recover committed vote failed: {e}"))?
                 .record_share(&db, share_index, &sent_to_urls, submit_at)
                 .map_err(|e| format!("record_share_delegation failed: {e}"))
-        })?;
-        log::info!(
-            "{VOTING_VOTE_LOG} record-share bundle={bundle_index} proposal={proposal_id} share={share_index} elapsed={:.3}s",
-            started.elapsed().as_secs_f64()
-        );
-        Ok(())
+        })
     })
 }
 

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1,4 +1,9 @@
-use std::{panic, path::Path, sync::Arc};
+use std::{
+    panic,
+    path::Path,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
 
 #[cfg(test)]
 use super::voting_helpers::bundle_policy;
@@ -34,6 +39,9 @@ const PHASE_DELEGATION_PROGRESS: &str = "delegation_progress";
 const PHASE_BUILDING_SHARE_PAYLOADS: &str = "building_share_payloads";
 const PHASE_SIGNING: &str = "signing";
 const PHASE_VOTE_COMMIT_STAGE: &str = "vote_commit_stage";
+
+/// Prefix for Release-visible cast-vote timings (`log show` subsystem `frb_user`).
+const VOTING_VOTE_LOG: &str = "[VOTING_VOTE]";
 
 /// Return the shared last-moment helper-share buffer, in Unix seconds.
 #[flutter_rust_bridge::frb(sync)]
@@ -201,6 +209,10 @@ pub fn vote_commitment_wire_json(
     commitment: zcash_voting::wire::VoteCommitmentWire,
 ) -> Result<String, String> {
     catch(|| {
+        log::info!(
+            "{VOTING_VOTE_LOG} submit-encode proposal={}",
+            commitment.proposal_id
+        );
         // Serialize validated cast-vote commitment into chain wire JSON.
         commitment.to_json().map_err(|e| e.to_string())
     })
@@ -213,6 +225,11 @@ pub fn vote_share_wire_json(
     submit_at: u64,
 ) -> Result<String, String> {
     catch(|| {
+        log::info!(
+            "{VOTING_VOTE_LOG} share-encode bundle-proposal={} share={}",
+            share.proposal_id,
+            share.share_index
+        );
         // Bind late fields before emitting helper wire JSON.
         share
             .with_late_bound(vc_tree_position, submit_at)
@@ -807,7 +824,7 @@ pub fn warm_voting_proving_caches() {
 /// share posts, per-bundle chain summaries) go through this helper.
 #[flutter_rust_bridge::frb(sync)]
 pub fn log_voting_timing(message: String) {
-    let _ = message;
+    log::info!("{VOTING_VOTE_LOG} {message}");
 }
 
 /// Streaming variant of `build_prove_and_sign_delegation_payload`.
@@ -829,14 +846,32 @@ pub async fn build_prove_and_sign_delegation_payload_with_progress(
     bundle_index: u32,
     sink: StreamSink<ApiDelegationProofEvent>,
 ) -> Result<(), String> {
+    let total_started = Instant::now();
+    log::info!("[VOTING_PROVE] bundle={bundle_index} api-start");
     // Resolve static delegation inputs and validate the app-owned stored hotkey.
+    let static_inputs_started = Instant::now();
     let (voting_network, bundle_policy) =
         delegation_static_inputs(&ctx.network, ctx.max_real_notes_per_bundle)?;
+    log::info!(
+        "[VOTING_PROVE] bundle={bundle_index} static-inputs elapsed={:.3}s",
+        static_inputs_started.elapsed().as_secs_f64()
+    );
+    let seed_started = Instant::now();
     let seed = seed_from_mnemonic(mnemonic)?;
+    log::info!(
+        "[VOTING_PROVE] bundle={bundle_index} seed elapsed={:.3}s",
+        seed_started.elapsed().as_secs_f64()
+    );
+    let hotkey_started = Instant::now();
     let voting_hotkey =
         hotkey::voting_hotkey_from_stored_secret(stored_hotkey_secret, voting_network)?;
+    log::info!(
+        "[VOTING_PROVE] bundle={bundle_index} hotkey elapsed={:.3}s",
+        hotkey_started.elapsed().as_secs_f64()
+    );
 
     // Resolve lightwalletd inputs and assemble delegation prepare parameters.
+    let lwd_started = Instant::now();
     let lwd = resolve_delegation_lwd_inputs(
         &ctx.lightwalletd_url,
         ctx.round_params,
@@ -844,6 +879,11 @@ pub async fn build_prove_and_sign_delegation_payload_with_progress(
         voting_network,
     )
     .await?;
+    log::info!(
+        "[VOTING_PROVE] bundle={bundle_index} lwd-inputs elapsed={:.3}s",
+        lwd_started.elapsed().as_secs_f64()
+    );
+    let prepare_params_started = Instant::now();
     let prepare_params = prepare_delegation_bundle_params(
         lwd,
         ctx.session_json.as_deref(),
@@ -852,11 +892,16 @@ pub async fn build_prove_and_sign_delegation_payload_with_progress(
         bundle_index,
         bundle_policy,
     );
+    log::info!(
+        "[VOTING_PROVE] bundle={bundle_index} prepare-params elapsed={:.3}s",
+        prepare_params_started.elapsed().as_secs_f64()
+    );
 
     // Stream local progress events and emit one final result/error event.
     let sink = Arc::new(sink);
     let progress_sink = sink.clone();
-    let signed_result = delegation::build_prove_and_sign_delegation_payload(
+    let wallet_flow_started = Instant::now();
+    let delegation_result = delegation::build_prove_and_sign_delegation_payload(
         &ctx.db_path,
         &pir_server_url,
         ctx.pir_layout,
@@ -868,11 +913,27 @@ pub async fn build_prove_and_sign_delegation_payload_with_progress(
             }
         },
     )
-    .await
-    .and_then(|bundle| {
+    .await;
+    log::info!(
+        "[VOTING_PROVE] bundle={bundle_index} wallet-prove-sign elapsed={:.3}s",
+        wallet_flow_started.elapsed().as_secs_f64()
+    );
+    let conversion_started = Instant::now();
+    let signed_result = delegation_result.and_then(|bundle| {
         zcash_voting::wire::SignedDelegationPayloadView::try_from(bundle).map_err(|e| e.to_string())
     });
-    emit_signed_delegation_result(sink.as_ref(), signed_result)
+    log::info!(
+        "[VOTING_PROVE] bundle={bundle_index} wire-conversion elapsed={:.3}s",
+        conversion_started.elapsed().as_secs_f64()
+    );
+    let emit_started = Instant::now();
+    let result = emit_signed_delegation_result(sink.as_ref(), signed_result);
+    log::info!(
+        "[VOTING_PROVE] bundle={bundle_index} emit elapsed={:.3}s total={:.3}s",
+        emit_started.elapsed().as_secs_f64(),
+        total_started.elapsed().as_secs_f64()
+    );
+    result
 }
 
 /// Build and redact voting PCZTs that Keystone can sign in one or more batches.
@@ -1233,10 +1294,17 @@ pub fn sync_vote_tree(
     node_url: String,
 ) -> Result<u32, String> {
     catch(|| {
+        let started = Instant::now();
+        log::info!("{VOTING_VOTE_LOG} sync-tree start round={round_id}");
         // Sync and cache vote tree state for this wallet/round.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
-        zcash_voting::precompute::sync_vote_tree(&db, &round_id, &node_url)
-            .map_err(|e| format!("sync_vote_tree failed: {e}"))
+        let height = zcash_voting::precompute::sync_vote_tree(&db, &round_id, &node_url)
+            .map_err(|e| format!("sync_vote_tree failed: {e}"))?;
+        log::info!(
+            "{VOTING_VOTE_LOG} sync-tree complete round={round_id} height={height} elapsed={:.3}s",
+            started.elapsed().as_secs_f64()
+        );
+        Ok(height)
     })
 }
 
@@ -1257,6 +1325,10 @@ pub fn generate_van_witness(
     anchor_height: u32,
 ) -> Result<zcash_voting::wire::VanWitness, String> {
     catch(|| {
+        let started = Instant::now();
+        log::info!(
+            "{VOTING_VOTE_LOG} van-witness start bundle={bundle_index} anchor={anchor_height}"
+        );
         let db = db::open_voting_db(&db_path, &account_uuid)?;
 
         // Validate bundle index against persisted bundle count first.
@@ -1265,8 +1337,15 @@ pub fn generate_van_witness(
             .map_err(|e| format!("get_bundle_count failed: {e}"))?;
         zcash_voting::validate_bundle_index(bundle_count, bundle_index, "voting")
             .map_err(|e| e.to_string())?;
-        zcash_voting::precompute::van_witness(&db, &round_id, bundle_index, anchor_height)
-            .map_err(|e| format!("generate_van_witness failed: {e}"))
+        let witness =
+            zcash_voting::precompute::van_witness(&db, &round_id, bundle_index, anchor_height)
+                .map_err(|e| format!("generate_van_witness failed: {e}"))?;
+        log::info!(
+            "{VOTING_VOTE_LOG} van-witness complete bundle={bundle_index} position={} elapsed={:.3}s",
+            witness.position,
+            started.elapsed().as_secs_f64()
+        );
+        Ok(witness)
     })
 }
 
@@ -1430,14 +1509,26 @@ pub fn recover_vote_commitment(
     proposal_id: u32,
 ) -> Result<zcash_voting::wire::SignedVoteCommitmentsView, String> {
     catch(|| {
+        let started = Instant::now();
+        log::info!("{VOTING_VOTE_LOG} recover-start bundle={bundle_index} proposal={proposal_id}");
         // Recover persisted commitments and convert to public wire view.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
-        zcash_voting::vote::recover_signed_commitments(&db, &round_id, bundle_index, proposal_id)
-            .map_err(|e| format!("vote commitment recovery failed: {e}"))
-            .and_then(|commitments| {
-                zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments)
-                    .map_err(|e| e.to_string())
-            })
+        let commitments = zcash_voting::vote::recover_signed_commitments(
+            &db,
+            &round_id,
+            bundle_index,
+            proposal_id,
+        )
+        .map_err(|e| format!("vote commitment recovery failed: {e}"))
+        .and_then(|commitments| {
+            zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments)
+                .map_err(|e| e.to_string())
+        })?;
+        log::info!(
+            "{VOTING_VOTE_LOG} recover-complete bundle={bundle_index} proposal={proposal_id} elapsed={:.3}s",
+            started.elapsed().as_secs_f64()
+        );
+        Ok(commitments)
     })
 }
 
@@ -1459,18 +1550,84 @@ where
     // Parse network once and keep hotkey bytes in a secrecy wrapper.
     let network = keys::parse_network(&network)?;
     let stored_hotkey_secret = secrecy::SecretVec::new(stored_hotkey_secret);
+    let total_started = Instant::now();
+    let proposal_label = draft_votes
+        .iter()
+        .map(|draft| draft.proposal_id.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    log::info!("{VOTING_VOTE_LOG} bundle={bundle_index} prove-start proposals=[{proposal_label}]");
 
+    let stage_last = Mutex::new(Instant::now());
+    let stage_total = Instant::now();
+    let logged_on_stage = move |stage: zcash_voting::vote::VoteCommitStage| {
+        let step_s = stage_last
+            .lock()
+            .map(|mut last| {
+                let step = last.elapsed().as_secs_f64();
+                *last = Instant::now();
+                step
+            })
+            .unwrap_or(0.0);
+        let total_s = stage_total.elapsed().as_secs_f64();
+        match &stage {
+            zcash_voting::vote::VoteCommitStage::ProofStarting {
+                proposal_id,
+                bundle_index,
+            } => log::info!(
+                "{VOTING_VOTE_LOG} bundle={bundle_index} proposal={proposal_id} event=ProofStarting step={step_s:.3}s total={total_s:.3}s"
+            ),
+            zcash_voting::vote::VoteCommitStage::ProofProgress {
+                proposal_id,
+                bundle_index,
+                progress,
+            } => log::info!(
+                "{VOTING_VOTE_LOG} bundle={bundle_index} proposal={proposal_id} event=ProofProgress({progress:.1}) step={step_s:.3}s total={total_s:.3}s"
+            ),
+            zcash_voting::vote::VoteCommitStage::SharePayloadsBuilding {
+                proposal_id,
+                bundle_index,
+            } => log::info!(
+                "{VOTING_VOTE_LOG} bundle={bundle_index} proposal={proposal_id} event=SharePayloadsBuilding step={step_s:.3}s total={total_s:.3}s"
+            ),
+            zcash_voting::vote::VoteCommitStage::Signing {
+                proposal_id,
+                bundle_index,
+            } => log::info!(
+                "{VOTING_VOTE_LOG} bundle={bundle_index} proposal={proposal_id} event=Signing step={step_s:.3}s total={total_s:.3}s"
+            ),
+            _ => log::info!(
+                "{VOTING_VOTE_LOG} bundle={bundle_index} event={stage:?} step={step_s:.3}s total={total_s:.3}s"
+            ),
+        }
+        on_stage(stage);
+    };
 
     // Commit/prove work is CPU-heavy; run it on a blocking worker thread.
     let commitment_result = tokio::task::spawn_blocking(move || {
-        let reporter = zcash_voting::VoteCommitStageBridge::new(on_stage);
+        log::info!(
+            "{VOTING_VOTE_LOG} bundle={bundle_index} worker-start queue_wait={:.3}s",
+            total_started.elapsed().as_secs_f64()
+        );
+        let reporter = zcash_voting::VoteCommitStageBridge::new(logged_on_stage);
+        let db_started = Instant::now();
         let voting_db = db::open_voting_db(&db_path, &account_uuid)?;
+        log::info!(
+            "{VOTING_VOTE_LOG} bundle={bundle_index} db-open elapsed={:.3}s",
+            db_started.elapsed().as_secs_f64()
+        );
+        let hotkey_started = Instant::now();
         let voting_hotkey = zcash_voting::VotingHotkey::from_stored_secret(
             stored_hotkey_secret.expose_secret(),
             voting_network(network),
         )
         .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
+        log::info!(
+            "{VOTING_VOTE_LOG} bundle={bundle_index} hotkey elapsed={:.3}s",
+            hotkey_started.elapsed().as_secs_f64()
+        );
 
+        let prepare_started = Instant::now();
         let prepared = zcash_voting::vote::prepare_commit_batch(
             &voting_db,
             zcash_voting::vote::VoteSigner::hotkey(&voting_hotkey),
@@ -1483,10 +1640,20 @@ where
             },
         )
         .map_err(|e| format!("vote commit batch preparation failed: {e}"))?;
+        log::info!(
+            "{VOTING_VOTE_LOG} bundle={bundle_index} prepare-batch elapsed={:.3}s",
+            prepare_started.elapsed().as_secs_f64()
+        );
+        let persist_started = Instant::now();
         let persisted = db::with_voting_sidecar_write_lock(&db_path, || {
             zcash_voting::vote::persist_prepared_commit_batch(&voting_db, prepared)
                 .map_err(|e| format!("vote commit batch persistence failed: {e}"))
         })?;
+        log::info!(
+            "{VOTING_VOTE_LOG} bundle={bundle_index} persist-batch elapsed={:.3}s worker_total={:.3}s",
+            persist_started.elapsed().as_secs_f64(),
+            total_started.elapsed().as_secs_f64()
+        );
         Ok(persisted)
     })
     .await
@@ -1495,7 +1662,15 @@ where
     let commitments = commitment_result?;
 
     // Convert internal commitment type into the FRB wire view.
-    zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments).map_err(|e| e.to_string())
+    let wire_started = Instant::now();
+    let view = zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments)
+        .map_err(|e| e.to_string())?;
+    log::info!(
+        "{VOTING_VOTE_LOG} bundle={bundle_index} emit elapsed={:.3}s total={:.3}s",
+        wire_started.elapsed().as_secs_f64(),
+        total_started.elapsed().as_secs_f64()
+    );
+    Ok(view)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1569,12 +1744,17 @@ pub fn mark_vote_submitted(
     tx_hash: String,
 ) -> Result<(), String> {
     catch(|| {
+        let started = Instant::now();
         db::with_voting_sidecar_write_lock(&db_path, || {
             // Persist submission hash for this round/bundle/proposal key.
             let db = db::open_voting_db(&db_path, &account_uuid)?;
             db.mark_vote_submitted(&round_id, bundle_index, proposal_id, &tx_hash)
                 .map_err(|e| e.to_string())
         })?;
+        log::info!(
+            "{VOTING_VOTE_LOG} mark-submitted bundle={bundle_index} proposal={proposal_id} elapsed={:.3}s",
+            started.elapsed().as_secs_f64()
+        );
         Ok(())
     })
 }
@@ -1595,6 +1775,7 @@ pub fn confirm_vote_submission(
     events_json: String,
 ) -> Result<zcash_voting::wire::VoteConfirmation, String> {
     catch(|| {
+        let started = Instant::now();
         let events = parse_tx_events_json(&events_json)?;
         let confirmation = db::with_voting_sidecar_write_lock(&db_path, || {
             // Parse tx events and persist vote confirmation fields.
@@ -1609,6 +1790,10 @@ pub fn confirm_vote_submission(
             )
             .map_err(|e| e.to_string())
         })?;
+        log::info!(
+            "{VOTING_VOTE_LOG} confirm-persist bundle={bundle_index} proposal={proposal_id} elapsed={:.3}s",
+            started.elapsed().as_secs_f64()
+        );
         Ok(confirmation)
     })
 }
@@ -1637,6 +1822,7 @@ pub fn record_share_delegation(
     submit_at: u64,
 ) -> Result<(), String> {
     catch(|| {
+        let started = Instant::now();
         db::with_voting_sidecar_write_lock(&db_path, || {
             let db = db::open_voting_db(&db_path, &account_uuid)?;
             // Recover vote context first, then persist helper submission metadata.
@@ -1645,6 +1831,10 @@ pub fn record_share_delegation(
                 .record_share(&db, share_index, &sent_to_urls, submit_at)
                 .map_err(|e| format!("record_share_delegation failed: {e}"))
         })?;
+        log::info!(
+            "{VOTING_VOTE_LOG} record-share bundle={bundle_index} proposal={proposal_id} share={share_index} elapsed={:.3}s",
+            started.elapsed().as_secs_f64()
+        );
         Ok(())
     })
 }

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1135,10 +1135,12 @@ pub fn mark_delegation_submitted(
     tx_hash: String,
 ) -> Result<(), String> {
     catch(|| {
-        // Persist submission hash for this round/bundle key.
-        let db = db::open_voting_db(&db_path, &account_uuid)?;
-        db.mark_delegation_submitted(&round_id, bundle_index, &tx_hash)
-            .map_err(|e| e.to_string())
+        db::with_voting_sidecar_write_lock(&db_path, || {
+            // Persist submission hash for this round/bundle key.
+            let db = db::open_voting_db(&db_path, &account_uuid)?;
+            db.mark_delegation_submitted(&round_id, bundle_index, &tx_hash)
+                .map_err(|e| e.to_string())
+        })
     })
 }
 
@@ -1158,16 +1160,18 @@ pub fn confirm_delegation_submission(
 ) -> Result<zcash_voting::wire::DelegationConfirmation, String> {
     catch(|| {
         let events = parse_tx_events_json(&events_json)?;
-        // Parse tx events and persist confirmation details for this bundle.
-        let db = db::open_voting_db(&db_path, &account_uuid)?;
-        zcash_voting::confirmation::confirm_delegation_submission(
-            &db,
-            &round_id,
-            bundle_index,
-            &tx_hash,
-            &events,
-        )
-        .map_err(|e| e.to_string())
+        db::with_voting_sidecar_write_lock(&db_path, || {
+            // Parse tx events and persist confirmation details for this bundle.
+            let db = db::open_voting_db(&db_path, &account_uuid)?;
+            zcash_voting::confirmation::confirm_delegation_submission(
+                &db,
+                &round_id,
+                bundle_index,
+                &tx_hash,
+                &events,
+            )
+            .map_err(|e| e.to_string())
+        })
     })
 }
 
@@ -1538,10 +1542,13 @@ pub fn mark_vote_submitted(
     tx_hash: String,
 ) -> Result<(), String> {
     catch(|| {
-        // Persist submission hash for this round/bundle/proposal key.
-        let db = db::open_voting_db(&db_path, &account_uuid)?;
-        db.mark_vote_submitted(&round_id, bundle_index, proposal_id, &tx_hash)
-            .map_err(|e| e.to_string())
+        db::with_voting_sidecar_write_lock(&db_path, || {
+            // Persist submission hash for this round/bundle/proposal key.
+            let db = db::open_voting_db(&db_path, &account_uuid)?;
+            db.mark_vote_submitted(&round_id, bundle_index, proposal_id, &tx_hash)
+                .map_err(|e| e.to_string())
+        })?;
+        Ok(())
     })
 }
 
@@ -1562,17 +1569,20 @@ pub fn confirm_vote_submission(
 ) -> Result<zcash_voting::wire::VoteConfirmation, String> {
     catch(|| {
         let events = parse_tx_events_json(&events_json)?;
-        // Parse tx events and persist vote confirmation fields.
-        let db = db::open_voting_db(&db_path, &account_uuid)?;
-        zcash_voting::confirmation::confirm_vote_submission(
-            &db,
-            &round_id,
-            bundle_index,
-            proposal_id,
-            &tx_hash,
-            &events,
-        )
-        .map_err(|e| e.to_string())
+        let confirmation = db::with_voting_sidecar_write_lock(&db_path, || {
+            // Parse tx events and persist vote confirmation fields.
+            let db = db::open_voting_db(&db_path, &account_uuid)?;
+            zcash_voting::confirmation::confirm_vote_submission(
+                &db,
+                &round_id,
+                bundle_index,
+                proposal_id,
+                &tx_hash,
+                &events,
+            )
+            .map_err(|e| e.to_string())
+        })?;
+        Ok(confirmation)
     })
 }
 
@@ -1600,13 +1610,14 @@ pub fn record_share_delegation(
     submit_at: u64,
 ) -> Result<(), String> {
     catch(|| {
-        let db = db::open_voting_db(&db_path, &account_uuid)?;
-
-        // Recover vote context first, then persist helper submission metadata.
-        zcash_voting::vote::CommittedVote::recover(&db, &round_id, bundle_index, proposal_id)
-            .map_err(|e| format!("recover committed vote failed: {e}"))?
-            .record_share(&db, share_index, &sent_to_urls, submit_at)
-            .map_err(|e| format!("record_share_delegation failed: {e}"))?;
+        db::with_voting_sidecar_write_lock(&db_path, || {
+            let db = db::open_voting_db(&db_path, &account_uuid)?;
+            // Recover vote context first, then persist helper submission metadata.
+            zcash_voting::vote::CommittedVote::recover(&db, &round_id, bundle_index, proposal_id)
+                .map_err(|e| format!("recover committed vote failed: {e}"))?
+                .record_share(&db, share_index, &sent_to_urls, submit_at)
+                .map_err(|e| format!("record_share_delegation failed: {e}"))
+        })?;
         Ok(())
     })
 }
@@ -1626,14 +1637,14 @@ pub fn mark_share_confirmed(
     share_index: u32,
 ) -> Result<(), String> {
     catch(|| {
-        let db = db::open_voting_db(&db_path, &account_uuid)?;
-
-        // Recover vote context first, then mark the specific share as confirmed.
-        zcash_voting::vote::CommittedVote::recover(&db, &round_id, bundle_index, proposal_id)
-            .map_err(|e| format!("recover committed vote failed: {e}"))?
-            .confirm_share(&db, share_index)
-            .map_err(|e| format!("mark_share_confirmed failed: {e}"))?;
-        Ok(())
+        db::with_voting_sidecar_write_lock(&db_path, || {
+            let db = db::open_voting_db(&db_path, &account_uuid)?;
+            // Recover vote context first, then mark the specific share as confirmed.
+            zcash_voting::vote::CommittedVote::recover(&db, &round_id, bundle_index, proposal_id)
+                .map_err(|e| format!("recover committed vote failed: {e}"))?
+                .confirm_share(&db, share_index)
+                .map_err(|e| format!("mark_share_confirmed failed: {e}"))
+        })
     })
 }
 
@@ -1653,17 +1664,19 @@ pub fn add_sent_servers(
     new_urls: Vec<String>,
 ) -> Result<(), String> {
     catch(|| {
-        // Merge additional helper URLs into persisted share delivery state.
-        let db = db::open_voting_db(&db_path, &account_uuid)?;
-        zcash_voting::share::add_sent_servers(
-            &db,
-            &round_id,
-            bundle_index,
-            proposal_id,
-            share_index,
-            &new_urls,
-        )
-        .map_err(|e| format!("add_sent_servers failed: {e}"))
+        db::with_voting_sidecar_write_lock(&db_path, || {
+            // Merge additional helper URLs into persisted share delivery state.
+            let db = db::open_voting_db(&db_path, &account_uuid)?;
+            zcash_voting::share::add_sent_servers(
+                &db,
+                &round_id,
+                bundle_index,
+                proposal_id,
+                share_index,
+                &new_urls,
+            )
+            .map_err(|e| format!("add_sent_servers failed: {e}"))
+        })
     })
 }
 
@@ -1714,19 +1727,20 @@ pub fn set_ballot_intent(
     choice: Option<u32>,
 ) -> Result<(), String> {
     catch(|| {
-        let db = db::open_voting_db(&db_path, &account_uuid)?;
-
-        // `skipped` takes precedence; otherwise a concrete choice is required.
-        let decision = if skipped {
-            zcash_voting::session::Decision::Skipped
-        } else {
-            let c = choice.ok_or_else(|| {
-                "set_ballot_intent: choice must be Some when skipped is false".to_string()
-            })?;
-            zcash_voting::session::Decision::Choice(c)
-        };
-        db.set_ballot_intent(&round_id, proposal_id, decision, num_options)
-            .map_err(|e| format!("set_ballot_intent failed: {e}"))
+        db::with_voting_sidecar_write_lock(&db_path, || {
+            let db = db::open_voting_db(&db_path, &account_uuid)?;
+            // `skipped` takes precedence; otherwise a concrete choice is required.
+            let decision = if skipped {
+                zcash_voting::session::Decision::Skipped
+            } else {
+                let c = choice.ok_or_else(|| {
+                    "set_ballot_intent: choice must be Some when skipped is false".to_string()
+                })?;
+                zcash_voting::session::Decision::Choice(c)
+            };
+            db.set_ballot_intent(&round_id, proposal_id, decision, num_options)
+                .map_err(|e| format!("set_ballot_intent failed: {e}"))
+        })
     })
 }
 

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1460,6 +1460,7 @@ where
     let network = keys::parse_network(&network)?;
     let stored_hotkey_secret = secrecy::SecretVec::new(stored_hotkey_secret);
 
+
     // Commit/prove work is CPU-heavy; run it on a blocking worker thread.
     let commitment_result = tokio::task::spawn_blocking(move || {
         let reporter = zcash_voting::VoteCommitStageBridge::new(on_stage);
@@ -1470,16 +1471,23 @@ where
         )
         .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
 
-        zcash_voting::vote::commit_batch(
+        let prepared = zcash_voting::vote::prepare_commit_batch(
             &voting_db,
-            &round_id,
-            bundle_index,
-            &draft_votes,
-            &van_witness,
             zcash_voting::vote::VoteSigner::hotkey(&voting_hotkey),
-            &reporter,
+            zcash_voting::vote::VoteCommitBatch {
+                round_id: &round_id,
+                bundle_index,
+                drafts: &draft_votes,
+                witness: &van_witness,
+                stages: &reporter,
+            },
         )
-        .map_err(|e| format!("vote commit batch failed: {e}"))
+        .map_err(|e| format!("vote commit batch preparation failed: {e}"))?;
+        let persisted = db::with_voting_sidecar_write_lock(&db_path, || {
+            zcash_voting::vote::persist_prepared_commit_batch(&voting_db, prepared)
+                .map_err(|e| format!("vote commit batch persistence failed: {e}"))
+        })?;
+        Ok(persisted)
     })
     .await
     .map_err(|e| format!("vote commitment task failed: {e}"))

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 582226879;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -310653252;
 
 // Section: executor
 
@@ -4290,6 +4290,38 @@ fn wire__crate__api__voting__list_pending_share_rounds_impl(
         },
     )
 }
+fn wire__crate__api__voting__log_voting_timing_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "log_voting_timing",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_message = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::voting::log_voting_timing(api_message);
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__voting__mark_delegation_submitted_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -6912,6 +6944,37 @@ fn wire__crate__api__wallet__wallet_exists_impl(
             transform_result_sse::<_, ()>((move || {
                 let output_ok =
                     Result::<_, ()>::Ok(crate::api::wallet::wallet_exists(api_db_path))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__voting__warm_voting_proving_caches_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "warm_voting_proving_caches",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::voting::warm_voting_proving_caches();
+                })?;
                 Ok(output_ok)
             })())
         },
@@ -10513,64 +10576,64 @@ fn pde_ffi_dispatcher_primary_impl(
 106 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
 108 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
 109 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-117 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
-119 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-172 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-174 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-175 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
+116 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+118 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+176 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+177 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10608,18 +10671,22 @@ fn pde_ffi_dispatcher_sync_impl(
         107 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        116 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        135 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        145 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
-        147 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        110 => wire__crate__api__voting__log_voting_timing_impl(ptr, rust_vec_len, data_len),
+        117 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        136 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        146 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
+        148 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        148 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        158 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        170 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        173 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        149 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        159 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        171 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        174 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        175 => {
+            wire__crate__api__voting__warm_voting_proving_caches_impl(ptr, rust_vec_len, data_len)
+        }
         _ => unreachable!(),
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -310653252;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1543264106;
 
 // Section: executor
 
@@ -4287,38 +4287,6 @@ fn wire__crate__api__voting__list_pending_share_rounds_impl(
                     Ok(output_ok)
                 })())
             }
-        },
-    )
-}
-fn wire__crate__api__voting__log_voting_timing_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "log_voting_timing",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_message = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let output_ok = Result::<_, ()>::Ok({
-                    crate::api::voting::log_voting_timing(api_message);
-                })?;
-                Ok(output_ok)
-            })())
         },
     )
 }
@@ -10576,64 +10544,64 @@ fn pde_ffi_dispatcher_primary_impl(
 106 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
 108 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
 109 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
-116 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-119 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-135 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-145 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-172 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-173 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-176 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-177 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+117 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+118 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+136 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+146 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+175 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+176 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10671,20 +10639,19 @@ fn pde_ffi_dispatcher_sync_impl(
         107 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        110 => wire__crate__api__voting__log_voting_timing_impl(ptr, rust_vec_len, data_len),
-        117 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        136 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        146 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
-        148 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        116 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        135 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        145 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
+        147 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        149 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        159 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        171 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        174 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
-        175 => {
+        148 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        158 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        170 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        173 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        174 => {
             wire__crate__api__voting__warm_voting_proving_caches_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),

--- a/rust/src/wallet/voting/README.md
+++ b/rust/src/wallet/voting/README.md
@@ -109,7 +109,7 @@ directly. The mapping from FRB functions to crate APIs:
 | Bundle setup | `setup_delegation_bundles` | `delegate::ensure_round_context`, `VotingDb::ensure_bundles_with_skipped_suffix_with_policy` |
 | Delegation prove/sign | `build_prove_and_sign_delegation_payload_with_progress`, Keystone variant | `delegate::{prepare_delegation_bundle, setup, prove, signing_request, signed_bundle, keystone_request}` |
 | Delegation submit/confirm | `mark_delegation_submitted`, `confirm_delegation_submission` | `VotingDb::mark_delegation_submitted`, `confirmation::confirm_delegation_submission` |
-| Vote commit | `build_vote_commitments_with_progress`, `recover_vote_commitment` | `vote::commit_batch`, `vote::recover_signed_commitments` |
+| Vote commit | `build_vote_commitments_with_progress`, `recover_vote_commitment` | `vote::prepare_commit_batch`, `vote::persist_prepared_commit_batch`, `vote::recover_signed_commitments` |
 | Vote submit/confirm | `mark_vote_submitted`, `confirm_vote_submission` | `VotingDb::mark_vote_submitted`, `confirmation::confirm_vote_submission` |
 | Share submit/confirm | `record_share_delegation`, `mark_share_confirmed`, `add_sent_servers` | `vote::CommittedVote::{record_share, confirm_share}`, `share::add_sent_servers` |
 | Ballot intent / restart | `set_ballot_intent`, `get_round_plan`, `get_round_recovery_state` | `VotingDb::set_ballot_intent`, `session::resume_plan`, `recovery::round_snapshot` |

--- a/rust/src/wallet/voting/db.rs
+++ b/rust/src/wallet/voting/db.rs
@@ -1,3 +1,88 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, OnceLock},
+};
+
+fn sidecar_write_locks() -> &'static Mutex<HashMap<PathBuf, Arc<Mutex<()>>>> {
+    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
+    LOCKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn sidecar_write_lock(db_path: &str) -> Arc<Mutex<()>> {
+    let sidecar_path = zcash_voting::storage::VotingDb::wallet_sidecar_path(Path::new(db_path));
+    let mut locks = sidecar_write_locks()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    locks
+        .entry(sidecar_path)
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
+/// Runs a sidecar-mutating operation exclusively for one wallet database.
+///
+/// Delegation bundles use independent SQLite connections. WAL permits their
+/// reads to overlap, but SQLite still has a single writer; this process-local
+/// coordinator keeps the short setup, proof-persistence, submission, and
+/// confirmation write phases from racing each other.
+pub fn with_voting_sidecar_write_lock<T>(
+    db_path: &str,
+    operation: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    let lock = sidecar_write_lock(db_path);
+    let _guard = lock
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    operation()
+}
+
+/// Opens a voting sidecar and runs one write-bearing operation under its lock.
+///
+/// Opening is part of the critical section because a fresh connection may run
+/// schema migration or update SQLite pragmas. The returned database handle can
+/// be reused for read-only or internally coordinated work after the lock is
+/// released.
+pub fn with_open_voting_db_write<T>(
+    db_path: &str,
+    account_uuid: &str,
+    operation: impl FnOnce(&zcash_voting::storage::VotingDb) -> Result<T, String>,
+) -> Result<(zcash_voting::storage::VotingDb, T), String> {
+    with_voting_sidecar_write_lock(db_path, || {
+        let db = open_voting_db(db_path, account_uuid)?;
+        let value = operation(&db)?;
+        Ok((db, value))
+    })
+}
+
+/// Retries a complete idempotent voting operation after SQLite writer races.
+///
+/// Proof generation deliberately runs outside the sidecar write lock so up to
+/// three bundles can perform PIR and Halo2 work concurrently. Its final SQLite
+/// transaction can still lose the single-writer race; retrying the bundle
+/// operation is safe because its setup, PIR cache, and proof persistence are
+/// bundle-keyed and idempotent.
+pub fn retry_voting_db_locks<T>(
+    mut operation: impl FnMut() -> Result<T, String>,
+) -> Result<T, String> {
+    const MAX_LOCK_RETRIES: u32 = 3;
+    for attempt in 0..=MAX_LOCK_RETRIES {
+        match operation() {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                let locked = error.to_ascii_lowercase().contains("database is locked");
+                if !locked || attempt == MAX_LOCK_RETRIES {
+                    return Err(error);
+                }
+                std::thread::sleep(std::time::Duration::from_millis(
+                    50 * u64::from(attempt + 1),
+                ));
+            }
+        }
+    }
+    unreachable!("the bounded voting database retry loop always returns")
+}
+
 /// Opens the voting sidecar database for a wallet and binds it to `account_uuid`.
 ///
 /// `db_path` is the main wallet database path; the voting DB is opened at the
@@ -35,6 +120,10 @@ pub fn open_voting_db(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Barrier,
+    };
 
     #[test]
     fn open_voting_db_initializes_upstream_schema() {
@@ -78,5 +167,146 @@ mod tests {
 
         release.join().unwrap();
         assert!(db.list_rounds().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sidecar_write_lock_serializes_three_writers_for_one_wallet() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("zcash_wallet.db");
+        let db_path = Arc::new(db_path.to_string_lossy().into_owned());
+        let start = Arc::new(Barrier::new(3));
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+
+        let writers = (0..3)
+            .map(|_| {
+                let db_path = Arc::clone(&db_path);
+                let start = Arc::clone(&start);
+                let active = Arc::clone(&active);
+                let max_active = Arc::clone(&max_active);
+                std::thread::spawn(move || {
+                    start.wait();
+                    with_voting_sidecar_write_lock(&db_path, || {
+                        let now_active = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_active.fetch_max(now_active, Ordering::SeqCst);
+                        std::thread::sleep(std::time::Duration::from_millis(20));
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        Ok(())
+                    })
+                    .unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for writer in writers {
+            writer.join().unwrap();
+        }
+        assert_eq!(max_active.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn locked_open_serializes_real_same_sidecar_writes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = Arc::new(
+            temp_dir
+                .path()
+                .join("zcash_wallet.db")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let start = Arc::new(Barrier::new(3));
+
+        let writers = (0..3)
+            .map(|writer| {
+                let db_path = Arc::clone(&db_path);
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    with_open_voting_db_write(&db_path, "wallet-1", |db| {
+                        db.conn()
+                            .execute_batch(
+                                "CREATE TABLE IF NOT EXISTS concurrency_probe (
+                                    writer INTEGER NOT NULL
+                                 );",
+                            )
+                            .map_err(|error| error.to_string())?;
+                        db.conn()
+                            .execute(
+                                "INSERT INTO concurrency_probe (writer) VALUES (?1)",
+                                [writer],
+                            )
+                            .map_err(|error| error.to_string())?;
+                        Ok(())
+                    })
+                    .map(|_| ())
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for writer in writers {
+            writer.join().unwrap().unwrap();
+        }
+
+        let db = open_voting_db(&db_path, "wallet-1").unwrap();
+        let count: u32 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM concurrency_probe", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn sidecar_write_locks_allow_different_wallets_to_overlap() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let start = Arc::new(Barrier::new(2));
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+
+        let writers = (0..2)
+            .map(|wallet| {
+                let db_path = temp_dir
+                    .path()
+                    .join(format!("wallet-{wallet}.db"))
+                    .to_string_lossy()
+                    .into_owned();
+                let start = Arc::clone(&start);
+                let active = Arc::clone(&active);
+                let max_active = Arc::clone(&max_active);
+                std::thread::spawn(move || {
+                    start.wait();
+                    with_open_voting_db_write(&db_path, "wallet-1", |_| {
+                        let now_active = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_active.fetch_max(now_active, Ordering::SeqCst);
+                        std::thread::sleep(std::time::Duration::from_millis(100));
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        Ok(())
+                    })
+                    .unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for writer in writers {
+            writer.join().unwrap();
+        }
+        assert_eq!(max_active.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn voting_db_lock_retry_recovers_after_transient_writer_races() {
+        let attempts = AtomicUsize::new(0);
+        let result = retry_voting_db_locks(|| {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            if attempt < 2 {
+                Err("database is locked".to_string())
+            } else {
+                Ok(42)
+            }
+        });
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
     }
 }

--- a/rust/src/wallet/voting/db.rs
+++ b/rust/src/wallet/voting/db.rs
@@ -83,6 +83,27 @@ pub fn retry_voting_db_locks<T>(
     unreachable!("the bounded voting database retry loop always returns")
 }
 
+/// Retries an idempotent operation under the sidecar writer after a lock race.
+///
+/// The first attempt remains outside the coordinator so expensive proof work
+/// can run concurrently. If its final persistence loses a SQLite writer race,
+/// subsequent attempts hold the coordinator for the complete operation. This
+/// is intentionally an exceptional recovery path: it guarantees progress
+/// against other coordinated writers without serializing successful proofs.
+pub fn retry_voting_db_locks_coordinated<T>(
+    db_path: &str,
+    mut operation: impl FnMut() -> Result<T, String>,
+) -> Result<T, String> {
+    let mut first_attempt = true;
+    retry_voting_db_locks(|| {
+        if std::mem::replace(&mut first_attempt, false) {
+            operation()
+        } else {
+            with_voting_sidecar_write_lock(db_path, &mut operation)
+        }
+    })
+}
+
 /// Opens the voting sidecar database for a wallet and binds it to `account_uuid`.
 ///
 /// `db_path` is the main wallet database path; the voting DB is opened at the
@@ -308,5 +329,34 @@ mod tests {
 
         assert_eq!(result.unwrap(), 42);
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn coordinated_retry_only_locks_after_the_initial_writer_race() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir
+            .path()
+            .join("zcash_wallet.db")
+            .to_string_lossy()
+            .into_owned();
+        let attempts = AtomicUsize::new(0);
+
+        let result = retry_voting_db_locks_coordinated(&db_path, || {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            let lock = sidecar_write_lock(&db_path);
+            if attempt == 0 {
+                assert!(lock.try_lock().is_ok(), "first attempt must stay parallel");
+                Err("database is locked".to_string())
+            } else {
+                assert!(
+                    lock.try_lock().is_err(),
+                    "retry must hold the sidecar writer coordinator"
+                );
+                Ok(42)
+            }
+        });
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 }

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    sync::{Arc, OnceLock},
+    thread::{self, JoinHandle},
+};
 
 use ff::PrimeField;
 use secrecy::{ExposeSecret, SecretVec};
@@ -10,7 +13,8 @@ use crate::wallet::sync::open_wallet_db_for_read;
 use crate::wallet::voting::network::wallet_network;
 
 use super::db::{
-    open_voting_db, with_open_voting_db_write, with_voting_sidecar_write_lock,
+    open_voting_db, retry_voting_db_locks, with_open_voting_db_write,
+    with_voting_sidecar_write_lock,
 };
 
 use zcash_voting::config::PirLayout;
@@ -24,6 +28,10 @@ use zcash_voting::BundlePolicy;
 
 const ZATOSHI_PER_ZEC: u64 = 100_000_000;
 const WHALE_PROTECTION_BUNDLE_ADDITION_THRESHOLD_ZATOSHI: u64 = 25_000 * ZATOSHI_PER_ZEC;
+// Matches zcash_voting / voting-circuits keygen warm-up threads.
+const PROVING_CACHE_STACK_BYTES: usize = 64 * 1024 * 1024;
+
+static PROVING_CACHE_WARMUP_STARTED: OnceLock<()> = OnceLock::new();
 
 /// Start a new bundle before adding a note would cross the whale threshold.
 ///
@@ -40,11 +48,103 @@ fn prepare_params_with_whale_protection<'a>(
     prepare_params
 }
 
+/// Start process-lifetime Halo2 proving-key warm-up if it has not started yet.
+///
+/// Returns immediately. The first proof that needs keys blocks on the shared
+/// cache until this warm-up (or an inline cold keygen) finishes.
+pub fn start_proving_cache_warmup() {
+    if PROVING_CACHE_WARMUP_STARTED.set(()).is_err() {
+        return;
+    }
+    let spawn_result = thread::Builder::new()
+        .name("voting-proving-cache-warmup".to_string())
+        .stack_size(PROVING_CACHE_STACK_BYTES)
+        .spawn(|| {
+            zcash_voting::warm_proving_caches();
+        });
+    if let Err(error) = spawn_result {
+        log::warn!(
+            "[VOTING_PROVE] proving-cache warmup spawn failed: {error}; \
+             prove will keygen inline if needed"
+        );
+    }
+}
+
+struct OwnedResultThread<T> {
+    name: &'static str,
+    handle: Option<JoinHandle<Result<T, String>>>,
+}
+
+impl<T> OwnedResultThread<T> {
+    fn new(name: &'static str, handle: JoinHandle<Result<T, String>>) -> Self {
+        Self {
+            name,
+            handle: Some(handle),
+        }
+    }
+
+    fn join(mut self) -> Result<T, String> {
+        self.handle
+            .take()
+            .expect("owned result thread can only be joined once")
+            .join()
+            .map_err(|_| format!("{} thread panicked", self.name))?
+    }
+}
+
+impl<T> Drop for OwnedResultThread<T> {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            if handle.join().is_err() {
+                log::warn!(
+                    "[VOTING_PROVE] {} thread panicked while draining",
+                    self.name
+                );
+            }
+        }
+    }
+}
+
+type PirConnectThread = OwnedResultThread<zcash_voting::PirClientBlocking>;
+
+fn spawn_pir_connect(
+    pir_server_url: &str,
+    pir_layout: PirLayout,
+) -> Result<PirConnectThread, String> {
+    let pir_server_url = pir_server_url.to_string();
+    let handle = thread::Builder::new()
+        .name("voting-pir-connect".to_string())
+        .spawn(move || {
+            let client = zcash_voting::connect_pir_blocking(
+                pir_layout,
+                &pir_server_url,
+                Arc::new(zcash_voting::HyperTransport::new()),
+            )
+            .map_err(|e| format!("connect to PIR server failed: {e}"))?;
+            Ok(client)
+        })
+        .map_err(|e| format!("failed to spawn PIR connect thread: {e}"))?;
+    Ok(OwnedResultThread::new("PIR connect", handle))
+}
+
+async fn drain_pir_connect_after_error(handle: PirConnectThread) {
+    match tokio::task::spawn_blocking(move || handle.join()).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => {
+            log::warn!("[VOTING_PROVE] PIR connect also failed while draining: {error}");
+        }
+        Err(error) => {
+            log::warn!("[VOTING_PROVE] PIR connect drain task failed: {error}");
+        }
+    }
+}
+
 /// Completes the proof phase for a previously prepared delegation bundle.
 ///
-/// Opens the voting database for `account_uuid`, connects to `pir_server_url`,
-/// then runs bundle proving on a blocking worker thread while forwarding
-/// `DelegationProgress` updates to `on_progress`.
+/// Opens the voting database for `account_uuid`, optionally joins an in-flight
+/// PIR connect, warms PIR rows when needed, then runs bundle proving on a
+/// blocking worker thread while forwarding `DelegationProgress` updates to
+/// `on_progress`.
 ///
 /// # Errors
 ///
@@ -53,35 +153,47 @@ fn prepare_params_with_whale_protection<'a>(
 /// the spawned blocking task is cancelled or panics.
 async fn prove_delegation_bundle<F>(
     db_path: &str,
-    pir_server_url: &str,
-    pir_layout: PirLayout,
     account_uuid: &str,
     prepared: &PreparedDelegationBundle,
+    pir_connect: PirConnectThread,
     on_progress: Arc<F>,
 ) -> Result<(), String>
 where
     F: Fn(DelegationProgress) + Send + Sync + 'static,
 {
     let proof_db_path = db_path.to_string();
-    let proof_pir_server_url = pir_server_url.to_string();
     let proof_account_uuid = account_uuid.to_string();
     let prepared = prepared.clone();
     let proof_progress = on_progress.clone();
     tokio::task::spawn_blocking(move || {
         let proof_voting_db = open_voting_db(&proof_db_path, &proof_account_uuid)?;
-        let pir_client = zcash_voting::connect_pir_blocking(
-            pir_layout,
-            &proof_pir_server_url,
-            Arc::new(zcash_voting::HyperTransport::new()),
-        )
-        .map_err(|e| format!("connect to PIR server failed: {e}"))?;
-        let reporter = zcash_voting::DelegationProgressBridge::new(move |progress| {
-            proof_progress(progress);
-        });
-        prepared
-            .prove(&proof_voting_db, &pir_client, &reporter)
-            .map(|_| ())
-            .map_err(|e| format!("delegate::prove failed: {e}"))
+        let proof_wallet_db = open_wallet_db_for_read(
+            &proof_db_path,
+            wallet_network(prepared.network),
+        )?;
+        let pir_client = pir_connect.join()?;
+
+        // Fetch/cache PIR rows before Halo2 prove so remaining keygen warm-up
+        // can overlap the network round-trip when the early warm thread is still
+        // running.
+        retry_voting_db_locks(|| {
+            prepared
+                .precompute(&proof_voting_db, &proof_wallet_db, &pir_client)
+                .map(|_| ())
+                .map_err(|e| format!("delegate::precompute failed: {e}"))
+        })?;
+
+        let reporter =
+            zcash_voting::DelegationProgressBridge::new(move |progress| {
+                proof_progress(progress);
+            });
+        retry_voting_db_locks(|| {
+            prepared
+                .prove(&proof_voting_db, &pir_client, &reporter)
+                .map(|_| ())
+                .map_err(|e| format!("delegate::prove failed: {e}"))
+        })?;
+        Ok::<_, String>(())
     })
     .await
     .map_err(|e| format!("delegation proof task failed: {e}"))??;
@@ -257,13 +369,14 @@ pub async fn precompute_delegation_pir(
     let network = voting_hotkey.network();
     let stored_hotkey_secret = Zeroizing::new(voting_hotkey.stored_secret().to_vec());
 
+    start_proving_cache_warmup();
+
     tokio::task::spawn_blocking(move || {
         let voting_hotkey = zcash_voting::VotingHotkey::from_stored_secret(
             stored_hotkey_secret.as_slice(),
             network,
         )
         .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
-        let voting_db = open_voting_db(&db_path, &account_uuid)?;
         let wallet_db = open_wallet_db_for_read(&db_path, wallet_network(voting_hotkey.network()))?;
         let prepare_params = PrepareDelegationBundleParams {
             lwd,
@@ -274,21 +387,26 @@ pub async fn precompute_delegation_pir(
             bundle_policy,
         };
         let prepare_params = prepare_params_with_whale_protection(prepare_params);
-        let prepared = zcash_voting::delegate::prepare_delegation_bundle(
-            &voting_db,
-            &wallet_db,
-            prepare_params,
-        )
-        .map_err(|e| e.to_string())?;
+        let (voting_db, prepared) =
+            with_open_voting_db_write(&db_path, &account_uuid, |voting_db| {
+                zcash_voting::delegate::prepare_delegation_bundle(
+                    voting_db,
+                    &wallet_db,
+                    prepare_params,
+                )
+                .map_err(|e| e.to_string())
+            })?;
         let pir_client = zcash_voting::connect_pir_blocking(
             pir_layout,
             &pir_server_url,
             Arc::new(zcash_voting::HyperTransport::new()),
         )
         .map_err(|e| format!("connect to PIR server failed: {e}"))?;
-        prepared
-            .precompute(&voting_db, &wallet_db, &pir_client)
-            .map_err(|e| e.to_string())
+        retry_voting_db_locks(|| {
+            prepared
+                .precompute(&voting_db, &wallet_db, &pir_client)
+                .map_err(|e| e.to_string())
+        })
     })
     .await
     .map_err(|e| format!("delegation PIR precompute task failed: {e}"))?
@@ -320,32 +438,47 @@ where
 
     zcash_voting::validate_round_params(&prepare_params.lwd.round_params)
         .map_err(|e| format!("Invalid voting round params: {e}"))?;
+
+    // Overlap independent warm-ups with local preparation/PCZT setup.
+    start_proving_cache_warmup();
+    let pir_connect = spawn_pir_connect(pir_server_url, pir_layout)?;
+
     on_progress(DelegationProgress::SelectingNotes);
-    let voting_db = open_voting_db(db_path, account_uuid)?;
-    let wallet_db = open_wallet_db_for_read(
-        db_path,
-        wallet_network(prepare_params.voting_hotkey.network()),
-    )?;
-    let prepare_params = prepare_params_with_whale_protection(prepare_params);
-
-    let prepared_bundle =
-        zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
+    let preparation = (|| {
+        let wallet_db = open_wallet_db_for_read(
+            db_path,
+            wallet_network(prepare_params.voting_hotkey.network()),
+        )?;
+        let prepare_params = prepare_params_with_whale_protection(prepare_params);
+        let pczt_progress = on_progress.clone();
+        let setup_stages = zcash_voting::DelegationProgressBridge::new(move |progress| {
+            pczt_progress(progress);
+        });
+        with_open_voting_db_write(db_path, account_uuid, |voting_db| {
+            let prepared_bundle = zcash_voting::delegate::prepare_delegation_bundle(
+                voting_db,
+                &wallet_db,
+                prepare_params,
+            )
             .map_err(|e| e.to_string())?;
-
-    let pczt_progress = on_progress.clone();
-    let setup_stages = zcash_voting::DelegationProgressBridge::new(move |progress| {
-        pczt_progress(progress);
-    });
-    let delegation_setup = prepared_bundle
-        .setup(&voting_db, &setup_stages)
-        .map_err(|e| format!("delegate::setup failed: {e}"))?;
-
+            let delegation_setup = prepared_bundle
+                .setup(voting_db, &setup_stages)
+                .map_err(|e| format!("delegate::setup failed: {e}"))?;
+            Ok((prepared_bundle, delegation_setup))
+        })
+    })();
+    let (voting_db, (prepared_bundle, delegation_setup)) = match preparation {
+        Ok(value) => value,
+        Err(error) => {
+            drain_pir_connect_after_error(pir_connect).await;
+            return Err(error);
+        }
+    };
     prove_delegation_bundle(
         db_path,
-        pir_server_url,
-        pir_layout,
         account_uuid,
         &prepared_bundle,
+        pir_connect,
         on_progress.clone(),
     )
     .await?;
@@ -462,22 +595,33 @@ where
 {
     let on_progress = Arc::new(on_progress);
 
+    start_proving_cache_warmup();
+    let pir_connect = spawn_pir_connect(pir_server_url, pir_layout)?;
+
     on_progress(DelegationProgress::SelectingNotes);
-    let voting_db = open_voting_db(db_path, account_uuid)?;
-    let wallet_db = open_wallet_db_for_read(
-        db_path,
-        wallet_network(prepare_params.voting_hotkey.network()),
-    )?;
-    let prepare_params = prepare_params_with_whale_protection(prepare_params);
-    let prepared_bundle =
-        zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
-            .map_err(|e| e.to_string())?;
+    let preparation = (|| {
+        let wallet_db = open_wallet_db_for_read(
+            db_path,
+            wallet_network(prepare_params.voting_hotkey.network()),
+        )?;
+        let prepare_params = prepare_params_with_whale_protection(prepare_params);
+        with_open_voting_db_write(db_path, account_uuid, |voting_db| {
+            zcash_voting::delegate::prepare_delegation_bundle(voting_db, &wallet_db, prepare_params)
+                .map_err(|e| e.to_string())
+        })
+    })();
+    let (voting_db, prepared_bundle) = match preparation {
+        Ok(value) => value,
+        Err(error) => {
+            drain_pir_connect_after_error(pir_connect).await;
+            return Err(error);
+        }
+    };
     prove_delegation_bundle(
         db_path,
-        pir_server_url,
-        pir_layout,
         account_uuid,
         &prepared_bundle,
+        pir_connect,
         on_progress.clone(),
     )
     .await?;
@@ -506,7 +650,10 @@ mod tests {
         primitives::redpallas::{Signature, SpendAuth, VerificationKey},
     };
     use secrecy::ExposeSecret;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Barrier, Mutex,
+    };
     use zip32::{fingerprint::SeedFingerprint, AccountId};
 
     fn note_with_value(position: u64, value: u64) -> zcash_voting::NoteInfo {
@@ -746,6 +893,50 @@ mod tests {
 
         assert!(err.contains("Invalid voting round params"));
         assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn start_proving_cache_warmup_is_idempotent() {
+        start_proving_cache_warmup();
+        start_proving_cache_warmup();
+        assert!(PROVING_CACHE_WARMUP_STARTED.get().is_some());
+    }
+
+    #[test]
+    fn owned_result_thread_joins_success_error_and_panic() {
+        let success = OwnedResultThread::new("test", std::thread::spawn(|| Ok(7)));
+        assert_eq!(success.join().unwrap(), 7);
+
+        let failure =
+            OwnedResultThread::<u32>::new("test", std::thread::spawn(|| Err("failed".to_string())));
+        assert_eq!(failure.join().unwrap_err(), "failed");
+
+        let panic =
+            OwnedResultThread::<u32>::new("test", std::thread::spawn(|| panic!("injected panic")));
+        assert_eq!(panic.join().unwrap_err(), "test thread panicked");
+    }
+
+    #[test]
+    fn dropping_owned_result_thread_drains_it() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(Barrier::new(2));
+        let active_for_thread = Arc::clone(&active);
+        let started_for_thread = Arc::clone(&started);
+        let guard = OwnedResultThread::new(
+            "test",
+            std::thread::spawn(move || {
+                active_for_thread.fetch_add(1, Ordering::SeqCst);
+                started_for_thread.wait();
+                std::thread::sleep(std::time::Duration::from_millis(25));
+                active_for_thread.fetch_sub(1, Ordering::SeqCst);
+                Ok(())
+            }),
+        );
+        started.wait();
+
+        drop(guard);
+
+        assert_eq!(active.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -9,7 +9,9 @@ use zip32::{fingerprint::SeedFingerprint, AccountId};
 use crate::wallet::sync::open_wallet_db_for_read;
 use crate::wallet::voting::network::wallet_network;
 
-use super::db::open_voting_db;
+use super::db::{
+    open_voting_db, with_open_voting_db_write, with_voting_sidecar_write_lock,
+};
 
 use zcash_voting::config::PirLayout;
 pub use zcash_voting::delegate::DelegationProgress;
@@ -108,14 +110,16 @@ pub async fn setup_delegation_bundles(
         round_params,
         round_name,
     } = lwd_params;
-    let round_context = zcash_voting::delegate::ensure_round_context(
-        voting_db,
-        network,
-        &round_params,
-        round_name,
-        session_json,
-    )
-    .map_err(|e| e.to_string())?;
+    let round_context = with_voting_sidecar_write_lock(db_path, || {
+        zcash_voting::delegate::ensure_round_context(
+            voting_db,
+            network,
+            &round_params,
+            round_name,
+            session_json,
+        )
+        .map_err(|e| e.to_string())
+    })?;
     let selected = select_notes_with_lwd(
         voting_db,
         db_path,
@@ -127,13 +131,15 @@ pub async fn setup_delegation_bundles(
     .map_err(|e| e.to_string())?;
     let note_infos = selected.voting_note_infos();
     let bundle_policy = whale_protected_bundle_policy(bundle_policy);
-    voting_db
-        .ensure_bundles_with_skipped_suffix_with_policy(
-            round_params.vote_round_id.as_str(),
-            &note_infos,
-            bundle_policy,
-        )
-        .map_err(|e| format!("ensure_bundles_with_skipped_suffix failed: {e}"))
+    with_voting_sidecar_write_lock(db_path, || {
+        voting_db
+            .ensure_bundles_with_skipped_suffix_with_policy(
+                round_params.vote_round_id.as_str(),
+                &note_infos,
+                bundle_policy,
+            )
+            .map_err(|e| format!("ensure_bundles_with_skipped_suffix failed: {e}"))
+    })
 }
 
 /// Minimum voting eligibility plus the note value the privacy trim withholds.
@@ -411,19 +417,24 @@ pub async fn build_keystone_delegation_request(
     account_uuid: &str,
     prepare_params: PrepareDelegationBundleParams<'_>,
 ) -> Result<zcash_voting::delegate::KeystoneSigningRequest, String> {
-    let voting_db = open_voting_db(db_path, account_uuid)?;
     let wallet_db = open_wallet_db_for_read(
         db_path,
         wallet_network(prepare_params.voting_hotkey.network()),
     )?;
     let prepare_params = prepare_params_with_whale_protection(prepare_params);
-    let prepared =
-        zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
-            .map_err(|e| e.to_string())?;
-    let noop_stages = zcash_voting::NoopProgressReporter;
-    prepared
-        .keystone_request(&voting_db, &noop_stages)
-        .map_err(|e| format!("delegate::keystone_request failed: {e}"))
+    with_open_voting_db_write(db_path, account_uuid, |voting_db| {
+        let prepared = zcash_voting::delegate::prepare_delegation_bundle(
+            voting_db,
+            &wallet_db,
+            prepare_params,
+        )
+        .map_err(|e| e.to_string())?;
+        let noop_stages = zcash_voting::NoopProgressReporter;
+        prepared
+            .keystone_request(voting_db, &noop_stages)
+            .map_err(|e| format!("delegate::keystone_request failed: {e}"))
+    })
+    .map(|(_, request)| request)
 }
 
 /// Build a delegation proof and assemble the submission using a Keystone signature.

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -1,5 +1,5 @@
 use std::{
-    sync::{Arc, Mutex, OnceLock},
+    sync::{Arc, OnceLock},
     thread::{self, JoinHandle},
     time::Instant,
 };
@@ -181,27 +181,12 @@ where
     let prepared = prepared.clone();
     let proof_progress = on_progress.clone();
     tokio::task::spawn_blocking(move || {
-        let worker_started = Instant::now();
-        log::info!(
-            "[VOTING_PROVE] bundle={bundle_index} worker-start queue_wait={:.3}s",
-            total_started.elapsed().as_secs_f64()
-        );
-        let db_started = Instant::now();
         let proof_voting_db = open_voting_db(&proof_db_path, &proof_account_uuid)?;
         let proof_wallet_db = open_wallet_db_for_read(
             &proof_db_path,
             wallet_network(prepared.network),
         )?;
-        log::info!(
-            "[VOTING_PROVE] bundle={bundle_index} db-open elapsed={:.3}s",
-            db_started.elapsed().as_secs_f64()
-        );
-        let pir_join_started = Instant::now();
         let pir_client = pir_connect.join()?;
-        log::info!(
-            "[VOTING_PROVE] bundle={bundle_index} pir-connect-join elapsed={:.3}s",
-            pir_join_started.elapsed().as_secs_f64()
-        );
 
         // Fetch/cache PIR rows before Halo2 prove so remaining keygen warm-up
         // can overlap the network round-trip when the early warm thread is still
@@ -218,23 +203,7 @@ where
             precompute_started.elapsed().as_secs_f64()
         );
 
-        let previous_event = Arc::new(Mutex::new(worker_started));
-        let event_clock = previous_event.clone();
         let reporter = zcash_voting::DelegationProgressBridge::new(move |progress| {
-            let now = Instant::now();
-            let step_elapsed = {
-                let mut previous = event_clock
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                let elapsed = now.duration_since(*previous);
-                *previous = now;
-                elapsed
-            };
-            log::info!(
-                "[VOTING_PROVE] bundle={bundle_index} event={progress:?} step={:.3}s total={:.3}s",
-                step_elapsed.as_secs_f64(),
-                total_started.elapsed().as_secs_f64()
-            );
             proof_progress(progress);
         });
         let prove_started = Instant::now();
@@ -245,9 +214,8 @@ where
                 .map_err(|e| format!("delegate::prove failed: {e}"))
         })?;
         log::info!(
-            "[VOTING_PROVE] bundle={bundle_index} prepared-prove elapsed={:.3}s worker_total={:.3}s",
-            prove_started.elapsed().as_secs_f64(),
-            worker_started.elapsed().as_secs_f64()
+            "[VOTING_PROVE] bundle={bundle_index} prepared-prove elapsed={:.3}s",
+            prove_started.elapsed().as_secs_f64()
         );
         Ok::<_, String>(())
     })
@@ -496,31 +464,20 @@ where
     let total_started = Instant::now();
     let on_progress = Arc::new(on_progress);
     let account_uuid = prepare_params.account_uuid;
-    let bundle_index = prepare_params.bundle_index;
 
-    let validation_started = Instant::now();
     zcash_voting::validate_round_params(&prepare_params.lwd.round_params)
         .map_err(|e| format!("Invalid voting round params: {e}"))?;
-    log::info!(
-        "[VOTING_PROVE] bundle={bundle_index} validate-round elapsed={:.3}s",
-        validation_started.elapsed().as_secs_f64()
-    );
 
     // Overlap independent warm-ups with local preparation/PCZT setup.
     start_proving_cache_warmup();
     let pir_connect = spawn_pir_connect(pir_server_url, pir_layout)?;
 
     on_progress(DelegationProgress::SelectingNotes);
-    let db_open_started = Instant::now();
     let preparation = (|| {
         let wallet_db = open_wallet_db_for_read(
             db_path,
             wallet_network(prepare_params.voting_hotkey.network()),
         )?;
-        log::info!(
-            "[VOTING_PROVE] bundle={bundle_index} wallet-db-open elapsed={:.3}s",
-            db_open_started.elapsed().as_secs_f64()
-        );
         let prepare_params = prepare_params_with_whale_protection(prepare_params);
         let prepare_bundle_started = Instant::now();
         let pczt_progress = on_progress.clone();
@@ -586,14 +543,12 @@ where
         prepared_bundle.bundle_index,
         signing_started.elapsed().as_secs_f64()
     );
-    let assembly_started = Instant::now();
     let signed_bundle = prepared_bundle
         .signed_bundle(&voting_db, delegation_setup.pczt_bytes, signer)
         .map_err(|e| format!("delegate::signed_bundle failed: {e}"))?;
     log::info!(
-        "[VOTING_PROVE] bundle={} signed-bundle elapsed={:.3}s total={:.3}s",
+        "[VOTING_PROVE] bundle={} signed-bundle total={:.3}s",
         prepared_bundle.bundle_index,
-        assembly_started.elapsed().as_secs_f64(),
         total_started.elapsed().as_secs_f64()
     );
 

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -1,6 +1,7 @@
 use std::{
-    sync::{Arc, OnceLock},
+    sync::{Arc, Mutex, OnceLock},
     thread::{self, JoinHandle},
+    time::Instant,
 };
 
 use ff::PrimeField;
@@ -60,7 +61,13 @@ pub fn start_proving_cache_warmup() {
         .name("voting-proving-cache-warmup".to_string())
         .stack_size(PROVING_CACHE_STACK_BYTES)
         .spawn(|| {
+            let started = Instant::now();
+            log::info!("[VOTING_PROVE] proving-cache warmup start");
             zcash_voting::warm_proving_caches();
+            log::info!(
+                "[VOTING_PROVE] proving-cache warmup complete elapsed={:.3}s",
+                started.elapsed().as_secs_f64()
+            );
         });
     if let Err(error) = spawn_result {
         log::warn!(
@@ -115,12 +122,18 @@ fn spawn_pir_connect(
     let handle = thread::Builder::new()
         .name("voting-pir-connect".to_string())
         .spawn(move || {
+            let started = Instant::now();
+            log::info!("[VOTING_PROVE] pir-connect start");
             let client = zcash_voting::connect_pir_blocking(
                 pir_layout,
                 &pir_server_url,
                 Arc::new(zcash_voting::HyperTransport::new()),
             )
             .map_err(|e| format!("connect to PIR server failed: {e}"))?;
+            log::info!(
+                "[VOTING_PROVE] pir-connect complete elapsed={:.3}s",
+                started.elapsed().as_secs_f64()
+            );
             Ok(client)
         })
         .map_err(|e| format!("failed to spawn PIR connect thread: {e}"))?;
@@ -161,42 +174,89 @@ async fn prove_delegation_bundle<F>(
 where
     F: Fn(DelegationProgress) + Send + Sync + 'static,
 {
+    let total_started = Instant::now();
     let proof_db_path = db_path.to_string();
     let proof_account_uuid = account_uuid.to_string();
+    let bundle_index = prepared.bundle_index;
     let prepared = prepared.clone();
     let proof_progress = on_progress.clone();
     tokio::task::spawn_blocking(move || {
+        let worker_started = Instant::now();
+        log::info!(
+            "[VOTING_PROVE] bundle={bundle_index} worker-start queue_wait={:.3}s",
+            total_started.elapsed().as_secs_f64()
+        );
+        let db_started = Instant::now();
         let proof_voting_db = open_voting_db(&proof_db_path, &proof_account_uuid)?;
         let proof_wallet_db = open_wallet_db_for_read(
             &proof_db_path,
             wallet_network(prepared.network),
         )?;
+        log::info!(
+            "[VOTING_PROVE] bundle={bundle_index} db-open elapsed={:.3}s",
+            db_started.elapsed().as_secs_f64()
+        );
+        let pir_join_started = Instant::now();
         let pir_client = pir_connect.join()?;
+        log::info!(
+            "[VOTING_PROVE] bundle={bundle_index} pir-connect-join elapsed={:.3}s",
+            pir_join_started.elapsed().as_secs_f64()
+        );
 
         // Fetch/cache PIR rows before Halo2 prove so remaining keygen warm-up
         // can overlap the network round-trip when the early warm thread is still
         // running.
+        let precompute_started = Instant::now();
         retry_voting_db_locks(|| {
             prepared
                 .precompute(&proof_voting_db, &proof_wallet_db, &pir_client)
                 .map(|_| ())
                 .map_err(|e| format!("delegate::precompute failed: {e}"))
         })?;
+        log::info!(
+            "[VOTING_PROVE] bundle={bundle_index} pir-precompute elapsed={:.3}s",
+            precompute_started.elapsed().as_secs_f64()
+        );
 
-        let reporter =
-            zcash_voting::DelegationProgressBridge::new(move |progress| {
-                proof_progress(progress);
-            });
+        let previous_event = Arc::new(Mutex::new(worker_started));
+        let event_clock = previous_event.clone();
+        let reporter = zcash_voting::DelegationProgressBridge::new(move |progress| {
+            let now = Instant::now();
+            let step_elapsed = {
+                let mut previous = event_clock
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let elapsed = now.duration_since(*previous);
+                *previous = now;
+                elapsed
+            };
+            log::info!(
+                "[VOTING_PROVE] bundle={bundle_index} event={progress:?} step={:.3}s total={:.3}s",
+                step_elapsed.as_secs_f64(),
+                total_started.elapsed().as_secs_f64()
+            );
+            proof_progress(progress);
+        });
+        let prove_started = Instant::now();
         retry_voting_db_locks(|| {
             prepared
                 .prove(&proof_voting_db, &pir_client, &reporter)
                 .map(|_| ())
                 .map_err(|e| format!("delegate::prove failed: {e}"))
         })?;
+        log::info!(
+            "[VOTING_PROVE] bundle={bundle_index} prepared-prove elapsed={:.3}s worker_total={:.3}s",
+            prove_started.elapsed().as_secs_f64(),
+            worker_started.elapsed().as_secs_f64()
+        );
         Ok::<_, String>(())
     })
     .await
     .map_err(|e| format!("delegation proof task failed: {e}"))??;
+    log::info!(
+        "[VOTING_PROVE] bundle={bundle_index} complete total={:.3}s",
+        total_started.elapsed().as_secs_f64()
+    );
     Ok(())
 }
 
@@ -433,23 +493,36 @@ pub async fn build_prove_and_sign_delegation_payload<F>(
 where
     F: Fn(DelegationProgress) + Send + Sync + 'static,
 {
+    let total_started = Instant::now();
     let on_progress = Arc::new(on_progress);
     let account_uuid = prepare_params.account_uuid;
+    let bundle_index = prepare_params.bundle_index;
 
+    let validation_started = Instant::now();
     zcash_voting::validate_round_params(&prepare_params.lwd.round_params)
         .map_err(|e| format!("Invalid voting round params: {e}"))?;
+    log::info!(
+        "[VOTING_PROVE] bundle={bundle_index} validate-round elapsed={:.3}s",
+        validation_started.elapsed().as_secs_f64()
+    );
 
     // Overlap independent warm-ups with local preparation/PCZT setup.
     start_proving_cache_warmup();
     let pir_connect = spawn_pir_connect(pir_server_url, pir_layout)?;
 
     on_progress(DelegationProgress::SelectingNotes);
+    let db_open_started = Instant::now();
     let preparation = (|| {
         let wallet_db = open_wallet_db_for_read(
             db_path,
             wallet_network(prepare_params.voting_hotkey.network()),
         )?;
+        log::info!(
+            "[VOTING_PROVE] bundle={bundle_index} wallet-db-open elapsed={:.3}s",
+            db_open_started.elapsed().as_secs_f64()
+        );
         let prepare_params = prepare_params_with_whale_protection(prepare_params);
+        let prepare_bundle_started = Instant::now();
         let pczt_progress = on_progress.clone();
         let setup_stages = zcash_voting::DelegationProgressBridge::new(move |progress| {
             pczt_progress(progress);
@@ -461,9 +534,20 @@ where
                 prepare_params,
             )
             .map_err(|e| e.to_string())?;
+            log::info!(
+                "[VOTING_PROVE] bundle={} prepare-bundle elapsed={:.3}s",
+                prepared_bundle.bundle_index,
+                prepare_bundle_started.elapsed().as_secs_f64()
+            );
+            let pczt_setup_started = Instant::now();
             let delegation_setup = prepared_bundle
                 .setup(voting_db, &setup_stages)
                 .map_err(|e| format!("delegate::setup failed: {e}"))?;
+            log::info!(
+                "[VOTING_PROVE] bundle={} pczt-setup elapsed={:.3}s",
+                prepared_bundle.bundle_index,
+                pczt_setup_started.elapsed().as_secs_f64()
+            );
             Ok((prepared_bundle, delegation_setup))
         })
     })();
@@ -474,6 +558,7 @@ where
             return Err(error);
         }
     };
+    let prove_started = Instant::now();
     prove_delegation_bundle(
         db_path,
         account_uuid,
@@ -482,17 +567,35 @@ where
         on_progress.clone(),
     )
     .await?;
+    log::info!(
+        "[VOTING_PROVE] bundle={} prove-only elapsed={:.3}s",
+        prepared_bundle.bundle_index,
+        prove_started.elapsed().as_secs_f64()
+    );
 
     on_progress(DelegationProgress::SigningPayload);
+    let signing_started = Instant::now();
     let signing_request = prepared_bundle
         .signing_request(&voting_db)
         .map_err(|e| format!("delegation signing request failed: {e}"))?;
     let (sig, sighash) = sign_delegation_request(seed, signing_request)
         .map_err(|e| format!("delegation signing failed: {e}"))?;
     let signer = zcash_voting::delegate::PreparedSigner::signature(sig, sighash);
+    log::info!(
+        "[VOTING_PROVE] bundle={} signing elapsed={:.3}s",
+        prepared_bundle.bundle_index,
+        signing_started.elapsed().as_secs_f64()
+    );
+    let assembly_started = Instant::now();
     let signed_bundle = prepared_bundle
         .signed_bundle(&voting_db, delegation_setup.pczt_bytes, signer)
         .map_err(|e| format!("delegate::signed_bundle failed: {e}"))?;
+    log::info!(
+        "[VOTING_PROVE] bundle={} signed-bundle elapsed={:.3}s total={:.3}s",
+        prepared_bundle.bundle_index,
+        assembly_started.elapsed().as_secs_f64(),
+        total_started.elapsed().as_secs_f64()
+    );
 
     on_progress(DelegationProgress::PayloadReady);
     Ok(signed_bundle)

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -14,8 +14,8 @@ use crate::wallet::sync::open_wallet_db_for_read;
 use crate::wallet::voting::network::wallet_network;
 
 use super::db::{
-    open_voting_db, retry_voting_db_locks, retry_voting_db_locks_coordinated,
-    with_open_voting_db_write, with_voting_sidecar_write_lock,
+    open_voting_db, retry_voting_db_locks_coordinated, with_open_voting_db_write,
+    with_voting_sidecar_write_lock,
 };
 
 use zcash_voting::config::PirLayout;
@@ -188,9 +188,10 @@ where
 
         // Fetch/cache PIR rows before Halo2 prove so remaining keygen warm-up
         // can overlap the network round-trip when the early warm thread is still
-        // running.
+        // running. Keep the first attempt parallel; only a SQLite writer-race
+        // retry joins the per-wallet coordinator.
         let precompute_started = Instant::now();
-        retry_voting_db_locks(|| {
+        retry_voting_db_locks_coordinated(&proof_db_path, || {
             prepared
                 .precompute(&proof_voting_db, &proof_wallet_db, &pir_client)
                 .map(|_| ())
@@ -428,7 +429,9 @@ pub async fn precompute_delegation_pir(
             Arc::new(zcash_voting::HyperTransport::new()),
         )
         .map_err(|e| format!("connect to PIR server failed: {e}"))?;
-        retry_voting_db_locks(|| {
+        // Preserve parallel warm-up on the first attempt, but wait behind the
+        // per-wallet writer coordinator if persistence loses a SQLite race.
+        retry_voting_db_locks_coordinated(&db_path, || {
             prepared
                 .precompute(&voting_db, &wallet_db, &pir_client)
                 .map_err(|e| e.to_string())

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -14,8 +14,8 @@ use crate::wallet::sync::open_wallet_db_for_read;
 use crate::wallet::voting::network::wallet_network;
 
 use super::db::{
-    open_voting_db, retry_voting_db_locks, with_open_voting_db_write,
-    with_voting_sidecar_write_lock,
+    open_voting_db, retry_voting_db_locks, retry_voting_db_locks_coordinated,
+    with_open_voting_db_write, with_voting_sidecar_write_lock,
 };
 
 use zcash_voting::config::PirLayout;
@@ -182,10 +182,8 @@ where
     let proof_progress = on_progress.clone();
     tokio::task::spawn_blocking(move || {
         let proof_voting_db = open_voting_db(&proof_db_path, &proof_account_uuid)?;
-        let proof_wallet_db = open_wallet_db_for_read(
-            &proof_db_path,
-            wallet_network(prepared.network),
-        )?;
+        let proof_wallet_db =
+            open_wallet_db_for_read(&proof_db_path, wallet_network(prepared.network))?;
         let pir_client = pir_connect.join()?;
 
         // Fetch/cache PIR rows before Halo2 prove so remaining keygen warm-up
@@ -207,7 +205,7 @@ where
             proof_progress(progress);
         });
         let prove_started = Instant::now();
-        retry_voting_db_locks(|| {
+        retry_voting_db_locks_coordinated(&proof_db_path, || {
             prepared
                 .prove(&proof_voting_db, &pir_client, &reporter)
                 .map(|_| ())

--- a/test/features/voting/voting_state_test.dart
+++ b/test/features/voting/voting_state_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/voting/voting_resume_plan.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_state.dart';
 import 'package:zcash_wallet/src/services/voting/voting_models.dart';
 
@@ -28,6 +29,64 @@ void main() {
           .privacyTrimDroppedValueZatoshi,
       BigInt.zero,
     );
+  });
+
+  test('session state snapshots delegation progress maps', () {
+    final progress = <int, VotingSessionProgress>{
+      0: const VotingSessionProgress(phase: 'proving', bundleIndex: 0),
+      1: const VotingSessionProgress(phase: 'submitted', bundleIndex: 1),
+    };
+    final state = VotingSessionState(
+      roundId: 'round-1',
+      delegationProgress: progress,
+    );
+
+    progress[0] = const VotingSessionProgress(
+      phase: 'confirmed',
+      bundleIndex: 0,
+    );
+    progress[2] = const VotingSessionProgress(phase: 'proving', bundleIndex: 2);
+
+    expect(state.delegationProgress[0]?.phase, 'proving');
+    expect(state.delegationProgress[1]?.phase, 'submitted');
+    expect(state.delegationProgress, isNot(contains(2)));
+    expect(
+      () => state.delegationProgress[3] = const VotingSessionProgress(
+        phase: 'proving',
+        bundleIndex: 3,
+      ),
+      throwsUnsupportedError,
+    );
+  });
+
+  test('session state carries in-flight and completed vote progress', () {
+    const activeA = VotingVoteKey(bundleIndex: 0, proposalId: 7);
+    const activeB = VotingVoteKey(bundleIndex: 1, proposalId: 7);
+    const completed = VotingVoteKey(bundleIndex: 2, proposalId: 7);
+    final state = VotingSessionState(
+      roundId: 'round-1',
+      voteProgress: {
+        activeA: const VotingSessionProgress(
+          phase: 'proving',
+          bundleIndex: 0,
+          proposalId: 7,
+        ),
+        activeB: const VotingSessionProgress(
+          phase: 'witness',
+          bundleIndex: 1,
+          proposalId: 7,
+        ),
+        completed: const VotingSessionProgress(
+          phase: 'completed',
+          bundleIndex: 2,
+          proposalId: 7,
+        ),
+      },
+    );
+
+    expect(state.voteProgress[activeA]?.phase, 'proving');
+    expect(state.voteProgress[activeB]?.phase, 'witness');
+    expect(state.voteProgress[completed]?.phase, 'completed');
   });
 
   test('round details reject fractional snapshot heights', () {

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1239,6 +1239,14 @@ void main() {
       addTearDown(() {
         if (!refreshGate.isCompleted) refreshGate.complete(null);
       });
+      final jobNotifier = _CompletableVotingSubmissionJobNotifier(
+        key,
+        const VotingSubmissionJobState(
+          key: key,
+          status: VotingSubmissionJobStatus.running,
+          generation: 1,
+        ),
+      );
       final completedState = VotingSessionState(
         roundId: _roundId,
         accountUuid: key.accountUuid,
@@ -1252,16 +1260,7 @@ void main() {
               const VotingSubmissionJobsState(jobKeys: [key]),
             ),
           ),
-          votingSubmissionJobProvider(key).overrideWith(
-            () => _StaticVotingSubmissionJobNotifier(
-              key,
-              const VotingSubmissionJobState(
-                key: key,
-                status: VotingSubmissionJobStatus.complete,
-                generation: 1,
-              ),
-            ),
-          ),
+          votingSubmissionJobProvider(key).overrideWith(() => jobNotifier),
           votingSubmissionJobSessionProvider(
             key,
           ).overrideWithValue(AsyncValue.data(completedState)),
@@ -1270,81 +1269,6 @@ void main() {
               key,
               completedState,
               refreshGate,
-            ),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-
-      final router = GoRouter(
-        initialLocation: '/home',
-        routes: [
-          GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
-          GoRoute(
-            path: '/voting/poll/:roundId/status',
-            builder: (_, state) => VotingStatusView(
-              roundId: state.pathParameters['roundId']!,
-              accountUuid: state.uri.queryParameters['account'],
-              requireCurrentRouteForConfirmation: true,
-            ),
-          ),
-          GoRoute(
-            path: '/voting/poll/:roundId/submitted',
-            builder: (_, _) => const Text('submission confirmed route'),
-          ),
-        ],
-      );
-      addTearDown(router.dispose);
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: MaterialApp.router(
-            routerConfig: router,
-            builder: (_, child) =>
-                AppTheme(data: AppThemeData.light, child: child!),
-          ),
-        ),
-      );
-      unawaited(
-        router.pushReplacement(
-          votingStatusRoute(_roundId, accountUuid: key.accountUuid),
-        ),
-      );
-      await _pumpUntilFound(tester, find.text('submission confirmed route'));
-
-      expect(find.text('submission confirmed route'), findsOneWidget);
-      expect(refreshGate.isCompleted, isFalse);
-    },
-  );
-
-  testWidgets(
-    'completed mobile status navigates from an imperative voting stack',
-    (tester) async {
-      const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
-      final jobNotifier = _CompletableVotingSubmissionJobNotifier(
-        key,
-        const VotingSubmissionJobState(
-          key: key,
-          status: VotingSubmissionJobStatus.running,
-          generation: 1,
-        ),
-      );
-      final container = _statusContainer(
-        accountOverride: _MnemonicAccountNotifier.new,
-        overrides: [
-          votingSubmissionJobsProvider.overrideWith(
-            () => _StaticVotingSubmissionJobsNotifier(
-              const VotingSubmissionJobsState(jobKeys: [key]),
-            ),
-          ),
-          votingSubmissionJobProvider(key).overrideWith(() => jobNotifier),
-          votingSubmissionJobSessionProvider(key).overrideWithValue(
-            AsyncValue.data(
-              VotingSessionState(
-                roundId: _roundId,
-                accountUuid: key.accountUuid,
-                phase: VotingSessionPhase.done,
-              ),
             ),
           ),
         ],
@@ -1410,6 +1334,7 @@ void main() {
       await _pumpUntilFound(tester, find.text('submission confirmed route'));
 
       expect(find.text('submission confirmed route'), findsOneWidget);
+      expect(refreshGate.isCompleted, isFalse);
     },
   );
 

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -4305,6 +4305,12 @@ class _NoopVotingRustApi implements VotingRustApi {
   }
 
   @override
+  void warmVotingProvingCaches() {}
+
+  @override
+  void logVotingTiming({required String message}) {}
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1306,12 +1306,98 @@ void main() {
         ),
       );
       unawaited(
-        router.push(votingStatusRoute(_roundId, accountUuid: key.accountUuid)),
+        router.pushReplacement(
+          votingStatusRoute(_roundId, accountUuid: key.accountUuid),
+        ),
       );
       await _pumpUntilFound(tester, find.text('submission confirmed route'));
 
       expect(find.text('submission confirmed route'), findsOneWidget);
       expect(refreshGate.isCompleted, isFalse);
+    },
+  );
+
+  testWidgets(
+    'completed mobile status does not replace a route pushed above it',
+    (tester) async {
+      const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+      final jobNotifier = _CompletableVotingSubmissionJobNotifier(
+        key,
+        const VotingSubmissionJobState(
+          key: key,
+          status: VotingSubmissionJobStatus.running,
+          generation: 1,
+        ),
+      );
+      final container = _statusContainer(
+        accountOverride: _MnemonicAccountNotifier.new,
+        overrides: [
+          votingSubmissionJobsProvider.overrideWith(
+            () => _StaticVotingSubmissionJobsNotifier(
+              const VotingSubmissionJobsState(jobKeys: [key]),
+            ),
+          ),
+          votingSubmissionJobProvider(key).overrideWith(() => jobNotifier),
+          votingSubmissionJobSessionProvider(key).overrideWithValue(
+            AsyncValue.data(
+              VotingSessionState(
+                roundId: _roundId,
+                accountUuid: key.accountUuid,
+                phase: VotingSessionPhase.submittingShares,
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final router = GoRouter(
+        initialLocation: votingStatusRoute(
+          _roundId,
+          accountUuid: key.accountUuid,
+        ),
+        routes: [
+          GoRoute(
+            path: '/voting/poll/:roundId/status',
+            builder: (_, state) => VotingStatusView(
+              roundId: state.pathParameters['roundId']!,
+              accountUuid: state.uri.queryParameters['account'],
+              requireCurrentRouteForConfirmation: true,
+            ),
+          ),
+          GoRoute(
+            path: '/voting/poll/:roundId/submitted',
+            builder: (_, _) => const Text('submission confirmed route'),
+          ),
+          GoRoute(
+            path: '/pushed-route',
+            builder: (_, _) => const Text('pushed route'),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+            builder: (_, child) =>
+                AppTheme(data: AppThemeData.light, child: child!),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      unawaited(router.push('/pushed-route'));
+      await _pumpUntilFound(tester, find.text('pushed route'));
+      expect(find.text('pushed route'), findsOneWidget);
+
+      jobNotifier.complete();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('pushed route'), findsOneWidget);
+      expect(find.text('submission confirmed route'), findsNothing);
     },
   );
 
@@ -4096,6 +4182,20 @@ class _StaticVotingSubmissionJobNotifier extends VotingSubmissionJobNotifier {
 
   @override
   VotingSubmissionJobState build() => _initial;
+}
+
+class _CompletableVotingSubmissionJobNotifier
+    extends VotingSubmissionJobNotifier {
+  _CompletableVotingSubmissionJobNotifier(super.key, this._initial);
+
+  final VotingSubmissionJobState _initial;
+
+  @override
+  VotingSubmissionJobState build() => _initial;
+
+  void complete() {
+    state = state.copyWith(status: VotingSubmissionJobStatus.complete);
+  }
 }
 
 class _StaticVotingSubmissionJobsNotifier extends VotingSubmissionJobsNotifier {

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1318,6 +1318,102 @@ void main() {
   );
 
   testWidgets(
+    'completed mobile status navigates from an imperative voting stack',
+    (tester) async {
+      const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+      final jobNotifier = _CompletableVotingSubmissionJobNotifier(
+        key,
+        const VotingSubmissionJobState(
+          key: key,
+          status: VotingSubmissionJobStatus.running,
+          generation: 1,
+        ),
+      );
+      final container = _statusContainer(
+        accountOverride: _MnemonicAccountNotifier.new,
+        overrides: [
+          votingSubmissionJobsProvider.overrideWith(
+            () => _StaticVotingSubmissionJobsNotifier(
+              const VotingSubmissionJobsState(jobKeys: [key]),
+            ),
+          ),
+          votingSubmissionJobProvider(key).overrideWith(() => jobNotifier),
+          votingSubmissionJobSessionProvider(key).overrideWithValue(
+            AsyncValue.data(
+              VotingSessionState(
+                roundId: _roundId,
+                accountUuid: key.accountUuid,
+                phase: VotingSessionPhase.done,
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final router = GoRouter(
+        initialLocation: '/home',
+        routes: [
+          GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
+          GoRoute(
+            path: '/voting',
+            builder: (_, _) => const Text('voting route'),
+          ),
+          GoRoute(
+            path: '/voting/poll/:roundId',
+            builder: (_, _) => const Text('poll route'),
+          ),
+          GoRoute(
+            path: '/voting/poll/:roundId/review',
+            builder: (_, _) => const Text('review route'),
+          ),
+          GoRoute(
+            path: '/voting/poll/:roundId/status',
+            builder: (_, state) => VotingStatusView(
+              roundId: state.pathParameters['roundId']!,
+              accountUuid: state.uri.queryParameters['account'],
+              requireCurrentRouteForConfirmation: true,
+            ),
+          ),
+          GoRoute(
+            path: '/voting/poll/:roundId/submitted',
+            builder: (_, _) => const Text('submission confirmed route'),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+            builder: (_, child) =>
+                AppTheme(data: AppThemeData.light, child: child!),
+          ),
+        ),
+      );
+
+      unawaited(router.push('/voting'));
+      await _pumpUntilFound(tester, find.text('voting route'));
+      unawaited(router.push(votingPollRoute(_roundId)));
+      await _pumpUntilFound(tester, find.text('poll route'));
+      unawaited(router.push(votingReviewRoute(_roundId)));
+      await _pumpUntilFound(tester, find.text('review route'));
+      unawaited(
+        router.pushReplacement(
+          votingStatusRoute(_roundId, accountUuid: key.accountUuid),
+        ),
+      );
+      await _pumpUntilFound(tester, find.text('Finalizing submission'));
+
+      jobNotifier.complete();
+      await _pumpUntilFound(tester, find.text('submission confirmed route'));
+
+      expect(find.text('submission confirmed route'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
     'completed mobile status does not replace a route pushed above it',
     (tester) async {
       const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1039,7 +1039,7 @@ void main() {
     expect(find.text('submission confirmed route'), findsOne);
     expect(find.text('Sign bundle 1 of 1'), findsNothing);
     expect(find.text('Scan signature'), findsNothing);
-    expect(rust.eligibilityCheckCalls, 2);
+    expect(rust.eligibilityCheckCalls, 1);
     expect(rust.setupDelegationBundleCalls, 0);
     expect(rust.keystoneDelegationRequestCalls, 0);
     expect(recoveryApi.ballotIntents, isEmpty);
@@ -1142,7 +1142,7 @@ void main() {
     expect(find.text('submission confirmed route'), findsOne);
     expect(find.text('Sign bundle 1 of 1'), findsNothing);
     expect(find.text('Scan signature'), findsNothing);
-    expect(rust.eligibilityCheckCalls, 2);
+    expect(rust.eligibilityCheckCalls, 1);
     expect(rust.setupDelegationBundleCalls, 0);
     expect(rust.keystoneDelegationRequestCalls, 0);
     expect(

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -4531,9 +4531,6 @@ class _NoopVotingRustApi implements VotingRustApi {
   void warmVotingProvingCaches() {}
 
   @override
-  void logVotingTiming({required String message}) {}
-
-  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1231,6 +1231,90 @@ void main() {
     },
   );
 
+  testWidgets(
+    'completed mobile status navigates before voting power refresh finishes',
+    (tester) async {
+      const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+      final refreshGate = Completer<BigInt?>();
+      addTearDown(() {
+        if (!refreshGate.isCompleted) refreshGate.complete(null);
+      });
+      final completedState = VotingSessionState(
+        roundId: _roundId,
+        accountUuid: key.accountUuid,
+        phase: VotingSessionPhase.done,
+      );
+      final container = _statusContainer(
+        accountOverride: _MnemonicAccountNotifier.new,
+        overrides: [
+          votingSubmissionJobsProvider.overrideWith(
+            () => _StaticVotingSubmissionJobsNotifier(
+              const VotingSubmissionJobsState(jobKeys: [key]),
+            ),
+          ),
+          votingSubmissionJobProvider(key).overrideWith(
+            () => _StaticVotingSubmissionJobNotifier(
+              key,
+              const VotingSubmissionJobState(
+                key: key,
+                status: VotingSubmissionJobStatus.complete,
+                generation: 1,
+              ),
+            ),
+          ),
+          votingSubmissionJobSessionProvider(
+            key,
+          ).overrideWithValue(AsyncValue.data(completedState)),
+          votingSubmissionSessionProvider(key).overrideWith(
+            () => _BlockedRefreshVotingSubmissionSessionNotifier(
+              key,
+              completedState,
+              refreshGate,
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final router = GoRouter(
+        initialLocation: '/home',
+        routes: [
+          GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
+          GoRoute(
+            path: '/voting/poll/:roundId/status',
+            builder: (_, state) => VotingStatusView(
+              roundId: state.pathParameters['roundId']!,
+              accountUuid: state.uri.queryParameters['account'],
+              requireCurrentRouteForConfirmation: true,
+            ),
+          ),
+          GoRoute(
+            path: '/voting/poll/:roundId/submitted',
+            builder: (_, _) => const Text('submission confirmed route'),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+            builder: (_, child) =>
+                AppTheme(data: AppThemeData.light, child: child!),
+          ),
+        ),
+      );
+      unawaited(
+        router.push(votingStatusRoute(_roundId, accountUuid: key.accountUuid)),
+      );
+      await _pumpUntilFound(tester, find.text('submission confirmed route'));
+
+      expect(find.text('submission confirmed route'), findsOneWidget);
+      expect(refreshGate.isCompleted, isFalse);
+    },
+  );
+
   testWidgets('status screen shows finalizing step before job completion', (
     tester,
   ) async {
@@ -4165,6 +4249,24 @@ class _StaticVotingSessionNotifier extends VotingSessionNotifier {
 
   @override
   Future<BigInt?> refreshEligibleWeight() async => _state.eligibleWeightZatoshi;
+}
+
+class _BlockedRefreshVotingSubmissionSessionNotifier
+    extends VotingSubmissionSessionNotifier {
+  _BlockedRefreshVotingSubmissionSessionNotifier(
+    super.key,
+    this._state,
+    this._refreshGate,
+  );
+
+  final VotingSessionState _state;
+  final Completer<BigInt?> _refreshGate;
+
+  @override
+  Future<VotingSessionState> build() async => _state;
+
+  @override
+  Future<BigInt?> refreshEligibleWeight() => _refreshGate.future;
 }
 
 class _FailingEligibilityVotingSessionNotifier

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart' show ThemeMode;
@@ -368,6 +369,17 @@ void main() {
     );
   });
 
+  test(
+    'account deletion drains live share tracking before the wallet mutation',
+    () => _expectAccountDeletionDrainsLiveShareTracking(),
+  );
+
+  test(
+    'mobile account deletion drains live share tracking before the wallet mutation',
+    () => _expectAccountDeletionDrainsLiveShareTracking(),
+    tags: ['mobile'],
+  );
+
   test('drain failures resume tracking after destructive mutations', () async {
     final shareTracking = VotingShareTrackingRegistry();
     var restoreRequests = 0;
@@ -539,6 +551,70 @@ class _AccountMutationRustApiFake implements RustLibApi {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<void> _expectAccountDeletionDrainsLiveShareTracking() async {
+  FlutterSecureStorage.setMockInitialValues({});
+  final supportDirectory = Directory.systemTemp.createTempSync(
+    'vizor-account-share-drain',
+  );
+  addTearDown(() {
+    if (supportDirectory.existsSync()) {
+      supportDirectory.deleteSync(recursive: true);
+    }
+  });
+  const pathProvider = MethodChannel('plugins.flutter.io/path_provider');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(pathProvider, (call) async {
+        if (call.method == 'getApplicationSupportDirectory') {
+          return supportDirectory.path;
+        }
+        throw MissingPluginException('Unexpected path provider call.');
+      });
+  addTearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProvider, null);
+  });
+
+  final shareTracking = VotingShareTrackingRegistry();
+  final drainStarted = Completer<void>();
+  final drainGate = Completer<void>();
+  expect(
+    shareTracking.register(
+      key: const VotingSessionKey(
+        accountUuid: 'account-2',
+        roundId: 'round-delete',
+      ),
+      owner: Object(),
+      stopAndDrain: () async {
+        if (!drainStarted.isCompleted) drainStarted.complete();
+        await drainGate.future;
+      },
+    ),
+    isTrue,
+  );
+
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrapWithAccounts()),
+      votingShareTrackingRegistryProvider.overrideWithValue(shareTracking),
+    ],
+  );
+  addTearDown(container.dispose);
+  await container.read(accountProvider.future);
+
+  final removal = container
+      .read(accountProvider.notifier)
+      .removeAccount('account-2');
+  await drainStarted.future;
+  expect(_rustApi.deletedAccountUuids, isEmpty);
+  expect(shareTracking.isQuiesced('account-2'), isTrue);
+
+  drainGate.complete();
+  await removal;
+
+  expect(_rustApi.deletedAccountUuids, ['account-2']);
+  expect(shareTracking.isQuiesced('account-2'), isFalse);
 }
 
 AppBootstrapState _bootstrapWithAccounts() {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6045,73 +6045,9 @@ void main() {
     expect(rust.recordedShares, isEmpty);
   });
 
-  test('initial share submission uses planned helper targets', () async {
+  test('initial shares replace an unavailable helper', () async {
     final helperUrls = [
       for (var i = 1; i <= 6; i++)
-        {'url': 'https://helper-$i.example', 'label': 'helper-$i'},
-    ];
-    final http = FakeVotingHttpClient(
-      responses: votingHttpResponses(
-        dynamicConfig: dynamicConfigJson(voteServers: helperUrls),
-      ),
-    );
-    final rust = FakeVotingRustApi(emitCommitments: true);
-    final recoveryApi = FakeVotingRecoveryApi(
-      state: recoveryState(
-        bundleCount: 1,
-        delegationTxHashes: [
-          rust_frb_types.DelegationRecoveryView(
-            bundleIndex: 0,
-            phase: VotingWorkflowPhase.submittedDelegation,
-            txHash: 'delegation-0',
-            vanLeafPosition: null,
-          ),
-        ],
-        votes: [vote(bundleIndex: 0, proposalId: 7)],
-      ),
-    );
-    final container = _sessionContainer(
-      http: http,
-      rust: rust,
-      recoveryApi: recoveryApi,
-    );
-    addTearDown(container.dispose);
-
-    await container.read(votingSessionProvider(kRoundId).future);
-    await container
-        .read(votingSessionProvider(kRoundId).notifier)
-        .castVotes(
-          draftVotes: [
-            rust_wire.DraftVote(
-              proposalId: 7,
-              choice: 1,
-              numOptions: 2,
-              vcTreePosition: BigInt.zero,
-              singleShare: false,
-            ),
-          ],
-        );
-
-    final sharePosts = http.requests.where(
-      (request) =>
-          request.method == 'POST' &&
-          request.uri.path == '/shielded-vote/v1/shares',
-    );
-    expect(sharePosts.map((request) => request.uri.host), [
-      'helper-1.example',
-      'helper-2.example',
-      'helper-3.example',
-    ]);
-    expect(rust.recordedShares.single.sentToUrls, [
-      'https://helper-1.example',
-      'https://helper-2.example',
-      'https://helper-3.example',
-    ]);
-  });
-
-  test('helper preflight overlaps confirmation and replaces target', () async {
-    final helperUrls = [
-      for (var i = 1; i <= 4; i++)
         {'url': 'https://helper-$i.example', 'label': 'helper-$i'},
     ];
     final http = _GatedVotingHttpClient(
@@ -6180,8 +6116,7 @@ void main() {
     final statusHosts = http.requests
         .where(
           (request) =>
-              request.method == 'GET' &&
-              request.uri.path == '/shielded-vote/v1/status',
+              request.method == 'GET' && request.uri.path == statusPath,
         )
         .map((request) => request.uri.host);
     expect(
@@ -6191,19 +6126,25 @@ void main() {
         'helper-2.example',
         'helper-3.example',
         'helper-4.example',
+        'helper-5.example',
+        'helper-6.example',
       ]),
     );
-    final sharePostHosts = http.requests
-        .where(
-          (request) =>
-              request.method == 'POST' &&
-              request.uri.path == '/shielded-vote/v1/shares',
-        )
-        .map((request) => request.uri.host);
-    expect(sharePostHosts, ['helper-2.example', 'helper-3.example']);
+
+    final sharePosts = http.requests.where(
+      (request) =>
+          request.method == 'POST' &&
+          request.uri.path == '/shielded-vote/v1/shares',
+    );
+    expect(sharePosts.map((request) => request.uri.host), [
+      'helper-2.example',
+      'helper-3.example',
+      'helper-4.example',
+    ]);
     expect(rust.recordedShares.single.sentToUrls, [
       'https://helper-2.example',
       'https://helper-3.example',
+      'https://helper-4.example',
     ]);
   });
 

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -9574,9 +9574,6 @@ class FakeVotingRustApi implements VotingRustApi {
   }
 
   @override
-  void logVotingTiming({required String message}) {}
-
-  @override
   Future<void> markDelegationSubmitted({
     required String dbPath,
     required String accountUuid,

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -5981,12 +5981,27 @@ void main() {
 
       expect(rust.precomputeStoredHotkeySecrets.single, [9, 9, 9]);
       expect(rust.setupCalls, 0);
+      expect(rust.warmVotingProvingCachesCalls, greaterThanOrEqualTo(1));
 
       precomputeGate.complete();
       await rust.precomputeFinished.future;
       await Future<void>.delayed(Duration.zero);
     },
   );
+
+  test('prepareDelegation warms proving caches before bundle setup', () async {
+    final rust = FakeVotingRustApi();
+    final container = _sessionContainer(rust: rust);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .prepareDelegation();
+
+    expect(rust.warmVotingProvingCachesCalls, greaterThanOrEqualTo(1));
+    expect(rust.setupCalls, 1);
+  });
 
   test(
     'delegation PIR warmup skips cold plans without durable setup',
@@ -7684,6 +7699,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final precomputedDelegationPir = <int>[];
   final precomputeStoredHotkeySecrets = <List<int>>[];
   final delegationStoredHotkeySecrets = <List<int>>[];
+  int warmVotingProvingCachesCalls = 0;
   final setupStarted = Completer<void>();
   final delegationProofStarted = Completer<void>();
   final keystoneDelegationProofStarted = Completer<void>();
@@ -8060,6 +8076,14 @@ class FakeVotingRustApi implements VotingRustApi {
       bundleIndex: bundleIndex,
     );
   }
+
+  @override
+  void warmVotingProvingCaches() {
+    warmVotingProvingCachesCalls++;
+  }
+
+  @override
+  void logVotingTiming({required String message}) {}
 
   @override
   Future<void> markDelegationSubmitted({

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3436,6 +3436,84 @@ void main() {
     },
   );
 
+  test(
+    'share tracking releases its registration when the round expires',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final voteEndSeconds = nowSeconds + 2;
+      final acceptedShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        nullifier: Uint8List.fromList(List.filled(32, 1)),
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.zero,
+        createdAt: BigInt.one,
+      );
+      final trackingGate = Completer<void>();
+      final rust = FakeVotingRustApi(shareTrackingFlagsGate: trackingGate);
+      addTearDown(() {
+        if (!trackingGate.isCompleted) trackingGate.complete();
+      });
+      final http = FakeVotingHttpClient(
+        responses: votingHttpResponses(
+          roundStatus: roundStatusJson(
+            roundId: kRoundId,
+            voteEnd: voteEndSeconds,
+          ),
+          dynamicConfig: dynamicConfigJson(
+            voteServers: const [
+              {'url': 'https://helper-a.example', 'label': 'helper-a'},
+            ],
+          ),
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: _submittedDelegationWithShareRecoveryApi(acceptedShare),
+        txConfirmationPolling: _fastTxConfirmationPolling,
+      );
+      addTearDown(container.dispose);
+
+      final startedKey = await container
+          .read(votingSubmissionJobsProvider.notifier)
+          .start(kRoundId);
+      expect(
+        startedKey,
+        const VotingSessionKey(roundId: kRoundId, accountUuid: 'account-1'),
+      );
+      await _waitForStoredVanPosition(rust, '0:0');
+      await _waitForJobStatus(
+        container,
+        startedKey!,
+        VotingSubmissionJobStatus.complete,
+      );
+      await rust.shareTrackingFlagsStarted.future;
+
+      final registry = container.read(votingShareTrackingRegistryProvider);
+      expect(registry.registeredKeys, {startedKey});
+
+      final waitUntilExpiry = DateTime.fromMillisecondsSinceEpoch(
+        voteEndSeconds * 1000,
+      ).difference(DateTime.now());
+      if (waitUntilExpiry > Duration.zero) {
+        await Future<void>.delayed(
+          waitUntilExpiry + const Duration(milliseconds: 50),
+        );
+      }
+      trackingGate.complete();
+      for (var i = 0; i < 100 && registry.registeredKeys.isNotEmpty; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+
+      expect(registry.registeredKeys, isEmpty);
+    },
+  );
+
   test('share tracking failure fails the job and releases its guard', () async {
     final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final pendingShare = rust_frb_types.ShareDelegationRecordView(

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3367,7 +3367,11 @@ void main() {
         submitAt: BigInt.zero,
         createdAt: BigInt.one,
       );
-      final rust = FakeVotingRustApi();
+      final trackingGate = Completer<void>();
+      final rust = FakeVotingRustApi(shareTrackingFlagsGate: trackingGate);
+      addTearDown(() {
+        if (!trackingGate.isCompleted) trackingGate.complete();
+      });
       final http = FakeVotingHttpClient(
         responses: votingHttpResponses(
           dynamicConfig: dynamicConfigJson(
@@ -3407,6 +3411,13 @@ void main() {
         isNull,
       );
       expect(rust.confirmedShares, isEmpty);
+      expect(trackingGate.isCompleted, isFalse);
+      await rust.shareTrackingFlagsStarted.future;
+      expect(
+        container.read(votingSubmissionJobProvider(startedKey)).status,
+        VotingSubmissionJobStatus.complete,
+      );
+      trackingGate.complete();
     },
   );
 
@@ -7176,6 +7187,60 @@ void main() {
     expect(rust.resetVotingSessionStateCalls, ['account-1:$kRoundId']);
   });
 
+  test(
+    'session dispose skips process-local reset while a submission is guarded',
+    () async {
+      final rust = FakeVotingRustApi();
+      final container = _sessionContainer(rust: rust);
+      addTearDown(container.dispose);
+
+      final guard = container
+          .read(votingSubmissionGuardProvider.notifier)
+          .acquire(accountUuid: 'account-1', roundId: kRoundId);
+      addTearDown(
+        () => container
+            .read(votingSubmissionGuardProvider.notifier)
+            .release(guard),
+      );
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      container.invalidate(votingSessionProvider(kRoundId));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(rust.resetVotingSessionStateCalls, isEmpty);
+    },
+  );
+
+  test(
+    'submission session dispose skips process-local reset while guarded',
+    () async {
+      final rust = FakeVotingRustApi();
+      final container = _sessionContainer(rust: rust);
+      addTearDown(container.dispose);
+      const key = VotingSessionKey(accountUuid: 'account-1', roundId: kRoundId);
+
+      final guard = container
+          .read(votingSubmissionGuardProvider.notifier)
+          .acquire(accountUuid: key.accountUuid, roundId: key.roundId);
+      addTearDown(
+        () => container
+            .read(votingSubmissionGuardProvider.notifier)
+            .release(guard),
+      );
+
+      final subscription = container.listen(
+        votingSubmissionSessionProvider(key),
+        (_, _) {},
+      );
+      await container.read(votingSubmissionSessionProvider(key).future);
+      subscription.close();
+      container.invalidate(votingSubmissionSessionProvider(key));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(rust.resetVotingSessionStateCalls, isEmpty);
+    },
+  );
+
   test('hotkey failure moves session into error phase', () async {
     final rust = FakeVotingRustApi();
     final recoveryApi = FakeVotingRecoveryApi(
@@ -8869,6 +8934,7 @@ class FakeVotingRustApi implements VotingRustApi {
     this.keystoneSignatureBatchFailuresRemaining = 0,
     this.shareResubmissionError,
     this.nextShareTrackingDelayGate,
+    this.shareTrackingFlagsGate,
     this.failingVoteShareWireIndexes = const {},
     this.failingRecordShareIndexes = const {},
   });
@@ -8902,6 +8968,7 @@ class FakeVotingRustApi implements VotingRustApi {
   int keystoneSignatureBatchFailuresRemaining;
   final Object? shareResubmissionError;
   final Completer<void>? nextShareTrackingDelayGate;
+  final Completer<void>? shareTrackingFlagsGate;
   final Set<int> failingVoteShareWireIndexes;
   final Set<int> failingRecordShareIndexes;
   int setupCalls = 0;
@@ -8939,6 +9006,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final precomputeStarted = Completer<void>();
   final precomputeFinished = Completer<void>();
   final nextShareTrackingDelayStarted = Completer<void>();
+  final shareTrackingFlagsStarted = Completer<void>();
   final resetVoteTreeCalls = <String>[];
   final resetVotingSessionStateCalls = <String>[];
   final draftSingleShareValues = <bool>[];
@@ -9711,6 +9779,10 @@ class FakeVotingRustApi implements VotingRustApi {
     required BigInt nowSeconds,
     BigInt? voteEndTimeSeconds,
   }) async {
+    if (!shareTrackingFlagsStarted.isCompleted) {
+      shareTrackingFlagsStarted.complete();
+    }
+    await shareTrackingFlagsGate?.future;
     final now = nowSeconds.toInt();
     final base = share.submitAt > BigInt.zero
         ? share.submitAt.toInt()

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6109,12 +6109,12 @@ void main() {
     ]);
   });
 
-  test('helper preflight replaces an unavailable planned target', () async {
+  test('helper preflight overlaps confirmation and replaces target', () async {
     final helperUrls = [
       for (var i = 1; i <= 4; i++)
         {'url': 'https://helper-$i.example', 'label': 'helper-$i'},
     ];
-    final http = FakeVotingHttpClient(
+    final http = _GatedVotingHttpClient(
       responses: {
         ...votingHttpResponses(
           dynamicConfig: dynamicConfigJson(voteServers: helperUrls),
@@ -6124,6 +6124,9 @@ void main() {
         }, statusCode: 503),
       },
     );
+    const confirmationPath = '/shielded-vote/v1/tx/vote-tx';
+    const statusPath = '/shielded-vote/v1/status';
+    final confirmationGate = http.gateNextGet(confirmationPath);
     final rust = FakeVotingRustApi(emitCommitments: true);
     final recoveryApi = FakeVotingRecoveryApi(
       state: recoveryState(
@@ -6145,9 +6148,12 @@ void main() {
       recoveryApi: recoveryApi,
     );
     addTearDown(container.dispose);
+    addTearDown(() {
+      if (!confirmationGate.isCompleted) confirmationGate.complete();
+    });
 
     await container.read(votingSessionProvider(kRoundId).future);
-    await container
+    final submission = container
         .read(votingSessionProvider(kRoundId).notifier)
         .castVotes(
           draftVotes: [
@@ -6160,6 +6166,16 @@ void main() {
             ),
           ],
         );
+    await http
+        .waitForGetCount(confirmationPath, 1)
+        .timeout(const Duration(seconds: 1));
+    await http
+        .waitForGetCount(statusPath, helperUrls.length)
+        .timeout(const Duration(seconds: 1));
+
+    expect(confirmationGate.isCompleted, isFalse);
+    confirmationGate.complete();
+    await submission;
 
     final statusHosts = http.requests
         .where(

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1689,6 +1689,137 @@ void main() {
     expect(rust.storedVanPositions, ['0:0']);
   });
 
+  test('delegation proves at most three bundles concurrently', () async {
+    final proofGate = Completer<void>();
+    final rust = FakeVotingRustApi(
+      bundleCount: 4,
+      delegationProofGate: proofGate,
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(bundleCount: 4),
+    );
+    final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final delegation = container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .delegatePendingBundles(mnemonic: kTestMnemonic);
+    while (rust.delegationBundleCalls.length < 3 ||
+        (container
+                    .read(votingSessionProvider(kRoundId))
+                    .value
+                    ?.delegationProgress
+                    .length ??
+                0) <
+            3) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    expect(rust.delegationBundleCalls, [0, 1, 2]);
+    expect(rust.maxConcurrentDelegationProofs, 3);
+    final activeState = container.read(votingSessionProvider(kRoundId)).value!;
+    expect(activeState.currentBundleIndex, isNull);
+    expect(activeState.delegationProgress.keys, {0, 1, 2});
+
+    proofGate.complete();
+    await delegation;
+
+    expect(rust.delegationBundleCalls, [0, 1, 2, 3]);
+    expect(rust.maxConcurrentDelegationProofs, 3);
+    expect(rust.storedDelegationTxHashes, [
+      '0:delegation-tx',
+      '1:delegation-tx',
+      '2:delegation-tx',
+      '3:delegation-tx',
+    ]);
+  });
+
+  test('delegation drains siblings and preserves successful bundles', () async {
+    final proofErrors = <int, Object>{
+      1: StateError('injected bundle proof failure'),
+    };
+    final confirmed = <int, rust_frb_types.DelegationRecoveryView>{};
+    late FakeVotingRecoveryApi recoveryApi;
+    final rust = FakeVotingRustApi(
+      bundleCount: 3,
+      delegationStreamErrorsByBundle: proofErrors,
+      onDelegationConfirmed: (bundleIndex, txHash, vanLeafPosition) {
+        confirmed[bundleIndex] = rust_frb_types.DelegationRecoveryView(
+          bundleIndex: bundleIndex,
+          phase: VotingWorkflowPhase.submittedDelegation,
+          txHash: txHash,
+          vanLeafPosition: vanLeafPosition,
+        );
+        recoveryApi.state = recoveryState(
+          bundleCount: 3,
+          delegationWorkflows: confirmed.values.toList(),
+        );
+      },
+    );
+    recoveryApi = FakeVotingRecoveryApi(state: recoveryState(bundleCount: 3));
+    final http = FakeVotingHttpClient(responses: votingHttpResponses());
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final notifier = container.read(votingSessionProvider(kRoundId).notifier);
+    await notifier.delegatePendingBundles(mnemonic: kTestMnemonic);
+    var state = container.read(votingSessionProvider(kRoundId)).value!;
+
+    expect(state.phase, VotingSessionPhase.error);
+    expect(state.error?.message, contains('bundle proof failure'));
+    expect(state.resumePlan?.pendingDelegationBundleIndexes, [1]);
+    expect(rust.delegationBundleCalls, [0, 1, 2]);
+    expect(rust.storedDelegationTxHashes, [
+      '0:delegation-tx',
+      '2:delegation-tx',
+    ]);
+    expect(rust.resetVotingSessionStateCalls, isEmpty);
+
+    proofErrors.clear();
+    await notifier.delegatePendingBundles(mnemonic: kTestMnemonic);
+    state = container.read(votingSessionProvider(kRoundId)).value!;
+
+    expect(state.phase, VotingSessionPhase.delegated);
+    expect(rust.delegationBundleCalls, [0, 1, 2, 1]);
+    expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 3);
+    expect(rust.storedDelegationTxHashes, [
+      '0:delegation-tx',
+      '2:delegation-tx',
+      '1:delegation-tx',
+    ]);
+    expect(rust.resetVotingSessionStateCalls, isEmpty);
+  });
+
+  test('delegation serializes broadcasts and overlaps confirmations', () async {
+    final http = _DelegationConcurrencyHttpClient(
+      responses: votingHttpResponses(),
+    );
+    final rust = FakeVotingRustApi(bundleCount: 3);
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(bundleCount: 3),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .delegatePendingBundles(mnemonic: kTestMnemonic);
+
+    expect(http.maxConcurrentDelegationPosts, 1);
+    expect(http.maxConcurrentConfirmationGets, 3);
+  });
+
   test('delegation stream errors surface the Rust failure', () async {
     final rust = FakeVotingRustApi(
       delegationStreamError: StateError(
@@ -2261,10 +2392,76 @@ void main() {
 
     expect(state.phase, VotingSessionPhase.delegated);
     expect(rust.keystoneProofBundleCalls, [0, 1]);
+    expect(rust.maxConcurrentKeystoneDelegationProofs, 2);
     expect(rust.storedDelegationTxHashes, [
       '0:delegation-tx',
       '1:delegation-tx',
     ]);
+  });
+
+  test('hardware partial delegation retry skips confirmed siblings', () async {
+    final proofErrors = <int, Object>{
+      1: StateError('injected Keystone bundle proof failure'),
+    };
+    final confirmed = <int, rust_frb_types.DelegationRecoveryView>{};
+    late FakeVotingRecoveryApi recoveryApi;
+    final rust = FakeVotingRustApi(
+      bundleCount: 3,
+      keystoneDelegationStreamErrorsByBundle: proofErrors,
+      onDelegationConfirmed: (bundleIndex, txHash, vanLeafPosition) {
+        confirmed[bundleIndex] = rust_frb_types.DelegationRecoveryView(
+          bundleIndex: bundleIndex,
+          phase: VotingWorkflowPhase.submittedDelegation,
+          txHash: txHash,
+          vanLeafPosition: vanLeafPosition,
+        );
+        recoveryApi.state = recoveryState(
+          bundleCount: 3,
+          delegationWorkflows: confirmed.values.toList(),
+        );
+      },
+    );
+    for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++) {
+      rust.storedKeystoneSignatures[bundleIndex] =
+          rust_wire.KeystoneSignatureRecord(
+            bundleIndex: bundleIndex,
+            sig: Uint8List.fromList([3, bundleIndex]),
+            sighash: Uint8List.fromList([10, bundleIndex]),
+            rk: Uint8List.fromList([2, bundleIndex]),
+          );
+    }
+    recoveryApi = FakeVotingRecoveryApi(state: recoveryState(bundleCount: 3));
+    final http = FakeVotingHttpClient(responses: votingHttpResponses());
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+      accountIsHardware: true,
+      hotkeyStore: FakeVotingHotkeyStore(const [42, 43, 44]),
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final notifier = container.read(votingSessionProvider(kRoundId).notifier);
+    await notifier.delegatePendingBundlesWithKeystoneSignatures();
+    var state = container.read(votingSessionProvider(kRoundId)).value!;
+
+    expect(state.phase, VotingSessionPhase.error);
+    expect(state.error?.message, contains('Keystone bundle proof failure'));
+    expect(state.resumePlan?.pendingDelegationBundleIndexes, [1]);
+    expect(rust.keystoneProofBundleCalls, [0, 1, 2]);
+    expect(rust.storedKeystoneSignatures.keys, [0, 1, 2]);
+    expect(rust.resetVotingSessionStateCalls, isEmpty);
+
+    proofErrors.clear();
+    await notifier.delegatePendingBundlesWithKeystoneSignatures();
+    state = container.read(votingSessionProvider(kRoundId)).value!;
+
+    expect(state.phase, VotingSessionPhase.delegated);
+    expect(rust.keystoneProofBundleCalls, [0, 1, 2, 1]);
+    expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 3);
+    expect(rust.storedKeystoneSignatures.keys, [0, 1, 2]);
+    expect(rust.resetVotingSessionStateCalls, isEmpty);
   });
 
   test(
@@ -6116,7 +6313,8 @@ void main() {
       }
     }
 
-    expect(activeState?.currentBundleIndex, 0);
+    expect(activeState?.phase, VotingSessionPhase.delegating);
+    expect(activeState?.currentBundleIndex, isNull);
     expect(rust.delegationBundleCalls, isEmpty);
 
     precomputeGate.complete();
@@ -7623,6 +7821,75 @@ class _MutableVotingSecurityNotifier extends AppSecurityNotifier {
   }
 }
 
+class _DelegationConcurrencyHttpClient extends FakeVotingHttpClient {
+  _DelegationConcurrencyHttpClient({required super.responses});
+
+  int _activeDelegationPosts = 0;
+  int _activeVotePosts = 0;
+  int _activeConfirmationGets = 0;
+  int maxConcurrentDelegationPosts = 0;
+  int maxConcurrentVotePosts = 0;
+  int maxConcurrentConfirmationGets = 0;
+
+  @override
+  Future<VotingHttpResponse> postJson(
+    Uri uri,
+    Map<String, dynamic> body, {
+    Duration? timeout,
+  }) async {
+    final isDelegation = uri.path.endsWith('/delegate-vote');
+    final isVote = uri.path.endsWith('/cast-vote');
+    if (!isDelegation && !isVote) {
+      return super.postJson(uri, body, timeout: timeout);
+    }
+    if (isDelegation) {
+      _activeDelegationPosts++;
+      if (_activeDelegationPosts > maxConcurrentDelegationPosts) {
+        maxConcurrentDelegationPosts = _activeDelegationPosts;
+      }
+    } else {
+      _activeVotePosts++;
+      if (_activeVotePosts > maxConcurrentVotePosts) {
+        maxConcurrentVotePosts = _activeVotePosts;
+      }
+    }
+    try {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      return await super.postJson(uri, body, timeout: timeout);
+    } finally {
+      if (isDelegation) {
+        _activeDelegationPosts--;
+      } else {
+        _activeVotePosts--;
+      }
+    }
+  }
+
+  @override
+  Future<VotingHttpResponse> get(
+    Uri uri, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
+    if (!uri.path.contains('/tx/')) {
+      return super.get(uri, headers: headers, timeout: timeout);
+    }
+    _activeConfirmationGets++;
+    if (_activeConfirmationGets > maxConcurrentConfirmationGets) {
+      maxConcurrentConfirmationGets = _activeConfirmationGets;
+    }
+    try {
+      // Deliberately slower than a broadcast POST, matching real chains where
+      // a confirmation wait spans blocks. This is what makes "confirmations
+      // overlap the next bundle's broadcast" observable.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      return await super.get(uri, headers: headers, timeout: timeout);
+    } finally {
+      _activeConfirmationGets--;
+    }
+  }
+}
+
 class FakeVotingRustApi implements VotingRustApi {
   FakeVotingRustApi({
     this.setupDelay = Duration.zero,
@@ -7641,9 +7908,14 @@ class FakeVotingRustApi implements VotingRustApi {
     this.commitmentShareCount = 1,
     this.mismatchKeystoneSubmission = false,
     this.delegationStreamError,
+    this.delegationStreamErrorsByBundle = const {},
+    this.keystoneDelegationStreamErrorsByBundle = const {},
+    this.onDelegationConfirmed,
     this.delegationProofGate,
     this.keystoneDelegationProofGate,
     this.voteCommitmentGate,
+    this.voteCommitmentErrorsByKey = const {},
+    this.failingVoteConfirmationKeys = const {},
     this.onDeleteSkippedBundles,
     this.keystoneDelegationRequestFailuresByCall = const {},
     this.failingVoteTreeNodeUrls = const {},
@@ -7668,9 +7940,15 @@ class FakeVotingRustApi implements VotingRustApi {
   final int commitmentShareCount;
   final bool mismatchKeystoneSubmission;
   final Object? delegationStreamError;
+  final Map<int, Object> delegationStreamErrorsByBundle;
+  final Map<int, Object> keystoneDelegationStreamErrorsByBundle;
+  final void Function(int bundleIndex, String txHash, int vanLeafPosition)?
+  onDelegationConfirmed;
   final Completer<void>? delegationProofGate;
   final Completer<void>? keystoneDelegationProofGate;
   final Completer<void>? voteCommitmentGate;
+  final Map<String, Object> voteCommitmentErrorsByKey;
+  final Set<String> failingVoteConfirmationKeys;
   final void Function(int keepCount)? onDeleteSkippedBundles;
   final Map<int, Object> keystoneDelegationRequestFailuresByCall;
   final Set<String> failingVoteTreeNodeUrls;
@@ -7682,6 +7960,10 @@ class FakeVotingRustApi implements VotingRustApi {
   int setupCalls = 0;
   int _activeSetups = 0;
   int maxConcurrentSetups = 0;
+  int _activeDelegationProofs = 0;
+  int maxConcurrentDelegationProofs = 0;
+  int _activeKeystoneDelegationProofs = 0;
+  int maxConcurrentKeystoneDelegationProofs = 0;
   final delegationBundleCalls = <int>[];
   final delegationMnemonics = <String>[];
   final voteCommitBundleCalls = <int>[];
@@ -7811,38 +8093,54 @@ class FakeVotingRustApi implements VotingRustApi {
     delegationBundleCalls.add(bundleIndex);
     delegationMnemonics.add(mnemonic);
     delegationStoredHotkeySecrets.add(List<int>.from(storedHotkeySecret));
-    final error = delegationStreamError;
-    if (error != null) throw error;
-    if (!delegationProofStarted.isCompleted) {
-      delegationProofStarted.complete();
+    _activeDelegationProofs++;
+    if (_activeDelegationProofs > maxConcurrentDelegationProofs) {
+      maxConcurrentDelegationProofs = _activeDelegationProofs;
     }
-    await delegationProofGate?.future;
-    yield rust_api.ApiDelegationProofEvent(
-      phase: 'result',
-      proofProgress: null,
-      signedDelegationPayload: rust_wire.SignedDelegationPayloadView(
-        pcztBytes: Uint8List.fromList(const []),
-        status: 'ready_for_submission',
-        message: null,
-        submission: rust_wire.DelegationSubmissionWire(
-          rk: base64Encode(const [2]),
-          spendAuthSig: base64Encode(const [3]),
-          tx1Effects: base64Encode(const [4]),
-          nfSigned: base64Encode(const [5]),
-          cmxNew: base64Encode(const [6]),
-          govComm: base64Encode(const [7]),
-          govNullifiers: [
-            base64Encode(const [8]),
-          ],
-          proof: base64Encode(const [1]),
-          voteRoundId: base64Encode(_bytesFromHex(ctx.roundParams.voteRoundId)),
+    try {
+      final error =
+          delegationStreamErrorsByBundle[bundleIndex] ?? delegationStreamError;
+      if (error != null) throw error;
+      if (!delegationProofStarted.isCompleted) {
+        delegationProofStarted.complete();
+      }
+      yield const rust_api.ApiDelegationProofEvent(
+        phase: 'proving',
+        proofProgress: 0.1,
+        signedDelegationPayload: null,
+      );
+      await delegationProofGate?.future;
+      yield rust_api.ApiDelegationProofEvent(
+        phase: 'result',
+        proofProgress: null,
+        signedDelegationPayload: rust_wire.SignedDelegationPayloadView(
+          pcztBytes: Uint8List.fromList(const []),
+          status: 'ready_for_submission',
+          message: null,
+          submission: rust_wire.DelegationSubmissionWire(
+            rk: base64Encode(const [2]),
+            spendAuthSig: base64Encode(const [3]),
+            tx1Effects: base64Encode(const [4]),
+            nfSigned: base64Encode(const [5]),
+            cmxNew: base64Encode(const [6]),
+            govComm: base64Encode(const [7]),
+            govNullifiers: [
+              base64Encode(const [8]),
+            ],
+            proof: base64Encode(const [1]),
+            voteRoundId: base64Encode(
+              _bytesFromHex(ctx.roundParams.voteRoundId),
+            ),
+          ),
+          eligibleWeightZatoshi: BigInt.from(100),
+          delegatedWeightZatoshi: BigInt.from(100),
+          bundleCount: bundleCount,
+          bundleIndex: bundleIndex,
         ),
-        eligibleWeightZatoshi: BigInt.from(100),
-        delegatedWeightZatoshi: BigInt.from(100),
-        bundleCount: 1,
-        bundleIndex: bundleIndex,
-      ),
-    );
+      );
+    } finally {
+      _activeDelegationProofs--;
+    }
   }
 
   @override
@@ -7992,40 +8290,58 @@ class FakeVotingRustApi implements VotingRustApi {
   }) async* {
     accountUuids.add(ctx.accountUuid);
     keystoneProofBundleCalls.add(bundleIndex);
-    if (!keystoneDelegationProofStarted.isCompleted) {
-      keystoneDelegationProofStarted.complete();
+    _activeKeystoneDelegationProofs++;
+    if (_activeKeystoneDelegationProofs >
+        maxConcurrentKeystoneDelegationProofs) {
+      maxConcurrentKeystoneDelegationProofs = _activeKeystoneDelegationProofs;
     }
-    await keystoneDelegationProofGate?.future;
-    final signature = storedKeystoneSignatures[bundleIndex];
-    final rk = mismatchKeystoneSubmission
-        ? const [99]
-        : signature?.rk ?? const [2];
-    yield rust_api.ApiDelegationProofEvent(
-      phase: 'result',
-      proofProgress: null,
-      signedDelegationPayload: rust_wire.SignedDelegationPayloadView(
-        pcztBytes: Uint8List.fromList(const []),
-        status: 'ready_for_submission',
-        message: null,
-        submission: rust_wire.DelegationSubmissionWire(
-          rk: base64Encode(rk),
-          spendAuthSig: base64Encode(keystoneSig),
-          tx1Effects: base64Encode(keystoneSighash),
-          nfSigned: base64Encode(const [5]),
-          cmxNew: base64Encode(const [6]),
-          govComm: base64Encode(const [7]),
-          govNullifiers: [
-            base64Encode(const [8]),
-          ],
-          proof: base64Encode(const [1]),
-          voteRoundId: base64Encode(_bytesFromHex(ctx.roundParams.voteRoundId)),
+    try {
+      if (!keystoneDelegationProofStarted.isCompleted) {
+        keystoneDelegationProofStarted.complete();
+      }
+      yield const rust_api.ApiDelegationProofEvent(
+        phase: 'proving',
+        proofProgress: 0.1,
+        signedDelegationPayload: null,
+      );
+      await keystoneDelegationProofGate?.future;
+      final error = keystoneDelegationStreamErrorsByBundle[bundleIndex];
+      if (error != null) throw error;
+      final signature = storedKeystoneSignatures[bundleIndex];
+      final rk = mismatchKeystoneSubmission
+          ? const [99]
+          : signature?.rk ?? const [2];
+      yield rust_api.ApiDelegationProofEvent(
+        phase: 'result',
+        proofProgress: null,
+        signedDelegationPayload: rust_wire.SignedDelegationPayloadView(
+          pcztBytes: Uint8List.fromList(const []),
+          status: 'ready_for_submission',
+          message: null,
+          submission: rust_wire.DelegationSubmissionWire(
+            rk: base64Encode(rk),
+            spendAuthSig: base64Encode(keystoneSig),
+            tx1Effects: base64Encode(keystoneSighash),
+            nfSigned: base64Encode(const [5]),
+            cmxNew: base64Encode(const [6]),
+            govComm: base64Encode(const [7]),
+            govNullifiers: [
+              base64Encode(const [8]),
+            ],
+            proof: base64Encode(const [1]),
+            voteRoundId: base64Encode(
+              _bytesFromHex(ctx.roundParams.voteRoundId),
+            ),
+          ),
+          eligibleWeightZatoshi: BigInt.from(100),
+          delegatedWeightZatoshi: BigInt.from(100),
+          bundleCount: bundleCount,
+          bundleIndex: bundleIndex,
         ),
-        eligibleWeightZatoshi: BigInt.from(100),
-        delegatedWeightZatoshi: BigInt.from(100),
-        bundleCount: bundleCount,
-        bundleIndex: bundleIndex,
-      ),
-    );
+      );
+    } finally {
+      _activeKeystoneDelegationProofs--;
+    }
   }
 
   @override
@@ -8125,6 +8441,7 @@ class FakeVotingRustApi implements VotingRustApi {
       txHash: txHash,
       vanLeafPosition: vanLeafPosition,
     );
+    onDelegationConfirmed?.call(bundleIndex, txHash, vanLeafPosition);
     return rust_wire.DelegationConfirmation(
       txHash: txHash,
       vanLeafPosition: vanLeafPosition,

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6109,6 +6109,88 @@ void main() {
     ]);
   });
 
+  test('helper preflight replaces an unavailable planned target', () async {
+    final helperUrls = [
+      for (var i = 1; i <= 4; i++)
+        {'url': 'https://helper-$i.example', 'label': 'helper-$i'},
+    ];
+    final http = FakeVotingHttpClient(
+      responses: {
+        ...votingHttpResponses(
+          dynamicConfig: dynamicConfigJson(voteServers: helperUrls),
+        ),
+        'https://helper-1.example/shielded-vote/v1/status': jsonResponse({
+          'error': 'unavailable',
+        }, statusCode: 503),
+      },
+    );
+    final rust = FakeVotingRustApi(emitCommitments: true);
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 1,
+        delegationTxHashes: [
+          rust_frb_types.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.submittedDelegation,
+            txHash: 'delegation-0',
+            vanLeafPosition: null,
+          ),
+        ],
+        votes: [vote(bundleIndex: 0, proposalId: 7)],
+      ),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(
+          draftVotes: [
+            rust_wire.DraftVote(
+              proposalId: 7,
+              choice: 1,
+              numOptions: 2,
+              vcTreePosition: BigInt.zero,
+              singleShare: false,
+            ),
+          ],
+        );
+
+    final statusHosts = http.requests
+        .where(
+          (request) =>
+              request.method == 'GET' &&
+              request.uri.path == '/shielded-vote/v1/status',
+        )
+        .map((request) => request.uri.host);
+    expect(
+      statusHosts,
+      unorderedEquals([
+        'helper-1.example',
+        'helper-2.example',
+        'helper-3.example',
+        'helper-4.example',
+      ]),
+    );
+    final sharePostHosts = http.requests
+        .where(
+          (request) =>
+              request.method == 'POST' &&
+              request.uri.path == '/shielded-vote/v1/shares',
+        )
+        .map((request) => request.uri.host);
+    expect(sharePostHosts, ['helper-2.example', 'helper-3.example']);
+    expect(rust.recordedShares.single.sentToUrls, [
+      'https://helper-2.example',
+      'https://helper-3.example',
+    ]);
+  });
+
   test(
     'share submission schedules submit_at before last-moment buffer',
     () async {
@@ -8040,6 +8122,7 @@ Map<String, Object> votingHttpResponses({
     ],
   },
   '/shielded-vote/v1/cast-vote': {'tx_hash': 'vote-tx', 'code': 0, 'log': ''},
+  '/shielded-vote/v1/status': {'status': 'ok'},
   '/shielded-vote/v1/shares': {'status': 'queued'},
   '/shielded-vote/v1/tx/vote-tx': {
     'height': 11,

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3410,6 +3410,10 @@ void main() {
             .guardForAccount('account-1'),
         isNull,
       );
+      expect(
+        container.read(votingShareTrackingRegistryProvider).registeredKeys,
+        {startedKey},
+      );
       expect(rust.confirmedShares, isEmpty);
       expect(trackingGate.isCompleted, isFalse);
       await rust.shareTrackingFlagsStarted.future;
@@ -3417,7 +3421,18 @@ void main() {
         container.read(votingSubmissionJobProvider(startedKey)).status,
         VotingSubmissionJobStatus.complete,
       );
+
+      var drained = false;
+      final drain = container
+          .read(votingShareTrackingRegistryProvider)
+          .quiesceAndDrain(accountUuid: 'account-1')
+          .then((_) => drained = true);
+      await Future<void>.delayed(Duration.zero);
+      expect(drained, isFalse);
+
       trackingGate.complete();
+      await drain;
+      expect(drained, isTrue);
     },
   );
 

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3836,7 +3836,7 @@ void main() {
   );
 
   test('vote progress is isolated by bundle index', () async {
-    final rust = FakeVotingRustApi();
+    final rust = FakeVotingRustApi(emitCommitments: true);
     final recoveryApi = FakeVotingRecoveryApi(
       state: recoveryState(
         bundleCount: 2,
@@ -3976,13 +3976,20 @@ void main() {
           .map((state) => state.voteSubmissionCompletedCount)
           .toSet();
       expect(activeProgressCounts, containsAll(<int>{0, 1, 2}));
-      expect(
-        observed
-            .where((state) => state.voteSubmissionTotalCount == 2)
-            .map((state) => state.voteSubmissionProgress)
-            .whereType<double>(),
-        containsAll(<double>[0, 0.25, 0.5, 0.75, 1]),
-      );
+      final progressValues = observed
+          .where((state) => state.voteSubmissionTotalCount == 2)
+          .map((state) => state.voteSubmissionProgress)
+          .whereType<double>()
+          .toList();
+      expect(progressValues.first, greaterThanOrEqualTo(0));
+      expect(progressValues.last, 1);
+      expect(progressValues.any((value) => value > 0 && value < 1), isTrue);
+      for (var index = 1; index < progressValues.length; index++) {
+        expect(
+          progressValues[index],
+          greaterThanOrEqualTo(progressValues[index - 1]),
+        );
+      }
 
       expect(
         observed.where(
@@ -3995,6 +4002,722 @@ void main() {
       );
     },
   );
+
+  test('proposal wave proves at most three bundles concurrently', () async {
+    final proofGate = Completer<void>();
+    final rust = FakeVotingRustApi(
+      emitCommitments: true,
+      bundleCount: 4,
+      voteCommitmentGate: proofGate,
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 4,
+        delegationTxHashes: [
+          for (var bundleIndex = 0; bundleIndex < 4; bundleIndex++)
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: bundleIndex,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-$bundleIndex',
+              vanLeafPosition: null,
+            ),
+        ],
+        votes: [
+          for (var bundleIndex = 0; bundleIndex < 4; bundleIndex++)
+            vote(bundleIndex: bundleIndex, proposalId: 7),
+        ],
+      ),
+    );
+    final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final cast = container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(
+          draftVotes: [
+            rust_wire.DraftVote(
+              proposalId: 7,
+              choice: 1,
+              numOptions: 2,
+              vcTreePosition: BigInt.zero,
+              singleShare: false,
+            ),
+          ],
+        );
+    while (rust.voteCommitBundleCalls.length < 3 ||
+        (container
+                    .read(votingSessionProvider(kRoundId))
+                    .value
+                    ?.voteProgress
+                    .length ??
+                0) <
+            3) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    expect(rust.voteCommitBundleCalls, [0, 1, 2]);
+    expect(rust.maxConcurrentVoteCommitments, 3);
+    expect(rust.syncedVoteTrees, [kRoundId]);
+    expect(
+      container.read(votingSessionProvider(kRoundId)).value!.voteProgress.keys,
+      {
+        const VotingVoteKey(bundleIndex: 0, proposalId: 7),
+        const VotingVoteKey(bundleIndex: 1, proposalId: 7),
+        const VotingVoteKey(bundleIndex: 2, proposalId: 7),
+      },
+    );
+
+    proofGate.complete();
+    await cast;
+
+    expect(rust.voteCommitBundleCalls, [0, 1, 2, 3]);
+    expect(rust.maxConcurrentVoteCommitments, 3);
+  });
+
+  test(
+    'proposal wave preserves successful bundles after proof failure',
+    () async {
+      final rust = FakeVotingRustApi(
+        emitCommitments: true,
+        bundleCount: 3,
+        voteCommitmentErrorsByKey: {
+          '1:7': StateError('injected vote proof failure'),
+        },
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 3,
+          delegationTxHashes: [
+            for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
+              rust_frb_types.DelegationRecoveryView(
+                bundleIndex: bundleIndex,
+                phase: VotingWorkflowPhase.submittedDelegation,
+                txHash: 'delegation-$bundleIndex',
+                vanLeafPosition: null,
+              ),
+          ],
+          votes: [
+            for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
+              vote(bundleIndex: bundleIndex, proposalId: 7),
+          ],
+        ),
+      );
+      final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+      final state = container.read(votingSessionProvider(kRoundId)).value!;
+
+      expect(state.phase, VotingSessionPhase.error);
+      expect(state.error?.message, contains('vote proof failure'));
+      expect(rust.storedVoteTxHashes, ['0:7:vote-tx', '2:7:vote-tx']);
+      expect(rust.resetVotingSessionStateCalls, isEmpty);
+    },
+  );
+
+  test('proposal wave settles every confirmation persistence result', () async {
+    final rust = FakeVotingRustApi(
+      emitCommitments: true,
+      bundleCount: 3,
+      failingVoteConfirmationKeys: const {'1:7'},
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 3,
+        delegationTxHashes: [
+          for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: bundleIndex,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-$bundleIndex',
+              vanLeafPosition: null,
+            ),
+        ],
+        votes: [
+          for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
+            vote(bundleIndex: bundleIndex, proposalId: 7),
+        ],
+      ),
+    );
+    final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(
+          draftVotes: [
+            rust_wire.DraftVote(
+              proposalId: 7,
+              choice: 1,
+              numOptions: 2,
+              vcTreePosition: BigInt.zero,
+              singleShare: false,
+            ),
+          ],
+        );
+    final state = container.read(votingSessionProvider(kRoundId)).value!;
+
+    expect(state.phase, VotingSessionPhase.error);
+    expect(state.error?.message, contains('confirmation persistence failure'));
+    expect(
+      rust.storedVanPositions.any((value) => value.startsWith('0:')),
+      isTrue,
+    );
+    expect(
+      rust.storedVanPositions.any((value) => value.startsWith('1:')),
+      isFalse,
+    );
+    expect(
+      rust.storedVanPositions.any((value) => value.startsWith('2:')),
+      isTrue,
+    );
+    expect(recoveryApi.roundPlanProposalIds.length, greaterThan(1));
+  });
+
+  test(
+    'proposal wave submits ready bundle shares while another confirms',
+    () async {
+      final confirmationResponse =
+          votingHttpResponses()['/shielded-vote/v1/tx/vote-tx']!;
+      final http = _GatedVoteConfirmationHttpClient(
+        responses: {
+          ...votingHttpResponses(),
+          '/shielded-vote/v1/tx/vote-tx-0': confirmationResponse,
+          '/shielded-vote/v1/tx/vote-tx-1': confirmationResponse,
+        },
+      );
+      final rust = FakeVotingRustApi(emitCommitments: true, bundleCount: 2);
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 2,
+          delegationTxHashes: [
+            for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++)
+              rust_frb_types.DelegationRecoveryView(
+                bundleIndex: bundleIndex,
+                phase: VotingWorkflowPhase.submittedDelegation,
+                txHash: 'delegation-$bundleIndex',
+                vanLeafPosition: null,
+              ),
+          ],
+          votes: [
+            for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++)
+              vote(bundleIndex: bundleIndex, proposalId: 7),
+          ],
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+      );
+      addTearDown(container.dispose);
+      addTearDown(() {
+        if (!http.releaseSlowConfirmation.isCompleted) {
+          http.releaseSlowConfirmation.complete();
+        }
+      });
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final cast = container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+
+      await http.slowConfirmationStarted.future;
+      for (var attempt = 0; attempt < 100; attempt++) {
+        if (rust.recordedShares.any((share) => share.bundleIndex == 1)) break;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+
+      expect(
+        rust.recordedShares.any((share) => share.bundleIndex == 1),
+        isTrue,
+      );
+      expect(
+        rust.recordedShares.any((share) => share.bundleIndex == 0),
+        isFalse,
+      );
+      expect(rust.operationLog, contains('mark_vote_confirmed:1:7'));
+
+      http.releaseSlowConfirmation.complete();
+      await cast;
+
+      expect(rust.recordedShares.map((share) => share.bundleIndex).toSet(), {
+        0,
+        1,
+      });
+    },
+  );
+
+  test(
+    'proposal wave polls later bundles while the share pool is saturated',
+    () async {
+      final confirmationResponse =
+          votingHttpResponses()['/shielded-vote/v1/tx/vote-tx']!;
+      final http = _SeparatedVoteStagePoolsHttpClient(
+        responses: {
+          ...votingHttpResponses(),
+          for (var bundleIndex = 0; bundleIndex < 4; bundleIndex++)
+            '/shielded-vote/v1/tx/vote-tx-$bundleIndex': confirmationResponse,
+        },
+      );
+      final rust = FakeVotingRustApi(emitCommitments: true, bundleCount: 4);
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 4,
+          delegationTxHashes: [
+            for (var bundleIndex = 0; bundleIndex < 4; bundleIndex++)
+              rust_frb_types.DelegationRecoveryView(
+                bundleIndex: bundleIndex,
+                phase: VotingWorkflowPhase.submittedDelegation,
+                txHash: 'delegation-$bundleIndex',
+                vanLeafPosition: null,
+              ),
+          ],
+          votes: [
+            for (var bundleIndex = 0; bundleIndex < 4; bundleIndex++)
+              vote(bundleIndex: bundleIndex, proposalId: 7),
+          ],
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+      );
+      addTearDown(container.dispose);
+      addTearDown(http.releaseShares);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final cast = container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+
+      await http.firstThreeSharesStarted.future;
+      await http.fourthConfirmationStarted.future.timeout(
+        const Duration(seconds: 1),
+      );
+      const fourthKey = VotingVoteKey(bundleIndex: 3, proposalId: 7);
+      for (var attempt = 0; attempt < 100; attempt++) {
+        final fourthProgress = container
+            .read(votingSessionProvider(kRoundId))
+            .value
+            ?.voteProgress[fourthKey];
+        if (fourthProgress?.phase == 'confirmed') break;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+
+      expect(http.sharePostCount, 3);
+      expect(http.maxConcurrentSharePosts, 3);
+      final saturatedState = container
+          .read(votingSessionProvider(kRoundId))
+          .value!;
+      expect(saturatedState.voteProgress[fourthKey]?.phase, 'confirmed');
+      expect(saturatedState.voteSubmissionProgress, closeTo(0.95, 0.001));
+      for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++) {
+        final key = VotingVoteKey(bundleIndex: bundleIndex, proposalId: 7);
+        expect(
+          saturatedState.voteProgress[key]?.phase,
+          'submitting_shares',
+          reason: 'bundle $bundleIndex must remain visibly in flight',
+        );
+      }
+
+      http.releaseShares();
+      await cast;
+
+      expect(http.sharePostCount, 4);
+      expect(http.maxConcurrentSharePosts, 3);
+      expect(rust.recordedShares.map((share) => share.bundleIndex).toSet(), {
+        0,
+        1,
+        2,
+        3,
+      });
+    },
+  );
+
+  test(
+    'proposal wave serializes broadcasts and overlaps confirmations',
+    () async {
+      final http = _DelegationConcurrencyHttpClient(
+        responses: votingHttpResponses(),
+      );
+      final rust = FakeVotingRustApi(emitCommitments: true, bundleCount: 3);
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 3,
+          delegationTxHashes: [
+            for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
+              rust_frb_types.DelegationRecoveryView(
+                bundleIndex: bundleIndex,
+                phase: VotingWorkflowPhase.submittedDelegation,
+                txHash: 'delegation-$bundleIndex',
+                vanLeafPosition: null,
+              ),
+          ],
+          votes: [
+            for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
+              vote(bundleIndex: bundleIndex, proposalId: 7),
+          ],
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+
+      expect(http.maxConcurrentVotePosts, 1);
+      expect(http.maxConcurrentConfirmationGets, 3);
+    },
+  );
+
+  test('each bundle confirms a proposal before proving the next one', () async {
+    final confirmationResponse =
+        votingHttpResponses()['/shielded-vote/v1/tx/vote-tx']!;
+    final http = _UniqueVoteTxHttpClient(
+      responses: {
+        ...votingHttpResponses(),
+        for (var index = 0; index < 4; index++)
+          '/shielded-vote/v1/tx/vote-tx-$index': confirmationResponse,
+      },
+    );
+    final rust = FakeVotingRustApi(emitCommitments: true, bundleCount: 2);
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 2,
+        delegationTxHashes: [
+          for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++)
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: bundleIndex,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-$bundleIndex',
+              vanLeafPosition: null,
+            ),
+        ],
+        votes: [
+          for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++) ...[
+            vote(bundleIndex: bundleIndex, proposalId: 7),
+            vote(bundleIndex: bundleIndex, proposalId: 8),
+          ],
+        ],
+      ),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(draftVotes: _twoProposalDrafts());
+
+    // The fake rejects a vote proved against an already-spent vote authority
+    // note, so reaching four submissions is itself the ordering proof.
+    expect(
+      rust.operationLog
+          .where((entry) => entry.startsWith('mark_vote_submitted:'))
+          .toSet(),
+      {
+        'mark_vote_submitted:0:7',
+        'mark_vote_submitted:1:7',
+        'mark_vote_submitted:0:8',
+        'mark_vote_submitted:1:8',
+      },
+    );
+    for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++) {
+      expect(
+        rust.operationLog.indexOf('build_vote:$bundleIndex:8'),
+        greaterThan(
+          rust.operationLog.indexOf('mark_vote_confirmed:$bundleIndex:7'),
+        ),
+        reason:
+            'bundle $bundleIndex must confirm proposal 7 before proving '
+            'proposal 8 — the confirmation is what advances its VAN',
+      );
+    }
+    // At least one sync per proposal step, and never more than one per
+    // (bundle, proposal) pair. How many of the four collapse depends on
+    // whether the bundles reach a step together; the deterministic
+    // coalescing case is pinned by the 4-bundle single-proposal test.
+    expect(rust.syncedVoteTrees.length, greaterThanOrEqualTo(2));
+    expect(rust.syncedVoteTrees.length, lessThanOrEqualTo(4));
+    expect(rust.maxConcurrentVoteTreeSyncs, 1);
+    expect(rust.syncedVoteTrees.toSet(), {kRoundId});
+  });
+
+  test('a slow bundle does not hold back the other bundles', () async {
+    final confirmationResponse =
+        votingHttpResponses()['/shielded-vote/v1/tx/vote-tx']!;
+    final http = _GatedVoteConfirmationHttpClient(
+      responses: {
+        ...votingHttpResponses(),
+        for (var index = 0; index < 4; index++)
+          '/shielded-vote/v1/tx/vote-tx-$index': confirmationResponse,
+      },
+    );
+    final rust = FakeVotingRustApi(emitCommitments: true, bundleCount: 2);
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 2,
+        delegationTxHashes: [
+          for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++)
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: bundleIndex,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-$bundleIndex',
+              vanLeafPosition: null,
+            ),
+        ],
+        votes: [
+          for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++) ...[
+            vote(bundleIndex: bundleIndex, proposalId: 7),
+            vote(bundleIndex: bundleIndex, proposalId: 8),
+          ],
+        ],
+      ),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+    );
+    addTearDown(container.dispose);
+    addTearDown(() {
+      if (!http.releaseSlowConfirmation.isCompleted) {
+        http.releaseSlowConfirmation.complete();
+      }
+    });
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final cast = container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(draftVotes: _twoProposalDrafts());
+
+    // `vote-tx-0` is the first broadcast, and its confirmation is held open.
+    await http.slowConfirmationStarted.future;
+    final gatedEntry = rust.storedVoteTxHashes.firstWhere(
+      (entry) => entry.endsWith(':vote-tx-0'),
+    );
+    final gatedBundle = int.parse(gatedEntry.split(':').first);
+    final freeBundle = gatedBundle == 0 ? 1 : 0;
+
+    // The unblocked bundle must reach its second proposal while the gated one
+    // is still waiting on its first confirmation.
+    for (var attempt = 0; attempt < 200; attempt++) {
+      if (rust.operationLog.contains('build_vote:$freeBundle:8')) break;
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    expect(
+      rust.operationLog,
+      contains('build_vote:$freeBundle:8'),
+      reason: 'bundle $freeBundle must not wait on bundle $gatedBundle',
+    );
+    expect(rust.operationLog, isNot(contains('build_vote:$gatedBundle:8')));
+
+    http.releaseSlowConfirmation.complete();
+    await cast;
+
+    expect(
+      rust.operationLog
+          .where((entry) => entry.startsWith('mark_vote_confirmed:'))
+          .toSet(),
+      {
+        'mark_vote_confirmed:0:7',
+        'mark_vote_confirmed:1:7',
+        'mark_vote_confirmed:0:8',
+        'mark_vote_confirmed:1:8',
+      },
+    );
+  });
+
+  test(
+    'fake rejects a second vote proved against an already-spent VAN',
+    () async {
+      // Pins the regression guard itself: if this stops throwing, the
+      // "each bundle confirms before proving the next" test above silently
+      // stops proving anything.
+      final rust = FakeVotingRustApi(emitCommitments: true, bundleCount: 1);
+      const dbPath = 'db';
+      const account = 'account-1';
+
+      final anchorHeight = await rust.syncVoteTree(
+        dbPath: dbPath,
+        accountUuid: account,
+        roundId: kRoundId,
+        nodeUrl: 'https://voting.example',
+      );
+      final witness = await rust.generateVanWitness(
+        dbPath: dbPath,
+        accountUuid: account,
+        roundId: kRoundId,
+        bundleIndex: 0,
+        anchorHeight: anchorHeight,
+      );
+
+      // Prove both proposals against the same VAN state — the shape the
+      // round-wide pipeline produced.
+      for (final proposalId in [7, 8]) {
+        await rust
+            .buildVoteCommitmentsWithProgress(
+              dbPath: dbPath,
+              accountUuid: account,
+              network: 'main',
+              roundId: kRoundId,
+              bundleIndex: 0,
+              storedHotkeySecret: const [42, 43, 44],
+              vanWitness: witness,
+              draftVotes: [
+                rust_wire.DraftVote(
+                  proposalId: proposalId,
+                  choice: 0,
+                  numOptions: 2,
+                  vcTreePosition: BigInt.zero,
+                  singleShare: false,
+                ),
+              ],
+            )
+            .drain<void>();
+      }
+
+      await rust.markVoteSubmitted(
+        dbPath: dbPath,
+        accountUuid: account,
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        txHash: 'vote-tx-0',
+      );
+      await expectLater(
+        rust.markVoteSubmitted(
+          dbPath: dbPath,
+          accountUuid: account,
+          roundId: kRoundId,
+          bundleIndex: 0,
+          proposalId: 8,
+          txHash: 'vote-tx-1',
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('duplicate van_nullifier'),
+          ),
+        ),
+      );
+    },
+  );
+
+  test('a failed bundle chain stops at that bundle only', () async {
+    final rust = FakeVotingRustApi(
+      emitCommitments: true,
+      bundleCount: 2,
+      voteCommitmentErrorsByKey: {
+        '0:7': StateError('injected earlier proposal proof failure'),
+      },
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 2,
+        delegationTxHashes: [
+          for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++)
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: bundleIndex,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-$bundleIndex',
+              vanLeafPosition: null,
+            ),
+        ],
+        votes: [
+          for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++) ...[
+            vote(bundleIndex: bundleIndex, proposalId: 7),
+            vote(bundleIndex: bundleIndex, proposalId: 8),
+          ],
+        ],
+      ),
+    );
+    final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(draftVotes: _twoProposalDrafts());
+
+    // Bundle 1 runs to completion; bundle 0 stops at the failed step because
+    // proposal 8 cannot be proved without proposal 7's VAN advance.
+    expect(
+      rust.operationLog,
+      containsAll(['mark_vote_submitted:1:7', 'mark_vote_submitted:1:8']),
+    );
+    expect(rust.operationLog, isNot(contains('mark_vote_submitted:0:7')));
+    expect(rust.operationLog, isNot(contains('build_vote:0:8')));
+    final message = container
+        .read(votingSessionProvider(kRoundId))
+        .value!
+        .error!
+        .message;
+    expect(message, contains('earlier proposal proof failure'));
+    expect(
+      message,
+      contains('proposal 7'),
+      reason: 'failures must name the proposal, not just the bundle',
+    );
+  });
 
   test('draft votes persist and can be cleared proposal by proposal', () async {
     final persistence = FakeVotingDraftPersistence();
@@ -4510,6 +5233,123 @@ void main() {
   });
 
   test(
+    'submitted vote recovery ignores a successful stale confirmation response',
+    () async {
+      final logs = <String>[];
+      final previousDebugPrint = debugPrint;
+      debugPrint = (message, {wrapWidth}) => logs.add(message ?? '');
+      addTearDown(() => debugPrint = previousDebugPrint);
+
+      final responses = votingHttpResponses();
+      responses['/shielded-vote/v1/tx/submitted-vote-tx'] =
+          responses['/shielded-vote/v1/tx/vote-tx']!;
+      final http = _GatedSubmittedVoteConfirmationHttpClient(
+        responses: responses,
+      );
+      final rust = FakeVotingRustApi();
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 1,
+          votes: [vote(bundleIndex: 0, proposalId: 7)],
+          voteWorkflows: [
+            rust_frb_types.VoteRecoveryView(
+              bundleIndex: 0,
+              proposalId: 7,
+              choice: 0,
+              phase: VotingWorkflowPhase.submittedVote,
+              txHash: 'submitted-vote-tx',
+              vcTreePosition: null,
+              hasCommitmentBundle: true,
+            ),
+          ],
+          voteTxHashes: [
+            rust_frb_types.VoteRecoveryView(
+              bundleIndex: 0,
+              proposalId: 7,
+              choice: 0,
+              phase: VotingWorkflowPhase.submittedVote,
+              txHash: 'submitted-vote-tx',
+              vcTreePosition: null,
+              hasCommitmentBundle: false,
+            ),
+          ],
+          commitmentBundles: [
+            rust_frb_types.RecoverableCommitmentBundle(
+              bundleIndex: 0,
+              proposalId: 7,
+              commitmentBundleJson: '{"proposal_id":7}',
+              vcTreePosition: BigInt.zero,
+            ),
+          ],
+        ),
+      );
+      final activeAccountProvider =
+          NotifierProvider<_ActiveVotingAccountNotifier, String?>(
+            _ActiveVotingAccountNotifier.new,
+          );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+        hotkeyStore: const FailingVotingHotkeyStore(),
+        activeAccountUuidListenable: activeAccountProvider,
+        txConfirmationPolling: const VotingTxConfirmationPolling(
+          attempts: 2,
+          delay: Duration.zero,
+        ),
+      );
+      final subscription = container.listen(
+        votingSessionProvider(kRoundId),
+        (_, _) {},
+      );
+      addTearDown(subscription.close);
+      addTearDown(container.dispose);
+      addTearDown(() {
+        if (!http.releaseConfirmation.isCompleted) {
+          http.releaseConfirmation.complete();
+        }
+      });
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final casting = container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(draftVotes: const []);
+      await http.confirmationStarted.future;
+
+      container.read(activeAccountProvider.notifier).set('account-2');
+      final switched = await container.read(
+        votingSessionProvider(kRoundId).future,
+      );
+      expect(switched.accountUuid, 'account-2');
+
+      http.releaseConfirmation.complete();
+      await casting;
+
+      expect(container.read(votingSessionProvider(kRoundId)).hasError, isFalse);
+      expect(
+        container.read(votingSessionProvider(kRoundId)).value!.accountUuid,
+        'account-2',
+      );
+      expect(
+        logs.any((line) => line.contains('session action failed')),
+        isFalse,
+        reason:
+            'stale recovery poll must rethrow _StaleVotingSessionAction, '
+            'not wrap it in _VoteWaveBatchException',
+      );
+      expect(
+        logs.any(
+          (line) =>
+              line.contains('ignored stale session update') &&
+              line.contains('reason=action'),
+        ),
+        isTrue,
+      );
+      expect(rust.operationLog, isNot(contains('mark_vote_confirmed:0:7')));
+    },
+  );
+
+  test(
     'recovery-only vote confirmation does not rewrite ballot intents',
     () async {
       final httpResponses = votingHttpResponses()
@@ -4627,32 +5467,17 @@ void main() {
   });
 
   test('vote tree sync runs before each proposal', () async {
-    final rust = FakeVotingRustApi();
+    final rust = FakeVotingRustApi(emitCommitments: true);
     final container = _sessionContainer(rust: rust);
     addTearDown(container.dispose);
 
     await container.read(votingSessionProvider(kRoundId).future);
     await container
         .read(votingSessionProvider(kRoundId).notifier)
-        .castVotes(
-          draftVotes: [
-            rust_wire.DraftVote(
-              proposalId: 7,
-              choice: 1,
-              numOptions: 2,
-              vcTreePosition: BigInt.zero,
-              singleShare: false,
-            ),
-            rust_wire.DraftVote(
-              proposalId: 8,
-              choice: 0,
-              numOptions: 2,
-              vcTreePosition: BigInt.one,
-              singleShare: false,
-            ),
-          ],
-        );
+        .castVotes(draftVotes: _twoProposalDrafts());
 
+    // A bundle's second vote needs the VAN leaf its first vote created, and
+    // that leaf is only witnessable after another sync.
     expect(rust.syncedVoteTrees, [kRoundId, kRoundId]);
     expect(rust.voteCommitBundleCalls, [0, 0]);
   });
@@ -6393,7 +7218,7 @@ void main() {
     expect(state.phase, VotingSessionPhase.error);
     expect(state.error?.cause, isA<VotingHotkeyUnavailable>());
     expect(recoveryApi.ballotIntents, isEmpty);
-    expect(rust.resetVotingSessionStateCalls, contains('account-1:$kRoundId'));
+    expect(rust.resetVotingSessionStateCalls, isEmpty);
   });
 }
 
@@ -7890,6 +8715,128 @@ class _DelegationConcurrencyHttpClient extends FakeVotingHttpClient {
   }
 }
 
+class _UniqueVoteTxHttpClient extends FakeVotingHttpClient {
+  _UniqueVoteTxHttpClient({required super.responses});
+
+  var _votePostCount = 0;
+
+  @override
+  Future<VotingHttpResponse> postJson(
+    Uri uri,
+    Map<String, dynamic> body, {
+    Duration? timeout,
+  }) async {
+    if (!uri.path.endsWith('/cast-vote')) {
+      return super.postJson(uri, body, timeout: timeout);
+    }
+    requests.add(
+      FakeVotingHttpRequest('POST', uri, body: body, timeout: timeout),
+    );
+    return jsonResponse({
+      'tx_hash': 'vote-tx-${_votePostCount++}',
+      'code': 0,
+      'log': '',
+    });
+  }
+}
+
+class _GatedVoteConfirmationHttpClient extends _UniqueVoteTxHttpClient {
+  _GatedVoteConfirmationHttpClient({required super.responses});
+
+  final Completer<void> slowConfirmationStarted = Completer<void>();
+  final Completer<void> releaseSlowConfirmation = Completer<void>();
+
+  @override
+  Future<VotingHttpResponse> get(
+    Uri uri, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
+    if (uri.path.endsWith('/tx/vote-tx-0')) {
+      if (!slowConfirmationStarted.isCompleted) {
+        slowConfirmationStarted.complete();
+      }
+      await releaseSlowConfirmation.future;
+    }
+    return super.get(uri, headers: headers, timeout: timeout);
+  }
+}
+
+class _GatedSubmittedVoteConfirmationHttpClient extends FakeVotingHttpClient {
+  _GatedSubmittedVoteConfirmationHttpClient({required super.responses});
+
+  final Completer<void> confirmationStarted = Completer<void>();
+  final Completer<void> releaseConfirmation = Completer<void>();
+
+  @override
+  Future<VotingHttpResponse> get(
+    Uri uri, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
+    if (uri.path.endsWith('/tx/submitted-vote-tx')) {
+      if (!confirmationStarted.isCompleted) {
+        confirmationStarted.complete();
+      }
+      await releaseConfirmation.future;
+    }
+    return super.get(uri, headers: headers, timeout: timeout);
+  }
+}
+
+class _SeparatedVoteStagePoolsHttpClient extends _UniqueVoteTxHttpClient {
+  _SeparatedVoteStagePoolsHttpClient({required super.responses});
+
+  final Completer<void> firstThreeSharesStarted = Completer<void>();
+  final Completer<void> fourthConfirmationStarted = Completer<void>();
+  final Completer<void> _releaseSharePosts = Completer<void>();
+  var sharePostCount = 0;
+  var _activeSharePosts = 0;
+  var maxConcurrentSharePosts = 0;
+
+  void releaseShares() {
+    if (!_releaseSharePosts.isCompleted) _releaseSharePosts.complete();
+  }
+
+  @override
+  Future<VotingHttpResponse> postJson(
+    Uri uri,
+    Map<String, dynamic> body, {
+    Duration? timeout,
+  }) async {
+    if (!uri.path.endsWith('/shares')) {
+      return super.postJson(uri, body, timeout: timeout);
+    }
+    sharePostCount++;
+    _activeSharePosts++;
+    if (_activeSharePosts > maxConcurrentSharePosts) {
+      maxConcurrentSharePosts = _activeSharePosts;
+    }
+    if (sharePostCount == 3 && !firstThreeSharesStarted.isCompleted) {
+      firstThreeSharesStarted.complete();
+    }
+    try {
+      if (sharePostCount <= 3) await _releaseSharePosts.future;
+      return await super.postJson(uri, body, timeout: timeout);
+    } finally {
+      _activeSharePosts--;
+    }
+  }
+
+  @override
+  Future<VotingHttpResponse> get(
+    Uri uri, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
+    if (uri.path.endsWith('/tx/vote-tx-3') &&
+        !fourthConfirmationStarted.isCompleted) {
+      fourthConfirmationStarted.complete();
+    }
+    return super.get(uri, headers: headers, timeout: timeout);
+  }
+}
+
 class FakeVotingRustApi implements VotingRustApi {
   FakeVotingRustApi({
     this.setupDelay = Duration.zero,
@@ -7964,6 +8911,8 @@ class FakeVotingRustApi implements VotingRustApi {
   int maxConcurrentDelegationProofs = 0;
   int _activeKeystoneDelegationProofs = 0;
   int maxConcurrentKeystoneDelegationProofs = 0;
+  int _activeVoteCommitments = 0;
+  int maxConcurrentVoteCommitments = 0;
   final delegationBundleCalls = <int>[];
   final delegationMnemonics = <String>[];
   final voteCommitBundleCalls = <int>[];
@@ -8011,6 +8960,31 @@ class FakeVotingRustApi implements VotingRustApi {
   BigInt privacyTrimDroppedValueZatoshi = BigInt.zero;
   int generateVotingHotkeyCalls = 0;
   int extractSpendAuthSignatureCalls = 0;
+
+  // --- Vote authority note (VAN) model -------------------------------------
+  //
+  // A cast vote spends the bundle's VAN: the proof binds the bundle's current
+  // proposal-authority mask and VAN leaf position, submission clears that
+  // proposal's bit, and confirmation appends the replacement leaf. Two votes on
+  // one bundle proved against the same state share a `van_nullifier`, so the
+  // second is a double spend. The fake reproduces that so the provider's
+  // ordering is checked here instead of on-chain.
+  static const int _fullProposalAuthority = 0xFFFE; // bit 0 is the sentinel
+  final Map<int, int> _bundleAuthority = <int, int>{};
+  final Map<int, int> _bundleVanPosition = <int, int>{};
+  final Map<int, int> _bundleMinAnchor = <int, int>{};
+  final Map<String, int> _capturedAuthority = <String, int>{};
+  final Map<String, int> _capturedVanPosition = <String, int>{};
+  int _voteTreeAnchor = 10;
+  int _nextVanPosition = 1000;
+  int _activeVoteTreeSyncs = 0;
+  int maxConcurrentVoteTreeSyncs = 0;
+
+  int _authorityFor(int bundleIndex) =>
+      _bundleAuthority[bundleIndex] ?? _fullProposalAuthority;
+
+  int _vanPositionFor(int bundleIndex) =>
+      _bundleVanPosition[bundleIndex] ?? bundleIndex;
 
   @override
   Future<rust_wire.VotingRoundParams> trustedVotingRoundParamsFromConfig({
@@ -8457,10 +9431,21 @@ class FakeVotingRustApi implements VotingRustApi {
   }) async {
     syncedVoteTrees.add(roundId);
     syncedVoteTreeNodeUrls.add(nodeUrl);
-    if (failingVoteTreeNodeUrls.contains(nodeUrl)) {
-      throw StateError('syncVoteTree failed for $nodeUrl');
+    _activeVoteTreeSyncs++;
+    if (_activeVoteTreeSyncs > maxConcurrentVoteTreeSyncs) {
+      maxConcurrentVoteTreeSyncs = _activeVoteTreeSyncs;
     }
-    return 10;
+    try {
+      // Yield so overlapping syncs would actually be observable; failover
+      // resets round-global state, so the provider must never allow one.
+      await Future<void>.delayed(Duration.zero);
+      if (failingVoteTreeNodeUrls.contains(nodeUrl)) {
+        throw StateError('syncVoteTree failed for $nodeUrl');
+      }
+      return ++_voteTreeAnchor;
+    } finally {
+      _activeVoteTreeSyncs--;
+    }
   }
 
   @override
@@ -8471,9 +9456,16 @@ class FakeVotingRustApi implements VotingRustApi {
     required int bundleIndex,
     required int anchorHeight,
   }) async {
+    final minAnchor = _bundleMinAnchor[bundleIndex];
+    if (minAnchor != null && anchorHeight < minAnchor) {
+      throw StateError(
+        'vote tree witness for bundle $bundleIndex is stale: anchor '
+        '$anchorHeight predates this bundle\'s last cast-vote confirmation',
+      );
+    }
     return rust_vote.VanWitness(
       authPath: const [],
-      position: bundleIndex,
+      position: _vanPositionFor(bundleIndex),
       anchorHeight: anchorHeight,
     );
   }
@@ -8508,29 +9500,67 @@ class FakeVotingRustApi implements VotingRustApi {
     required List<rust_wire.DraftVote> draftVotes,
   }) async* {
     voteCommitBundleCalls.add(bundleIndex);
-    if (!voteCommitmentStarted.isCompleted) {
-      voteCommitmentStarted.complete();
+    _activeVoteCommitments++;
+    if (_activeVoteCommitments > maxConcurrentVoteCommitments) {
+      maxConcurrentVoteCommitments = _activeVoteCommitments;
     }
-    await voteCommitmentGate?.future;
-    for (final draft in draftVotes) {
-      voteCommitmentKeys.add('$bundleIndex:${draft.proposalId}');
-      operationLog.add('build_vote:$bundleIndex:${draft.proposalId}');
-      draftSingleShareValues.add(draft.singleShare);
-      yield rust_api.ApiVoteCommitEvent(
-        phase: 'result',
-        proposalId: draft.proposalId,
-        bundleIndex: bundleIndex,
-        proofProgress: null,
-        commitments: emitCommitments
-            ? _commitments(
-                roundId: roundId,
-                bundleIndex: bundleIndex,
-                proposalId: draft.proposalId,
-                choice: draft.choice,
-                shareCount: commitmentShareCount,
-              )
-            : null,
-      );
+    try {
+      if (!voteCommitmentStarted.isCompleted) {
+        voteCommitmentStarted.complete();
+      }
+      for (final draft in draftVotes) {
+        yield rust_api.ApiVoteCommitEvent(
+          phase: 'proving',
+          proposalId: draft.proposalId,
+          bundleIndex: bundleIndex,
+          proofProgress: 0.1,
+          commitments: null,
+        );
+      }
+      await voteCommitmentGate?.future;
+      for (final draft in draftVotes) {
+        final key = '$bundleIndex:${draft.proposalId}';
+        final error = voteCommitmentErrorsByKey[key];
+        if (error != null) throw error;
+        if (vanWitness.position != _vanPositionFor(bundleIndex)) {
+          throw StateError(
+            'VAN witness position ${vanWitness.position} does not match '
+            'current bundle position ${_vanPositionFor(bundleIndex)} for '
+            'bundle $bundleIndex',
+          );
+        }
+        final minAnchor = _bundleMinAnchor[bundleIndex];
+        if (minAnchor != null && vanWitness.anchorHeight < minAnchor) {
+          throw StateError(
+            'vote tree witness for bundle $bundleIndex is stale: anchor '
+            '${vanWitness.anchorHeight} predates this bundle\'s last '
+            'cast-vote confirmation',
+          );
+        }
+        // Snapshot the state this proof binds; submission re-checks it.
+        _capturedAuthority[key] = _authorityFor(bundleIndex);
+        _capturedVanPosition[key] = _vanPositionFor(bundleIndex);
+        voteCommitmentKeys.add(key);
+        operationLog.add('build_vote:$key');
+        draftSingleShareValues.add(draft.singleShare);
+        yield rust_api.ApiVoteCommitEvent(
+          phase: 'result',
+          proposalId: draft.proposalId,
+          bundleIndex: bundleIndex,
+          proofProgress: null,
+          commitments: emitCommitments
+              ? _commitments(
+                  roundId: roundId,
+                  bundleIndex: bundleIndex,
+                  proposalId: draft.proposalId,
+                  choice: draft.choice,
+                  shareCount: commitmentShareCount,
+                )
+              : null,
+        );
+      }
+    } finally {
+      _activeVoteCommitments--;
     }
   }
 
@@ -8781,6 +9811,23 @@ class FakeVotingRustApi implements VotingRustApi {
     required int proposalId,
     required String txHash,
   }) async {
+    final key = '$bundleIndex:$proposalId';
+    final capturedAuthority = _capturedAuthority[key];
+    if (capturedAuthority != null) {
+      // Stand-in for the chain rejecting a duplicate `van_nullifier`: the proof
+      // spent a vote authority note that another vote on this bundle already
+      // spent.
+      if (capturedAuthority != _authorityFor(bundleIndex) ||
+          _capturedVanPosition[key] != _vanPositionFor(bundleIndex)) {
+        throw StateError(
+          'cast-vote rejected: duplicate van_nullifier for bundle '
+          '$bundleIndex proposal $proposalId (proved against a vote authority '
+          'note that was already spent)',
+        );
+      }
+    }
+    _bundleAuthority[bundleIndex] =
+        _authorityFor(bundleIndex) & ~(1 << proposalId);
     _addUnique(storedVoteTxHashes, '$bundleIndex:$proposalId:$txHash');
     operationLog.add('mark_vote_submitted:$bundleIndex:$proposalId');
   }
@@ -8808,10 +9855,20 @@ class FakeVotingRustApi implements VotingRustApi {
     required String txHash,
     required String eventsJson,
   }) async {
+    if (failingVoteConfirmationKeys.contains('$bundleIndex:$proposalId')) {
+      throw StateError(
+        'injected vote confirmation persistence failure '
+        '$bundleIndex:$proposalId',
+      );
+    }
     final leafPositions = castVoteLeafPositionsFromTxEventsJson(
       eventsJson,
       roundId,
     );
+    // The replacement VAN leaf only becomes witnessable after another tree
+    // sync, so require a strictly newer anchor for this bundle from here on.
+    _bundleVanPosition[bundleIndex] = ++_nextVanPosition;
+    _bundleMinAnchor[bundleIndex] = _voteTreeAnchor + 1;
     _recordVoteConfirmed(
       bundleIndex: bundleIndex,
       proposalId: proposalId,
@@ -8903,6 +9960,23 @@ class _RecordedShare {
   final BigInt submitAt;
   final List<String> sentToUrls;
 }
+
+List<rust_wire.DraftVote> _twoProposalDrafts() => [
+  rust_wire.DraftVote(
+    proposalId: 7,
+    choice: 1,
+    numOptions: 2,
+    vcTreePosition: BigInt.zero,
+    singleShare: false,
+  ),
+  rust_wire.DraftVote(
+    proposalId: 8,
+    choice: 0,
+    numOptions: 2,
+    vcTreePosition: BigInt.one,
+    singleShare: false,
+  ),
+];
 
 rust_wire.SignedVoteCommitmentsView _commitments({
   required String roundId,

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -4604,6 +4604,91 @@ void main() {
     expect(rust.syncedVoteTrees.toSet(), {kRoundId});
   });
 
+  test('vote tree failover waits for prior sync witnesses', () async {
+    final rust = _WitnessHandoffVotingRustApi();
+    final http = FakeVotingHttpClient(
+      responses: votingHttpResponses(
+        dynamicConfig: dynamicConfigJson(
+          voteServers: const [
+            {'url': 'https://voting.example', 'label': 'primary'},
+            {'url': 'https://voting-failover.example', 'label': 'failover'},
+          ],
+        ),
+      ),
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 2,
+        delegationTxHashes: [
+          for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++)
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: bundleIndex,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-$bundleIndex',
+              vanLeafPosition: null,
+            ),
+        ],
+        votes: [
+          for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++) ...[
+            vote(bundleIndex: bundleIndex, proposalId: 7),
+            vote(bundleIndex: bundleIndex, proposalId: 8),
+          ],
+        ],
+      ),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+    );
+    addTearDown(container.dispose);
+    addTearDown(rust.releaseFirstWitness);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final cast = container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(draftVotes: _twoProposalDrafts());
+
+    await rust.firstWitnessStarted.future;
+    for (var attempt = 0; attempt < 100; attempt++) {
+      if (rust.operationLog.contains('mark_vote_confirmed:1:7')) break;
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    expect(rust.operationLog, contains('mark_vote_confirmed:1:7'));
+
+    // Bundle 1 has requested its next fresh sync, but bundle 0 is still using
+    // the tree produced by the first sync. Starting failover now would clear
+    // bundle 0's witness source before it can materialize the witness.
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(rust.syncedVoteTreeNodeUrls, ['https://voting.example']);
+    expect(rust.resetVoteTreeCalls, isEmpty);
+
+    rust.releaseFirstWitness();
+    await cast;
+
+    expect(
+      rust.syncedVoteTreeNodeUrls,
+      containsAllInOrder([
+        'https://voting.example',
+        'https://voting.example',
+        'https://voting-failover.example',
+      ]),
+    );
+    expect(rust.resetVoteTreeCalls, ['account-1:$kRoundId']);
+    expect(rust.resetVotingSessionStateCalls, isEmpty);
+    expect(
+      rust.operationLog
+          .where((entry) => entry.startsWith('mark_vote_submitted:'))
+          .toSet(),
+      {
+        'mark_vote_submitted:0:7',
+        'mark_vote_submitted:1:7',
+        'mark_vote_submitted:0:8',
+        'mark_vote_submitted:1:8',
+      },
+    );
+  });
+
   test('a slow bundle does not hold back the other bundles', () async {
     final confirmationResponse =
         votingHttpResponses()['/shielded-vote/v1/tx/vote-tx']!;
@@ -5622,7 +5707,8 @@ void main() {
       'https://voting.example',
       'https://voting-failover.example',
     ]);
-    expect(rust.resetVotingSessionStateCalls, ['account-1:$kRoundId']);
+    expect(rust.resetVoteTreeCalls, ['account-1:$kRoundId']);
+    expect(rust.resetVotingSessionStateCalls, isEmpty);
   });
 
   test('vote commitments submit shares and record recovery rows', () async {
@@ -9032,6 +9118,83 @@ class _SeparatedVoteStagePoolsHttpClient extends _UniqueVoteTxHttpClient {
       fourthConfirmationStarted.complete();
     }
     return super.get(uri, headers: headers, timeout: timeout);
+  }
+}
+
+class _WitnessHandoffVotingRustApi extends FakeVotingRustApi {
+  _WitnessHandoffVotingRustApi() : super(emitCommitments: true, bundleCount: 2);
+
+  final Completer<void> firstWitnessStarted = Completer<void>();
+  final Completer<void> _releaseFirstWitness = Completer<void>();
+  var _primarySyncCalls = 0;
+  var _firstWitnessReleased = false;
+  var _treeReady = false;
+
+  void releaseFirstWitness() {
+    if (!_releaseFirstWitness.isCompleted) {
+      _releaseFirstWitness.complete();
+    }
+  }
+
+  @override
+  Future<int> syncVoteTree({
+    required String dbPath,
+    required String accountUuid,
+    required String roundId,
+    required String nodeUrl,
+  }) async {
+    if (nodeUrl == 'https://voting.example' && _primarySyncCalls++ == 1) {
+      syncedVoteTrees.add(roundId);
+      syncedVoteTreeNodeUrls.add(nodeUrl);
+      throw StateError('injected second primary tree-sync failure');
+    }
+    final height = await super.syncVoteTree(
+      dbPath: dbPath,
+      accountUuid: accountUuid,
+      roundId: roundId,
+      nodeUrl: nodeUrl,
+    );
+    _treeReady = true;
+    return height;
+  }
+
+  @override
+  Future<rust_vote.VanWitness> generateVanWitness({
+    required String dbPath,
+    required String accountUuid,
+    required String roundId,
+    required int bundleIndex,
+    required int anchorHeight,
+  }) async {
+    if (bundleIndex == 0 && !_firstWitnessReleased) {
+      _firstWitnessReleased = true;
+      if (!firstWitnessStarted.isCompleted) firstWitnessStarted.complete();
+      await _releaseFirstWitness.future;
+    }
+    if (!_treeReady) {
+      throw StateError('vote tree cache reset before witness generation');
+    }
+    return super.generateVanWitness(
+      dbPath: dbPath,
+      accountUuid: accountUuid,
+      roundId: roundId,
+      bundleIndex: bundleIndex,
+      anchorHeight: anchorHeight,
+    );
+  }
+
+  @override
+  Future<void> resetVoteTree({
+    required String dbPath,
+    required String accountUuid,
+    String? roundId,
+  }) async {
+    _treeReady = false;
+    await super.resetVoteTree(
+      dbPath: dbPath,
+      accountUuid: accountUuid,
+      roundId: roundId,
+    );
   }
 }
 

--- a/test/services/voting/fake_voting_http.dart
+++ b/test/services/voting/fake_voting_http.dart
@@ -34,7 +34,7 @@ class FakeVotingHttpClient implements VotingHttpClient {
     return _responseFor(uri);
   }
 
-  VotingHttpResponse _responseFor(Uri uri) {
+  Future<VotingHttpResponse> _responseFor(Uri uri) async {
     final configured = responses[uri.toString()] ?? responses[uri.path];
     final response = configured is SequentialVotingHttpResponses
         ? configured.next()
@@ -47,6 +47,9 @@ class FakeVotingHttpClient implements VotingHttpClient {
     }
     if (response is Error) {
       throw response;
+    }
+    if (response is Future<VotingHttpResponse>) {
+      return response;
     }
     if (response is VotingHttpResponse) {
       return response;

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/services/voting/voting_api_client.dart';
+import 'package:zcash_wallet/src/services/voting/voting_http.dart';
 import 'package:zcash_wallet/src/services/voting/voting_retry.dart';
 
 import 'fake_voting_http.dart';
@@ -832,6 +833,138 @@ void main() {
       'vote_round_id': hexRoundId,
     });
     expect(http.requests.single.timeout, const Duration(seconds: 5));
+  });
+
+  test('preflights helpers concurrently and caches readiness', () async {
+    final primaryResponse = Completer<VotingHttpResponse>();
+    final secondaryResponse = Completer<VotingHttpResponse>();
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://helper-1.example/shielded-vote/v1/status':
+            primaryResponse.future,
+        'https://helper-2.example/shielded-vote/v1/status':
+            secondaryResponse.future,
+      },
+    );
+    final client = VotingApiClient(
+      baseUrl: Uri.parse('https://voting.valargroup.org'),
+      httpClient: http,
+      helperPreflightTimeout: const Duration(seconds: 1),
+    );
+
+    final pending = client.preflightHelpers([
+      Uri.parse('https://helper-1.example'),
+      Uri.parse('https://helper-2.example'),
+      Uri.parse('https://helper-1.example'),
+    ]);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(http.requests.map((request) => request.uri.host), [
+      'helper-1.example',
+      'helper-2.example',
+    ]);
+    primaryResponse.complete(jsonResponse({'status': 'ok'}));
+    secondaryResponse.complete(jsonResponse({'status': 'ok'}));
+    expect(await pending, {
+      'https://helper-1.example': true,
+      'https://helper-2.example': true,
+    });
+
+    expect(
+      await client.preflightHelpers([Uri.parse('https://helper-1.example')]),
+      {'https://helper-1.example': true},
+    );
+    expect(http.requests, hasLength(2));
+    expect(
+      http.requests.map((request) => request.timeout),
+      everyElement(const Duration(seconds: 1)),
+    );
+  });
+
+  test(
+    'preflight reports failed and malformed helpers as unavailable',
+    () async {
+      final http = FakeVotingHttpClient(
+        responses: {
+          'https://helper-1.example/shielded-vote/v1/status': jsonResponse({
+            'error': 'unavailable',
+          }, statusCode: 503),
+          'https://helper-2.example/shielded-vote/v1/status': {
+            'status': 'starting',
+          },
+          'https://helper-3.example/shielded-vote/v1/status': timeoutResponse(),
+        },
+      );
+      final client = VotingApiClient(
+        baseUrl: Uri.parse('https://voting.valargroup.org'),
+        httpClient: http,
+      );
+
+      final readiness = await client.preflightHelpers([
+        Uri.parse('https://helper-1.example'),
+        Uri.parse('https://helper-2.example'),
+        Uri.parse('https://helper-3.example'),
+      ]);
+
+      expect(readiness.values, everyElement(isFalse));
+    },
+  );
+
+  test('retries fast transient initial helper failures', () async {
+    final delays = <Duration>[];
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://helper.example/shielded-vote/v1/shares':
+            SequentialVotingHttpResponses([
+              jsonResponse({'error': 'unavailable'}, statusCode: 503),
+              {'status': 'queued'},
+            ]),
+      },
+    );
+    final client = VotingApiClient(
+      baseUrl: Uri.parse('https://voting.valargroup.org'),
+      httpClient: http,
+      helperRetryPolicy: VotingRetryPolicy.transientHttp(
+        name: 'test-helper-retry',
+        delays: const [Duration(milliseconds: 2)],
+      ),
+      delay: (delay) async => delays.add(delay),
+    );
+
+    final result = await client.submitShare(
+      serverUrl: Uri.parse('https://helper.example'),
+      share: {'share_index': 0, 'vote_round_id': hexRoundId},
+    );
+
+    expect(result.status, 'queued');
+    expect(http.requests, hasLength(2));
+    expect(delays, const [Duration(milliseconds: 2)]);
+  });
+
+  test('bounds a blackholed initial helper to one total timeout', () async {
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://helper.example/shielded-vote/v1/shares':
+            Completer<VotingHttpResponse>().future,
+      },
+    );
+    final client = VotingApiClient(
+      baseUrl: Uri.parse('https://voting.valargroup.org'),
+      httpClient: http,
+      helperTimeout: const Duration(milliseconds: 30),
+    );
+    final timer = Stopwatch()..start();
+
+    await expectLater(
+      client.submitShare(
+        serverUrl: Uri.parse('https://helper.example'),
+        share: {'share_index': 0, 'vote_round_id': hexRoundId},
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+
+    expect(http.requests, hasLength(1));
+    expect(timer.elapsed, lessThan(const Duration(seconds: 1)));
   });
 
   test('does not retry initial helper submission after a timeout', () async {

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -501,14 +501,14 @@ void main() {
   });
 
   test(
-    'tries tx confirmation fallbacks before returning null on 404',
+    'tries each tx confirmation server once before returning null',
     () async {
       final primary = Uri.parse('https://vote-primary.example');
       final secondary = Uri.parse('https://vote-secondary.example');
       final http = FakeVotingHttpClient(
         responses: {
           'https://vote-primary.example/shielded-vote/v1/tx/delegation-tx':
-              jsonResponse({'error': 'not found'}, statusCode: 404),
+              timeoutResponse(),
           'https://vote-secondary.example/shielded-vote/v1/tx/delegation-tx': {
             'height': '12',
             'code': 0,
@@ -579,50 +579,6 @@ void main() {
         'vote-primary.example',
         'vote-secondary.example',
       ]);
-    },
-  );
-
-  test(
-    'tries the next tx confirmation server without retrying a timeout',
-    () async {
-      final primary = Uri.parse('https://vote-primary.example');
-      final offline = Uri.parse('https://vote-offline.example');
-      final tertiary = Uri.parse('https://vote-tertiary.example');
-      final delays = <Duration>[];
-      final http = FakeVotingHttpClient(
-        responses: {
-          'https://vote-primary.example/shielded-vote/v1/tx/vote-tx':
-              jsonResponse({'error': 'not found'}, statusCode: 404),
-          'https://vote-offline.example/shielded-vote/v1/tx/vote-tx':
-              timeoutResponse(),
-          'https://vote-tertiary.example/shielded-vote/v1/tx/vote-tx': {
-            'height': '12',
-            'code': 0,
-            'log': '',
-            'events': const [],
-          },
-        },
-      );
-      final client = VotingApiClient(
-        baseUrl: primary,
-        fallbackBaseUrls: [offline, tertiary],
-        httpClient: http,
-        readRetryPolicy: VotingRetryPolicy.transientHttp(
-          name: 'test-confirmation-failover',
-          delays: const [Duration(milliseconds: 300), Duration(seconds: 1)],
-        ),
-        delay: (delay) async => delays.add(delay),
-      );
-
-      final confirmation = await client.getTxConfirmation('vote-tx');
-
-      expect(confirmation?.height, 12);
-      expect(http.requests.map((request) => request.uri.host), [
-        'vote-primary.example',
-        'vote-offline.example',
-        'vote-tertiary.example',
-      ]);
-      expect(delays, isEmpty);
     },
   );
 
@@ -835,88 +791,65 @@ void main() {
     expect(http.requests.single.timeout, const Duration(seconds: 5));
   });
 
-  test('preflights helpers concurrently and caches readiness', () async {
-    final primaryResponse = Completer<VotingHttpResponse>();
-    final secondaryResponse = Completer<VotingHttpResponse>();
-    final http = FakeVotingHttpClient(
-      responses: {
-        'https://helper-1.example/shielded-vote/v1/status':
-            primaryResponse.future,
-        'https://helper-2.example/shielded-vote/v1/status':
-            secondaryResponse.future,
-      },
-    );
-    final client = VotingApiClient(
-      baseUrl: Uri.parse('https://voting.valargroup.org'),
-      httpClient: http,
-      helperPreflightTimeout: const Duration(seconds: 1),
-    );
-
-    final pending = client.preflightHelpers([
-      Uri.parse('https://helper-1.example'),
-      Uri.parse('https://helper-2.example'),
-      Uri.parse('https://helper-1.example'),
-    ]);
-    await Future<void>.delayed(Duration.zero);
-
-    expect(http.requests.map((request) => request.uri.host), [
-      'helper-1.example',
-      'helper-2.example',
-    ]);
-    primaryResponse.complete(jsonResponse({'status': 'ok'}));
-    secondaryResponse.complete(jsonResponse({'status': 'ok'}));
-    expect(await pending, {
-      'https://helper-1.example': true,
-      'https://helper-2.example': true,
-    });
-
-    expect(
-      await client.preflightHelpers([Uri.parse('https://helper-1.example')]),
-      {'https://helper-1.example': true},
-    );
-    expect(http.requests, hasLength(2));
-    expect(
-      http.requests.map((request) => request.timeout),
-      everyElement(const Duration(seconds: 1)),
-    );
-  });
-
   test(
-    'preflight reports failed and malformed helpers as unavailable',
+    'preflights helpers concurrently and treats failures as unavailable',
     () async {
+      final primaryResponse = Completer<VotingHttpResponse>();
+      final secondaryResponse = Completer<VotingHttpResponse>();
+      final blackholedResponse = Completer<VotingHttpResponse>();
       final http = FakeVotingHttpClient(
         responses: {
-          'https://helper-1.example/shielded-vote/v1/status': jsonResponse({
-            'error': 'unavailable',
-          }, statusCode: 503),
-          'https://helper-2.example/shielded-vote/v1/status': {
-            'status': 'starting',
-          },
-          'https://helper-3.example/shielded-vote/v1/status': timeoutResponse(),
+          'https://helper-1.example/shielded-vote/v1/status':
+              primaryResponse.future,
+          'https://helper-2.example/shielded-vote/v1/status':
+              secondaryResponse.future,
+          'https://helper-3.example/shielded-vote/v1/status':
+              blackholedResponse.future,
         },
       );
       final client = VotingApiClient(
         baseUrl: Uri.parse('https://voting.valargroup.org'),
         httpClient: http,
+        helperPreflightTimeout: const Duration(milliseconds: 30),
       );
 
-      final readiness = await client.preflightHelpers([
+      final pending = client.preflightHelpers([
         Uri.parse('https://helper-1.example'),
         Uri.parse('https://helper-2.example'),
         Uri.parse('https://helper-3.example'),
       ]);
+      await Future<void>.delayed(Duration.zero);
 
-      expect(readiness.values, everyElement(isFalse));
+      expect(http.requests.map((request) => request.uri.host), [
+        'helper-1.example',
+        'helper-2.example',
+        'helper-3.example',
+      ]);
+      primaryResponse.complete(jsonResponse({'status': 'ok'}));
+      secondaryResponse.complete(jsonResponse({'status': 'starting'}));
+      expect(await pending, {
+        'https://helper-1.example': true,
+        'https://helper-2.example': false,
+        'https://helper-3.example': false,
+      });
+
+      expect(http.requests, hasLength(3));
+      expect(
+        http.requests.map((request) => request.timeout),
+        everyElement(const Duration(milliseconds: 30)),
+      );
     },
   );
 
-  test('retries fast transient initial helper failures', () async {
+  test('retries fast helper failures but not a blackholed attempt', () async {
     final delays = <Duration>[];
+    final blackholedResponse = Completer<VotingHttpResponse>();
     final http = FakeVotingHttpClient(
       responses: {
         'https://helper.example/shielded-vote/v1/shares':
             SequentialVotingHttpResponses([
               jsonResponse({'error': 'unavailable'}, statusCode: 503),
+              blackholedResponse.future,
               {'status': 'queued'},
             ]),
       },
@@ -924,34 +857,12 @@ void main() {
     final client = VotingApiClient(
       baseUrl: Uri.parse('https://voting.valargroup.org'),
       httpClient: http,
+      helperTimeout: const Duration(milliseconds: 30),
       helperRetryPolicy: VotingRetryPolicy.transientHttp(
         name: 'test-helper-retry',
-        delays: const [Duration(milliseconds: 2)],
+        delays: const [Duration(milliseconds: 2), Duration(milliseconds: 4)],
       ),
       delay: (delay) async => delays.add(delay),
-    );
-
-    final result = await client.submitShare(
-      serverUrl: Uri.parse('https://helper.example'),
-      share: {'share_index': 0, 'vote_round_id': hexRoundId},
-    );
-
-    expect(result.status, 'queued');
-    expect(http.requests, hasLength(2));
-    expect(delays, const [Duration(milliseconds: 2)]);
-  });
-
-  test('bounds a blackholed initial helper to one total timeout', () async {
-    final http = FakeVotingHttpClient(
-      responses: {
-        'https://helper.example/shielded-vote/v1/shares':
-            Completer<VotingHttpResponse>().future,
-      },
-    );
-    final client = VotingApiClient(
-      baseUrl: Uri.parse('https://voting.valargroup.org'),
-      httpClient: http,
-      helperTimeout: const Duration(milliseconds: 30),
     );
     final timer = Stopwatch()..start();
 
@@ -963,41 +874,9 @@ void main() {
       throwsA(isA<TimeoutException>()),
     );
 
-    expect(http.requests, hasLength(1));
+    expect(http.requests, hasLength(2));
+    expect(delays, const [Duration(milliseconds: 2)]);
     expect(timer.elapsed, lessThan(const Duration(seconds: 1)));
-  });
-
-  test('does not retry initial helper submission after a timeout', () async {
-    final delays = <Duration>[];
-    final http = FakeVotingHttpClient(
-      responses: {
-        'https://helper.example/shielded-vote/v1/shares':
-            SequentialVotingHttpResponses([
-              timeoutResponse(),
-              {'status': 'queued'},
-            ]),
-      },
-    );
-    final client = VotingApiClient(
-      baseUrl: Uri.parse('https://voting.valargroup.org'),
-      httpClient: http,
-      helperRetryPolicy: VotingRetryPolicy.transientHttp(
-        name: 'test-helper-retry',
-        delays: const [Duration(milliseconds: 2)],
-      ),
-      delay: (delay) async => delays.add(delay),
-    );
-
-    await expectLater(
-      client.submitShare(
-        serverUrl: Uri.parse('https://helper.example'),
-        share: {'share_index': 0, 'vote_round_id': hexRoundId},
-      ),
-      throwsA(isA<TimeoutException>()),
-    );
-
-    expect(http.requests, hasLength(1));
-    expect(delays, isEmpty);
   });
 
   test('does not repeat a resubmission after an ambiguous timeout', () async {

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -577,9 +577,51 @@ void main() {
       expect(flakyFallbackHttp.requests.map((request) => request.uri.host), [
         'vote-primary.example',
         'vote-secondary.example',
-        'vote-secondary.example',
-        'vote-secondary.example',
       ]);
+    },
+  );
+
+  test(
+    'tries the next tx confirmation server without retrying a timeout',
+    () async {
+      final primary = Uri.parse('https://vote-primary.example');
+      final offline = Uri.parse('https://vote-offline.example');
+      final tertiary = Uri.parse('https://vote-tertiary.example');
+      final delays = <Duration>[];
+      final http = FakeVotingHttpClient(
+        responses: {
+          'https://vote-primary.example/shielded-vote/v1/tx/vote-tx':
+              jsonResponse({'error': 'not found'}, statusCode: 404),
+          'https://vote-offline.example/shielded-vote/v1/tx/vote-tx':
+              timeoutResponse(),
+          'https://vote-tertiary.example/shielded-vote/v1/tx/vote-tx': {
+            'height': '12',
+            'code': 0,
+            'log': '',
+            'events': const [],
+          },
+        },
+      );
+      final client = VotingApiClient(
+        baseUrl: primary,
+        fallbackBaseUrls: [offline, tertiary],
+        httpClient: http,
+        readRetryPolicy: VotingRetryPolicy.transientHttp(
+          name: 'test-confirmation-failover',
+          delays: const [Duration(milliseconds: 300), Duration(seconds: 1)],
+        ),
+        delay: (delay) async => delays.add(delay),
+      );
+
+      final confirmation = await client.getTxConfirmation('vote-tx');
+
+      expect(confirmation?.height, 12);
+      expect(http.requests.map((request) => request.uri.host), [
+        'vote-primary.example',
+        'vote-offline.example',
+        'vote-tertiary.example',
+      ]);
+      expect(delays, isEmpty);
     },
   );
 

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -834,7 +834,7 @@ void main() {
     expect(http.requests.single.timeout, const Duration(seconds: 5));
   });
 
-  test('retries helper share submission on transient timeout', () async {
+  test('does not retry initial helper submission after a timeout', () async {
     final delays = <Duration>[];
     final http = FakeVotingHttpClient(
       responses: {
@@ -855,14 +855,16 @@ void main() {
       delay: (delay) async => delays.add(delay),
     );
 
-    final result = await client.submitShare(
-      serverUrl: Uri.parse('https://helper.example'),
-      share: {'share_index': 0, 'vote_round_id': hexRoundId},
+    await expectLater(
+      client.submitShare(
+        serverUrl: Uri.parse('https://helper.example'),
+        share: {'share_index': 0, 'vote_round_id': hexRoundId},
+      ),
+      throwsA(isA<TimeoutException>()),
     );
 
-    expect(result.status, 'queued');
-    expect(http.requests.length, 2);
-    expect(delays, const [Duration(milliseconds: 2)]);
+    expect(http.requests, hasLength(1));
+    expect(delays, isEmpty);
   });
 
   test('does not repeat a resubmission after an ambiguous timeout', () async {

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -559,7 +559,7 @@ void main() {
       final flakyFallbackHttp = FakeVotingHttpClient(
         responses: {
           'https://vote-primary.example/shielded-vote/v1/tx/flaky-tx':
-              jsonResponse({'error': 'not found'}, statusCode: 404),
+              timeoutResponse(),
           'https://vote-secondary.example/shielded-vote/v1/tx/flaky-tx':
               jsonResponse({'error': 'unavailable'}, statusCode: 503),
         },


### PR DESCRIPTION
## Summary

Performance work on the voting flow, benchmarked against a 3-bundle wallet
voting on 6 questions. End to end this branch takes the **vote phase from ~60s
to ~20s** and **delegation from ~26s to ~17s**.

Measurements come from the voting perf thread in Slack
([link](https://zcashzcaloors.slack.com/archives/C0BN1U4GZSN/p1787329254687119)).
All numbers below are wall clock on a Mac, 3 delegation bundles, 3 concurrent
workers.

The branch is organized as 7 commits in dependency order. **The sections below
are ordered by measured impact instead**, so they do not follow commit order —
each one links the commits it covers.

| Commit | | |
|---|---|---|
| 75054576 | `deps: bump zcash_voting to 3.1.0-rc.7` | [§7](#7-dependency-bump) |
| be0d655b | `voting: serialize sidecar writes behind a per-wallet lock` | [§4](#4-sidecar-write-serialization--enabler-no-standalone-perf) |
| 6fe350a4 | `voting: warm proving caches and overlap PIR connect with setup` | [§3](#3-warm-proving-caches--pir-overlap--254s-first-delegation-only) |
| 6aef392d | `voting: split vote commit into prepare and persist phases` | [§1](#1-vote-casting-pipelining--60s-to-20s) |
| c66df4d7 | `voting: run delegation bundle proofs in bounded parallel` | [§2](#2-cross-bundle-delegation-concurrency--263s-to-17s-35), [§5](#5-partial-failure-recovery--correctness-tax-of-1-and-2) |
| 93211351 | `voting: pipeline vote casting per bundle VAN chain` | [§1](#1-vote-casting-pipelining--60s-to-20s), [§5](#5-partial-failure-recovery--correctness-tax-of-1-and-2) |
| e0a315d1 | `TEMP: voting timing instrumentation` | [§6](#6-instrumentation) |

Every commit builds clean, analyzes clean, and passes both test suites — see
[Verification](#verification).

## Changes by measured impact

### 1. Vote-casting pipelining — ~60s to ~20s

> Commits: 93211351, plus its Rust prerequisite 6aef392d

The dominant win, worth roughly 4x more than everything else combined.

Casting a vote spends the bundle's vote authority note: the proof binds the
current VAN leaf position and proposal-authority mask, submission clears that
proposal's bit, and confirmation appends the replacement leaf. Proving two
proposals of one bundle against the same state yields the same `van_nullifier`,
so the second transaction is a double spend. Each bundle must therefore run
`prove -> submit -> confirm -> re-sync` in order.

Different bundles own independent VAN chains, so they never need to wait on each
other. This restructures casting into one serial chain per bundle with all
bundles in flight at once:

- `_runVoteRoundChains` replaces the proposal-major loop with a bundle-major
  fan-out. Only the CPU-heavy witness+proof step is capped (3 permits); a bundle
  parked on a block confirmation holds no proof permit.
- `_VoteTreeSyncCoalescer` keeps tree syncs both non-concurrent (failover resets
  round-global process state) and non-stale (`fresh()` only resolves with a sync
  that *started after* the call). Bundles finishing a proposal together cost one
  round trip, not N.
- `_submitVoteCommitmentsWithoutConfirmation` / `_persistVoteConfirmations`
  split submission from confirmation so the two can be scheduled separately.
- Share submission is dispatched off the chain — the VAN advance is already
  durable by then, so the next proposal does not wait on helper delivery.
- Rust (6aef392d): `commit_batch` is split into `prepare_commit_batch`
  (expensive, lock-free) and `persist_prepared_commit_batch` (short, under the
  write lock), so the crypto no longer holds the single-writer lock.

**Remaining bottleneck is not client-side.** Confirmation wait is ~2.3s and sits
on the critical path once per proposal per chain: ~13.8s of the remaining ~20s.
Further gains need shorter block time or cheaper re-sync, not more concurrency
here.

### 2. Cross-bundle delegation concurrency — ~26.3s to ~17s (35%)

> Commit: c66df4d7

Proof work for independent delegation bundles now runs in bounded parallel
batches (`_votingWorkConcurrency = 3`), while broadcasts and sidecar writes stay
serialized and ordered.

- `_runBoundedBundleWork<T>` is a shared bounded worker pool returning a
  per-bundle `_BundleWorkOutcome` (success **or** captured error + stack trace),
  so no batch aborts on the first throw.
- `_runDelegationBundleBatch` drives proof (parallel) -> broadcast (serial,
  because the vote server API exposes no idempotency key) -> confirmation
  (parallel). `_submitDelegation` and `_confirmDelegation` are split out of
  `_submitAndConfirmDelegation` to make that ordering expressible.
- Timing instrumentation logs `wall=` vs `serialEquivalent=` per fan-in so the
  speedup stays visible in logs.

### 3. Warm proving caches + PIR overlap — ~2.5-4s, first delegation only

> Commit: 6fe350a4

Smallest win, and partly a bug fix: the existing warm-up path was never being
hit.

Per-stage breakdown of a cold first bundle (12.89s total) showed the actual
Halo2 proof was only **0.68s**. The rest was 2.47s of cold proving-key
generation and 2.15s of a PIR connect that was being remade on every call.

- `warm_voting_proving_caches()` (new `#[frb(sync)]` API) starts a
  process-lifetime Halo2 warm-up on a dedicated 64 MB-stack thread. Idempotent
  via `OnceLock`, returns immediately, called from the prepare and PIR-precompute
  paths so warm-up overlaps PIR resolve and bundle setup. Spawn failure degrades
  to inline cold keygen rather than erroring.
- `spawn_pir_connect` / `join_pir_connect`: the PIR connect is kicked off before
  note selection and joined inside the proving worker, so the network round trip
  overlaps setup. `OwnedResultThread` drains the connect thread on the error path
  instead of detaching it.
- PIR row precompute now runs before the Halo2 prove so remaining keygen can
  overlap it.

### 4. Sidecar write serialization — enabler, no standalone perf

> Commit: be0d655b

Prerequisite for groups 1 and 2. Bundles use independent SQLite connections; WAL
lets their reads overlap, but SQLite still has a single writer.

- `with_voting_sidecar_write_lock` (`wallet/voting/db.rs`): process-local,
  per-wallet-sidecar-path mutex. Every short write phase runs under it —
  `mark_delegation_submitted`, `confirm_delegation_submission`,
  `mark_vote_submitted`, `confirm_vote_submission`, `record_share_delegation`,
  `mark_share_confirmed`, `add_sent_servers`, `set_ballot_intent`, PCZT setup.
  `with_open_voting_db_write` extends the critical section to cover opening,
  since a fresh connection may migrate schema or set pragmas.
- `retry_voting_db_locks`: bounded retry (3 attempts, 50/100/150 ms) for
  `database is locked`. Proof generation deliberately runs *outside* the write
  lock so up to three bundles can do PIR + Halo2 work concurrently; its final
  transaction can still lose the writer race, and retrying is safe because setup,
  PIR cache, and proof persistence are bundle-keyed and idempotent.

### 5. Partial-failure recovery — correctness tax of 1 and 2

> Commits: c66df4d7 (delegation paths), 93211351 (vote paths)

No perf effect; this is what keeps parallel partial failure recoverable, and it
lands inside the two commits whose concurrency creates the need.

- Failures are collected per bundle and reported together
  (`_DelegationBundleBatchException`, `_VoteWaveBatchException`) instead of the
  first throw killing sibling work.
- **`cleanupProcessStateOnError: false`** on `delegate`, the Keystone delegate
  path, and `castVotes`. A failed action no longer resets round-global Rust
  process state, because with bundles partially through the pipeline that reset
  would discard work a retry can resume from. This is a real behavior change and
  the one most worth scrutiny in review.
- `_refreshDelegationPlansAfterBatchFailure` reloads resume/round plans after a
  partial batch failure so a retry sees durable state, and preserves the original
  bundle error for the user if the refresh itself fails.
- `_awaitTxConfirmation` takes the session context and checks staleness around
  each poll, so an abandoned round stops polling promptly.
- `VotingSessionState` defensively copies every collection before wrapping it in
  an unmodifiable view — with concurrent workers mutating progress maps, wrapping
  the caller's live instance was a real aliasing hazard.
- Progress reporting is concurrency-safe: a single `publish()` closure aggregates
  per-bundle progress into one session-level value, and share progress is clamped
  monotonic so out-of-order completions cannot move the bar backwards.

### 6. Instrumentation

> Commit: e0a315d1 — **not for merge as-is**

`[VOTING_PROVE]` and `[VOTING_VOTE]` timing logs, plus a `log_voting_timing`
FRB call so Dart-side timings reach Release `log show` (subsystem `frb_user`).
This is what produced every number above. It is isolated at the tip of the branch
so it can be dropped or trimmed on its own.

Much of it is bisection scaffolding rather than permanent observability — it
times sub-millisecond steps (`seed`, `static-inputs`, `hotkey`,
`wire-conversion`), and both the vote-commit stage reporter and the delegation
progress reporter are wrapped in `Mutex<Instant>` closures that lock and format
on every progress event, which is real overhead in the hot path.

Intent before merge is to keep only the coarse per-stage timings and the `wall=`
vs `serialEquivalent=` fan-in summaries, and drop the rest.

Two things could not be isolated here: the generated FRB bindings, which cannot
be meaningfully split, and therefore the `log_voting_timing` Rust entry point
they dispatch to. Both live in 6fe350a4. Dropping this commit should be followed
by removing that entry point and re-running codegen.

### 7. Dependency bump

> Commit: 75054576

`zcash_voting` `=3.1.0-rc.6` -> `=3.1.0-rc.7`, required by 6aef392d for
`prepare_commit_batch` / `persist_prepared_commit_batch`. Cleanest resolution is
to rebase onto an rc.7 base rather than land the bump inside a perf PR.

## Suggested review order

The commits are already in dependency order, so reviewing them as pushed works
top to bottom. If this is split into separate PRs, the cut points are:

1. 75054576 + be0d655b — no perf claim, reviewable on its own terms, makes the
   rest diffs about scheduling rather than locking.
2. 6aef392d + 93211351 — the big win.
3. c66df4d7 — same invariant as the previous one, reads fast afterwards.
4. 6fe350a4 — independent, smallest.

## Concurrency invariant

The rule this branch preserves throughout: **proof, PIR, and network work runs in
parallel; anything that mutates chain or sidecar state runs serialized and in
order.** Broadcast ordering and per-bundle idempotency are what make partial
failure recoverable.

## Verification

Run at **every commit**, not just the tip, so the stack bisects:

| Commit | `cargo check` | `flutter analyze` | Rust voting tests | Dart voting tests |
|---|---|---|---|---|
| 75054576 | clean | clean | 60 passed | 243 passed |
| be0d655b | clean | clean | 64 passed | 243 passed |
| 6fe350a4 | clean | clean | 68 passed | 244 passed |
| 6aef392d | clean | clean | 68 passed | 244 passed |
| c66df4d7 | clean | clean | 68 passed | 250 passed |
| 93211351 | clean | clean | 68 passed | 261 passed |
| e0a315d1 | clean | clean | 68 passed | 261 passed |

"Clean" means zero errors **and** zero warnings. Commands:
`cargo check`, `cargo test --lib voting`,
`fvm flutter test test/providers/voting test/features/voting`,
`fvm flutter analyze lib/src/providers/voting lib/src/features/voting test/providers/voting test/features/voting`
(1 pre-existing skip in the Dart suites).

New concurrency coverage in be0d655b:
`sidecar_write_lock_serializes_three_writers_for_one_wallet` (asserts max
concurrent writers == 1), `sidecar_write_locks_allow_different_wallets_to_overlap`,
`locked_open_serializes_real_same_sidecar_writes`,
`voting_db_lock_retry_recovers_after_transient_writer_races`.

## Follow-ups

- Trim the instrumentation in e0a315d1 as described in §6, then drop
  `log_voting_timing` and re-run codegen.
- Rename `_votingWorkConcurrency` if the four pools it caps (delegation proofs,
  vote proofs, share submission, recovery polling) should be tuned separately.
- Confirm the FRB-generated files match CI's codegen toolchain, or they will
  churn on the next regen.
