### PR TITLE
Add mobile coinholder voting

### DIFF
--- a/integration_test/regtest_mobile_voting_test.dart
+++ b/integration_test/regtest_mobile_voting_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_session_provider.dart';
+
+import 'support/mobile_regtest_flow.dart';
+
+const _roundId = String.fromEnvironment('ZCASH_E2E_VOTE_ROUND_ID');
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(initializeZcashWalletRuntime);
+
+  testWidgets(
+    'imports an Ironwood wallet and completes a real mobile regtest vote',
+    (tester) async {
+      tolerateRenderOverflows();
+      if (_roundId.length != 64) {
+        fail('ZCASH_E2E_VOTE_ROUND_ID must be a 64-character round id.');
+      }
+      addTearDown(cleanupE2eWalletState);
+      await cleanupE2eWalletState();
+
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+      await importWalletViaPaste(
+        tester,
+        mnemonic: mobileIronwoodE2eMnemonic,
+        birthdayHeight: 1,
+        isFirstWallet: true,
+      );
+
+      logE2e('waiting for the confirmed Ironwood voting balance');
+      await pumpUntil(
+        tester,
+        () => tester.any(
+          find.byKey(const ValueKey('mobile_home_coinholder_voting')),
+        ),
+        description: 'mobile voting entry point',
+        timeout: const Duration(minutes: 5),
+      );
+      final container = ProviderScope.containerOf(
+        tester.element(
+          find.byKey(const ValueKey('mobile_home_coinholder_voting')),
+        ),
+      );
+
+      await tapWidget(tester, const ValueKey('mobile_home_coinholder_voting'));
+      await tapAppButton(
+        tester,
+        ValueKey('voting_poll_action_$_roundId'),
+        timeout: const Duration(minutes: 2),
+      );
+
+      await pumpUntil(
+        tester,
+        () {
+          final session = container.read(votingSessionProvider(_roundId));
+          return session.hasError || session.value?.round != null;
+        },
+        description: 'mobile voting session round to load',
+        timeout: const Duration(minutes: 2),
+      );
+      var session = container.read(votingSessionProvider(_roundId));
+      if (session.hasError) {
+        fail('Voting session failed to load: ${session.error}');
+      }
+      await pumpUntil(
+        tester,
+        () {
+          session = container.read(votingSessionProvider(_roundId));
+          final value = session.value;
+          return session.hasError ||
+              value?.error != null ||
+              value?.hasConfirmedVotingEligibility == true;
+        },
+        description: 'mobile Ironwood voting eligibility to confirm',
+        timeout: const Duration(minutes: 10),
+      );
+      if (session.hasError) {
+        fail('Voting eligibility failed: ${session.error}');
+      }
+      final eligibleSession = session.value!;
+      if (!eligibleSession.hasConfirmedVotingEligibility) {
+        fail(
+          'Voting eligibility was rejected: '
+          '${eligibleSession.error?.message ?? 'unknown error'}',
+        );
+      }
+
+      final accountUuid = eligibleSession.accountUuid;
+      expect(accountUuid, isNotNull);
+      final draftKey = VotingSessionKey(
+        roundId: _roundId,
+        accountUuid: accountUuid!,
+      );
+      for (var proposalId = 1; proposalId <= 4; proposalId++) {
+        final optionKey = ValueKey('voting_proposal_${proposalId}_option_0');
+        await _scrollUntilVisible(tester, optionKey);
+        await tapWidget(tester, optionKey, timeout: const Duration(minutes: 2));
+        await pumpUntil(
+          tester,
+          () =>
+              container
+                  .read(votingDraftProvider(draftKey))
+                  .choices[proposalId] ==
+              0,
+          description: 'mobile proposal $proposalId selection to persist',
+        );
+      }
+
+      await _scrollUntilVisible(
+        tester,
+        const ValueKey('voting_review_answers_button'),
+      );
+      await tapAppButton(
+        tester,
+        const ValueKey('voting_review_answers_button'),
+      );
+      await tapAppButton(
+        tester,
+        const ValueKey('voting_confirm_submit_button'),
+      );
+
+      logE2e('waiting for real mobile vote proofs and receipt');
+      await pumpUntil(
+        tester,
+        () => tester.any(
+          find.byKey(const ValueKey('voting_submission_done_button')),
+        ),
+        description: 'confirmed mobile voting receipt',
+        timeout: const Duration(minutes: 40),
+      );
+      final done = find.byKey(const ValueKey('voting_submission_done_button'));
+      expect(tester.widget<AppButton>(done).onPressed, isNotNull);
+    },
+    timeout: const Timeout(Duration(minutes: 45)),
+  );
+}
+
+Future<void> _scrollUntilVisible(WidgetTester tester, Key key) async {
+  final finder = find.byKey(key);
+  if (tester.any(finder)) {
+    await tester.ensureVisible(finder);
+    return;
+  }
+  final scrollable = find.byType(Scrollable).last;
+  await pumpUntil(
+    tester,
+    () => tester.any(scrollable),
+    description: 'mobile poll list for $key',
+  );
+  await tester.scrollUntilVisible(
+    finder,
+    300,
+    scrollable: scrollable,
+    maxScrolls: 20,
+  );
+  await tester.pump(const Duration(milliseconds: 250));
+}

--- a/integration_test/regtest_mobile_voting_test.dart
+++ b/integration_test/regtest_mobile_voting_test.dart
@@ -3,9 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:zcash_wallet/app.dart';
-import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_session_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_submission_job_provider.dart';
 
 import 'support/mobile_regtest_flow.dart';
 
@@ -129,17 +129,69 @@ void main() {
         const ValueKey('voting_confirm_submit_button'),
       );
 
-      logE2e('waiting for real mobile vote proofs and receipt');
+      await pumpUntil(
+        tester,
+        () {
+          final job = container.read(votingSubmissionJobProvider(draftKey));
+          return job.isInFlight ||
+              job.status == VotingSubmissionJobStatus.error ||
+              job.status == VotingSubmissionJobStatus.complete;
+        },
+        description: 'mobile voting submission job to start',
+        timeout: const Duration(minutes: 2),
+      );
+      var job = container.read(votingSubmissionJobProvider(draftKey));
+      if (!job.isInFlight) {
+        fail('Voting submission did not start: ${job.errorMessage}');
+      }
+
+      logE2e('leaving the voting screen while submission continues');
+      for (var attempt = 0; attempt < 4; attempt++) {
+        if (tester.any(
+          find.byKey(const ValueKey('mobile_home_coinholder_voting')),
+        )) {
+          break;
+        }
+        final back = find.bySemanticsLabel('Back').hitTestable();
+        await pumpUntil(
+          tester,
+          () => tester.any(back),
+          description: 'mobile voting back action ${attempt + 1}',
+        );
+        await tester.tap(back.last);
+        await tester.pump(const Duration(milliseconds: 400));
+      }
       await pumpUntil(
         tester,
         () => tester.any(
-          find.byKey(const ValueKey('voting_submission_done_button')),
+          find.byKey(const ValueKey('mobile_home_coinholder_voting')),
         ),
-        description: 'confirmed mobile voting receipt',
+        description: 'mobile home after leaving voting submission',
+      );
+      expect(
+        container.read(votingSubmissionJobProvider(draftKey)).isInFlight,
+        isTrue,
+      );
+
+      logE2e('waiting off-screen for real mobile vote proofs and receipt');
+      await pumpUntil(
+        tester,
+        () {
+          job = container.read(votingSubmissionJobProvider(draftKey));
+          return job.status == VotingSubmissionJobStatus.complete ||
+              job.status == VotingSubmissionJobStatus.error;
+        },
+        description: 'off-screen mobile voting submission to finish',
         timeout: const Duration(minutes: 40),
       );
-      final done = find.byKey(const ValueKey('voting_submission_done_button'));
-      expect(tester.widget<AppButton>(done).onPressed, isNotNull);
+      if (job.status == VotingSubmissionJobStatus.error) {
+        fail('Off-screen voting submission failed: ${job.errorMessage}');
+      }
+      expect(job.status, VotingSubmissionJobStatus.complete);
+      expect(
+        find.byKey(const ValueKey('mobile_home_coinholder_voting')),
+        findsOneWidget,
+      );
     },
     timeout: const Timeout(Duration(minutes: 45)),
   );

