### PR TITLE
Orchestrate the payment link lifecycle

### DIFF
--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -26,6 +26,7 @@ const kSyncKeepAwakeEnabledKey = 'zcash_sync_keep_awake_enabled';
 const kSyncKeepAwakePromptSeenKey = 'zcash_sync_keep_awake_prompt_seen';
 const kRpcEndpointUrlKey = 'zcash_rpc_endpoint_url';
 const kRpcEndpointPresetKey = 'zcash_rpc_endpoint_preset';
+const kPaymentLinkRecoveryStorageKey = 'zcash_payment_link_recovery_v1';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';
 const _passwordVerifierKey = 'zcash_password_verifier';
 const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
@@ -377,7 +378,8 @@ class AppSecureStore {
       });
       return;
     }
-    if (key.startsWith(_votingHotkeyKeyPrefix)) {
+    if (key.startsWith(_votingHotkeyKeyPrefix) ||
+        key == kPaymentLinkRecoveryStorageKey) {
       await _secretMutationLock.run(() async {
         await _runStorageOperation(
           'delete "$key"',
@@ -470,8 +472,9 @@ class AppSecureStore {
 
   /// Rotates the wallet password and re-encrypts every app-managed secret.
   ///
-  /// Account mnemonics and voting hotkeys are both encrypted with the wallet
-  /// password, but they may live in different secure storage backends.
+  /// Account mnemonics, voting hotkeys, and payment-link recovery records are
+  /// encrypted with the wallet password, but they may live in different secure
+  /// storage backends.
   Future<bool> changePassword({
     required String currentPassword,
     required String newPassword,
@@ -550,12 +553,12 @@ class AppSecureStore {
           ),
         );
       }
-      final votingHotkeyValues = await _runStorageOperation(
-        'read all voting hotkeys',
+      final appManagedSecretValues = await _runStorageOperation(
+        'read all app-managed secrets',
         _storage.readAll,
       );
-      for (final entry in votingHotkeyValues.entries) {
-        if (!entry.key.startsWith(_votingHotkeyKeyPrefix)) continue;
+      for (final entry in appManagedSecretValues.entries) {
+        if (!_isAppManagedGeneralSecretKey(entry.key)) continue;
 
         if (!_isEncryptedPayload(entry.value)) {
           throw StateError(
@@ -1033,6 +1036,11 @@ class AppSecureStore {
     return key.startsWith(_accountMnemonicKeyPrefix)
         ? _mnemonicStorage
         : _storage;
+  }
+
+  bool _isAppManagedGeneralSecretKey(String key) {
+    return key.startsWith(_votingHotkeyKeyPrefix) ||
+        key == kPaymentLinkRecoveryStorageKey;
   }
 
   Future<void> _deleteRotationRecordBestEffort() async {

--- a/lib/src/core/storage/wallet_paths.dart
+++ b/lib/src/core/storage/wallet_paths.dart
@@ -4,6 +4,11 @@ import 'package:path_provider/path_provider.dart';
 
 import 'app_secure_store.dart';
 
+const kPaymentLinkClaimWalletDirectoryPrefix = 'payment_link_claim_';
+final _paymentLinkClaimWalletDirectoryPattern = RegExp(
+  r'^payment_link_claim_[0-9a-f]{64}$',
+);
+
 Future<Directory> getWalletSupportDirectory() async {
   final dir = await getApplicationSupportDirectory();
   await dir.create(recursive: true);
@@ -23,4 +28,21 @@ Future<String> getWalletDbPath() async {
 Future<String> getTorDataDirectoryPath() async {
   final dir = await getWalletSupportDirectory();
   return '${dir.path}${Platform.pathSeparator}tor';
+}
+
+Future<void> deletePaymentLinkClaimWalletDirectories({
+  Future<Directory> Function() resolveSupportDirectory =
+      getWalletSupportDirectory,
+}) async {
+  final supportDirectory = await resolveSupportDirectory();
+  if (!await supportDirectory.exists()) return;
+
+  await for (final entity in supportDirectory.list(followLinks: false)) {
+    if (entity is! Directory) continue;
+    final directoryName = entity.path.split(Platform.pathSeparator).last;
+    if (!_paymentLinkClaimWalletDirectoryPattern.hasMatch(directoryName)) {
+      continue;
+    }
+    await entity.delete(recursive: true);
+  }
 }

--- a/lib/src/features/payment_links/models/vizor_payment_link.dart
+++ b/lib/src/features/payment_links/models/vizor_payment_link.dart
@@ -1,0 +1,223 @@
+import 'dart:convert';
+
+import 'package:characters/characters.dart';
+
+class PaymentLinkPresentation {
+  const PaymentLinkPresentation({this.artworkId, this.message});
+
+  static const maxArtworkIdLength = 64;
+  static const maxMessageCharacters = 128;
+  static const maxMessageUtf8Bytes = 512;
+
+  final String? artworkId;
+  final String? message;
+
+  Map<String, Object?>? toPayload() {
+    final normalizedArtworkId = _normalizeOptionalString(artworkId);
+    final normalizedMessage = _normalizeOptionalString(message);
+    _validate(artworkId: normalizedArtworkId, message: normalizedMessage);
+    if (normalizedArtworkId == null && normalizedMessage == null) {
+      return null;
+    }
+    return <String, Object?>{
+      'artworkId': ?normalizedArtworkId,
+      'message': ?normalizedMessage,
+    };
+  }
+
+  static PaymentLinkPresentation? fromPayload(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, Object?>) {
+      throw const FormatException('Payment link presentation is invalid.');
+    }
+    final artworkId = _readOptionalString(value, 'artworkId');
+    final message = _readOptionalString(value, 'message');
+    _validate(artworkId: artworkId, message: message);
+    if (artworkId == null && message == null) return null;
+    return PaymentLinkPresentation(artworkId: artworkId, message: message);
+  }
+
+  static void _validate({String? artworkId, String? message}) {
+    if (artworkId != null &&
+        !RegExp(
+          '^[a-zA-Z0-9_-]{1,$maxArtworkIdLength}\$',
+        ).hasMatch(artworkId)) {
+      throw const FormatException('Payment link artwork is invalid.');
+    }
+    if (message != null) {
+      if (message.characters.length > maxMessageCharacters) {
+        throw const FormatException('Payment link message is too long.');
+      }
+      if (utf8.encode(message).length > maxMessageUtf8Bytes) {
+        throw const FormatException('Payment link message is too large.');
+      }
+    }
+  }
+
+  static String? _readOptionalString(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value == null) return null;
+    if (value is! String) {
+      throw FormatException('Payment link presentation "$key" is invalid.');
+    }
+    return _normalizeOptionalString(value);
+  }
+
+  static String? _normalizeOptionalString(String? value) {
+    final trimmed = value?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+}
+
+class VizorPaymentLink {
+  const VizorPaymentLink({
+    required this.network,
+    required this.address,
+    required this.amountZatoshi,
+    required this.mnemonic,
+    required this.birthdayHeight,
+    required this.label,
+    required this.createdAt,
+    this.presentation,
+  });
+
+  static const scheme = 'vizor';
+  static const host = 'payment-link';
+  static const maxEncodedLength = 16 * 1024;
+  static const _version = 1;
+
+  final String network;
+  final String address;
+  final BigInt amountZatoshi;
+  final String mnemonic;
+  final int birthdayHeight;
+  final String label;
+  final DateTime createdAt;
+  final PaymentLinkPresentation? presentation;
+
+  String encode() {
+    final payload = <String, Object?>{
+      'v': _version,
+      'network': network.trim(),
+      'address': address.trim(),
+      'amountZatoshi': amountZatoshi.toString(),
+      'mnemonic': mnemonic.trim(),
+      'birthdayHeight': birthdayHeight,
+      'label': label.trim(),
+      'createdAt': createdAt.toUtc().toIso8601String(),
+    };
+    final presentationPayload = presentation?.toPayload();
+    if (presentationPayload != null) {
+      payload['presentation'] = presentationPayload;
+    }
+    final encoded = base64UrlEncode(utf8.encode(jsonEncode(payload)));
+    return Uri(
+      scheme: scheme,
+      host: host,
+      queryParameters: {'p': encoded},
+    ).toString();
+  }
+
+  static VizorPaymentLink decode(String rawLink) {
+    final trimmed = rawLink.trim();
+    if (trimmed.length > maxEncodedLength) {
+      throw const FormatException('Payment link is too large.');
+    }
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null || uri.scheme != scheme || uri.host != host) {
+      throw const FormatException('This is not a Vizor payment link.');
+    }
+
+    final encoded = uri.queryParameters['p'];
+    if (encoded == null || encoded.isEmpty) {
+      throw const FormatException('Payment link is missing its payload.');
+    }
+
+    late final Object? decodedJson;
+    try {
+      decodedJson = jsonDecode(
+        utf8.decode(base64Url.decode(base64Url.normalize(encoded))),
+      );
+    } catch (_) {
+      throw const FormatException('Payment link payload could not be read.');
+    }
+
+    if (decodedJson is! Map<String, Object?>) {
+      throw const FormatException('Payment link payload is invalid.');
+    }
+    final payload = decodedJson;
+    if (payload['v'] != _version) {
+      throw const FormatException('Payment link version is not supported.');
+    }
+
+    final network = _readString(payload, 'network');
+    final address = _readString(payload, 'address');
+    final amountZatoshi = _readBigInt(payload, 'amountZatoshi');
+    final mnemonic = _readString(payload, 'mnemonic');
+    final birthdayHeight = _readInt(payload, 'birthdayHeight');
+    final label = _readString(payload, 'label');
+    final createdAtRaw = _readString(payload, 'createdAt');
+    final createdAt = DateTime.tryParse(createdAtRaw);
+    final presentation = PaymentLinkPresentation.fromPayload(
+      payload['presentation'],
+    );
+
+    if (network.isEmpty) {
+      throw const FormatException('Payment link network is missing.');
+    }
+    if (address.isEmpty) {
+      throw const FormatException('Payment link address is missing.');
+    }
+    if (amountZatoshi <= BigInt.zero) {
+      throw const FormatException('Payment link amount is invalid.');
+    }
+    if (mnemonic.split(RegExp(r'\s+')).length < 12) {
+      throw const FormatException('Payment link recovery phrase is invalid.');
+    }
+    if (birthdayHeight <= 0) {
+      throw const FormatException('Payment link birthday height is invalid.');
+    }
+    if (createdAt == null) {
+      throw const FormatException('Payment link timestamp is invalid.');
+    }
+
+    return VizorPaymentLink(
+      network: network,
+      address: address,
+      amountZatoshi: amountZatoshi,
+      mnemonic: mnemonic,
+      birthdayHeight: birthdayHeight,
+      label: label,
+      createdAt: createdAt,
+      presentation: presentation,
+    );
+  }
+
+  static String _readString(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value is! String) {
+      throw FormatException('Payment link is missing "$key".');
+    }
+    return value.trim();
+  }
+
+  static int _readInt(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value is int) return value;
+    if (value is String) {
+      final parsed = int.tryParse(value.trim());
+      if (parsed != null) return parsed;
+    }
+    throw FormatException('Payment link "$key" is invalid.');
+  }
+
+  static BigInt _readBigInt(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value is int) return BigInt.from(value);
+    if (value is String) {
+      final parsed = BigInt.tryParse(value.trim());
+      if (parsed != null) return parsed;
+    }
+    throw FormatException('Payment link "$key" is invalid.');
+  }
+}

--- a/lib/src/features/payment_links/models/vizor_payment_link.dart
+++ b/lib/src/features/payment_links/models/vizor_payment_link.dart
@@ -99,7 +99,24 @@ class VizorPaymentLink {
 
   static bool supportsNetwork(String network) => network.trim() == 'main';
 
+  /// Compares every field carried by the versioned payment-link payload after
+  /// applying the same normalization as [toUri]. This is intentionally stricter
+  /// than claim-wallet cache identity: a corrected amount or changed
+  /// presentation must remain a distinct intake item.
+  bool hasSameCanonicalPayload(VizorPaymentLink other) {
+    return _encodedPayload() == other._encodedPayload();
+  }
+
   Uri toUri() {
+    return Uri(
+      scheme: scheme,
+      host: host,
+      path: path,
+      fragment: '$_fragmentPrefix${_encodedPayload()}',
+    );
+  }
+
+  String _encodedPayload() {
     final normalizedNetwork = network.trim();
     if (!supportsNetwork(normalizedNetwork)) {
       throw const FormatException(
@@ -120,13 +137,7 @@ class VizorPaymentLink {
     if (presentationPayload != null) {
       payload['presentation'] = presentationPayload;
     }
-    final encoded = base64UrlEncode(utf8.encode(jsonEncode(payload)));
-    return Uri(
-      scheme: scheme,
-      host: host,
-      path: path,
-      fragment: '$_fragmentPrefix$encoded',
-    );
+    return base64UrlEncode(utf8.encode(jsonEncode(payload)));
   }
 
   static bool matchesEndpoint(Uri uri) {

--- a/lib/src/features/payment_links/models/vizor_payment_link.dart
+++ b/lib/src/features/payment_links/models/vizor_payment_link.dart
@@ -81,10 +81,12 @@ class VizorPaymentLink {
     this.presentation,
   });
 
-  static const scheme = 'vizor';
-  static const host = 'payment-link';
+  static const scheme = 'https';
+  static const host = 'functions.vizor.cash';
+  static const path = '/payment-links/open';
   static const maxEncodedLength = 16 * 1024;
   static const _version = 1;
+  static const _fragmentPrefix = 'v1=';
 
   final String network;
   final String address;
@@ -95,10 +97,18 @@ class VizorPaymentLink {
   final DateTime createdAt;
   final PaymentLinkPresentation? presentation;
 
-  String encode() {
+  static bool supportsNetwork(String network) => network.trim() == 'main';
+
+  Uri toUri() {
+    final normalizedNetwork = network.trim();
+    if (!supportsNetwork(normalizedNetwork)) {
+      throw const FormatException(
+        'Payment links are only available on mainnet.',
+      );
+    }
     final payload = <String, Object?>{
       'v': _version,
-      'network': network.trim(),
+      'network': normalizedNetwork,
       'address': address.trim(),
       'amountZatoshi': amountZatoshi.toString(),
       'mnemonic': mnemonic.trim(),
@@ -114,23 +124,37 @@ class VizorPaymentLink {
     return Uri(
       scheme: scheme,
       host: host,
-      queryParameters: {'p': encoded},
-    ).toString();
+      path: path,
+      fragment: '$_fragmentPrefix$encoded',
+    );
   }
 
-  static VizorPaymentLink decode(String rawLink) {
+  static bool matchesEndpoint(Uri uri) {
+    return uri.scheme.toLowerCase() == scheme &&
+        uri.host.toLowerCase() == host &&
+        uri.path == path;
+  }
+
+  static VizorPaymentLink parse(String rawLink) {
     final trimmed = rawLink.trim();
     if (trimmed.length > maxEncodedLength) {
       throw const FormatException('Payment link is too large.');
     }
     final uri = Uri.tryParse(trimmed);
-    if (uri == null || uri.scheme != scheme || uri.host != host) {
+    if (uri == null || !matchesEndpoint(uri)) {
       throw const FormatException('This is not a Vizor payment link.');
     }
+    if (uri.userInfo.isNotEmpty || uri.hasPort || uri.hasQuery) {
+      throw const FormatException('Payment link URL is invalid.');
+    }
 
-    final encoded = uri.queryParameters['p'];
-    if (encoded == null || encoded.isEmpty) {
+    final fragment = uri.fragment;
+    if (!fragment.startsWith(_fragmentPrefix)) {
       throw const FormatException('Payment link is missing its payload.');
+    }
+    final encoded = fragment.substring(_fragmentPrefix.length);
+    if (encoded.isEmpty || encoded.contains('&')) {
+      throw const FormatException('Payment link payload is invalid.');
     }
 
     late final Object? decodedJson;
@@ -162,8 +186,8 @@ class VizorPaymentLink {
       payload['presentation'],
     );
 
-    if (network.isEmpty) {
-      throw const FormatException('Payment link network is missing.');
+    if (!supportsNetwork(network)) {
+      throw const FormatException('Payment link network is not supported.');
     }
     if (address.isEmpty) {
       throw const FormatException('Payment link address is missing.');

--- a/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
+++ b/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/vizor_payment_link.dart';
+
+enum PaymentLinkIntakeResult { accepted, ignored, rejected }
+
+const kPaymentLinkIntakeQueueCapacity = 16;
+
+class PaymentLinkIntakeState {
+  const PaymentLinkIntakeState({
+    this.pendingLinks = const [],
+    this.errorMessage,
+  });
+
+  final List<VizorPaymentLink> pendingLinks;
+  final String? errorMessage;
+
+  VizorPaymentLink? get pendingLink =>
+      pendingLinks.isEmpty ? null : pendingLinks.first;
+}
+
+class PaymentLinkIntakeNotifier extends Notifier<PaymentLinkIntakeState> {
+  @override
+  PaymentLinkIntakeState build() => const PaymentLinkIntakeState();
+
+  PaymentLinkIntakeResult ingest(String rawUri) {
+    final uri = Uri.tryParse(rawUri.trim());
+    if (uri == null || uri.scheme.toLowerCase() != VizorPaymentLink.scheme) {
+      return PaymentLinkIntakeResult.ignored;
+    }
+
+    try {
+      final link = VizorPaymentLink.decode(rawUri);
+      final pendingLinks = state.pendingLinks;
+      final duplicate = pendingLinks.any(
+        (pending) =>
+            pending.network == link.network &&
+            pending.address == link.address &&
+            pending.mnemonic == link.mnemonic,
+      );
+      if (duplicate) {
+        state = PaymentLinkIntakeState(pendingLinks: pendingLinks);
+        return PaymentLinkIntakeResult.accepted;
+      }
+      if (pendingLinks.length >= kPaymentLinkIntakeQueueCapacity) {
+        state = PaymentLinkIntakeState(
+          pendingLinks: pendingLinks,
+          errorMessage: 'Too many payment links are waiting to open.',
+        );
+        return PaymentLinkIntakeResult.rejected;
+      }
+      state = PaymentLinkIntakeState(pendingLinks: [...pendingLinks, link]);
+      return PaymentLinkIntakeResult.accepted;
+    } on FormatException {
+      state = PaymentLinkIntakeState(
+        pendingLinks: state.pendingLinks,
+        errorMessage: 'Payment link could not be opened.',
+      );
+      return PaymentLinkIntakeResult.rejected;
+    }
+  }
+
+  VizorPaymentLink? takePending() {
+    final link = state.pendingLink;
+    if (link == null) return null;
+    state = PaymentLinkIntakeState(
+      pendingLinks: state.pendingLinks.sublist(1),
+      errorMessage: state.errorMessage,
+    );
+    return link;
+  }
+
+  void clearError() {
+    state = PaymentLinkIntakeState(pendingLinks: state.pendingLinks);
+  }
+}
+
+final paymentLinkIntakeProvider =
+    NotifierProvider<PaymentLinkIntakeNotifier, PaymentLinkIntakeState>(
+      PaymentLinkIntakeNotifier.new,
+    );

--- a/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
+++ b/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
@@ -23,14 +23,14 @@ class PaymentLinkIntakeNotifier extends Notifier<PaymentLinkIntakeState> {
   @override
   PaymentLinkIntakeState build() => const PaymentLinkIntakeState();
 
-  PaymentLinkIntakeResult ingest(String rawUri) {
+  PaymentLinkIntakeResult receive(String rawUri) {
     final uri = Uri.tryParse(rawUri.trim());
-    if (uri == null || uri.scheme.toLowerCase() != VizorPaymentLink.scheme) {
+    if (uri == null || !VizorPaymentLink.matchesEndpoint(uri)) {
       return PaymentLinkIntakeResult.ignored;
     }
 
     try {
-      final link = VizorPaymentLink.decode(rawUri);
+      final link = VizorPaymentLink.parse(rawUri);
       final pendingLinks = state.pendingLinks;
       final duplicate = pendingLinks.any(
         (pending) =>

--- a/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
+++ b/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
@@ -32,12 +32,10 @@ class PaymentLinkIntakeNotifier extends Notifier<PaymentLinkIntakeState> {
     try {
       final link = VizorPaymentLink.parse(rawUri);
       final pendingLinks = state.pendingLinks;
+      // Account and birthday identify a reusable claim wallet, not a duplicate
+      // user intent. Only an identical versioned payload can be coalesced.
       final duplicate = pendingLinks.any(
-        (pending) =>
-            pending.network == link.network &&
-            pending.address == link.address &&
-            pending.mnemonic == link.mnemonic &&
-            pending.birthdayHeight == link.birthdayHeight,
+        (pending) => pending.hasSameCanonicalPayload(link),
       );
       if (duplicate) {
         state = PaymentLinkIntakeState(pendingLinks: pendingLinks);

--- a/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
+++ b/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
@@ -36,7 +36,8 @@ class PaymentLinkIntakeNotifier extends Notifier<PaymentLinkIntakeState> {
         (pending) =>
             pending.network == link.network &&
             pending.address == link.address &&
-            pending.mnemonic == link.mnemonic,
+            pending.mnemonic == link.mnemonic &&
+            pending.birthdayHeight == link.birthdayHeight,
       );
       if (duplicate) {
         state = PaymentLinkIntakeState(pendingLinks: pendingLinks);

--- a/lib/src/features/payment_links/services/payment_link_recovery_store.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_store.dart
@@ -1,0 +1,390 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/storage/app_secure_store.dart';
+import '../models/vizor_payment_link.dart';
+
+const _storageVersion = 1;
+
+final paymentLinkRecoveryStoreProvider = Provider<PaymentLinkRecoveryStore>((
+  ref,
+) {
+  return PaymentLinkRecoveryStore(
+    AppSecureStorePaymentLinkRecoveryStorage(AppSecureStore.instance),
+  );
+});
+
+enum PaymentLinkRecoveryState { draft, funded, shared }
+
+const _fieldNotProvided = Object();
+
+class PaymentLinkRecoveryRecord {
+  const PaymentLinkRecoveryRecord({
+    required this.link,
+    required this.sourceAccountUuid,
+    required this.state,
+    required this.updatedAt,
+    this.fundingTxids,
+    this.archivedAt,
+  });
+
+  final VizorPaymentLink link;
+  final String sourceAccountUuid;
+  final PaymentLinkRecoveryState state;
+  final DateTime updatedAt;
+  final String? fundingTxids;
+  final DateTime? archivedAt;
+
+  bool get isArchived => archivedAt != null;
+
+  PaymentLinkRecoveryRecord copyWith({
+    required PaymentLinkRecoveryState state,
+    required DateTime updatedAt,
+    String? fundingTxids,
+    Object? archivedAt = _fieldNotProvided,
+  }) {
+    return PaymentLinkRecoveryRecord(
+      link: link,
+      sourceAccountUuid: sourceAccountUuid,
+      state: state,
+      updatedAt: updatedAt,
+      fundingTxids: fundingTxids ?? this.fundingTxids,
+      archivedAt: identical(archivedAt, _fieldNotProvided)
+          ? this.archivedAt
+          : archivedAt as DateTime?,
+    );
+  }
+}
+
+class PaymentLinkRecoveryStoreFormatException implements Exception {
+  const PaymentLinkRecoveryStoreFormatException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'PaymentLinkRecoveryStoreFormatException: $message';
+}
+
+abstract interface class PaymentLinkRecoveryStorage {
+  Future<String?> read();
+
+  Future<void> write(String value);
+
+  Future<void> delete();
+}
+
+class AppSecureStorePaymentLinkRecoveryStorage
+    implements PaymentLinkRecoveryStorage {
+  const AppSecureStorePaymentLinkRecoveryStorage(this._store);
+
+  final AppSecureStore _store;
+
+  @override
+  Future<String?> read() {
+    return _store.readSecretStringWithOptions(
+      kPaymentLinkRecoveryStorageKey,
+      requireUnlockedSession: true,
+    );
+  }
+
+  @override
+  Future<void> write(String value) {
+    return _store.writeSecretString(kPaymentLinkRecoveryStorageKey, value);
+  }
+
+  @override
+  Future<void> delete() {
+    return _store.delete(kPaymentLinkRecoveryStorageKey);
+  }
+}
+
+class PaymentLinkRecoveryStore {
+  PaymentLinkRecoveryStore(this._storage);
+
+  final PaymentLinkRecoveryStorage _storage;
+  Future<void> _operationTail = Future<void>.value();
+
+  Future<List<PaymentLinkRecoveryRecord>> load() {
+    return _runExclusive(_loadUnlocked);
+  }
+
+  Future<PaymentLinkRecoveryRecord> saveDraft({
+    required VizorPaymentLink link,
+    required String sourceAccountUuid,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      if (sourceAccountUuid.isEmpty) {
+        throw ArgumentError.value(
+          sourceAccountUuid,
+          'sourceAccountUuid',
+          'Payment link source account is required.',
+        );
+      }
+      final records = await _loadUnlocked();
+      final existing = _findByAddress(records, link.address);
+      if (existing != null &&
+          existing.state != PaymentLinkRecoveryState.draft) {
+        throw StateError(
+          'Payment link recovery cannot replace a funded record with a draft.',
+        );
+      }
+      final record = PaymentLinkRecoveryRecord(
+        link: link,
+        sourceAccountUuid: sourceAccountUuid,
+        state: PaymentLinkRecoveryState.draft,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+      );
+      await _writeRecords(_replaceByAddress(records, record));
+      return record;
+    });
+  }
+
+  Future<PaymentLinkRecoveryRecord> markFunded({
+    required String address,
+    required String fundingTxids,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      if (fundingTxids.trim().isEmpty) {
+        throw ArgumentError.value(
+          fundingTxids,
+          'fundingTxids',
+          'A funded payment link requires a transaction id.',
+        );
+      }
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      if (existing.state != PaymentLinkRecoveryState.draft &&
+          existing.state != PaymentLinkRecoveryState.funded) {
+        throw StateError('Payment link funding state cannot move backwards.');
+      }
+      final updated = existing.copyWith(
+        state: PaymentLinkRecoveryState.funded,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+        fundingTxids: fundingTxids.trim(),
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<PaymentLinkRecoveryRecord> markShared({
+    required String address,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      if (existing.state != PaymentLinkRecoveryState.funded &&
+          existing.state != PaymentLinkRecoveryState.shared) {
+        throw StateError('Only a funded payment link can be marked shared.');
+      }
+      final updated = existing.copyWith(
+        state: PaymentLinkRecoveryState.shared,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<PaymentLinkRecoveryRecord> setArchived({
+    required String address,
+    required bool archived,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      final now = (updatedAt ?? DateTime.now()).toUtc();
+      final updated = existing.copyWith(
+        state: existing.state,
+        updatedAt: now,
+        archivedAt: archived ? now : null,
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<List<PaymentLinkRecoveryRecord>> _loadUnlocked() async {
+    final raw = await _storage.read();
+    if (raw == null || raw.trim().isEmpty) return const [];
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        throw const PaymentLinkRecoveryStoreFormatException(
+          'Recovery payload must be a JSON object.',
+        );
+      }
+      if (decoded['version'] != _storageVersion) {
+        throw const PaymentLinkRecoveryStoreFormatException(
+          'Recovery payload version is not supported.',
+        );
+      }
+      final items = decoded['records'];
+      if (items is! List) {
+        throw const PaymentLinkRecoveryStoreFormatException(
+          'Recovery payload records are missing.',
+        );
+      }
+      return [for (final item in items) _recordFromJson(item)];
+    } on PaymentLinkRecoveryStoreFormatException {
+      rethrow;
+    } catch (error) {
+      throw PaymentLinkRecoveryStoreFormatException(
+        'Recovery payload could not be decoded: $error',
+      );
+    }
+  }
+
+  Future<void> _writeRecords(List<PaymentLinkRecoveryRecord> records) async {
+    if (records.isEmpty) {
+      await _storage.delete();
+      return;
+    }
+    await _storage.write(
+      jsonEncode({
+        'version': _storageVersion,
+        'records': [for (final record in records) _recordToJson(record)],
+      }),
+    );
+  }
+
+  Future<T> _runExclusive<T>(Future<T> Function() operation) {
+    final result = _operationTail.then((_) => operation());
+    _operationTail = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+}
+
+class PaymentLinkFundingRecovery {
+  const PaymentLinkFundingRecovery(this._store);
+
+  final PaymentLinkRecoveryStore _store;
+
+  Future<T> fund<T>({
+    required VizorPaymentLink link,
+    required String sourceAccountUuid,
+    required Future<T> Function() createTransaction,
+    required String Function(T result) fundingTxids,
+  }) async {
+    await _store.saveDraft(link: link, sourceAccountUuid: sourceAccountUuid);
+    final result = await createTransaction();
+    await _store.markFunded(
+      address: link.address,
+      fundingTxids: fundingTxids(result),
+    );
+    return result;
+  }
+}
+
+PaymentLinkRecoveryRecord? _findByAddress(
+  List<PaymentLinkRecoveryRecord> records,
+  String address,
+) {
+  for (final record in records) {
+    if (record.link.address == address) return record;
+  }
+  return null;
+}
+
+PaymentLinkRecoveryRecord _findRequired(
+  List<PaymentLinkRecoveryRecord> records,
+  String address,
+) {
+  final record = _findByAddress(records, address);
+  if (record == null) {
+    throw StateError('Payment link recovery record was not found.');
+  }
+  return record;
+}
+
+List<PaymentLinkRecoveryRecord> _replaceByAddress(
+  List<PaymentLinkRecoveryRecord> records,
+  PaymentLinkRecoveryRecord replacement,
+) {
+  final replaced = <PaymentLinkRecoveryRecord>[];
+  var didReplace = false;
+  for (final record in records) {
+    if (record.link.address == replacement.link.address) {
+      replaced.add(replacement);
+      didReplace = true;
+    } else {
+      replaced.add(record);
+    }
+  }
+  if (!didReplace) replaced.add(replacement);
+  return replaced;
+}
+
+Map<String, Object?> _recordToJson(PaymentLinkRecoveryRecord record) {
+  return {
+    'link': record.link.encode(),
+    'sourceAccountUuid': record.sourceAccountUuid,
+    'state': record.state.name,
+    'fundingTxids': record.fundingTxids,
+    'archivedAt': record.archivedAt?.toUtc().toIso8601String(),
+    'updatedAt': record.updatedAt.toUtc().toIso8601String(),
+  };
+}
+
+PaymentLinkRecoveryRecord _recordFromJson(Object? value) {
+  if (value is! Map<String, dynamic>) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record must be a JSON object.',
+    );
+  }
+  final linkRaw = value['link'];
+  final sourceAccountUuid = value['sourceAccountUuid'];
+  final stateRaw = value['state'];
+  final fundingTxids = value['fundingTxids'];
+  final archivedAtRaw = value['archivedAt'];
+  final updatedAtRaw = value['updatedAt'];
+  if (linkRaw is! String ||
+      sourceAccountUuid is! String ||
+      sourceAccountUuid.isEmpty ||
+      stateRaw is! String ||
+      (fundingTxids != null && fundingTxids is! String) ||
+      (archivedAtRaw != null && archivedAtRaw is! String) ||
+      updatedAtRaw is! String) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record fields are invalid.',
+    );
+  }
+  final updatedAt = DateTime.tryParse(updatedAtRaw);
+  if (updatedAt == null) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record timestamp is invalid.',
+    );
+  }
+  final archivedAt = archivedAtRaw == null
+      ? null
+      : DateTime.tryParse(archivedAtRaw);
+  if (archivedAtRaw != null && archivedAt == null) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record archive timestamp is invalid.',
+    );
+  }
+  late final PaymentLinkRecoveryState state;
+  try {
+    state = PaymentLinkRecoveryState.values.byName(stateRaw);
+  } on ArgumentError {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record state is invalid.',
+    );
+  }
+
+  return PaymentLinkRecoveryRecord(
+    link: VizorPaymentLink.decode(linkRaw),
+    sourceAccountUuid: sourceAccountUuid,
+    state: state,
+    fundingTxids: fundingTxids as String?,
+    archivedAt: archivedAt?.toUtc(),
+    updatedAt: updatedAt.toUtc(),
+  );
+}

--- a/lib/src/features/payment_links/services/payment_link_recovery_store.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_store.dart
@@ -7,6 +7,7 @@ import '../../../core/storage/app_secure_store.dart';
 import '../models/vizor_payment_link.dart';
 
 const _storageVersion = 1;
+const _fundingMetadataWriteAttempts = 2;
 
 final paymentLinkRecoveryStoreProvider = Provider<PaymentLinkRecoveryStore>((
   ref,
@@ -262,12 +263,26 @@ class PaymentLinkRecoveryStore {
   }
 }
 
+class PaymentLinkFundingRecoveryResult<T> {
+  const PaymentLinkFundingRecoveryResult({
+    required this.transaction,
+    this.recoveryError,
+    this.recoveryStackTrace,
+  });
+
+  final T transaction;
+  final Object? recoveryError;
+  final StackTrace? recoveryStackTrace;
+
+  bool get fundingMetadataSaved => recoveryError == null;
+}
+
 class PaymentLinkFundingRecovery {
   const PaymentLinkFundingRecovery(this._store);
 
   final PaymentLinkRecoveryStore _store;
 
-  Future<T> fund<T>({
+  Future<PaymentLinkFundingRecoveryResult<T>> fund<T>({
     required VizorPaymentLink link,
     required String sourceAccountUuid,
     required Future<T> Function() createTransaction,
@@ -275,11 +290,23 @@ class PaymentLinkFundingRecovery {
   }) async {
     await _store.saveDraft(link: link, sourceAccountUuid: sourceAccountUuid);
     final result = await createTransaction();
-    await _store.markFunded(
-      address: link.address,
-      fundingTxids: fundingTxids(result),
+    final txids = fundingTxids(result);
+    Object? recoveryError;
+    StackTrace? recoveryStackTrace;
+    for (var attempt = 0; attempt < _fundingMetadataWriteAttempts; attempt++) {
+      try {
+        await _store.markFunded(address: link.address, fundingTxids: txids);
+        return PaymentLinkFundingRecoveryResult(transaction: result);
+      } catch (error, stackTrace) {
+        recoveryError = error;
+        recoveryStackTrace = stackTrace;
+      }
+    }
+    return PaymentLinkFundingRecoveryResult(
+      transaction: result,
+      recoveryError: recoveryError,
+      recoveryStackTrace: recoveryStackTrace,
     );
-    return result;
   }
 }
 

--- a/lib/src/features/payment_links/services/payment_link_recovery_store.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_store.dart
@@ -351,7 +351,7 @@ List<PaymentLinkRecoveryRecord> _replaceByAddress(
 
 Map<String, Object?> _recordToJson(PaymentLinkRecoveryRecord record) {
   return {
-    'link': record.link.encode(),
+    'link': record.link.toUri().toString(),
     'sourceAccountUuid': record.sourceAccountUuid,
     'state': record.state.name,
     'fundingTxids': record.fundingTxids,
@@ -407,7 +407,7 @@ PaymentLinkRecoveryRecord _recordFromJson(Object? value) {
   }
 
   return PaymentLinkRecoveryRecord(
-    link: VizorPaymentLink.decode(linkRaw),
+    link: VizorPaymentLink.parse(linkRaw),
     sourceAccountUuid: sourceAccountUuid,
     state: state,
     fundingTxids: fundingTxids as String?,

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -1,0 +1,693 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/storage/wallet_paths.dart';
+import '../../../providers/account_provider.dart';
+import '../../../providers/app_security_provider.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../providers/sync_provider.dart';
+import '../../../rust/api/sync.dart' as rust_sync;
+import '../../../rust/api/wallet.dart' as rust_wallet;
+import '../../send/services/sapling_params.dart';
+import '../models/vizor_payment_link.dart';
+import 'payment_link_recovery_store.dart';
+
+final paymentLinkServiceProvider = Provider<PaymentLinkService>((ref) {
+  return PaymentLinkService(ref, ref.read(paymentLinkRecoveryStoreProvider));
+});
+
+const kPaymentLinkMaxClaimLookbackBlocks = 100000;
+
+/// The ZIP-317 fee for the payment link's expected one-input, one-output
+/// shielded claim transaction.
+const kPaymentLinkClaimFeeReserveZatoshi = 10000;
+
+BigInt paymentLinkFundingAmountZatoshi(BigInt recipientAmountZatoshi) {
+  if (recipientAmountZatoshi <= BigInt.zero) {
+    throw ArgumentError.value(
+      recipientAmountZatoshi,
+      'recipientAmountZatoshi',
+      'Payment link amount must be positive.',
+    );
+  }
+  return recipientAmountZatoshi +
+      BigInt.from(kPaymentLinkClaimFeeReserveZatoshi);
+}
+
+@visibleForTesting
+BigInt paymentLinkClaimableAmountZatoshi({
+  required BigInt recipientAmountZatoshi,
+  required BigInt maxSpendableZatoshi,
+}) {
+  return maxSpendableZatoshi >= recipientAmountZatoshi
+      ? recipientAmountZatoshi
+      : BigInt.zero;
+}
+
+class PaymentLinkClaimSession {
+  const PaymentLinkClaimSession({
+    required this.link,
+    required this.destinationAddress,
+    required this.directory,
+    required this.dbPath,
+    required this.accountUuid,
+    required this.totalZatoshi,
+    required this.claimableZatoshi,
+    required this.feeZatoshi,
+  });
+
+  final VizorPaymentLink link;
+  final String destinationAddress;
+  final Directory directory;
+  final String dbPath;
+  final String accountUuid;
+  final BigInt totalZatoshi;
+  final BigInt claimableZatoshi;
+  final BigInt feeZatoshi;
+
+  bool get canClaim => claimableZatoshi > BigInt.zero;
+}
+
+enum PaymentLinkClaimBroadcastStatus {
+  broadcasted,
+  pendingBroadcast,
+  partialBroadcast,
+}
+
+@visibleForTesting
+PaymentLinkClaimBroadcastStatus paymentLinkClaimBroadcastStatusFromWire(
+  String status,
+) {
+  return switch (status) {
+    'broadcasted' => PaymentLinkClaimBroadcastStatus.broadcasted,
+    'pending_broadcast' => PaymentLinkClaimBroadcastStatus.pendingBroadcast,
+    'partial_broadcast' => PaymentLinkClaimBroadcastStatus.partialBroadcast,
+    _ => throw StateError('Unknown payment link broadcast status: $status'),
+  };
+}
+
+@visibleForTesting
+bool shouldRetainPaymentLinkClaimWallet(
+  PaymentLinkClaimBroadcastStatus status,
+) {
+  return status != PaymentLinkClaimBroadcastStatus.broadcasted;
+}
+
+@visibleForTesting
+bool shouldRecreatePaymentLinkClaimWallet({
+  required List<String> accountAddresses,
+  required String expectedAddress,
+}) {
+  return accountAddresses.length != 1 ||
+      accountAddresses.single != expectedAddress;
+}
+
+@visibleForTesting
+void requireUnlockedPaymentLinkWallet({required bool requiresUnlock}) {
+  if (requiresUnlock) {
+    throw StateError('Wallet is locked.');
+  }
+}
+
+@visibleForTesting
+int validatePaymentLinkClaimBirthday({
+  required int advertisedBirthdayHeight,
+  required int currentTipHeight,
+}) {
+  if (currentTipHeight <= 0) {
+    throw StateError('Current chain tip is unavailable.');
+  }
+  if (advertisedBirthdayHeight > currentTipHeight) {
+    throw const FormatException(
+      'Payment link birthday is ahead of the current chain tip.',
+    );
+  }
+  final earliestSupportedHeight = max(
+    1,
+    currentTipHeight - kPaymentLinkMaxClaimLookbackBlocks,
+  );
+  if (advertisedBirthdayHeight < earliestSupportedHeight) {
+    throw const FormatException(
+      'Payment link birthday is outside the supported claim window.',
+    );
+  }
+  return advertisedBirthdayHeight;
+}
+
+@visibleForTesting
+String paymentLinkClaimWalletDirectoryName(VizorPaymentLink link) {
+  final identity = sha256
+      .convert(utf8.encode('${link.network}:${link.address}:${link.mnemonic}'))
+      .toString();
+  return '$kPaymentLinkClaimWalletDirectoryPrefix$identity';
+}
+
+class PaymentLinkClaimResult {
+  const PaymentLinkClaimResult({required this.txids, required this.status});
+
+  final String txids;
+  final PaymentLinkClaimBroadcastStatus status;
+
+  bool get isBroadcasted =>
+      status == PaymentLinkClaimBroadcastStatus.broadcasted;
+}
+
+class PaymentLinkBroadcastPendingException implements Exception {
+  const PaymentLinkBroadcastPendingException({
+    required this.txids,
+    required this.status,
+    required this.message,
+  });
+
+  final String txids;
+  final String status;
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class PaymentLinkService {
+  PaymentLinkService(this._ref, this._recoveryStore);
+
+  final Ref _ref;
+  final PaymentLinkRecoveryStore _recoveryStore;
+
+  Future<VizorPaymentLink> createFundedLink({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+    PaymentLinkPresentation? presentation,
+  }) async {
+    if (sourceAccountUuid.isEmpty) {
+      throw StateError('No active account.');
+    }
+    if (amountZatoshi <= BigInt.zero) {
+      throw ArgumentError.value(
+        amountZatoshi,
+        'amountZatoshi',
+        'Payment link amount must be positive.',
+      );
+    }
+    if (_ref
+        .read(accountProvider.notifier)
+        .isHardwareAccount(sourceAccountUuid)) {
+      throw StateError(
+        'Keystone payment links require the hardware signing flow.',
+      );
+    }
+
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    final paymentAccount = await rust_wallet.previewNewSoftwareAccount(
+      network: endpoint.networkName,
+    );
+    final ephemeralAddress = paymentAccount.unifiedAddress;
+    if (ephemeralAddress.isEmpty) {
+      throw StateError('Payment link account was created without an address.');
+    }
+
+    final birthdayHeight = await _ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .getLatestBlockHeight();
+    final link = VizorPaymentLink(
+      network: endpoint.networkName,
+      address: ephemeralAddress,
+      amountZatoshi: amountZatoshi,
+      mnemonic: paymentAccount.mnemonic,
+      birthdayHeight: birthdayHeight.toInt(),
+      label: 'Payment link',
+      createdAt: DateTime.now(),
+      presentation: presentation,
+    );
+
+    final fundingResult = await PaymentLinkFundingRecovery(_recoveryStore)
+        .fund<rust_sync.ExecuteProposalResult>(
+          link: link,
+          sourceAccountUuid: sourceAccountUuid,
+          createTransaction: () {
+            return _sendShielded(
+              fromAccountUuid: sourceAccountUuid,
+              toAddress: ephemeralAddress,
+              amountZatoshi: paymentLinkFundingAmountZatoshi(amountZatoshi),
+              memo: null,
+            );
+          },
+          fundingTxids: (result) => result.txids,
+        );
+
+    unawaited(_ref.read(syncProvider.notifier).refreshAfterSend());
+    _requireFullyBroadcasted(fundingResult);
+    return link;
+  }
+
+  Future<List<PaymentLinkRecoveryRecord>> loadCreatedLinkRecoveries() {
+    return _recoveryStore.load();
+  }
+
+  Future<PaymentLinkRecoveryRecord> markCreatedLinkShared(
+    VizorPaymentLink link,
+  ) {
+    return _recoveryStore.markShared(address: link.address);
+  }
+
+  Future<PaymentLinkRecoveryRecord> setCreatedLinkArchived(
+    VizorPaymentLink link, {
+    required bool archived,
+  }) {
+    return _recoveryStore.setArchived(
+      address: link.address,
+      archived: archived,
+    );
+  }
+
+  Future<PaymentLinkClaimSession> prepareClaim(VizorPaymentLink link) async {
+    final receiverState = _ref.read(accountProvider).value;
+    final receiverAddress = receiverState?.activeAddress;
+    if (receiverState?.activeAccountUuid == null ||
+        receiverAddress == null ||
+        receiverAddress.isEmpty) {
+      throw StateError('No active receive account.');
+    }
+    return _prepareSpend(link: link, destinationAddress: receiverAddress);
+  }
+
+  Future<PaymentLinkClaimSession> _prepareSpend({
+    required VizorPaymentLink link,
+    required String destinationAddress,
+  }) async {
+    await _requireShieldedAddress(destinationAddress);
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    if (link.network != endpoint.networkName) {
+      throw StateError(
+        'Payment link is for ${link.network}, but this wallet is using '
+        '${endpoint.networkName}.',
+      );
+    }
+
+    final currentTipHeight = await _ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .getLatestBlockHeight();
+    final claimBirthdayHeight = validatePaymentLinkClaimBirthday(
+      advertisedBirthdayHeight: link.birthdayHeight,
+      currentTipHeight: currentTipHeight.toInt(),
+    );
+
+    final tempWallet = await _createOrOpenTemporaryWalletDb(link);
+    var deleteOnError = !tempWallet.existed;
+    try {
+      final String importedAddress;
+      final String importedAccountUuid;
+      if (tempWallet.existed) {
+        List<rust_wallet.AccountInfo>? accounts;
+        try {
+          accounts = await rust_wallet.listAccounts(
+            dbPath: tempWallet.dbPath,
+            network: endpoint.networkName,
+          );
+        } catch (e, st) {
+          log(
+            'PaymentLinkService: reopening payment-link claim wallet failed; '
+            'recreating it: $e\n$st',
+          );
+        }
+        if (accounts == null ||
+            shouldRecreatePaymentLinkClaimWallet(
+              accountAddresses: [
+                for (final account in accounts) account.unifiedAddress,
+              ],
+              expectedAddress: link.address,
+            )) {
+          if (accounts != null) {
+            log(
+              'PaymentLinkService: recreating incomplete payment-link claim '
+              'wallet with ${accounts.length} account(s)',
+            );
+          }
+          deleteOnError = true;
+          await _resetTemporaryWalletDb(tempWallet.directory);
+          final imported = await _importPaymentLinkClaimAccount(
+            link: link,
+            birthdayHeight: claimBirthdayHeight,
+            dbPath: tempWallet.dbPath,
+            network: endpoint.networkName,
+          );
+          importedAddress = imported.address;
+          importedAccountUuid = imported.accountUuid;
+        } else {
+          importedAddress = accounts.single.unifiedAddress;
+          importedAccountUuid = accounts.single.uuid;
+        }
+      } else {
+        final imported = await _importPaymentLinkClaimAccount(
+          link: link,
+          birthdayHeight: claimBirthdayHeight,
+          dbPath: tempWallet.dbPath,
+          network: endpoint.networkName,
+        );
+        importedAddress = imported.address;
+        importedAccountUuid = imported.accountUuid;
+      }
+      if (importedAddress != link.address) {
+        throw const FormatException(
+          'Payment link address does not match its recovery phrase.',
+        );
+      }
+
+      await _runBlockingSync(dbPath: tempWallet.dbPath);
+      final balance = await rust_sync.getBalance(
+        dbPath: tempWallet.dbPath,
+        network: endpoint.networkName,
+        accountUuid: importedAccountUuid,
+      );
+      var claimableZatoshi = BigInt.zero;
+      var feeZatoshi = BigInt.zero;
+      try {
+        final estimate = await rust_sync.estimateSendMaxMinConfirmations(
+          dbPath: tempWallet.dbPath,
+          network: endpoint.networkName,
+          accountUuid: importedAccountUuid,
+          toAddress: destinationAddress,
+        );
+        claimableZatoshi = paymentLinkClaimableAmountZatoshi(
+          recipientAmountZatoshi: link.amountZatoshi,
+          maxSpendableZatoshi: estimate.amountZatoshi,
+        );
+        feeZatoshi = estimate.feeZatoshi;
+      } catch (e) {
+        final message = e.toString().toLowerCase();
+        if (!message.contains('insufficient balance')) {
+          rethrow;
+        }
+      }
+
+      return PaymentLinkClaimSession(
+        link: link,
+        destinationAddress: destinationAddress,
+        directory: tempWallet.directory,
+        dbPath: tempWallet.dbPath,
+        accountUuid: importedAccountUuid,
+        totalZatoshi: balance.total,
+        claimableZatoshi: claimableZatoshi,
+        feeZatoshi: feeZatoshi,
+      );
+    } catch (_) {
+      if (deleteOnError) {
+        await _deleteTemporaryWalletDb(tempWallet.directory);
+      }
+      rethrow;
+    }
+  }
+
+  Future<PaymentLinkClaimResult> claimPreparedLink(
+    PaymentLinkClaimSession session,
+  ) async {
+    return _broadcastPreparedSpend(session);
+  }
+
+  Future<PaymentLinkClaimResult> _broadcastPreparedSpend(
+    PaymentLinkClaimSession session,
+  ) async {
+    if (!session.canClaim) {
+      throw StateError('Payment link has no spendable shielded balance yet.');
+    }
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    if (session.link.network != endpoint.networkName) {
+      throw StateError(
+        'Payment link is for ${session.link.network}, but this wallet is '
+        'using ${endpoint.networkName}.',
+      );
+    }
+    final estimate = await rust_sync.estimateSendMaxMinConfirmations(
+      dbPath: session.dbPath,
+      network: endpoint.networkName,
+      accountUuid: session.accountUuid,
+      toAddress: session.destinationAddress,
+    );
+    if (estimate.amountZatoshi < session.link.amountZatoshi) {
+      throw StateError(
+        'Payment link does not yet have enough spendable shielded balance.',
+      );
+    }
+
+    _requireWalletUnlocked();
+    final sendResult = await _sendShielded(
+      dbPath: session.dbPath,
+      fromAccountUuid: session.accountUuid,
+      toAddress: session.destinationAddress,
+      amountZatoshi: session.link.amountZatoshi,
+      memo: null,
+      mnemonic: session.link.mnemonic,
+      useMinConfirmations: true,
+    );
+    final claimResult = PaymentLinkClaimResult(
+      txids: sendResult.txids,
+      status: paymentLinkClaimBroadcastStatusFromWire(sendResult.status),
+    );
+    if (!shouldRetainPaymentLinkClaimWallet(claimResult.status)) {
+      await discardClaimSession(session);
+    }
+    unawaited(_ref.read(syncProvider.notifier).refreshAfterSend());
+    return claimResult;
+  }
+
+  Future<PaymentLinkClaimResult> claimLink(VizorPaymentLink link) async {
+    final session = await prepareClaim(link);
+    return claimPreparedLink(session);
+  }
+
+  Future<void> discardClaimSession(PaymentLinkClaimSession session) =>
+      _deleteTemporaryWalletDb(session.directory);
+
+  Future<rust_sync.ExecuteProposalResult> _sendShielded({
+    String? dbPath,
+    required String fromAccountUuid,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+    String? mnemonic,
+    bool useMinConfirmations = false,
+  }) async {
+    await _requireShieldedAddress(toAddress);
+    final walletDbPath = dbPath ?? await getWalletDbPath();
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    final sendFlowId = _newSendFlowId();
+    final proposal = useMinConfirmations
+        ? await rust_sync.proposeSendMinConfirmations(
+            dbPath: walletDbPath,
+            network: endpoint.networkName,
+            accountUuid: fromAccountUuid,
+            sendFlowId: sendFlowId,
+            toAddress: toAddress,
+            amountZatoshi: amountZatoshi,
+            memo: memo,
+          )
+        : await rust_sync.proposeSend(
+            dbPath: walletDbPath,
+            network: endpoint.networkName,
+            accountUuid: fromAccountUuid,
+            sendFlowId: sendFlowId,
+            toAddress: toAddress,
+            amountZatoshi: amountZatoshi,
+            memo: memo,
+          );
+
+    try {
+      final result = await _executeProposal(
+        dbPath: walletDbPath,
+        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        accountUuid: fromAccountUuid,
+        proposalId: proposal.proposalId,
+        sendFlowId: sendFlowId,
+        needsSaplingParams: proposal.needsSaplingParams,
+        mnemonic: mnemonic,
+      );
+      paymentLinkClaimBroadcastStatusFromWire(result.status);
+      return result;
+    } catch (e) {
+      try {
+        await rust_sync.discardProposal(
+          proposalId: proposal.proposalId,
+          sendFlowId: sendFlowId,
+        );
+      } catch (discardError) {
+        log('PaymentLinkService: discardProposal failed: $discardError');
+      }
+      rethrow;
+    }
+  }
+
+  Future<rust_sync.ExecuteProposalResult> _executeProposal({
+    required String dbPath,
+    required String lightwalletdUrl,
+    required String accountUuid,
+    required BigInt proposalId,
+    required String sendFlowId,
+    required bool needsSaplingParams,
+    String? mnemonic,
+  }) async {
+    var saplingParams = await loadSaplingParamsStatus();
+    if (needsSaplingParams && !saplingParams.complete) {
+      await downloadMissingSaplingParams(
+        saplingParams,
+        log: (message) => log('PaymentLinkService: $message'),
+      );
+      saplingParams = await loadSaplingParamsStatus();
+    }
+
+    _requireWalletUnlocked();
+
+    if (Platform.isMacOS && mnemonic == null) {
+      final password = _ref
+          .read(appSecurityProvider.notifier)
+          .requireSessionPasswordForNativeSecretUse();
+      return rust_sync.executeProposalWithMacosStoredMnemonic(
+        dbPath: dbPath,
+        lightwalletdUrl: lightwalletdUrl,
+        proposalId: proposalId,
+        sendFlowId: sendFlowId,
+        password: password,
+        spendParamsPath: needsSaplingParams ? saplingParams.spendPath : null,
+        outputParamsPath: needsSaplingParams ? saplingParams.outputPath : null,
+      );
+    }
+
+    final mnemonicBytes = mnemonic == null
+        ? await _ref
+              .read(accountProvider.notifier)
+              .getMnemonicBytesForAccount(accountUuid)
+        : Uint8List.fromList(utf8.encode(mnemonic));
+    if (mnemonicBytes == null || mnemonicBytes.isEmpty) {
+      throw StateError('Mnemonic not found for payment link account.');
+    }
+    late final Future<rust_sync.ExecuteProposalResult> result;
+    try {
+      result = rust_sync.executeProposal(
+        dbPath: dbPath,
+        lightwalletdUrl: lightwalletdUrl,
+        proposalId: proposalId,
+        sendFlowId: sendFlowId,
+        mnemonicBytes: mnemonicBytes,
+        spendParamsPath: needsSaplingParams ? saplingParams.spendPath : null,
+        outputParamsPath: needsSaplingParams ? saplingParams.outputPath : null,
+      );
+    } finally {
+      _zeroize(mnemonicBytes);
+    }
+    return result;
+  }
+
+  Future<void> _runBlockingSync({required String dbPath}) async {
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    await _ref
+        .read(syncProvider.notifier)
+        .runWithExclusiveRustSync(
+          () => rust_sync.runFullSyncBlocking(
+            dbPath: dbPath,
+            lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+            network: endpoint.networkName,
+            mode: 1,
+          ),
+        );
+  }
+
+  Future<({Directory directory, String dbPath, bool existed})>
+  _createOrOpenTemporaryWalletDb(VizorPaymentLink link) async {
+    final supportDir = await getWalletSupportDirectory();
+    final separator = Platform.pathSeparator;
+    final directory = Directory(
+      '${supportDir.path}$separator${paymentLinkClaimWalletDirectoryName(link)}',
+    );
+    final dbPath = '${directory.path}${separator}zcash_wallet.db';
+    final existed = await File(dbPath).exists();
+    await directory.create(recursive: true);
+    return (directory: directory, dbPath: dbPath, existed: existed);
+  }
+
+  Future<({String address, String accountUuid})>
+  _importPaymentLinkClaimAccount({
+    required VizorPaymentLink link,
+    required int birthdayHeight,
+    required String dbPath,
+    required String network,
+  }) async {
+    final imported = await rust_wallet.importWallet(
+      mnemonic: link.mnemonic,
+      bip39Passphrase: '',
+      birthdayHeight: BigInt.from(birthdayHeight),
+      network: network,
+      dbPath: dbPath,
+      accountName: 'Payment link claim',
+    );
+    return (
+      address: imported.unifiedAddress,
+      accountUuid: imported.accountUuid,
+    );
+  }
+
+  Future<void> _resetTemporaryWalletDb(Directory directory) async {
+    if (await directory.exists()) {
+      await directory.delete(recursive: true);
+    }
+    await directory.create(recursive: true);
+  }
+
+  void _requireFullyBroadcasted(rust_sync.ExecuteProposalResult result) {
+    if (paymentLinkClaimBroadcastStatusFromWire(result.status) ==
+        PaymentLinkClaimBroadcastStatus.broadcasted) {
+      return;
+    }
+    throw PaymentLinkBroadcastPendingException(
+      txids: result.txids,
+      status: result.status,
+      message:
+          result.message ??
+          'Payment link funding transaction is waiting to be broadcast.',
+    );
+  }
+
+  Future<void> _deleteTemporaryWalletDb(Directory directory) async {
+    try {
+      if (await directory.exists()) {
+        await directory.delete(recursive: true);
+      }
+    } catch (e, st) {
+      log(
+        'PaymentLinkService: failed to delete temporary payment-link DB '
+        '${directory.path}: $e\n$st',
+      );
+    }
+  }
+
+  Future<void> _requireShieldedAddress(String address) async {
+    final validation = await rust_sync.validateAddress(address: address);
+    if (!validation.isValid ||
+        (validation.addressType != 'unified' &&
+            validation.addressType != 'sapling')) {
+      throw StateError('Payment links only support shielded addresses.');
+    }
+  }
+
+  void _requireWalletUnlocked() {
+    requireUnlockedPaymentLinkWallet(
+      requiresUnlock: _ref.read(appSecurityProvider).requiresUnlock,
+    );
+  }
+
+  String _newSendFlowId() {
+    final random = Random.secure();
+    return List<int>.generate(
+      16,
+      (_) => random.nextInt(256),
+    ).map((byte) => byte.toRadixString(16).padLeft(2, '0')).join();
+  }
+
+  void _zeroize(Uint8List bytes) {
+    bytes.fillRange(0, bytes.length, 0);
+  }
+}

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -224,6 +224,9 @@ class PaymentLinkService {
     }
 
     final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    if (!VizorPaymentLink.supportsNetwork(endpoint.networkName)) {
+      throw StateError('Payment links are only available on mainnet.');
+    }
     final paymentAccount = await rust_wallet.generateSoftwareAccount(
       network: endpoint.networkName,
     );

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -144,7 +144,12 @@ int validatePaymentLinkClaimBirthday({
 @visibleForTesting
 String paymentLinkClaimWalletDirectoryName(VizorPaymentLink link) {
   final identity = sha256
-      .convert(utf8.encode('${link.network}:${link.address}:${link.mnemonic}'))
+      .convert(
+        utf8.encode(
+          '${link.network}:${link.address}:${link.mnemonic}:'
+          '${link.birthdayHeight}',
+        ),
+      )
       .toString();
   return '$kPaymentLinkClaimWalletDirectoryPrefix$identity';
 }

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -518,18 +518,35 @@ class PaymentLinkService {
     String? mnemonic,
   }) async {
     await _requireShieldedAddress(toAddress);
-    final walletDbPath = dbPath ?? await getWalletDbPath();
     final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
     final sendFlowId = _newSendFlowId();
-    final proposal = await rust_sync.proposeSend(
-      dbPath: walletDbPath,
-      network: endpoint.networkName,
-      accountUuid: fromAccountUuid,
-      sendFlowId: sendFlowId,
-      toAddress: toAddress,
-      amountZatoshi: amountZatoshi,
-      memo: memo,
-    );
+    Future<({String dbPath, rust_sync.ProposalResult proposal})> createProposal(
+      String proposalDbPath,
+    ) async {
+      final proposal = await rust_sync.proposeSend(
+        dbPath: proposalDbPath,
+        network: endpoint.networkName,
+        accountUuid: fromAccountUuid,
+        sendFlowId: sendFlowId,
+        toAddress: toAddress,
+        amountZatoshi: amountZatoshi,
+        memo: memo,
+      );
+      return (dbPath: proposalDbPath, proposal: proposal);
+    }
+
+    // The primary wallet shares the ordinary send flow's authoritative
+    // spendable lease. Claim wallets are fully synchronized before this path.
+    final proposalContext = dbPath == null
+        ? await _ref
+              .read(syncProvider.notifier)
+              .runWithAuthoritativeSpendable(
+                accountUuid: fromAccountUuid,
+                operation: () async => createProposal(await getWalletDbPath()),
+              )
+        : await createProposal(dbPath);
+    final walletDbPath = proposalContext.dbPath;
+    final proposal = proposalContext.proposal;
 
     try {
       final result = await _executeProposal(

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -204,7 +204,7 @@ class PaymentLinkService {
     }
 
     final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
-    final paymentAccount = await rust_wallet.previewNewSoftwareAccount(
+    final paymentAccount = await rust_wallet.generateSoftwareAccount(
       network: endpoint.networkName,
     );
     final ephemeralAddress = paymentAccount.unifiedAddress;
@@ -241,7 +241,7 @@ class PaymentLinkService {
           fundingTxids: (result) => result.txids,
         );
 
-    unawaited(_ref.read(syncProvider.notifier).refreshAfterSend());
+    unawaited(_refreshMainWalletAfterSend());
     _requireFullyBroadcasted(fundingResult);
     return link;
   }
@@ -368,7 +368,7 @@ class PaymentLinkService {
       var claimableZatoshi = BigInt.zero;
       var feeZatoshi = BigInt.zero;
       try {
-        final estimate = await rust_sync.estimateSendMaxMinConfirmations(
+        final estimate = await rust_sync.estimateSendMax(
           dbPath: tempWallet.dbPath,
           network: endpoint.networkName,
           accountUuid: importedAccountUuid,
@@ -423,7 +423,7 @@ class PaymentLinkService {
         'using ${endpoint.networkName}.',
       );
     }
-    final estimate = await rust_sync.estimateSendMaxMinConfirmations(
+    final estimate = await rust_sync.estimateSendMax(
       dbPath: session.dbPath,
       network: endpoint.networkName,
       accountUuid: session.accountUuid,
@@ -443,7 +443,6 @@ class PaymentLinkService {
       amountZatoshi: session.link.amountZatoshi,
       memo: null,
       mnemonic: session.link.mnemonic,
-      useMinConfirmations: true,
     );
     final claimResult = PaymentLinkClaimResult(
       txids: sendResult.txids,
@@ -452,7 +451,7 @@ class PaymentLinkService {
     if (!shouldRetainPaymentLinkClaimWallet(claimResult.status)) {
       await discardClaimSession(session);
     }
-    unawaited(_ref.read(syncProvider.notifier).refreshAfterSend());
+    unawaited(_refreshMainWalletAfterSend());
     return claimResult;
   }
 
@@ -464,6 +463,17 @@ class PaymentLinkService {
   Future<void> discardClaimSession(PaymentLinkClaimSession session) =>
       _deleteTemporaryWalletDb(session.directory);
 
+  Future<void> _refreshMainWalletAfterSend() async {
+    try {
+      await _ref.read(syncProvider.notifier).refreshAfterSend();
+    } catch (e, stackTrace) {
+      log(
+        'PaymentLinkService: refreshAfterSend failed (non-critical): $e\n'
+        '$stackTrace',
+      );
+    }
+  }
+
   Future<rust_sync.ExecuteProposalResult> _sendShielded({
     String? dbPath,
     required String fromAccountUuid,
@@ -471,31 +481,20 @@ class PaymentLinkService {
     required BigInt amountZatoshi,
     String? memo,
     String? mnemonic,
-    bool useMinConfirmations = false,
   }) async {
     await _requireShieldedAddress(toAddress);
     final walletDbPath = dbPath ?? await getWalletDbPath();
     final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
     final sendFlowId = _newSendFlowId();
-    final proposal = useMinConfirmations
-        ? await rust_sync.proposeSendMinConfirmations(
-            dbPath: walletDbPath,
-            network: endpoint.networkName,
-            accountUuid: fromAccountUuid,
-            sendFlowId: sendFlowId,
-            toAddress: toAddress,
-            amountZatoshi: amountZatoshi,
-            memo: memo,
-          )
-        : await rust_sync.proposeSend(
-            dbPath: walletDbPath,
-            network: endpoint.networkName,
-            accountUuid: fromAccountUuid,
-            sendFlowId: sendFlowId,
-            toAddress: toAddress,
-            amountZatoshi: amountZatoshi,
-            memo: memo,
-          );
+    final proposal = await rust_sync.proposeSend(
+      dbPath: walletDbPath,
+      network: endpoint.networkName,
+      accountUuid: fromAccountUuid,
+      sendFlowId: sendFlowId,
+      toAddress: toAddress,
+      amountZatoshi: amountZatoshi,
+      memo: memo,
+    );
 
     try {
       final result = await _executeProposal(

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -141,6 +141,10 @@ int validatePaymentLinkClaimBirthday({
   return advertisedBirthdayHeight;
 }
 
+/// Claim databases are cached by the fields that determine the recovered
+/// account and its scan range. Share-payload fields such as amount, label,
+/// timestamp, and presentation deliberately do not participate, so a corrected
+/// payload can reuse already-scanned state.
 @visibleForTesting
 String paymentLinkClaimWalletDirectoryName(VizorPaymentLink link) {
   final identity = sha256

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -159,6 +159,26 @@ class PaymentLinkClaimResult {
       status == PaymentLinkClaimBroadcastStatus.broadcasted;
 }
 
+/// A fully broadcast payment-link funding result.
+///
+/// When [fundingMetadataSaved] is false, the durable draft still preserves the
+/// bearer secret, but callers must not offer another funding attempt as the
+/// transaction already reached the network.
+class PaymentLinkFundingResult {
+  const PaymentLinkFundingResult({
+    required this.link,
+    required this.txids,
+    required this.fundingMetadataSaved,
+  });
+
+  final VizorPaymentLink link;
+  final String txids;
+
+  /// Whether the durable recovery record advanced from draft to funded.
+  /// The link remains recoverable from its draft when this is false.
+  final bool fundingMetadataSaved;
+}
+
 class PaymentLinkBroadcastPendingException implements Exception {
   const PaymentLinkBroadcastPendingException({
     required this.txids,
@@ -180,7 +200,7 @@ class PaymentLinkService {
   final Ref _ref;
   final PaymentLinkRecoveryStore _recoveryStore;
 
-  Future<VizorPaymentLink> createFundedLink({
+  Future<PaymentLinkFundingResult> createFundedLink({
     required BigInt amountZatoshi,
     required String sourceAccountUuid,
     PaymentLinkPresentation? presentation,
@@ -226,7 +246,7 @@ class PaymentLinkService {
       presentation: presentation,
     );
 
-    final fundingResult = await PaymentLinkFundingRecovery(_recoveryStore)
+    final funding = await PaymentLinkFundingRecovery(_recoveryStore)
         .fund<rust_sync.ExecuteProposalResult>(
           link: link,
           sourceAccountUuid: sourceAccountUuid,
@@ -240,10 +260,22 @@ class PaymentLinkService {
           },
           fundingTxids: (result) => result.txids,
         );
+    final fundingResult = funding.transaction;
+    if (!funding.fundingMetadataSaved) {
+      log(
+        'PaymentLinkService: funding was submitted but recovery metadata '
+        'could not be saved after retry: ${funding.recoveryError}\n'
+        '${funding.recoveryStackTrace}',
+      );
+    }
 
     unawaited(_refreshMainWalletAfterSend());
     _requireFullyBroadcasted(fundingResult);
-    return link;
+    return PaymentLinkFundingResult(
+      link: link,
+      txids: fundingResult.txids,
+      fundingMetadataSaved: funding.fundingMetadataSaved,
+    );
   }
 
   Future<List<PaymentLinkRecoveryRecord>> loadCreatedLinkRecoveries() {

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -817,6 +817,11 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         log('resetWallet: failed to evict wallet summary cache: $e\n$st');
       }
       try {
+        await deletePaymentLinkClaimWalletDirectories();
+      } catch (e, st) {
+        recordError('payment-link claim db deletion', e, st);
+      }
+      try {
         await _storage.deleteAll();
       } catch (e, st) {
         recordError('secure storage wipe', e, st);

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -816,11 +816,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         // and must not prevent the secure-storage wipe from completing.
         log('resetWallet: failed to evict wallet summary cache: $e\n$st');
       }
-      try {
-        await deletePaymentLinkClaimWalletDirectories();
-      } catch (e, st) {
-        recordError('payment-link claim db deletion', e, st);
-      }
+      await clearPaymentLinkClaimWalletsForReset();
       try {
         await _storage.deleteAll();
       } catch (e, st) {
@@ -1410,6 +1406,27 @@ String _normalizedExceptionMessage(Object error) {
 final accountProvider = AsyncNotifierProvider<AccountNotifier, AccountState>(
   AccountNotifier.new,
 );
+
+/// Best-effort cleanup for isolated payment-link claim databases.
+///
+/// A wallet reset that already deleted its primary database must still clear
+/// account/security state and route to onboarding when this ancillary cleanup
+/// fails.
+@visibleForTesting
+Future<void> clearPaymentLinkClaimWalletsForReset({
+  Future<void> Function() deleteDirectories =
+      deletePaymentLinkClaimWalletDirectories,
+  void Function(String message) reportError = log,
+}) async {
+  try {
+    await deleteDirectories();
+  } catch (error, stackTrace) {
+    reportError(
+      'resetWallet: payment-link claim db cleanup failed (non-critical): '
+      '$error\n$stackTrace',
+    );
+  }
+}
 
 @visibleForTesting
 String? resolveNextActiveAccountUuidAfterRemoval({

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -680,6 +680,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   int _authoritativeBalanceVersion = 0;
   Future<void>? _authoritativeBalanceRecovery;
   int _authoritativeSpendableOperationCount = 0;
+  Future<void> _exclusiveRustSyncTail = Future<void>.value();
   bool _syncStartDeferred = false;
   int? _deferredSyncLatestTipHeight;
   // Mempool observer subscription. Started in `startSync` and
@@ -1635,12 +1636,43 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   void resumeAfterWalletMutation(WalletMutationSyncPause pause) {
     if (_requiresUnlock) return;
 
-    if (pause.hadActiveSync) {
-      log('SyncNotifier: resuming sync after wallet DB mutation');
+    if (pause.hadActiveSync || pause.hadMempoolObserver) {
+      log('SyncNotifier: resuming sync and mempool observation after pause');
       startSync();
     }
     if (pause.hadPolling || pause.hadActiveSync) {
       _startPolling();
+    }
+  }
+
+  /// Serializes a non-wallet foreground sync against the process-global Rust
+  /// sync engine. New foreground starts stay deferred until the operation has
+  /// completed and any previously active wallet sync can be resumed.
+  Future<T> runWithExclusiveRustSync<T>(Future<T> Function() operation) {
+    final result = _exclusiveRustSyncTail.then(
+      (_) => _runWithExclusiveRustSync(operation),
+    );
+    _exclusiveRustSyncTail = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+
+  Future<T> _runWithExclusiveRustSync<T>(Future<T> Function() operation) async {
+    if (_requiresUnlock) {
+      throw StateError('Wallet is locked.');
+    }
+    _authoritativeSpendableOperationCount++;
+    WalletMutationSyncPause? pause;
+    try {
+      pause = await pauseForWalletMutation();
+      if (_requiresUnlock) {
+        throw StateError('Wallet is locked.');
+      }
+      return await operation();
+    } finally {
+      if (pause != null) {
+        resumeAfterWalletMutation(pause);
+      }
+      _releaseForegroundSyncLease();
     }
   }
 
@@ -2538,16 +2570,21 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       await waitForAuthoritativeSpendable(accountUuid: accountUuid);
       return await operation();
     } finally {
-      _authoritativeSpendableOperationCount--;
-      if (_authoritativeSpendableOperationCount == 0 &&
-          _syncStartDeferred &&
-          ref.mounted &&
-          !_requiresUnlock) {
-        final latestTipHeight = _deferredSyncLatestTipHeight;
-        _syncStartDeferred = false;
-        _deferredSyncLatestTipHeight = null;
-        startSync(latestTipHeight: latestTipHeight);
-      }
+      _releaseForegroundSyncLease();
+    }
+  }
+
+  void _releaseForegroundSyncLease() {
+    assert(_authoritativeSpendableOperationCount > 0);
+    _authoritativeSpendableOperationCount--;
+    if (_authoritativeSpendableOperationCount == 0 &&
+        _syncStartDeferred &&
+        ref.mounted &&
+        !_requiresUnlock) {
+      final latestTipHeight = _deferredSyncLatestTipHeight;
+      _syncStartDeferred = false;
+      _deferredSyncLatestTipHeight = null;
+      startSync(latestTipHeight: latestTipHeight);
     }
   }
 

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -105,6 +105,40 @@ void main() {
     expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
   });
 
+  test(
+    'payment-link recovery stays encrypted across password rotation',
+    () async {
+      const recoveryPayload =
+          '{"link":"vizor://payment-link?p=secret-mnemonic-payload"}';
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(
+        kPaymentLinkRecoveryStorageKey,
+        recoveryPayload,
+      );
+
+      final storedBeforeRotation = await store.readPlain(
+        kPaymentLinkRecoveryStorageKey,
+      );
+      expect(storedBeforeRotation, isNot(contains('secret-mnemonic-payload')));
+
+      final didChange = await store.changePassword(
+        currentPassword: _oldPassword,
+        newPassword: _newPassword,
+      );
+
+      expect(didChange, isTrue);
+      store.clearSessionPassword();
+      expect(await store.verifyPassword(_newPassword), isTrue);
+      expect(
+        await store.readSecretStringWithOptions(
+          kPaymentLinkRecoveryStorageKey,
+          requireUnlockedSession: true,
+        ),
+        recoveryPayload,
+      );
+    },
+  );
+
   test('readAccountMnemonicBytes returns mutable mnemonic bytes', () async {
     await store.configurePassword(_oldPassword);
     await store.writeAccountMnemonic(_accountUuid, _mnemonic);

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -109,7 +109,7 @@ void main() {
     'payment-link recovery stays encrypted across password rotation',
     () async {
       const recoveryPayload =
-          '{"link":"vizor://payment-link?p=secret-mnemonic-payload"}';
+          '{"link":"https://functions.vizor.cash/payment-links/open#v1=secret-mnemonic-payload"}';
       await store.configurePassword(_oldPassword);
       await store.writeSecretString(
         kPaymentLinkRecoveryStorageKey,

--- a/test/features/payment_links/payment_link_intake_provider_test.dart
+++ b/test/features/payment_links/payment_link_intake_provider_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_intake_provider.dart';
+
+void main() {
+  test('accepts and exposes a valid Vizor payment link', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final link = _link();
+
+    final result = container
+        .read(paymentLinkIntakeProvider.notifier)
+        .ingest(link.encode());
+
+    expect(result, PaymentLinkIntakeResult.accepted);
+    expect(
+      container.read(paymentLinkIntakeProvider).pendingLink?.address,
+      link.address,
+    );
+    expect(container.read(paymentLinkIntakeProvider).errorMessage, isNull);
+  });
+
+  test('ignores other URI schemes so ZIP-321 can share the channel', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final result = container
+        .read(paymentLinkIntakeProvider.notifier)
+        .ingest('zcash:u1recipient?amount=1');
+
+    expect(result, PaymentLinkIntakeResult.ignored);
+    expect(container.read(paymentLinkIntakeProvider).pendingLink, isNull);
+  });
+
+  test('rejects malformed Vizor links without clearing an earlier secret', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final link = _link();
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    notifier.ingest(link.encode());
+
+    final result = notifier.ingest('vizor://payment-link?p=not-base64');
+
+    expect(result, PaymentLinkIntakeResult.rejected);
+    final state = container.read(paymentLinkIntakeProvider);
+    expect(state.pendingLink?.address, link.address);
+    expect(state.errorMessage, isNotNull);
+    expect(state.errorMessage, isNot(contains('not-base64')));
+  });
+
+  test('takePending removes the link from memory', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    final link = _link();
+    notifier.ingest(link.encode());
+
+    final taken = notifier.takePending();
+
+    expect(taken?.address, link.address);
+    expect(container.read(paymentLinkIntakeProvider).pendingLink, isNull);
+  });
+
+  test('queues multiple accepted links in arrival order', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    final first = _link();
+    final second = VizorPaymentLink(
+      network: first.network,
+      address: 'u1secondpaymentlinkaddress',
+      amountZatoshi: BigInt.from(200000),
+      mnemonic: first.mnemonic,
+      birthdayHeight: first.birthdayHeight,
+      label: first.label,
+      createdAt: first.createdAt.add(const Duration(minutes: 1)),
+    );
+
+    notifier.ingest(first.encode());
+    notifier.ingest(second.encode());
+
+    expect(notifier.takePending()?.address, first.address);
+    expect(notifier.takePending()?.address, second.address);
+    expect(notifier.takePending(), isNull);
+  });
+
+  test('coalesces duplicate links without growing the queue', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    final link = _link();
+
+    expect(notifier.ingest(link.encode()), PaymentLinkIntakeResult.accepted);
+    expect(notifier.ingest(link.encode()), PaymentLinkIntakeResult.accepted);
+
+    expect(
+      container.read(paymentLinkIntakeProvider).pendingLinks,
+      hasLength(1),
+    );
+  });
+
+  test('rejects unique links beyond the bounded intake queue', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+
+    for (var i = 0; i < kPaymentLinkIntakeQueueCapacity; i++) {
+      expect(
+        notifier.ingest(_link(address: 'u1paymentlinkaddress$i').encode()),
+        PaymentLinkIntakeResult.accepted,
+      );
+    }
+
+    expect(
+      notifier.ingest(_link(address: 'u1paymentlinkoverflow').encode()),
+      PaymentLinkIntakeResult.rejected,
+    );
+    final state = container.read(paymentLinkIntakeProvider);
+    expect(state.pendingLinks, hasLength(kPaymentLinkIntakeQueueCapacity));
+    expect(state.errorMessage, 'Too many payment links are waiting to open.');
+  });
+}
+
+VizorPaymentLink _link({String address = 'u1paymentlinkaddress'}) {
+  return VizorPaymentLink(
+    network: 'main',
+    address: address,
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 3_456_789,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 8, 5, 12),
+  );
+}

--- a/test/features/payment_links/payment_link_intake_provider_test.dart
+++ b/test/features/payment_links/payment_link_intake_provider_test.dart
@@ -118,6 +118,25 @@ void main() {
     );
   });
 
+  test('keeps a corrected claim birthday in the intake queue', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    final original = _link();
+    final corrected = _link(birthdayHeight: original.birthdayHeight - 1);
+
+    notifier.receive(original.toUri().toString());
+    notifier.receive(corrected.toUri().toString());
+
+    expect(
+      container
+          .read(paymentLinkIntakeProvider)
+          .pendingLinks
+          .map((link) => link.birthdayHeight),
+      [original.birthdayHeight, corrected.birthdayHeight],
+    );
+  });
+
   test('rejects unique links beyond the bounded intake queue', () {
     final container = ProviderContainer();
     addTearDown(container.dispose);
@@ -144,14 +163,17 @@ void main() {
   });
 }
 
-VizorPaymentLink _link({String address = 'u1paymentlinkaddress'}) {
+VizorPaymentLink _link({
+  String address = 'u1paymentlinkaddress',
+  int birthdayHeight = 3_456_789,
+}) {
   return VizorPaymentLink(
     network: 'main',
     address: address,
     amountZatoshi: BigInt.from(100000),
     mnemonic:
         'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
-    birthdayHeight: 3_456_789,
+    birthdayHeight: birthdayHeight,
     label: 'Payment link',
     createdAt: DateTime.utc(2026, 8, 5, 12),
   );

--- a/test/features/payment_links/payment_link_intake_provider_test.dart
+++ b/test/features/payment_links/payment_link_intake_provider_test.dart
@@ -11,7 +11,7 @@ void main() {
 
     final result = container
         .read(paymentLinkIntakeProvider.notifier)
-        .ingest(link.encode());
+        .receive(link.toUri().toString());
 
     expect(result, PaymentLinkIntakeResult.accepted);
     expect(
@@ -21,26 +21,38 @@ void main() {
     expect(container.read(paymentLinkIntakeProvider).errorMessage, isNull);
   });
 
-  test('ignores other URI schemes so ZIP-321 can share the channel', () {
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
+  test(
+    'ignores unrelated links so ZIP-321 and HTTPS can share the channel',
+    () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
 
-    final result = container
-        .read(paymentLinkIntakeProvider.notifier)
-        .ingest('zcash:u1recipient?amount=1');
+      final result = container
+          .read(paymentLinkIntakeProvider.notifier)
+          .receive('zcash:u1recipient?amount=1');
 
-    expect(result, PaymentLinkIntakeResult.ignored);
-    expect(container.read(paymentLinkIntakeProvider).pendingLink, isNull);
-  });
+      expect(result, PaymentLinkIntakeResult.ignored);
+      expect(container.read(paymentLinkIntakeProvider).pendingLink, isNull);
+
+      expect(
+        container
+            .read(paymentLinkIntakeProvider.notifier)
+            .receive('https://functions.vizor.cash/health'),
+        PaymentLinkIntakeResult.ignored,
+      );
+    },
+  );
 
   test('rejects malformed Vizor links without clearing an earlier secret', () {
     final container = ProviderContainer();
     addTearDown(container.dispose);
     final link = _link();
     final notifier = container.read(paymentLinkIntakeProvider.notifier);
-    notifier.ingest(link.encode());
+    notifier.receive(link.toUri().toString());
 
-    final result = notifier.ingest('vizor://payment-link?p=not-base64');
+    final result = notifier.receive(
+      'https://functions.vizor.cash/payment-links/open#v1=not-base64',
+    );
 
     expect(result, PaymentLinkIntakeResult.rejected);
     final state = container.read(paymentLinkIntakeProvider);
@@ -54,7 +66,7 @@ void main() {
     addTearDown(container.dispose);
     final notifier = container.read(paymentLinkIntakeProvider.notifier);
     final link = _link();
-    notifier.ingest(link.encode());
+    notifier.receive(link.toUri().toString());
 
     final taken = notifier.takePending();
 
@@ -77,8 +89,8 @@ void main() {
       createdAt: first.createdAt.add(const Duration(minutes: 1)),
     );
 
-    notifier.ingest(first.encode());
-    notifier.ingest(second.encode());
+    notifier.receive(first.toUri().toString());
+    notifier.receive(second.toUri().toString());
 
     expect(notifier.takePending()?.address, first.address);
     expect(notifier.takePending()?.address, second.address);
@@ -91,8 +103,14 @@ void main() {
     final notifier = container.read(paymentLinkIntakeProvider.notifier);
     final link = _link();
 
-    expect(notifier.ingest(link.encode()), PaymentLinkIntakeResult.accepted);
-    expect(notifier.ingest(link.encode()), PaymentLinkIntakeResult.accepted);
+    expect(
+      notifier.receive(link.toUri().toString()),
+      PaymentLinkIntakeResult.accepted,
+    );
+    expect(
+      notifier.receive(link.toUri().toString()),
+      PaymentLinkIntakeResult.accepted,
+    );
 
     expect(
       container.read(paymentLinkIntakeProvider).pendingLinks,
@@ -107,13 +125,17 @@ void main() {
 
     for (var i = 0; i < kPaymentLinkIntakeQueueCapacity; i++) {
       expect(
-        notifier.ingest(_link(address: 'u1paymentlinkaddress$i').encode()),
+        notifier.receive(
+          _link(address: 'u1paymentlinkaddress$i').toUri().toString(),
+        ),
         PaymentLinkIntakeResult.accepted,
       );
     }
 
     expect(
-      notifier.ingest(_link(address: 'u1paymentlinkoverflow').encode()),
+      notifier.receive(
+        _link(address: 'u1paymentlinkoverflow').toUri().toString(),
+      ),
       PaymentLinkIntakeResult.rejected,
     );
     final state = container.read(paymentLinkIntakeProvider);

--- a/test/features/payment_links/payment_link_intake_provider_test.dart
+++ b/test/features/payment_links/payment_link_intake_provider_test.dart
@@ -118,22 +118,30 @@ void main() {
     );
   });
 
-  test('keeps a corrected claim birthday in the intake queue', () {
+  test('only coalesces links with the same complete canonical payload', () {
     final container = ProviderContainer();
     addTearDown(container.dispose);
     final notifier = container.read(paymentLinkIntakeProvider.notifier);
     final original = _link();
-    final corrected = _link(birthdayHeight: original.birthdayHeight - 1);
+    final changedPayloads = <VizorPaymentLink>[
+      _link(amountZatoshi: original.amountZatoshi + BigInt.one),
+      _link(birthdayHeight: original.birthdayHeight - 1),
+      _link(label: '${original.label} updated'),
+      _link(createdAt: original.createdAt.add(const Duration(seconds: 1))),
+      _link(presentation: const PaymentLinkPresentation(message: 'Updated')),
+    ];
 
     notifier.receive(original.toUri().toString());
-    notifier.receive(corrected.toUri().toString());
+    for (final changed in changedPayloads) {
+      notifier.receive(changed.toUri().toString());
+    }
 
     expect(
       container
           .read(paymentLinkIntakeProvider)
           .pendingLinks
-          .map((link) => link.birthdayHeight),
-      [original.birthdayHeight, corrected.birthdayHeight],
+          .map((link) => link.toUri().fragment),
+      [original, ...changedPayloads].map((link) => link.toUri().fragment),
     );
   });
 
@@ -165,16 +173,21 @@ void main() {
 
 VizorPaymentLink _link({
   String address = 'u1paymentlinkaddress',
+  BigInt? amountZatoshi,
   int birthdayHeight = 3_456_789,
+  String label = 'Payment link',
+  DateTime? createdAt,
+  PaymentLinkPresentation? presentation,
 }) {
   return VizorPaymentLink(
     network: 'main',
     address: address,
-    amountZatoshi: BigInt.from(100000),
+    amountZatoshi: amountZatoshi ?? BigInt.from(100000),
     mnemonic:
         'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
     birthdayHeight: birthdayHeight,
-    label: 'Payment link',
-    createdAt: DateTime.utc(2026, 8, 5, 12),
+    label: label,
+    createdAt: createdAt ?? DateTime.utc(2026, 8, 5, 12),
+    presentation: presentation,
   );
 }

--- a/test/features/payment_links/payment_link_recovery_store_test.dart
+++ b/test/features/payment_links/payment_link_recovery_store_test.dart
@@ -1,0 +1,206 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
+
+void main() {
+  group('PaymentLinkRecoveryStore', () {
+    test(
+      'persists the secret before broadcast and records funding success',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage();
+        final store = PaymentLinkRecoveryStore(storage);
+        final link = _link();
+
+        final fundingTxid = await PaymentLinkFundingRecovery(store).fund(
+          link: link,
+          sourceAccountUuid: 'source-account',
+          createTransaction: () async {
+            final restartedRecords = await PaymentLinkRecoveryStore(
+              storage,
+            ).load();
+            expect(restartedRecords, hasLength(1));
+            expect(
+              restartedRecords.single.state,
+              PaymentLinkRecoveryState.draft,
+            );
+            expect(restartedRecords.single.link.mnemonic, link.mnemonic);
+            return 'funding-txid';
+          },
+          fundingTxids: (txid) => txid,
+        );
+
+        expect(fundingTxid, 'funding-txid');
+        final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+        expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
+        expect(restartedRecords.single.fundingTxids, 'funding-txid');
+      },
+    );
+
+    test(
+      'transaction failure leaves the draft recoverable after restart',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage();
+        final link = _link();
+
+        await expectLater(
+          PaymentLinkFundingRecovery(
+            PaymentLinkRecoveryStore(storage),
+          ).fund<String>(
+            link: link,
+            sourceAccountUuid: 'source-account',
+            createTransaction: () => throw StateError('transaction failed'),
+            fundingTxids: (txid) => txid,
+          ),
+          throwsStateError,
+        );
+
+        final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+        expect(restartedRecords, hasLength(1));
+        expect(restartedRecords.single.state, PaymentLinkRecoveryState.draft);
+        expect(restartedRecords.single.link.encode(), link.encode());
+      },
+    );
+
+    test(
+      'funding metadata failure still preserves the earlier draft',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage(failOnWrite: 2);
+        final link = _link();
+
+        await expectLater(
+          PaymentLinkFundingRecovery(PaymentLinkRecoveryStore(storage)).fund(
+            link: link,
+            sourceAccountUuid: 'source-account',
+            createTransaction: () async => 'funding-txid',
+            fundingTxids: (txid) => txid,
+          ),
+          throwsStateError,
+        );
+
+        final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+        expect(restartedRecords.single.state, PaymentLinkRecoveryState.draft);
+        expect(restartedRecords.single.link.mnemonic, link.mnemonic);
+      },
+    );
+
+    test('records pending transaction ids before status handling', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+
+      final result = await PaymentLinkFundingRecovery(store).fund(
+        link: link,
+        sourceAccountUuid: 'source-account',
+        createTransaction: () async =>
+            (txids: 'pending-funding-txid', status: 'pending_broadcast'),
+        fundingTxids: (result) => result.txids,
+      );
+
+      expect(result.status, 'pending_broadcast');
+      final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+      expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
+      expect(restartedRecords.single.fundingTxids, 'pending-funding-txid');
+    });
+
+    test('archiving a shared record keeps its recovery secret', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+
+      await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+      await store.markFunded(
+        address: link.address,
+        fundingTxids: 'funding-txid',
+      );
+      await store.markShared(address: link.address);
+      await store.setArchived(address: link.address, archived: true);
+
+      final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+      expect(restartedRecords.single.state, PaymentLinkRecoveryState.shared);
+      expect(restartedRecords.single.fundingTxids, 'funding-txid');
+      expect(restartedRecords.single.isArchived, isTrue);
+      expect(restartedRecords.single.archivedAt, isNotNull);
+      expect(restartedRecords.single.link.mnemonic, link.mnemonic);
+
+      await PaymentLinkRecoveryStore(
+        storage,
+      ).setArchived(address: link.address, archived: false);
+      final restored = await PaymentLinkRecoveryStore(storage).load();
+      expect(restored.single.isArchived, isFalse);
+      expect(restored.single.archivedAt, isNull);
+      expect(restored.single.link.mnemonic, link.mnemonic);
+    });
+
+    test('rejects recovery states outside the v1 schema', () async {
+      final link = _link();
+      final storage = _FakePaymentLinkRecoveryStorage()
+        ..value = jsonEncode({
+          'version': 1,
+          'records': [
+            {
+              'link': link.encode(),
+              'sourceAccountUuid': 'source-account',
+              'state': 'unsupported',
+              'fundingTxids': 'funding-txid',
+              'archivedAt': null,
+              'updatedAt': DateTime.utc(2026, 8, 5).toIso8601String(),
+            },
+          ],
+        });
+
+      await expectLater(
+        PaymentLinkRecoveryStore(storage).load(),
+        throwsA(isA<PaymentLinkRecoveryStoreFormatException>()),
+      );
+    });
+
+    test('fails loud instead of hiding corrupted recovery data', () async {
+      final storage = _FakePaymentLinkRecoveryStorage()..value = '{not-json';
+
+      await expectLater(
+        PaymentLinkRecoveryStore(storage).load(),
+        throwsA(isA<PaymentLinkRecoveryStoreFormatException>()),
+      );
+    });
+  });
+}
+
+VizorPaymentLink _link() {
+  return VizorPaymentLink(
+    network: 'main',
+    address: 'u1paymentlinkaddress',
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 3_456_789,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 8, 5, 12),
+  );
+}
+
+class _FakePaymentLinkRecoveryStorage implements PaymentLinkRecoveryStorage {
+  _FakePaymentLinkRecoveryStorage({this.failOnWrite});
+
+  final int? failOnWrite;
+  String? value;
+  int _writeCount = 0;
+
+  @override
+  Future<void> delete() async {
+    value = null;
+  }
+
+  @override
+  Future<String?> read() async => value;
+
+  @override
+  Future<void> write(String nextValue) async {
+    _writeCount += 1;
+    if (_writeCount == failOnWrite) {
+      throw StateError('storage write failed');
+    }
+    value = nextValue;
+  }
+}

--- a/test/features/payment_links/payment_link_recovery_store_test.dart
+++ b/test/features/payment_links/payment_link_recovery_store_test.dart
@@ -13,7 +13,7 @@ void main() {
         final store = PaymentLinkRecoveryStore(storage);
         final link = _link();
 
-        final fundingTxid = await PaymentLinkFundingRecovery(store).fund(
+        final funding = await PaymentLinkFundingRecovery(store).fund(
           link: link,
           sourceAccountUuid: 'source-account',
           createTransaction: () async {
@@ -31,7 +31,8 @@ void main() {
           fundingTxids: (txid) => txid,
         );
 
-        expect(fundingTxid, 'funding-txid');
+        expect(funding.transaction, 'funding-txid');
+        expect(funding.recoveryError, isNull);
         final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
         expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
         expect(restartedRecords.single.fundingTxids, 'funding-txid');
@@ -63,22 +64,51 @@ void main() {
       },
     );
 
-    test(
-      'funding metadata failure still preserves the earlier draft',
-      () async {
-        final storage = _FakePaymentLinkRecoveryStorage(failOnWrite: 2);
-        final link = _link();
+    test('retries a transient funding metadata write failure', () async {
+      final storage = _FakePaymentLinkRecoveryStorage(failOnWrites: {2});
+      final link = _link();
 
-        await expectLater(
-          PaymentLinkFundingRecovery(PaymentLinkRecoveryStore(storage)).fund(
-            link: link,
-            sourceAccountUuid: 'source-account',
-            createTransaction: () async => 'funding-txid',
-            fundingTxids: (txid) => txid,
-          ),
-          throwsStateError,
+      final funding = await PaymentLinkFundingRecovery(
+        PaymentLinkRecoveryStore(storage),
+      ).fund(
+        link: link,
+        sourceAccountUuid: 'source-account',
+        createTransaction: () async => 'funding-txid',
+        fundingTxids: (txid) => txid,
+      );
+
+      expect(funding.transaction, 'funding-txid');
+      expect(funding.recoveryError, isNull);
+      final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+      expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
+      expect(restartedRecords.single.fundingTxids, 'funding-txid');
+    });
+
+    test(
+      'returns the broadcast result when funding metadata cannot be updated',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage(
+          failOnWrites: {2, 3},
+        );
+        final link = _link();
+        var transactionCount = 0;
+
+        final funding = await PaymentLinkFundingRecovery(
+          PaymentLinkRecoveryStore(storage),
+        ).fund(
+          link: link,
+          sourceAccountUuid: 'source-account',
+          createTransaction: () async {
+            transactionCount += 1;
+            return 'funding-txid';
+          },
+          fundingTxids: (txid) => txid,
         );
 
+        expect(funding.transaction, 'funding-txid');
+        expect(funding.recoveryError, isA<StateError>());
+        expect(funding.recoveryStackTrace, isNotNull);
+        expect(transactionCount, 1);
         final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
         expect(restartedRecords.single.state, PaymentLinkRecoveryState.draft);
         expect(restartedRecords.single.link.mnemonic, link.mnemonic);
@@ -90,7 +120,7 @@ void main() {
       final store = PaymentLinkRecoveryStore(storage);
       final link = _link();
 
-      final result = await PaymentLinkFundingRecovery(store).fund(
+      final funding = await PaymentLinkFundingRecovery(store).fund(
         link: link,
         sourceAccountUuid: 'source-account',
         createTransaction: () async =>
@@ -98,7 +128,8 @@ void main() {
         fundingTxids: (result) => result.txids,
       );
 
-      expect(result.status, 'pending_broadcast');
+      expect(funding.transaction.status, 'pending_broadcast');
+      expect(funding.recoveryError, isNull);
       final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
       expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
       expect(restartedRecords.single.fundingTxids, 'pending-funding-txid');
@@ -181,9 +212,9 @@ VizorPaymentLink _link() {
 }
 
 class _FakePaymentLinkRecoveryStorage implements PaymentLinkRecoveryStorage {
-  _FakePaymentLinkRecoveryStorage({this.failOnWrite});
+  _FakePaymentLinkRecoveryStorage({this.failOnWrites = const {}});
 
-  final int? failOnWrite;
+  final Set<int> failOnWrites;
   String? value;
   int _writeCount = 0;
 
@@ -198,7 +229,7 @@ class _FakePaymentLinkRecoveryStorage implements PaymentLinkRecoveryStorage {
   @override
   Future<void> write(String nextValue) async {
     _writeCount += 1;
-    if (_writeCount == failOnWrite) {
+    if (failOnWrites.contains(_writeCount)) {
       throw StateError('storage write failed');
     }
     value = nextValue;

--- a/test/features/payment_links/payment_link_recovery_store_test.dart
+++ b/test/features/payment_links/payment_link_recovery_store_test.dart
@@ -60,7 +60,7 @@ void main() {
         final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
         expect(restartedRecords, hasLength(1));
         expect(restartedRecords.single.state, PaymentLinkRecoveryState.draft);
-        expect(restartedRecords.single.link.encode(), link.encode());
+        expect(restartedRecords.single.link.toUri(), link.toUri());
       },
     );
 
@@ -68,14 +68,15 @@ void main() {
       final storage = _FakePaymentLinkRecoveryStorage(failOnWrites: {2});
       final link = _link();
 
-      final funding = await PaymentLinkFundingRecovery(
-        PaymentLinkRecoveryStore(storage),
-      ).fund(
-        link: link,
-        sourceAccountUuid: 'source-account',
-        createTransaction: () async => 'funding-txid',
-        fundingTxids: (txid) => txid,
-      );
+      final funding =
+          await PaymentLinkFundingRecovery(
+            PaymentLinkRecoveryStore(storage),
+          ).fund(
+            link: link,
+            sourceAccountUuid: 'source-account',
+            createTransaction: () async => 'funding-txid',
+            fundingTxids: (txid) => txid,
+          );
 
       expect(funding.transaction, 'funding-txid');
       expect(funding.recoveryError, isNull);
@@ -87,23 +88,22 @@ void main() {
     test(
       'returns the broadcast result when funding metadata cannot be updated',
       () async {
-        final storage = _FakePaymentLinkRecoveryStorage(
-          failOnWrites: {2, 3},
-        );
+        final storage = _FakePaymentLinkRecoveryStorage(failOnWrites: {2, 3});
         final link = _link();
         var transactionCount = 0;
 
-        final funding = await PaymentLinkFundingRecovery(
-          PaymentLinkRecoveryStore(storage),
-        ).fund(
-          link: link,
-          sourceAccountUuid: 'source-account',
-          createTransaction: () async {
-            transactionCount += 1;
-            return 'funding-txid';
-          },
-          fundingTxids: (txid) => txid,
-        );
+        final funding =
+            await PaymentLinkFundingRecovery(
+              PaymentLinkRecoveryStore(storage),
+            ).fund(
+              link: link,
+              sourceAccountUuid: 'source-account',
+              createTransaction: () async {
+                transactionCount += 1;
+                return 'funding-txid';
+              },
+              fundingTxids: (txid) => txid,
+            );
 
         expect(funding.transaction, 'funding-txid');
         expect(funding.recoveryError, isA<StateError>());
@@ -171,7 +171,7 @@ void main() {
           'version': 1,
           'records': [
             {
-              'link': link.encode(),
+              'link': link.toUri().toString(),
               'sourceAccountUuid': 'source-account',
               'state': 'unsupported',
               'fundingTxids': 'funding-txid',

--- a/test/features/payment_links/payment_link_service_test.dart
+++ b/test/features/payment_links/payment_link_service_test.dart
@@ -1,0 +1,242 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_service.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+
+void main() {
+  test('funding covers the exact recipient amount and claim fee', () {
+    final recipientAmount = BigInt.from(100000000);
+
+    expect(
+      paymentLinkFundingAmountZatoshi(recipientAmount),
+      BigInt.from(100010000),
+    );
+    expect(
+      () => paymentLinkFundingAmountZatoshi(BigInt.zero),
+      throwsArgumentError,
+    );
+  });
+
+  test('claim exposes only the amount promised by the link', () {
+    final recipientAmount = BigInt.from(100000000);
+
+    expect(
+      paymentLinkClaimableAmountZatoshi(
+        recipientAmountZatoshi: recipientAmount,
+        maxSpendableZatoshi: BigInt.from(100000000),
+      ),
+      recipientAmount,
+    );
+    expect(
+      paymentLinkClaimableAmountZatoshi(
+        recipientAmountZatoshi: recipientAmount,
+        maxSpendableZatoshi: BigInt.from(120000000),
+      ),
+      recipientAmount,
+    );
+    expect(
+      paymentLinkClaimableAmountZatoshi(
+        recipientAmountZatoshi: recipientAmount,
+        maxSpendableZatoshi: BigInt.from(99999999),
+      ),
+      BigInt.zero,
+    );
+  });
+
+  test('pending and partial claim broadcasts retain their wallet DB', () {
+    expect(
+      shouldRetainPaymentLinkClaimWallet(
+        paymentLinkClaimBroadcastStatusFromWire('pending_broadcast'),
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRetainPaymentLinkClaimWallet(
+        paymentLinkClaimBroadcastStatusFromWire('partial_broadcast'),
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRetainPaymentLinkClaimWallet(
+        paymentLinkClaimBroadcastStatusFromWire('broadcasted'),
+      ),
+      isFalse,
+    );
+    expect(
+      () => paymentLinkClaimBroadcastStatusFromWire('unexpected'),
+      throwsStateError,
+    );
+  });
+
+  test('only reuses a complete claim wallet for the expected address', () {
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const [],
+        expectedAddress: 'u1expected',
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const ['u1expected', 'u1unexpected'],
+        expectedAddress: 'u1expected',
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const ['u1unexpected'],
+        expectedAddress: 'u1expected',
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const ['u1expected'],
+        expectedAddress: 'u1expected',
+      ),
+      isFalse,
+    );
+  });
+
+  test('claim broadcast stops when the wallet locks', () {
+    expect(
+      () => requireUnlockedPaymentLinkWallet(requiresUnlock: true),
+      throwsStateError,
+    );
+    expect(
+      () => requireUnlockedPaymentLinkWallet(requiresUnlock: false),
+      returnsNormally,
+    );
+  });
+
+  test('bounds claim birthdays to a recent chain-tip window', () {
+    const currentTip = 3500000;
+    expect(
+      validatePaymentLinkClaimBirthday(
+        advertisedBirthdayHeight:
+            currentTip - kPaymentLinkMaxClaimLookbackBlocks,
+        currentTipHeight: currentTip,
+      ),
+      currentTip - kPaymentLinkMaxClaimLookbackBlocks,
+    );
+    expect(
+      () => validatePaymentLinkClaimBirthday(
+        advertisedBirthdayHeight:
+            currentTip - kPaymentLinkMaxClaimLookbackBlocks - 1,
+        currentTipHeight: currentTip,
+      ),
+      throwsFormatException,
+    );
+    expect(
+      () => validatePaymentLinkClaimBirthday(
+        advertisedBirthdayHeight: currentTip + 1,
+        currentTipHeight: currentTip,
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('claim wallet directory is deterministic without exposing its secret', () {
+    final link = _link();
+    final sameLinkName = paymentLinkClaimWalletDirectoryName(link);
+    final differentSecretName = paymentLinkClaimWalletDirectoryName(
+      VizorPaymentLink(
+        network: link.network,
+        address: link.address,
+        amountZatoshi: link.amountZatoshi,
+        mnemonic:
+            'legal winner thank year wave sausage worth useful legal winner thank yellow',
+        birthdayHeight: link.birthdayHeight,
+        label: link.label,
+        createdAt: link.createdAt,
+      ),
+    );
+
+    expect(paymentLinkClaimWalletDirectoryName(link), sameLinkName);
+    expect(differentSecretName, isNot(sameLinkName));
+    expect(sameLinkName, isNot(contains(link.address)));
+    expect(sameLinkName, isNot(contains('abandon')));
+  });
+
+  test(
+    'hardware funding is rejected before creating a recovery draft',
+    () async {
+      final storage = _RecordingPaymentLinkRecoveryStorage();
+      final container = ProviderContainer(
+        overrides: [
+          accountProvider.overrideWith(_HardwareAccountNotifier.new),
+          paymentLinkRecoveryStoreProvider.overrideWithValue(
+            PaymentLinkRecoveryStore(storage),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(accountProvider.future);
+
+      await expectLater(
+        container
+            .read(paymentLinkServiceProvider)
+            .createFundedLink(
+              amountZatoshi: BigInt.from(100000),
+              sourceAccountUuid: 'hardware-account',
+            ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'Keystone payment links require the hardware signing flow.',
+          ),
+        ),
+      );
+      expect(storage.writeCount, 0);
+    },
+  );
+}
+
+class _HardwareAccountNotifier extends AccountNotifier {
+  @override
+  AccountState build() => const AccountState(
+    accounts: [
+      AccountInfo(
+        uuid: 'hardware-account',
+        name: 'Keystone',
+        order: 0,
+        isHardware: true,
+      ),
+    ],
+    activeAccountUuid: 'hardware-account',
+    activeAddress: 'u1hardwareaddress',
+  );
+}
+
+class _RecordingPaymentLinkRecoveryStorage
+    implements PaymentLinkRecoveryStorage {
+  int writeCount = 0;
+
+  @override
+  Future<void> delete() async {}
+
+  @override
+  Future<String?> read() async => null;
+
+  @override
+  Future<void> write(String value) async {
+    writeCount += 1;
+  }
+}
+
+VizorPaymentLink _link() {
+  return VizorPaymentLink(
+    network: 'main',
+    address: 'u1paymentlinkaddress',
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 3_456_789,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 8, 5, 12),
+  );
+}

--- a/test/features/payment_links/payment_link_service_test.dart
+++ b/test/features/payment_links/payment_link_service_test.dart
@@ -139,7 +139,7 @@ void main() {
     );
   });
 
-  test('claim wallet directory is deterministic without exposing its secret', () {
+  test('claim wallet cache identity uses the account and birthday only', () {
     final link = _link();
     final sameLinkName = paymentLinkClaimWalletDirectoryName(link);
     final differentSecretName = paymentLinkClaimWalletDirectoryName(
@@ -165,10 +165,23 @@ void main() {
         createdAt: link.createdAt,
       ),
     );
+    final differentSharePayloadName = paymentLinkClaimWalletDirectoryName(
+      VizorPaymentLink(
+        network: link.network,
+        address: link.address,
+        amountZatoshi: link.amountZatoshi + BigInt.one,
+        mnemonic: link.mnemonic,
+        birthdayHeight: link.birthdayHeight,
+        label: '${link.label} updated',
+        createdAt: link.createdAt.add(const Duration(seconds: 1)),
+        presentation: const PaymentLinkPresentation(message: 'Updated'),
+      ),
+    );
 
     expect(paymentLinkClaimWalletDirectoryName(link), sameLinkName);
     expect(differentSecretName, isNot(sameLinkName));
     expect(differentBirthdayName, isNot(sameLinkName));
+    expect(differentSharePayloadName, sameLinkName);
     expect(sameLinkName, isNot(contains(link.address)));
     expect(sameLinkName, isNot(contains('abandon')));
   });

--- a/test/features/payment_links/payment_link_service_test.dart
+++ b/test/features/payment_links/payment_link_service_test.dart
@@ -154,9 +154,21 @@ void main() {
         createdAt: link.createdAt,
       ),
     );
+    final differentBirthdayName = paymentLinkClaimWalletDirectoryName(
+      VizorPaymentLink(
+        network: link.network,
+        address: link.address,
+        amountZatoshi: link.amountZatoshi,
+        mnemonic: link.mnemonic,
+        birthdayHeight: link.birthdayHeight - 1,
+        label: link.label,
+        createdAt: link.createdAt,
+      ),
+    );
 
     expect(paymentLinkClaimWalletDirectoryName(link), sameLinkName);
     expect(differentSecretName, isNot(sameLinkName));
+    expect(differentBirthdayName, isNot(sameLinkName));
     expect(sameLinkName, isNot(contains(link.address)));
     expect(sameLinkName, isNot(contains('abandon')));
   });

--- a/test/features/payment_links/vizor_payment_link_test.dart
+++ b/test/features/payment_links/vizor_payment_link_test.dart
@@ -1,0 +1,185 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+
+void main() {
+  group('VizorPaymentLink', () {
+    test('round trips a payment link payload', () {
+      final link = _link(
+        presentation: const PaymentLinkPresentation(
+          artworkId: 'celebration_03',
+          message: '축하해! 🎉',
+        ),
+      );
+
+      final encoded = link.encode();
+      final decoded = VizorPaymentLink.decode(encoded);
+      final payload =
+          jsonDecode(
+                utf8.decode(
+                  base64Url.decode(
+                    base64Url.normalize(
+                      Uri.parse(encoded).queryParameters['p']!,
+                    ),
+                  ),
+                ),
+              )
+              as Map<String, Object?>;
+
+      expect(encoded, startsWith('vizor://payment-link?p='));
+      expect(decoded.network, 'main');
+      expect(decoded.address, link.address);
+      expect(decoded.amountZatoshi, BigInt.from(123456789));
+      expect(decoded.mnemonic, link.mnemonic);
+      expect(decoded.birthdayHeight, 3_456_789);
+      expect(decoded.label, link.label);
+      expect(decoded.createdAt, link.createdAt);
+      expect(decoded.presentation?.artworkId, 'celebration_03');
+      expect(decoded.presentation?.message, '축하해! 🎉');
+      expect(payload['presentation'], {
+        'artworkId': 'celebration_03',
+        'message': '축하해! 🎉',
+      });
+    });
+
+    test('omits an empty presentation payload', () {
+      final encoded = _link(
+        presentation: const PaymentLinkPresentation(
+          artworkId: '  ',
+          message: '  ',
+        ),
+      ).encode();
+      final payload =
+          jsonDecode(
+                utf8.decode(
+                  base64Url.decode(
+                    base64Url.normalize(
+                      Uri.parse(encoded).queryParameters['p']!,
+                    ),
+                  ),
+                ),
+              )
+              as Map<String, Object?>;
+
+      expect(payload, isNot(contains('presentation')));
+      expect(VizorPaymentLink.decode(encoded).presentation, isNull);
+    });
+
+    test('rejects invalid presentation values', () {
+      final maxSimpleEmojiMessage = List.filled(128, '🎉').join();
+      expect(
+        PaymentLinkPresentation(
+          message: maxSimpleEmojiMessage,
+        ).toPayload()?['message'],
+        maxSimpleEmojiMessage,
+      );
+      expect(
+        () => _link(
+          presentation: const PaymentLinkPresentation(
+            artworkId: 'not an artwork id',
+          ),
+        ).encode(),
+        throwsFormatException,
+      );
+      expect(
+        () => _link(
+          presentation: PaymentLinkPresentation(
+            message: List.filled(129, 'a').join(),
+          ),
+        ).encode(),
+        throwsFormatException,
+      );
+      expect(
+        () => _link(
+          presentation: PaymentLinkPresentation(
+            message: List.filled(25, '👨‍👩‍👧‍👦').join(),
+          ),
+        ).encode(),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects links without Vizor payment-link scheme', () {
+      expect(
+        () => VizorPaymentLink.decode('https://example.com/pay'),
+        throwsFormatException,
+      );
+    });
+
+    test('accepts the scheme and host case-insensitively', () {
+      final link = _link();
+      final uppercaseLink = link.encode().replaceFirst(
+        'vizor://payment-link',
+        'VIZOR://PAYMENT-LINK',
+      );
+
+      final decoded = VizorPaymentLink.decode(uppercaseLink);
+
+      expect(decoded.address, link.address);
+      expect(decoded.mnemonic, link.mnemonic);
+    });
+
+    test('rejects malformed payloads', () {
+      expect(
+        () => VizorPaymentLink.decode('vizor://payment-link?p=not-base64'),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects oversized inbound links before decoding', () {
+      expect(
+        () => VizorPaymentLink.decode(
+          'vizor://payment-link?p=${'a' * VizorPaymentLink.maxEncodedLength}',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects unsupported versions', () {
+      final encoded = Uri(
+        scheme: 'vizor',
+        host: 'payment-link',
+        queryParameters: {'p': 'eyJ2IjoyfQ=='},
+      ).toString();
+
+      expect(() => VizorPaymentLink.decode(encoded), throwsFormatException);
+    });
+
+    test('rejects links without network', () {
+      final payload = {
+        'v': 1,
+        'address': 'u1exampleaddress',
+        'amountZatoshi': '1',
+        'mnemonic':
+            'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+        'birthdayHeight': 1,
+        'label': 'Demo link',
+        'createdAt': DateTime.utc(2026, 6, 21).toIso8601String(),
+      };
+      final encoded = Uri(
+        scheme: VizorPaymentLink.scheme,
+        host: VizorPaymentLink.host,
+        queryParameters: {
+          'p': base64UrlEncode(utf8.encode(jsonEncode(payload))),
+        },
+      ).toString();
+
+      expect(() => VizorPaymentLink.decode(encoded), throwsFormatException);
+    });
+  });
+}
+
+VizorPaymentLink _link({PaymentLinkPresentation? presentation}) {
+  return VizorPaymentLink(
+    network: 'main',
+    address: 'u1exampleaddress',
+    amountZatoshi: BigInt.from(123456789),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 3_456_789,
+    label: 'Demo link',
+    createdAt: DateTime.utc(2026, 6, 21, 12),
+    presentation: presentation,
+  );
+}

--- a/test/features/payment_links/vizor_payment_link_test.dart
+++ b/test/features/payment_links/vizor_payment_link_test.dart
@@ -13,21 +13,15 @@ void main() {
         ),
       );
 
-      final encoded = link.encode();
-      final decoded = VizorPaymentLink.decode(encoded);
-      final payload =
-          jsonDecode(
-                utf8.decode(
-                  base64Url.decode(
-                    base64Url.normalize(
-                      Uri.parse(encoded).queryParameters['p']!,
-                    ),
-                  ),
-                ),
-              )
-              as Map<String, Object?>;
+      final uri = link.toUri();
+      final decoded = VizorPaymentLink.parse(uri.toString());
+      final payload = _decodePayload(uri);
 
-      expect(encoded, startsWith('vizor://payment-link?p='));
+      expect(uri.scheme, 'https');
+      expect(uri.host, 'functions.vizor.cash');
+      expect(uri.path, '/payment-links/open');
+      expect(uri.query, isEmpty);
+      expect(uri.fragment, startsWith('v1='));
       expect(decoded.network, 'main');
       expect(decoded.address, link.address);
       expect(decoded.amountZatoshi, BigInt.from(123456789));
@@ -44,26 +38,16 @@ void main() {
     });
 
     test('omits an empty presentation payload', () {
-      final encoded = _link(
+      final uri = _link(
         presentation: const PaymentLinkPresentation(
           artworkId: '  ',
           message: '  ',
         ),
-      ).encode();
-      final payload =
-          jsonDecode(
-                utf8.decode(
-                  base64Url.decode(
-                    base64Url.normalize(
-                      Uri.parse(encoded).queryParameters['p']!,
-                    ),
-                  ),
-                ),
-              )
-              as Map<String, Object?>;
+      ).toUri();
+      final payload = _decodePayload(uri);
 
       expect(payload, isNot(contains('presentation')));
-      expect(VizorPaymentLink.decode(encoded).presentation, isNull);
+      expect(VizorPaymentLink.parse(uri.toString()).presentation, isNull);
     });
 
     test('rejects invalid presentation values', () {
@@ -79,7 +63,7 @@ void main() {
           presentation: const PaymentLinkPresentation(
             artworkId: 'not an artwork id',
           ),
-        ).encode(),
+        ).toUri(),
         throwsFormatException,
       );
       expect(
@@ -87,7 +71,7 @@ void main() {
           presentation: PaymentLinkPresentation(
             message: List.filled(129, 'a').join(),
           ),
-        ).encode(),
+        ).toUri(),
         throwsFormatException,
       );
       expect(
@@ -95,26 +79,36 @@ void main() {
           presentation: PaymentLinkPresentation(
             message: List.filled(25, '👨‍👩‍👧‍👦').join(),
           ),
-        ).encode(),
+        ).toUri(),
         throwsFormatException,
       );
     });
 
-    test('rejects links without Vizor payment-link scheme', () {
+    test('rejects URLs outside the Vizor payment-link endpoint', () {
       expect(
-        () => VizorPaymentLink.decode('https://example.com/pay'),
+        () => VizorPaymentLink.parse('vizor://payment-link?p=legacy'),
+        throwsFormatException,
+      );
+      expect(
+        () => VizorPaymentLink.parse('https://example.com/pay'),
+        throwsFormatException,
+      );
+      expect(
+        () => VizorPaymentLink.parse(
+          'https://functions.vizor.cash/payment-links/other#v1=payload',
+        ),
         throwsFormatException,
       );
     });
 
     test('accepts the scheme and host case-insensitively', () {
       final link = _link();
-      final uppercaseLink = link.encode().replaceFirst(
-        'vizor://payment-link',
-        'VIZOR://PAYMENT-LINK',
+      final uppercaseLink = link.toUri().toString().replaceFirst(
+        'https://functions.vizor.cash',
+        'HTTPS://FUNCTIONS.VIZOR.CASH',
       );
 
-      final decoded = VizorPaymentLink.decode(uppercaseLink);
+      final decoded = VizorPaymentLink.parse(uppercaseLink);
 
       expect(decoded.address, link.address);
       expect(decoded.mnemonic, link.mnemonic);
@@ -122,15 +116,18 @@ void main() {
 
     test('rejects malformed payloads', () {
       expect(
-        () => VizorPaymentLink.decode('vizor://payment-link?p=not-base64'),
+        () => VizorPaymentLink.parse(
+          'https://functions.vizor.cash/payment-links/open#v1=not-base64',
+        ),
         throwsFormatException,
       );
     });
 
     test('rejects oversized inbound links before decoding', () {
       expect(
-        () => VizorPaymentLink.decode(
-          'vizor://payment-link?p=${'a' * VizorPaymentLink.maxEncodedLength}',
+        () => VizorPaymentLink.parse(
+          'https://functions.vizor.cash/payment-links/open#v1='
+          '${'a' * VizorPaymentLink.maxEncodedLength}',
         ),
         throwsFormatException,
       );
@@ -138,12 +135,36 @@ void main() {
 
     test('rejects unsupported versions', () {
       final encoded = Uri(
-        scheme: 'vizor',
-        host: 'payment-link',
-        queryParameters: {'p': 'eyJ2IjoyfQ=='},
+        scheme: VizorPaymentLink.scheme,
+        host: VizorPaymentLink.host,
+        path: VizorPaymentLink.path,
+        fragment: 'v1=eyJ2IjoyfQ==',
       ).toString();
 
-      expect(() => VizorPaymentLink.decode(encoded), throwsFormatException);
+      expect(() => VizorPaymentLink.parse(encoded), throwsFormatException);
+    });
+
+    test('rejects query parameters, credentials, and explicit ports', () {
+      final payload = _link().toUri().fragment;
+
+      expect(
+        () => VizorPaymentLink.parse(
+          'https://functions.vizor.cash/payment-links/open?payload=hidden#$payload',
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => VizorPaymentLink.parse(
+          'https://user@functions.vizor.cash/payment-links/open#$payload',
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => VizorPaymentLink.parse(
+          'https://functions.vizor.cash:8443/payment-links/open#$payload',
+        ),
+        throwsFormatException,
+      );
     });
 
     test('rejects links without network', () {
@@ -160,14 +181,34 @@ void main() {
       final encoded = Uri(
         scheme: VizorPaymentLink.scheme,
         host: VizorPaymentLink.host,
-        queryParameters: {
-          'p': base64UrlEncode(utf8.encode(jsonEncode(payload))),
-        },
+        path: VizorPaymentLink.path,
+        fragment: 'v1=${base64UrlEncode(utf8.encode(jsonEncode(payload)))}',
       ).toString();
 
-      expect(() => VizorPaymentLink.decode(encoded), throwsFormatException);
+      expect(() => VizorPaymentLink.parse(encoded), throwsFormatException);
+    });
+
+    test('rejects non-mainnet payment links', () {
+      final testnetLink = VizorPaymentLink(
+        network: 'test',
+        address: 'utest1exampleaddress',
+        amountZatoshi: BigInt.one,
+        mnemonic:
+            'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+        birthdayHeight: 1,
+        label: 'Test link',
+        createdAt: DateTime.utc(2026, 8, 24),
+      );
+
+      expect(testnetLink.toUri, throwsFormatException);
     });
   });
+}
+
+Map<String, Object?> _decodePayload(Uri uri) {
+  final encoded = uri.fragment.substring('v1='.length);
+  return jsonDecode(utf8.decode(base64Url.decode(base64Url.normalize(encoded))))
+      as Map<String, Object?>;
 }
 
 VizorPaymentLink _link({PaymentLinkPresentation? presentation}) {

--- a/test/features/payment_links/vizor_payment_link_test.dart
+++ b/test/features/payment_links/vizor_payment_link_test.dart
@@ -37,6 +37,45 @@ void main() {
       });
     });
 
+    test('compares the complete canonical payment-link payload', () {
+      final original = _link();
+      final roundTripped = VizorPaymentLink.parse(original.toUri().toString());
+
+      expect(original.hasSameCanonicalPayload(roundTripped), isTrue);
+      expect(
+        original.hasSameCanonicalPayload(
+          _link(
+            network: ' main ',
+            address: ' ${original.address} ',
+            mnemonic: ' ${original.mnemonic} ',
+            label: ' ${original.label} ',
+            createdAt: DateTime.parse('2026-06-21T14:00:00+02:00'),
+          ),
+        ),
+        isTrue,
+      );
+
+      final changedPayloads = <String, VizorPaymentLink>{
+        'address': _link(address: '${original.address}2'),
+        'amount': _link(amountZatoshi: original.amountZatoshi + BigInt.one),
+        'mnemonic': _link(
+          mnemonic:
+              'legal winner thank year wave sausage worth useful legal winner thank yellow',
+        ),
+        'birthday': _link(birthdayHeight: original.birthdayHeight - 1),
+        'label': _link(label: '${original.label} updated'),
+        'createdAt': _link(
+          createdAt: original.createdAt.add(const Duration(seconds: 1)),
+        ),
+        'presentation': _link(
+          presentation: const PaymentLinkPresentation(message: 'Updated'),
+        ),
+      };
+      for (final MapEntry(:key, :value) in changedPayloads.entries) {
+        expect(original.hasSameCanonicalPayload(value), isFalse, reason: key);
+      }
+    });
+
     test('omits an empty presentation payload', () {
       final uri = _link(
         presentation: const PaymentLinkPresentation(
@@ -211,16 +250,25 @@ Map<String, Object?> _decodePayload(Uri uri) {
       as Map<String, Object?>;
 }
 
-VizorPaymentLink _link({PaymentLinkPresentation? presentation}) {
+VizorPaymentLink _link({
+  String network = 'main',
+  String address = 'u1exampleaddress',
+  BigInt? amountZatoshi,
+  String mnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+  int birthdayHeight = 3_456_789,
+  String label = 'Demo link',
+  DateTime? createdAt,
+  PaymentLinkPresentation? presentation,
+}) {
   return VizorPaymentLink(
-    network: 'main',
-    address: 'u1exampleaddress',
-    amountZatoshi: BigInt.from(123456789),
-    mnemonic:
-        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
-    birthdayHeight: 3_456_789,
-    label: 'Demo link',
-    createdAt: DateTime.utc(2026, 6, 21, 12),
+    network: network,
+    address: address,
+    amountZatoshi: amountZatoshi ?? BigInt.from(123456789),
+    mnemonic: mnemonic,
+    birthdayHeight: birthdayHeight,
+    label: label,
+    createdAt: createdAt ?? DateTime.utc(2026, 6, 21, 12),
     presentation: presentation,
   );
 }

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -90,6 +90,23 @@ void main() {
   );
 
   test(
+    'wallet reset treats payment-link claim cleanup as best effort',
+    () async {
+      final loggedMessages = <String>[];
+
+      await clearPaymentLinkClaimWalletsForReset(
+        deleteDirectories: () async {
+          throw StateError('claim cleanup failed');
+        },
+        reportError: loggedMessages.add,
+      );
+
+      expect(loggedMessages, hasLength(1));
+      expect(loggedMessages.single, contains('claim cleanup failed'));
+    },
+  );
+
+  test(
     'wallet reset clears the tor data directory and route preference',
     () async {
       SharedPreferences.setMockInitialValues({kTorEnabledPreferenceKey: true});

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
 import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
@@ -58,6 +59,35 @@ void main() {
       '.receive.redb',
     ]);
   });
+
+  test(
+    'wallet reset cleanup removes only payment-link claim directories',
+    () async {
+      final supportDirectory = Directory.systemTemp.createTempSync(
+        'vizor-payment-link-reset',
+      );
+      addTearDown(() {
+        if (supportDirectory.existsSync()) {
+          supportDirectory.deleteSync(recursive: true);
+        }
+      });
+      final claimDirectory = Directory(
+        '${supportDirectory.path}${Platform.pathSeparator}'
+        '$kPaymentLinkClaimWalletDirectoryPrefix${List.filled(64, 'a').join()}',
+      )..createSync();
+      final unrelatedDirectory = Directory(
+        '${supportDirectory.path}${Platform.pathSeparator}'
+        '${kPaymentLinkClaimWalletDirectoryPrefix}draft',
+      )..createSync();
+
+      await deletePaymentLinkClaimWalletDirectories(
+        resolveSupportDirectory: () async => supportDirectory,
+      );
+
+      expect(claimDirectory.existsSync(), isFalse);
+      expect(unrelatedDirectory.existsSync(), isTrue);
+    },
+  );
 
   test(
     'wallet reset clears the tor data directory and route preference',

--- a/test/providers/sync_provider_test.dart
+++ b/test/providers/sync_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/formatting/sync_status_label.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_failure.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
@@ -89,6 +90,86 @@ void main() {
       expect(resolveCount, 2);
     },
   );
+
+  test('exclusive Rust sync operations are serialized and bracketed', () async {
+    late _ExclusiveRustSyncTestNotifier notifier;
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+        syncProvider.overrideWith(
+          () => notifier = _ExclusiveRustSyncTestNotifier(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.listen(syncProvider, (_, _) {});
+    await container.read(syncProvider.future);
+
+    final firstRelease = Completer<void>();
+    final firstStarted = Completer<void>();
+    var secondStarted = false;
+    final first = notifier.runWithExclusiveRustSync(() async {
+      firstStarted.complete();
+      await firstRelease.future;
+      return 'first';
+    });
+    await firstStarted.future;
+    final second = notifier.runWithExclusiveRustSync(() async {
+      secondStarted = true;
+      return 'second';
+    });
+
+    await Future<void>.delayed(Duration.zero);
+    expect(secondStarted, isFalse);
+    firstRelease.complete();
+
+    expect(await Future.wait([first, second]), ['first', 'second']);
+    expect(notifier.pauseCount, 2);
+    expect(notifier.resumeCount, 2);
+  });
+
+  test('queued exclusive Rust sync aborts when the wallet locks', () async {
+    late _ExclusiveRustSyncTestNotifier notifier;
+    late _MutableSecurityNotifier security;
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+        appSecurityProvider.overrideWith(
+          () => security = _MutableSecurityNotifier(),
+        ),
+        syncProvider.overrideWith(
+          () => notifier = _ExclusiveRustSyncTestNotifier(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.listen(syncProvider, (_, _) {});
+    await container.read(syncProvider.future);
+    container.read(appSecurityProvider);
+
+    final firstRelease = Completer<void>();
+    final firstStarted = Completer<void>();
+    var secondStarted = false;
+    final first = notifier.runWithExclusiveRustSync(() async {
+      firstStarted.complete();
+      await firstRelease.future;
+      return 'first';
+    });
+    await firstStarted.future;
+    final second = notifier.runWithExclusiveRustSync(() async {
+      secondStarted = true;
+      return 'second';
+    });
+    final secondExpectation = expectLater(second, throwsStateError);
+
+    security.lock();
+    firstRelease.complete();
+
+    expect(await first, 'first');
+    await secondExpectation;
+    expect(secondStarted, isFalse);
+    expect(notifier.pauseCount, 1);
+  });
 
   test('refreshAfterUnlock propagates DB path resolution failures', () async {
     final container = ProviderContainer(
@@ -529,6 +610,49 @@ class _LifecycleTestSyncNotifier extends SyncNotifier {
 
   void replaceState(SyncState next) {
     state = AsyncData(next);
+  }
+}
+
+class _ExclusiveRustSyncTestNotifier extends SyncNotifier {
+  _ExclusiveRustSyncTestNotifier()
+    : super(walletDbPathResolver: () async => 'wallet.db');
+
+  var pauseCount = 0;
+  var resumeCount = 0;
+
+  @override
+  Future<SyncState> build() async => SyncState();
+
+  @override
+  Future<WalletMutationSyncPause> pauseForWalletMutation({
+    FutureOr<void> Function()? onStoppingSync,
+  }) async {
+    pauseCount++;
+    await onStoppingSync?.call();
+    return const WalletMutationSyncPause(
+      hadActiveSync: false,
+      hadPolling: false,
+      hadMempoolObserver: false,
+    );
+  }
+
+  @override
+  void resumeAfterWalletMutation(WalletMutationSyncPause pause) {
+    resumeCount++;
+  }
+}
+
+class _MutableSecurityNotifier extends AppSecurityNotifier {
+  @override
+  AppSecurityState build() =>
+      const AppSecurityState(isPasswordConfigured: true, isUnlocked: true);
+
+  @override
+  void lock() {
+    state = const AppSecurityState(
+      isPasswordConfigured: true,
+      isUnlocked: false,
+    );
   }
 }
 


### PR DESCRIPTION
## Payment link lifecycle

This PR adds the platform-neutral Dart orchestration layer on top of #551. It owns the versioned bearer-link model, encrypted recovery state, bounded intake, funding, isolated claim-wallet lifecycle, and foreground-sync coordination. OS URI registration and user-facing screens stay outside this PR.

```mermaid
flowchart TD
  subgraph Create["Create and fund"]
    A[Create request] --> B[Generate one-time software account]
    B --> C[Build versioned bearer link]
    C --> D[Persist encrypted draft]
    D --> E[Fund exact amount + claim fee reserve]
    E --> F[Record txids and funded state]
    F --> G[Expose shared/archive state to later UI]
  end

  subgraph Claim["Open and claim"]
    H[Decoded vizor payment link] --> I[Validate size, version, network, and birthday]
    I --> J[Queue in bounded intake]
    J --> K[Open isolated claim wallet DB]
    K --> L[Import mnemonic and verify address]
    L --> M[Run exclusive bounded sync]
    M --> N[Estimate standard spendable balance]
    N --> O[Send exact promised amount]
    O --> P{Broadcast status}
    P -->|broadcasted| Q[Delete temporary claim DB]
    P -->|pending or partial| R[Retain DB for retry]
  end
```

## Core contracts

- The mnemonic in the link is bearer authority. Created-link recovery data is encrypted and persisted before funding starts, so a failed or interrupted broadcast remains recoverable.
- Funding sends the promised amount plus a 10,000 zatoshi claim-fee reserve. Claiming sends only the exact amount promised by the link.
- Claiming never imports the bearer mnemonic into the primary wallet DB. It uses a deterministic, isolated DB whose directory name hashes the secret-bearing identity.
- Claim birthdays are bounded to the current tip and a 100,000-block lookback. Inbound links are size/version/network validated and the in-memory intake queue is bounded and deduplicated.
- Temporary claim DBs are deleted only after a fully broadcast claim. Pending or partial broadcasts retain them for retry, and a full wallet reset removes all claim DBs.
- Claim sync is serialized through `runWithExclusiveRustSync`, which pauses the normal foreground sync/mempool lane and resumes it afterward.
- Funding and claiming use the ordinary wallet proposal APIs. The inherited confirmation policy is 3 confirmations for trusted funds and 6 for untrusted funds; there is no payment-link-only minimum-confirmation override. Any link-exposure confirmation gate belongs to the later UI layer.
- Post-send balance refresh is best-effort. Refresh failures are caught and logged so they cannot turn an already successful funding or claim operation into an uncaught asynchronous error.

## Verification

- `fvm flutter test test/features/payment_links` — 31 passed
- Focused `fvm flutter analyze` across payment-link, storage, account, and sync files — no issues
- `git diff --check` — clean

Depends on #551.
