### PR TITLE
Fix vote failover delay and mobile completion

### DIFF
--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -555,13 +555,7 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
 
   bool _isCurrentStatusRoute(VotingSessionKey key) {
     if (!mounted) return false;
-    final currentPath = GoRouter.of(
-      context,
-    ).routerDelegate.currentConfiguration.uri.path;
-    final statusPath = Uri.parse(
-      votingStatusRoute(key.roundId, accountUuid: key.accountUuid),
-    ).path;
-    return currentPath == statusPath;
+    return ModalRoute.of(context)?.isCurrent ?? false;
   }
 }
 

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -61,9 +61,19 @@ final votingApiRequestTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 10);
 });
 
-/// Timeout for helper share endpoints.
+/// Total retry budget for an initial helper share submission.
 final votingHelperRequestTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 5);
+});
+
+/// Timeout for one helper readiness probe.
+final votingHelperPreflightTimeoutProvider = Provider<Duration>((ref) {
+  return const Duration(seconds: 2);
+});
+
+/// Short cache lifetime for helper readiness results shared by vote batches.
+final votingHelperPreflightTtlProvider = Provider<Duration>((ref) {
+  return const Duration(seconds: 10);
 });
 
 /// Delay before retrying a failed automatic helper-share tracking pass.
@@ -132,6 +142,8 @@ final votingApiClientProvider =
         httpClient: ref.watch(votingHttpClientProvider),
         timeout: ref.watch(votingApiRequestTimeoutProvider),
         helperTimeout: ref.watch(votingHelperRequestTimeoutProvider),
+        helperPreflightTimeout: ref.watch(votingHelperPreflightTimeoutProvider),
+        helperPreflightTtl: ref.watch(votingHelperPreflightTtlProvider),
         readRetryPolicy: ref.watch(votingApiReadRetryPolicyProvider),
         helperRetryPolicy: ref.watch(votingHelperRetryPolicyProvider),
         broadcastRetryPolicy: ref.watch(votingBroadcastRetryPolicyProvider),

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -61,7 +61,7 @@ final votingApiRequestTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 10);
 });
 
-/// Total retry budget for an initial helper share submission.
+/// Timeout for one helper share request.
 final votingHelperRequestTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 5);
 });
@@ -69,11 +69,6 @@ final votingHelperRequestTimeoutProvider = Provider<Duration>((ref) {
 /// Timeout for one helper readiness probe.
 final votingHelperPreflightTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 2);
-});
-
-/// Short cache lifetime for helper readiness results shared by vote batches.
-final votingHelperPreflightTtlProvider = Provider<Duration>((ref) {
-  return const Duration(seconds: 10);
 });
 
 /// Delay before retrying a failed automatic helper-share tracking pass.
@@ -143,7 +138,6 @@ final votingApiClientProvider =
         timeout: ref.watch(votingApiRequestTimeoutProvider),
         helperTimeout: ref.watch(votingHelperRequestTimeoutProvider),
         helperPreflightTimeout: ref.watch(votingHelperPreflightTimeoutProvider),
-        helperPreflightTtl: ref.watch(votingHelperPreflightTtlProvider),
         readRetryPolicy: ref.watch(votingApiReadRetryPolicyProvider),
         helperRetryPolicy: ref.watch(votingHelperRetryPolicyProvider),
         broadcastRetryPolicy: ref.watch(votingBroadcastRetryPolicyProvider),

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1764,6 +1764,21 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     return [...responsive, ...unknown, ...unavailable];
   }
 