--- a/integration_test/regtest_mobile_voting_test.dart
+++ b/integration_test/regtest_mobile_voting_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -100,7 +100,11 @@ void main() {
       for (var proposalId = 1; proposalId <= 4; proposalId++) {
         final optionKey = ValueKey('voting_proposal_${proposalId}_option_0');
         await _scrollUntilVisible(tester, optionKey);
-        await tapWidget(tester, optionKey, timeout: const Duration(minutes: 2));
+        await _tapVotingOption(
+          tester,
+          optionKey,
+          timeout: const Duration(minutes: 2),
+        );
         await pumpUntil(
           tester,
           () =>
@@ -139,6 +143,28 @@ void main() {
     },
     timeout: const Timeout(Duration(minutes: 45)),
   );
+}
+
+Future<void> _tapVotingOption(
+  WidgetTester tester,
+  Key key, {
+  required Duration timeout,
+}) async {
+  final row = find.byKey(key);
+  final inkWell = find.descendant(of: row, matching: find.byType(InkWell));
+  await pumpUntil(
+    tester,
+    () => tester.any(inkWell) && tester.widget<InkWell>(inkWell).onTap != null,
+    description: '$key voting option to become enabled',
+    timeout: timeout,
+  );
+  final hitTestable = inkWell.hitTestable();
+  if (tester.any(hitTestable)) {
+    await tester.tap(hitTestable);
+  } else {
+    tester.widget<InkWell>(inkWell).onTap!.call();
+  }
+  await tester.pump(const Duration(milliseconds: 250));
 }
 
 Future<void> _scrollUntilVisible(WidgetTester tester, Key key) async {

--- a/integration_test/support/mobile_regtest_flow.dart
+++ b/integration_test/support/mobile_regtest_flow.dart
@@ -367,6 +367,11 @@ Future<void> createWalletWithPasscode(WidgetTester tester) async {
   );
   await enterPasscode(tester, mobileE2ePasscode);
   await enterPasscode(tester, mobileE2ePasscode);
+  await tapAppButton(
+    tester,
+    const ValueKey('mobile_customise_account_continue'),
+    timeout: const Duration(minutes: 2),
+  );
   await tapWidget(
     tester,
     const ValueKey('mobile_biometrics_not_now'),
@@ -405,6 +410,13 @@ Future<void> importWalletViaPaste(
   if (isFirstWallet) {
     await enterPasscode(tester, mobileE2ePasscode);
     await enterPasscode(tester, mobileE2ePasscode);
+  }
+  await tapAppButton(
+    tester,
+    const ValueKey('mobile_customise_account_continue'),
+    timeout: const Duration(minutes: 2),
+  );
+  if (isFirstWallet) {
     await tapWidget(
       tester,
       const ValueKey('mobile_biometrics_not_now'),

--- a/integration_test/support/mobile_regtest_flow.dart
+++ b/integration_test/support/mobile_regtest_flow.dart
@@ -265,7 +265,15 @@ Future<void> cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
-  for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
+  for (final name in [
+    dbName,
+    '$dbName-shm',
+    '$dbName-wal',
+    '$dbName.voting',
+    '$dbName.voting-journal',
+    '$dbName.voting-shm',
+    '$dbName.voting-wal',
+  ]) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();
   }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1120,9 +1120,7 @@ class ZcashWalletApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (kAppFormFactor == AppFormFactor.desktop) {
-      ref.watch(votingShareTrackingRestorerProvider);
-    }
+    ref.watch(votingShareTrackingRestorerProvider);
     final appRouter = ref.watch(_routerProvider);
     final router = appRouter.router;
     final themeMode = ref.watch(themeModeProvider);

--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -217,6 +217,13 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     mobile: true,
   ),
   FigmaCompareScenario(
+    id: 'mobile-voting-config',
+    description: 'Mobile voting config source modal',
+    builder: buildMobileVotingConfigUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
     id: 'mobile-activity-default',
     description: 'Mobile Activity screen with deterministic transactions',
     builder: buildMobileActivityDefaultUseCase,

--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -9,6 +9,7 @@ import '../widgetbook/pay_use_cases.dart';
 import '../widgetbook/carousel_use_cases.dart';
 import '../widgetbook/screen_use_cases.dart';
 import '../widgetbook/swap_use_cases.dart';
+import '../widgetbook/voting_use_cases.dart';
 
 typedef FigmaCompareScenarioBuilder = Widget Function(BuildContext context);
 
@@ -205,6 +206,20 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     id: 'mobile-home-default',
     description: 'Mobile home with deterministic balance and activity',
     builder: buildMobileHomeDefaultUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-voting-polls',
+    description: 'Mobile coinholder voting poll list with mock rounds',
+    builder: buildMobileVotingPollsUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-activity-default',
+    description: 'Mobile Activity screen with deterministic transactions',
+    builder: buildMobileActivityDefaultUseCase,
     desktop: false,
     mobile: true,
   ),

--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -224,6 +224,20 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     mobile: true,
   ),
   FigmaCompareScenario(
+    id: 'mobile-voting-keystone-request',
+    description: 'Mobile voting Keystone request QR step',
+    builder: buildMobileVotingKeystoneRequestUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-voting-keystone-scanner',
+    description: 'Mobile voting Keystone signed-result scanner step',
+    builder: buildMobileVotingKeystoneScannerUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
     id: 'mobile-activity-default',
     description: 'Mobile Activity screen with deterministic transactions',
     builder: buildMobileActivityDefaultUseCase,

--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -331,15 +331,6 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
       ),
     ),
     GoRoute(
-      path: '/voting/keystone/scan',
-      pageBuilder: (context, state) => CupertinoPage(
-        key: state.pageKey,
-        child: const MobileVotingAccountGuard(
-          child: MobileKeystoneVotingScanScreen(),
-        ),
-      ),
-    ),
-    GoRoute(
       path: '/voting/poll/:roundId/submitted',
       pageBuilder: (context, state) => CupertinoPage(
         key: state.pageKey,

--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -40,6 +40,7 @@ import '../../features/settings/screens/mobile/mobile_seed_phrase_screen.dart';
 import '../../features/settings/screens/mobile/mobile_settings_screen.dart';
 import '../../features/settings/screens/mobile/mobile_viewing_key_screen.dart';
 import '../../features/swap/screens/mobile/mobile_swap_screen.dart';
+import '../../features/voting/screens/mobile/mobile_voting_screens.dart';
 import '../config/swap_feature_config.dart';
 import '../layout/mobile/app_mobile_shell.dart';
 import '../layout/mobile/app_mobile_tab_bar.dart';
@@ -286,6 +287,79 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
       pageBuilder: (context, state) => CupertinoPage(
         key: state.pageKey,
         child: const MobileKeystoneShieldScreen(),
+      ),
+    ),
+    GoRoute(
+      path: '/voting',
+      pageBuilder: (context, state) => CupertinoPage(
+        key: state.pageKey,
+        child: const MobileVotingAccountGuard(child: MobileVotingPollsScreen()),
+      ),
+    ),
+    GoRoute(
+      path: '/voting/poll/:roundId',
+      pageBuilder: (context, state) => CupertinoPage(
+        key: state.pageKey,
+        child: MobileVotingAccountGuard(
+          child: MobileVotingProposalDetailScreen(
+            roundId: state.pathParameters['roundId'] ?? '',
+          ),
+        ),
+      ),
+    ),
+    GoRoute(
+      path: '/voting/poll/:roundId/review',
+      pageBuilder: (context, state) => CupertinoPage(
+        key: state.pageKey,
+        child: MobileVotingAccountGuard(
+          child: MobileVotingReviewScreen(
+            roundId: state.pathParameters['roundId'] ?? '',
+          ),
+        ),
+      ),
+    ),
+    GoRoute(
+      path: '/voting/poll/:roundId/status',
+      pageBuilder: (context, state) => CupertinoPage(
+        key: state.pageKey,
+        child: MobileVotingAccountGuard(
+          child: MobileVotingStatusScreen(
+            roundId: state.pathParameters['roundId'] ?? '',
+            accountUuid: state.uri.queryParameters['account'],
+          ),
+        ),
+      ),
+    ),
+    GoRoute(
+      path: '/voting/keystone/scan',
+      pageBuilder: (context, state) => CupertinoPage(
+        key: state.pageKey,
+        child: const MobileVotingAccountGuard(
+          child: MobileKeystoneVotingScanScreen(),
+        ),
+      ),
+    ),
+    GoRoute(
+      path: '/voting/poll/:roundId/submitted',
+      pageBuilder: (context, state) => CupertinoPage(
+        key: state.pageKey,
+        child: MobileVotingAccountGuard(
+          child: MobileVotingSubmissionConfirmationScreen(
+            roundId: state.pathParameters['roundId'] ?? '',
+            accountUuid: state.uri.queryParameters['account'],
+          ),
+        ),
+      ),
+    ),
+    GoRoute(
+      path: '/voting/poll/:roundId/results',
+      pageBuilder: (context, state) => CupertinoPage(
+        key: state.pageKey,
+        child: MobileVotingAccountGuard(
+          child: MobileVotingResultsScreen(
+            roundId: state.pathParameters['roundId'] ?? '',
+          ),
+        ),
       ),
     ),
     GoRoute(

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -1333,7 +1333,6 @@ class _MobileVotingEntryCard extends StatelessWidget {
             color: colors.background.ground,
             borderRadius: BorderRadius.circular(AppRadii.medium),
             border: Border.all(color: colors.border.subtle),
-            boxShadow: appSurfaceShadow(colors),
           ),
           child: Row(
             children: [

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -1346,7 +1346,7 @@ class _MobileVotingEntryCard extends StatelessWidget {
                 ),
                 child: Center(
                   child: AppIcon(
-                    AppIcons.coins,
+                    AppIcons.endpoint,
                     size: 20,
                     color: colors.icon.inverse,
                   ),

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -1215,6 +1215,8 @@ class _HomeContentState extends ConsumerState<_HomeContent> {
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
+                const SizedBox(height: AppSpacing.s),
+                _MobileVotingEntryCard(onTap: () => context.push('/voting')),
                 if (widget.ironwoodMigrationCta.visible) ...[
                   const SizedBox(height: AppSpacing.s),
                   MobileIronwoodMigrationBanner(
@@ -1302,6 +1304,87 @@ class _HomeContentState extends ConsumerState<_HomeContent> {
           ],
         ),
       ],
+    );
+  }
+}
+
+class _MobileVotingEntryCard extends StatelessWidget {
+  const _MobileVotingEntryCard({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Semantics(
+      button: true,
+      label: 'Open coinholder voting',
+      child: GestureDetector(
+        key: const ValueKey('mobile_home_coinholder_voting'),
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          constraints: const BoxConstraints(minHeight: 72),
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.sm,
+            vertical: AppSpacing.s,
+          ),
+          decoration: BoxDecoration(
+            color: colors.background.ground,
+            borderRadius: BorderRadius.circular(AppRadii.medium),
+            border: Border.all(color: colors.border.subtle),
+            boxShadow: appSurfaceShadow(colors),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: colors.background.inverse,
+                  borderRadius: BorderRadius.circular(AppRadii.full),
+                ),
+                child: Center(
+                  child: AppIcon(
+                    AppIcons.coins,
+                    size: 20,
+                    color: colors.icon.inverse,
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.s),
+              Expanded(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Coinholder voting',
+                      style: AppTypography.bodyLarge.copyWith(
+                        color: colors.text.accent,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.xxs),
+                    Text(
+                      'Use your ZEC to help shape the network.',
+                      style: AppTypography.bodySmall.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppSpacing.s),
+              AppIcon(
+                AppIcons.chevronForward,
+                size: 20,
+                color: colors.icon.regular,
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
+++ b/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
@@ -117,6 +117,15 @@ class MobileKeystonePcztSigningFlow extends ConsumerStatefulWidget {
     this.onCancel,
     this.signedPcztDecoder,
     this.scannerBuilder,
+    this.expectedSignedUrType = 'zcash-pczt',
+    this.unexpectedUrMessage,
+    this.recoverSignedCallbackErrorInScanner = false,
+    this.signingContextLabel,
+    this.requestDetails,
+    this.requestAuxiliaryActionLabel,
+    this.onRequestAuxiliaryAction,
+    this.showCancelAction = true,
+    this.allowQrContentScrolling = false,
     this.forceScannerActiveForTesting = false,
     this.startInScannerForTesting = false,
     this.onScanWindowForTesting,
@@ -139,6 +148,15 @@ class MobileKeystonePcztSigningFlow extends ConsumerStatefulWidget {
   final MobileKeystonePcztFriendlyError friendlyError;
   final MobileKeystonePcztDecoder? signedPcztDecoder;
   final MobileKeystonePcztScannerBuilder? scannerBuilder;
+  final String expectedSignedUrType;
+  final String? unexpectedUrMessage;
+  final bool recoverSignedCallbackErrorInScanner;
+  final String? signingContextLabel;
+  final Widget? requestDetails;
+  final String? requestAuxiliaryActionLabel;
+  final VoidCallback? onRequestAuxiliaryAction;
+  final bool showCancelAction;
+  final bool allowQrContentScrolling;
   final bool forceScannerActiveForTesting;
   final bool startInScannerForTesting;
   final ValueChanged<Rect>? onScanWindowForTesting;
@@ -321,6 +339,16 @@ class _MobileKeystonePcztSigningFlowState
     } catch (e, st) {
       log('${widget.logTag}._onSigned: ERROR: $e\n$st');
       if (!mounted) return;
+      if (widget.recoverSignedCallbackErrorInScanner) {
+        setState(() {
+          _decoding = false;
+          _scanSessionResetToken++;
+          _scanProgressStarted = false;
+          _scanProgress = 0;
+          _scanHint = widget.friendlyError(e);
+        });
+        return;
+      }
       _stopScannerIfActive();
       setState(() {
         _decoding = false;
@@ -333,7 +361,8 @@ class _MobileKeystonePcztSigningFlowState
   void _handleDecodeError(Object error) {
     if (!mounted || _decoding) return;
     final message = error.toString().contains('Unexpected UR type')
-        ? 'Open the signed transaction QR on Keystone, then scan again.'
+        ? widget.unexpectedUrMessage ??
+              'Open the signed transaction QR on Keystone, then scan again.'
         : 'Keep the QR code steady and fully visible.';
     if (_scanHint == message && !_scanProgressStarted) return;
     setState(() {
@@ -496,6 +525,18 @@ class _MobileKeystonePcztSigningFlowState
               titleColor: colors.text.accent,
               subtitleColor: colors.text.accent,
             ),
+            if (widget.signingContextLabel != null) ...[
+              const SizedBox(height: AppSpacing.xxs),
+              _KeystoneSigningContextBadge(
+                label: widget.signingContextLabel!,
+                foreground: colors.text.accent,
+                background: colors.background.neutralSubtleOpacity,
+              ),
+            ],
+            if (widget.requestDetails != null) ...[
+              const SizedBox(height: AppSpacing.xs),
+              widget.requestDetails!,
+            ],
             Expanded(
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
@@ -513,22 +554,31 @@ class _MobileKeystonePcztSigningFlowState
                         .clamp(120.0, _mobileKeystoneQrFrameSize)
                         .toDouble();
 
-                    return Center(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          _buildQrFrame(frameSize: frameSize),
-                          const SizedBox(height: _mobileKeystoneQrPromptGap),
-                          if (message != null)
-                            _KeystoneSigningPromptText(
-                              text: message,
-                              color: isFailed
-                                  ? colors.text.destructive
-                                  : colors.text.primary,
-                            )
-                          else
-                            _KeystoneScanPrompt(color: colors.text.primary),
-                        ],
+                    final qrContent = Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        _buildQrFrame(frameSize: frameSize),
+                        const SizedBox(height: _mobileKeystoneQrPromptGap),
+                        if (message != null)
+                          _KeystoneSigningPromptText(
+                            text: message,
+                            color: isFailed
+                                ? colors.text.destructive
+                                : colors.text.primary,
+                          )
+                        else
+                          _KeystoneScanPrompt(color: colors.text.primary),
+                      ],
+                    );
+                    if (!widget.allowQrContentScrolling) {
+                      return Center(child: qrContent);
+                    }
+                    return SingleChildScrollView(
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(
+                          minHeight: constraints.maxHeight,
+                        ),
+                        child: Center(child: qrContent),
                       ),
                     );
                   },
@@ -553,14 +603,28 @@ class _MobileKeystonePcztSigningFlowState
                     trailing: const AppIcon(AppIcons.chevronForward, size: 20),
                     child: const Text('Next step'),
                   ),
-                  const SizedBox(height: AppSpacing.s),
-                  AppButton(
-                    key: _key('cancel'),
-                    expand: true,
-                    variant: AppButtonVariant.ghost,
-                    onPressed: _cancel,
-                    child: const Text('Cancel'),
-                  ),
+                  if (widget.requestAuxiliaryActionLabel != null &&
+                      widget.onRequestAuxiliaryAction != null) ...[
+                    const SizedBox(height: AppSpacing.s),
+                    AppButton(
+                      key: _key('auxiliary_action'),
+                      expand: true,
+                      constrainContent: true,
+                      variant: AppButtonVariant.secondary,
+                      onPressed: widget.onRequestAuxiliaryAction,
+                      child: Text(widget.requestAuxiliaryActionLabel!),
+                    ),
+                  ],
+                  if (widget.showCancelAction) ...[
+                    const SizedBox(height: AppSpacing.s),
+                    AppButton(
+                      key: _key('cancel'),
+                      expand: true,
+                      variant: AppButtonVariant.ghost,
+                      onPressed: _cancel,
+                      child: const Text('Cancel'),
+                    ),
+                  ],
                 ],
               ),
             ),
@@ -648,7 +712,8 @@ class _MobileKeystonePcztSigningFlowState
                   (AppTypography.displayLarge.height ?? 1) +
               AppSpacing.s +
               (AppTypography.bodyLarge.fontSize ?? 18) *
-                  (AppTypography.bodyLarge.height ?? 1);
+                  (AppTypography.bodyLarge.height ?? 1) +
+              (widget.signingContextLabel == null ? 0 : 30);
           // Space reserved for the caption + action row below the viewfinder.
           const chromeReserve =
               _mobileKeystoneScanMinCaptionGap +
@@ -751,7 +816,7 @@ class _MobileKeystonePcztSigningFlowState
               ) ??
               AnimatedUrScannerView(
                 controller: scanController,
-                expectedUrType: 'zcash-pczt',
+                expectedUrType: widget.expectedSignedUrType,
                 scanSessionResetToken: scanSessionResetToken,
                 // Constrain detection to the visible viewfinder (this full-screen
                 // scanner's viewfinder is positioned, not centred), so a QR is
@@ -817,6 +882,16 @@ class _MobileKeystonePcztSigningFlowState
                       titleColor: _mobileKeystoneLightText,
                       subtitleColor: _mobileKeystoneLightText,
                     ),
+                    if (widget.signingContextLabel != null) ...[
+                      const SizedBox(height: AppSpacing.xxs),
+                      _KeystoneSigningContextBadge(
+                        label: widget.signingContextLabel!,
+                        foreground: _mobileKeystoneLightText,
+                        background: _mobileKeystoneLightText.withValues(
+                          alpha: 0.16,
+                        ),
+                      ),
+                    ],
                   ],
                 ),
               ),
@@ -1117,6 +1192,43 @@ class _KeystoneSigningTitle extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _KeystoneSigningContextBadge extends StatelessWidget {
+  const _KeystoneSigningContextBadge({
+    required this.label,
+    required this.foreground,
+    required this.background,
+  });
+
+  final String label;
+  final Color foreground;
+  final Color background;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(AppRadii.full),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.xs,
+          vertical: AppSpacing.xxs,
+        ),
+        child: Text(
+          label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTypography.bodySmall.copyWith(
+            color: foreground,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
       ),
     );
   }

--- a/lib/src/features/voting/screens/keystone_voting_scan_screen.dart
+++ b/lib/src/features/voting/screens/keystone_voting_scan_screen.dart
@@ -6,20 +6,39 @@ import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
-import '../../../core/widgets/app_back_link.dart';
 import '../../../services/qr_scanner.dart';
 import '../../keystone/widgets/keystone_qr_scanner_card.dart';
 
-class KeystoneVotingScanScreen extends ConsumerStatefulWidget {
+class KeystoneVotingScanScreen extends StatelessWidget {
   const KeystoneVotingScanScreen({super.key});
 
   @override
-  ConsumerState<KeystoneVotingScanScreen> createState() =>
-      _KeystoneVotingScanScreenState();
+  Widget build(BuildContext context) {
+    return const AppDesktopShell(
+      sidebar: AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: EdgeInsets.zero,
+        child: Column(
+          children: [
+            AppPaneToolbar(),
+            Expanded(child: KeystoneVotingScanView()),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
-class _KeystoneVotingScanScreenState
-    extends ConsumerState<KeystoneVotingScanScreen> {
+class KeystoneVotingScanView extends ConsumerStatefulWidget {
+  const KeystoneVotingScanView({super.key});
+
+  @override
+  ConsumerState<KeystoneVotingScanView> createState() =>
+      _KeystoneVotingScanViewState();
+}
+
+class _KeystoneVotingScanViewState
+    extends ConsumerState<KeystoneVotingScanView> {
   bool _decoding = false;
   String? _error;
 
@@ -28,7 +47,9 @@ class _KeystoneVotingScanScreenState
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      ref.read(appLayoutProvider.notifier).setMode(AppLayoutMode.large);
+      if (kAppFormFactor == AppFormFactor.desktop) {
+        ref.read(appLayoutProvider.notifier).setMode(AppLayoutMode.large);
+      }
     });
   }
 
@@ -54,79 +75,51 @@ class _KeystoneVotingScanScreenState
     });
   }
 
-  void _goBack() {
-    if (context.canPop()) {
-      context.pop();
-      return;
-    }
-    context.go('/voting');
-  }
-
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return AppDesktopShell(
-      sidebar: const AppMainSidebar(),
-      pane: AppDesktopPane(
-        // Back chevron sits 16px into the pane per the shared design rule
-        // (4px pane padding + AppBackLink's 12px internal inset); the centered
-        // content keeps md on the other sides.
-        padding: const EdgeInsets.fromLTRB(
-          AppSpacing.xxs,
-          AppSpacing.md,
-          AppSpacing.md,
-          AppSpacing.md,
-        ),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.s,
+        AppSpacing.md,
+        AppSpacing.md,
+      ),
+      child: Center(
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Align(
-              alignment: Alignment.centerLeft,
-              child: AppBackLink(label: 'Back', onTap: _goBack),
-            ),
-            const SizedBox(height: AppSpacing.xs),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: AppSpacing.s),
-                child: Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        'Scan voting signature',
-                        style: AppTypography.displaySmall.copyWith(
-                          color: colors.text.accent,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                      const SizedBox(height: AppSpacing.sm),
-                      Text(
-                        'Hold the Keystone QR code steady in front of your camera',
-                        style: AppTypography.bodyMediumStrong.copyWith(
-                          color: colors.text.accent,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                      const SizedBox(height: AppSpacing.base),
-                      KeystoneQrScannerCard(
-                        expectedUrType: 'zcash-batch-sig-result',
-                        decoding: _decoding,
-                        error: _error,
-                        onProgress: (progress) {
-                          if (!mounted) return;
-                          setState(() {
-                            if (progress > 0) _error = null;
-                          });
-                        },
-                        onDecodeError: _handleDecodeError,
-                        onComplete: _handleScanComplete,
-                        decodingLabel: 'Reading signature...',
-                        unavailableMessage:
-                            'Keystone voting uses camera QR scanning only. Connect a camera and try again.',
-                      ),
-                    ],
-                  ),
-                ),
+            Text(
+              'Scan voting signature',
+              style: AppTypography.displaySmall.copyWith(
+                color: colors.text.accent,
               ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'Hold the Keystone QR code steady in front of your camera',
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: colors.text.accent,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.base),
+            KeystoneQrScannerCard(
+              expectedUrType: 'zcash-batch-sig-result',
+              decoding: _decoding,
+              error: _error,
+              onProgress: (progress) {
+                if (!mounted) return;
+                setState(() {
+                  if (progress > 0) _error = null;
+                });
+              },
+              onDecodeError: _handleDecodeError,
+              onComplete: _handleScanComplete,
+              decodingLabel: 'Reading signature...',
+              unavailableMessage:
+                  'Keystone voting uses camera QR scanning only. Connect a camera and try again.',
             ),
           ],
         ),

--- a/lib/src/features/voting/screens/keystone_voting_scan_screen.dart
+++ b/lib/src/features/voting/screens/keystone_voting_scan_screen.dart
@@ -6,39 +6,20 @@ import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../services/qr_scanner.dart';
 import '../../keystone/widgets/keystone_qr_scanner_card.dart';
 
-class KeystoneVotingScanScreen extends StatelessWidget {
+class KeystoneVotingScanScreen extends ConsumerStatefulWidget {
   const KeystoneVotingScanScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return const AppDesktopShell(
-      sidebar: AppMainSidebar(),
-      pane: AppDesktopPane(
-        padding: EdgeInsets.zero,
-        child: Column(
-          children: [
-            AppPaneToolbar(),
-            Expanded(child: KeystoneVotingScanView()),
-          ],
-        ),
-      ),
-    );
-  }
+  ConsumerState<KeystoneVotingScanScreen> createState() =>
+      _KeystoneVotingScanScreenState();
 }
 
-class KeystoneVotingScanView extends ConsumerStatefulWidget {
-  const KeystoneVotingScanView({super.key});
-
-  @override
-  ConsumerState<KeystoneVotingScanView> createState() =>
-      _KeystoneVotingScanViewState();
-}
-
-class _KeystoneVotingScanViewState
-    extends ConsumerState<KeystoneVotingScanView> {
+class _KeystoneVotingScanScreenState
+    extends ConsumerState<KeystoneVotingScanScreen> {
   bool _decoding = false;
   String? _error;
 
@@ -47,9 +28,7 @@ class _KeystoneVotingScanViewState
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      if (kAppFormFactor == AppFormFactor.desktop) {
-        ref.read(appLayoutProvider.notifier).setMode(AppLayoutMode.large);
-      }
+      ref.read(appLayoutProvider.notifier).setMode(AppLayoutMode.large);
     });
   }
 
@@ -75,51 +54,79 @@ class _KeystoneVotingScanViewState
     });
   }
 
+  void _goBack() {
+    if (context.canPop()) {
+      context.pop();
+      return;
+    }
+    context.go('/voting');
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.md,
-        AppSpacing.s,
-        AppSpacing.md,
-        AppSpacing.md,
-      ),
-      child: Center(
+    return AppDesktopShell(
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        // Back chevron sits 16px into the pane per the shared design rule
+        // (4px pane padding + AppBackLink's 12px internal inset); the centered
+        // content keeps md on the other sides.
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.xxs,
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.md,
+        ),
         child: Column(
-          mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
-              'Scan voting signature',
-              style: AppTypography.displaySmall.copyWith(
-                color: colors.text.accent,
-              ),
-              textAlign: TextAlign.center,
+            Align(
+              alignment: Alignment.centerLeft,
+              child: AppBackLink(label: 'Back', onTap: _goBack),
             ),
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              'Hold the Keystone QR code steady in front of your camera',
-              style: AppTypography.bodyMediumStrong.copyWith(
-                color: colors.text.accent,
+            const SizedBox(height: AppSpacing.xs),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: AppSpacing.s),
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        'Scan voting signature',
+                        style: AppTypography.displaySmall.copyWith(
+                          color: colors.text.accent,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: AppSpacing.sm),
+                      Text(
+                        'Hold the Keystone QR code steady in front of your camera',
+                        style: AppTypography.bodyMediumStrong.copyWith(
+                          color: colors.text.accent,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: AppSpacing.base),
+                      KeystoneQrScannerCard(
+                        expectedUrType: 'zcash-batch-sig-result',
+                        decoding: _decoding,
+                        error: _error,
+                        onProgress: (progress) {
+                          if (!mounted) return;
+                          setState(() {
+                            if (progress > 0) _error = null;
+                          });
+                        },
+                        onDecodeError: _handleDecodeError,
+                        onComplete: _handleScanComplete,
+                        decodingLabel: 'Reading signature...',
+                        unavailableMessage:
+                            'Keystone voting uses camera QR scanning only. Connect a camera and try again.',
+                      ),
+                    ],
+                  ),
+                ),
               ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: AppSpacing.base),
-            KeystoneQrScannerCard(
-              expectedUrType: 'zcash-batch-sig-result',
-              decoding: _decoding,
-              error: _error,
-              onProgress: (progress) {
-                if (!mounted) return;
-                setState(() {
-                  if (progress > 0) _error = null;
-                });
-              },
-              onDecodeError: _handleDecodeError,
-              onComplete: _handleScanComplete,
-              decodingLabel: 'Reading signature...',
-              unavailableMessage:
-                  'Keystone voting uses camera QR scanning only. Connect a camera and try again.',
             ),
           ],
         ),

--- a/lib/src/features/voting/screens/mobile/mobile_keystone_voting_signing_screen.dart
+++ b/lib/src/features/voting/screens/mobile/mobile_keystone_voting_signing_screen.dart
@@ -1,0 +1,212 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_icon.dart';
+import '../../../../providers/voting/voting_submission_job_provider.dart';
+import '../../../keystone/widgets/mobile_keystone_pczt_signing_flow.dart';
+import '../voting_status_screen.dart';
+
+class MobileKeystoneVotingSigningScreen extends StatelessWidget {
+  const MobileKeystoneVotingSigningScreen({
+    super.key,
+    required this.presentation,
+    this.scannerBuilder,
+    this.forceScannerActiveForTesting = false,
+    this.startInScannerForTesting = false,
+  });
+
+  final VotingKeystoneStatusPresentation presentation;
+  final MobileKeystonePcztScannerBuilder? scannerBuilder;
+  final bool forceScannerActiveForTesting;
+  final bool startInScannerForTesting;
+
+  @override
+  Widget build(BuildContext context) {
+    final batchCount = presentation.batchMessageCount;
+    final totalCount = presentation.batchTotalCount;
+    final contextLabel = batchCount <= 0
+        ? null
+        : totalCount > batchCount
+        ? '$batchCount of $totalCount remaining bundles'
+        : batchCount == 1
+        ? '1 voting bundle'
+        : '$batchCount voting bundles';
+    final flowKey = ValueKey<String>(
+      'mobile_voting_keystone_${presentation.bundleIndex}_'
+      '${presentation.urParts.first.hashCode}',
+    );
+
+    return MobileKeystonePcztSigningFlow(
+      key: flowKey,
+      title: 'Sign vote with Keystone',
+      failedTitle: 'Voting signature failed',
+      description:
+          'Scan the voting request with Keystone, approve it, then scan the signed result with this device.',
+      keyPrefix: 'mobile_voting_keystone',
+      logTag: 'MobileKeystoneVoting',
+      readingSignatureLabel: 'Reading voting signature...',
+      finalizingSignatureLabel: 'Checking voting signature...',
+      scanCaption: 'Scan the signed voting QR shown on Keystone',
+      expectedSignedUrType: 'zcash-batch-sig-result',
+      unexpectedUrMessage:
+          'Open the signed voting QR on Keystone, then scan again.',
+      recoverSignedCallbackErrorInScanner: true,
+      signingContextLabel: contextLabel,
+      requestDetails: presentation.batchMemos.isEmpty
+          ? null
+          : _MobileVotingMemoPager(memos: presentation.batchMemos),
+      requestAuxiliaryActionLabel: presentation.canSkipRemainingBundles
+          ? 'Skip unsigned bundles'
+          : null,
+      onRequestAuxiliaryAction: presentation.canSkipRemainingBundles
+          ? presentation.onSkipRemainingBundles
+          : null,
+      showCancelAction: false,
+      allowQrContentScrolling: true,
+      preparePczt: (_, _) async => MobileKeystonePcztSigningPayload(
+        urParts: presentation.urParts,
+        pcztWithProofs: Future<List<int>>.value(const []),
+      ),
+      signedPcztDecoder: (responseCbor) async =>
+          Uint8List.fromList(responseCbor),
+      onSigned: (_, _, _, responseCbor) => presentation.onSigned(responseCbor),
+      friendlyError: (error) =>
+          presentation.scanError ?? _friendlyVotingScanError(error),
+      scannerBuilder: scannerBuilder,
+      forceScannerActiveForTesting: forceScannerActiveForTesting,
+      startInScannerForTesting: startInScannerForTesting,
+      onCancel: () => context.go('/voting'),
+    );
+  }
+}
+
+String _friendlyVotingScanError(Object error) {
+  final message = error.toString();
+  return message
+      .replaceFirst(RegExp(r'^(Bad state|StateError):\s*'), '')
+      .trim();
+}
+
+class _MobileVotingMemoPager extends StatefulWidget {
+  const _MobileVotingMemoPager({required this.memos});
+
+  final List<VotingKeystoneBatchMemo> memos;
+
+  @override
+  State<_MobileVotingMemoPager> createState() => _MobileVotingMemoPagerState();
+}
+
+class _MobileVotingMemoPagerState extends State<_MobileVotingMemoPager> {
+  int _index = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final memos = [
+      for (final memo in widget.memos)
+        if (memo.displayMemo.trim().isNotEmpty) memo,
+    ];
+    if (memos.isEmpty) return const SizedBox.shrink();
+    final index = _index.clamp(0, memos.length - 1);
+    final memo = memos[index];
+    final colors = context.colors;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: colors.background.ground,
+          border: Border.all(color: colors.border.subtle),
+          borderRadius: BorderRadius.circular(AppRadii.small),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.xs,
+            vertical: AppSpacing.xxs,
+          ),
+          child: Row(
+            children: [
+              _MemoPagerAction(
+                semanticLabel: 'Previous voting bundle',
+                icon: AppIcons.chevronBackward,
+                onTap: index > 0
+                    ? () => setState(() => _index = index - 1)
+                    : null,
+              ),
+              Expanded(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Bundle ${memo.bundleIndex + 1} of ${memo.bundleCount}',
+                      style: AppTypography.bodySmall.copyWith(
+                        color: colors.text.secondary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      memo.displayMemo,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                      style: AppTypography.bodySmall.copyWith(
+                        color: colors.text.accent,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              _MemoPagerAction(
+                semanticLabel: 'Next voting bundle',
+                icon: AppIcons.chevronForward,
+                onTap: index + 1 < memos.length
+                    ? () => setState(() => _index = index + 1)
+                    : null,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MemoPagerAction extends StatelessWidget {
+  const _MemoPagerAction({
+    required this.semanticLabel,
+    required this.icon,
+    required this.onTap,
+  });
+
+  final String semanticLabel;
+  final String icon;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticLabel,
+      button: true,
+      enabled: onTap != null,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: SizedBox.square(
+          dimension: 36,
+          child: Center(
+            child: AppIcon(
+              icon,
+              size: 18,
+              color: context.colors.icon.accent.withValues(
+                alpha: onTap == null ? 0.3 : 1,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
+++ b/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/layout/mobile/mobile_top_nav.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../../../providers/account_provider.dart';
+import '../keystone_voting_scan_screen.dart';
+import '../voting_polls_screen.dart';
+import '../voting_proposal_detail_screen.dart';
+import '../voting_results_screen.dart';
+import '../voting_review_screen.dart';
+import '../voting_status_screen.dart';
+import '../voting_submission_confirmation_screen.dart';
+import '../../widgets/voting_pane_scroll_area.dart';
+
+class MobileVotingPollsScreen extends StatelessWidget {
+  const MobileVotingPollsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const _MobileVotingScaffold(
+      title: 'Coinholder voting',
+      fallbackPath: '/home',
+      child: VotingPollsView(showDesktopChrome: false),
+    );
+  }
+}
+
+class MobileVotingProposalDetailScreen extends StatelessWidget {
+  const MobileVotingProposalDetailScreen({super.key, required this.roundId});
+
+  final String roundId;
+
+  @override
+  Widget build(BuildContext context) {
+    return _MobileVotingScaffold(
+      title: 'Coinholder voting',
+      child: VotingProposalDetailView(
+        roundId: roundId,
+        showDesktopToolbar: false,
+      ),
+    );
+  }
+}
+
+class MobileVotingReviewScreen extends StatelessWidget {
+  const MobileVotingReviewScreen({super.key, required this.roundId});
+
+  final String roundId;
+
+  @override
+  Widget build(BuildContext context) {
+    return _MobileVotingScaffold(
+      title: 'Review vote',
+      child: VotingReviewView(roundId: roundId, showDesktopToolbar: false),
+    );
+  }
+}
+
+class MobileVotingStatusScreen extends StatelessWidget {
+  const MobileVotingStatusScreen({
+    super.key,
+    required this.roundId,
+    this.accountUuid,
+  });
+
+  final String roundId;
+  final String? accountUuid;
+
+  @override
+  Widget build(BuildContext context) {
+    return _MobileVotingScaffold(
+      title: 'Submit vote',
+      horizontalPadding: AppSpacing.sm,
+      child: VotingStatusView(roundId: roundId, accountUuid: accountUuid),
+    );
+  }
+}
+
+class MobileVotingSubmissionConfirmationScreen extends StatelessWidget {
+  const MobileVotingSubmissionConfirmationScreen({
+    super.key,
+    required this.roundId,
+    this.accountUuid,
+  });
+
+  final String roundId;
+  final String? accountUuid;
+
+  @override
+  Widget build(BuildContext context) {
+    return _MobileVotingScaffold(
+      title: 'Vote submitted',
+      child: VotingSubmissionConfirmationView(
+        roundId: roundId,
+        accountUuid: accountUuid,
+        showDesktopToolbar: false,
+      ),
+    );
+  }
+}
+
+class MobileVotingResultsScreen extends StatelessWidget {
+  const MobileVotingResultsScreen({super.key, required this.roundId});
+
+  final String roundId;
+
+  @override
+  Widget build(BuildContext context) {
+    return _MobileVotingScaffold(
+      title: 'Voting results',
+      horizontalPadding: AppSpacing.sm,
+      child: VotingResultsView(roundId: roundId, showDesktopToolbar: false),
+    );
+  }
+}
+
+class MobileKeystoneVotingScanScreen extends StatelessWidget {
+  const MobileKeystoneVotingScanScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const _MobileVotingScaffold(
+      title: 'Scan signature',
+      child: KeystoneVotingScanView(),
+    );
+  }
+}
+
+/// Account loading/error boundary for the mobile voting route tree. The
+/// desktop guard remains desktop-only; both consume the same account state.
+class MobileVotingAccountGuard extends ConsumerWidget {
+  const MobileVotingAccountGuard({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ref
+        .watch(accountProvider)
+        .when(
+          loading: () => const _MobileVotingScaffold(
+            title: 'Coinholder voting',
+            fallbackPath: '/home',
+            child: VotingPaneLoading(),
+          ),
+          error: (error, _) => _MobileVotingScaffold(
+            title: 'Coinholder voting',
+            fallbackPath: '/home',
+            horizontalPadding: AppSpacing.sm,
+            child: Center(
+              child: Text(
+                "Couldn't load account.\n$error",
+                textAlign: TextAlign.center,
+                style: AppTypography.bodyMedium.copyWith(
+                  color: context.colors.text.secondary,
+                ),
+              ),
+            ),
+          ),
+          data: (_) => child,
+        );
+  }
+}
+
+class _MobileVotingScaffold extends StatelessWidget {
+  const _MobileVotingScaffold({
+    required this.title,
+    required this.child,
+    this.fallbackPath = '/voting',
+    this.horizontalPadding = 0,
+  });
+
+  final String title;
+  final Widget child;
+  final String fallbackPath;
+  final double horizontalPadding;
+
+  @override
+  Widget build(BuildContext context) {
+    final body = horizontalPadding == 0
+        ? child
+        : Padding(
+            padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+            child: child,
+          );
+    return SafeArea(
+      bottom: false,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          MobileTopNav.back(
+            title: title,
+            onBack: () {
+              if (context.canPop()) {
+                context.pop();
+              } else {
+                context.go(fallbackPath);
+              }
+            },
+          ),
+          Expanded(child: body),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
+++ b/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
@@ -6,8 +6,7 @@ import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/app_icon.dart';
 import '../../../../providers/account_provider.dart';
-import '../../../../services/qr_scanner.dart';
-import '../../../keystone/widgets/keystone_qr_scanner_card.dart';
+import 'mobile_keystone_voting_signing_screen.dart';
 import '../voting_polls_screen.dart';
 import '../voting_proposal_detail_screen.dart';
 import '../voting_results_screen.dart';
@@ -76,14 +75,17 @@ class MobileVotingStatusScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _MobileVotingScaffold(
-      title: 'Submit vote',
-      horizontalPadding: AppSpacing.sm,
-      child: VotingStatusView(
-        roundId: roundId,
-        accountUuid: accountUuid,
-        requireCurrentRouteForConfirmation: true,
+    return VotingStatusView(
+      roundId: roundId,
+      accountUuid: accountUuid,
+      requireCurrentRouteForConfirmation: true,
+      contentWrapper: (_, content) => _MobileVotingScaffold(
+        title: 'Submit vote',
+        horizontalPadding: AppSpacing.sm,
+        child: content,
       ),
+      keystoneStatusBuilder: (_, presentation) =>
+          MobileKeystoneVotingSigningScreen(presentation: presentation),
     );
   }
 }
@@ -122,102 +124,6 @@ class MobileVotingResultsScreen extends StatelessWidget {
       title: 'Voting results',
       horizontalPadding: AppSpacing.sm,
       child: VotingResultsView(roundId: roundId, showDesktopToolbar: false),
-    );
-  }
-}
-
-class MobileKeystoneVotingScanScreen extends StatelessWidget {
-  const MobileKeystoneVotingScanScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const _MobileVotingScaffold(
-      title: 'Scan signature',
-      child: _MobileKeystoneVotingScanView(),
-    );
-  }
-}
-
-class _MobileKeystoneVotingScanView extends ConsumerStatefulWidget {
-  const _MobileKeystoneVotingScanView();
-
-  @override
-  ConsumerState<_MobileKeystoneVotingScanView> createState() =>
-      _MobileKeystoneVotingScanViewState();
-}
-
-class _MobileKeystoneVotingScanViewState
-    extends ConsumerState<_MobileKeystoneVotingScanView> {
-  bool _decoding = false;
-  String? _error;
-
-  void _handleScanComplete(ScanResult result) {
-    if (_decoding) return;
-    setState(() {
-      _decoding = true;
-      _error = null;
-    });
-    context.pop(result.data);
-  }
-
-  void _handleDecodeError(Object error) {
-    if (!mounted || _decoding) return;
-    final message = error.toString().contains('Unexpected UR type')
-        ? 'Open the signed voting QR on Keystone, then scan again.'
-        : 'Keep the QR code steady and fully visible.';
-    if (_error == message) return;
-    setState(() => _error = message);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.md,
-        AppSpacing.s,
-        AppSpacing.md,
-        AppSpacing.md,
-      ),
-      child: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              'Scan voting signature',
-              style: AppTypography.displaySmall.copyWith(
-                color: colors.text.accent,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              'Hold the Keystone QR code steady in front of your camera',
-              style: AppTypography.bodyMediumStrong.copyWith(
-                color: colors.text.accent,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: AppSpacing.base),
-            KeystoneQrScannerCard(
-              expectedUrType: 'zcash-batch-sig-result',
-              decoding: _decoding,
-              error: _error,
-              onProgress: (progress) {
-                if (!mounted) return;
-                setState(() {
-                  if (progress > 0) _error = null;
-                });
-              },
-              onDecodeError: _handleDecodeError,
-              onComplete: _handleScanComplete,
-              decodingLabel: 'Reading signature...',
-              unavailableMessage:
-                  'Keystone voting uses camera QR scanning only. Connect a camera and try again.',
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
+++ b/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/layout/mobile/mobile_bottom_safe_area.dart';
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/app_icon.dart';
@@ -191,22 +192,25 @@ class _MobileVotingScaffold extends StatelessWidget {
       color: context.colors.background.window,
       child: SafeArea(
         bottom: false,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            MobileTopNav.back(
-              title: title,
-              trailing: trailing,
-              onBack: () {
-                if (context.canPop()) {
-                  context.pop();
-                } else {
-                  context.go(fallbackPath);
-                }
-              },
-            ),
-            Expanded(child: body),
-          ],
+        child: MobileBottomSafeArea(
+          bottomPadding: AppSpacing.md,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              MobileTopNav.back(
+                title: title,
+                trailing: trailing,
+                onBack: () {
+                  if (context.canPop()) {
+                    context.pop();
+                  } else {
+                    context.go(fallbackPath);
+                  }
+                },
+              ),
+              Expanded(child: body),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
+++ b/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
@@ -192,24 +192,27 @@ class _MobileVotingScaffold extends StatelessWidget {
             padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
             child: child,
           );
-    return SafeArea(
-      bottom: false,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          MobileTopNav.back(
-            title: title,
-            trailing: trailing,
-            onBack: () {
-              if (context.canPop()) {
-                context.pop();
-              } else {
-                context.go(fallbackPath);
-              }
-            },
-          ),
-          Expanded(child: body),
-        ],
+    return Material(
+      color: context.colors.background.window,
+      child: SafeArea(
+        bottom: false,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            MobileTopNav.back(
+              title: title,
+              trailing: trailing,
+              onBack: () {
+                if (context.canPop()) {
+                  context.pop();
+                } else {
+                  context.go(fallbackPath);
+                }
+              },
+            ),
+            Expanded(child: body),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
+++ b/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_icon.dart';
 import '../../../../providers/account_provider.dart';
 import '../keystone_voting_scan_screen.dart';
 import '../voting_polls_screen.dart';
@@ -13,16 +14,20 @@ import '../voting_review_screen.dart';
 import '../voting_status_screen.dart';
 import '../voting_submission_confirmation_screen.dart';
 import '../../widgets/voting_pane_scroll_area.dart';
+import '../../widgets/mobile/mobile_voting_config_settings_sheet.dart';
 
 class MobileVotingPollsScreen extends StatelessWidget {
   const MobileVotingPollsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const _MobileVotingScaffold(
+    return _MobileVotingScaffold(
       title: 'Coinholder voting',
       fallbackPath: '/home',
-      child: VotingPollsView(showDesktopChrome: false),
+      trailing: _MobileVotingSettingsButton(
+        onTap: () => showMobileVotingConfigSettingsSheet(context),
+      ),
+      child: const VotingPollsView(showDesktopChrome: false),
     );
   }
 }
@@ -170,12 +175,14 @@ class _MobileVotingScaffold extends StatelessWidget {
     required this.child,
     this.fallbackPath = '/voting',
     this.horizontalPadding = 0,
+    this.trailing,
   });
 
   final String title;
   final Widget child;
   final String fallbackPath;
   final double horizontalPadding;
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
@@ -192,6 +199,7 @@ class _MobileVotingScaffold extends StatelessWidget {
         children: [
           MobileTopNav.back(
             title: title,
+            trailing: trailing,
             onBack: () {
               if (context.canPop()) {
                 context.pop();
@@ -202,6 +210,35 @@ class _MobileVotingScaffold extends StatelessWidget {
           ),
           Expanded(child: body),
         ],
+      ),
+    );
+  }
+}
+
+class _MobileVotingSettingsButton extends StatelessWidget {
+  const _MobileVotingSettingsButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Voting config settings',
+      button: true,
+      child: GestureDetector(
+        key: const ValueKey('mobile_voting_settings_button'),
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: SizedBox.square(
+          dimension: 44,
+          child: Center(
+            child: AppIcon(
+              AppIcons.cog,
+              size: 22,
+              color: context.colors.icon.accent,
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
+++ b/lib/src/features/voting/screens/mobile/mobile_voting_screens.dart
@@ -6,7 +6,8 @@ import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/app_icon.dart';
 import '../../../../providers/account_provider.dart';
-import '../keystone_voting_scan_screen.dart';
+import '../../../../services/qr_scanner.dart';
+import '../../../keystone/widgets/keystone_qr_scanner_card.dart';
 import '../voting_polls_screen.dart';
 import '../voting_proposal_detail_screen.dart';
 import '../voting_results_screen.dart';
@@ -78,7 +79,11 @@ class MobileVotingStatusScreen extends StatelessWidget {
     return _MobileVotingScaffold(
       title: 'Submit vote',
       horizontalPadding: AppSpacing.sm,
-      child: VotingStatusView(roundId: roundId, accountUuid: accountUuid),
+      child: VotingStatusView(
+        roundId: roundId,
+        accountUuid: accountUuid,
+        requireCurrentRouteForConfirmation: true,
+      ),
     );
   }
 }
@@ -128,7 +133,91 @@ class MobileKeystoneVotingScanScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return const _MobileVotingScaffold(
       title: 'Scan signature',
-      child: KeystoneVotingScanView(),
+      child: _MobileKeystoneVotingScanView(),
+    );
+  }
+}
+
+class _MobileKeystoneVotingScanView extends ConsumerStatefulWidget {
+  const _MobileKeystoneVotingScanView();
+
+  @override
+  ConsumerState<_MobileKeystoneVotingScanView> createState() =>
+      _MobileKeystoneVotingScanViewState();
+}
+
+class _MobileKeystoneVotingScanViewState
+    extends ConsumerState<_MobileKeystoneVotingScanView> {
+  bool _decoding = false;
+  String? _error;
+
+  void _handleScanComplete(ScanResult result) {
+    if (_decoding) return;
+    setState(() {
+      _decoding = true;
+      _error = null;
+    });
+    context.pop(result.data);
+  }
+
+  void _handleDecodeError(Object error) {
+    if (!mounted || _decoding) return;
+    final message = error.toString().contains('Unexpected UR type')
+        ? 'Open the signed voting QR on Keystone, then scan again.'
+        : 'Keep the QR code steady and fully visible.';
+    if (_error == message) return;
+    setState(() => _error = message);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.s,
+        AppSpacing.md,
+        AppSpacing.md,
+      ),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Scan voting signature',
+              style: AppTypography.displaySmall.copyWith(
+                color: colors.text.accent,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'Hold the Keystone QR code steady in front of your camera',
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: colors.text.accent,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.base),
+            KeystoneQrScannerCard(
+              expectedUrType: 'zcash-batch-sig-result',
+              decoding: _decoding,
+              error: _error,
+              onProgress: (progress) {
+                if (!mounted) return;
+                setState(() {
+                  if (progress > 0) _error = null;
+                });
+              },
+              onDecodeError: _handleDecodeError,
+              onComplete: _handleScanComplete,
+              decodingLabel: 'Reading signature...',
+              unavailableMessage:
+                  'Keystone voting uses camera QR scanning only. Connect a camera and try again.',
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -413,88 +413,93 @@ class _PollCard extends StatelessWidget {
 
     return Material(
       color: const Color(0x00000000),
-      child: Ink(
-        key: ValueKey('voting_poll_card_${round.roundId}'),
-        padding: EdgeInsets.symmetric(
-          horizontal: AppSpacing.sm,
-          vertical: compact ? AppSpacing.s : AppSpacing.sm,
-        ),
-        decoration: BoxDecoration(
-          color: colors.background.ground,
-          borderRadius: BorderRadius.circular(AppRadii.medium),
-          border: Border.all(color: colors.border.subtle),
-          boxShadow: [
-            BoxShadow(
-              color: const Color(0x0A231F20),
-              offset: const Offset(0, 1),
-              blurRadius: 1,
-              spreadRadius: -0.5,
-            ),
-          ],
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _StatusBadge(state: state),
-                const Spacer(),
-                if (dateLabel != null)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 2),
-                    child: Text(
-                      dateLabel,
-                      textAlign: TextAlign.right,
-                      style: AppTypography.bodyMediumStrong.copyWith(
-                        color: colors.text.secondary,
-                        height: 20 / 14,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-            SizedBox(height: compact ? AppSpacing.s : AppSpacing.sm),
-            Text(
-              title,
-              style: AppTypography.headlineSmall.copyWith(
-                color: colors.text.accent,
-                fontWeight: FontWeight.w600,
-                height: 24 / 16,
-                letterSpacing: 0,
-              ),
-            ),
-            SizedBox(height: compact ? AppSpacing.s : AppSpacing.md),
-            Text(
-              description.isEmpty ? round.roundId : description,
-              maxLines: 4,
-              overflow: TextOverflow.ellipsis,
-              style: AppTypography.bodyMediumStrong.copyWith(
-                color: colors.text.primary,
-                height: 20 / 14,
-                letterSpacing: 0,
-              ),
-            ),
-            if (forumUri != null) ...[
-              const SizedBox(height: AppSpacing.xs),
-              Align(
-                alignment: Alignment.centerRight,
-                child: VotingForumLinkButton(uri: forumUri),
+      child: InkWell(
+        key: ValueKey('voting_poll_card_tap_${round.roundId}'),
+        onTap: compact ? onAction : null,
+        borderRadius: BorderRadius.circular(AppRadii.medium),
+        child: Ink(
+          key: ValueKey('voting_poll_card_${round.roundId}'),
+          padding: EdgeInsets.symmetric(
+            horizontal: AppSpacing.sm,
+            vertical: compact ? AppSpacing.s : AppSpacing.sm,
+          ),
+          decoration: BoxDecoration(
+            color: colors.background.ground,
+            borderRadius: BorderRadius.circular(AppRadii.medium),
+            border: Border.all(color: colors.border.subtle),
+            boxShadow: [
+              BoxShadow(
+                color: const Color(0x0A231F20),
+                offset: const Offset(0, 1),
+                blurRadius: 1,
+                spreadRadius: -0.5,
               ),
             ],
-            SizedBox(height: compact ? AppSpacing.sm : AppSpacing.md),
-            Align(
-              alignment: Alignment.centerRight,
-              child: AppButton(
-                key: ValueKey('voting_poll_action_${round.roundId}'),
-                onPressed: onAction,
-                variant: _actionButtonVariant(state),
-                size: AppButtonSize.medium,
-                child: Text(_actionLabel(state)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _StatusBadge(state: state),
+                  const Spacer(),
+                  if (dateLabel != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: Text(
+                        dateLabel,
+                        textAlign: TextAlign.right,
+                        style: AppTypography.bodyMediumStrong.copyWith(
+                          color: colors.text.secondary,
+                          height: 20 / 14,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ),
+                ],
               ),
-            ),
-          ],
+              SizedBox(height: compact ? AppSpacing.s : AppSpacing.sm),
+              Text(
+                title,
+                style: AppTypography.headlineSmall.copyWith(
+                  color: colors.text.accent,
+                  fontWeight: FontWeight.w600,
+                  height: 24 / 16,
+                  letterSpacing: 0,
+                ),
+              ),
+              SizedBox(height: compact ? AppSpacing.s : AppSpacing.md),
+              Text(
+                description.isEmpty ? round.roundId : description,
+                maxLines: 4,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.bodyMediumStrong.copyWith(
+                  color: colors.text.primary,
+                  height: 20 / 14,
+                  letterSpacing: 0,
+                ),
+              ),
+              if (forumUri != null) ...[
+                const SizedBox(height: AppSpacing.xs),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: VotingForumLinkButton(uri: forumUri),
+                ),
+              ],
+              SizedBox(height: compact ? AppSpacing.sm : AppSpacing.md),
+              Align(
+                alignment: Alignment.centerRight,
+                child: AppButton(
+                  key: ValueKey('voting_poll_action_${round.roundId}'),
+                  onPressed: onAction,
+                  variant: _actionButtonVariant(state),
+                  size: AppButtonSize.medium,
+                  child: Text(_actionLabel(state)),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -156,11 +156,10 @@ class _VotingPollsViewState extends ConsumerState<VotingPollsView> {
       ),
       itemBuilder: (context, index) {
         final round = sortedItems[index];
-        return _PollCard(
-          round: round,
-          compact: !widget.showDesktopChrome,
-          onAction: () => _openRoundAction(round),
-        );
+        void onAction() => _openRoundAction(round);
+        return widget.showDesktopChrome
+            ? _DesktopPollCard(round: round, onAction: onAction)
+            : _MobilePollCard(round: round, onAction: onAction);
       },
     );
   }
@@ -391,16 +390,103 @@ class _VotingBetaLabel extends StatelessWidget {
   }
 }
 
-class _PollCard extends StatelessWidget {
-  const _PollCard({
+class _MobilePollCard extends StatelessWidget {
+  const _MobilePollCard({required this.round, required this.onAction});
+
+  final VotingRoundView round;
+  final VoidCallback onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0x00000000),
+      child: InkWell(
+        key: ValueKey('voting_poll_card_tap_${round.roundId}'),
+        onTap: onAction,
+        borderRadius: BorderRadius.circular(AppRadii.medium),
+        child: Ink(
+          key: ValueKey('voting_poll_card_${round.roundId}'),
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.sm,
+            vertical: AppSpacing.s,
+          ),
+          decoration: _mobilePollCardDecoration(context),
+          child: _PollCardContent(
+            round: round,
+            onAction: onAction,
+            titleGap: AppSpacing.s,
+            descriptionGap: AppSpacing.s,
+            actionGap: AppSpacing.sm,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DesktopPollCard extends StatelessWidget {
+  const _DesktopPollCard({required this.round, required this.onAction});
+
+  final VotingRoundView round;
+  final VoidCallback onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0x00000000),
+      child: Ink(
+        key: ValueKey('voting_poll_card_${round.roundId}'),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.sm,
+        ),
+        decoration: _desktopPollCardDecoration(context),
+        child: _PollCardContent(
+          round: round,
+          onAction: onAction,
+          titleGap: AppSpacing.sm,
+          descriptionGap: AppSpacing.md,
+          actionGap: AppSpacing.md,
+        ),
+      ),
+    );
+  }
+}
+
+BoxDecoration _mobilePollCardDecoration(BuildContext context) => BoxDecoration(
+  color: context.colors.background.ground,
+  borderRadius: BorderRadius.circular(AppRadii.medium),
+  border: Border.all(color: context.colors.border.subtle),
+);
+
+BoxDecoration _desktopPollCardDecoration(BuildContext context) => BoxDecoration(
+  color: context.colors.background.ground,
+  borderRadius: BorderRadius.circular(AppRadii.medium),
+  border: Border.all(color: context.colors.border.subtle),
+  boxShadow: const [
+    BoxShadow(
+      color: Color(0x0A231F20),
+      offset: Offset(0, 1),
+      blurRadius: 1,
+      spreadRadius: -0.5,
+    ),
+  ],
+);
+
+class _PollCardContent extends StatelessWidget {
+  const _PollCardContent({
     required this.round,
-    required this.compact,
     required this.onAction,
+    required this.titleGap,
+    required this.descriptionGap,
+    required this.actionGap,
   });
 
   final VotingRoundView round;
-  final bool compact;
   final VoidCallback onAction;
+  final double titleGap;
+  final double descriptionGap;
+  final double actionGap;
 
   @override
   Widget build(BuildContext context) {
@@ -411,97 +497,69 @@ class _PollCard extends StatelessWidget {
     final state = _pollCardState(round);
     final dateLabel = _roundDateLabel(round.rawJson, state);
 
-    return Material(
-      color: const Color(0x00000000),
-      child: InkWell(
-        key: ValueKey('voting_poll_card_tap_${round.roundId}'),
-        onTap: compact ? onAction : null,
-        borderRadius: BorderRadius.circular(AppRadii.medium),
-        child: Ink(
-          key: ValueKey('voting_poll_card_${round.roundId}'),
-          padding: EdgeInsets.symmetric(
-            horizontal: AppSpacing.sm,
-            vertical: compact ? AppSpacing.s : AppSpacing.sm,
-          ),
-          decoration: BoxDecoration(
-            color: colors.background.ground,
-            borderRadius: BorderRadius.circular(AppRadii.medium),
-            border: Border.all(color: colors.border.subtle),
-            boxShadow: [
-              BoxShadow(
-                color: const Color(0x0A231F20),
-                offset: const Offset(0, 1),
-                blurRadius: 1,
-                spreadRadius: -0.5,
-              ),
-            ],
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _StatusBadge(state: state),
-                  const Spacer(),
-                  if (dateLabel != null)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 2),
-                      child: Text(
-                        dateLabel,
-                        textAlign: TextAlign.right,
-                        style: AppTypography.bodyMediumStrong.copyWith(
-                          color: colors.text.secondary,
-                          height: 20 / 14,
-                          letterSpacing: 0,
-                        ),
-                      ),
-                    ),
-                ],
-              ),
-              SizedBox(height: compact ? AppSpacing.s : AppSpacing.sm),
-              Text(
-                title,
-                style: AppTypography.headlineSmall.copyWith(
-                  color: colors.text.accent,
-                  fontWeight: FontWeight.w600,
-                  height: 24 / 16,
-                  letterSpacing: 0,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _StatusBadge(state: state),
+            const Spacer(),
+            if (dateLabel != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 2),
+                child: Text(
+                  dateLabel,
+                  textAlign: TextAlign.right,
+                  style: AppTypography.bodyMediumStrong.copyWith(
+                    color: colors.text.secondary,
+                    height: 20 / 14,
+                    letterSpacing: 0,
+                  ),
                 ),
               ),
-              SizedBox(height: compact ? AppSpacing.s : AppSpacing.md),
-              Text(
-                description.isEmpty ? round.roundId : description,
-                maxLines: 4,
-                overflow: TextOverflow.ellipsis,
-                style: AppTypography.bodyMediumStrong.copyWith(
-                  color: colors.text.primary,
-                  height: 20 / 14,
-                  letterSpacing: 0,
-                ),
-              ),
-              if (forumUri != null) ...[
-                const SizedBox(height: AppSpacing.xs),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: VotingForumLinkButton(uri: forumUri),
-                ),
-              ],
-              SizedBox(height: compact ? AppSpacing.sm : AppSpacing.md),
-              Align(
-                alignment: Alignment.centerRight,
-                child: AppButton(
-                  key: ValueKey('voting_poll_action_${round.roundId}'),
-                  onPressed: onAction,
-                  variant: _actionButtonVariant(state),
-                  size: AppButtonSize.medium,
-                  child: Text(_actionLabel(state)),
-                ),
-              ),
-            ],
+          ],
+        ),
+        SizedBox(height: titleGap),
+        Text(
+          title,
+          style: AppTypography.headlineSmall.copyWith(
+            color: colors.text.accent,
+            fontWeight: FontWeight.w600,
+            height: 24 / 16,
+            letterSpacing: 0,
           ),
         ),
-      ),
+        SizedBox(height: descriptionGap),
+        Text(
+          description.isEmpty ? round.roundId : description,
+          maxLines: 4,
+          overflow: TextOverflow.ellipsis,
+          style: AppTypography.bodyMediumStrong.copyWith(
+            color: colors.text.primary,
+            height: 20 / 14,
+            letterSpacing: 0,
+          ),
+        ),
+        if (forumUri != null) ...[
+          const SizedBox(height: AppSpacing.xs),
+          Align(
+            alignment: Alignment.centerRight,
+            child: VotingForumLinkButton(uri: forumUri),
+          ),
+        ],
+        SizedBox(height: actionGap),
+        Align(
+          alignment: Alignment.centerRight,
+          child: AppButton(
+            key: ValueKey('voting_poll_action_${round.roundId}'),
+            onPressed: onAction,
+            variant: _actionButtonVariant(state),
+            size: AppButtonSize.medium,
+            child: Text(_actionLabel(state)),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -154,7 +154,11 @@ class _VotingPollsViewState extends ConsumerState<VotingPollsView> {
       separatorBuilder: (_, _) => const SizedBox(height: AppSpacing.base),
       itemBuilder: (context, index) {
         final round = sortedItems[index];
-        return _PollCard(round: round, onAction: () => _openRoundAction(round));
+        return _PollCard(
+          round: round,
+          compact: !widget.showDesktopChrome,
+          onAction: () => _openRoundAction(round),
+        );
       },
     );
   }
@@ -386,9 +390,14 @@ class _VotingBetaLabel extends StatelessWidget {
 }
 
 class _PollCard extends StatelessWidget {
-  const _PollCard({required this.round, required this.onAction});
+  const _PollCard({
+    required this.round,
+    required this.compact,
+    required this.onAction,
+  });
 
   final VotingRoundView round;
+  final bool compact;
   final VoidCallback onAction;
 
   @override
@@ -404,7 +413,10 @@ class _PollCard extends StatelessWidget {
       color: const Color(0x00000000),
       child: Ink(
         key: ValueKey('voting_poll_card_${round.roundId}'),
-        padding: const EdgeInsets.all(AppSpacing.sm),
+        padding: EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: compact ? AppSpacing.s : AppSpacing.sm,
+        ),
         decoration: BoxDecoration(
           color: colors.background.ground,
           borderRadius: BorderRadius.circular(AppRadii.medium),
@@ -441,7 +453,7 @@ class _PollCard extends StatelessWidget {
                   ),
               ],
             ),
-            const SizedBox(height: AppSpacing.sm),
+            SizedBox(height: compact ? AppSpacing.s : AppSpacing.sm),
             Text(
               title,
               style: AppTypography.headlineSmall.copyWith(
@@ -451,7 +463,7 @@ class _PollCard extends StatelessWidget {
                 letterSpacing: 0,
               ),
             ),
-            const SizedBox(height: AppSpacing.md),
+            SizedBox(height: compact ? AppSpacing.s : AppSpacing.md),
             Text(
               description.isEmpty ? round.roundId : description,
               maxLines: 4,
@@ -469,7 +481,7 @@ class _PollCard extends StatelessWidget {
                 child: VotingForumLinkButton(uri: forumUri),
               ),
             ],
-            const SizedBox(height: AppSpacing.md),
+            SizedBox(height: compact ? AppSpacing.sm : AppSpacing.md),
             Align(
               alignment: Alignment.centerRight,
               child: AppButton(

--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -151,7 +151,9 @@ class _VotingPollsViewState extends ConsumerState<VotingPollsView> {
         40,
       ),
       itemCount: sortedItems.length,
-      separatorBuilder: (_, _) => const SizedBox(height: AppSpacing.base),
+      separatorBuilder: (_, _) => SizedBox(
+        height: widget.showDesktopChrome ? AppSpacing.base : AppSpacing.sm,
+      ),
       itemBuilder: (context, index) {
         final round = sortedItems[index];
         return _PollCard(

--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -31,14 +31,33 @@ const _votingBetaLabelCenterDx = 34.0;
 const _votingBetaLabelTopOffset = -10.0;
 const _votingHeaderTitleHeight = 33.0;
 
-class VotingPollsScreen extends ConsumerStatefulWidget {
+class VotingPollsScreen extends StatelessWidget {
   const VotingPollsScreen({super.key});
 
   @override
-  ConsumerState<VotingPollsScreen> createState() => _VotingPollsScreenState();
+  Widget build(BuildContext context) {
+    return const AppDesktopShell(
+      sidebar: AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: EdgeInsets.zero,
+        child: VotingPollsView(showDesktopChrome: true),
+      ),
+    );
+  }
 }
 
-class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
+/// Shared poll-list behavior and cards. Platform screens own the surrounding
+/// navigation chrome.
+class VotingPollsView extends ConsumerStatefulWidget {
+  const VotingPollsView({required this.showDesktopChrome, super.key});
+
+  final bool showDesktopChrome;
+
+  @override
+  ConsumerState<VotingPollsView> createState() => _VotingPollsViewState();
+}
+
+class _VotingPollsViewState extends ConsumerState<VotingPollsView> {
   bool _showSettings = false;
   bool _entryRefreshInFlight = true;
   bool _pollListRefreshInFlight = false;
@@ -69,49 +88,45 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
       _handleExternalRefreshRequest();
     });
     final rounds = ref.watch(votingRoundsProvider);
-    return AppDesktopShell(
-      sidebar: const AppMainSidebar(),
-      pane: AppDesktopPane(
-        padding: EdgeInsets.zero,
-        child: Stack(
+    return Stack(
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                const AppPaneToolbar(backLinkMinWidth: 60),
-                _VotingHeader(onSettings: _openSettings),
-                Expanded(
-                  child: _entryRefreshInFlight && !rounds.hasValue
-                      ? const VotingPaneLoading()
-                      : (_pollListRefreshInFlight || _entryRefreshInFlight) &&
-                            rounds.hasValue
-                      ? _buildRoundList(rounds.requireValue)
-                      : rounds.when(
-                          skipLoadingOnRefresh: false,
-                          skipLoadingOnReload: false,
-                          loading: () => const VotingPaneLoading(),
-                          error: (error, _) => _VotingMessage(
-                            title: "Couldn't load voting rounds",
-                            message: friendlyVotingErrorMessage(error),
-                            actionLabel: 'Try again',
-                            onAction: () => _reloadRoundsWithFreshConfig(),
-                          ),
-                          data: _buildRoundList,
-                        ),
-                ),
-              ],
+            if (widget.showDesktopChrome) ...[
+              const AppPaneToolbar(backLinkMinWidth: 60),
+              _VotingHeader(onSettings: _openSettings),
+            ],
+            Expanded(
+              child: _entryRefreshInFlight && !rounds.hasValue
+                  ? const VotingPaneLoading()
+                  : (_pollListRefreshInFlight || _entryRefreshInFlight) &&
+                        rounds.hasValue
+                  ? _buildRoundList(rounds.requireValue)
+                  : rounds.when(
+                      skipLoadingOnRefresh: false,
+                      skipLoadingOnReload: false,
+                      loading: () => const VotingPaneLoading(),
+                      error: (error, _) => _VotingMessage(
+                        title: "Couldn't load voting rounds",
+                        message: friendlyVotingErrorMessage(error),
+                        actionLabel: 'Try again',
+                        onAction: () => _reloadRoundsWithFreshConfig(),
+                      ),
+                      data: _buildRoundList,
+                    ),
             ),
-            if (_showSettings)
-              AppPaneModalOverlay(
-                onDismiss: _closeSettings,
-                child: VotingConfigSettingsPanel(
-                  onClose: _closeSettings,
-                  onUpdated: _closeSettings,
-                ),
-              ),
           ],
         ),
-      ),
+        if (_showSettings)
+          AppPaneModalOverlay(
+            onDismiss: _closeSettings,
+            child: VotingConfigSettingsPanel(
+              onClose: _closeSettings,
+              onUpdated: _closeSettings,
+            ),
+          ),
+      ],
     );
   }
 
@@ -123,13 +138,16 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
       );
     }
     final sortedItems = sortVotingRoundsForPollList(items);
+    final horizontalPadding = widget.showDesktopChrome
+        ? AppSpacing.md
+        : AppSpacing.sm;
     _preSyncVisibleRoundTrees(sortedItems);
     return VotingPaneListView.separated(
       maxWidth: 560,
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.md,
+      padding: EdgeInsets.fromLTRB(
+        horizontalPadding,
         AppSpacing.sm,
-        AppSpacing.md,
+        horizontalPadding,
         40,
       ),
       itemCount: sortedItems.length,
@@ -385,6 +403,7 @@ class _PollCard extends StatelessWidget {
     return Material(
       color: const Color(0x00000000),
       child: Ink(
+        key: ValueKey('voting_poll_card_${round.roundId}'),
         padding: const EdgeInsets.all(AppSpacing.sm),
         decoration: BoxDecoration(
           color: colors.background.ground,

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -24,18 +24,45 @@ import '../voting_routes.dart';
 import '../widgets/voting_metadata_widgets.dart';
 import '../widgets/voting_pane_scroll_area.dart';
 
-class VotingProposalDetailScreen extends ConsumerStatefulWidget {
+class VotingProposalDetailScreen extends StatelessWidget {
   const VotingProposalDetailScreen({super.key, required this.roundId});
 
   final String roundId;
 
   @override
-  ConsumerState<VotingProposalDetailScreen> createState() =>
-      _VotingProposalDetailScreenState();
+  Widget build(BuildContext context) {
+    return AppDesktopShell(
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: EdgeInsets.zero,
+        child: VotingProposalDetailView(
+          roundId: roundId,
+          showDesktopToolbar: true,
+        ),
+      ),
+    );
+  }
 }
 
-class _VotingProposalDetailScreenState
-    extends ConsumerState<VotingProposalDetailScreen> {
+/// Shared proposal/session behavior. Platform screens provide their own shell
+/// and navigation bar.
+class VotingProposalDetailView extends ConsumerStatefulWidget {
+  const VotingProposalDetailView({
+    required this.roundId,
+    required this.showDesktopToolbar,
+    super.key,
+  });
+
+  final String roundId;
+  final bool showDesktopToolbar;
+
+  @override
+  ConsumerState<VotingProposalDetailView> createState() =>
+      _VotingProposalDetailViewState();
+}
+
+class _VotingProposalDetailViewState
+    extends ConsumerState<VotingProposalDetailView> {
   bool _votingPowerPreparationStarted = false;
   bool _votingPowerPreparationInFlight = false;
   String? _votingPowerPreparationKey;
@@ -43,7 +70,7 @@ class _VotingProposalDetailScreenState
   String? _resultsRedirectRoundId;
 
   @override
-  void didUpdateWidget(covariant VotingProposalDetailScreen oldWidget) {
+  void didUpdateWidget(covariant VotingProposalDetailView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.roundId != widget.roundId) {
       _votingPowerPreparationStarted = false;
@@ -58,164 +85,156 @@ class _VotingProposalDetailScreenState
   Widget build(BuildContext context) {
     final roundId = widget.roundId;
     final session = ref.watch(votingSessionProvider(roundId));
-    return AppDesktopShell(
-      sidebar: const AppMainSidebar(),
-      pane: AppDesktopPane(
-        padding: EdgeInsets.zero,
-        child: session.when(
-          skipLoadingOnRefresh: false,
-          loading: () => const VotingPaneStateView(
-            backLinkMinWidth: 60,
-            child: VotingPaneLoading(),
-          ),
-          error: (error, _) => VotingPaneStateView(
-            backLinkMinWidth: 60,
-            child: _Message(
-              title: "Couldn't load voting round",
-              message: friendlyVotingErrorMessage(error),
-            ),
-          ),
-          data: (state) {
-            final round = state.round;
-            if (round == null) {
-              return const VotingPaneStateView(
-                backLinkMinWidth: 60,
-                child: _Message(
-                  title: 'Voting round unavailable',
-                  message: 'The selected voting round could not be loaded.',
-                ),
-              );
-            }
-            if (shouldPreSyncVotingTree(round.status)) {
-              unawaited(
-                ref.read(votingTreePreSyncProvider).preSyncRound(round.roundId),
-              );
-            }
-            final accountUuid = state.accountUuid;
-            final proposals = proposalsFromRound(round);
-            final forumUri = votingRoundForumUriFromJson(round.rawJson);
-            final completedVote = _CompletedVote.fromPlan(state.roundPlan);
-            final pendingVote = _PendingVoteRecovery.fromPlan(state.roundPlan);
-            final hasConfirmedVotingEligibility =
-                state.hasConfirmedVotingEligibility;
-            final isVotingEligibilityPending = _isVotingEligibilityPending(
-              state,
-            );
-            final hasBlockingRecovery = hasBlockingRoundRecoveryWork(
-              state.roundPlan,
-            );
-            _maybePrepareVotingPower(state);
-            // Foreground recovery takes precedence over the read-only voted view.
-            // Accepted helper shares may still be tracked after submission, but
-            // that background work should not keep this screen resumable.
-            if (hasBlockingRecovery && hasConfirmedVotingEligibility) {
-              return _PendingVoteContent(
-                roundTitle: round.title.isEmpty
-                    ? 'Token holder voting'
-                    : round.title,
-                snapshotHeight: round.snapshotHeight,
-                description: _roundDescription(round.rawJson),
-                forumUri: forumUri,
-                roundId: roundId,
-                accountUuid: accountUuid,
-              );
-            }
-            if (completedVote != null &&
-                (hasConfirmedVotingEligibility || isVotingEligibilityPending)) {
-              return _VotedPollContent(
-                roundTitle: round.title.isEmpty
-                    ? 'Token holder voting'
-                    : round.title,
-                snapshotHeight: round.snapshotHeight,
-                description: _roundDescription(round.rawJson),
-                forumUri: forumUri,
-                votingPowerZatoshi: state.eligibleWeightZatoshi,
-                votingPowerPreparing: _votingPowerPreparationInFlight,
-                votedAt: completedVote.votedAt,
-                proposals: proposals,
-                choicesByProposalId: completedVote.choicesByProposalId,
-              );
-            }
-            if (pendingVote != null && hasConfirmedVotingEligibility) {
-              return _PendingVoteContent(
-                roundTitle: round.title.isEmpty
-                    ? 'Token holder voting'
-                    : round.title,
-                snapshotHeight: round.snapshotHeight,
-                description: _roundDescription(round.rawJson),
-                forumUri: forumUri,
-                roundId: roundId,
-                accountUuid: accountUuid,
-              );
-            }
-            if (votingPollListStatus(round.status) !=
-                    VotingPollListStatus.active &&
-                !hasBlockingRecovery) {
-              _redirectToResults(round.roundId);
-              return const VotingPaneStateView(
-                backLinkMinWidth: 60,
-                child: VotingPaneLoading(),
-              );
-            }
-            final draftKey = accountUuid == null
-                ? null
-                : VotingSessionKey(roundId: roundId, accountUuid: accountUuid);
-            final draft = draftKey == null
-                ? const VotingDraftState()
-                : ref.watch(votingDraftProvider(draftKey));
-            final votingPowerPreparing =
-                _votingPowerPreparationInFlight ||
-                (state.eligibleWeightZatoshi == null &&
-                    state.error == null &&
-                    _shouldPrepareVotingPower(state));
-            final votingEligibilityMessage = _votingEligibilityMessage(
-              state,
-              preparing: votingPowerPreparing,
-            );
-            final votingError = state.error;
-            final votingEligibilityError = votingError == null
-                ? false
-                : isVotingEligibilityErrorText(votingError.message);
-            _maybePrecomputeDelegationPir(state);
-            return _ActivePollContent(
-              roundId: roundId,
-              title: round.title.isEmpty ? 'Token holder voting' : round.title,
-              snapshotHeight: round.snapshotHeight,
-              description: _roundDescription(round.rawJson),
-              forumUri: forumUri,
-              endDate: _roundEndDate(round.rawJson),
-              votingPowerZatoshi: votingEligibilityError
-                  ? BigInt.zero
-                  : state.eligibleWeightZatoshi,
-              votingPowerPreparing: votingPowerPreparing,
-              votingEligibilityConfirmed: hasConfirmedVotingEligibility,
-              votingEligibilityMessage: votingEligibilityError
-                  ? null
-                  : votingEligibilityMessage,
-              votingEligibilityErrorMessage: votingEligibilityError
-                  ? votingEligibilityMessage
-                  : null,
-              onVotingEligibilityRetry: _retryVotingPowerPreparation,
-              proposals: proposals,
-              draft: draft,
-              onChoice: draftKey == null
-                  ? (_, _) {}
-                  : (proposalId, choice) {
-                      if (!hasConfirmedVotingEligibility) return;
-                      final notifier = ref.read(
-                        votingDraftProvider(draftKey).notifier,
-                      );
-                      if (choice == null) {
-                        notifier.clearChoice(proposalId);
-                      } else {
-                        notifier.setChoice(proposalId, choice);
-                      }
-                    },
-            );
-          },
+    return session.when(
+      skipLoadingOnRefresh: false,
+      loading: () => _stateView(const VotingPaneLoading()),
+      error: (error, _) => _stateView(
+        _Message(
+          title: "Couldn't load voting round",
+          message: friendlyVotingErrorMessage(error),
         ),
       ),
+      data: (state) {
+        final round = state.round;
+        if (round == null) {
+          return _stateView(
+            const _Message(
+              title: 'Voting round unavailable',
+              message: 'The selected voting round could not be loaded.',
+            ),
+          );
+        }
+        if (shouldPreSyncVotingTree(round.status)) {
+          unawaited(
+            ref.read(votingTreePreSyncProvider).preSyncRound(round.roundId),
+          );
+        }
+        final accountUuid = state.accountUuid;
+        final proposals = proposalsFromRound(round);
+        final forumUri = votingRoundForumUriFromJson(round.rawJson);
+        final completedVote = _CompletedVote.fromPlan(state.roundPlan);
+        final pendingVote = _PendingVoteRecovery.fromPlan(state.roundPlan);
+        final hasConfirmedVotingEligibility =
+            state.hasConfirmedVotingEligibility;
+        final isVotingEligibilityPending = _isVotingEligibilityPending(state);
+        final hasBlockingRecovery = hasBlockingRoundRecoveryWork(
+          state.roundPlan,
+        );
+        _maybePrepareVotingPower(state);
+        // Foreground recovery takes precedence over the read-only voted view.
+        // Accepted helper shares may still be tracked after submission, but
+        // that background work should not keep this screen resumable.
+        if (hasBlockingRecovery && hasConfirmedVotingEligibility) {
+          return _PendingVoteContent(
+            showDesktopToolbar: widget.showDesktopToolbar,
+            roundTitle: round.title.isEmpty
+                ? 'Token holder voting'
+                : round.title,
+            snapshotHeight: round.snapshotHeight,
+            description: _roundDescription(round.rawJson),
+            forumUri: forumUri,
+            roundId: roundId,
+            accountUuid: accountUuid,
+          );
+        }
+        if (completedVote != null &&
+            (hasConfirmedVotingEligibility || isVotingEligibilityPending)) {
+          return _VotedPollContent(
+            showDesktopToolbar: widget.showDesktopToolbar,
+            roundTitle: round.title.isEmpty
+                ? 'Token holder voting'
+                : round.title,
+            snapshotHeight: round.snapshotHeight,
+            description: _roundDescription(round.rawJson),
+            forumUri: forumUri,
+            votingPowerZatoshi: state.eligibleWeightZatoshi,
+            votingPowerPreparing: _votingPowerPreparationInFlight,
+            votedAt: completedVote.votedAt,
+            proposals: proposals,
+            choicesByProposalId: completedVote.choicesByProposalId,
+          );
+        }
+        if (pendingVote != null && hasConfirmedVotingEligibility) {
+          return _PendingVoteContent(
+            showDesktopToolbar: widget.showDesktopToolbar,
+            roundTitle: round.title.isEmpty
+                ? 'Token holder voting'
+                : round.title,
+            snapshotHeight: round.snapshotHeight,
+            description: _roundDescription(round.rawJson),
+            forumUri: forumUri,
+            roundId: roundId,
+            accountUuid: accountUuid,
+          );
+        }
+        if (votingPollListStatus(round.status) != VotingPollListStatus.active &&
+            !hasBlockingRecovery) {
+          _redirectToResults(round.roundId);
+          return _stateView(const VotingPaneLoading());
+        }
+        final draftKey = accountUuid == null
+            ? null
+            : VotingSessionKey(roundId: roundId, accountUuid: accountUuid);
+        final draft = draftKey == null
+            ? const VotingDraftState()
+            : ref.watch(votingDraftProvider(draftKey));
+        final votingPowerPreparing =
+            _votingPowerPreparationInFlight ||
+            (state.eligibleWeightZatoshi == null &&
+                state.error == null &&
+                _shouldPrepareVotingPower(state));
+        final votingEligibilityMessage = _votingEligibilityMessage(
+          state,
+          preparing: votingPowerPreparing,
+        );
+        final votingError = state.error;
+        final votingEligibilityError = votingError == null
+            ? false
+            : isVotingEligibilityErrorText(votingError.message);
+        _maybePrecomputeDelegationPir(state);
+        return _ActivePollContent(
+          showDesktopToolbar: widget.showDesktopToolbar,
+          roundId: roundId,
+          title: round.title.isEmpty ? 'Token holder voting' : round.title,
+          snapshotHeight: round.snapshotHeight,
+          description: _roundDescription(round.rawJson),
+          forumUri: forumUri,
+          endDate: _roundEndDate(round.rawJson),
+          votingPowerZatoshi: votingEligibilityError
+              ? BigInt.zero
+              : state.eligibleWeightZatoshi,
+          votingPowerPreparing: votingPowerPreparing,
+          votingEligibilityConfirmed: hasConfirmedVotingEligibility,
+          votingEligibilityMessage: votingEligibilityError
+              ? null
+              : votingEligibilityMessage,
+          votingEligibilityErrorMessage: votingEligibilityError
+              ? votingEligibilityMessage
+              : null,
+          onVotingEligibilityRetry: _retryVotingPowerPreparation,
+          proposals: proposals,
+          draft: draft,
+          onChoice: draftKey == null
+              ? (_, _) {}
+              : (proposalId, choice) {
+                  if (!hasConfirmedVotingEligibility) return;
+                  final notifier = ref.read(
+                    votingDraftProvider(draftKey).notifier,
+                  );
+                  if (choice == null) {
+                    notifier.clearChoice(proposalId);
+                  } else {
+                    notifier.setChoice(proposalId, choice);
+                  }
+                },
+        );
+      },
     );
+  }
+
+  Widget _stateView(Widget child) {
+    if (!widget.showDesktopToolbar) return child;
+    return VotingPaneStateView(backLinkMinWidth: 60, child: child);
   }
 
   void _redirectToResults(String roundId) {
@@ -366,6 +385,7 @@ String? _privacyTrimNotice(BigInt? droppedValueZatoshi) {
 
 class _ActivePollContent extends StatefulWidget {
   const _ActivePollContent({
+    required this.showDesktopToolbar,
     required this.roundId,
     required this.title,
     required this.snapshotHeight,
@@ -383,6 +403,7 @@ class _ActivePollContent extends StatefulWidget {
     required this.onChoice,
   });
 
+  final bool showDesktopToolbar;
   final String roundId;
   final String title;
   final int snapshotHeight;
@@ -453,7 +474,8 @@ class _ActivePollContentState extends State<_ActivePollContent> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        const AppPaneToolbar(backLinkMinWidth: 60),
+        if (widget.showDesktopToolbar)
+          const AppPaneToolbar(backLinkMinWidth: 60),
         Expanded(
           child: widget.proposals.isEmpty
               ? const _Message(
@@ -462,10 +484,10 @@ class _ActivePollContentState extends State<_ActivePollContent> {
                 )
               : VotingPaneListView.separated(
                   maxWidth: 560,
-                  padding: const EdgeInsets.fromLTRB(
-                    AppSpacing.md,
+                  padding: EdgeInsets.fromLTRB(
+                    widget.showDesktopToolbar ? AppSpacing.md : AppSpacing.sm,
                     AppSpacing.sm,
-                    AppSpacing.md,
+                    widget.showDesktopToolbar ? AppSpacing.md : AppSpacing.sm,
                     AppSpacing.md,
                   ),
                   itemCount: widget.proposals.length + 2,
@@ -838,6 +860,7 @@ class _ReviewAnswersButton extends StatelessWidget {
 
 class _VotedPollContent extends StatelessWidget {
   const _VotedPollContent({
+    required this.showDesktopToolbar,
     required this.roundTitle,
     required this.snapshotHeight,
     required this.description,
@@ -849,6 +872,7 @@ class _VotedPollContent extends StatelessWidget {
     required this.choicesByProposalId,
   });
 
+  final bool showDesktopToolbar;
   final String roundTitle;
   final int snapshotHeight;
   final String description;
@@ -864,12 +888,14 @@ class _VotedPollContent extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        const AppPaneToolbar(),
+        if (showDesktopToolbar) const AppPaneToolbar(),
         Center(
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 560),
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+              padding: EdgeInsets.symmetric(
+                horizontal: showDesktopToolbar ? AppSpacing.md : AppSpacing.sm,
+              ),
               child: _VotedPollHeader(
                 title: roundTitle,
                 snapshotHeight: snapshotHeight,
@@ -891,10 +917,10 @@ class _VotedPollContent extends StatelessWidget {
                 )
               : VotingPaneListView.separated(
                   maxWidth: 560,
-                  padding: const EdgeInsets.fromLTRB(
-                    AppSpacing.md,
+                  padding: EdgeInsets.fromLTRB(
+                    showDesktopToolbar ? AppSpacing.md : AppSpacing.sm,
                     0,
-                    AppSpacing.md,
+                    showDesktopToolbar ? AppSpacing.md : AppSpacing.sm,
                     AppSpacing.md,
                   ),
                   itemCount: proposals.length,
@@ -920,6 +946,7 @@ class _VotedPollContent extends StatelessWidget {
 
 class _PendingVoteContent extends StatelessWidget {
   const _PendingVoteContent({
+    required this.showDesktopToolbar,
     required this.roundTitle,
     required this.snapshotHeight,
     required this.description,
@@ -928,6 +955,7 @@ class _PendingVoteContent extends StatelessWidget {
     required this.accountUuid,
   });
 
+  final bool showDesktopToolbar;
   final String roundTitle;
   final int snapshotHeight;
   final String description;
@@ -941,13 +969,13 @@ class _PendingVoteContent extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        const AppPaneToolbar(),
+        if (showDesktopToolbar) const AppPaneToolbar(),
         Expanded(
           child: Padding(
-            padding: const EdgeInsets.fromLTRB(
-              AppSpacing.md,
+            padding: EdgeInsets.fromLTRB(
+              showDesktopToolbar ? AppSpacing.md : AppSpacing.sm,
               0,
-              AppSpacing.md,
+              showDesktopToolbar ? AppSpacing.md : AppSpacing.sm,
               AppSpacing.md,
             ),
             child: Column(

--- a/lib/src/features/voting/screens/voting_results_screen.dart
+++ b/lib/src/features/voting/screens/voting_results_screen.dart
@@ -35,21 +35,42 @@ final _roundTallyProvider = FutureProvider.autoDispose.family((
       .getRoundTally(roundId);
 });
 
-class VotingResultsScreen extends ConsumerStatefulWidget {
+class VotingResultsScreen extends StatelessWidget {
   const VotingResultsScreen({super.key, required this.roundId});
 
   final String roundId;
 
   @override
-  ConsumerState<VotingResultsScreen> createState() =>
-      _VotingResultsScreenState();
+  Widget build(BuildContext context) {
+    return AppDesktopShell(
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: EdgeInsets.zero,
+        child: VotingResultsView(roundId: roundId, showDesktopToolbar: true),
+      ),
+    );
+  }
 }
 
-class _VotingResultsScreenState extends ConsumerState<VotingResultsScreen> {
+class VotingResultsView extends ConsumerStatefulWidget {
+  const VotingResultsView({
+    required this.roundId,
+    required this.showDesktopToolbar,
+    super.key,
+  });
+
+  final String roundId;
+  final bool showDesktopToolbar;
+
+  @override
+  ConsumerState<VotingResultsView> createState() => _VotingResultsViewState();
+}
+
+class _VotingResultsViewState extends ConsumerState<VotingResultsView> {
   Timer? _pendingTallyRefreshTimer;
 
   @override
-  void didUpdateWidget(covariant VotingResultsScreen oldWidget) {
+  void didUpdateWidget(covariant VotingResultsView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.roundId != widget.roundId) {
       _clearPendingTallyRefresh();
@@ -67,101 +88,95 @@ class _VotingResultsScreenState extends ConsumerState<VotingResultsScreen> {
     final session = ref.watch(votingSessionProvider(widget.roundId));
     final tally = ref.watch(_roundTallyProvider(widget.roundId));
 
-    return AppDesktopShell(
-      sidebar: const AppMainSidebar(),
-      pane: AppDesktopPane(
-        padding: EdgeInsets.zero,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const AppPaneToolbar(),
-            Expanded(
-              child: tally.when(
-                skipLoadingOnRefresh: false,
-                loading: () => const VotingPaneLoading(),
-                error: (error, _) {
-                  final round = session.value?.round;
-                  if (round != null &&
-                      _roundIsTallying(round) &&
-                      _isTallyNotReadyError(error)) {
-                    return _pendingResults();
-                  }
-                  _clearPendingTallyRefresh();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (widget.showDesktopToolbar) const AppPaneToolbar(),
+        Expanded(
+          child: tally.when(
+            skipLoadingOnRefresh: false,
+            loading: () => const VotingPaneLoading(),
+            error: (error, _) {
+              final round = session.value?.round;
+              if (round != null &&
+                  _roundIsTallying(round) &&
+                  _isTallyNotReadyError(error)) {
+                return _pendingResults();
+              }
+              _clearPendingTallyRefresh();
+              return _Message(
+                "Couldn't load results: ${friendlyVotingErrorMessage(error)}",
+              );
+            },
+            data: (result) {
+              final round = session.value?.round;
+              if (round == null) {
+                _clearPendingTallyRefresh();
+                if (session.hasError) {
                   return _Message(
-                    "Couldn't load results: ${friendlyVotingErrorMessage(error)}",
+                    "Couldn't load voting round details: "
+                    "${friendlyVotingErrorMessage(session.error!)}",
                   );
-                },
-                data: (result) {
-                  final round = session.value?.round;
-                  if (round == null) {
-                    _clearPendingTallyRefresh();
-                    if (session.hasError) {
-                      return _Message(
-                        "Couldn't load voting round details: "
-                        "${friendlyVotingErrorMessage(session.error!)}",
-                      );
-                    }
-                    return const VotingPaneLoading();
-                  }
-                  final proposals = proposalsFromRound(round);
-                  if (_isTallying(result.rawJson)) {
-                    return _pendingResults();
-                  }
-                  _clearPendingTallyRefresh();
-                  return VotingPaneScrollView(
-                    maxWidth: 560,
-                    scrollPadding: const EdgeInsets.only(bottom: AppSpacing.md),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        _ResultsHeader(
-                          title: _roundTitle(round),
-                          snapshotHeight: round.snapshotHeight,
-                          description: _roundDescription(round) ?? '',
-                          forumUri: votingRoundForumUriFromJson(round.rawJson),
-                        ),
-                        const SizedBox(height: AppSpacing.md),
-                        Text(
-                          'Results',
-                          style: AppTypography.headlineSmall.copyWith(
-                            color: context.colors.text.accent,
+                }
+                return const VotingPaneLoading();
+              }
+              final proposals = proposalsFromRound(round);
+              if (_isTallying(result.rawJson)) {
+                return _pendingResults();
+              }
+              _clearPendingTallyRefresh();
+              return VotingPaneScrollView(
+                maxWidth: 560,
+                scrollPadding: const EdgeInsets.only(bottom: AppSpacing.md),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _ResultsHeader(
+                      title: _roundTitle(round),
+                      snapshotHeight: round.snapshotHeight,
+                      description: _roundDescription(round) ?? '',
+                      forumUri: votingRoundForumUriFromJson(round.rawJson),
+                    ),
+                    const SizedBox(height: AppSpacing.md),
+                    Text(
+                      'Results',
+                      style: AppTypography.headlineSmall.copyWith(
+                        color: context.colors.text.accent,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    if (proposals.isEmpty)
+                      const _Message('No proposals in this round.')
+                    else
+                      for (var index = 0; index < proposals.length; index++)
+                        Padding(
+                          padding: EdgeInsets.only(
+                            bottom: index == proposals.length - 1
+                                ? 0
+                                : AppSpacing.s,
+                          ),
+                          child: _ResultCard(
+                            key: ValueKey(
+                              'voting-result-card-${proposals[index].id}',
+                            ),
+                            proposal: proposals[index],
+                            tally: _proposalTally(
+                              result.rawJson,
+                              proposals[index].id,
+                            ),
+                            selectedChoice: _selectedChoiceForProposal(
+                              session.value,
+                              proposals[index].id,
+                            ),
                           ),
                         ),
-                        const SizedBox(height: AppSpacing.s),
-                        if (proposals.isEmpty)
-                          const _Message('No proposals in this round.')
-                        else
-                          for (var index = 0; index < proposals.length; index++)
-                            Padding(
-                              padding: EdgeInsets.only(
-                                bottom: index == proposals.length - 1
-                                    ? 0
-                                    : AppSpacing.s,
-                              ),
-                              child: _ResultCard(
-                                key: ValueKey(
-                                  'voting-result-card-${proposals[index].id}',
-                                ),
-                                proposal: proposals[index],
-                                tally: _proposalTally(
-                                  result.rawJson,
-                                  proposals[index].id,
-                                ),
-                                selectedChoice: _selectedChoiceForProposal(
-                                  session.value,
-                                  proposals[index].id,
-                                ),
-                              ),
-                            ),
-                      ],
-                    ),
-                  );
-                },
-              ),
-            ),
-          ],
+                  ],
+                ),
+              );
+            },
+          ),
         ),
-      ),
+      ],
     );
   }
 

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -17,16 +17,38 @@ import '../voting_routes.dart';
 import '../widgets/voting_metadata_widgets.dart';
 import '../widgets/voting_pane_scroll_area.dart';
 
-class VotingReviewScreen extends ConsumerStatefulWidget {
+class VotingReviewScreen extends StatelessWidget {
   const VotingReviewScreen({super.key, required this.roundId});
 
   final String roundId;
 
   @override
-  ConsumerState<VotingReviewScreen> createState() => _VotingReviewScreenState();
+  Widget build(BuildContext context) {
+    return AppDesktopShell(
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: EdgeInsets.zero,
+        child: VotingReviewView(roundId: roundId, showDesktopToolbar: true),
+      ),
+    );
+  }
 }
 
-class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
+class VotingReviewView extends ConsumerStatefulWidget {
+  const VotingReviewView({
+    required this.roundId,
+    required this.showDesktopToolbar,
+    super.key,
+  });
+
+  final String roundId;
+  final bool showDesktopToolbar;
+
+  @override
+  ConsumerState<VotingReviewView> createState() => _VotingReviewViewState();
+}
+
+class _VotingReviewViewState extends ConsumerState<VotingReviewView> {
   bool _precomputeStarted = false;
   bool _votingPowerPreparationStarted = false;
   bool _votingPowerPreparationInFlight = false;
@@ -35,7 +57,7 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
   String? _resultsRedirectRoundId;
 
   @override
-  void didUpdateWidget(covariant VotingReviewScreen oldWidget) {
+  void didUpdateWidget(covariant VotingReviewView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.roundId != widget.roundId) {
       _precomputeStarted = false;
@@ -127,141 +149,132 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
   @override
   Widget build(BuildContext context) {
     final session = ref.watch(votingSessionProvider(widget.roundId));
-    return AppDesktopShell(
-      sidebar: const AppMainSidebar(),
-      pane: AppDesktopPane(
-        padding: EdgeInsets.zero,
-        child: session.when(
-          skipLoadingOnRefresh: false,
-          loading: () => const VotingPaneStateView(
-            backLinkMinWidth: 60,
-            child: VotingPaneLoading(),
-          ),
-          error: (error, _) => VotingPaneStateView(
-            backLinkMinWidth: 60,
-            child: _Message(
-              "Couldn't load review: ${friendlyVotingErrorMessage(error)}",
-            ),
-          ),
-          data: (state) {
-            final round = state.round;
-            if (round != null &&
-                votingPollListStatus(round.status) !=
-                    VotingPollListStatus.active) {
-              _redirectToResults(round.roundId);
-              return const VotingPaneStateView(
-                backLinkMinWidth: 60,
-                child: VotingPaneLoading(),
+    return session.when(
+      skipLoadingOnRefresh: false,
+      loading: () => _stateView(const VotingPaneLoading()),
+      error: (error, _) => _stateView(
+        _Message("Couldn't load review: ${friendlyVotingErrorMessage(error)}"),
+      ),
+      data: (state) {
+        final round = state.round;
+        if (round != null &&
+            votingPollListStatus(round.status) != VotingPollListStatus.active) {
+          _redirectToResults(round.roundId);
+          return _stateView(const VotingPaneLoading());
+        }
+        _maybePrepareVotingPower(state);
+        _maybePrecomputeDelegationPir(state);
+        final proposals = round == null
+            ? <VotingProposalView>[]
+            : proposalsFromRound(round);
+        final roundForumUri = round == null
+            ? null
+            : votingRoundForumUriFromJson(round.rawJson);
+        final accountUuid = state.accountUuid;
+        final draft = accountUuid == null
+            ? const VotingDraftState()
+            : ref.watch(
+                votingDraftProvider(
+                  VotingSessionKey(
+                    roundId: widget.roundId,
+                    accountUuid: accountUuid,
+                  ),
+                ),
               );
-            }
-            _maybePrepareVotingPower(state);
-            _maybePrecomputeDelegationPir(state);
-            final proposals = round == null
-                ? <VotingProposalView>[]
-                : proposalsFromRound(round);
-            final roundForumUri = round == null
-                ? null
-                : votingRoundForumUriFromJson(round.rawJson);
-            final accountUuid = state.accountUuid;
-            final draft = accountUuid == null
-                ? const VotingDraftState()
-                : ref.watch(
-                    votingDraftProvider(
-                      VotingSessionKey(
-                        roundId: widget.roundId,
-                        accountUuid: accountUuid,
+        final votingPowerPreparing =
+            _votingPowerPreparationInFlight ||
+            (state.eligibleWeightZatoshi == null &&
+                state.error == null &&
+                _shouldPrepareVotingPower(state));
+        final eligibilityMessage = _votingEligibilityMessage(
+          state,
+          preparing: votingPowerPreparing,
+        );
+        final onSubmit = draft.isEmpty || !state.hasConfirmedVotingEligibility
+            ? null
+            : () => context.go(
+                votingStatusRoute(widget.roundId, accountUuid: accountUuid),
+              );
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (widget.showDesktopToolbar)
+              const AppPaneToolbar(backLinkMinWidth: 60),
+            Expanded(
+              child: VotingPaneScrollView(
+                maxWidth: 560,
+                padding: EdgeInsets.symmetric(
+                  horizontal: widget.showDesktopToolbar
+                      ? AppSpacing.md
+                      : AppSpacing.sm,
+                ),
+                scrollPadding: const EdgeInsets.only(bottom: AppSpacing.md),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      'Review your answers',
+                      textAlign: TextAlign.center,
+                      style: AppTypography.displaySmall.copyWith(
+                        color: context.colors.text.accent,
+                        letterSpacing: 0,
                       ),
                     ),
-                  );
-            final votingPowerPreparing =
-                _votingPowerPreparationInFlight ||
-                (state.eligibleWeightZatoshi == null &&
-                    state.error == null &&
-                    _shouldPrepareVotingPower(state));
-            final eligibilityMessage = _votingEligibilityMessage(
-              state,
-              preparing: votingPowerPreparing,
-            );
-            final onSubmit =
-                draft.isEmpty || !state.hasConfirmedVotingEligibility
-                ? null
-                : () => context.go(
-                    votingStatusRoute(widget.roundId, accountUuid: accountUuid),
-                  );
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                const AppPaneToolbar(backLinkMinWidth: 60),
-                Expanded(
-                  child: VotingPaneScrollView(
-                    maxWidth: 560,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: AppSpacing.md,
-                    ),
-                    scrollPadding: const EdgeInsets.only(bottom: AppSpacing.md),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Text(
-                          'Review your answers',
-                          textAlign: TextAlign.center,
-                          style: AppTypography.displaySmall.copyWith(
-                            color: context.colors.text.accent,
-                            letterSpacing: 0,
-                          ),
+                    const SizedBox(height: AppSpacing.md),
+                    if (state.hasConfirmedVotingEligibility)
+                      for (final entry in proposals.asMap().entries) ...[
+                        VotingProposalCard(
+                          proposal: entry.value,
+                          fallbackForumUri: roundForumUri,
+                          selectedChoice: draft.choices[entry.value.id],
+                          readOnly: true,
+                          statusLabel: draft.choices[entry.value.id] == null
+                              ? 'Skipped'
+                              : null,
+                          titleCollapsedMaxLines: 1,
                         ),
-                        const SizedBox(height: AppSpacing.md),
-                        if (state.hasConfirmedVotingEligibility)
-                          for (final entry in proposals.asMap().entries) ...[
-                            VotingProposalCard(
-                              proposal: entry.value,
-                              fallbackForumUri: roundForumUri,
-                              selectedChoice: draft.choices[entry.value.id],
-                              readOnly: true,
-                              statusLabel: draft.choices[entry.value.id] == null
-                                  ? 'Skipped'
-                                  : null,
-                              titleCollapsedMaxLines: 1,
-                            ),
-                            if (entry.key != proposals.length - 1)
-                              const SizedBox(height: AppSpacing.s),
-                          ],
-                        if (state.hasConfirmedVotingEligibility &&
-                            draft.isEmpty) ...[
-                          const SizedBox(height: AppSpacing.xs),
-                          const _Message(
-                            'Choose at least one option before submitting.',
-                          ),
-                        ],
-                        if (eligibilityMessage != null) ...[
-                          const SizedBox(height: AppSpacing.xs),
-                          _Message(eligibilityMessage),
-                        ],
+                        if (entry.key != proposals.length - 1)
+                          const SizedBox(height: AppSpacing.s),
                       ],
-                    ),
-                  ),
+                    if (state.hasConfirmedVotingEligibility &&
+                        draft.isEmpty) ...[
+                      const SizedBox(height: AppSpacing.xs),
+                      const _Message(
+                        'Choose at least one option before submitting.',
+                      ),
+                    ],
+                    if (eligibilityMessage != null) ...[
+                      const SizedBox(height: AppSpacing.xs),
+                      _Message(eligibilityMessage),
+                    ],
+                  ],
                 ),
-                Padding(
-                  padding: const EdgeInsets.only(
-                    top: AppSpacing.xs,
-                    bottom: AppSpacing.md,
-                  ),
-                  child: Center(
-                    child: AppButton(
-                      key: const ValueKey('voting_confirm_submit_button'),
-                      onPressed: onSubmit,
-                      variant: AppButtonVariant.primary,
-                      minWidth: 240,
-                      child: const Text('Confirm & submit'),
-                    ),
-                  ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(
+                top: AppSpacing.xs,
+                bottom: AppSpacing.md,
+              ),
+              child: Center(
+                child: AppButton(
+                  key: const ValueKey('voting_confirm_submit_button'),
+                  onPressed: onSubmit,
+                  variant: AppButtonVariant.primary,
+                  minWidth: 240,
+                  child: const Text('Confirm & submit'),
                 ),
-              ],
-            );
-          },
-        ),
-      ),
+              ),
+            ),
+          ],
+        );
+      },
     );
+  }
+
+  Widget _stateView(Widget child) {
+    if (!widget.showDesktopToolbar) return child;
+    return VotingPaneStateView(backLinkMinWidth: 60, child: child);
   }
 }
 

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -192,9 +192,17 @@ class _VotingReviewViewState extends ConsumerState<VotingReviewView> {
         );
         final onSubmit = draft.isEmpty || !state.hasConfirmedVotingEligibility
             ? null
-            : () => context.go(
-                votingStatusRoute(widget.roundId, accountUuid: accountUuid),
-              );
+            : () {
+                final route = votingStatusRoute(
+                  widget.roundId,
+                  accountUuid: accountUuid,
+                );
+                if (widget.showDesktopToolbar) {
+                  context.go(route);
+                } else {
+                  context.pushReplacement(route);
+                }
+              };
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -442,10 +442,11 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
   }
 
   void _scheduleConfirmationNavigation(VotingSessionKey key) {
+    if (!_isCurrentStatusRoute(key)) return;
     if (_confirmationNavigationScheduledFor == key) return;
     _confirmationNavigationScheduledFor = key;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
+      if (!mounted || !_isCurrentStatusRoute(key)) return;
       if (_selectedJobKey() != key) {
         if (_confirmationNavigationScheduledFor == key) {
           _confirmationNavigationScheduledFor = null;
@@ -467,10 +468,23 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
         'round=${key.roundId} account=${key.accountUuid} error=$error',
       );
     }
-    if (!mounted || _selectedJobKey() != key) return;
+    if (!mounted || _selectedJobKey() != key || !_isCurrentStatusRoute(key)) {
+      return;
+    }
     context.go(
       votingSubmissionConfirmedRoute(key.roundId, accountUuid: key.accountUuid),
     );
+  }
+
+  bool _isCurrentStatusRoute(VotingSessionKey key) {
+    if (!mounted) return false;
+    final currentPath = GoRouter.of(
+      context,
+    ).routerDelegate.currentConfiguration.uri.path;
+    final statusPath = Uri.parse(
+      votingStatusRoute(key.roundId, accountUuid: key.accountUuid),
+    ).path;
+    return currentPath == statusPath;
   }
 }
 

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -45,10 +45,16 @@ class VotingStatusScreen extends StatelessWidget {
 }
 
 class VotingStatusView extends ConsumerStatefulWidget {
-  const VotingStatusView({super.key, required this.roundId, this.accountUuid});
+  const VotingStatusView({
+    super.key,
+    required this.roundId,
+    this.accountUuid,
+    this.requireCurrentRouteForConfirmation = false,
+  });
 
   final String roundId;
   final String? accountUuid;
+  final bool requireCurrentRouteForConfirmation;
 
   @override
   ConsumerState<VotingStatusView> createState() => _VotingStatusViewState();
@@ -442,11 +448,11 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
   }
 
   void _scheduleConfirmationNavigation(VotingSessionKey key) {
-    if (!_isCurrentStatusRoute(key)) return;
+    if (!_canNavigateToConfirmation(key)) return;
     if (_confirmationNavigationScheduledFor == key) return;
     _confirmationNavigationScheduledFor = key;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !_isCurrentStatusRoute(key)) return;
+      if (!mounted || !_canNavigateToConfirmation(key)) return;
       if (_selectedJobKey() != key) {
         if (_confirmationNavigationScheduledFor == key) {
           _confirmationNavigationScheduledFor = null;
@@ -468,12 +474,19 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
         'round=${key.roundId} account=${key.accountUuid} error=$error',
       );
     }
-    if (!mounted || _selectedJobKey() != key || !_isCurrentStatusRoute(key)) {
+    if (!mounted ||
+        _selectedJobKey() != key ||
+        !_canNavigateToConfirmation(key)) {
       return;
     }
     context.go(
       votingSubmissionConfirmedRoute(key.roundId, accountUuid: key.accountUuid),
     );
+  }
+
+  bool _canNavigateToConfirmation(VotingSessionKey key) {
+    return !widget.requireCurrentRouteForConfirmation ||
+        _isCurrentStatusRoute(key);
   }
 
   bool _isCurrentStatusRoute(VotingSessionKey key) {

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -22,6 +22,38 @@ import '../voting_resume_plan.dart';
 import '../voting_routes.dart';
 import '../widgets/voting_pane_scroll_area.dart';
 
+typedef VotingStatusContentWrapper =
+    Widget Function(BuildContext context, Widget content);
+typedef VotingKeystoneStatusBuilder =
+    Widget Function(
+      BuildContext context,
+      VotingKeystoneStatusPresentation presentation,
+    );
+
+class VotingKeystoneStatusPresentation {
+  const VotingKeystoneStatusPresentation({
+    required this.bundleIndex,
+    required this.urParts,
+    required this.batchMemos,
+    required this.batchMessageCount,
+    required this.batchTotalCount,
+    required this.onSigned,
+    this.scanError,
+    this.canSkipRemainingBundles = false,
+    this.onSkipRemainingBundles,
+  });
+
+  final int bundleIndex;
+  final List<String> urParts;
+  final List<VotingKeystoneBatchMemo> batchMemos;
+  final int batchMessageCount;
+  final int batchTotalCount;
+  final String? scanError;
+  final bool canSkipRemainingBundles;
+  final Future<void> Function(List<int> responseCbor) onSigned;
+  final VoidCallback? onSkipRemainingBundles;
+}
+
 class VotingStatusScreen extends StatelessWidget {
   const VotingStatusScreen({
     super.key,
@@ -50,11 +82,15 @@ class VotingStatusView extends ConsumerStatefulWidget {
     required this.roundId,
     this.accountUuid,
     this.requireCurrentRouteForConfirmation = false,
+    this.contentWrapper,
+    this.keystoneStatusBuilder,
   });
 
   final String roundId;
   final String? accountUuid;
   final bool requireCurrentRouteForConfirmation;
+  final VotingStatusContentWrapper? contentWrapper;
+  final VotingKeystoneStatusBuilder? keystoneStatusBuilder;
 
   @override
   ConsumerState<VotingStatusView> createState() => _VotingStatusViewState();
@@ -150,6 +186,18 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
         .handleKeystoneBatchSignResponse(key, responseCbor);
   }
 
+  Future<void> _handleInlineKeystoneSignature(List<int> responseCbor) async {
+    final key = _selectedJobKey();
+    if (key == null || responseCbor.isEmpty) return;
+    await ref
+        .read(votingSubmissionJobsProvider.notifier)
+        .handleKeystoneBatchSignResponse(key, responseCbor);
+    if (!mounted || _selectedJobKey() != key) return;
+    final session = ref.read(votingSubmissionJobSessionProvider(key)).value;
+    final scanError = session?.keystoneScanError;
+    if (scanError != null) throw StateError(scanError);
+  }
+
   Future<void> _skipRemainingKeystoneBundles() async {
     final key = _selectedJobKey();
     if (key == null) return;
@@ -214,6 +262,7 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
         job?.status == VotingSubmissionJobStatus.complete) {
       _scheduleConfirmationNavigation(selectedKey);
     }
+    var usesPlatformKeystoneScreen = false;
     final content = session.when(
       skipLoadingOnRefresh: false,
       loading: () {
@@ -261,6 +310,31 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
                 completedSubmission: completedSubmission,
               )
             : VotingSessionPhase.error;
+        final keystoneBuilder = widget.keystoneStatusBuilder;
+        final bundleIndex = state.keystoneSigningRequest?.bundleIndex;
+        final urParts = job?.keystoneUrParts ?? const <String>[];
+        if (keystoneBuilder != null &&
+            state.isHardwareAccount &&
+            phase == VotingSessionPhase.keystoneSigning &&
+            bundleIndex != null &&
+            urParts.isNotEmpty &&
+            job?.keystoneQrError == null) {
+          usesPlatformKeystoneScreen = true;
+          return keystoneBuilder(
+            context,
+            VotingKeystoneStatusPresentation(
+              bundleIndex: bundleIndex,
+              urParts: urParts,
+              batchMemos: job?.keystoneBatchMemos ?? const [],
+              batchMessageCount: job?.keystoneBatchMessageCount ?? 0,
+              batchTotalCount: job?.keystoneBatchTotalCount ?? 0,
+              scanError: state.keystoneScanError,
+              canSkipRemainingBundles: state.canSkipRemainingKeystoneBundles,
+              onSigned: _handleInlineKeystoneSignature,
+              onSkipRemainingBundles: _skipRemainingKeystoneBundles,
+            ),
+          );
+        }
         return _StatusContent(
           phase: phase,
           voteSubmissionDetail: _voteSubmissionDetail(state),
@@ -296,7 +370,8 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
         );
       },
     );
-    return content;
+    if (usesPlatformKeystoneScreen) return content;
+    return widget.contentWrapper?.call(context, content) ?? content;
   }
 
   VotingSessionPhase _displayPhase(

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -22,7 +22,7 @@ import '../voting_resume_plan.dart';
 import '../voting_routes.dart';
 import '../widgets/voting_pane_scroll_area.dart';
 
-class VotingStatusScreen extends ConsumerStatefulWidget {
+class VotingStatusScreen extends StatelessWidget {
   const VotingStatusScreen({
     super.key,
     required this.roundId,
@@ -33,10 +33,28 @@ class VotingStatusScreen extends ConsumerStatefulWidget {
   final String? accountUuid;
 
   @override
-  ConsumerState<VotingStatusScreen> createState() => _VotingStatusScreenState();
+  Widget build(BuildContext context) {
+    return AppDesktopShell(
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: EdgeInsets.zero,
+        child: VotingStatusView(roundId: roundId, accountUuid: accountUuid),
+      ),
+    );
+  }
 }
 
-class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
+class VotingStatusView extends ConsumerStatefulWidget {
+  const VotingStatusView({super.key, required this.roundId, this.accountUuid});
+
+  final String roundId;
+  final String? accountUuid;
+
+  @override
+  ConsumerState<VotingStatusView> createState() => _VotingStatusViewState();
+}
+
+class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
   bool _startScheduled = false;
   int _startGeneration = 0;
   VotingSessionKey? _jobKey;
@@ -49,7 +67,7 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
   }
 
   @override
-  void didUpdateWidget(covariant VotingStatusScreen oldWidget) {
+  void didUpdateWidget(covariant VotingStatusView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.roundId == widget.roundId &&
         oldWidget.accountUuid == widget.accountUuid) {
@@ -190,95 +208,89 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
         job?.status == VotingSubmissionJobStatus.complete) {
       _scheduleConfirmationNavigation(selectedKey);
     }
-    return AppDesktopShell(
-      sidebar: const AppMainSidebar(),
-      pane: AppDesktopPane(
-        padding: EdgeInsets.zero,
-        child: session.when(
-          skipLoadingOnRefresh: false,
-          loading: () {
-            if (startError != null) {
-              return _StatusContent(
-                phase: VotingSessionPhase.error,
-                errorMessage: startError,
-                onRetry: _retry,
-              );
-            }
-            if (job?.status == VotingSubmissionJobStatus.error &&
-                job?.key?.roundId == widget.roundId) {
-              return _StatusContent(
-                phase: VotingSessionPhase.error,
-                errorMessage: job?.errorMessage,
-                onRetry: _retry,
-                onClear: _clearError,
-              );
-            }
-            return const VotingPaneLoading();
-          },
-          error: (error, _) => _StatusContent(
+    final content = session.when(
+      skipLoadingOnRefresh: false,
+      loading: () {
+        if (startError != null) {
+          return _StatusContent(
             phase: VotingSessionPhase.error,
-            errorMessage: job?.errorMessage ?? _messageFromError(error),
+            errorMessage: startError,
             onRetry: _retry,
-            onClear: job?.status == VotingSubmissionJobStatus.error
-                ? _clearError
-                : null,
-          ),
-          data: (state) {
-            final localError = job?.errorMessage;
-            final submissionJobComplete =
-                job?.status == VotingSubmissionJobStatus.complete;
-            final submissionJobInFlight = job?.isInFlight ?? false;
-            final sessionCompleted = _hasCompletedSubmission(state);
-            final completedSubmission =
-                submissionJobComplete ||
-                (!submissionJobInFlight && sessionCompleted) ||
-                (submissionJobInFlight &&
-                    sessionCompleted &&
-                    _hasCompletedCurrentSubmissionProgress(state));
-            final phase = job?.status != VotingSubmissionJobStatus.error
-                ? _displayPhase(
-                    state.phase,
-                    completedSubmission: completedSubmission,
-                  )
-                : VotingSessionPhase.error;
-            return _StatusContent(
-              phase: phase,
-              voteSubmissionDetail: _voteSubmissionDetail(state),
-              voteSubmissionProgress: _voteSubmissionProgress(
-                state,
-                completedSubmission: completedSubmission,
-              ),
-              delegationProgress: _delegationProgress(state),
-              completedSubmission: completedSubmission,
-              submissionJobComplete: submissionJobComplete,
-              submissionJobInFlight: submissionJobInFlight,
-              softwareAccountRequired: job?.softwareAccountRequired ?? false,
-              isHardwareAccount: state.isHardwareAccount,
-              keystoneSigningBundleIndex:
-                  state.keystoneSigningRequest?.bundleIndex,
-              canSkipRemainingKeystoneBundles:
-                  state.canSkipRemainingKeystoneBundles,
-              keystoneUrParts: job?.keystoneUrParts ?? const [],
-              keystoneBatchMemos: job?.keystoneBatchMemos ?? const [],
-              keystoneBatchMessageCount: job?.keystoneBatchMessageCount ?? 0,
-              keystoneBatchTotalCount: job?.keystoneBatchTotalCount ?? 0,
-              keystoneQrError: job?.keystoneQrError,
-              keystoneScanError: state.keystoneScanError,
-              walletScannedHeight: state.walletScannedHeight,
-              walletSnapshotHeight: state.walletSnapshotHeight,
-              walletChainTipHeight: state.walletChainTipHeight,
-              errorMessage: _sessionErrorMessage(state, localError),
-              onRetry: _retry,
-              onClear: job?.status == VotingSubmissionJobStatus.error
-                  ? _clearError
-                  : null,
-              onScanKeystone: _scanKeystoneSignature,
-              onSkipKeystoneBundles: _skipRemainingKeystoneBundles,
-            );
-          },
-        ),
+          );
+        }
+        if (job?.status == VotingSubmissionJobStatus.error &&
+            job?.key?.roundId == widget.roundId) {
+          return _StatusContent(
+            phase: VotingSessionPhase.error,
+            errorMessage: job?.errorMessage,
+            onRetry: _retry,
+            onClear: _clearError,
+          );
+        }
+        return const VotingPaneLoading();
+      },
+      error: (error, _) => _StatusContent(
+        phase: VotingSessionPhase.error,
+        errorMessage: job?.errorMessage ?? _messageFromError(error),
+        onRetry: _retry,
+        onClear: job?.status == VotingSubmissionJobStatus.error
+            ? _clearError
+            : null,
       ),
+      data: (state) {
+        final localError = job?.errorMessage;
+        final submissionJobComplete =
+            job?.status == VotingSubmissionJobStatus.complete;
+        final submissionJobInFlight = job?.isInFlight ?? false;
+        final sessionCompleted = _hasCompletedSubmission(state);
+        final completedSubmission =
+            submissionJobComplete ||
+            (!submissionJobInFlight && sessionCompleted) ||
+            (submissionJobInFlight &&
+                sessionCompleted &&
+                _hasCompletedCurrentSubmissionProgress(state));
+        final phase = job?.status != VotingSubmissionJobStatus.error
+            ? _displayPhase(
+                state.phase,
+                completedSubmission: completedSubmission,
+              )
+            : VotingSessionPhase.error;
+        return _StatusContent(
+          phase: phase,
+          voteSubmissionDetail: _voteSubmissionDetail(state),
+          voteSubmissionProgress: _voteSubmissionProgress(
+            state,
+            completedSubmission: completedSubmission,
+          ),
+          delegationProgress: _delegationProgress(state),
+          completedSubmission: completedSubmission,
+          submissionJobComplete: submissionJobComplete,
+          submissionJobInFlight: submissionJobInFlight,
+          softwareAccountRequired: job?.softwareAccountRequired ?? false,
+          isHardwareAccount: state.isHardwareAccount,
+          keystoneSigningBundleIndex: state.keystoneSigningRequest?.bundleIndex,
+          canSkipRemainingKeystoneBundles:
+              state.canSkipRemainingKeystoneBundles,
+          keystoneUrParts: job?.keystoneUrParts ?? const [],
+          keystoneBatchMemos: job?.keystoneBatchMemos ?? const [],
+          keystoneBatchMessageCount: job?.keystoneBatchMessageCount ?? 0,
+          keystoneBatchTotalCount: job?.keystoneBatchTotalCount ?? 0,
+          keystoneQrError: job?.keystoneQrError,
+          keystoneScanError: state.keystoneScanError,
+          walletScannedHeight: state.walletScannedHeight,
+          walletSnapshotHeight: state.walletSnapshotHeight,
+          walletChainTipHeight: state.walletChainTipHeight,
+          errorMessage: _sessionErrorMessage(state, localError),
+          onRetry: _retry,
+          onClear: job?.status == VotingSubmissionJobStatus.error
+              ? _clearError
+              : null,
+          onScanKeystone: _scanKeystoneSignature,
+          onSkipKeystoneBundles: _skipRemainingKeystoneBundles,
+        );
+      },
     );
+    return content;
   }
 
   VotingSessionPhase _displayPhase(

--- a/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
+++ b/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
@@ -21,7 +21,7 @@ import '../voting_formatters.dart';
 import '../voting_resume_plan.dart';
 import '../widgets/voting_pane_scroll_area.dart';
 
-class VotingSubmissionConfirmationScreen extends ConsumerStatefulWidget {
+class VotingSubmissionConfirmationScreen extends StatelessWidget {
   const VotingSubmissionConfirmationScreen({
     super.key,
     required this.roundId,
@@ -32,12 +32,40 @@ class VotingSubmissionConfirmationScreen extends ConsumerStatefulWidget {
   final String? accountUuid;
 
   @override
-  ConsumerState<VotingSubmissionConfirmationScreen> createState() =>
-      _VotingSubmissionConfirmationScreenState();
+  Widget build(BuildContext context) {
+    return AppDesktopShell(
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: EdgeInsets.zero,
+        child: VotingSubmissionConfirmationView(
+          roundId: roundId,
+          accountUuid: accountUuid,
+          showDesktopToolbar: true,
+        ),
+      ),
+    );
+  }
 }
 
-class _VotingSubmissionConfirmationScreenState
-    extends ConsumerState<VotingSubmissionConfirmationScreen> {
+class VotingSubmissionConfirmationView extends ConsumerStatefulWidget {
+  const VotingSubmissionConfirmationView({
+    super.key,
+    required this.roundId,
+    required this.showDesktopToolbar,
+    this.accountUuid,
+  });
+
+  final String roundId;
+  final String? accountUuid;
+  final bool showDesktopToolbar;
+
+  @override
+  ConsumerState<VotingSubmissionConfirmationView> createState() =>
+      _VotingSubmissionConfirmationViewState();
+}
+
+class _VotingSubmissionConfirmationViewState
+    extends ConsumerState<VotingSubmissionConfirmationView> {
   bool _isReturningToPolls = false;
   bool _refreshingVotingPower = false;
   bool _votingPowerRefreshAttempted = false;
@@ -51,7 +79,7 @@ class _VotingSubmissionConfirmationScreenState
   String? _returnErrorMessage;
 
   @override
-  void didUpdateWidget(covariant VotingSubmissionConfirmationScreen oldWidget) {
+  void didUpdateWidget(covariant VotingSubmissionConfirmationView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.roundId == widget.roundId &&
         oldWidget.accountUuid == widget.accountUuid) {
@@ -80,36 +108,33 @@ class _VotingSubmissionConfirmationScreenState
     final session = jobKey == null
         ? ref.watch(votingSessionProvider(widget.roundId))
         : ref.watch(votingSubmissionJobSessionProvider(jobKey));
-    return AppDesktopShell(
-      sidebar: const AppMainSidebar(),
-      pane: AppDesktopPane(
-        padding: EdgeInsets.zero,
-        child: session.when(
-          skipLoadingOnRefresh: false,
-          loading: () => const VotingPaneStateView(child: VotingPaneLoading()),
-          error: (error, _) {
-            final cachedState = _lastSubmissionState;
-            if (cachedState != null) {
-              return _buildSubmissionContent(
-                state: cachedState,
-                jobKey: jobKey,
-                loadError: error,
-              );
-            }
-            return _ConfirmationScaffold(
-              confirmed: false,
-              title: 'Submission not complete',
-              pollTitle: 'Token holder voting',
-              message:
-                  "Couldn't load submission details: ${friendlyVotingErrorMessage(error)}",
-              votingPower: 'Not available',
-            );
-          },
-          data: (state) {
-            return _buildSubmissionContent(state: state, jobKey: jobKey);
-          },
-        ),
-      ),
+    return session.when(
+      skipLoadingOnRefresh: false,
+      loading: () => widget.showDesktopToolbar
+          ? const VotingPaneStateView(child: VotingPaneLoading())
+          : const VotingPaneLoading(),
+      error: (error, _) {
+        final cachedState = _lastSubmissionState;
+        if (cachedState != null) {
+          return _buildSubmissionContent(
+            state: cachedState,
+            jobKey: jobKey,
+            loadError: error,
+          );
+        }
+        return _ConfirmationScaffold(
+          showDesktopToolbar: widget.showDesktopToolbar,
+          confirmed: false,
+          title: 'Submission not complete',
+          pollTitle: 'Token holder voting',
+          message:
+              "Couldn't load submission details: ${friendlyVotingErrorMessage(error)}",
+          votingPower: 'Not available',
+        );
+      },
+      data: (state) {
+        return _buildSubmissionContent(state: state, jobKey: jobKey);
+      },
     );
   }
 
@@ -142,6 +167,7 @@ class _VotingSubmissionConfirmationScreenState
 
     if (!hasCompletedSubmission) {
       return _ConfirmationScaffold(
+        showDesktopToolbar: widget.showDesktopToolbar,
         confirmed: false,
         title: 'Submission not complete',
         pollTitle: pollTitle,
@@ -167,6 +193,7 @@ class _VotingSubmissionConfirmationScreenState
           !_refreshingVotingPower &&
           !isVotingEligibilityErrorText(latestRefreshMessage);
       return _ConfirmationScaffold(
+        showDesktopToolbar: widget.showDesktopToolbar,
         confirmed: false,
         title: 'Submission not complete',
         pollTitle: pollTitle,
@@ -185,6 +212,7 @@ class _VotingSubmissionConfirmationScreenState
       );
     }
     return _ConfirmationScaffold(
+      showDesktopToolbar: widget.showDesktopToolbar,
       confirmed: true,
       title: 'Submission confirmed!',
       pollTitle: pollTitle,
@@ -376,6 +404,7 @@ class _VotingSubmissionConfirmationScreenState
 
 class _ConfirmationScaffold extends StatelessWidget {
   const _ConfirmationScaffold({
+    required this.showDesktopToolbar,
     required this.confirmed,
     required this.title,
     required this.pollTitle,
@@ -390,6 +419,7 @@ class _ConfirmationScaffold extends StatelessWidget {
     this.returnErrorMessage,
   });
 
+  final bool showDesktopToolbar;
   final bool confirmed;
   final String title;
   final String pollTitle;
@@ -412,13 +442,13 @@ class _ConfirmationScaffold extends StatelessWidget {
         Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const AppPaneToolbar(),
+            if (showDesktopToolbar) const AppPaneToolbar(),
             Expanded(
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(
-                  AppSpacing.md,
+                padding: EdgeInsets.fromLTRB(
+                  showDesktopToolbar ? AppSpacing.md : AppSpacing.sm,
                   0,
-                  AppSpacing.md,
+                  showDesktopToolbar ? AppSpacing.md : AppSpacing.sm,
                   AppSpacing.md,
                 ),
                 child: Center(

--- a/lib/src/features/voting/widgets/mobile/mobile_voting_config_settings_sheet.dart
+++ b/lib/src/features/voting/widgets/mobile/mobile_voting_config_settings_sheet.dart
@@ -38,6 +38,7 @@ class _MobileVotingConfigSettingsSheetState
   final _nameController = TextEditingController();
   final _urlController = TextEditingController();
   bool _showEditor = false;
+  String? _editingSourceId;
   bool _busy = false;
   String? _error;
 
@@ -76,9 +77,29 @@ class _MobileVotingConfigSettingsSheetState
       await _validateSource(url);
       await ref
           .read(votingConfigSourceProvider.notifier)
-          .saveSource(name: name, sourceUrl: url);
+          .saveSource(id: _editingSourceId, name: name, sourceUrl: url);
       await _refreshVoting();
       if (mounted) Navigator.of(context).pop();
+    });
+  }
+
+  void _openEditor([SavedVotingConfigSource? source]) {
+    setState(() {
+      _editingSourceId = source?.id;
+      _nameController.text = source?.name ?? '';
+      _urlController.text = source?.sourceUrl ?? '';
+      _showEditor = true;
+      _error = null;
+    });
+  }
+
+  void _closeEditor() {
+    setState(() {
+      _editingSourceId = null;
+      _nameController.clear();
+      _urlController.clear();
+      _showEditor = false;
+      _error = null;
     });
   }
 
@@ -198,6 +219,7 @@ class _MobileVotingConfigSettingsSheetState
                             url: saved.sourceUrl,
                             isDefault: false,
                           ),
+                    onEdit: _busy ? null : () => _openEditor(saved),
                     onDelete: _busy ? null : () => _deleteSource(saved),
                   ),
                 ],
@@ -257,12 +279,7 @@ class _MobileVotingConfigSettingsSheetState
                   AppButton(
                     expand: true,
                     variant: AppButtonVariant.ghost,
-                    onPressed: _busy
-                        ? null
-                        : () => setState(() {
-                            _showEditor = false;
-                            _error = null;
-                          }),
+                    onPressed: _busy ? null : _closeEditor,
                     child: const Text('Cancel'),
                   ),
                 ] else
@@ -270,9 +287,7 @@ class _MobileVotingConfigSettingsSheetState
                     key: const ValueKey('mobile_voting_add_source'),
                     expand: true,
                     variant: AppButtonVariant.secondary,
-                    onPressed: _busy
-                        ? null
-                        : () => setState(() => _showEditor = true),
+                    onPressed: _busy ? null : _openEditor,
                     child: const Text('Add custom source'),
                   ),
               ],
@@ -290,6 +305,7 @@ class _MobileSourceRow extends StatelessWidget {
     required this.subtitle,
     required this.selected,
     this.onTap,
+    this.onEdit,
     this.onDelete,
     super.key,
   });
@@ -298,6 +314,7 @@ class _MobileSourceRow extends StatelessWidget {
   final String subtitle;
   final bool selected;
   final VoidCallback? onTap;
+  final VoidCallback? onEdit;
   final VoidCallback? onDelete;
 
   @override
@@ -356,6 +373,23 @@ class _MobileSourceRow extends StatelessWidget {
                   ],
                 ),
               ),
+              if (onEdit != null)
+                Semantics(
+                  label: 'Edit $title',
+                  button: true,
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: onEdit,
+                    child: Padding(
+                      padding: const EdgeInsets.all(AppSpacing.s),
+                      child: AppIcon(
+                        AppIcons.options,
+                        size: 18,
+                        color: colors.icon.regular,
+                      ),
+                    ),
+                  ),
+                ),
               if (onDelete != null)
                 Semantics(
                   label: 'Delete $title',

--- a/lib/src/features/voting/widgets/mobile/mobile_voting_config_settings_sheet.dart
+++ b/lib/src/features/voting/widgets/mobile/mobile_voting_config_settings_sheet.dart
@@ -1,0 +1,479 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_button.dart';
+import '../../../../core/widgets/app_icon.dart';
+import '../../../../core/widgets/app_text_field.dart';
+import '../../../../providers/voting/voting_config_provider.dart';
+import '../../../../providers/voting/voting_config_source_provider.dart';
+import '../../../../providers/voting/voting_round_visibility_provider.dart';
+import '../../../../providers/voting/voting_rounds_provider.dart';
+import '../../../../providers/voting/voting_service_providers.dart';
+import '../../../../providers/voting/voting_submission_guard_provider.dart';
+import '../../../../services/voting/voting_config_loader.dart';
+
+Future<void> showMobileVotingConfigSettingsSheet(BuildContext context) {
+  return showAppMobileSheet<void>(
+    context: context,
+    builder: (_) => const MobileVotingConfigSettingsSheet(),
+  );
+}
+
+/// Mobile presentation for the shared voting-config providers. Desktop keeps
+/// its pane modal; this sheet follows the app's floating mobile modal system.
+class MobileVotingConfigSettingsSheet extends ConsumerStatefulWidget {
+  const MobileVotingConfigSettingsSheet({super.key});
+
+  @override
+  ConsumerState<MobileVotingConfigSettingsSheet> createState() =>
+      _MobileVotingConfigSettingsSheetState();
+}
+
+class _MobileVotingConfigSettingsSheetState
+    extends ConsumerState<MobileVotingConfigSettingsSheet> {
+  static const _maxSourceNameLength = 15;
+
+  final _nameController = TextEditingController();
+  final _urlController = TextEditingController();
+  bool _showEditor = false;
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _urlController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _selectSource({required String url, required bool isDefault}) {
+    return _runMutation(() async {
+      if (isDefault) {
+        await ref.read(votingConfigSourceProvider.notifier).resetDefault();
+      } else {
+        await _validateSource(url);
+        await ref.read(votingConfigSourceProvider.notifier).setCustom(url);
+      }
+      await _refreshVoting();
+      if (mounted) Navigator.of(context).pop();
+    });
+  }
+
+  Future<void> _saveSource() async {
+    final name = _nameController.text.trim();
+    final url = _urlController.text.trim();
+    if (name.isEmpty || name.length > _maxSourceNameLength || url.isEmpty) {
+      setState(() {
+        _error = name.length > _maxSourceNameLength
+            ? 'Title must be $_maxSourceNameLength characters or less.'
+            : 'Enter a title and source URL.';
+      });
+      return;
+    }
+    await _runMutation(() async {
+      await _validateSource(url);
+      await ref
+          .read(votingConfigSourceProvider.notifier)
+          .saveSource(name: name, sourceUrl: url);
+      await _refreshVoting();
+      if (mounted) Navigator.of(context).pop();
+    });
+  }
+
+  Future<void> _deleteSource(SavedVotingConfigSource source) {
+    return _runMutation(() async {
+      await ref
+          .read(votingConfigSourceProvider.notifier)
+          .deleteSavedSource(source.id);
+      await _refreshVoting();
+    });
+  }
+
+  Future<void> _toggleTestRounds(bool enabled) {
+    return _runMutation(() async {
+      await ref
+          .read(showTestVotingRoundsProvider.notifier)
+          .setShowTestRounds(!enabled);
+      await ref.read(votingRoundsProvider.notifier).reload();
+    });
+  }
+
+  Future<void> _runMutation(Future<void> Function() action) async {
+    if (_busy) return;
+    final guards = ref.read(votingSubmissionGuardProvider);
+    if (guards.isNotEmpty) {
+      setState(() => _error = guards.first.message);
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      await action();
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _error = _friendlyError(error));
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _validateSource(String input) async {
+    final parsed = parseStaticVotingConfigSource(input);
+    await VotingConfigLoader(
+      httpClient: ref.read(votingHttpClientProvider),
+      sourceUrl: parsed.raw,
+    ).load();
+  }
+
+  Future<void> _refreshVoting() async {
+    await ref.read(votingConfigProvider.notifier).refresh();
+    await ref.read(votingRoundsProvider.notifier).reload();
+  }
+
+  String _friendlyError(Object error) {
+    if (error is StaticVotingConfigSourceMalformed ||
+        error is DuplicateVotingConfigSource) {
+      return error.toString();
+    }
+    return "Couldn't update voting config. Check the source and try again.";
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final source = ref.watch(votingConfigSourceProvider);
+    final testRounds = ref.watch(showTestVotingRoundsProvider);
+    return MobileModalScaffold(
+      key: const ValueKey('mobile_voting_config_sheet'),
+      title: 'Voting config',
+      onClose: () => Navigator.of(context).pop(),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.sizeOf(context).height * 0.68,
+        ),
+        child: source.when(
+          loading: () => const SizedBox(
+            height: 220,
+            child: Center(child: AppIcon(AppIcons.loader)),
+          ),
+          error: (error, _) => _LoadError(message: error.toString()),
+          data: (state) => SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Choose where Vizor gets authenticated voting rounds.',
+                  style: AppTypography.bodyMedium.copyWith(
+                    color: context.colors.text.secondary,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                _MobileSourceRow(
+                  key: const ValueKey('mobile_voting_source_default'),
+                  title: 'Token holder voting',
+                  subtitle: 'Default Vizor source',
+                  selected: state.isDefault,
+                  onTap: _busy
+                      ? null
+                      : () => _selectSource(
+                          url: kDefaultStaticVotingConfigSource,
+                          isDefault: true,
+                        ),
+                ),
+                for (final saved in state.savedSources) ...[
+                  const SizedBox(height: AppSpacing.xs),
+                  _MobileSourceRow(
+                    key: ValueKey('mobile_voting_source_${saved.id}'),
+                    title: saved.name,
+                    subtitle: _compactUrl(saved.sourceUrl),
+                    selected:
+                        !state.isDefault && state.sourceUrl == saved.sourceUrl,
+                    onTap: _busy
+                        ? null
+                        : () => _selectSource(
+                            url: saved.sourceUrl,
+                            isDefault: false,
+                          ),
+                    onDelete: _busy ? null : () => _deleteSource(saved),
+                  ),
+                ],
+                if (!state.isDefault &&
+                    !state.savedSources.any(
+                      (saved) => saved.sourceUrl == state.sourceUrl,
+                    )) ...[
+                  const SizedBox(height: AppSpacing.xs),
+                  _MobileSourceRow(
+                    title: 'Custom source',
+                    subtitle: _compactUrl(state.sourceUrl),
+                    selected: true,
+                  ),
+                ],
+                const SizedBox(height: AppSpacing.sm),
+                _TestRoundsRow(
+                  enabled: testRounds.value ?? false,
+                  busy: _busy || testRounds.isLoading,
+                  onTap: () => _toggleTestRounds(testRounds.value ?? false),
+                ),
+                if (_error != null) ...[
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    _error!,
+                    key: const ValueKey('mobile_voting_config_error'),
+                    style: AppTypography.bodySmall.copyWith(
+                      color: context.colors.text.destructive,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: AppSpacing.sm),
+                if (_showEditor) ...[
+                  AppTextField(
+                    key: const ValueKey('mobile_voting_source_name'),
+                    label: 'Title',
+                    controller: _nameController,
+                    enabled: !_busy,
+                    onChanged: (_) => setState(() => _error = null),
+                  ),
+                  const SizedBox(height: AppSpacing.s),
+                  AppTextField(
+                    key: const ValueKey('mobile_voting_source_url'),
+                    label: 'Source URL',
+                    controller: _urlController,
+                    enabled: !_busy,
+                    keyboardType: TextInputType.url,
+                    onChanged: (_) => setState(() => _error = null),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  AppButton(
+                    key: const ValueKey('mobile_voting_source_save'),
+                    expand: true,
+                    onPressed: _busy ? null : _saveSource,
+                    child: Text(_busy ? 'Saving...' : 'Save source'),
+                  ),
+                  const SizedBox(height: AppSpacing.s),
+                  AppButton(
+                    expand: true,
+                    variant: AppButtonVariant.ghost,
+                    onPressed: _busy
+                        ? null
+                        : () => setState(() {
+                            _showEditor = false;
+                            _error = null;
+                          }),
+                    child: const Text('Cancel'),
+                  ),
+                ] else
+                  AppButton(
+                    key: const ValueKey('mobile_voting_add_source'),
+                    expand: true,
+                    variant: AppButtonVariant.secondary,
+                    onPressed: _busy
+                        ? null
+                        : () => setState(() => _showEditor = true),
+                    child: const Text('Add custom source'),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MobileSourceRow extends StatelessWidget {
+  const _MobileSourceRow({
+    required this.title,
+    required this.subtitle,
+    required this.selected,
+    this.onTap,
+    this.onDelete,
+    super.key,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool selected;
+  final VoidCallback? onTap;
+  final VoidCallback? onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: selected ? colors.background.raised : colors.surface.card,
+          borderRadius: BorderRadius.circular(AppRadii.medium),
+          border: Border.all(
+            color: selected ? colors.border.medium : colors.border.subtle,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.s),
+          child: Row(
+            children: [
+              if (selected)
+                AppIcon(
+                  AppIcons.checkCircle,
+                  size: 20,
+                  color: colors.icon.success,
+                )
+              else
+                Container(
+                  width: 20,
+                  height: 20,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    border: Border.all(color: colors.border.medium, width: 2),
+                  ),
+                ),
+              const SizedBox(width: AppSpacing.s),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: AppTypography.bodyMediumStrong.copyWith(
+                        color: colors.text.accent,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.xxs),
+                    Text(
+                      subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.bodySmall.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (onDelete != null)
+                Semantics(
+                  label: 'Delete $title',
+                  button: true,
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: onDelete,
+                    child: Padding(
+                      padding: const EdgeInsets.all(AppSpacing.s),
+                      child: AppIcon(
+                        AppIcons.trash,
+                        size: 18,
+                        color: colors.icon.regular,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TestRoundsRow extends StatelessWidget {
+  const _TestRoundsRow({
+    required this.enabled,
+    required this.busy,
+    required this.onTap,
+  });
+
+  final bool enabled;
+  final bool busy;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return GestureDetector(
+      key: const ValueKey('mobile_voting_show_test_rounds'),
+      behavior: HitTestBehavior.opaque,
+      onTap: busy ? null : onTap,
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Show test rounds',
+                  style: AppTypography.bodyMediumStrong.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+                Text(
+                  'Include authenticated rounds marked [TEST].',
+                  style: AppTypography.bodySmall.copyWith(
+                    color: colors.text.secondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: AppSpacing.s),
+          AnimatedContainer(
+            duration: const Duration(milliseconds: 140),
+            width: 44,
+            height: 24,
+            padding: const EdgeInsets.all(3),
+            decoration: BoxDecoration(
+              color: enabled
+                  ? colors.background.brandCrimsonStrong
+                  : colors.background.overlay,
+              borderRadius: BorderRadius.circular(AppRadii.full),
+            ),
+            child: AnimatedAlign(
+              duration: const Duration(milliseconds: 140),
+              alignment: enabled ? Alignment.centerRight : Alignment.centerLeft,
+              child: const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: Color(0xFFFFFFFF),
+                  shape: BoxShape.circle,
+                ),
+                child: SizedBox.square(dimension: 18),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LoadError extends StatelessWidget {
+  const _LoadError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 180,
+      child: Center(
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+          style: AppTypography.bodyMedium.copyWith(
+            color: context.colors.text.secondary,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _compactUrl(String source) {
+  final uri = Uri.tryParse(source);
+  if (uri == null || uri.host.isEmpty) return source;
+  return '${uri.host}${uri.path}';
+}

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -7,7 +7,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/formatting/duration_format.dart';
 import '../../core/formatting/hex_codec.dart';
-import '../../core/layout/app_form_factor.dart';
 import '../../features/voting/voting_error_messages.dart';
 import '../../features/voting/voting_flow_models.dart';
 import '../../features/voting/voting_formatters.dart';
@@ -29,11 +28,6 @@ import 'voting_state.dart';
 import 'voting_submission_guard_provider.dart';
 
 final _minimumVotingBundleWeightZatoshi = BigInt.from(12500000);
-
-@visibleForTesting
-bool automaticVotingShareTrackingEnabled() {
-  return kAppFormFactor == AppFormFactor.desktop;
-}
 
 /// The PCZT value-pool tag for Ironwood actions.
 ///
@@ -3746,7 +3740,7 @@ class VotingSubmissionSessionNotifier extends VotingSessionNotifier {
   void Function()? _closeShareTrackingKeepAlive;
 
   @override
-  bool get _ownsAutomaticShareTracking => automaticVotingShareTrackingEnabled();
+  bool get _ownsAutomaticShareTracking => true;
 
   @override
   bool _retainAutomaticShareTracking() {

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1690,8 +1690,15 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required BigInt submitAt,
   }) async {
     final acceptedServers = <String>[];
-    for (final serverUrl in candidateServers) {
-      if (acceptedServers.length >= targetCount) break;
+    final remainingServers = LinkedHashSet<String>.of(candidateServers);
+    while (remainingServers.isNotEmpty &&
+        acceptedServers.length < targetCount) {
+      // Re-evaluate health before every attempt so failures observed by
+      // concurrent submissions can move a degraded helper behind healthy
+      // alternatives. The tracker still returns every helper when all are
+      // degraded, preserving the liveness fallback.
+      final serverUrl = helperHealth.candidateServers(remainingServers).first;
+      remainingServers.remove(serverUrl);
       try {
         debugPrint(
           '[zcash] Voting: submitting share '

--- a/lib/src/providers/voting/voting_share_tracking_restorer_provider.dart
+++ b/lib/src/providers/voting/voting_share_tracking_restorer_provider.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../core/layout/app_form_factor.dart';
 import '../../features/voting/voting_flow_models.dart';
 import '../../rust/api/voting.dart' as rust_api;
 import '../../services/voting/resolved_voting_config_extensions.dart';
@@ -38,17 +37,14 @@ final votingPendingShareRestoreRetryDelayProvider = Provider((ref) {
 });
 
 class VotingShareTrackingRestorer {
-  VotingShareTrackingRestorer(this._ref, {required bool enabled})
-    : _enabled = enabled;
+  VotingShareTrackingRestorer(this._ref);
 
   final Ref _ref;
-  final bool _enabled;
   Future<void>? _restoreInFlight;
   Future<void> _pauseInFlight = Future.value();
   Timer? _retryTimer;
 
   Future<void> restore() {
-    if (!_enabled) return Future.value();
     final inFlight = _restoreInFlight;
     if (inFlight != null) return inFlight;
     late final Future<void> restore;
@@ -60,7 +56,6 @@ class VotingShareTrackingRestorer {
   }
 
   Future<void> pause() {
-    if (!_enabled) return Future.value();
     _cancelRetry();
     final pause = _ref
         .read(votingShareTrackingRegistryProvider)
@@ -71,7 +66,6 @@ class VotingShareTrackingRestorer {
   }
 
   Future<void> resume() async {
-    if (!_enabled) return;
     try {
       await _pauseInFlight;
     } finally {
@@ -188,9 +182,7 @@ class VotingShareTrackingRestorer {
 }
 
 final votingShareTrackingRestorerProvider = Provider((ref) {
-  const enabled = kAppFormFactor == AppFormFactor.desktop;
-  final restorer = VotingShareTrackingRestorer(ref, enabled: enabled);
-  if (!enabled) return restorer;
+  final restorer = VotingShareTrackingRestorer(ref);
   final registry = ref.read(votingShareTrackingRegistryProvider);
   void requestRestore() => unawaited(restorer.restore());
   registry.addRestoreRequestListener(requestRestore);

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -28,6 +28,7 @@ import '../src/features/about/screens/about_screen.dart';
 import '../src/features/accounts/screens/mobile/mobile_accounts_screen.dart';
 import '../src/features/accounts/widgets/mobile/mobile_accounts_sheet.dart';
 import '../src/features/activity/swap_activity_row_items_provider.dart';
+import '../src/features/activity/screens/mobile/mobile_activity_screen.dart';
 import '../src/features/home/screens/home_screen.dart';
 import '../src/features/home/screens/mobile/mobile_home_screen.dart';
 import '../src/features/migration/providers/ironwood_migration_announcement_provider.dart';
@@ -934,6 +935,38 @@ Widget buildMobileHomeDefaultUseCase(BuildContext context) {
     syncState: _homeSyncedState(
       orchardBalance: BigInt.from(14312000000),
       recentTransactions: [_homeTx(1), _homeTx(2)],
+    ),
+  );
+}
+
+Widget buildMobileActivityDefaultUseCase(BuildContext context) {
+  final accountUuid = _accountsDesignState.activeAccountUuid;
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(
+        _homeBootstrap(_accountsDesignState),
+      ),
+      accountProvider.overrideWith(
+        () => _PreviewAccountNotifier(_accountsDesignState),
+      ),
+      syncProvider.overrideWith(
+        () => _PreviewSyncNotifier(
+          accountUuid,
+          initialState: _homeSyncedState(
+            orchardBalance: BigInt.from(14312000000),
+            recentTransactions: [_homeTx(1), _homeTx(2)],
+          ),
+        ),
+      ),
+      privacyModeProvider.overrideWith(_PreviewPrivacyModeNotifier.new),
+      swapActivityRowItemsProvider.overrideWith((ref, accountUuid) async {
+        return const [];
+      }),
+    ],
+    child: _MobilePreviewFrame(
+      child: MobileActivityScreen(
+        historyLoader: (_) async => [_homeTx(1), _homeTx(2), _homeTx(3)],
+      ),
     ),
   );
 }

--- a/lib/widgetbook/voting_use_cases.dart
+++ b/lib/widgetbook/voting_use_cases.dart
@@ -4,14 +4,18 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../src/core/layout/mobile/app_mobile_sheet.dart';
+import '../src/features/voting/screens/mobile/mobile_keystone_voting_signing_screen.dart';
 import '../src/features/voting/screens/mobile/mobile_voting_screens.dart';
+import '../src/features/voting/screens/voting_status_screen.dart';
 import '../src/features/voting/widgets/mobile/mobile_voting_config_settings_sheet.dart';
 import '../src/providers/voting/voting_config_provider.dart';
 import '../src/providers/voting/voting_config_source_provider.dart';
 import '../src/providers/voting/voting_round_visibility_provider.dart';
 import '../src/providers/voting/voting_rounds_provider.dart';
 import '../src/providers/voting/voting_state.dart';
+import '../src/providers/voting/voting_submission_job_provider.dart';
 import '../src/rust/third_party/zcash_voting/config.dart';
+import '../src/services/qr_scanner.dart';
 import '../src/services/voting/voting_config_loader.dart';
 
 Widget buildMobileVotingPollsUseCase(BuildContext context) {
@@ -48,6 +52,64 @@ Widget buildMobileVotingConfigUseCase(BuildContext context) {
     ),
   );
 }
+
+Widget buildMobileVotingKeystoneRequestUseCase(BuildContext context) {
+  return ProviderScope(
+    child: MobileKeystoneVotingSigningScreen(
+      presentation: _previewKeystonePresentation,
+      scannerBuilder: _previewVotingScanner,
+      forceScannerActiveForTesting: true,
+    ),
+  );
+}
+
+Widget buildMobileVotingKeystoneScannerUseCase(BuildContext context) {
+  return ProviderScope(
+    child: MobileKeystoneVotingSigningScreen(
+      presentation: _previewKeystonePresentation,
+      scannerBuilder: _previewVotingScanner,
+      forceScannerActiveForTesting: true,
+      startInScannerForTesting: true,
+    ),
+  );
+}
+
+Widget _previewVotingScanner(
+  BuildContext context,
+  ValueChanged<ScanResult> onComplete,
+  ValueChanged<int> onProgress,
+  Object? resetToken,
+) {
+  return const ColoredBox(color: Color(0xFF111515));
+}
+
+final _previewKeystonePresentation = VotingKeystoneStatusPresentation(
+  bundleIndex: 0,
+  urParts: const [_previewVotingKeystoneUr],
+  batchMemos: const [
+    VotingKeystoneBatchMemo(
+      bundleIndex: 0,
+      bundleCount: 3,
+      displayMemo: 'Amount: 1.25 ZEC\nProposal: Community grants',
+    ),
+    VotingKeystoneBatchMemo(
+      bundleIndex: 1,
+      bundleCount: 3,
+      displayMemo: 'Amount: 0.75 ZEC\nProposal: Network priorities',
+    ),
+  ],
+  batchMessageCount: 2,
+  batchTotalCount: 3,
+  canSkipRemainingBundles: true,
+  onSigned: _previewSignedVotingResponse,
+  onSkipRemainingBundles: _previewNoop,
+);
+
+Future<void> _previewSignedVotingResponse(List<int> _) async {}
+void _previewNoop() {}
+
+const _previewVotingKeystoneUr =
+    'ur:zcash-sign-batch/1-1/lpadaxcsfwdmfwfwhdcxhdcxfwcxhdcxhdcxfwcx';
 
 class _PreviewVotingConfigNotifier extends VotingConfigNotifier {
   @override

--- a/lib/widgetbook/voting_use_cases.dart
+++ b/lib/widgetbook/voting_use_cases.dart
@@ -3,19 +3,49 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../src/core/layout/mobile/app_mobile_sheet.dart';
 import '../src/features/voting/screens/mobile/mobile_voting_screens.dart';
+import '../src/features/voting/widgets/mobile/mobile_voting_config_settings_sheet.dart';
 import '../src/providers/voting/voting_config_provider.dart';
+import '../src/providers/voting/voting_config_source_provider.dart';
+import '../src/providers/voting/voting_round_visibility_provider.dart';
 import '../src/providers/voting/voting_rounds_provider.dart';
 import '../src/providers/voting/voting_state.dart';
 import '../src/rust/third_party/zcash_voting/config.dart';
+import '../src/services/voting/voting_config_loader.dart';
 
 Widget buildMobileVotingPollsUseCase(BuildContext context) {
   return ProviderScope(
     overrides: [
       votingConfigProvider.overrideWith(_PreviewVotingConfigNotifier.new),
       votingRoundsProvider.overrideWith(_PreviewVotingRoundsNotifier.new),
+      votingConfigSourceProvider.overrideWith(
+        _PreviewVotingConfigSourceNotifier.new,
+      ),
+      showTestVotingRoundsProvider.overrideWith(
+        _PreviewShowTestVotingRoundsNotifier.new,
+      ),
     ],
     child: const MobileVotingPollsScreen(),
+  );
+}
+
+Widget buildMobileVotingConfigUseCase(BuildContext context) {
+  return ProviderScope(
+    overrides: [
+      votingConfigProvider.overrideWith(_PreviewVotingConfigNotifier.new),
+      votingRoundsProvider.overrideWith(_PreviewVotingRoundsNotifier.new),
+      votingConfigSourceProvider.overrideWith(
+        _PreviewVotingConfigSourceNotifier.new,
+      ),
+      showTestVotingRoundsProvider.overrideWith(
+        _PreviewShowTestVotingRoundsNotifier.new,
+      ),
+    ],
+    child: const MobileModalOverlay(
+      background: MobileVotingPollsScreen(),
+      child: MobileVotingConfigSettingsSheet(),
+    ),
   );
 }
 
@@ -34,6 +64,40 @@ class _PreviewVotingRoundsNotifier extends VotingRoundsNotifier {
   @override
   Future<void> reload() async {
     state = const AsyncData(_previewVotingRounds);
+  }
+}
+
+class _PreviewVotingConfigSourceNotifier extends VotingConfigSourceNotifier {
+  @override
+  Future<VotingConfigSourceState> build() async => _previewSourceState;
+
+  @override
+  Future<void> resetDefault() async {
+    state = const AsyncData(_previewSourceState);
+  }
+
+  @override
+  Future<void> setCustom(String sourceUrl) async {}
+
+  @override
+  Future<void> saveSource({
+    String? id,
+    required String name,
+    required String sourceUrl,
+  }) async {}
+
+  @override
+  Future<void> deleteSavedSource(String id) async {}
+}
+
+class _PreviewShowTestVotingRoundsNotifier
+    extends ShowTestVotingRoundsNotifier {
+  @override
+  Future<bool> build() async => false;
+
+  @override
+  Future<void> setShowTestRounds(bool show) async {
+    state = AsyncData(show);
   }
 }
 
@@ -58,6 +122,19 @@ const _previewVotingConfig = ResolvedVotingConfig(
   authenticatedRounds: [],
   skippedRoundIds: [],
   conditions: [],
+);
+
+const _previewSourceState = VotingConfigSourceState(
+  sourceUrl: kDefaultStaticVotingConfigSource,
+  isDefault: true,
+  savedSources: [
+    SavedVotingConfigSource(
+      id: 'community',
+      name: 'Community',
+      sourceUrl:
+          'https://vote.example.org/static.json?checksum=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    ),
+  ],
 );
 
 const _previewVotingRounds = [

--- a/lib/widgetbook/voting_use_cases.dart
+++ b/lib/widgetbook/voting_use_cases.dart
@@ -1,0 +1,87 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../src/features/voting/screens/mobile/mobile_voting_screens.dart';
+import '../src/providers/voting/voting_config_provider.dart';
+import '../src/providers/voting/voting_rounds_provider.dart';
+import '../src/providers/voting/voting_state.dart';
+import '../src/rust/third_party/zcash_voting/config.dart';
+
+Widget buildMobileVotingPollsUseCase(BuildContext context) {
+  return ProviderScope(
+    overrides: [
+      votingConfigProvider.overrideWith(_PreviewVotingConfigNotifier.new),
+      votingRoundsProvider.overrideWith(_PreviewVotingRoundsNotifier.new),
+    ],
+    child: const MobileVotingPollsScreen(),
+  );
+}
+
+class _PreviewVotingConfigNotifier extends VotingConfigNotifier {
+  @override
+  Future<ResolvedVotingConfig> build() async => _previewVotingConfig;
+
+  @override
+  Future<void> refresh() async {}
+}
+
+class _PreviewVotingRoundsNotifier extends VotingRoundsNotifier {
+  @override
+  Future<List<VotingRoundView>> build() async => _previewVotingRounds;
+
+  @override
+  Future<void> reload() async {
+    state = const AsyncData(_previewVotingRounds);
+  }
+}
+
+const _previewVotingConfig = ResolvedVotingConfig(
+  sourceFingerprint: 'preview-source',
+  trustedKeyFingerprint: 'preview-key',
+  dynamicConfigFingerprint: 'preview-config',
+  voteServers: [],
+  pirEndpoints: [],
+  pirLayout: PirLayout(
+    pirDepth: 19,
+    tier0Layers: 12,
+    tier1Layers: 7,
+    polyLen: 4096,
+  ),
+  supportedVersions: SupportedVersions(
+    pir: [],
+    voteProtocol: 'preview',
+    tally: 'preview',
+    voteServer: 'preview',
+  ),
+  authenticatedRounds: [],
+  skippedRoundIds: [],
+  conditions: [],
+);
+
+const _previewVotingRounds = [
+  VotingRoundView(
+    roundId: 'community-grants-2026',
+    title: 'Community Grants Renewal',
+    status: 'active',
+    rawJson: {
+      'description':
+          'Choose how the next community grants pool should support Zcash '
+          'builders and public goods.',
+      'end_time': '2026-09-02T12:00:00Z',
+    },
+  ),
+  VotingRoundView(
+    roundId: 'network-priorities-2026',
+    title: 'Network Priorities',
+    status: 'closed',
+    voted: true,
+    rawJson: {
+      'description':
+          'Rank the ecosystem priorities that should guide the next funding '
+          'cycle.',
+      'end_time': '2026-08-14T12:00:00Z',
+    },
+  ),
+];

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "addchain"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5665045de74fda906c0abfaec40cf2551f88c34dccea869f3fe950dde7209764"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,7 +52,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "zeroize",
 ]
 
@@ -62,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -151,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -177,16 +188,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arti-client"
@@ -211,7 +216,7 @@ dependencies = [
  "rand 0.9.5",
  "safelog",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -257,7 +262,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -268,7 +273,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -280,7 +285,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -291,9 +296,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -303,13 +308,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -378,9 +383,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -388,14 +393,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -489,16 +495,21 @@ dependencies = [
  "bitvec",
  "blake2s_simd",
  "byteorder",
- "crossbeam-channel",
- "ff",
- "group",
- "lazy_static",
- "log",
- "num_cpus",
+ "ff 0.13.1",
+ "group 0.13.0",
  "pairing",
  "rand_core 0.6.4",
- "rayon",
  "subtle",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "serde",
+ "unty",
 ]
 
 [[package]]
@@ -509,7 +520,7 @@ checksum = "568b6890865156d9043af490d4c4081c385dd68ea10acd6ca15733d511e6b51c"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
- "rand 0.8.6",
+ "rand 0.8.7",
  "sha2 0.10.9",
  "unicode-normalization",
  "zeroize",
@@ -548,15 +559,21 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -566,22 +583,20 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+checksum = "3560a7b1951efe814fcd721938313adc56753ca39f4b23847d7e9a2402f5dbff"
 dependencies = [
- "arrayref",
  "arrayvec",
  "constant_time_eq",
 ]
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
+checksum = "2380c0236432f7b22a70229df30f218f5293870c056beb76f5ca068e3273a366"
 dependencies = [
- "arrayref",
  "arrayvec",
  "constant_time_eq",
 ]
@@ -594,7 +609,7 @@ checksum = "e0b121a9fe0df916e362fb3271088d071159cdf11db0e4182d02152850756eff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -621,8 +636,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
- "ff",
- "group",
+ "ff 0.13.1",
+ "group 0.13.0",
  "pairing",
  "rand_core 0.6.4",
  "subtle",
@@ -634,7 +649,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dc0086e469182132244e9b8d313a0742e1132da43a08c24b9dd3c18e0faf3a"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -649,13 +664,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -678,9 +693,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -690,9 +705,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "caret"
@@ -717,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -741,7 +756,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -751,7 +777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -759,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -809,18 +835,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -858,14 +884,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
@@ -876,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -958,6 +984,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,18 +1067,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1060,18 +1095,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1127,7 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1144,7 +1179,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1168,12 +1203,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1192,16 +1227,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1217,13 +1251,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1256,19 +1290,50 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "delegate-attr"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
+checksum = "a84c9a9c129b98e707ac9a31e204c10c064dd9f949b7da362310ff1a8b137d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1323,13 +1388,13 @@ checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck 0.5.0",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "sha3",
  "strum",
- "syn 2.0.117",
+ "syn 2.0.119",
  "void",
 ]
 
@@ -1341,7 +1406,7 @@ checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1394,7 +1459,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -1453,13 +1518,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1506,7 +1571,7 @@ checksum = "5ac0893f103ae7bf50181323d748d505f27b6255777c28b502030bdaf8749f4c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1563,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "elliptic-curve"
@@ -1576,9 +1641,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
+ "group 0.13.0",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1608,7 +1673,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1620,7 +1685,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1692,9 +1757,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -1705,6 +1770,33 @@ dependencies = [
  "bitvec",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "bitvec",
+ "ff_derive",
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241afe8c15ffa21933eaefe8a563af36fd9fc98a3e8a044e8f7db52eb1fae3d8"
+dependencies = [
+ "addchain",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1738,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -1821,7 +1913,7 @@ dependencies = [
  "md-5",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1881,7 +1973,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serdect",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "visibility",
  "zeroize",
  "zeroize_derive",
@@ -1911,7 +2003,7 @@ dependencies = [
  "libc",
  "pwd-grp",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
 ]
 
@@ -1939,9 +2031,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1954,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1964,15 +2056,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1981,19 +2073,19 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2009,21 +2101,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2076,27 +2168,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2127,17 +2217,29 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "memuse",
  "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.17"
+name = "group"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "memuse",
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2171,13 +2273,13 @@ checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
 dependencies = [
  "arrayvec",
  "bitvec",
- "ff",
- "group",
+ "ff 0.13.1",
+ "group 0.13.0",
  "halo2_poseidon",
  "halo2_proofs",
  "lazy_static",
  "pasta_curves",
- "rand 0.8.6",
+ "rand 0.8.7",
  "sinsemilla",
  "subtle",
  "uint",
@@ -2196,20 +2298,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa3da60b81f02f9b33ebc6252d766f843291fb4d2247a07ae73d20b791fc56f"
 dependencies = [
  "bitvec",
- "ff",
- "group",
+ "ff 0.13.1",
+ "group 0.13.0",
  "pasta_curves",
 ]
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05713f117155643ce10975e0bee44a274bcda2f4bb5ef29a999ad67c1fa8d4d3"
+checksum = "f5aca1c66059a919227dec97444a11a4350d2f9c820ca48690988f0aa0e81cbf"
 dependencies = [
  "blake2b_simd",
- "ff",
- "group",
+ "ff 0.13.1",
+ "group 0.13.0",
  "halo2_legacy_pdqsort",
  "indexmap 1.9.3",
  "maybe-rayon",
@@ -2356,9 +2458,9 @@ checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2366,9 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2376,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2401,9 +2503,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "humantime-serde"
@@ -2426,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2507,7 +2609,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2521,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2535,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2548,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2562,16 +2664,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2582,15 +2685,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2600,12 +2703,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2636,12 +2733,11 @@ dependencies = [
 
 [[package]]
 name = "imt-tree"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e76a0e9767d86505105a2bf6756ff73ab13c9fa0342de743dff470c39b6515fd"
+checksum = "78e431fb9b7ffc982771ad153e735ff186bfd92d4d20ca371a96bbe8a2e73082"
 dependencies = [
  "anyhow",
- "ff",
  "hex",
  "rayon",
  "voting-crypto-deps",
@@ -2681,20 +2777,20 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -2745,30 +2841,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
+name = "jiff"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
- "getrandom 0.3.4",
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2780,8 +2937,8 @@ checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
 dependencies = [
  "bitvec",
  "bls12_381",
- "ff",
- "group",
+ "ff 0.13.1",
+ "group 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2792,7 +2949,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2819,9 +2976,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -2829,11 +2986,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -2847,16 +3004,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libflate"
@@ -2884,18 +3035,18 @@ dependencies = [
 
 [[package]]
 name = "liblzma"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45aec2360b3933207e27908049d8e4df4e476b58180afb1e56b2a4fb72efe4ba"
+checksum = "2fe0a34ca854fd4f20c07f696fc8675aec78f87d88d29f5e10257a7490a1b2e1"
 dependencies = [
  "liblzma-sys",
 ]
 
 [[package]]
 name = "liblzma-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a046c7f353ba30f810545151e04f63545833803f5b86ee3ddf1517247fe560a5"
+checksum = "a0dad045e4b1b7b170be4b60b54b780cafb4490165461bac7d1cf7b703f61d5f"
 dependencies = [
  "cc",
  "libc",
@@ -2910,9 +3061,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -2942,9 +3093,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -2963,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchers"
@@ -3004,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -3079,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -3094,6 +3245,12 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nanorand"
@@ -3141,7 +3298,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "inotify",
  "kqueue",
  "libc",
@@ -3158,7 +3315,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3181,9 +3338,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3200,7 +3357,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -3213,20 +3370,19 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3270,7 +3426,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3279,7 +3435,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3336,18 +3492,18 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793e2e8c2323f35f082d1b3467ca8f576d646f9c93aef8c5168809d099245af8"
+checksum = "a3cb2b35534bba3c63fbf640dc6cd9dfd1ece2fae886cdab4ab1f1e380dd6ca1"
 dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
  "corez",
- "ff",
+ "ff 0.13.1",
  "fpe",
  "getset",
- "group",
+ "group 0.13.0",
  "halo2_gadgets",
  "halo2_poseidon",
  "halo2_proofs",
@@ -3357,7 +3513,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "pasta_curves",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_core 0.6.4",
  "reddsa",
  "serde",
@@ -3443,7 +3599,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group",
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -3493,10 +3649,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3437083215c505e867eea5478371feba43d7689d6d15ec0a209eb46fb0d4cda6"
 dependencies = [
  "blake2b_simd",
- "ff",
- "group",
+ "ff 0.13.1",
+ "group 0.13.0",
  "lazy_static",
- "rand 0.8.6",
+ "rand 0.8.7",
  "static_assertions",
  "subtle",
 ]
@@ -3520,14 +3676,13 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aead0b7ecb4363d8560ac76687c02ef896292fb836c1c68f3a4d99443f32e1a0"
+checksum = "a5592f4f3eba7f9344cc423f45b6e65911e0630c9b89968d5a20792aadd5a0eb"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
- "document-features",
- "ff",
+ "ff 0.13.1",
  "getset",
  "jubjub",
  "nonempty",
@@ -3621,7 +3776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3644,7 +3799,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3657,7 +3812,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3695,7 +3850,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3706,12 +3861,11 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pir-client"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bb3a0dc7dbe1d1f6ed5e9b14324f94cd79911a993d41a62acd8c2b4c5cc25d"
+checksum = "0ba7cc9c2ff36b0a9ec4d44b142424f74c35360b7f5681960b8487356a589855"
 dependencies = [
  "anyhow",
- "ff",
  "futures",
  "hex",
  "imt-tree",
@@ -3725,12 +3879,11 @@ dependencies = [
 
 [[package]]
 name = "pir-types"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a2da79e15134d11243b0899a62ba70641c178244bb0a780dc81bee83a9a634"
+checksum = "a84cb73ad0b223b14509e72633e255f275c103d657ef1b6f9a288ea07b06a886"
 dependencies = [
  "anyhow",
- "ff",
  "imt-tree",
  "serde",
  "voting-crypto-deps",
@@ -3759,9 +3912,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plotters"
@@ -3797,7 +3950,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3809,16 +3962,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postage"
@@ -3850,9 +4012,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -3889,7 +4051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3918,36 +4080,14 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3964,12 +4104,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -3983,7 +4123,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "log",
- "multimap",
+ "multimap 0.8.3",
  "petgraph 0.6.5",
  "prettyplease 0.1.25",
  "prost 0.11.9",
@@ -3996,20 +4136,20 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
  "log",
- "multimap",
+ "multimap 0.10.1",
  "petgraph 0.8.3",
  "prettyplease 0.2.37",
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -4028,15 +4168,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4050,11 +4190,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -4066,14 +4206,14 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -4098,9 +4238,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4115,6 +4255,17 @@ checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4156,13 +4307,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -4216,9 +4383,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+checksum = "de6c3b63e007e90ce536ec2ae4690826136a20ec8dbbbb400daef1bb999d2e36"
 dependencies = [
  "libc",
 ]
@@ -4232,13 +4399,13 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "frost-rerandomized",
- "group",
+ "group 0.13.0",
  "hex",
  "jubjub",
  "pasta_curves",
  "rand_core 0.6.4",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zeroize",
 ]
 
@@ -4260,7 +4427,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4271,34 +4438,34 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4308,9 +4475,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4319,9 +4486,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "retry-error"
@@ -4404,7 +4571,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -4416,9 +4583,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.42.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -4434,9 +4601,8 @@ dependencies = [
  "aes-gcm",
  "base64",
  "bip0039",
- "bls12_381",
  "bytes",
- "ff",
+ "ff 0.14.0",
  "flutter_rust_bridge",
  "futures",
  "hex",
@@ -4445,13 +4611,12 @@ dependencies = [
  "hyper",
  "hyper-util",
  "incrementalmerkletree",
- "jubjub",
  "log",
  "minicbor",
  "nonempty",
  "pbkdf2",
- "prost 0.14.3",
- "rand 0.8.6",
+ "prost 0.14.4",
+ "rand 0.8.7",
  "rand_core 0.6.4",
  "redb",
  "rusqlite",
@@ -4472,8 +4637,11 @@ dependencies = [
  "url",
  "uuid",
  "vote-commitment-tree",
+ "voting-crypto-deps",
+ "zakura-bls12-381",
  "zakura-client-backend",
  "zakura-client-sqlite",
+ "zakura-jubjub",
  "zakura-keys",
  "zakura-orchard",
  "zakura-pasta-curves",
@@ -4493,9 +4661,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc_version"
@@ -4521,7 +4689,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4534,7 +4702,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -4543,9 +4711,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4559,18 +4727,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4580,9 +4748,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "safelog"
@@ -4594,7 +4762,7 @@ dependencies = [
  "educe",
  "either",
  "fluid-let",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4629,16 +4797,16 @@ dependencies = [
  "bls12_381",
  "corez",
  "document-features",
- "ff",
+ "ff 0.13.1",
  "fpe",
  "getset",
- "group",
+ "group 0.13.0",
  "hex",
  "incrementalmerkletree",
  "jubjub",
  "lazy_static",
  "memuse",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_core 0.6.4",
  "redjubjub",
  "subtle",
@@ -4662,9 +4830,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4749,7 +4917,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4774,9 +4942,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4794,22 +4962,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4824,9 +4992,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4855,17 +5023,19 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -4874,14 +5044,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4896,12 +5066,12 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4912,7 +5082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4923,15 +5093,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.11.0-pre.9",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -4948,11 +5118,11 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc96e9b6b1c307749019e7e2cf9dd29881b1928ce6866e3702a02a4800aa345"
+checksum = "8147447aed7be4736e271825b8c3a4432efb7182e71363169b572371ddef452e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "either",
  "incrementalmerkletree",
  "tracing",
@@ -4997,9 +5167,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "sinsemilla"
@@ -5007,7 +5177,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d268ae0ea06faafe1662e9967cd4f9022014f5eeb798e0c302c876df8b7af9c"
 dependencies = [
- "group",
+ "group 0.13.0",
  "pasta_curves",
  "subtle",
 ]
@@ -5043,21 +5213,21 @@ dependencies = [
  "paste",
  "serde",
  "slotmap",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "void",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5065,9 +5235,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -5166,7 +5336,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5188,9 +5358,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5211,7 +5392,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5241,7 +5422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -5258,11 +5439,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -5282,7 +5463,7 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5293,25 +5474,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -5357,9 +5538,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -5378,9 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5393,9 +5574,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5409,13 +5590,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5430,9 +5611,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5441,14 +5622,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -5523,23 +5705,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5550,9 +5732,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -5594,7 +5776,7 @@ dependencies = [
  "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5604,7 +5786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -5616,10 +5798,10 @@ checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease 0.2.37",
  "proc-macro2",
- "prost-build 0.14.3",
- "prost-types 0.14.3",
+ "prost-build 0.14.4",
+ "prost-types 0.14.4",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -5636,7 +5818,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "pin-project",
  "postage",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "void",
 ]
 
@@ -5656,7 +5838,7 @@ dependencies = [
  "serde",
  "slab",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5671,7 +5853,7 @@ dependencies = [
  "educe",
  "getrandom 0.3.4",
  "safelog",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-error",
  "tor-llcrypto",
  "zeroize",
@@ -5684,7 +5866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79ba1b43f22fab2daee3e0c902f1455b3aed8e086b2d83d8c60b36523b173d25"
 dependencies = [
  "amplify",
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "caret",
  "derive-deftly",
@@ -5694,7 +5876,7 @@ dependencies = [
  "paste",
  "rand 0.9.5",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-basic-utils",
  "tor-bytes",
  "tor-cert",
@@ -5718,7 +5900,7 @@ dependencies = [
  "derive_builder_fork_arti",
  "derive_more",
  "digest 0.10.7",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-bytes",
  "tor-checkable",
  "tor-llcrypto",
@@ -5741,7 +5923,7 @@ dependencies = [
  "rand 0.9.5",
  "safelog",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-cell",
@@ -5768,7 +5950,7 @@ checksum = "7c9839e9bb302f17447c350e290bb107084aca86c640882a91522f2059f6a686"
 dependencies = [
  "humantime",
  "signature",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-llcrypto",
 ]
 
@@ -5797,7 +5979,7 @@ dependencies = [
  "retry-error",
  "safelog",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-cell",
@@ -5845,7 +6027,7 @@ dependencies = [
  "serde-value",
  "serde_ignored",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "toml 0.9.12+spec-1.1.0",
  "tor-basic-utils",
  "tor-error",
@@ -5863,7 +6045,7 @@ dependencies = [
  "directories",
  "serde",
  "shellexpand",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-error",
  "tor-general-addr",
 ]
@@ -5876,7 +6058,7 @@ checksum = "c1690438c1fc778fc7c89c132e529365b1430d6afe03aeecbc2508324807bf0b"
 dependencies = [
  "digest 0.10.7",
  "hex",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-llcrypto",
 ]
 
@@ -5896,7 +6078,7 @@ dependencies = [
  "httpdate",
  "itertools 0.14.0",
  "memchr",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-circmgr",
  "tor-error",
  "tor-hscrypto",
@@ -5962,7 +6144,7 @@ dependencies = [
  "signature",
  "static_assertions",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -5996,7 +6178,7 @@ dependencies = [
  "retry-error",
  "static_assertions",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "void",
 ]
@@ -6008,7 +6190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42cb5b5aec0584db2fba4a88c4e08fb09535ef61e4ef5674315a89e69ec31a2"
 dependencies = [
  "derive_more",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "void",
 ]
 
@@ -6037,7 +6219,7 @@ dependencies = [
  "safelog",
  "serde",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-config",
@@ -6075,7 +6257,7 @@ dependencies = [
  "safelog",
  "slotmap-careful",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-bytes",
@@ -6118,7 +6300,7 @@ dependencies = [
  "serde",
  "signature",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-basic-utils",
  "tor-bytes",
  "tor-error",
@@ -6143,7 +6325,7 @@ dependencies = [
  "rsa",
  "signature",
  "ssh-key",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-bytes",
  "tor-cert",
  "tor-checkable",
@@ -6175,7 +6357,7 @@ dependencies = [
  "serde",
  "signature",
  "ssh-key",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-basic-utils",
  "tor-bytes",
  "tor-config",
@@ -6209,7 +6391,7 @@ dependencies = [
  "serde",
  "serde_with",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-basic-utils",
  "tor-bytes",
  "tor-config",
@@ -6250,7 +6432,7 @@ dependencies = [
  "sha3",
  "signature",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-error",
  "tor-memquota",
  "visibility",
@@ -6266,7 +6448,7 @@ checksum = "845d65304be6a614198027c4b2d1b35aaf073335c26df619d17e5f4027f2657f"
 dependencies = [
  "futures",
  "humantime",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-error",
  "tor-rtcompat",
  "tracing",
@@ -6292,7 +6474,7 @@ dependencies = [
  "slotmap-careful",
  "static_assertions",
  "sysinfo",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-config",
@@ -6310,7 +6492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "638b4e6507e3786488859d3c463fa73addbad4f788806c6972603727e527672e"
 dependencies = [
  "async-trait",
- "bitflags",
+ "bitflags 2.13.1",
  "derive_more",
  "digest 0.10.7",
  "futures",
@@ -6321,7 +6503,7 @@ dependencies = [
  "rand 0.9.5",
  "serde",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tor-basic-utils",
  "tor-error",
@@ -6343,7 +6525,7 @@ checksum = "1dbc32d89e7ea2e2799168d0c453061647a727e39fc66f52e1bcb4c38c8dc433"
 dependencies = [
  "amplify",
  "base64ct",
- "bitflags",
+ "bitflags 2.13.1",
  "cipher",
  "derive-deftly",
  "derive_builder_fork_arti",
@@ -6363,7 +6545,7 @@ dependencies = [
  "smallvec",
  "strum",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tinystr",
  "tor-basic-utils",
@@ -6400,7 +6582,7 @@ dependencies = [
  "sanitize-filename",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -6447,7 +6629,7 @@ dependencies = [
  "static_assertions",
  "subtle",
  "sync_wrapper",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tor-async-utils",
@@ -6483,7 +6665,7 @@ dependencies = [
  "caret",
  "paste",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-bytes",
 ]
 
@@ -6522,7 +6704,7 @@ dependencies = [
  "pin-project",
  "rustls-pki-types",
  "rustls-webpki",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tor-error",
@@ -6551,7 +6733,7 @@ dependencies = [
  "priority-queue",
  "slotmap-careful",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-error",
  "tor-general-addr",
  "tor-rtcompat",
@@ -6572,7 +6754,7 @@ dependencies = [
  "educe",
  "safelog",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-bytes",
  "tor-error",
 ]
@@ -6586,7 +6768,7 @@ dependencies = [
  "derive-deftly",
  "derive_more",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tor-memquota",
 ]
 
@@ -6640,7 +6822,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6700,18 +6882,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "trait-variant"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+checksum = "b19a4867a870f6edc4c283f2b455804b1879c0baf0e642f26b03ed8ee262d9d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6722,10 +6904,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-index-collections"
-version = "3.2.3"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d844b11f547a6fb9dee7ed073d9860174917a072aabe05df6ee60dbe79e7afa"
+checksum = "898160f1dfd383b4e92e17f0512a7d62f3c51c44937b23b6ffc3a1614a8eaccd"
 dependencies = [
+ "bincode",
  "serde",
 ]
 
@@ -6800,6 +6983,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "ur"
 version = "0.3.0"
 source = "git+https://github.com/KeystoneHQ/ur-rs?tag=0.3.3#81b8bb3b6b3a823128489c81ffee5bb4001ba2ae"
@@ -6851,11 +7040,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -6869,7 +7058,7 @@ checksum = "208d4b69c6a9b7b0c7d856133009a514e10236cdc698ad0b6b87f2e3c4e6d9cb"
 dependencies = [
  "fastrand",
  "getrandom 0.2.17",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_chacha 0.3.1",
  "serde_json",
  "sha2 0.10.9",
@@ -6885,7 +7074,7 @@ dependencies = [
  "cc",
  "fastrand",
  "log",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_chacha 0.3.1",
  "serde",
  "serde_json",
@@ -6919,7 +7108,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6930,12 +7119,11 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b341759f23454409a432b51d127e62df1ea0c5c2e2e14420d40fd506be00462b"
+checksum = "d7f5f6190045301a6f713015b698bc43881786ab3f30973429630ea71aa04d17"
 dependencies = [
  "anyhow",
- "ff",
  "imt-tree",
  "incrementalmerkletree",
  "lazy_static",
@@ -6946,42 +7134,39 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211c6a63a87e0063b6af575657fef1d7e2f1ba520591c389bd0bb4d78980ffd3"
+checksum = "613504fa62ac7832b9d8b17a3da936b35fdf7403a5286576a377f0728918958e"
 dependencies = [
  "base64",
- "ff",
  "hex",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "vote-commitment-tree",
  "voting-crypto-deps",
 ]
 
 [[package]]
 name = "voting-circuits"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5eaba983e549c7d466bda1a96cccc7c56c1e4c53aee18b8f5d545d6972536c"
+checksum = "253e5b264156444bc8d314aa4a96ff04c5952bb48a11d4df22264c87935d8c77"
 dependencies = [
  "blake2b_simd",
- "ff",
- "group",
  "incrementalmerkletree",
  "itertools 0.14.0",
  "lazy_static",
- "rand 0.8.6",
  "voting-crypto-deps",
 ]
 
 [[package]]
 name = "voting-crypto-deps"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4a58c1a77abf2198fd5a377da53b8ac39233bd62d66d655f6830875234fc30"
+checksum = "f34b3dc14dfd6f1ea3bff693b7efcb0f6689bd94d86feb85236852743ffa6e1e"
 dependencies = [
+ "rand 0.10.2",
  "zakura-halo2-gadgets",
  "zakura-halo2-poseidon",
  "zakura-halo2-proofs",
@@ -7017,20 +7202,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -7044,9 +7220,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7058,9 +7234,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7068,9 +7244,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7078,58 +7254,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -7140,9 +7282,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7150,9 +7292,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7171,9 +7313,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]
@@ -7216,7 +7358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -7228,7 +7370,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7240,8 +7382,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -7250,7 +7405,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -7263,7 +7418,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7274,7 +7429,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7295,7 +7450,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -7309,12 +7464,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7502,20 +7675,11 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -7525,89 +7689,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease 0.2.37",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease 0.2.37",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -7638,9 +7723,9 @@ checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7655,22 +7740,56 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
-name = "zakura-client-backend"
-version = "0.1.0-rc1"
+name = "zakura-bellman"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e446cc7bbd3ca1d859b6df7e46dcd9845018119551940debc385330220faf4ee"
+checksum = "9ab49244f0020cb3e51d66070204f126a5f938bf1f960641e89658c597443522"
+dependencies = [
+ "bitvec",
+ "blake2s_simd",
+ "byteorder",
+ "crossbeam-channel",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "rayon",
+ "subtle",
+ "zakura-pairing",
+]
+
+[[package]]
+name = "zakura-bls12-381"
+version = "1.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56ae6036dbd383c68dd407a69f7325c29f429d30539092fe8f0dced4cb05b9b"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zakura-pairing",
+]
+
+[[package]]
+name = "zakura-client-backend"
+version = "0.1.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a042cb0d6f6a22d976ed5dda9de3c9c51abe868324bc186ba5064be8f22756c"
 dependencies = [
  "arti-client",
  "async-trait",
  "base64",
  "bech32",
  "bip32",
- "bls12_381",
  "bs58",
  "byteorder",
  "document-features",
@@ -7679,7 +7798,7 @@ dependencies = [
  "fs-mistrust",
  "futures-util",
  "getset",
- "group",
+ "group 0.14.0",
  "hex",
  "http-body-util",
  "hyper",
@@ -7689,9 +7808,9 @@ dependencies = [
  "nonempty",
  "percent-encoding",
  "postcard",
- "prost 0.14.3",
- "rand 0.8.6",
- "rand_core 0.6.4",
+ "prost 0.14.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rayon",
  "rust_decimal",
  "secp256k1",
@@ -7711,7 +7830,8 @@ dependencies = [
  "tracing",
  "trait-variant",
  "webpki-roots",
- "which 8.0.2",
+ "which 8.0.5",
+ "zakura-bls12-381",
  "zakura-keys",
  "zakura-orchard",
  "zakura-pasta-curves",
@@ -7730,25 +7850,24 @@ dependencies = [
 
 [[package]]
 name = "zakura-client-sqlite"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935fb2970f0612b5f8f390fe07b4357335d82c8a07a85cfed208d83aec04048e"
+checksum = "a47a7238ca986c3caec99ffe409fa49226cfe9fb5a0583ae2a5bb32466a12624"
 dependencies = [
  "bip32",
- "bitflags",
+ "bitflags 2.13.1",
  "bs58",
  "byteorder",
  "document-features",
- "group",
+ "group 0.14.0",
  "hex",
  "incrementalmerkletree",
- "jubjub",
  "maybe-rayon",
  "nonempty",
- "prost 0.14.3",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "rand_distr",
+ "prost 0.14.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "rand_distr 0.6.0",
  "regex",
  "rusqlite",
  "schemerz",
@@ -7763,6 +7882,7 @@ dependencies = [
  "tracing",
  "uuid",
  "zakura-client-backend",
+ "zakura-jubjub",
  "zakura-keys",
  "zakura-orchard",
  "zakura-pczt",
@@ -7778,16 +7898,16 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-gadgets"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea4f65916f14036420da6f487db68eca9f6cd69ff187e2ba6ba5fe467dba1b6"
+checksum = "df3af75089fb0e2056c34fe7d56df8fb452c69f0deca8de9daa7ef41fbf1fa16"
 dependencies = [
  "arrayvec",
  "bitvec",
- "ff",
- "group",
+ "ff 0.14.0",
+ "group 0.14.0",
  "lazy_static",
- "rand 0.8.6",
+ "rand 0.10.2",
  "subtle",
  "uint",
  "zakura-halo2-poseidon",
@@ -7798,60 +7918,75 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-legacy-pdqsort"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7dc9de3579d54ea35e9d1982ce47e96901e7d7f2f3c2040dcd591952d6eeaa3"
+checksum = "7f59499e588bd68c58298f1a11e3d2e7fa47d9c746d5dcf3776e5a687ff39667"
 
 [[package]]
 name = "zakura-halo2-poseidon"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb66e808e2f7b83333051be6691c679d3a32eb43fbea58be59595f5f36fa4e1"
+checksum = "3bee31c45dcc963002d73119291d54feb02628b1dff95c322bad0eba16216ccf"
 dependencies = [
  "bitvec",
- "ff",
- "group",
+ "ff 0.14.0",
+ "group 0.14.0",
  "zakura-pasta-curves",
 ]
 
 [[package]]
 name = "zakura-halo2-proofs"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b0e307f5bc2c888bd82682ca468672b3896713ac8553f8107a3d1664326c90"
+checksum = "520b25c1fb619ce3b05f84e6c2d5b1c8983696d6f57472e8c959fc63cd398904"
 dependencies = [
  "blake2b_simd",
- "ff",
- "group",
+ "ff 0.14.0",
+ "group 0.14.0",
  "indexmap 1.9.3",
  "maybe-rayon",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "tracing",
  "zakura-halo2-legacy-pdqsort",
  "zakura-pasta-curves",
 ]
 
 [[package]]
-name = "zakura-keys"
-version = "1.0.0-rc.1"
+name = "zakura-jubjub"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f2b37a4ebbdb0ed5020711a9bdefc08d42c885bb1549aabe32036eb0793166"
+checksum = "5b5bbe1f733ae656ba1a03f5d2701419f2543f85586d8db1f20ac2553ac566c4"
+dependencies = [
+ "bitvec",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zakura-bls12-381",
+]
+
+[[package]]
+name = "zakura-keys"
+version = "1.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37cad4f2abd1ab654cc648a0dde622af3f05a964e310f13140953c7bfc1a7a0f"
 dependencies = [
  "bech32",
  "bip32",
  "blake2b_simd",
- "bls12_381",
  "bs58",
  "byteorder",
  "corez",
  "document-features",
- "group",
+ "group 0.14.0",
  "memuse",
  "nonempty",
  "rand_core 0.6.4",
  "secrecy",
  "subtle",
  "tracing",
+ "zakura-bls12-381",
  "zakura-orchard",
  "zakura-sapling-crypto",
  "zcash_address",
@@ -7863,24 +7998,25 @@ dependencies = [
 
 [[package]]
 name = "zakura-orchard"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc54f01c582fc174c74bc05bbd7b25718a98c360b7e62541969e7ffecf8215b"
+checksum = "abbb21f5c148e06e370d91da0b1aadc07680968d46589eaf3012e7577c893eb4"
 dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
  "corez",
- "ff",
+ "ff 0.14.0",
  "fpe",
  "getset",
- "group",
+ "group 0.14.0",
  "hex",
  "incrementalmerkletree",
  "lazy_static",
  "memuse",
  "nonempty",
- "rand 0.8.6",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "serde",
  "subtle",
@@ -7898,39 +8034,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "zakura-pasta-curves"
-version = "1.0.0-rc.1"
+name = "zakura-pairing"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb522ddc5c66ec58632313e31f8863d0c221c76e65d6ab6a32a3e3295cc21b3"
+checksum = "fefa17420b54d7a08bbb4afcb35cde18fa9ddcc3897628bad80520ea084ec8fd"
+dependencies = [
+ "group 0.14.0",
+]
+
+[[package]]
+name = "zakura-pasta-curves"
+version = "1.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ae7848bc9fafb0ec81847251ce3d36a25d605377222c453de753323484ab9a"
 dependencies = [
  "blake2b_simd",
  "cc",
- "ff",
- "group",
+ "ff 0.14.0",
+ "group 0.14.0",
  "lazy_static",
- "rand 0.8.6",
+ "rand 0.10.2",
  "static_assertions",
  "subtle",
 ]
 
 [[package]]
 name = "zakura-pczt"
-version = "0.1.0-rc0"
+version = "0.1.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f3ca7e1b5785b709ba0c8a25f1efa4bf98a0b115be16042faa998ac30f016e"
+checksum = "226558d15d544c890bdb0cfaa935402b6697d1edf78ec0b541c4fd7e8033ce52"
 dependencies = [
  "blake2b_simd",
- "bls12_381",
  "document-features",
- "ff",
+ "ff 0.14.0",
  "getset",
- "jubjub",
  "nonempty",
  "postcard",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "secp256k1",
  "serde",
  "serde_with",
+ "zakura-bls12-381",
+ "zakura-jubjub",
  "zakura-orchard",
  "zakura-pasta-curves",
  "zakura-primitives",
@@ -7944,9 +8090,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-primitives"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155bc30ce20ea60b953acd39b437df24c8a31a6d656df57f628d639443b7f34a"
+checksum = "87ffcd0f3a2c4d8ed0aa3087378c48b8e362bd693008c3cc88502e7bbf67f8c2"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7954,15 +8100,15 @@ dependencies = [
  "crypto-common 0.2.0-rc.1",
  "document-features",
  "equihash",
- "ff",
+ "ff 0.14.0",
  "hex",
  "incrementalmerkletree",
- "jubjub",
  "memuse",
  "nonempty",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "secp256k1",
  "sha2 0.10.9",
+ "zakura-jubjub",
  "zakura-orchard",
  "zakura-redjubjub",
  "zakura-sapling-crypto",
@@ -7975,21 +8121,22 @@ dependencies = [
 
 [[package]]
 name = "zakura-proofs"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15debcada7148cf5e91a2b41bf94a43499c8ec2c45e448d97e8d39310e5ae93"
+checksum = "1c62244ceceb01c085e1ec8f548490dfb33e1d2d23dfe2277327b477127a85c7"
 dependencies = [
- "bellman",
  "blake2b_simd",
- "bls12_381",
  "document-features",
- "group",
+ "group 0.14.0",
  "home",
- "jubjub",
  "known-folders",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "tracing",
  "xdg",
+ "zakura-bellman",
+ "zakura-bls12-381",
+ "zakura-jubjub",
  "zakura-primitives",
  "zakura-redjubjub",
  "zakura-sapling-crypto",
@@ -7997,30 +8144,30 @@ dependencies = [
 
 [[package]]
 name = "zakura-reddsa"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f689e9394925e16e5c896fcdee8b7375c0bdab9ebfee4d41728ab0df20b7"
+checksum = "e8351c15be16d8716d0ccc56f3e8a54c2585ecd03b7bfdf87d932a424606e8a2"
 dependencies = [
  "blake2b_simd",
  "byteorder",
  "frost-rerandomized",
- "group",
+ "group 0.14.0",
  "hex",
- "jubjub",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
+ "zakura-jubjub",
  "zakura-pasta-curves",
  "zeroize",
 ]
 
 [[package]]
 name = "zakura-redjubjub"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c898072d6bf762423dd05f0193a486dae6684602a673e59847aa2487cfef81"
+checksum = "e1ac2ad992df5bb713921d18ffa77c14b9f0460fc21312e4afc61e97dc7e7a56"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "thiserror 1.0.69",
  "zakura-reddsa",
  "zeroize",
@@ -8028,31 +8175,32 @@ dependencies = [
 
 [[package]]
 name = "zakura-sapling-crypto"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799ccbf7446c09e97e82c5e385f36cf0f076cf6297ba624df170e696307993fc"
+checksum = "f0583b3ff0a183b41d49cf9dc41d0fe1d3d050246bfe725ca3017e1df852069e"
 dependencies = [
  "aes",
- "bellman",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
- "bls12_381",
  "corez",
  "document-features",
- "ff",
+ "ff 0.14.0",
  "fpe",
  "getset",
- "group",
+ "group 0.14.0",
  "hex",
  "incrementalmerkletree",
- "jubjub",
  "lazy_static",
  "memuse",
- "rand 0.8.6",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "subtle",
  "tracing",
+ "zakura-bellman",
+ "zakura-bls12-381",
+ "zakura-jubjub",
  "zakura-redjubjub",
  "zcash_note_encryption",
  "zcash_spec",
@@ -8061,11 +8209,11 @@ dependencies = [
 
 [[package]]
 name = "zakura-sinsemilla"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2514ff447516a189656567de0d571018d9dcc265da6f931be56fa324db94d681"
+checksum = "f24c3c8ebb5cf5e988b840470eec86f955f2ee2e3b4fa7b64ca5d9bbc6d0f78e"
 dependencies = [
- "group",
+ "group 0.14.0",
  "lazy_static",
  "subtle",
  "zakura-pasta-curves",
@@ -8073,9 +8221,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-wallet-lib"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148371355bc6f83546a0304914a0aa832b843b57ae0dfcbcf400525a9665716c"
+checksum = "28b53acd746f74acdbdd39401cba4ad1516c8e82d54da461a8de6dbb2da47ff4"
 dependencies = [
  "zakura-client-backend",
  "zakura-client-sqlite",
@@ -8104,9 +8252,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.7"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49636f1d22b0511b2a117548cc9dcf569440a3589b06bf6df422c6b738f6231"
+checksum = "07ad58d8ca5daacbc089bf82ec09e45cf2a8be40adeb40b9399b16545c81a528"
 dependencies = [
  "base64",
  "bech32",
@@ -8116,7 +8264,7 @@ dependencies = [
  "document-features",
  "flume",
  "getset",
- "group",
+ "group 0.13.0",
  "hex",
  "incrementalmerkletree",
  "memuse",
@@ -8124,7 +8272,7 @@ dependencies = [
  "orchard",
  "pasta_curves",
  "percent-encoding",
- "prost 0.14.3",
+ "prost 0.14.4",
  "rand_core 0.6.4",
  "rayon",
  "sapling-crypto",
@@ -8134,7 +8282,7 @@ dependencies = [
  "time",
  "tonic-prost-build",
  "tracing",
- "which 8.0.2",
+ "which 8.0.5",
  "zcash_address",
  "zcash_encoding",
  "zcash_keys",
@@ -8149,15 +8297,15 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.7"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7a9511b23d123fabf23b797e9d750dabe69bd31ebcfd2de9423e0f5c0a3c73"
+checksum = "dd92e4334619b1e3f67019254049318ec0d0240a3c15d853bdf2ac4bba597078"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bs58",
  "byteorder",
  "document-features",
- "group",
+ "group 0.13.0",
  "hex",
  "incrementalmerkletree",
  "jubjub",
@@ -8165,10 +8313,10 @@ dependencies = [
  "nonempty",
  "orchard",
  "pczt",
- "prost 0.14.3",
- "rand 0.8.6",
+ "prost 0.14.4",
+ "rand 0.8.7",
  "rand_core 0.6.4",
- "rand_distr",
+ "rand_distr 0.4.3",
  "regex",
  "rusqlite",
  "sapling-crypto",
@@ -8216,7 +8364,7 @@ dependencies = [
  "bs58",
  "corez",
  "document-features",
- "group",
+ "group 0.13.0",
  "memuse",
  "nonempty",
  "orchard",
@@ -8238,7 +8386,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cb1b9170c94370e3d66c5cc0877661db743337588b64de7711239eed462198"
 dependencies = [
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "cipher",
  "rand_core 0.6.4",
@@ -8247,10 +8395,11 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.6"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb981e23ad66171cfad0bd4e0ed481f771d317ff7f14148a4fd49e85f0a1307"
+checksum = "6188c544911aad647bdb0730d18a0309991da1ccbbdab0415d4ef3113ecadcb3"
 dependencies = [
+ "blake2b_simd",
  "corez",
  "getset",
  "incrementalmerkletree",
@@ -8268,9 +8417,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+checksum = "403d5be1e96339534be098e3377fb8a78d68ca7585b1780133d884b810277418"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8278,7 +8427,7 @@ dependencies = [
  "crypto-common 0.2.0-rc.1",
  "document-features",
  "equihash",
- "ff",
+ "ff 0.13.1",
  "hex",
  "incrementalmerkletree",
  "jubjub",
@@ -8298,9 +8447,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043686451284bcb72e40ffa18e2cdcea3108e8468e3d021062c0b32c4a060c98"
+checksum = "314329b91ec4bbb517441840e47d0b2029bf0b946f086980c96c889c2d92dc5d"
 dependencies = [
  "corez",
  "document-features",
@@ -8316,14 +8465,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f872800287d118be71bdf6fe8c869c6a6ff6fb0a5762f68fb2af54c97edf0f2"
 dependencies = [
  "bip32",
- "bitflags",
+ "bitflags 2.13.1",
  "bounded-vec",
  "hex",
  "ripemd 0.1.3",
  "secp256k1",
  "sha1",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8362,17 +8511,15 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "3.1.0-rc.5"
+version = "3.1.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e093951ad367d19ec5e81b367b704158319e23d4e8261025886295e2de4c2be4"
+checksum = "43bd14a025fd4b3c0d8b78e01fc987025ee511c2a3a5b6b0d5ccf35c58cbe0ce"
 dependencies = [
  "anyhow",
  "base64",
  "blake2b_simd",
  "bytes",
  "ed25519-dalek",
- "ff",
- "group",
  "hex",
  "http",
  "http-body-util",
@@ -8384,15 +8531,15 @@ dependencies = [
  "nonempty",
  "pir-client",
  "pir-types",
- "prost 0.14.3",
- "rand 0.8.6",
+ "prost 0.14.4",
+ "rand 0.8.7",
  "rusqlite",
  "rustls",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tonic",
  "uuid",
@@ -8416,22 +8563,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8451,35 +8598,35 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -8488,9 +8635,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "serde",
  "yoke",
@@ -8500,13 +8647,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8524,9 +8671,9 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+checksum = "e0180028b8807c60498f01eb805a125eed095ab4c4a1737635c80e6ef7cb0a9c"
 dependencies = [
  "base64",
  "nom",
@@ -8537,9 +8684,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,14 +10,15 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 flutter_rust_bridge = "=2.11.1"
 
 zcash_script = "0.4.3"
-sapling-crypto = { package = "zakura-sapling-crypto", version = "1.0.0-rc.1", default-features = false, features = ["circuit"] }
+voting-crypto-deps = { version = "0.1.2", default-features = false, features = ["zakura"] }
+sapling-crypto = { package = "zakura-sapling-crypto", version = "1.0.0-rc.3", default-features = false, features = ["circuit"] }
 uuid = "1.1"
 zip32 = "0.2"
-pasta_curves = { package = "zakura-pasta-curves", version = "1.0.0-rc.1" }
-ff = "0.13"
+pasta_curves = { package = "zakura-pasta-curves", version = "1.0.0-rc.3" }
+ff = "0.14"
 # Required by no-op Sapling prover trait impls
-jubjub = "0.10"
-bls12_381 = "0.8"
+jubjub = { package = "zakura-jubjub", version = "1.0.0-rc.3" }
+bls12_381 = { package = "zakura-bls12-381", version = "1.0.0-rc.3" }
 rand_core = "0.6"
 
 # Key generation
@@ -79,14 +80,14 @@ url = "2.5.8"
 # `use orchard` / `use zcash_client_backend` keep working.
 [dependencies.zcash_primitives]
 package = "zakura-primitives"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 
 [dependencies.zcash_address]
 version = "0.13.0"
 
 [dependencies.zcash_keys]
 package = "zakura-keys"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 features = ["orchard"]
 
 [dependencies.zcash_protocol]
@@ -98,7 +99,7 @@ version = "0.10.0"
 
 [dependencies.zcash_client_backend]
 package = "zakura-client-backend"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 features = [
     "orchard",
     "transparent-inputs",
@@ -111,25 +112,25 @@ features = [
 
 [dependencies.zcash_client_sqlite]
 package = "zakura-client-sqlite"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 [dependencies.zcash_voting]
-version = "=3.1.0-rc.5"
+version = "=3.1.0-rc.6"
 default-features = false
 features = ["zakura"]
 
 [dependencies.orchard]
 package = "zakura-orchard"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 
 [dependencies.zcash_proofs]
 package = "zakura-proofs"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.3"
 
 [dependencies.pczt]
 package = "zakura-pczt"
-version = "0.1.0-rc0"
+version = "0.1.0-rc1"
 features = [
     "orchard",
     "io-finalizer",
@@ -162,7 +163,7 @@ rusqlite = "0.37"
 zcash_note_encryption = "0.4"
 
 [dev-dependencies.vote-commitment-tree]
-version = "=0.5.1"
+version = "=0.5.2"
 default-features = false
 features = ["zakura"]
 

--- a/rust/src/wallet/db.rs
+++ b/rust/src/wallet/db.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use rand::rngs::OsRng;
+use voting_crypto_deps::rand::rngs::OsRng;
 use zcash_client_sqlite::{util::SystemClock, WalletDb};
 
 use crate::wallet::network::WalletNetwork;

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -1310,7 +1310,7 @@ mod tests {
             creator::Creator, io_finalizer::IoFinalizer, prover::Prover, signer::Signer,
             updater::Updater,
         };
-        use rand_core::OsRng;
+        use voting_crypto_deps::rand::rngs::OsRng;
         use shardtree::{store::memory::MemoryShardStore, ShardTree};
         use zcash_note_encryption::try_note_decryption;
         use zcash_primitives::transaction::{builder::PcztResult, fees::zip317};

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -823,7 +823,7 @@ pub(crate) fn propose_send(
         // Lock the selected inputs before exposing the proposal ID. This closes
         // the review-screen race where a migration could otherwise reserve the
         // same notes after proposal creation but before execution.
-        let lock_owner = LockOwner::random(&mut OsRng);
+        let lock_owner = LockOwner::random(&mut voting_crypto_deps::rand::rngs::OsRng);
         let lock_expiry_height =
             send_proposal_lock_expiry(BlockHeight::from(proposal.min_target_height()));
         let input_refs = proposal_input_refs(&proposal);
@@ -1815,14 +1815,14 @@ fn build_orchard_migration_immediate_pczt(
             .map_err(|_| "Bad Immediate migration output amount")?;
         let built = pczt_from_build_result(
             make_builder(amount)?
-                .build_for_pczt(rand_core::OsRng, &fee_rule)
+                .build_for_pczt(voting_crypto_deps::rand::rngs::OsRng, &fee_rule)
                 .map_err(|e| format!("Build Immediate migration PCZT failed: {e}"))?,
             network,
             account_derivation,
             orchard_inputs.len(),
             0,
         )?;
-        let input_lock_owner = LockOwner::random(&mut OsRng);
+        let input_lock_owner = LockOwner::random(&mut voting_crypto_deps::rand::rngs::OsRng);
         let lock_expiry_height = immediate_migration_lock_expiry(BlockHeight::from(target_height))?;
         // Persist the owner and output references before taking the DB locks,
         // exactly like ephemeral send-proposal locks. A Keystone Immediate
@@ -6157,7 +6157,7 @@ impl SpendProver for NoOpSpendProver {
         None
     }
 
-    fn create_proof<R: rand_core::RngCore>(
+    fn create_proof<R: voting_crypto_deps::rand::Rng>(
         &self,
         _circuit: circuit::Spend,
         _rng: &mut R,
@@ -6194,7 +6194,7 @@ impl OutputProver for NoOpOutputProver {
         }
     }
 
-    fn create_proof<R: rand_core::RngCore>(
+    fn create_proof<R: voting_crypto_deps::rand::Rng>(
         &self,
         _circuit: circuit::Output,
         _rng: &mut R,

--- a/rust/src/wallet/sync/send/ironwood_migration/denomination_split.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/denomination_split.rs
@@ -500,7 +500,7 @@ fn create_padded_orchard_denomination_pczts(
             return Err("Padded denomination stage fee changed after planning".to_string());
         }
         let build_result = builder
-            .build_for_pczt(rand_core::OsRng, &fee_rule)
+            .build_for_pczt(voting_crypto_deps::rand::rngs::OsRng, &fee_rule)
             .map_err(|e| format!("Build padded denomination PCZT failed: {e}"))?;
         if u32::from(build_result.pczt_parts.expiry_height) != expiry_height {
             return Err("Padded denomination expiry changed during PCZT construction".to_string());

--- a/rust/src/wallet/sync/send/ironwood_migration/plan_child.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/plan_child.rs
@@ -418,7 +418,7 @@ fn create_orchard_to_ironwood_pczt_from_predicted_note(
     };
 
     let build_result = builder
-        .build_for_pczt(rand_core::OsRng, &fee_rule)
+        .build_for_pczt(voting_crypto_deps::rand::rngs::OsRng, &fee_rule)
         .map_err(|e| format!("Build predicted migration PCZT failed: {e}"))?;
     let expiry_height = u32::from(build_result.pczt_parts.expiry_height);
     let built_pczt = pczt_from_build_result(build_result, network, account_derivation, 1, 0)?;
@@ -737,7 +737,7 @@ fn create_orchard_to_ironwood_pczt_from_note(
     };
 
     let build_result = builder
-        .build_for_pczt(rand_core::OsRng, &fee_rule)
+        .build_for_pczt(voting_crypto_deps::rand::rngs::OsRng, &fee_rule)
         .map_err(|e| format!("Build exact-note migration PCZT failed: {e}"))?;
     let expiry_height = u32::from(build_result.pczt_parts.expiry_height);
     let built_pczt = pczt_from_build_result(

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -2614,7 +2614,7 @@ fn built_v6_split_pczt() -> (BuiltPczt, orchard::keys::SpendingKey) {
         .get_fee(&fee_rule)
         .unwrap();
     let builder = build_builder(output_value + u64::from(fee)).unwrap();
-    let build_result = builder.build_for_pczt(rand_core::OsRng, &fee_rule).unwrap();
+    let build_result = builder.build_for_pczt(voting_crypto_deps::rand::rngs::OsRng, &fee_rule).unwrap();
 
     assert_eq!(build_result.pczt_parts.version, TxVersion::V6);
     assert_eq!(
@@ -2688,7 +2688,7 @@ fn built_padded_v6_split_pczt() -> (BuiltPczt, UnifiedSpendingKey) {
     let input_value = outputs.iter().sum::<u64>() + u64::from(fee);
     let build_result = build_builder(input_value)
         .unwrap()
-        .build_for_pczt(rand_core::OsRng, &fee_rule)
+        .build_for_pczt(voting_crypto_deps::rand::rngs::OsRng, &fee_rule)
         .unwrap();
     assert_eq!(
         u32::from(build_result.pczt_parts.expiry_height),

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -392,7 +392,7 @@ fn sign_delegation_request(
     .ok_or_else(|| "delegation alpha is not a valid Pallas scalar".to_string())?;
     // Sign the request-specific sighash with the randomized spend auth key.
     let rsk = ask.randomize(&alpha);
-    let rng = rand::rngs::OsRng;
+    let rng = voting_crypto_deps::rand::rngs::OsRng;
     let sig = rsk.sign(rng, &request.sighash);
     Ok(((&sig).into(), request.sighash))
 }

--- a/scripts/e2e/flutter-ios-regtest-mobile-voting-slow-helper.sh
+++ b/scripts/e2e/flutter-ios-regtest-mobile-voting-slow-helper.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-SLOW_HELPER_MODE=1 \
+E2E_SLOW_HELPER_MODE=1 \
   exec "$ROOT_DIR/scripts/e2e/flutter-ios-regtest-mobile-voting.sh"

--- a/scripts/e2e/flutter-ios-regtest-mobile-voting-slow-helper.sh
+++ b/scripts/e2e/flutter-ios-regtest-mobile-voting-slow-helper.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+SLOW_HELPER_MODE=1 \
+  exec "$ROOT_DIR/scripts/e2e/flutter-ios-regtest-mobile-voting.sh"

--- a/scripts/e2e/flutter-ios-regtest-mobile-voting.sh
+++ b/scripts/e2e/flutter-ios-regtest-mobile-voting.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+source "$ROOT_DIR/scripts/e2e/lib-mobile.sh"
+
+require_cmd xcrun
+
+UDID="$(pick_simulator)"
+FLUTTER_DEVICE="$UDID" \
+VIZOR_FORM_FACTOR=mobile \
+E2E_VOTING_TEST_FILE=integration_test/regtest_mobile_voting_test.dart \
+  exec "$ROOT_DIR/scripts/e2e/flutter-macos-regtest-voting.sh"

--- a/scripts/e2e/flutter-macos-regtest-voting.sh
+++ b/scripts/e2e/flutter-macos-regtest-voting.sh
@@ -252,12 +252,13 @@ STATIC_URL="https://config.vizor-vote.invalid/static-voting-config.json?checksum
 
 echo "running real-proof Flutter voting E2E for round $ROUND_ID"
 cd "$ROOT_DIR"
-form_factor_args=()
+flutter_test_command=(
+  fvm flutter test "$VOTING_TEST_FILE" -d "$FLUTTER_DEVICE"
+)
 if [[ "$VIZOR_FORM_FACTOR" == "mobile" ]]; then
-  form_factor_args+=(--dart-define=VIZOR_FORM_FACTOR=mobile)
+  flutter_test_command+=(--dart-define=VIZOR_FORM_FACTOR=mobile)
 fi
-fvm flutter test "$VOTING_TEST_FILE" -d "$FLUTTER_DEVICE" \
-  "${form_factor_args[@]}" \
+"${flutter_test_command[@]}" \
   --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
   --dart-define=ZCASH_REGTEST_IRONWOOD_ACTIVATION_HEIGHT="$ACTIVATION_HEIGHT" \
   --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="http://127.0.0.1:$LWD_PORT" \

--- a/scripts/e2e/flutter-macos-regtest-voting.sh
+++ b/scripts/e2e/flutter-macos-regtest-voting.sh
@@ -25,6 +25,8 @@ GATEWAY_PORT="${E2E_VOTING_GATEWAY_PORT:-18080}"
 SLOW_HELPER_DELAY="${E2E_SLOW_HELPER_DELAY:-2.0}"
 SLOW_HELPER_MODE="${E2E_SLOW_HELPER_MODE:-0}"
 FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+VIZOR_FORM_FACTOR="${VIZOR_FORM_FACTOR:-desktop}"
+VOTING_TEST_FILE="${E2E_VOTING_TEST_FILE:-integration_test/regtest_voting_test.dart}"
 # Deterministic secp256k1 scalar 1, used only by the disposable local chain.
 VOTE_MANAGER_PRIVATE_KEY="0000000000000000000000000000000000000000000000000000000000000001"
 
@@ -248,7 +250,12 @@ STATIC_URL="https://config.vizor-vote.invalid/static-voting-config.json?checksum
 
 echo "running real-proof Flutter voting E2E for round $ROUND_ID"
 cd "$ROOT_DIR"
-fvm flutter test integration_test/regtest_voting_test.dart -d "$FLUTTER_DEVICE" \
+form_factor_args=()
+if [[ "$VIZOR_FORM_FACTOR" == "mobile" ]]; then
+  form_factor_args+=(--dart-define=VIZOR_FORM_FACTOR=mobile)
+fi
+fvm flutter test "$VOTING_TEST_FILE" -d "$FLUTTER_DEVICE" \
+  "${form_factor_args[@]}" \
   --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
   --dart-define=ZCASH_REGTEST_IRONWOOD_ACTIVATION_HEIGHT="$ACTIVATION_HEIGHT" \
   --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="http://127.0.0.1:$LWD_PORT" \

--- a/scripts/e2e/flutter-macos-regtest-voting.sh
+++ b/scripts/e2e/flutter-macos-regtest-voting.sh
@@ -112,6 +112,8 @@ cargo build --release --manifest-path "$PIR_DIR/Cargo.toml" \
 echo "creating voting power through the real Orchard-to-Ironwood migration"
 IRONWOOD_ACTIVATION_HEIGHT="$ACTIVATION_HEIGHT" \
   IRONWOOD_LIGHTWALLETD_PORT="$LWD_PORT" \
+  FLUTTER_DEVICE=macos \
+  VIZOR_FORM_FACTOR=desktop \
   E2E_TEST_FILE=integration_test/regtest_voting_ironwood_setup_test.dart \
   E2E_LIGHTWALLETD_URL="http://127.0.0.1:$LWD_PORT" \
   E2E_ORCHARD_FUNDING_AMOUNT=0.13 \

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -107,6 +107,25 @@ void main() {
     expect(paths, isNot(contains('/migration/private/review')));
   });
 
+  test('registers the complete mobile coinholder voting route tree', () {
+    final paths = buildMobileRoutes(
+      entryRoutes: const [],
+    ).whereType<GoRoute>().map((route) => route.path).toSet();
+
+    expect(
+      paths,
+      containsAll({
+        '/voting',
+        '/voting/poll/:roundId',
+        '/voting/poll/:roundId/review',
+        '/voting/poll/:roundId/status',
+        '/voting/keystone/scan',
+        '/voting/poll/:roundId/submitted',
+        '/voting/poll/:roundId/results',
+      }),
+    );
+  });
+
   test('shows migration options while guarding private-only routes', () {
     final routes = buildMobileRoutes(
       entryRoutes: const [],

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -119,7 +119,6 @@ void main() {
         '/voting/poll/:roundId',
         '/voting/poll/:roundId/review',
         '/voting/poll/:roundId/status',
-        '/voting/keystone/scan',
         '/voting/poll/:roundId/submitted',
         '/voting/poll/:roundId/results',
       }),

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -604,6 +604,12 @@ void main() {
         tester.getBottomLeft(find.byKey(const ValueKey('mobile_home_send'))).dy,
       ),
     );
+    final votingSurface = tester.widget<Container>(
+      find.descendant(of: entry, matching: find.byType(Container)).first,
+    );
+    final votingDecoration = votingSurface.decoration! as BoxDecoration;
+    expect(votingDecoration.boxShadow, isNull);
+    expect(votingDecoration.border, isNotNull);
 
     await tester.ensureVisible(entry);
     await tester.tap(entry);

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -258,6 +258,7 @@ Widget _app(
         path: '/activity',
         builder: (_, _) => const Text('activity route'),
       ),
+      GoRoute(path: '/voting', builder: (_, _) => const Text('voting route')),
       GoRoute(
         path: '/activity/tx/:txid',
         builder: (_, state) =>
@@ -577,6 +578,39 @@ SwapIntentRecord _externalToZecActivityRecord({
 }
 
 void main() {
+  testWidgets('shows coinholder voting below actions and opens the flow', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(393, 852));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(
+      _app(_syncedState(ironwoodBalance: BigInt.from(100000000))),
+    );
+    await tester.pumpAndSettle();
+
+    final entry = find.byKey(const ValueKey('mobile_home_coinholder_voting'));
+    expect(entry, findsOneWidget);
+    expect(find.text('Coinholder voting'), findsOneWidget);
+    expect(
+      find.text('Use your ZEC to help shape the network.'),
+      findsOneWidget,
+    );
+    expect(
+      tester.getTopLeft(entry).dy,
+      greaterThan(
+        tester.getBottomLeft(find.byKey(const ValueKey('mobile_home_send'))).dy,
+      ),
+    );
+
+    await tester.ensureVisible(entry);
+    await tester.tap(entry);
+    await tester.pumpAndSettle();
+    expect(find.text('voting route'), findsOneWidget);
+  });
+
   testWidgets('shows the Figma sync keep-awake prompt copy', (tester) async {
     await tester.binding.setSurfaceSize(const Size(393, 852));
     addTearDown(() async {
@@ -705,6 +739,9 @@ void main() {
     final receiveRect = tester.getRect(
       find.byKey(const ValueKey('mobile_home_receive')),
     );
+    final votingRect = tester.getRect(
+      find.byKey(const ValueKey('mobile_home_coinholder_voting')),
+    );
     final canvasRect = tester.getRect(
       find.byKey(const ValueKey('mobile_home_rest_canvas')),
     );
@@ -719,7 +756,7 @@ void main() {
     );
     expect(
       titleRect.top,
-      moreOrLessEquals(receiveRect.bottom + 36, epsilon: 0.1),
+      moreOrLessEquals(votingRect.bottom + 36, epsilon: 0.1),
     );
     expect(
       bodyRect.top - titleRect.bottom,

--- a/test/features/voting/mobile_keystone_voting_signing_screen_test.dart
+++ b/test/features/voting/mobile_keystone_voting_signing_screen_test.dart
@@ -1,0 +1,148 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/voting/screens/mobile/mobile_keystone_voting_signing_screen.dart';
+import 'package:zcash_wallet/src/features/voting/screens/voting_status_screen.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_submission_job_provider.dart';
+import 'package:zcash_wallet/src/services/qr_scanner.dart';
+
+void main() {
+  testWidgets('uses the mobile Keystone two-step signing presentation', (
+    tester,
+  ) async {
+    await _pumpSigningScreen(tester);
+
+    expect(find.text('Step 1/2'), findsOneWidget);
+    expect(find.text('Scan with Keystone'), findsOneWidget);
+    expect(find.text('2 of 3 remaining bundles'), findsOneWidget);
+    expect(find.text('Bundle 1 of 3'), findsOneWidget);
+    expect(find.textContaining('Amount: 1.25 ZEC'), findsOneWidget);
+    expect(find.text('Skip unsigned bundles'), findsOneWidget);
+    expect(find.text('Cancel'), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_voting_keystone_get_signature')),
+    );
+    await tester.pump();
+
+    expect(find.text('Step 2/2'), findsOneWidget);
+    expect(find.text('Confirm with Keystone'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('mobile_voting_keystone_scanner_card')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('keeps the camera open after a recoverable voting scan error', (
+    tester,
+  ) async {
+    await _pumpSigningScreen(
+      tester,
+      onSigned: (_) async => throw StateError('Signature does not match vote'),
+      interactiveScanner: true,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_voting_keystone_get_signature')),
+    );
+    await tester.pump();
+    tester
+        .widget<GestureDetector>(
+          find.byKey(const ValueKey('fake_voting_scanner')),
+        )
+        .onTap!();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pump();
+
+    expect(find.text('Signature does not match vote'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('mobile_voting_keystone_scanner_card')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('fits a compact mobile viewport without layout overflow', (
+    tester,
+  ) async {
+    await _pumpSigningScreen(tester, viewport: const Size(320, 568));
+
+    expect(find.text('Step 1/2'), findsOneWidget);
+    expect(find.text('Skip unsigned bundles'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpSigningScreen(
+  WidgetTester tester, {
+  Future<void> Function(List<int>)? onSigned,
+  bool interactiveScanner = false,
+  Size viewport = const Size(393, 852),
+}) async {
+  tester.view.devicePixelRatio = 1;
+  tester.view.physicalSize = viewport;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: ThemeData.dark(),
+        home: AppTheme(
+          data: AppThemeData.dark,
+          child: MobileKeystoneVotingSigningScreen(
+            presentation: VotingKeystoneStatusPresentation(
+              bundleIndex: 0,
+              urParts: const [_previewVotingUr],
+              batchMemos: const [
+                VotingKeystoneBatchMemo(
+                  bundleIndex: 0,
+                  bundleCount: 3,
+                  displayMemo: 'Amount: 1.25 ZEC\nProposal: Community grants',
+                ),
+                VotingKeystoneBatchMemo(
+                  bundleIndex: 1,
+                  bundleCount: 3,
+                  displayMemo: 'Amount: 0.75 ZEC\nProposal: Network priorities',
+                ),
+              ],
+              batchMessageCount: 2,
+              batchTotalCount: 3,
+              canSkipRemainingBundles: true,
+              onSigned: onSigned ?? _noopSigned,
+              onSkipRemainingBundles: _noop,
+            ),
+            scannerBuilder: (_, complete, progress, _) => GestureDetector(
+              key: const ValueKey('fake_voting_scanner'),
+              behavior: HitTestBehavior.opaque,
+              onTap: interactiveScanner
+                  ? () {
+                      progress(100);
+                      complete(
+                        const ScanResult(
+                          urType: 'zcash-batch-sig-result',
+                          data: [1, 2, 3],
+                        ),
+                      );
+                    }
+                  : null,
+              child: const ColoredBox(color: Color(0xFF111515)),
+            ),
+            forceScannerActiveForTesting: true,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump();
+}
+
+Future<void> _noopSigned(List<int> _) async {}
+void _noop() {}
+
+const _previewVotingUr =
+    'ur:zcash-sign-batch/1-1/lpadaxcsfwdmfwfwhdcxhdcxfwcxhdcxhdcxfwcx';

--- a/test/features/voting/mobile_voting_screen_test.dart
+++ b/test/features/voting/mobile_voting_screen_test.dart
@@ -45,6 +45,16 @@ void main() {
     expect(secondCard, findsOneWidget);
     expect(tester.getTopLeft(card).dx, 16);
     expect(
+      tester
+          .widget<InkWell>(
+            find.byKey(
+              const ValueKey('voting_poll_card_tap_community-grants-2026'),
+            ),
+          )
+          .onTap,
+      isNotNull,
+    );
+    expect(
       tester.getTopLeft(secondCard).dy - tester.getBottomLeft(card).dy,
       AppSpacing.sm,
     );

--- a/test/features/voting/mobile_voting_screen_test.dart
+++ b/test/features/voting/mobile_voting_screen_test.dart
@@ -1,0 +1,41 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/widgetbook/voting_use_cases.dart';
+
+void main() {
+  testWidgets('mobile polls use the standard header and 16px content inset', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(393, 852);
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: AppTheme(
+          data: AppThemeData.dark,
+          child: Builder(builder: buildMobileVotingPollsUseCase),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Coinholder voting'), findsOneWidget);
+    expect(find.bySemanticsLabel('Back'), findsOneWidget);
+    final firstAction = find.byKey(
+      const ValueKey('voting_poll_action_community-grants-2026'),
+    );
+    expect(firstAction, findsOneWidget);
+    final card = find.byKey(
+      const ValueKey('voting_poll_card_community-grants-2026'),
+    );
+    expect(card, findsOneWidget);
+    expect(tester.getTopLeft(card).dx, 16);
+  });
+}

--- a/test/features/voting/mobile_voting_screen_test.dart
+++ b/test/features/voting/mobile_voting_screen_test.dart
@@ -38,8 +38,16 @@ void main() {
     final card = find.byKey(
       const ValueKey('voting_poll_card_community-grants-2026'),
     );
+    final secondCard = find.byKey(
+      const ValueKey('voting_poll_card_network-priorities-2026'),
+    );
     expect(card, findsOneWidget);
+    expect(secondCard, findsOneWidget);
     expect(tester.getTopLeft(card).dx, 16);
+    expect(
+      tester.getTopLeft(secondCard).dy - tester.getBottomLeft(card).dy,
+      AppSpacing.sm,
+    );
 
     await tester.tap(
       find.byKey(const ValueKey('mobile_voting_settings_button')),

--- a/test/features/voting/mobile_voting_screen_test.dart
+++ b/test/features/voting/mobile_voting_screen_test.dart
@@ -4,6 +4,7 @@ library;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/mobile/mobile_bottom_safe_area.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_round_visibility_provider.dart';
 import 'package:zcash_wallet/widgetbook/voting_use_cases.dart';
@@ -31,6 +32,13 @@ void main() {
     expect(find.text('Coinholder voting'), findsOneWidget);
     expect(find.bySemanticsLabel('Back'), findsOneWidget);
     expect(find.bySemanticsLabel('Voting config settings'), findsOneWidget);
+    expect(find.byType(MobileBottomSafeArea), findsOneWidget);
+    expect(
+      tester
+          .widget<MobileBottomSafeArea>(find.byType(MobileBottomSafeArea))
+          .bottomPadding,
+      AppSpacing.md,
+    );
     final firstAction = find.byKey(
       const ValueKey('voting_poll_action_community-grants-2026'),
     );

--- a/test/features/voting/mobile_voting_screen_test.dart
+++ b/test/features/voting/mobile_voting_screen_test.dart
@@ -56,6 +56,7 @@ void main() {
       find.byKey(const ValueKey('mobile_voting_add_source')),
       findsOneWidget,
     );
+    expect(find.bySemanticsLabel('Edit Community'), findsOneWidget);
 
     final container = ProviderScope.containerOf(
       tester.element(find.byKey(const ValueKey('mobile_voting_config_sheet'))),

--- a/test/features/voting/mobile_voting_screen_test.dart
+++ b/test/features/voting/mobile_voting_screen_test.dart
@@ -44,6 +44,8 @@ void main() {
     expect(card, findsOneWidget);
     expect(secondCard, findsOneWidget);
     expect(tester.getTopLeft(card).dx, 16);
+    final cardDecoration = tester.widget<Ink>(card).decoration as BoxDecoration;
+    expect(cardDecoration.boxShadow, isNull);
     expect(
       tester
           .widget<InkWell>(

--- a/test/features/voting/mobile_voting_screen_test.dart
+++ b/test/features/voting/mobile_voting_screen_test.dart
@@ -2,8 +2,10 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_round_visibility_provider.dart';
 import 'package:zcash_wallet/widgetbook/voting_use_cases.dart';
 
 void main() {
@@ -28,6 +30,7 @@ void main() {
 
     expect(find.text('Coinholder voting'), findsOneWidget);
     expect(find.bySemanticsLabel('Back'), findsOneWidget);
+    expect(find.bySemanticsLabel('Voting config settings'), findsOneWidget);
     final firstAction = find.byKey(
       const ValueKey('voting_poll_action_community-grants-2026'),
     );
@@ -37,5 +40,41 @@ void main() {
     );
     expect(card, findsOneWidget);
     expect(tester.getTopLeft(card).dx, 16);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_voting_settings_button')),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(
+      find.byKey(const ValueKey('mobile_voting_config_sheet')),
+      findsOneWidget,
+    );
+    expect(find.text('Voting config'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('mobile_voting_add_source')),
+      findsOneWidget,
+    );
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byKey(const ValueKey('mobile_voting_config_sheet'))),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_voting_show_test_rounds')),
+    );
+    await tester.pump();
+    expect(container.read(showTestVotingRoundsProvider).value, isTrue);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_voting_add_source')));
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey('mobile_voting_source_name')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('mobile_voting_source_url')),
+      findsOneWidget,
+    );
   });
 }

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -4613,6 +4613,155 @@ void main() {
     },
   );
 
+  test('share submission deprioritizes a degraded planner target', () async {
+    const helperA = 'https://helper-a.example';
+    const helperB = 'https://helper-b.example';
+    final http = FakeVotingHttpClient(
+      responses: votingHttpResponses(
+        dynamicConfig: dynamicConfigJson(
+          voteServers: const [
+            {'url': helperA, 'label': 'helper-a'},
+            {'url': helperB, 'label': 'helper-b'},
+          ],
+        ),
+      ),
+    );
+    final rust = FakeVotingRustApi(emitCommitments: true);
+    final helperHealth = VotingHelperHealthTracker(
+      failureThreshold: 1,
+      cooldown: const Duration(hours: 1),
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 1,
+        delegationTxHashes: [
+          rust_frb_types.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.submittedDelegation,
+            txHash: 'delegation-0',
+            vanLeafPosition: null,
+          ),
+        ],
+        votes: [vote(bundleIndex: 0, proposalId: 7)],
+      ),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+      helperHealthTracker: helperHealth,
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    helperHealth.recordFailure(helperA);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(
+          draftVotes: [
+            rust_wire.DraftVote(
+              proposalId: 7,
+              choice: 1,
+              numOptions: 2,
+              vcTreePosition: BigInt.zero,
+              singleShare: false,
+            ),
+          ],
+        );
+
+    final sharePostHosts = http.requests
+        .where(
+          (request) =>
+              request.method == 'POST' &&
+              request.uri.path == '/shielded-vote/v1/shares',
+        )
+        .map((request) => request.uri.host)
+        .toList(growable: false);
+    expect(sharePostHosts, ['helper-b.example']);
+    expect(rust.recordedShares.single.sentToUrls, [helperB]);
+  });
+
+  test(
+    'share submission reorders remaining helpers after a concurrent failure',
+    () async {
+      const helperA = 'https://helper-a.example';
+      const helperB = 'https://helper-b.example';
+      const helperC = 'https://helper-c.example';
+      final http = _GatedSharePostVotingHttpClient(
+        expectedShareCount: 1,
+        gatedShareIndexes: const {0},
+        responses: votingHttpResponses(
+          dynamicConfig: dynamicConfigJson(
+            voteServers: const [
+              {'url': helperA, 'label': 'helper-a'},
+              {'url': helperB, 'label': 'helper-b'},
+              {'url': helperC, 'label': 'helper-c'},
+            ],
+          ),
+        ),
+      );
+      final rust = FakeVotingRustApi(emitCommitments: true);
+      final helperHealth = VotingHelperHealthTracker(
+        failureThreshold: 1,
+        cooldown: const Duration(hours: 1),
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 1,
+          delegationTxHashes: [
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: 0,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-0',
+              vanLeafPosition: null,
+            ),
+          ],
+          votes: [vote(bundleIndex: 0, proposalId: 7)],
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+        helperHealthTracker: helperHealth,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final cast = container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+
+      await http.allSharePostsStarted.future.timeout(
+        const Duration(seconds: 1),
+      );
+      helperHealth.recordFailure(helperB);
+      http.releaseSharePosts.complete();
+      await cast;
+
+      final sharePostHosts = http.requests
+          .where(
+            (request) =>
+                request.method == 'POST' &&
+                request.uri.path == '/shielded-vote/v1/shares',
+          )
+          .map((request) => request.uri.host)
+          .toList(growable: false);
+      expect(sharePostHosts, ['helper-a.example', 'helper-c.example']);
+      expect(rust.recordedShares.single.sentToUrls, [helperA, helperC]);
+    },
+  );
+
   test('vote commitment validates all shares before submission', () async {
     final http = FakeVotingHttpClient(responses: votingHttpResponses());
     final rust = FakeVotingRustApi(

--- a/test/providers/voting/voting_share_tracking_mobile_test.dart
+++ b/test/providers/voting/voting_share_tracking_mobile_test.dart
@@ -1,20 +1,29 @@
 @Tags(['mobile'])
 library;
 
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:zcash_wallet/src/providers/voting/voting_session_provider.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_service_providers.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_share_tracking_restorer_provider.dart';
 
 void main() {
-  test('mobile submission sessions do not own automatic share tracking', () {
-    expect(automaticVotingShareTrackingEnabled(), isFalse);
-  });
+  TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('mobile builds do not start desktop vote share recovery', () async {
+  test('mobile unlock starts persisted vote share recovery', () async {
     var discoveryCount = 0;
+    final security = _MobileVotingSecurityNotifier(
+      const AppSecurityState(isPasswordConfigured: true, isUnlocked: false),
+    );
     final container = ProviderContainer(
       overrides: [
+        appSecurityProvider.overrideWith(() => security),
+        accountProvider.overrideWith(_MobileVotingAccountNotifier.new),
+        votingWalletDbPathProvider.overrideWithValue(() async => 'wallet.db'),
         votingPendingShareRoundLoaderProvider.overrideWithValue(({
           required dbPath,
           required accountUuids,
@@ -26,12 +35,55 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    final restorer = container.read(votingShareTrackingRestorerProvider);
-    await restorer.restore();
-    await restorer.pause();
-    await restorer.resume();
+    container.read(votingShareTrackingRestorerProvider);
+    await pumpEventQueue();
+    expect(discoveryCount, 0);
+
+    security.setUnlocked(true);
     await pumpEventQueue();
 
-    expect(discoveryCount, 0);
+    expect(discoveryCount, 1);
+
+    for (final state in const [
+      AppLifecycleState.inactive,
+      AppLifecycleState.hidden,
+      AppLifecycleState.paused,
+      AppLifecycleState.hidden,
+      AppLifecycleState.inactive,
+      AppLifecycleState.resumed,
+    ]) {
+      TestWidgetsFlutterBinding.instance.handleAppLifecycleStateChanged(state);
+    }
+    await pumpEventQueue();
+
+    expect(discoveryCount, 2);
   });
+}
+
+class _MobileVotingAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => const AccountState(
+    accounts: [
+      AccountInfo(
+        uuid: 'account-1',
+        name: 'Account 1',
+        order: 0,
+        isSeedAnchor: true,
+      ),
+    ],
+    activeAccountUuid: 'account-1',
+  );
+}
+
+class _MobileVotingSecurityNotifier extends AppSecurityNotifier {
+  _MobileVotingSecurityNotifier(this.initialState);
+
+  final AppSecurityState initialState;
+
+  @override
+  AppSecurityState build() => initialState;
+
+  void setUnlocked(bool value) {
+    state = state.copyWith(isUnlocked: value);
+  }
 }


### PR DESCRIPTION
## Summary

- add a mobile-specific Coinholder voting entry point and complete voting screen flow
- add mobile voting configuration, tappable poll cards, off-screen submission, and a mobile Keystone signing flow
- preserve the existing desktop voting layouts and behavior while sharing platform-neutral voting logic
- include the helper health ordering fix from #540 and the Zakura RC3 / zcash_voting rc.6 update from #542
- fix the desktop voting E2E invocation for macOS Bash

## Verification

- desktop voting regtest E2E: passed
- desktop slow-helper voting regtest E2E: passed (64 shares, 40 slow-helper requests, max slow-helper concurrency 11)
- iOS mobile voting regtest E2E: passed, including off-screen completion
- iOS mobile slow-helper voting regtest E2E: passed (64 shares, 41 slow-helper requests, max slow-helper concurrency 12)
- voting provider tests: 133 passed
- Rust cargo check: passed

Tested on macOS and an iPhone 17 Pro iOS Simulator.