### PR TITLE
Complete vote jobs without waiting for helper share reveal

### DIFF
--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -9,7 +9,6 @@ import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
-import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_submission_job_provider.dart';
 import '../../../providers/voting/voting_state.dart';
 import '../../../services/voting/pir_snapshot_resolver.dart';
@@ -534,21 +533,11 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
         }
         return;
       }
-      unawaited(_navigateToConfirmation(key));
+      _navigateToConfirmation(key);
     });
   }
 
-  Future<void> _navigateToConfirmation(VotingSessionKey key) async {
-    try {
-      await ref
-          .read(votingSubmissionSessionProvider(key).notifier)
-          .refreshEligibleWeight();
-    } catch (error) {
-      debugPrint(
-        '[zcash] Voting: pre-confirmation voting power refresh failed '
-        'round=${key.roundId} account=${key.accountUuid} error=$error',
-      );
-    }
+  void _navigateToConfirmation(VotingSessionKey key) {
     if (!mounted ||
         _selectedJobKey() != key ||
         !_canNavigateToConfirmation(key)) {
@@ -566,9 +555,7 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
 
   bool _isCurrentStatusRoute(VotingSessionKey key) {
     if (!mounted) return false;
-    final currentPath = GoRouter.of(
-      context,
-    ).routerDelegate.currentConfiguration.uri.path;
+    final currentPath = GoRouterState.of(context).uri.path;
     final statusPath = Uri.parse(
       votingStatusRoute(key.roundId, accountUuid: key.accountUuid),
     ).path;

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -11,7 +11,6 @@ import '../../main.dart' show log;
 import '../app_bootstrap.dart';
 import '../core/account_name_policy.dart';
 import '../core/config/network_config.dart';
-import '../core/layout/app_form_factor.dart';
 import '../core/profile_pictures.dart';
 import '../core/security/software_wallet_secret.dart';
 import '../core/storage/app_secure_store.dart';
@@ -533,20 +532,17 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   /// Remove an account from the wallet.
   ///
   /// Destructive account changes are blocked while any vote submission is in
-  /// progress. Once removal is allowed, process-local voting state is cleared
-  /// before the wallet delete. Durable voting rows, hotkeys, and other
-  /// account-scoped sidecars are cleared after the wallet account is deleted.
+  /// progress. Once removal is allowed, in-flight helper-share tracking is
+  /// quiesced and drained so it cannot keep reading or writing this account's
+  /// voting records. Process-local voting state is then cleared before the
+  /// wallet delete. Durable voting rows, hotkeys, and other account-scoped
+  /// sidecars are cleared after the wallet account is deleted.
   Future<void> removeAccount(String uuid) async {
     ref.read(votingSubmissionGuardProvider.notifier).throwIfActive();
     final prev = state.value ?? const AccountState();
     final targetIndex = prev.accounts.indexWhere((a) => a.uuid == uuid);
     if (targetIndex < 0) {
       throw ArgumentError.value(uuid, 'uuid', 'Unknown account UUID');
-    }
-
-    if (kAppFormFactor == AppFormFactor.mobile) {
-      await _removeAccountWithShareTrackingStopped(uuid);
-      return;
     }
 
     final shareTracking = ref.read(votingShareTrackingRegistryProvider);
@@ -687,8 +683,10 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
 
   /// Delete all wallet data (DB + keychain). Caller must stop sync first.
   ///
-  /// This also clears voting state held in this process for every account
-  /// before the wallet DB and voting sidecar DB are deleted.
+  /// In-flight helper-share tracking is quiesced and drained first so it
+  /// cannot keep reading or writing voting records during the wipe. This also
+  /// clears voting state held in this process for every account before the
+  /// wallet DB and voting sidecar DB are deleted.
   ///
   /// Migration work must first stop without deleting its credential. After
   /// that fail-closed preflight, the wipe is best-effort: deletion steps remain
@@ -698,11 +696,6 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   /// and its on-disk state is cleared too — see [clearTorPrivacyStateForReset].
   Future<void> resetWallet() async {
     ref.read(votingSubmissionGuardProvider.notifier).throwIfActive();
-
-    if (kAppFormFactor == AppFormFactor.mobile) {
-      await _resetWalletWithShareTrackingStopped();
-      return;
-    }
 
     final shareTracking = ref.read(votingShareTrackingRegistryProvider);
     var restoreAfterFailure = false;

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -135,13 +135,20 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     if (_disposeHandlerRegistered) return;
     _disposeHandlerRegistered = true;
     final rust = ref.read(votingRustApiProvider);
+    final guardNotifier = ref.read(votingSubmissionGuardProvider.notifier);
     ref.onDispose(() {
+      // Snapshot guards before listener teardown. Do not ref.read here:
+      // Riverpod forbids using this provider's Ref inside onDispose.
+      final context = _currentContext;
+      final ownsSubmission =
+          context != null &&
+          (_guardsOwnContext(_activeSubmissionGuards, context) ||
+              _guardsOwnContext(_guardNotifierState(guardNotifier), context));
       _disposeHandlerRegistered = false;
       _activeAccountListenerRegistered = false;
       _submissionGuardListenerRegistered = false;
       // Provider disposal is round-scoped: clear abandoned prepared PCZTs but
       // keep account-wide vote-tree sync state reusable across rounds.
-      final context = _currentContext;
       _isDisposed = true;
       _advanceSessionGeneration();
       _delegationPirPrecomputes.clear();
@@ -149,7 +156,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       _shareTrackingTimer?.cancel();
       _releaseAutomaticShareTracking();
       if (context == null) return;
-      if (_activeSubmissionOwnsContext(context)) {
+      if (ownsSubmission) {
         debugPrint(
           '[zcash] Voting: process-local state reset skipped '
           'round=${context.round.roundId} account=${context.accountUuid} '
@@ -2107,6 +2114,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     if (_automaticShareTrackingStopped) return Future.value();
     final inFlight = _shareTrackingPass;
     if (inFlight != null) return inFlight;
+    if (_ownsAutomaticShareTracking && !_retainAutomaticShareTracking()) {
+      return Future.value();
+    }
 
     late final Future<void> pass;
     pass = _startPendingSharePass().whenComplete(() {
@@ -2122,7 +2132,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       _shareTrackingTimer = null;
       if (_automaticShareTrackingStopped) return;
       final current = await future;
+      if (_isDisposed || !ref.mounted) return;
       final context = await _loadContext(_roundId);
+      if (_shareTrackingCancelled(context)) return;
       _currentContext = context;
       var plan = await _loadResumePlan(context);
       var roundPlan = await _loadRoundPlan(context);
@@ -2171,6 +2183,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
               ? null
               : BigInt.from(voteEndSeconds),
         );
+        if (_shareTrackingCancelled(context)) return;
         final readyForStatusCheck = (trackingFlags & 1) != 0;
         final overdueForRetry = (trackingFlags & 2) != 0;
 
@@ -2221,6 +2234,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         }
       }
 
+      if (_shareTrackingCancelled(context)) return;
       final refreshedPlan = await _loadResumePlan(context);
       final refreshedRoundPlan = await _loadRoundPlan(context);
       final hasBlockingWork = hasBlockingRoundRecoveryWork(refreshedRoundPlan);
@@ -2267,6 +2281,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required List<String> configuredServerUrls,
     required Set<String> sentToUrls,
   }) async {
+    if (!ref.mounted || !_isCurrentContext(context)) return null;
     final rust = ref.read(votingRustApiProvider);
     final key = VotingVoteKey(
       bundleIndex: share.bundleIndex,
@@ -2482,8 +2497,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   }
 
   bool _shareTrackingCancelled(_VotingSessionContext context) {
-    return _automaticShareTrackingStopped ||
-        !_isCurrentContext(context) ||
+    if (_automaticShareTrackingStopped || _isDisposed || !ref.mounted) {
+      return true;
+    }
+    return !_isCurrentContext(context) ||
         ref.read(appSecurityProvider).requiresUnlock ||
         !shouldTrackPendingVotingShares(context.round);
   }
@@ -3327,7 +3344,28 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   }
 
   bool _activeSubmissionOwnsContext(_VotingSessionContext context) {
-    for (final guard in _activeSubmissionGuards) {
+    return _guardsOwnContext(_activeSubmissionGuards, context) ||
+        _guardsOwnContext(
+          _guardNotifierState(ref.read(votingSubmissionGuardProvider.notifier)),
+          context,
+        );
+  }
+
+  static List<VotingSubmissionGuard> _guardNotifierState(
+    VotingSubmissionGuardNotifier notifier,
+  ) {
+    try {
+      return notifier.state;
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  static bool _guardsOwnContext(
+    List<VotingSubmissionGuard> guards,
+    _VotingSessionContext context,
+  ) {
+    for (final guard in guards) {
       if (guard.accountUuid == context.accountUuid &&
           guard.roundId == context.round.roundId) {
         return true;

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -65,6 +65,14 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
 
   void _releaseAutomaticShareTracking() {}
 
+  /// Pins automatic helper-share tracking before a submission job can drop its
+  /// destructive-operation guard.
+  ///
+  /// Returns false when the registry is quiesced and new tracking must not
+  /// start. Account delete/reset drain through the registry, so the job must
+  /// register first when accepted shares still need confirmation.
+  bool pinAutomaticShareTracking() => _retainAutomaticShareTracking();
+
   Future<void> _operation = Future.value();
   final String _roundId;
   final Map<String, Future<void>> _delegationPirPrecomputes = {};
@@ -3785,6 +3793,8 @@ class VotingSubmissionSessionNotifier extends VotingSessionNotifier {
     if (_closeShareTrackingKeepAlive != null) return true;
     final registry = ref.read(votingShareTrackingRegistryProvider);
     final keepAlive = ref.keepAlive();
+    // Register before the submission job drops its guard so account
+    // delete/reset can drain this pass through the registry.
     if (!registry.register(
       key: _key,
       owner: this,

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -935,14 +935,42 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       );
     }
     if (!_isCurrentJob(key: key, generation: generation)) return;
-    final afterVotes = _sessionForJob(key);
-    if (afterVotes?.phase == VotingSessionPhase.error) {
-      _failFromSession(key: key, generation: generation, session: afterVotes!);
+    var done = _sessionForJob(key);
+    if (done?.phase == VotingSessionPhase.error) {
+      _failFromSession(key: key, generation: generation, session: done!);
+      return;
+    }
+    if (done != null) {
+      final completedEligibilitySession =
+          await _ensureEligibilityForCompletedSession(
+            key: key,
+            generation: generation,
+            sessionNotifier: sessionNotifier,
+            session: done,
+          );
+      if (completedEligibilitySession == null) return;
+      done = completedEligibilitySession;
+    }
+    if (_canCompleteSubmission(done)) {
+      // Helper reveal is background work. Awaiting it here keeps the status
+      // screen on "Finalizing submission" for every accepted-but-unrevealed
+      // share.
+      unawaited(
+        sessionNotifier.submitPendingShares().catchError((
+          Object error,
+          StackTrace stack,
+        ) {
+          debugPrint(
+            '[zcash] Voting: background share tracking failed: $error\n$stack',
+          );
+        }),
+      );
+      _completeJob(key: key, generation: generation);
       return;
     }
     await sessionNotifier.submitPendingShares();
     if (!_isCurrentJob(key: key, generation: generation)) return;
-    var done = _sessionForJob(key);
+    done = _sessionForJob(key);
     if (done?.phase == VotingSessionPhase.error) {
       _failFromSession(key: key, generation: generation, session: done!);
       return;

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -952,19 +952,6 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       done = completedEligibilitySession;
     }
     if (_canCompleteSubmission(done)) {
-      // Helper reveal is background work. Awaiting it here keeps the status
-      // screen on "Finalizing submission" for every accepted-but-unrevealed
-      // share.
-      unawaited(
-        sessionNotifier.submitPendingShares().catchError((
-          Object error,
-          StackTrace stack,
-        ) {
-          debugPrint(
-            '[zcash] Voting: background share tracking failed: $error\n$stack',
-          );
-        }),
-      );
       _completeJob(key: key, generation: generation);
       return;
     }
@@ -1027,6 +1014,10 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
   void _completeJob({required VotingSessionKey key, required int generation}) {
     if (!_isCurrentJob(key: key, generation: generation)) return;
     _cancelCompletionPoll();
+    // Register live helper-share tracking before releasing the submission
+    // guard. Account delete/reset drain through the registry; they must not
+    // observe an unguarded in-flight pass.
+    _pinLiveShareTracking(key);
     _releaseGuard();
     _releaseSessionSubscription();
     ref.invalidate(votingSessionProvider(key.roundId));
@@ -1128,6 +1119,32 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     if (guard == null) return;
     _guard = null;
     ref.read(votingSubmissionGuardProvider.notifier).release(guard);
+  }
+
+  void _pinLiveShareTracking(VotingSessionKey key) {
+    final hasUnconfirmedShares =
+        _sessionForJob(
+          key,
+        )?.resumePlan?.unconfirmedShareDelegations.isNotEmpty ??
+        false;
+    if (!hasUnconfirmedShares) return;
+    final sessionNotifier = ref.read(
+      votingSubmissionSessionProvider(key).notifier,
+    );
+    sessionNotifier.pinAutomaticShareTracking();
+    // Helper reveal is background work. Awaiting it in the job keeps the
+    // status screen on "Finalizing submission" for accepted-but-unrevealed
+    // shares. The registry, not the job guard, is the drain barrier.
+    unawaited(
+      sessionNotifier.submitPendingShares().catchError((
+        Object error,
+        StackTrace stack,
+      ) {
+        debugPrint(
+          '[zcash] Voting: background share tracking failed: $error\n$stack',
+        );
+      }),
+    );
   }
 
   void _scheduleCompletionPoll({

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1039,7 +1039,9 @@ void main() {
     expect(find.text('submission confirmed route'), findsOne);
     expect(find.text('Sign bundle 1 of 1'), findsNothing);
     expect(find.text('Scan signature'), findsNothing);
-    expect(rust.eligibilityCheckCalls, 2);
+    // Confirmation navigation no longer waits for a second voting-power
+    // refresh; the job's eligibility check is enough to leave status.
+    expect(rust.eligibilityCheckCalls, 1);
     expect(rust.setupDelegationBundleCalls, 0);
     expect(rust.keystoneDelegationRequestCalls, 0);
     expect(recoveryApi.ballotIntents, isEmpty);
@@ -1142,7 +1144,9 @@ void main() {
     expect(find.text('submission confirmed route'), findsOne);
     expect(find.text('Sign bundle 1 of 1'), findsNothing);
     expect(find.text('Scan signature'), findsNothing);
-    expect(rust.eligibilityCheckCalls, 2);
+    // Confirmation navigation no longer waits for a second voting-power
+    // refresh; the job's eligibility check is enough to leave status.
+    expect(rust.eligibilityCheckCalls, 1);
     expect(rust.setupDelegationBundleCalls, 0);
     expect(rust.keystoneDelegationRequestCalls, 0);
     expect(

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1231,6 +1231,90 @@ void main() {
     },
   );
 
+  testWidgets(
+    'completed mobile status navigates before voting power refresh finishes',
+    (tester) async {
+      const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+      final refreshGate = Completer<BigInt?>();
+      addTearDown(() {
+        if (!refreshGate.isCompleted) refreshGate.complete(null);
+      });
+      final completedState = VotingSessionState(
+        roundId: _roundId,
+        accountUuid: key.accountUuid,
+        phase: VotingSessionPhase.done,
+      );
+      final container = _statusContainer(
+        accountOverride: _MnemonicAccountNotifier.new,
+        overrides: [
+          votingSubmissionJobsProvider.overrideWith(
+            () => _StaticVotingSubmissionJobsNotifier(
+              const VotingSubmissionJobsState(jobKeys: [key]),
+            ),
+          ),
+          votingSubmissionJobProvider(key).overrideWith(
+            () => _StaticVotingSubmissionJobNotifier(
+              key,
+              const VotingSubmissionJobState(
+                key: key,
+                status: VotingSubmissionJobStatus.complete,
+                generation: 1,
+              ),
+            ),
+          ),
+          votingSubmissionJobSessionProvider(
+            key,
+          ).overrideWithValue(AsyncValue.data(completedState)),
+          votingSubmissionSessionProvider(key).overrideWith(
+            () => _BlockedRefreshVotingSubmissionSessionNotifier(
+              key,
+              completedState,
+              refreshGate,
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final router = GoRouter(
+        initialLocation: '/home',
+        routes: [
+          GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
+          GoRoute(
+            path: '/voting/poll/:roundId/status',
+            builder: (_, state) => VotingStatusView(
+              roundId: state.pathParameters['roundId']!,
+              accountUuid: state.uri.queryParameters['account'],
+              requireCurrentRouteForConfirmation: true,
+            ),
+          ),
+          GoRoute(
+            path: '/voting/poll/:roundId/submitted',
+            builder: (_, _) => const Text('submission confirmed route'),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+            builder: (_, child) =>
+                AppTheme(data: AppThemeData.light, child: child!),
+          ),
+        ),
+      );
+      unawaited(
+        router.push(votingStatusRoute(_roundId, accountUuid: key.accountUuid)),
+      );
+      await _pumpUntilFound(tester, find.text('submission confirmed route'));
+
+      expect(find.text('submission confirmed route'), findsOneWidget);
+      expect(refreshGate.isCompleted, isFalse);
+    },
+  );
+
   testWidgets('status screen shows finalizing step before job completion', (
     tester,
   ) async {
@@ -4165,6 +4249,24 @@ class _StaticVotingSessionNotifier extends VotingSessionNotifier {
 
   @override
   Future<BigInt?> refreshEligibleWeight() async => _state.eligibleWeightZatoshi;
+}
+
+class _BlockedRefreshVotingSubmissionSessionNotifier
+    extends VotingSubmissionSessionNotifier {
+  _BlockedRefreshVotingSubmissionSessionNotifier(
+    super.key,
+    this._state,
+    this._refreshGate,
+  );
+
+  final VotingSessionState _state;
+  final Completer<BigInt?> _refreshGate;
+
+  @override
+  Future<VotingSessionState> build() async => _state;
+
+  @override
+  Future<BigInt?> refreshEligibleWeight() => _refreshGate.future;
 }
 
 class _FailingEligibilityVotingSessionNotifier

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart' show ThemeMode;
@@ -368,6 +369,17 @@ void main() {
     );
   });
 
+  test(
+    'account deletion drains live share tracking before the wallet mutation',
+    () => _expectAccountDeletionDrainsLiveShareTracking(),
+  );
+
+  test(
+    'mobile account deletion drains live share tracking before the wallet mutation',
+    () => _expectAccountDeletionDrainsLiveShareTracking(),
+    tags: ['mobile'],
+  );
+
   test('drain failures resume tracking after destructive mutations', () async {
     final shareTracking = VotingShareTrackingRegistry();
     var restoreRequests = 0;
@@ -539,6 +551,70 @@ class _AccountMutationRustApiFake implements RustLibApi {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<void> _expectAccountDeletionDrainsLiveShareTracking() async {
+  FlutterSecureStorage.setMockInitialValues({});
+  final supportDirectory = Directory.systemTemp.createTempSync(
+    'vizor-account-share-drain',
+  );
+  addTearDown(() {
+    if (supportDirectory.existsSync()) {
+      supportDirectory.deleteSync(recursive: true);
+    }
+  });
+  const pathProvider = MethodChannel('plugins.flutter.io/path_provider');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(pathProvider, (call) async {
+        if (call.method == 'getApplicationSupportDirectory') {
+          return supportDirectory.path;
+        }
+        throw MissingPluginException('Unexpected path provider call.');
+      });
+  addTearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProvider, null);
+  });
+
+  final shareTracking = VotingShareTrackingRegistry();
+  final drainStarted = Completer<void>();
+  final drainGate = Completer<void>();
+  expect(
+    shareTracking.register(
+      key: const VotingSessionKey(
+        accountUuid: 'account-2',
+        roundId: 'round-delete',
+      ),
+      owner: Object(),
+      stopAndDrain: () async {
+        if (!drainStarted.isCompleted) drainStarted.complete();
+        await drainGate.future;
+      },
+    ),
+    isTrue,
+  );
+
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrapWithAccounts()),
+      votingShareTrackingRegistryProvider.overrideWithValue(shareTracking),
+    ],
+  );
+  addTearDown(container.dispose);
+  await container.read(accountProvider.future);
+
+  final removal = container
+      .read(accountProvider.notifier)
+      .removeAccount('account-2');
+  await drainStarted.future;
+  expect(_rustApi.deletedAccountUuids, isEmpty);
+  expect(shareTracking.isQuiesced('account-2'), isTrue);
+
+  drainGate.complete();
+  await removal;
+
+  expect(_rustApi.deletedAccountUuids, ['account-2']);
+  expect(shareTracking.isQuiesced('account-2'), isFalse);
 }
 
 AppBootstrapState _bootstrapWithAccounts() {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3213,6 +3213,10 @@ void main() {
             .guardForAccount('account-1'),
         isNull,
       );
+      expect(
+        container.read(votingShareTrackingRegistryProvider).registeredKeys,
+        {startedKey},
+      );
       expect(rust.confirmedShares, isEmpty);
       expect(trackingGate.isCompleted, isFalse);
       await rust.shareTrackingFlagsStarted.future;
@@ -3220,7 +3224,18 @@ void main() {
         container.read(votingSubmissionJobProvider(startedKey)).status,
         VotingSubmissionJobStatus.complete,
       );
+
+      var drained = false;
+      final drain = container
+          .read(votingShareTrackingRegistryProvider)
+          .quiesceAndDrain(accountUuid: 'account-1')
+          .then((_) => drained = true);
+      await Future<void>.delayed(Duration.zero);
+      expect(drained, isFalse);
+
       trackingGate.complete();
+      await drain;
+      expect(drained, isTrue);
     },
   );
 

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3170,7 +3170,11 @@ void main() {
         submitAt: BigInt.zero,
         createdAt: BigInt.one,
       );
-      final rust = FakeVotingRustApi();
+      final trackingGate = Completer<void>();
+      final rust = FakeVotingRustApi(shareTrackingFlagsGate: trackingGate);
+      addTearDown(() {
+        if (!trackingGate.isCompleted) trackingGate.complete();
+      });
       final http = FakeVotingHttpClient(
         responses: votingHttpResponses(
           dynamicConfig: dynamicConfigJson(
@@ -3210,6 +3214,13 @@ void main() {
         isNull,
       );
       expect(rust.confirmedShares, isEmpty);
+      expect(trackingGate.isCompleted, isFalse);
+      await rust.shareTrackingFlagsStarted.future;
+      expect(
+        container.read(votingSubmissionJobProvider(startedKey)).status,
+        VotingSubmissionJobStatus.complete,
+      );
+      trackingGate.complete();
     },
   );
 
@@ -6138,6 +6149,60 @@ void main() {
     expect(rust.resetVotingSessionStateCalls, ['account-1:$kRoundId']);
   });
 
+  test(
+    'session dispose skips process-local reset while a submission is guarded',
+    () async {
+      final rust = FakeVotingRustApi();
+      final container = _sessionContainer(rust: rust);
+      addTearDown(container.dispose);
+
+      final guard = container
+          .read(votingSubmissionGuardProvider.notifier)
+          .acquire(accountUuid: 'account-1', roundId: kRoundId);
+      addTearDown(
+        () => container
+            .read(votingSubmissionGuardProvider.notifier)
+            .release(guard),
+      );
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      container.invalidate(votingSessionProvider(kRoundId));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(rust.resetVotingSessionStateCalls, isEmpty);
+    },
+  );
+
+  test(
+    'submission session dispose skips process-local reset while guarded',
+    () async {
+      final rust = FakeVotingRustApi();
+      final container = _sessionContainer(rust: rust);
+      addTearDown(container.dispose);
+      const key = VotingSessionKey(accountUuid: 'account-1', roundId: kRoundId);
+
+      final guard = container
+          .read(votingSubmissionGuardProvider.notifier)
+          .acquire(accountUuid: key.accountUuid, roundId: key.roundId);
+      addTearDown(
+        () => container
+            .read(votingSubmissionGuardProvider.notifier)
+            .release(guard),
+      );
+
+      final subscription = container.listen(
+        votingSubmissionSessionProvider(key),
+        (_, _) {},
+      );
+      await container.read(votingSubmissionSessionProvider(key).future);
+      subscription.close();
+      container.invalidate(votingSubmissionSessionProvider(key));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(rust.resetVotingSessionStateCalls, isEmpty);
+    },
+  );
+
   test('hotkey failure moves session into error phase', () async {
     final rust = FakeVotingRustApi();
     final recoveryApi = FakeVotingRecoveryApi(
@@ -7635,6 +7700,7 @@ class FakeVotingRustApi implements VotingRustApi {
     this.keystoneSignatureBatchFailuresRemaining = 0,
     this.shareResubmissionError,
     this.nextShareTrackingDelayGate,
+    this.shareTrackingFlagsGate,
     this.failingVoteShareWireIndexes = const {},
     this.failingRecordShareIndexes = const {},
   });
@@ -7662,6 +7728,7 @@ class FakeVotingRustApi implements VotingRustApi {
   int keystoneSignatureBatchFailuresRemaining;
   final Object? shareResubmissionError;
   final Completer<void>? nextShareTrackingDelayGate;
+  final Completer<void>? shareTrackingFlagsGate;
   final Set<int> failingVoteShareWireIndexes;
   final Set<int> failingRecordShareIndexes;
   int setupCalls = 0;
@@ -7692,6 +7759,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final precomputeStarted = Completer<void>();
   final precomputeFinished = Completer<void>();
   final nextShareTrackingDelayStarted = Completer<void>();
+  final shareTrackingFlagsStarted = Completer<void>();
   final resetVoteTreeCalls = <String>[];
   final resetVotingSessionStateCalls = <String>[];
   final draftSingleShareValues = <bool>[];
@@ -8340,6 +8408,10 @@ class FakeVotingRustApi implements VotingRustApi {
     required BigInt nowSeconds,
     BigInt? voteEndTimeSeconds,
   }) async {
+    if (!shareTrackingFlagsStarted.isCompleted) {
+      shareTrackingFlagsStarted.complete();
+    }
+    await shareTrackingFlagsGate?.future;
     final now = nowSeconds.toInt();
     final base = share.submitAt > BigInt.zero
         ? share.submitAt.toInt()


### PR DESCRIPTION
## Summary
- Complete the submission job as soon as votes are display-complete, and keep helper share confirmation in the background so the status screen does not sit on Finalizing submission.
- Skip process-local Rust session reset on provider dispose while a submission guard is held, so in-flight vote work is not treated as abandoned.
- Drain live helper-share tracking before account delete or reset on both desktop and mobile, and navigate to confirmation without waiting for voting-power refresh.

This is [#546](https://github.com/chainapsis/vizor-wallet/pull/546) rebased onto `main`. The original PR targeted `roman/voting-perf`; the stall is already on `main`.

## Motivation / Why
Accepted-but-unrevealed helper shares kept the job in-flight, so the status screen stayed on **Finalizing submission** after votes were already display-complete. Completing the job earlier drops that wait, but share tracking must then stay registered so delete/reset can still drain it.

## Tests
- [x] `fvm dart format --output=none --set-exit-if-changed` on the 7 changed Dart files
- [x] `fvm flutter analyze` on the same files
- [x] `fvm flutter test test/providers/voting/voting_providers_test.dart test/features/voting/voting_status_screen_test.dart test/providers/account_provider_test.dart`
- [x] `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/providers/account_provider_test.dart --name "mobile account deletion drains live share tracking"`
- [ ] Re-run the iOS vote simulation: after helpers accept shares, the job should leave Finalizing submission without waiting for helper reveal.

Not run: full `fvm flutter test`, Rust tests, and regtest E2E. This change is Dart-only voting job/status/account-drain behavior; those suites are out of scope.