+  Future<void> _warmShareHelperPreflight({
+    required _VotingSessionContext context,
+    required VotingApiClient api,
+  }) async {
+    try {
+      await api.preflightHelpers(context.config.apiServers.all);
+    } catch (error) {
+      // Readiness is only an ordering hint. The just-in-time preflight and
+      // bounded share submission still provide the authoritative fallback.
+      debugPrint(
+        '[zcash] Voting: helper preflight warmup ignored error=$error',
+      );
+    }
+  }
+
   Future<Map<String, bool>> _preflightShareHelpers({
     required _VotingSessionContext context,
     required VotingApiClient api,
@@ -2319,6 +2334,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   ) async {
     final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
+    // Warm every configured helper while the commitment is broadcast and
+    // confirmed. The just-in-time preflight reuses this in-flight or cached
+    // result when it is still fresh, and refreshes it after the cache TTL.
+    unawaited(_warmShareHelperPreflight(context: context, api: api));
     final txHashes = <int, String>{};
     for (final commitment in commitments.commitments) {
       final result = await api.submitVoteCommitment(
@@ -2379,6 +2398,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   ) async {
     final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
+    unawaited(_warmShareHelperPreflight(context: context, api: api));
     final vcTreePositions = <int, BigInt>{};
     for (final commitment in commitments.commitments) {
       debugPrint(

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1153,6 +1153,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             0,
             (total, work) => total + work.bundleIndexes.length,
           );
+      final helperAvailability = totalBundleTasks == 0
+          ? Future.value(const <String, bool>{})
+          : ref
+                .read(votingApiClientProvider(context.config.apiServers))
+                .preflightHelpers(context.config.apiServers.all);
       var completedBundleTasks = 0;
       var completedQuestions = 0;
       final startTiming = _roundShareTiming(context, _nowSeconds());
@@ -1233,6 +1238,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         await _submitCommitmentShares(
           context,
           commitments,
+          helperAvailability: helperAvailability,
           vcTreePositions: vcTreePositions,
           singleShare: _commitmentsUseSingleShare(commitments),
           shareIndexFilter: shareIndexFilter,
@@ -1285,6 +1291,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             totalBundleTasks: totalBundleTasks,
             completedQuestions: completedQuestions,
             totalQuestions: totalQuestions,
+            helperAvailability: helperAvailability,
           );
         } catch (_) {
           plan = await _loadResumePlan(context);
@@ -1446,6 +1453,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   Future<void> _submitCommitmentShares(
     _VotingSessionContext context,
     rust_wire.SignedVoteCommitmentsView commitments, {
+    required Future<Map<String, bool>> helperAvailability,
     Map<int, BigInt> vcTreePositions = const {},
     Set<int>? shareIndexFilter,
     void Function(VotingSessionProgress progress)? publishProgress,
@@ -1463,6 +1471,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     if (serverUrls.isEmpty) {
       throw StateError('No vote servers configured for share submission.');
     }
+    final availableHelpers = await helperAvailability;
+    _throwIfContextStale(context, 'helper-preflight-finished');
 
     final timing = _roundShareTiming(context, _nowSeconds());
     final bundleProgressMessage = _bundleProgressMessage(
@@ -1492,16 +1502,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           '${shares.length} payload(s).',
         );
       }
-      final plannedServers = <String>{
-        for (final plan in plans) ...plan.targetServers,
-      };
-      final helperAvailability = await _preflightShareHelpers(
-        context: context,
-        api: api,
-        plannedServers: plannedServers,
-        configuredServers: serverUrls,
-      );
-
       // Validate every body before starting helper requests. Otherwise a later
       // serialization failure could abandon already accepted submissions.
       final preparedSubmissions = <_PreparedInitialShareSubmission>[];
@@ -1514,7 +1514,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         final candidateServers = _plannedShareServers(
           plannedServers: plan.targetServers,
           fallbackServers: helperHealth.candidateServers(serverUrls),
-          helperAvailability: helperAvailability,
+          helperAvailability: availableHelpers,
         );
         final body = await _wireJsonMap(
           rust.voteShareWireJson(
@@ -1748,79 +1748,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     for (final server in fallbackServers) {
       if (server.trim().isNotEmpty) ordered.add(server);
     }
-    final responsive = <String>[];
-    final unknown = <String>[];
-    final unavailable = <String>[];
-    for (final server in ordered) {
-      final isReady = helperAvailability[server];
-      if (isReady == true) {
-        responsive.add(server);
-      } else if (isReady == false) {
-        unavailable.add(server);
-      } else {
-        unknown.add(server);
-      }
-    }
-    return [...responsive, ...unknown, ...unavailable];
-  }
-
-  Future<void> _warmShareHelperPreflight({
-    required _VotingSessionContext context,
-    required VotingApiClient api,
-  }) async {
-    try {
-      await api.preflightHelpers(context.config.apiServers.all);
-    } catch (error) {
-      // Readiness is only an ordering hint. The just-in-time preflight and
-      // bounded share submission still provide the authoritative fallback.
-      debugPrint(
-        '[zcash] Voting: helper preflight warmup ignored error=$error',
-      );
-    }
-  }
-
-  Future<Map<String, bool>> _preflightShareHelpers({
-    required _VotingSessionContext context,
-    required VotingApiClient api,
-    required Iterable<String> plannedServers,
-    required List<String> configuredServers,
-  }) async {
-    _throwIfContextStale(context, 'helper-preflight-start');
-    final planned = plannedServers
-        .where((server) => server.trim().isNotEmpty)
-        .toSet();
-    if (planned.isEmpty) return const {};
-
-    final timer = Stopwatch()..start();
-    try {
-      final availability = <String, bool>{
-        ...await api.preflightHelpers(planned.map(Uri.parse)),
-      };
-      if (planned.any((server) => availability[server] == false)) {
-        final replacements = configuredServers.where(
-          (server) => !planned.contains(server),
-        );
-        availability.addAll(
-          await api.preflightHelpers(replacements.map(Uri.parse)),
-        );
-      }
-      _throwIfContextStale(context, 'helper-preflight-finished');
-      final readyCount = availability.values.where((ready) => ready).length;
-      final unavailableCount = availability.length - readyCount;
-      _logVoteTiming(
-        'helper preflight planned=${planned.length} '
-        'probed=${availability.length} ready=$readyCount '
-        'unavailable=$unavailableCount '
-        'elapsed=${formatElapsedSeconds(timer.elapsed)}',
-      );
-      return Map<String, bool>.unmodifiable(availability);
-    } on _StaleVotingSessionAction {
-      rethrow;
-    } catch (error) {
-      _throwIfContextStale(context, 'helper-preflight-failed');
-      debugPrint('[zcash] Voting: helper preflight ignored error=$error');
-      return const {};
-    }
+    return [
+      for (final readiness in const <bool?>[true, null, false])
+        for (final server in ordered)
+          if (helperAvailability[server] == readiness) server,
+    ];
   }
 
   void _setShareSubmissionProgress({
@@ -1894,6 +1826,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required int totalBundleTasks,
     required int completedQuestions,
     required int totalQuestions,
+    required Future<Map<String, bool>> helperAvailability,
   }) async {
     // Transpose proposal -> bundles into bundle -> proposals. Proposal order
     // within a bundle follows the draft order so a restart resumes the same
@@ -2218,6 +2151,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
               await _submitCommitmentShares(
                 context,
                 commitments,
+                helperAvailability: helperAvailability,
                 vcTreePositions: vcTreePositions,
                 publishProgress: publish,
                 singleShare: singleShare,
@@ -2334,10 +2268,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   ) async {
     final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
-    // Warm every configured helper while the commitment is broadcast and
-    // confirmed. The just-in-time preflight reuses this in-flight or cached
-    // result when it is still fresh, and refreshes it after the cache TTL.
-    unawaited(_warmShareHelperPreflight(context: context, api: api));
     final txHashes = <int, String>{};
     for (final commitment in commitments.commitments) {
       final result = await api.submitVoteCommitment(
@@ -2398,7 +2328,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   ) async {
     final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
-    unawaited(_warmShareHelperPreflight(context: context, api: api));
     final vcTreePositions = <int, BigInt>{};
     for (final commitment in commitments.commitments) {
       debugPrint(

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1492,6 +1492,15 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           '${shares.length} payload(s).',
         );
       }
+      final plannedServers = <String>{
+        for (final plan in plans) ...plan.targetServers,
+      };
+      final helperAvailability = await _preflightShareHelpers(
+        context: context,
+        api: api,
+        plannedServers: plannedServers,
+        configuredServers: serverUrls,
+      );
 
       // Validate every body before starting helper requests. Otherwise a later
       // serialization failure could abandon already accepted submissions.
@@ -1505,6 +1514,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         final candidateServers = _plannedShareServers(
           plannedServers: plan.targetServers,
           fallbackServers: helperHealth.candidateServers(serverUrls),
+          helperAvailability: helperAvailability,
         );
         final body = await _wireJsonMap(
           rust.voteShareWireJson(
@@ -1729,6 +1739,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   List<String> _plannedShareServers({
     required List<String> plannedServers,
     required Iterable<String> fallbackServers,
+    Map<String, bool> helperAvailability = const {},
   }) {
     final ordered = <String>{};
     for (final server in plannedServers) {
@@ -1737,7 +1748,64 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     for (final server in fallbackServers) {
       if (server.trim().isNotEmpty) ordered.add(server);
     }
-    return ordered.toList(growable: false);
+    final responsive = <String>[];
+    final unknown = <String>[];
+    final unavailable = <String>[];
+    for (final server in ordered) {
+      final isReady = helperAvailability[server];
+      if (isReady == true) {
+        responsive.add(server);
+      } else if (isReady == false) {
+        unavailable.add(server);
+      } else {
+        unknown.add(server);
+      }
+    }
+    return [...responsive, ...unknown, ...unavailable];
+  }
+
+  Future<Map<String, bool>> _preflightShareHelpers({
+    required _VotingSessionContext context,
+    required VotingApiClient api,
+    required Iterable<String> plannedServers,
+    required List<String> configuredServers,
+  }) async {
+    _throwIfContextStale(context, 'helper-preflight-start');
+    final planned = plannedServers
+        .where((server) => server.trim().isNotEmpty)
+        .toSet();
+    if (planned.isEmpty) return const {};
+
+    final timer = Stopwatch()..start();
+    try {
+      final availability = <String, bool>{
+        ...await api.preflightHelpers(planned.map(Uri.parse)),
+      };
+      if (planned.any((server) => availability[server] == false)) {
+        final replacements = configuredServers.where(
+          (server) => !planned.contains(server),
+        );
+        availability.addAll(
+          await api.preflightHelpers(replacements.map(Uri.parse)),
+        );
+      }
+      _throwIfContextStale(context, 'helper-preflight-finished');
+      final readyCount = availability.values.where((ready) => ready).length;
+      final unavailableCount = availability.length - readyCount;
+      _logVoteTiming(
+        'helper preflight planned=${planned.length} '
+        'probed=${availability.length} ready=$readyCount '
+        'unavailable=$unavailableCount '
+        'elapsed=${formatElapsedSeconds(timer.elapsed)}',
+      );
+      return Map<String, bool>.unmodifiable(availability);
+    } on _StaleVotingSessionAction {
+      rethrow;
+    } catch (error) {
+      _throwIfContextStale(context, 'helper-preflight-failed');
+      debugPrint('[zcash] Voting: helper preflight ignored error=$error');
+      return const {};
+    }
   }
 
   void _setShareSubmissionProgress({

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -19,7 +19,6 @@ class VotingApiClient {
     Duration timeout = const Duration(seconds: 10),
     Duration helperTimeout = const Duration(seconds: 5),
     Duration helperPreflightTimeout = const Duration(seconds: 2),
-    Duration helperPreflightTtl = const Duration(seconds: 10),
     VotingRetryPolicy? readRetryPolicy,
     VotingRetryPolicy? helperRetryPolicy,
     VotingRetryPolicy? broadcastRetryPolicy,
@@ -30,7 +29,6 @@ class VotingApiClient {
        _timeout = timeout,
        _helperTimeout = helperTimeout,
        _helperPreflightTimeout = helperPreflightTimeout,
-       _helperPreflightTtl = helperPreflightTtl,
        _readRetryPolicy =
            readRetryPolicy ??
            VotingRetryPolicy.transientHttp(
@@ -60,13 +58,10 @@ class VotingApiClient {
   final Duration _timeout;
   final Duration _helperTimeout;
   final Duration _helperPreflightTimeout;
-  final Duration _helperPreflightTtl;
   final VotingRetryPolicy _readRetryPolicy;
   final VotingRetryPolicy _helperRetryPolicy;
   final VotingRetryPolicy _broadcastRetryPolicy;
   final Future<void> Function(Duration delay) _delay;
-  final Map<String, _CachedHelperPreflight> _helperPreflightCache = {};
-  final Map<String, Future<bool>> _helperPreflightInFlight = {};
 
   /// Lists rounds from the vote server.
   ///
@@ -257,19 +252,13 @@ class VotingApiClient {
   /// Checks helper readiness concurrently without failing the voting flow.
   ///
   /// A helper is ready only when its public status endpoint returns a
-  /// successful `{"status":"ok"}` response. Results are cached briefly so
-  /// concurrent share batches do not repeatedly probe the same helpers.
+  /// successful `{"status":"ok"}` response.
   Future<Map<String, bool>> preflightHelpers(Iterable<Uri> serverUrls) async {
-    final uniqueServers = <String, Uri>{};
-    for (final serverUrl in serverUrls) {
-      uniqueServers.putIfAbsent(serverUrl.toString(), () => serverUrl);
-    }
     final entries = await Future.wait([
-      for (final entry in uniqueServers.entries)
-        _preflightHelper(
-          entry.key,
-          entry.value,
-        ).then((isReady) => MapEntry(entry.key, isReady)),
+      for (final serverUrl in serverUrls)
+        _probeHelper(
+          serverUrl,
+        ).then((isReady) => MapEntry(serverUrl.toString(), isReady)),
     ]);
     return Map<String, bool>.unmodifiable(Map.fromEntries(entries));
   }
@@ -278,9 +267,8 @@ class VotingApiClient {
   ///
   /// The share map is expected to be the complete service JSON body produced
   /// by the voting pipeline. Fast transient failures retain the helper retry
-  /// policy, but every attempt and backoff shares one [_helperTimeout] budget.
-  /// An ambiguous timeout is never retried against the same helper so the
-  /// caller can promptly move to another candidate.
+  /// policy. An ambiguous timeout is never retried against the same helper so
+  /// the caller can promptly move to another candidate.
   Future<VotingShareSubmissionResult> submitShare({
     required Uri serverUrl,
     required Map<String, dynamic> share,
@@ -385,32 +373,6 @@ class VotingApiClient {
     return jsonDecode(response.bodyText);
   }
 
-  Future<bool> _preflightHelper(String key, Uri serverUrl) async {
-    final current = DateTime.now();
-    final cached = _helperPreflightCache[key];
-    if (cached != null && current.isBefore(cached.expiresAt)) {
-      return cached.isReady;
-    }
-
-    final existing = _helperPreflightInFlight[key];
-    if (existing != null) return existing;
-
-    final probe = _probeHelper(serverUrl);
-    _helperPreflightInFlight[key] = probe;
-    try {
-      final isReady = await probe;
-      _helperPreflightCache[key] = _CachedHelperPreflight(
-        isReady: isReady,
-        expiresAt: DateTime.now().add(_helperPreflightTtl),
-      );
-      return isReady;
-    } finally {
-      if (identical(_helperPreflightInFlight[key], probe)) {
-        _helperPreflightInFlight.remove(key);
-      }
-    }
-  }
-
   Future<bool> _probeHelper(Uri serverUrl) async {
     final uri = _endpoint(['status'], baseUrl: serverUrl);
     try {
@@ -430,51 +392,25 @@ class VotingApiClient {
     Uri uri,
     Map<String, dynamic> body,
   ) async {
-    final budget = Stopwatch()..start();
-    Object? lastError;
-    StackTrace? lastStackTrace;
-    for (
-      var attempt = 0;
-      attempt <= _helperRetryPolicy.delays.length;
-      attempt++
-    ) {
-      final remaining = attempt == 0
-          ? _helperTimeout
-          : _helperTimeout - budget.elapsed;
-      if (remaining <= Duration.zero) {
-        if (lastError != null && lastStackTrace != null) {
-          Error.throwWithStackTrace(lastError, lastStackTrace);
-        }
-        throw TimeoutException(
-          'Helper submission budget exhausted for $uri',
-          _helperTimeout,
-        );
-      }
-      try {
+    final retryPolicy = VotingRetryPolicy(
+      name: '${_helperRetryPolicy.name}-initial',
+      delays: _helperRetryPolicy.delays,
+      shouldRetry: (error) =>
+          error is! TimeoutException && _helperRetryPolicy.shouldRetry(error),
+    );
+    final response = await _runRequestWithRetry(
+      retryPolicy: retryPolicy,
+      operation: () async {
         final response = await _post(
           uri,
           body,
-          timeout: remaining,
-        ).timeout(remaining);
+          timeout: _helperTimeout,
+        ).timeout(_helperTimeout);
         _throwIfNotSuccess(uri, response);
-        return jsonDecode(response.bodyText);
-      } catch (error, stackTrace) {
-        lastError = error;
-        lastStackTrace = stackTrace;
-        if (error is TimeoutException ||
-            attempt == _helperRetryPolicy.delays.length ||
-            !_helperRetryPolicy.shouldRetry(error)) {
-          rethrow;
-        }
-        final retryDelay = _helperRetryPolicy.delays[attempt];
-        final remainingAfterAttempt = _helperTimeout - budget.elapsed;
-        if (remainingAfterAttempt <= retryDelay) rethrow;
-        await _delay(retryDelay).timeout(remainingAfterAttempt);
-      }
-    }
-    throw StateError(
-      '${_helperRetryPolicy.name} retry exited unexpectedly: $lastError',
+        return response;
+      },
     );
+    return jsonDecode(response.bodyText);
   }
 
   Future<VotingHttpResponse> _get(Uri uri, {required Duration timeout}) {
@@ -567,16 +503,6 @@ class VotingApiClient {
     }
     return List<Uri>.unmodifiable(deduped);
   }
-}
-
-class _CachedHelperPreflight {
-  const _CachedHelperPreflight({
-    required this.isReady,
-    required this.expiresAt,
-  });
-
-  final bool isReady;
-  final DateTime expiresAt;
 }
 
 Map<String, dynamic> _objectFromValue(Object? value) {

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -227,18 +227,16 @@ class VotingApiClient {
   Future<VotingTxConfirmation?> getTxConfirmation(String txHash) async {
     final response = await _withVoteServerFailover(
       policy: _readRetryPolicy,
-      operation: (baseUrl) {
+      operation: (baseUrl) async {
         final requestUri = _endpoint(['tx', txHash], baseUrl: baseUrl);
-        return _runRequestWithRetry(
-          retryPolicy: _readRetryPolicy,
-          operation: () async {
-            final response = await _get(requestUri, timeout: _timeout);
-            if (response.statusCode != 404 && response.statusCode != 422) {
-              _throwIfNotSuccess(requestUri, response);
-            }
-            return response;
-          },
-        );
+        // Confirmation polling retries the complete lookup. Trying each server
+        // once per pass keeps one offline fallback from consuming the request
+        // timeout repeatedly before the next server gets a chance to answer.
+        final response = await _get(requestUri, timeout: _timeout);
+        if (response.statusCode != 404 && response.statusCode != 422) {
+          _throwIfNotSuccess(requestUri, response);
+        }
+        return response;
       },
       shouldTryNextCandidate: (response) => response.statusCode == 404,
     );

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -18,6 +18,8 @@ class VotingApiClient {
     List<Uri> fallbackBaseUrls = const [],
     Duration timeout = const Duration(seconds: 10),
     Duration helperTimeout = const Duration(seconds: 5),
+    Duration helperPreflightTimeout = const Duration(seconds: 2),
+    Duration helperPreflightTtl = const Duration(seconds: 10),
     VotingRetryPolicy? readRetryPolicy,
     VotingRetryPolicy? helperRetryPolicy,
     VotingRetryPolicy? broadcastRetryPolicy,
@@ -27,6 +29,8 @@ class VotingApiClient {
        _fallbackBaseUrls = _dedupeBaseUrls(fallbackBaseUrls, baseUrl: baseUrl),
        _timeout = timeout,
        _helperTimeout = helperTimeout,
+       _helperPreflightTimeout = helperPreflightTimeout,
+       _helperPreflightTtl = helperPreflightTtl,
        _readRetryPolicy =
            readRetryPolicy ??
            VotingRetryPolicy.transientHttp(
@@ -55,10 +59,14 @@ class VotingApiClient {
   final VotingHttpClient _httpClient;
   final Duration _timeout;
   final Duration _helperTimeout;
+  final Duration _helperPreflightTimeout;
+  final Duration _helperPreflightTtl;
   final VotingRetryPolicy _readRetryPolicy;
   final VotingRetryPolicy _helperRetryPolicy;
   final VotingRetryPolicy _broadcastRetryPolicy;
   final Future<void> Function(Duration delay) _delay;
+  final Map<String, _CachedHelperPreflight> _helperPreflightCache = {};
+  final Map<String, Future<bool>> _helperPreflightInFlight = {};
 
   /// Lists rounds from the vote server.
   ///
@@ -246,21 +254,40 @@ class VotingApiClient {
     );
   }
 
+  /// Checks helper readiness concurrently without failing the voting flow.
+  ///
+  /// A helper is ready only when its public status endpoint returns a
+  /// successful `{"status":"ok"}` response. Results are cached briefly so
+  /// concurrent share batches do not repeatedly probe the same helpers.
+  Future<Map<String, bool>> preflightHelpers(Iterable<Uri> serverUrls) async {
+    final uniqueServers = <String, Uri>{};
+    for (final serverUrl in serverUrls) {
+      uniqueServers.putIfAbsent(serverUrl.toString(), () => serverUrl);
+    }
+    final entries = await Future.wait([
+      for (final entry in uniqueServers.entries)
+        _preflightHelper(
+          entry.key,
+          entry.value,
+        ).then((isReady) => MapEntry(entry.key, isReady)),
+    ]);
+    return Map<String, bool>.unmodifiable(Map.fromEntries(entries));
+  }
+
   /// Posts one encrypted share directly to a helper server.
   ///
   /// The share map is expected to be the complete service JSON body produced
-  /// by the voting pipeline. This makes one transport attempt because the
-  /// caller already walks the remaining helper candidates after a failure.
-  /// Retrying an unresponsive helper here would delay that failover and a
-  /// timeout is ambiguous because the helper may have accepted the payload.
+  /// by the voting pipeline. Fast transient failures retain the helper retry
+  /// policy, but every attempt and backoff shares one [_helperTimeout] budget.
+  /// An ambiguous timeout is never retried against the same helper so the
+  /// caller can promptly move to another candidate.
   Future<VotingShareSubmissionResult> submitShare({
     required Uri serverUrl,
     required Map<String, dynamic> share,
   }) async {
-    final decoded = await _postJson(
+    final decoded = await _postInitialShareJson(
       _endpoint(['shares'], baseUrl: serverUrl),
       share,
-      timeout: _helperTimeout,
     );
     return VotingShareSubmissionResult.fromJson(_objectFromValue(decoded));
   }
@@ -358,6 +385,98 @@ class VotingApiClient {
     return jsonDecode(response.bodyText);
   }
 
+  Future<bool> _preflightHelper(String key, Uri serverUrl) async {
+    final current = DateTime.now();
+    final cached = _helperPreflightCache[key];
+    if (cached != null && current.isBefore(cached.expiresAt)) {
+      return cached.isReady;
+    }
+
+    final existing = _helperPreflightInFlight[key];
+    if (existing != null) return existing;
+
+    final probe = _probeHelper(serverUrl);
+    _helperPreflightInFlight[key] = probe;
+    try {
+      final isReady = await probe;
+      _helperPreflightCache[key] = _CachedHelperPreflight(
+        isReady: isReady,
+        expiresAt: DateTime.now().add(_helperPreflightTtl),
+      );
+      return isReady;
+    } finally {
+      if (identical(_helperPreflightInFlight[key], probe)) {
+        _helperPreflightInFlight.remove(key);
+      }
+    }
+  }
+
+  Future<bool> _probeHelper(Uri serverUrl) async {
+    final uri = _endpoint(['status'], baseUrl: serverUrl);
+    try {
+      final response = await _get(
+        uri,
+        timeout: _helperPreflightTimeout,
+      ).timeout(_helperPreflightTimeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) return false;
+      final status = _objectFromValue(jsonDecode(response.bodyText))['status'];
+      return status?.toString().trim().toLowerCase() == 'ok';
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<Object?> _postInitialShareJson(
+    Uri uri,
+    Map<String, dynamic> body,
+  ) async {
+    final budget = Stopwatch()..start();
+    Object? lastError;
+    StackTrace? lastStackTrace;
+    for (
+      var attempt = 0;
+      attempt <= _helperRetryPolicy.delays.length;
+      attempt++
+    ) {
+      final remaining = attempt == 0
+          ? _helperTimeout
+          : _helperTimeout - budget.elapsed;
+      if (remaining <= Duration.zero) {
+        if (lastError != null && lastStackTrace != null) {
+          Error.throwWithStackTrace(lastError, lastStackTrace);
+        }
+        throw TimeoutException(
+          'Helper submission budget exhausted for $uri',
+          _helperTimeout,
+        );
+      }
+      try {
+        final response = await _post(
+          uri,
+          body,
+          timeout: remaining,
+        ).timeout(remaining);
+        _throwIfNotSuccess(uri, response);
+        return jsonDecode(response.bodyText);
+      } catch (error, stackTrace) {
+        lastError = error;
+        lastStackTrace = stackTrace;
+        if (error is TimeoutException ||
+            attempt == _helperRetryPolicy.delays.length ||
+            !_helperRetryPolicy.shouldRetry(error)) {
+          rethrow;
+        }
+        final retryDelay = _helperRetryPolicy.delays[attempt];
+        final remainingAfterAttempt = _helperTimeout - budget.elapsed;
+        if (remainingAfterAttempt <= retryDelay) rethrow;
+        await _delay(retryDelay).timeout(remainingAfterAttempt);
+      }
+    }
+    throw StateError(
+      '${_helperRetryPolicy.name} retry exited unexpectedly: $lastError',
+    );
+  }
+
   Future<VotingHttpResponse> _get(Uri uri, {required Duration timeout}) {
     return _httpClient.get(uri, timeout: timeout);
   }
@@ -448,6 +567,16 @@ class VotingApiClient {
     }
     return List<Uri>.unmodifiable(deduped);
   }
+}
+
+class _CachedHelperPreflight {
+  const _CachedHelperPreflight({
+    required this.isReady,
+    required this.expiresAt,
+  });
+
+  final bool isReady;
+  final DateTime expiresAt;
 }
 
 Map<String, dynamic> _objectFromValue(Object? value) {

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -249,7 +249,10 @@ class VotingApiClient {
   /// Posts one encrypted share directly to a helper server.
   ///
   /// The share map is expected to be the complete service JSON body produced
-  /// by the voting pipeline.
+  /// by the voting pipeline. This makes one transport attempt because the
+  /// caller already walks the remaining helper candidates after a failure.
+  /// Retrying an unresponsive helper here would delay that failover and a
+  /// timeout is ambiguous because the helper may have accepted the payload.
   Future<VotingShareSubmissionResult> submitShare({
     required Uri serverUrl,
     required Map<String, dynamic> share,
@@ -258,7 +261,6 @@ class VotingApiClient {
       _endpoint(['shares'], baseUrl: serverUrl),
       share,
       timeout: _helperTimeout,
-      retryPolicy: _helperRetryPolicy,
     );
     return VotingShareSubmissionResult.fromJson(_objectFromValue(decoded));
   }

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -228,21 +228,27 @@ class VotingApiClient {
   }
 
   Future<VotingTxConfirmation?> getTxConfirmation(String txHash) async {
-    final response = await _withVoteServerFailover(
-      policy: _readRetryPolicy,
-      operation: (baseUrl) async {
-        final requestUri = _endpoint(['tx', txHash], baseUrl: baseUrl);
-        // Confirmation polling retries the complete lookup. Trying each server
-        // once per pass keeps one offline fallback from consuming the request
-        // timeout repeatedly before the next server gets a chance to answer.
-        final response = await _get(requestUri, timeout: _timeout);
-        if (response.statusCode != 404 && response.statusCode != 422) {
-          _throwIfNotSuccess(requestUri, response);
-        }
-        return response;
-      },
-      shouldTryNextCandidate: (response) => response.statusCode == 404,
-    );
+    final VotingHttpResponse response;
+    try {
+      response = await _withVoteServerFailover(
+        policy: _readRetryPolicy,
+        operation: (baseUrl) async {
+          final requestUri = _endpoint(['tx', txHash], baseUrl: baseUrl);
+          // Confirmation polling retries the complete lookup. Trying each
+          // server once per pass keeps one offline fallback from consuming the
+          // request timeout repeatedly before the next server gets a chance.
+          final response = await _get(requestUri, timeout: _timeout);
+          if (response.statusCode != 404 && response.statusCode != 422) {
+            _throwIfNotSuccess(requestUri, response);
+          }
+          return response;
+        },
+        shouldTryNextCandidate: (response) => response.statusCode == 404,
+      );
+    } catch (error) {
+      if (_readRetryPolicy.shouldRetry(error)) return null;
+      rethrow;
+    }
     if (response.statusCode == 404) return null;
     return VotingTxConfirmation.fromJson(
       _objectFromValue(jsonDecode(response.bodyText)),

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1239,6 +1239,14 @@ void main() {
       addTearDown(() {
         if (!refreshGate.isCompleted) refreshGate.complete(null);
       });
+      final jobNotifier = _CompletableVotingSubmissionJobNotifier(
+        key,
+        const VotingSubmissionJobState(
+          key: key,
+          status: VotingSubmissionJobStatus.running,
+          generation: 1,
+        ),
+      );
       final completedState = VotingSessionState(
         roundId: _roundId,
         accountUuid: key.accountUuid,
@@ -1252,16 +1260,7 @@ void main() {
               const VotingSubmissionJobsState(jobKeys: [key]),
             ),
           ),
-          votingSubmissionJobProvider(key).overrideWith(
-            () => _StaticVotingSubmissionJobNotifier(
-              key,
-              const VotingSubmissionJobState(
-                key: key,
-                status: VotingSubmissionJobStatus.complete,
-                generation: 1,
-              ),
-            ),
-          ),
+          votingSubmissionJobProvider(key).overrideWith(() => jobNotifier),
           votingSubmissionJobSessionProvider(
             key,
           ).overrideWithValue(AsyncValue.data(completedState)),
@@ -1270,81 +1269,6 @@ void main() {
               key,
               completedState,
               refreshGate,
-            ),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-
-      final router = GoRouter(
-        initialLocation: '/home',
-        routes: [
-          GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
-          GoRoute(
-            path: '/voting/poll/:roundId/status',
-            builder: (_, state) => VotingStatusView(
-              roundId: state.pathParameters['roundId']!,
-              accountUuid: state.uri.queryParameters['account'],
-              requireCurrentRouteForConfirmation: true,
-            ),
-          ),
-          GoRoute(
-            path: '/voting/poll/:roundId/submitted',
-            builder: (_, _) => const Text('submission confirmed route'),
-          ),
-        ],
-      );
-      addTearDown(router.dispose);
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: MaterialApp.router(
-            routerConfig: router,
-            builder: (_, child) =>
-                AppTheme(data: AppThemeData.light, child: child!),
-          ),
-        ),
-      );
-      unawaited(
-        router.pushReplacement(
-          votingStatusRoute(_roundId, accountUuid: key.accountUuid),
-        ),
-      );
-      await _pumpUntilFound(tester, find.text('submission confirmed route'));
-
-      expect(find.text('submission confirmed route'), findsOneWidget);
-      expect(refreshGate.isCompleted, isFalse);
-    },
-  );
-
-  testWidgets(
-    'completed mobile status navigates from an imperative voting stack',
-    (tester) async {
-      const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
-      final jobNotifier = _CompletableVotingSubmissionJobNotifier(
-        key,
-        const VotingSubmissionJobState(
-          key: key,
-          status: VotingSubmissionJobStatus.running,
-          generation: 1,
-        ),
-      );
-      final container = _statusContainer(
-        accountOverride: _MnemonicAccountNotifier.new,
-        overrides: [
-          votingSubmissionJobsProvider.overrideWith(
-            () => _StaticVotingSubmissionJobsNotifier(
-              const VotingSubmissionJobsState(jobKeys: [key]),
-            ),
-          ),
-          votingSubmissionJobProvider(key).overrideWith(() => jobNotifier),
-          votingSubmissionJobSessionProvider(key).overrideWithValue(
-            AsyncValue.data(
-              VotingSessionState(
-                roundId: _roundId,
-                accountUuid: key.accountUuid,
-                phase: VotingSessionPhase.done,
-              ),
             ),
           ),
         ],
@@ -1410,6 +1334,7 @@ void main() {
       await _pumpUntilFound(tester, find.text('submission confirmed route'));
 
       expect(find.text('submission confirmed route'), findsOneWidget);
+      expect(refreshGate.isCompleted, isFalse);
     },
   );
 

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1318,6 +1318,102 @@ void main() {
   );
 
   testWidgets(
+    'completed mobile status navigates from an imperative voting stack',
+    (tester) async {
+      const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+      final jobNotifier = _CompletableVotingSubmissionJobNotifier(
+        key,
+        const VotingSubmissionJobState(
+          key: key,
+          status: VotingSubmissionJobStatus.running,
+          generation: 1,
+        ),
+      );
+      final container = _statusContainer(
+        accountOverride: _MnemonicAccountNotifier.new,
+        overrides: [
+          votingSubmissionJobsProvider.overrideWith(
+            () => _StaticVotingSubmissionJobsNotifier(
+              const VotingSubmissionJobsState(jobKeys: [key]),
+            ),
+          ),
+          votingSubmissionJobProvider(key).overrideWith(() => jobNotifier),
+          votingSubmissionJobSessionProvider(key).overrideWithValue(
+            AsyncValue.data(
+              VotingSessionState(
+                roundId: _roundId,
+                accountUuid: key.accountUuid,
+                phase: VotingSessionPhase.done,
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final router = GoRouter(
+        initialLocation: '/home',
+        routes: [
+          GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
+          GoRoute(
+            path: '/voting',
+            builder: (_, _) => const Text('voting route'),
+          ),
+          GoRoute(
+            path: '/voting/poll/:roundId',
+            builder: (_, _) => const Text('poll route'),
+          ),
+          GoRoute(
+            path: '/voting/poll/:roundId/review',
+            builder: (_, _) => const Text('review route'),
+          ),
+          GoRoute(
+            path: '/voting/poll/:roundId/status',
+            builder: (_, state) => VotingStatusView(
+              roundId: state.pathParameters['roundId']!,
+              accountUuid: state.uri.queryParameters['account'],
+              requireCurrentRouteForConfirmation: true,
+            ),
+          ),
+          GoRoute(
+            path: '/voting/poll/:roundId/submitted',
+            builder: (_, _) => const Text('submission confirmed route'),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+            builder: (_, child) =>
+                AppTheme(data: AppThemeData.light, child: child!),
+          ),
+        ),
+      );
+
+      unawaited(router.push('/voting'));
+      await _pumpUntilFound(tester, find.text('voting route'));
+      unawaited(router.push(votingPollRoute(_roundId)));
+      await _pumpUntilFound(tester, find.text('poll route'));
+      unawaited(router.push(votingReviewRoute(_roundId)));
+      await _pumpUntilFound(tester, find.text('review route'));
+      unawaited(
+        router.pushReplacement(
+          votingStatusRoute(_roundId, accountUuid: key.accountUuid),
+        ),
+      );
+      await _pumpUntilFound(tester, find.text('Finalizing submission'));
+
+      jobNotifier.complete();
+      await _pumpUntilFound(tester, find.text('submission confirmed route'));
+
+      expect(find.text('submission confirmed route'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
     'completed mobile status does not replace a route pushed above it',
     (tester) async {
       const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6045,73 +6045,9 @@ void main() {
     expect(rust.recordedShares, isEmpty);
   });
 
-  test('initial share submission uses planned helper targets', () async {
+  test('initial shares replace an unavailable helper', () async {
     final helperUrls = [
       for (var i = 1; i <= 6; i++)
-        {'url': 'https://helper-$i.example', 'label': 'helper-$i'},
-    ];
-    final http = FakeVotingHttpClient(
-      responses: votingHttpResponses(
-        dynamicConfig: dynamicConfigJson(voteServers: helperUrls),
-      ),
-    );
-    final rust = FakeVotingRustApi(emitCommitments: true);
-    final recoveryApi = FakeVotingRecoveryApi(
-      state: recoveryState(
-        bundleCount: 1,
-        delegationTxHashes: [
-          rust_frb_types.DelegationRecoveryView(
-            bundleIndex: 0,
-            phase: VotingWorkflowPhase.submittedDelegation,
-            txHash: 'delegation-0',
-            vanLeafPosition: null,
-          ),
-        ],
-        votes: [vote(bundleIndex: 0, proposalId: 7)],
-      ),
-    );
-    final container = _sessionContainer(
-      http: http,
-      rust: rust,
-      recoveryApi: recoveryApi,
-    );
-    addTearDown(container.dispose);
-
-    await container.read(votingSessionProvider(kRoundId).future);
-    await container
-        .read(votingSessionProvider(kRoundId).notifier)
-        .castVotes(
-          draftVotes: [
-            rust_wire.DraftVote(
-              proposalId: 7,
-              choice: 1,
-              numOptions: 2,
-              vcTreePosition: BigInt.zero,
-              singleShare: false,
-            ),
-          ],
-        );
-
-    final sharePosts = http.requests.where(
-      (request) =>
-          request.method == 'POST' &&
-          request.uri.path == '/shielded-vote/v1/shares',
-    );
-    expect(sharePosts.map((request) => request.uri.host), [
-      'helper-1.example',
-      'helper-2.example',
-      'helper-3.example',
-    ]);
-    expect(rust.recordedShares.single.sentToUrls, [
-      'https://helper-1.example',
-      'https://helper-2.example',
-      'https://helper-3.example',
-    ]);
-  });
-
-  test('helper preflight overlaps confirmation and replaces target', () async {
-    final helperUrls = [
-      for (var i = 1; i <= 4; i++)
         {'url': 'https://helper-$i.example', 'label': 'helper-$i'},
     ];
     final http = _GatedVotingHttpClient(
@@ -6180,8 +6116,7 @@ void main() {
     final statusHosts = http.requests
         .where(
           (request) =>
-              request.method == 'GET' &&
-              request.uri.path == '/shielded-vote/v1/status',
+              request.method == 'GET' && request.uri.path == statusPath,
         )
         .map((request) => request.uri.host);
     expect(
@@ -6191,19 +6126,25 @@ void main() {
         'helper-2.example',
         'helper-3.example',
         'helper-4.example',
+        'helper-5.example',
+        'helper-6.example',
       ]),
     );
-    final sharePostHosts = http.requests
-        .where(
-          (request) =>
-              request.method == 'POST' &&
-              request.uri.path == '/shielded-vote/v1/shares',
-        )
-        .map((request) => request.uri.host);
-    expect(sharePostHosts, ['helper-2.example', 'helper-3.example']);
+
+    final sharePosts = http.requests.where(
+      (request) =>
+          request.method == 'POST' &&
+          request.uri.path == '/shielded-vote/v1/shares',
+    );
+    expect(sharePosts.map((request) => request.uri.host), [
+      'helper-2.example',
+      'helper-3.example',
+      'helper-4.example',
+    ]);
     expect(rust.recordedShares.single.sentToUrls, [
       'https://helper-2.example',
       'https://helper-3.example',
+      'https://helper-4.example',
     ]);
   });
 

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6109,12 +6109,12 @@ void main() {
     ]);
   });
 
-  test('helper preflight replaces an unavailable planned target', () async {
+  test('helper preflight overlaps confirmation and replaces target', () async {
     final helperUrls = [
       for (var i = 1; i <= 4; i++)
         {'url': 'https://helper-$i.example', 'label': 'helper-$i'},
     ];
-    final http = FakeVotingHttpClient(
+    final http = _GatedVotingHttpClient(
       responses: {
         ...votingHttpResponses(
           dynamicConfig: dynamicConfigJson(voteServers: helperUrls),
@@ -6124,6 +6124,9 @@ void main() {
         }, statusCode: 503),
       },
     );
+    const confirmationPath = '/shielded-vote/v1/tx/vote-tx';
+    const statusPath = '/shielded-vote/v1/status';
+    final confirmationGate = http.gateNextGet(confirmationPath);
     final rust = FakeVotingRustApi(emitCommitments: true);
     final recoveryApi = FakeVotingRecoveryApi(
       state: recoveryState(
@@ -6145,9 +6148,12 @@ void main() {
       recoveryApi: recoveryApi,
     );
     addTearDown(container.dispose);
+    addTearDown(() {
+      if (!confirmationGate.isCompleted) confirmationGate.complete();
+    });
 
     await container.read(votingSessionProvider(kRoundId).future);
-    await container
+    final submission = container
         .read(votingSessionProvider(kRoundId).notifier)
         .castVotes(
           draftVotes: [
@@ -6160,6 +6166,16 @@ void main() {
             ),
           ],
         );
+    await http
+        .waitForGetCount(confirmationPath, 1)
+        .timeout(const Duration(seconds: 1));
+    await http
+        .waitForGetCount(statusPath, helperUrls.length)
+        .timeout(const Duration(seconds: 1));
+
+    expect(confirmationGate.isCompleted, isFalse);
+    confirmationGate.complete();
+    await submission;
 
     final statusHosts = http.requests
         .where(

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6109,6 +6109,88 @@ void main() {
     ]);
   });
 
+  test('helper preflight replaces an unavailable planned target', () async {
+    final helperUrls = [
+      for (var i = 1; i <= 4; i++)
+        {'url': 'https://helper-$i.example', 'label': 'helper-$i'},
+    ];
+    final http = FakeVotingHttpClient(
+      responses: {
+        ...votingHttpResponses(
+          dynamicConfig: dynamicConfigJson(voteServers: helperUrls),
+        ),
+        'https://helper-1.example/shielded-vote/v1/status': jsonResponse({
+          'error': 'unavailable',
+        }, statusCode: 503),
+      },
+    );
+    final rust = FakeVotingRustApi(emitCommitments: true);
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 1,
+        delegationTxHashes: [
+          rust_frb_types.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.submittedDelegation,
+            txHash: 'delegation-0',
+            vanLeafPosition: null,
+          ),
+        ],
+        votes: [vote(bundleIndex: 0, proposalId: 7)],
+      ),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(
+          draftVotes: [
+            rust_wire.DraftVote(
+              proposalId: 7,
+              choice: 1,
+              numOptions: 2,
+              vcTreePosition: BigInt.zero,
+              singleShare: false,
+            ),
+          ],
+        );
+
+    final statusHosts = http.requests
+        .where(
+          (request) =>
+              request.method == 'GET' &&
+              request.uri.path == '/shielded-vote/v1/status',
+        )
+        .map((request) => request.uri.host);
+    expect(
+      statusHosts,
+      unorderedEquals([
+        'helper-1.example',
+        'helper-2.example',
+        'helper-3.example',
+        'helper-4.example',
+      ]),
+    );
+    final sharePostHosts = http.requests
+        .where(
+          (request) =>
+              request.method == 'POST' &&
+              request.uri.path == '/shielded-vote/v1/shares',
+        )
+        .map((request) => request.uri.host);
+    expect(sharePostHosts, ['helper-2.example', 'helper-3.example']);
+    expect(rust.recordedShares.single.sentToUrls, [
+      'https://helper-2.example',
+      'https://helper-3.example',
+    ]);
+  });
+
   test(
     'share submission schedules submit_at before last-moment buffer',
     () async {
@@ -8040,6 +8122,7 @@ Map<String, Object> votingHttpResponses({
     ],
   },
   '/shielded-vote/v1/cast-vote': {'tx_hash': 'vote-tx', 'code': 0, 'log': ''},
+  '/shielded-vote/v1/status': {'status': 'ok'},
   '/shielded-vote/v1/shares': {'status': 'queued'},
   '/shielded-vote/v1/tx/vote-tx': {
     'height': 11,

--- a/test/services/voting/fake_voting_http.dart
+++ b/test/services/voting/fake_voting_http.dart
@@ -34,7 +34,7 @@ class FakeVotingHttpClient implements VotingHttpClient {
     return _responseFor(uri);
   }
 
-  VotingHttpResponse _responseFor(Uri uri) {
+  Future<VotingHttpResponse> _responseFor(Uri uri) async {
     final configured = responses[uri.toString()] ?? responses[uri.path];
     final response = configured is SequentialVotingHttpResponses
         ? configured.next()
@@ -47,6 +47,9 @@ class FakeVotingHttpClient implements VotingHttpClient {
     }
     if (response is Error) {
       throw response;
+    }
+    if (response is Future<VotingHttpResponse>) {
+      return response;
     }
     if (response is VotingHttpResponse) {
       return response;

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/services/voting/voting_api_client.dart';
+import 'package:zcash_wallet/src/services/voting/voting_http.dart';
 import 'package:zcash_wallet/src/services/voting/voting_retry.dart';
 
 import 'fake_voting_http.dart';
@@ -832,6 +833,138 @@ void main() {
       'vote_round_id': hexRoundId,
     });
     expect(http.requests.single.timeout, const Duration(seconds: 5));
+  });
+
+  test('preflights helpers concurrently and caches readiness', () async {
+    final primaryResponse = Completer<VotingHttpResponse>();
+    final secondaryResponse = Completer<VotingHttpResponse>();
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://helper-1.example/shielded-vote/v1/status':
+            primaryResponse.future,
+        'https://helper-2.example/shielded-vote/v1/status':
+            secondaryResponse.future,
+      },
+    );
+    final client = VotingApiClient(
+      baseUrl: Uri.parse('https://voting.valargroup.org'),
+      httpClient: http,
+      helperPreflightTimeout: const Duration(seconds: 1),
+    );
+
+    final pending = client.preflightHelpers([
+      Uri.parse('https://helper-1.example'),
+      Uri.parse('https://helper-2.example'),
+      Uri.parse('https://helper-1.example'),
+    ]);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(http.requests.map((request) => request.uri.host), [
+      'helper-1.example',
+      'helper-2.example',
+    ]);
+    primaryResponse.complete(jsonResponse({'status': 'ok'}));
+    secondaryResponse.complete(jsonResponse({'status': 'ok'}));
+    expect(await pending, {
+      'https://helper-1.example': true,
+      'https://helper-2.example': true,
+    });
+
+    expect(
+      await client.preflightHelpers([Uri.parse('https://helper-1.example')]),
+      {'https://helper-1.example': true},
+    );
+    expect(http.requests, hasLength(2));
+    expect(
+      http.requests.map((request) => request.timeout),
+      everyElement(const Duration(seconds: 1)),
+    );
+  });
+
+  test(
+    'preflight reports failed and malformed helpers as unavailable',
+    () async {
+      final http = FakeVotingHttpClient(
+        responses: {
+          'https://helper-1.example/shielded-vote/v1/status': jsonResponse({
+            'error': 'unavailable',
+          }, statusCode: 503),
+          'https://helper-2.example/shielded-vote/v1/status': {
+            'status': 'starting',
+          },
+          'https://helper-3.example/shielded-vote/v1/status': timeoutResponse(),
+        },
+      );
+      final client = VotingApiClient(
+        baseUrl: Uri.parse('https://voting.valargroup.org'),
+        httpClient: http,
+      );
+
+      final readiness = await client.preflightHelpers([
+        Uri.parse('https://helper-1.example'),
+        Uri.parse('https://helper-2.example'),
+        Uri.parse('https://helper-3.example'),
+      ]);
+
+      expect(readiness.values, everyElement(isFalse));
+    },
+  );
+
+  test('retries fast transient initial helper failures', () async {
+    final delays = <Duration>[];
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://helper.example/shielded-vote/v1/shares':
+            SequentialVotingHttpResponses([
+              jsonResponse({'error': 'unavailable'}, statusCode: 503),
+              {'status': 'queued'},
+            ]),
+      },
+    );
+    final client = VotingApiClient(
+      baseUrl: Uri.parse('https://voting.valargroup.org'),
+      httpClient: http,
+      helperRetryPolicy: VotingRetryPolicy.transientHttp(
+        name: 'test-helper-retry',
+        delays: const [Duration(milliseconds: 2)],
+      ),
+      delay: (delay) async => delays.add(delay),
+    );
+
+    final result = await client.submitShare(
+      serverUrl: Uri.parse('https://helper.example'),
+      share: {'share_index': 0, 'vote_round_id': hexRoundId},
+    );
+
+    expect(result.status, 'queued');
+    expect(http.requests, hasLength(2));
+    expect(delays, const [Duration(milliseconds: 2)]);
+  });
+
+  test('bounds a blackholed initial helper to one total timeout', () async {
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://helper.example/shielded-vote/v1/shares':
+            Completer<VotingHttpResponse>().future,
+      },
+    );
+    final client = VotingApiClient(
+      baseUrl: Uri.parse('https://voting.valargroup.org'),
+      httpClient: http,
+      helperTimeout: const Duration(milliseconds: 30),
+    );
+    final timer = Stopwatch()..start();
+
+    await expectLater(
+      client.submitShare(
+        serverUrl: Uri.parse('https://helper.example'),
+        share: {'share_index': 0, 'vote_round_id': hexRoundId},
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+
+    expect(http.requests, hasLength(1));
+    expect(timer.elapsed, lessThan(const Duration(seconds: 1)));
   });
 
   test('does not retry initial helper submission after a timeout', () async {

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -501,14 +501,14 @@ void main() {
   });
 
   test(
-    'tries tx confirmation fallbacks before returning null on 404',
+    'tries each tx confirmation server once before returning null',
     () async {
       final primary = Uri.parse('https://vote-primary.example');
       final secondary = Uri.parse('https://vote-secondary.example');
       final http = FakeVotingHttpClient(
         responses: {
           'https://vote-primary.example/shielded-vote/v1/tx/delegation-tx':
-              jsonResponse({'error': 'not found'}, statusCode: 404),
+              timeoutResponse(),
           'https://vote-secondary.example/shielded-vote/v1/tx/delegation-tx': {
             'height': '12',
             'code': 0,
@@ -579,50 +579,6 @@ void main() {
         'vote-primary.example',
         'vote-secondary.example',
       ]);
-    },
-  );
-
-  test(
-    'tries the next tx confirmation server without retrying a timeout',
-    () async {
-      final primary = Uri.parse('https://vote-primary.example');
-      final offline = Uri.parse('https://vote-offline.example');
-      final tertiary = Uri.parse('https://vote-tertiary.example');
-      final delays = <Duration>[];
-      final http = FakeVotingHttpClient(
-        responses: {
-          'https://vote-primary.example/shielded-vote/v1/tx/vote-tx':
-              jsonResponse({'error': 'not found'}, statusCode: 404),
-          'https://vote-offline.example/shielded-vote/v1/tx/vote-tx':
-              timeoutResponse(),
-          'https://vote-tertiary.example/shielded-vote/v1/tx/vote-tx': {
-            'height': '12',
-            'code': 0,
-            'log': '',
-            'events': const [],
-          },
-        },
-      );
-      final client = VotingApiClient(
-        baseUrl: primary,
-        fallbackBaseUrls: [offline, tertiary],
-        httpClient: http,
-        readRetryPolicy: VotingRetryPolicy.transientHttp(
-          name: 'test-confirmation-failover',
-          delays: const [Duration(milliseconds: 300), Duration(seconds: 1)],
-        ),
-        delay: (delay) async => delays.add(delay),
-      );
-
-      final confirmation = await client.getTxConfirmation('vote-tx');
-
-      expect(confirmation?.height, 12);
-      expect(http.requests.map((request) => request.uri.host), [
-        'vote-primary.example',
-        'vote-offline.example',
-        'vote-tertiary.example',
-      ]);
-      expect(delays, isEmpty);
     },
   );
 
@@ -835,88 +791,65 @@ void main() {
     expect(http.requests.single.timeout, const Duration(seconds: 5));
   });
 
-  test('preflights helpers concurrently and caches readiness', () async {
-    final primaryResponse = Completer<VotingHttpResponse>();
-    final secondaryResponse = Completer<VotingHttpResponse>();
-    final http = FakeVotingHttpClient(
-      responses: {
-        'https://helper-1.example/shielded-vote/v1/status':
-            primaryResponse.future,
-        'https://helper-2.example/shielded-vote/v1/status':
-            secondaryResponse.future,
-      },
-    );
-    final client = VotingApiClient(
-      baseUrl: Uri.parse('https://voting.valargroup.org'),
-      httpClient: http,
-      helperPreflightTimeout: const Duration(seconds: 1),
-    );
-
-    final pending = client.preflightHelpers([
-      Uri.parse('https://helper-1.example'),
-      Uri.parse('https://helper-2.example'),
-      Uri.parse('https://helper-1.example'),
-    ]);
-    await Future<void>.delayed(Duration.zero);
-
-    expect(http.requests.map((request) => request.uri.host), [
-      'helper-1.example',
-      'helper-2.example',
-    ]);
-    primaryResponse.complete(jsonResponse({'status': 'ok'}));
-    secondaryResponse.complete(jsonResponse({'status': 'ok'}));
-    expect(await pending, {
-      'https://helper-1.example': true,
-      'https://helper-2.example': true,
-    });
-
-    expect(
-      await client.preflightHelpers([Uri.parse('https://helper-1.example')]),
-      {'https://helper-1.example': true},
-    );
-    expect(http.requests, hasLength(2));
-    expect(
-      http.requests.map((request) => request.timeout),
-      everyElement(const Duration(seconds: 1)),
-    );
-  });
-
   test(
-    'preflight reports failed and malformed helpers as unavailable',
+    'preflights helpers concurrently and treats failures as unavailable',
     () async {
+      final primaryResponse = Completer<VotingHttpResponse>();
+      final secondaryResponse = Completer<VotingHttpResponse>();
+      final blackholedResponse = Completer<VotingHttpResponse>();
       final http = FakeVotingHttpClient(
         responses: {
-          'https://helper-1.example/shielded-vote/v1/status': jsonResponse({
-            'error': 'unavailable',
-          }, statusCode: 503),
-          'https://helper-2.example/shielded-vote/v1/status': {
-            'status': 'starting',
-          },
-          'https://helper-3.example/shielded-vote/v1/status': timeoutResponse(),
+          'https://helper-1.example/shielded-vote/v1/status':
+              primaryResponse.future,
+          'https://helper-2.example/shielded-vote/v1/status':
+              secondaryResponse.future,
+          'https://helper-3.example/shielded-vote/v1/status':
+              blackholedResponse.future,
         },
       );
       final client = VotingApiClient(
         baseUrl: Uri.parse('https://voting.valargroup.org'),
         httpClient: http,
+        helperPreflightTimeout: const Duration(milliseconds: 30),
       );
 
-      final readiness = await client.preflightHelpers([
+      final pending = client.preflightHelpers([
         Uri.parse('https://helper-1.example'),
         Uri.parse('https://helper-2.example'),
         Uri.parse('https://helper-3.example'),
       ]);
+      await Future<void>.delayed(Duration.zero);
 
-      expect(readiness.values, everyElement(isFalse));
+      expect(http.requests.map((request) => request.uri.host), [
+        'helper-1.example',
+        'helper-2.example',
+        'helper-3.example',
+      ]);
+      primaryResponse.complete(jsonResponse({'status': 'ok'}));
+      secondaryResponse.complete(jsonResponse({'status': 'starting'}));
+      expect(await pending, {
+        'https://helper-1.example': true,
+        'https://helper-2.example': false,
+        'https://helper-3.example': false,
+      });
+
+      expect(http.requests, hasLength(3));
+      expect(
+        http.requests.map((request) => request.timeout),
+        everyElement(const Duration(milliseconds: 30)),
+      );
     },
   );
 
-  test('retries fast transient initial helper failures', () async {
+  test('retries fast helper failures but not a blackholed attempt', () async {
     final delays = <Duration>[];
+    final blackholedResponse = Completer<VotingHttpResponse>();
     final http = FakeVotingHttpClient(
       responses: {
         'https://helper.example/shielded-vote/v1/shares':
             SequentialVotingHttpResponses([
               jsonResponse({'error': 'unavailable'}, statusCode: 503),
+              blackholedResponse.future,
               {'status': 'queued'},
             ]),
       },
@@ -924,34 +857,12 @@ void main() {
     final client = VotingApiClient(
       baseUrl: Uri.parse('https://voting.valargroup.org'),
       httpClient: http,
+      helperTimeout: const Duration(milliseconds: 30),
       helperRetryPolicy: VotingRetryPolicy.transientHttp(
         name: 'test-helper-retry',
-        delays: const [Duration(milliseconds: 2)],
+        delays: const [Duration(milliseconds: 2), Duration(milliseconds: 4)],
       ),
       delay: (delay) async => delays.add(delay),
-    );
-
-    final result = await client.submitShare(
-      serverUrl: Uri.parse('https://helper.example'),
-      share: {'share_index': 0, 'vote_round_id': hexRoundId},
-    );
-
-    expect(result.status, 'queued');
-    expect(http.requests, hasLength(2));
-    expect(delays, const [Duration(milliseconds: 2)]);
-  });
-
-  test('bounds a blackholed initial helper to one total timeout', () async {
-    final http = FakeVotingHttpClient(
-      responses: {
-        'https://helper.example/shielded-vote/v1/shares':
-            Completer<VotingHttpResponse>().future,
-      },
-    );
-    final client = VotingApiClient(
-      baseUrl: Uri.parse('https://voting.valargroup.org'),
-      httpClient: http,
-      helperTimeout: const Duration(milliseconds: 30),
     );
     final timer = Stopwatch()..start();
 
@@ -963,41 +874,9 @@ void main() {
       throwsA(isA<TimeoutException>()),
     );
 
-    expect(http.requests, hasLength(1));
+    expect(http.requests, hasLength(2));
+    expect(delays, const [Duration(milliseconds: 2)]);
     expect(timer.elapsed, lessThan(const Duration(seconds: 1)));
-  });
-
-  test('does not retry initial helper submission after a timeout', () async {
-    final delays = <Duration>[];
-    final http = FakeVotingHttpClient(
-      responses: {
-        'https://helper.example/shielded-vote/v1/shares':
-            SequentialVotingHttpResponses([
-              timeoutResponse(),
-              {'status': 'queued'},
-            ]),
-      },
-    );
-    final client = VotingApiClient(
-      baseUrl: Uri.parse('https://voting.valargroup.org'),
-      httpClient: http,
-      helperRetryPolicy: VotingRetryPolicy.transientHttp(
-        name: 'test-helper-retry',
-        delays: const [Duration(milliseconds: 2)],
-      ),
-      delay: (delay) async => delays.add(delay),
-    );
-
-    await expectLater(
-      client.submitShare(
-        serverUrl: Uri.parse('https://helper.example'),
-        share: {'share_index': 0, 'vote_round_id': hexRoundId},
-      ),
-      throwsA(isA<TimeoutException>()),
-    );
-
-    expect(http.requests, hasLength(1));
-    expect(delays, isEmpty);
   });
 
   test('does not repeat a resubmission after an ambiguous timeout', () async {

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -577,9 +577,51 @@ void main() {
       expect(flakyFallbackHttp.requests.map((request) => request.uri.host), [
         'vote-primary.example',
         'vote-secondary.example',
-        'vote-secondary.example',
-        'vote-secondary.example',
       ]);
+    },
+  );
+
+  test(
+    'tries the next tx confirmation server without retrying a timeout',
+    () async {
+      final primary = Uri.parse('https://vote-primary.example');
+      final offline = Uri.parse('https://vote-offline.example');
+      final tertiary = Uri.parse('https://vote-tertiary.example');
+      final delays = <Duration>[];
+      final http = FakeVotingHttpClient(
+        responses: {
+          'https://vote-primary.example/shielded-vote/v1/tx/vote-tx':
+              jsonResponse({'error': 'not found'}, statusCode: 404),
+          'https://vote-offline.example/shielded-vote/v1/tx/vote-tx':
+              timeoutResponse(),
+          'https://vote-tertiary.example/shielded-vote/v1/tx/vote-tx': {
+            'height': '12',
+            'code': 0,
+            'log': '',
+            'events': const [],
+          },
+        },
+      );
+      final client = VotingApiClient(
+        baseUrl: primary,
+        fallbackBaseUrls: [offline, tertiary],
+        httpClient: http,
+        readRetryPolicy: VotingRetryPolicy.transientHttp(
+          name: 'test-confirmation-failover',
+          delays: const [Duration(milliseconds: 300), Duration(seconds: 1)],
+        ),
+        delay: (delay) async => delays.add(delay),
+      );
+
+      final confirmation = await client.getTxConfirmation('vote-tx');
+
+      expect(confirmation?.height, 12);
+      expect(http.requests.map((request) => request.uri.host), [
+        'vote-primary.example',
+        'vote-offline.example',
+        'vote-tertiary.example',
+      ]);
+      expect(delays, isEmpty);
     },
   );
 

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -834,7 +834,7 @@ void main() {
     expect(http.requests.single.timeout, const Duration(seconds: 5));
   });
 
-  test('retries helper share submission on transient timeout', () async {
+  test('does not retry initial helper submission after a timeout', () async {
     final delays = <Duration>[];
     final http = FakeVotingHttpClient(
       responses: {
@@ -855,14 +855,16 @@ void main() {
       delay: (delay) async => delays.add(delay),
     );
 
-    final result = await client.submitShare(
-      serverUrl: Uri.parse('https://helper.example'),
-      share: {'share_index': 0, 'vote_round_id': hexRoundId},
+    await expectLater(
+      client.submitShare(
+        serverUrl: Uri.parse('https://helper.example'),
+        share: {'share_index': 0, 'vote_round_id': hexRoundId},
+      ),
+      throwsA(isA<TimeoutException>()),
     );
 
-    expect(result.status, 'queued');
-    expect(http.requests.length, 2);
-    expect(delays, const [Duration(milliseconds: 2)]);
+    expect(http.requests, hasLength(1));
+    expect(delays, isEmpty);
   });
 
   test('does not repeat a resubmission after an ambiguous timeout', () async {

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -559,7 +559,7 @@ void main() {
       final flakyFallbackHttp = FakeVotingHttpClient(
         responses: {
           'https://vote-primary.example/shielded-vote/v1/tx/flaky-tx':
-              jsonResponse({'error': 'not found'}, statusCode: 404),
+              timeoutResponse(),
           'https://vote-secondary.example/shielded-vote/v1/tx/flaky-tx':
               jsonResponse({'error': 'unavailable'}, statusCode: 503),
         },


### PR DESCRIPTION
Transaction confirmation now tries each configured vote server once per polling pass. If every server has a transient failure, the normal polling loop continues; one silent server cannot multiply the 10-second request timeout through nested retries.

At the start of vote casting, Vizor checks all configured helpers concurrently while proof, broadcast, and confirmation work continues. Initial share submission prioritizes helpers that answered healthy, preserves the planned helper count through fallbacks, retries fast transient failures up to the existing three attempts, and moves on after one five-second nonresponse.

Mobile submission also advances from the completed status page when voting was opened through the normal pushed route stack, while leaving any page pushed above it undisturbed.