### PR TITLE
Add payment link OS URI handlers

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,9 +27,20 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
+            <meta-data
+                android:name="flutter_deeplinking_enabled"
+                android:value="false" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="vizor"
+                    android:host="payment-link" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
@@ -13,6 +13,9 @@ import io.flutter.plugin.common.MethodChannel
 // FlutterFragmentActivity: BiometricPrompt requires a FragmentActivity host.
 class MainActivity : FlutterFragmentActivity() {
     private lateinit var deviceOwnerAuthHandler: DeviceOwnerAuthHandler
+    private var incomingUriChannel: MethodChannel? = null
+    private val pendingIncomingUris = mutableListOf<String>()
+    private var incomingUriDartReady = false
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -85,6 +88,28 @@ class MainActivity : FlutterFragmentActivity() {
                 else -> result.notImplemented()
             }
         }
+
+        incomingUriChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            INCOMING_URI_CHANNEL
+        ).apply {
+            setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "takePendingUris" -> {
+                        val uris = pendingIncomingUris.toList()
+                        pendingIncomingUris.clear()
+                        result.success(uris)
+                    }
+                    "ready" -> {
+                        incomingUriDartReady = true
+                        flushPendingIncomingUris()
+                        result.success(null)
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+        }
+        captureIncomingUri(intent)
     }
 
     /** REJECT is the platform's error haptic; older APIs report
@@ -126,6 +151,12 @@ class MainActivity : FlutterFragmentActivity() {
         super.onActivityResult(requestCode, resultCode, data)
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        captureIncomingUri(intent)
+    }
+
     private fun openAppSettings(): Boolean {
         return try {
             val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
@@ -158,10 +189,36 @@ class MainActivity : FlutterFragmentActivity() {
         }
     }
 
+    private fun captureIncomingUri(intent: Intent?) {
+        if (intent == null || intent.action != Intent.ACTION_VIEW) return
+        if ((intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) return
+        val data = intent.data ?: return
+        if (!"vizor".equals(data.scheme, ignoreCase = true)) return
+        if (!"payment-link".equals(data.host, ignoreCase = true)) return
+        val rawUri = intent.dataString ?: data.toString()
+        if (rawUri.length > MAX_INCOMING_URI_BYTES) return
+        if (rawUri.toByteArray(Charsets.UTF_8).size > MAX_INCOMING_URI_BYTES) return
+        if (rawUri in pendingIncomingUris) return
+        if (pendingIncomingUris.size >= MAX_PENDING_INCOMING_URIS) return
+        pendingIncomingUris.add(rawUri)
+        flushPendingIncomingUris()
+    }
+
+    private fun flushPendingIncomingUris() {
+        if (!incomingUriDartReady || pendingIncomingUris.isEmpty()) return
+        val channel = incomingUriChannel ?: return
+        val uris = pendingIncomingUris.toList()
+        pendingIncomingUris.clear()
+        channel.invokeMethod("onUris", uris)
+    }
+
     companion object {
         private const val CAMERA_PERMISSION_CHANNEL = "com.zcash.wallet/camera_permission"
         private const val HAPTICS_CHANNEL = "com.zcash.wallet/haptics"
         private const val PRIVACY_SHIELD_CHANNEL = "com.zcash.wallet/privacy_shield"
         private const val SCREEN_AWAKE_CHANNEL = "com.zcash.wallet/screen_awake"
+        private const val INCOMING_URI_CHANNEL = "com.zcash.wallet/payment_uri"
+        private const val MAX_INCOMING_URI_BYTES = 16 * 1024
+        private const val MAX_PENDING_INCOMING_URIS = 16
     }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -536,6 +536,23 @@ import UIKit
       binaryMessenger: messenger
     )
     screenshotChannel.setStreamHandler(ScreenshotStreamHandler())
+
+    let incomingUriChannel = FlutterMethodChannel(
+      name: "com.zcash.wallet/payment_uri",
+      binaryMessenger: messenger
+    )
+    IncomingUriChannelBridge.shared.attach(channel: incomingUriChannel)
+    incomingUriChannel.setMethodCallHandler { call, result in
+      switch call.method {
+      case "takePendingUris":
+        result(IncomingUriChannelBridge.shared.takePending())
+      case "ready":
+        IncomingUriChannelBridge.shared.markReady()
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
   }
 
   private func completeOutboxArmWithBackgroundSchedule(
@@ -761,6 +778,67 @@ import UIKit
         return false
       }
     #endif
+  }
+}
+
+/// Buffers bearer payment links until the Dart isolate has installed its
+/// handler. Never logs the URL because it contains account recovery material.
+final class IncomingUriChannelBridge {
+  static let shared = IncomingUriChannelBridge()
+  private static let maxIncomingUriBytes = 16 * 1024
+  private static let maxPendingUris = 16
+  private init() {}
+
+  private var channel: FlutterMethodChannel?
+  private var pendingUris: [String] = []
+  private var dartReady = false
+
+  func attach(channel: FlutterMethodChannel) {
+    self.channel = channel
+    dartReady = false
+  }
+
+  func markReady() {
+    dartReady = true
+    flush()
+  }
+
+  func takePending() -> [String] {
+    let uris = pendingUris
+    pendingUris.removeAll()
+    return uris
+  }
+
+  func handle(urlContexts: Set<UIOpenURLContext>) {
+    var handledPaymentLink = false
+    for context in urlContexts {
+      let url = context.url
+      guard
+        url.scheme?.lowercased() == "vizor",
+        url.host?.lowercased() == "payment-link"
+      else {
+        continue
+      }
+      handledPaymentLink = true
+      let uri = url.absoluteString
+      guard
+        uri.utf8.count <= Self.maxIncomingUriBytes,
+        pendingUris.count < Self.maxPendingUris,
+        !pendingUris.contains(uri)
+      else {
+        continue
+      }
+      pendingUris.append(uri)
+    }
+    guard handledPaymentLink else { return }
+    flush()
+  }
+
+  private func flush() {
+    guard dartReady, let channel, !pendingUris.isEmpty else { return }
+    let uris = pendingUris
+    pendingUris.removeAll()
+    channel.invokeMethod("onUris", arguments: uris)
   }
 }
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -29,6 +29,19 @@
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER).payment-link</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>vizor</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -41,6 +54,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>FlutterDeepLinkingEnabled</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/ios/Runner/SceneDelegate.swift
+++ b/ios/Runner/SceneDelegate.swift
@@ -2,5 +2,28 @@ import Flutter
 import UIKit
 
 class SceneDelegate: FlutterSceneDelegate {
+  override func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    super.scene(scene, willConnectTo: session, options: connectionOptions)
+    IncomingUriChannelBridge.shared.handle(
+      urlContexts: connectionOptions.urlContexts
+    )
+  }
 
+  override func scene(
+    _ scene: UIScene,
+    openURLContexts URLContexts: Set<UIOpenURLContext>
+  ) {
+    IncomingUriChannelBridge.shared.handle(urlContexts: URLContexts)
+    let remaining = URLContexts.filter {
+      !($0.url.scheme?.lowercased() == "vizor" &&
+        $0.url.host?.lowercased() == "payment-link")
+    }
+    if !remaining.isEmpty {
+      super.scene(scene, openURLContexts: Set(remaining))
+    }
+  }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -59,6 +59,7 @@ import 'src/features/onboarding/mobile/mobile_unlock_screen.dart';
 import 'src/features/onboarding/unlock_screen.dart';
 import 'src/features/onboarding/welcome.dart';
 import 'src/features/pay/screens/pay_screen.dart';
+import 'src/features/payment_links/providers/payment_link_intake_provider.dart';
 import 'src/features/receive/screens/receive_screen.dart';
 import 'src/features/send/models/send_prefill_args.dart';
 import 'src/features/send/screens/keystone_send_scan_screen.dart';
@@ -102,6 +103,7 @@ import 'src/providers/windows_update_provider.dart';
 import 'src/rust/api/sync.dart' as rust_sync;
 import 'src/rust/frb_generated.dart';
 import 'src/rust/api/simple.dart' as rust_simple;
+import 'src/services/incoming_uri_service.dart';
 
 void log(String message) => debugPrint('[zcash] $message');
 
@@ -1148,29 +1150,31 @@ class ZcashWalletApp extends ConsumerWidget {
             child: _WindowsUpdateStartupCheck(
               child: _WindowsUpdatePromptHost(
                 router: router,
-                child: _RpcEndpointFailoverToastListener(
-                  child: _DesktopOpaqueWindowBackground(
-                    child: IronwoodMigrationCoordinatorHost(
-                      child: IronwoodMigrationPrivacyLockHost(
-                        child: SyncKeepAwakeNativeHost(
-                          child: SyncKeepAwakePrivacyLockHost(
-                            child: SyncKeepAwakeInteractionListener(
-                              child: GestureDetector(
-                                onTap: () {
-                                  // Leaf-only: skip when the primary focus is a
-                                  // `FocusScopeNode` rather than a concrete `FocusNode`.
-                                  // Unfocusing the scope itself strips the scope's
-                                  // "most-recently-focused child" memory, which leaves the
-                                  // next Tab with no deterministic starting point.
-                                  final primary =
-                                      FocusManager.instance.primaryFocus;
-                                  if (primary != null &&
-                                      primary is! FocusScopeNode) {
-                                    primary.unfocus();
-                                  }
-                                },
-                                behavior: HitTestBehavior.translucent,
-                                child: child!,
+                child: _IncomingPaymentLinkHost(
+                  child: _RpcEndpointFailoverToastListener(
+                    child: _DesktopOpaqueWindowBackground(
+                      child: IronwoodMigrationCoordinatorHost(
+                        child: IronwoodMigrationPrivacyLockHost(
+                          child: SyncKeepAwakeNativeHost(
+                            child: SyncKeepAwakePrivacyLockHost(
+                              child: SyncKeepAwakeInteractionListener(
+                                child: GestureDetector(
+                                  onTap: () {
+                                    // Leaf-only: skip when the primary focus is a
+                                    // `FocusScopeNode` rather than a concrete `FocusNode`.
+                                    // Unfocusing the scope itself strips the scope's
+                                    // "most-recently-focused child" memory, which leaves the
+                                    // next Tab with no deterministic starting point.
+                                    final primary =
+                                        FocusManager.instance.primaryFocus;
+                                    if (primary != null &&
+                                        primary is! FocusScopeNode) {
+                                      primary.unfocus();
+                                    }
+                                  },
+                                  behavior: HitTestBehavior.translucent,
+                                  child: child!,
+                                ),
                               ),
                             ),
                           ),
@@ -1220,6 +1224,40 @@ class _MacOSUpdatePrivacyChoiceHostState
     if (Platform.isMacOS) {
       PlatformNetworkPrivacyNativeUpdateCoordinator.clearDisableTorForUpdateHandler();
     }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+class _IncomingPaymentLinkHost extends ConsumerStatefulWidget {
+  const _IncomingPaymentLinkHost({required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<_IncomingPaymentLinkHost> createState() =>
+      _IncomingPaymentLinkHostState();
+}
+
+class _IncomingPaymentLinkHostState
+    extends ConsumerState<_IncomingPaymentLinkHost> {
+  StreamSubscription<String>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    final service = ref.read(incomingUriServiceProvider);
+    _subscription = service.uriStream.listen((rawUri) {
+      ref.read(paymentLinkIntakeProvider.notifier).ingest(rawUri);
+    });
+    unawaited(service.initialize());
+  }
+
+  @override
+  void dispose() {
+    unawaited(_subscription?.cancel());
     super.dispose();
   }
 

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -26,6 +26,7 @@ const kSyncKeepAwakeEnabledKey = 'zcash_sync_keep_awake_enabled';
 const kSyncKeepAwakePromptSeenKey = 'zcash_sync_keep_awake_prompt_seen';
 const kRpcEndpointUrlKey = 'zcash_rpc_endpoint_url';
 const kRpcEndpointPresetKey = 'zcash_rpc_endpoint_preset';
+const kPaymentLinkRecoveryStorageKey = 'zcash_payment_link_recovery_v1';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';
 const _passwordVerifierKey = 'zcash_password_verifier';
 const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
@@ -377,7 +378,8 @@ class AppSecureStore {
       });
       return;
     }
-    if (key.startsWith(_votingHotkeyKeyPrefix)) {
+    if (key.startsWith(_votingHotkeyKeyPrefix) ||
+        key == kPaymentLinkRecoveryStorageKey) {
       await _secretMutationLock.run(() async {
         await _runStorageOperation(
           'delete "$key"',
@@ -470,8 +472,9 @@ class AppSecureStore {
 
   /// Rotates the wallet password and re-encrypts every app-managed secret.
   ///
-  /// Account mnemonics and voting hotkeys are both encrypted with the wallet
-  /// password, but they may live in different secure storage backends.
+  /// Account mnemonics, voting hotkeys, and payment-link recovery records are
+  /// encrypted with the wallet password, but they may live in different secure
+  /// storage backends.
   Future<bool> changePassword({
     required String currentPassword,
     required String newPassword,
@@ -550,12 +553,12 @@ class AppSecureStore {
           ),
         );
       }
-      final votingHotkeyValues = await _runStorageOperation(
-        'read all voting hotkeys',
+      final appManagedSecretValues = await _runStorageOperation(
+        'read all app-managed secrets',
         _storage.readAll,
       );
-      for (final entry in votingHotkeyValues.entries) {
-        if (!entry.key.startsWith(_votingHotkeyKeyPrefix)) continue;
+      for (final entry in appManagedSecretValues.entries) {
+        if (!_isAppManagedGeneralSecretKey(entry.key)) continue;
 
         if (!_isEncryptedPayload(entry.value)) {
           throw StateError(
@@ -1033,6 +1036,11 @@ class AppSecureStore {
     return key.startsWith(_accountMnemonicKeyPrefix)
         ? _mnemonicStorage
         : _storage;
+  }
+
+  bool _isAppManagedGeneralSecretKey(String key) {
+    return key.startsWith(_votingHotkeyKeyPrefix) ||
+        key == kPaymentLinkRecoveryStorageKey;
   }
 
   Future<void> _deleteRotationRecordBestEffort() async {

--- a/lib/src/core/storage/wallet_paths.dart
+++ b/lib/src/core/storage/wallet_paths.dart
@@ -4,6 +4,11 @@ import 'package:path_provider/path_provider.dart';
 
 import 'app_secure_store.dart';
 
+const kPaymentLinkClaimWalletDirectoryPrefix = 'payment_link_claim_';
+final _paymentLinkClaimWalletDirectoryPattern = RegExp(
+  r'^payment_link_claim_[0-9a-f]{64}$',
+);
+
 Future<Directory> getWalletSupportDirectory() async {
   final dir = await getApplicationSupportDirectory();
   await dir.create(recursive: true);
@@ -23,4 +28,21 @@ Future<String> getWalletDbPath() async {
 Future<String> getTorDataDirectoryPath() async {
   final dir = await getWalletSupportDirectory();
   return '${dir.path}${Platform.pathSeparator}tor';
+}
+
+Future<void> deletePaymentLinkClaimWalletDirectories({
+  Future<Directory> Function() resolveSupportDirectory =
+      getWalletSupportDirectory,
+}) async {
+  final supportDirectory = await resolveSupportDirectory();
+  if (!await supportDirectory.exists()) return;
+
+  await for (final entity in supportDirectory.list(followLinks: false)) {
+    if (entity is! Directory) continue;
+    final directoryName = entity.path.split(Platform.pathSeparator).last;
+    if (!_paymentLinkClaimWalletDirectoryPattern.hasMatch(directoryName)) {
+      continue;
+    }
+    await entity.delete(recursive: true);
+  }
 }

--- a/lib/src/features/payment_links/models/vizor_payment_link.dart
+++ b/lib/src/features/payment_links/models/vizor_payment_link.dart
@@ -1,0 +1,223 @@
+import 'dart:convert';
+
+import 'package:characters/characters.dart';
+
+class PaymentLinkPresentation {
+  const PaymentLinkPresentation({this.artworkId, this.message});
+
+  static const maxArtworkIdLength = 64;
+  static const maxMessageCharacters = 128;
+  static const maxMessageUtf8Bytes = 512;
+
+  final String? artworkId;
+  final String? message;
+
+  Map<String, Object?>? toPayload() {
+    final normalizedArtworkId = _normalizeOptionalString(artworkId);
+    final normalizedMessage = _normalizeOptionalString(message);
+    _validate(artworkId: normalizedArtworkId, message: normalizedMessage);
+    if (normalizedArtworkId == null && normalizedMessage == null) {
+      return null;
+    }
+    return <String, Object?>{
+      'artworkId': ?normalizedArtworkId,
+      'message': ?normalizedMessage,
+    };
+  }
+
+  static PaymentLinkPresentation? fromPayload(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, Object?>) {
+      throw const FormatException('Payment link presentation is invalid.');
+    }
+    final artworkId = _readOptionalString(value, 'artworkId');
+    final message = _readOptionalString(value, 'message');
+    _validate(artworkId: artworkId, message: message);
+    if (artworkId == null && message == null) return null;
+    return PaymentLinkPresentation(artworkId: artworkId, message: message);
+  }
+
+  static void _validate({String? artworkId, String? message}) {
+    if (artworkId != null &&
+        !RegExp(
+          '^[a-zA-Z0-9_-]{1,$maxArtworkIdLength}\$',
+        ).hasMatch(artworkId)) {
+      throw const FormatException('Payment link artwork is invalid.');
+    }
+    if (message != null) {
+      if (message.characters.length > maxMessageCharacters) {
+        throw const FormatException('Payment link message is too long.');
+      }
+      if (utf8.encode(message).length > maxMessageUtf8Bytes) {
+        throw const FormatException('Payment link message is too large.');
+      }
+    }
+  }
+
+  static String? _readOptionalString(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value == null) return null;
+    if (value is! String) {
+      throw FormatException('Payment link presentation "$key" is invalid.');
+    }
+    return _normalizeOptionalString(value);
+  }
+
+  static String? _normalizeOptionalString(String? value) {
+    final trimmed = value?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+}
+
+class VizorPaymentLink {
+  const VizorPaymentLink({
+    required this.network,
+    required this.address,
+    required this.amountZatoshi,
+    required this.mnemonic,
+    required this.birthdayHeight,
+    required this.label,
+    required this.createdAt,
+    this.presentation,
+  });
+
+  static const scheme = 'vizor';
+  static const host = 'payment-link';
+  static const maxEncodedLength = 16 * 1024;
+  static const _version = 1;
+
+  final String network;
+  final String address;
+  final BigInt amountZatoshi;
+  final String mnemonic;
+  final int birthdayHeight;
+  final String label;
+  final DateTime createdAt;
+  final PaymentLinkPresentation? presentation;
+
+  String encode() {
+    final payload = <String, Object?>{
+      'v': _version,
+      'network': network.trim(),
+      'address': address.trim(),
+      'amountZatoshi': amountZatoshi.toString(),
+      'mnemonic': mnemonic.trim(),
+      'birthdayHeight': birthdayHeight,
+      'label': label.trim(),
+      'createdAt': createdAt.toUtc().toIso8601String(),
+    };
+    final presentationPayload = presentation?.toPayload();
+    if (presentationPayload != null) {
+      payload['presentation'] = presentationPayload;
+    }
+    final encoded = base64UrlEncode(utf8.encode(jsonEncode(payload)));
+    return Uri(
+      scheme: scheme,
+      host: host,
+      queryParameters: {'p': encoded},
+    ).toString();
+  }
+
+  static VizorPaymentLink decode(String rawLink) {
+    final trimmed = rawLink.trim();
+    if (trimmed.length > maxEncodedLength) {
+      throw const FormatException('Payment link is too large.');
+    }
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null || uri.scheme != scheme || uri.host != host) {
+      throw const FormatException('This is not a Vizor payment link.');
+    }
+
+    final encoded = uri.queryParameters['p'];
+    if (encoded == null || encoded.isEmpty) {
+      throw const FormatException('Payment link is missing its payload.');
+    }
+
+    late final Object? decodedJson;
+    try {
+      decodedJson = jsonDecode(
+        utf8.decode(base64Url.decode(base64Url.normalize(encoded))),
+      );
+    } catch (_) {
+      throw const FormatException('Payment link payload could not be read.');
+    }
+
+    if (decodedJson is! Map<String, Object?>) {
+      throw const FormatException('Payment link payload is invalid.');
+    }
+    final payload = decodedJson;
+    if (payload['v'] != _version) {
+      throw const FormatException('Payment link version is not supported.');
+    }
+
+    final network = _readString(payload, 'network');
+    final address = _readString(payload, 'address');
+    final amountZatoshi = _readBigInt(payload, 'amountZatoshi');
+    final mnemonic = _readString(payload, 'mnemonic');
+    final birthdayHeight = _readInt(payload, 'birthdayHeight');
+    final label = _readString(payload, 'label');
+    final createdAtRaw = _readString(payload, 'createdAt');
+    final createdAt = DateTime.tryParse(createdAtRaw);
+    final presentation = PaymentLinkPresentation.fromPayload(
+      payload['presentation'],
+    );
+
+    if (network.isEmpty) {
+      throw const FormatException('Payment link network is missing.');
+    }
+    if (address.isEmpty) {
+      throw const FormatException('Payment link address is missing.');
+    }
+    if (amountZatoshi <= BigInt.zero) {
+      throw const FormatException('Payment link amount is invalid.');
+    }
+    if (mnemonic.split(RegExp(r'\s+')).length < 12) {
+      throw const FormatException('Payment link recovery phrase is invalid.');
+    }
+    if (birthdayHeight <= 0) {
+      throw const FormatException('Payment link birthday height is invalid.');
+    }
+    if (createdAt == null) {
+      throw const FormatException('Payment link timestamp is invalid.');
+    }
+
+    return VizorPaymentLink(
+      network: network,
+      address: address,
+      amountZatoshi: amountZatoshi,
+      mnemonic: mnemonic,
+      birthdayHeight: birthdayHeight,
+      label: label,
+      createdAt: createdAt,
+      presentation: presentation,
+    );
+  }
+
+  static String _readString(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value is! String) {
+      throw FormatException('Payment link is missing "$key".');
+    }
+    return value.trim();
+  }
+
+  static int _readInt(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value is int) return value;
+    if (value is String) {
+      final parsed = int.tryParse(value.trim());
+      if (parsed != null) return parsed;
+    }
+    throw FormatException('Payment link "$key" is invalid.');
+  }
+
+  static BigInt _readBigInt(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value is int) return BigInt.from(value);
+    if (value is String) {
+      final parsed = BigInt.tryParse(value.trim());
+      if (parsed != null) return parsed;
+    }
+    throw FormatException('Payment link "$key" is invalid.');
+  }
+}

--- a/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
+++ b/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/vizor_payment_link.dart';
+
+enum PaymentLinkIntakeResult { accepted, ignored, rejected }
+
+const kPaymentLinkIntakeQueueCapacity = 16;
+
+class PaymentLinkIntakeState {
+  const PaymentLinkIntakeState({
+    this.pendingLinks = const [],
+    this.errorMessage,
+  });
+
+  final List<VizorPaymentLink> pendingLinks;
+  final String? errorMessage;
+
+  VizorPaymentLink? get pendingLink =>
+      pendingLinks.isEmpty ? null : pendingLinks.first;
+}
+
+class PaymentLinkIntakeNotifier extends Notifier<PaymentLinkIntakeState> {
+  @override
+  PaymentLinkIntakeState build() => const PaymentLinkIntakeState();
+
+  PaymentLinkIntakeResult ingest(String rawUri) {
+    final uri = Uri.tryParse(rawUri.trim());
+    if (uri == null || uri.scheme.toLowerCase() != VizorPaymentLink.scheme) {
+      return PaymentLinkIntakeResult.ignored;
+    }
+
+    try {
+      final link = VizorPaymentLink.decode(rawUri);
+      final pendingLinks = state.pendingLinks;
+      final duplicate = pendingLinks.any(
+        (pending) =>
+            pending.network == link.network &&
+            pending.address == link.address &&
+            pending.mnemonic == link.mnemonic,
+      );
+      if (duplicate) {
+        state = PaymentLinkIntakeState(pendingLinks: pendingLinks);
+        return PaymentLinkIntakeResult.accepted;
+      }
+      if (pendingLinks.length >= kPaymentLinkIntakeQueueCapacity) {
+        state = PaymentLinkIntakeState(
+          pendingLinks: pendingLinks,
+          errorMessage: 'Too many payment links are waiting to open.',
+        );
+        return PaymentLinkIntakeResult.rejected;
+      }
+      state = PaymentLinkIntakeState(pendingLinks: [...pendingLinks, link]);
+      return PaymentLinkIntakeResult.accepted;
+    } on FormatException {
+      state = PaymentLinkIntakeState(
+        pendingLinks: state.pendingLinks,
+        errorMessage: 'Payment link could not be opened.',
+      );
+      return PaymentLinkIntakeResult.rejected;
+    }
+  }
+
+  VizorPaymentLink? takePending() {
+    final link = state.pendingLink;
+    if (link == null) return null;
+    state = PaymentLinkIntakeState(
+      pendingLinks: state.pendingLinks.sublist(1),
+      errorMessage: state.errorMessage,
+    );
+    return link;
+  }
+
+  void clearError() {
+    state = PaymentLinkIntakeState(pendingLinks: state.pendingLinks);
+  }
+}
+
+final paymentLinkIntakeProvider =
+    NotifierProvider<PaymentLinkIntakeNotifier, PaymentLinkIntakeState>(
+      PaymentLinkIntakeNotifier.new,
+    );

--- a/lib/src/features/payment_links/services/payment_link_recovery_store.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_store.dart
@@ -1,0 +1,390 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/storage/app_secure_store.dart';
+import '../models/vizor_payment_link.dart';
+
+const _storageVersion = 1;
+
+final paymentLinkRecoveryStoreProvider = Provider<PaymentLinkRecoveryStore>((
+  ref,
+) {
+  return PaymentLinkRecoveryStore(
+    AppSecureStorePaymentLinkRecoveryStorage(AppSecureStore.instance),
+  );
+});
+
+enum PaymentLinkRecoveryState { draft, funded, shared }
+
+const _fieldNotProvided = Object();
+
+class PaymentLinkRecoveryRecord {
+  const PaymentLinkRecoveryRecord({
+    required this.link,
+    required this.sourceAccountUuid,
+    required this.state,
+    required this.updatedAt,
+    this.fundingTxids,
+    this.archivedAt,
+  });
+
+  final VizorPaymentLink link;
+  final String sourceAccountUuid;
+  final PaymentLinkRecoveryState state;
+  final DateTime updatedAt;
+  final String? fundingTxids;
+  final DateTime? archivedAt;
+
+  bool get isArchived => archivedAt != null;
+
+  PaymentLinkRecoveryRecord copyWith({
+    required PaymentLinkRecoveryState state,
+    required DateTime updatedAt,
+    String? fundingTxids,
+    Object? archivedAt = _fieldNotProvided,
+  }) {
+    return PaymentLinkRecoveryRecord(
+      link: link,
+      sourceAccountUuid: sourceAccountUuid,
+      state: state,
+      updatedAt: updatedAt,
+      fundingTxids: fundingTxids ?? this.fundingTxids,
+      archivedAt: identical(archivedAt, _fieldNotProvided)
+          ? this.archivedAt
+          : archivedAt as DateTime?,
+    );
+  }
+}
+
+class PaymentLinkRecoveryStoreFormatException implements Exception {
+  const PaymentLinkRecoveryStoreFormatException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'PaymentLinkRecoveryStoreFormatException: $message';
+}
+
+abstract interface class PaymentLinkRecoveryStorage {
+  Future<String?> read();
+
+  Future<void> write(String value);
+
+  Future<void> delete();
+}
+
+class AppSecureStorePaymentLinkRecoveryStorage
+    implements PaymentLinkRecoveryStorage {
+  const AppSecureStorePaymentLinkRecoveryStorage(this._store);
+
+  final AppSecureStore _store;
+
+  @override
+  Future<String?> read() {
+    return _store.readSecretStringWithOptions(
+      kPaymentLinkRecoveryStorageKey,
+      requireUnlockedSession: true,
+    );
+  }
+
+  @override
+  Future<void> write(String value) {
+    return _store.writeSecretString(kPaymentLinkRecoveryStorageKey, value);
+  }
+
+  @override
+  Future<void> delete() {
+    return _store.delete(kPaymentLinkRecoveryStorageKey);
+  }
+}
+
+class PaymentLinkRecoveryStore {
+  PaymentLinkRecoveryStore(this._storage);
+
+  final PaymentLinkRecoveryStorage _storage;
+  Future<void> _operationTail = Future<void>.value();
+
+  Future<List<PaymentLinkRecoveryRecord>> load() {
+    return _runExclusive(_loadUnlocked);
+  }
+
+  Future<PaymentLinkRecoveryRecord> saveDraft({
+    required VizorPaymentLink link,
+    required String sourceAccountUuid,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      if (sourceAccountUuid.isEmpty) {
+        throw ArgumentError.value(
+          sourceAccountUuid,
+          'sourceAccountUuid',
+          'Payment link source account is required.',
+        );
+      }
+      final records = await _loadUnlocked();
+      final existing = _findByAddress(records, link.address);
+      if (existing != null &&
+          existing.state != PaymentLinkRecoveryState.draft) {
+        throw StateError(
+          'Payment link recovery cannot replace a funded record with a draft.',
+        );
+      }
+      final record = PaymentLinkRecoveryRecord(
+        link: link,
+        sourceAccountUuid: sourceAccountUuid,
+        state: PaymentLinkRecoveryState.draft,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+      );
+      await _writeRecords(_replaceByAddress(records, record));
+      return record;
+    });
+  }
+
+  Future<PaymentLinkRecoveryRecord> markFunded({
+    required String address,
+    required String fundingTxids,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      if (fundingTxids.trim().isEmpty) {
+        throw ArgumentError.value(
+          fundingTxids,
+          'fundingTxids',
+          'A funded payment link requires a transaction id.',
+        );
+      }
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      if (existing.state != PaymentLinkRecoveryState.draft &&
+          existing.state != PaymentLinkRecoveryState.funded) {
+        throw StateError('Payment link funding state cannot move backwards.');
+      }
+      final updated = existing.copyWith(
+        state: PaymentLinkRecoveryState.funded,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+        fundingTxids: fundingTxids.trim(),
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<PaymentLinkRecoveryRecord> markShared({
+    required String address,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      if (existing.state != PaymentLinkRecoveryState.funded &&
+          existing.state != PaymentLinkRecoveryState.shared) {
+        throw StateError('Only a funded payment link can be marked shared.');
+      }
+      final updated = existing.copyWith(
+        state: PaymentLinkRecoveryState.shared,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<PaymentLinkRecoveryRecord> setArchived({
+    required String address,
+    required bool archived,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      final now = (updatedAt ?? DateTime.now()).toUtc();
+      final updated = existing.copyWith(
+        state: existing.state,
+        updatedAt: now,
+        archivedAt: archived ? now : null,
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<List<PaymentLinkRecoveryRecord>> _loadUnlocked() async {
+    final raw = await _storage.read();
+    if (raw == null || raw.trim().isEmpty) return const [];
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        throw const PaymentLinkRecoveryStoreFormatException(
+          'Recovery payload must be a JSON object.',
+        );
+      }
+      if (decoded['version'] != _storageVersion) {
+        throw const PaymentLinkRecoveryStoreFormatException(
+          'Recovery payload version is not supported.',
+        );
+      }
+      final items = decoded['records'];
+      if (items is! List) {
+        throw const PaymentLinkRecoveryStoreFormatException(
+          'Recovery payload records are missing.',
+        );
+      }
+      return [for (final item in items) _recordFromJson(item)];
+    } on PaymentLinkRecoveryStoreFormatException {
+      rethrow;
+    } catch (error) {
+      throw PaymentLinkRecoveryStoreFormatException(
+        'Recovery payload could not be decoded: $error',
+      );
+    }
+  }
+
+  Future<void> _writeRecords(List<PaymentLinkRecoveryRecord> records) async {
+    if (records.isEmpty) {
+      await _storage.delete();
+      return;
+    }
+    await _storage.write(
+      jsonEncode({
+        'version': _storageVersion,
+        'records': [for (final record in records) _recordToJson(record)],
+      }),
+    );
+  }
+
+  Future<T> _runExclusive<T>(Future<T> Function() operation) {
+    final result = _operationTail.then((_) => operation());
+    _operationTail = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+}
+
+class PaymentLinkFundingRecovery {
+  const PaymentLinkFundingRecovery(this._store);
+
+  final PaymentLinkRecoveryStore _store;
+
+  Future<T> fund<T>({
+    required VizorPaymentLink link,
+    required String sourceAccountUuid,
+    required Future<T> Function() createTransaction,
+    required String Function(T result) fundingTxids,
+  }) async {
+    await _store.saveDraft(link: link, sourceAccountUuid: sourceAccountUuid);
+    final result = await createTransaction();
+    await _store.markFunded(
+      address: link.address,
+      fundingTxids: fundingTxids(result),
+    );
+    return result;
+  }
+}
+
+PaymentLinkRecoveryRecord? _findByAddress(
+  List<PaymentLinkRecoveryRecord> records,
+  String address,
+) {
+  for (final record in records) {
+    if (record.link.address == address) return record;
+  }
+  return null;
+}
+
+PaymentLinkRecoveryRecord _findRequired(
+  List<PaymentLinkRecoveryRecord> records,
+  String address,
+) {
+  final record = _findByAddress(records, address);
+  if (record == null) {
+    throw StateError('Payment link recovery record was not found.');
+  }
+  return record;
+}
+
+List<PaymentLinkRecoveryRecord> _replaceByAddress(
+  List<PaymentLinkRecoveryRecord> records,
+  PaymentLinkRecoveryRecord replacement,
+) {
+  final replaced = <PaymentLinkRecoveryRecord>[];
+  var didReplace = false;
+  for (final record in records) {
+    if (record.link.address == replacement.link.address) {
+      replaced.add(replacement);
+      didReplace = true;
+    } else {
+      replaced.add(record);
+    }
+  }
+  if (!didReplace) replaced.add(replacement);
+  return replaced;
+}
+
+Map<String, Object?> _recordToJson(PaymentLinkRecoveryRecord record) {
+  return {
+    'link': record.link.encode(),
+    'sourceAccountUuid': record.sourceAccountUuid,
+    'state': record.state.name,
+    'fundingTxids': record.fundingTxids,
+    'archivedAt': record.archivedAt?.toUtc().toIso8601String(),
+    'updatedAt': record.updatedAt.toUtc().toIso8601String(),
+  };
+}
+
+PaymentLinkRecoveryRecord _recordFromJson(Object? value) {
+  if (value is! Map<String, dynamic>) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record must be a JSON object.',
+    );
+  }
+  final linkRaw = value['link'];
+  final sourceAccountUuid = value['sourceAccountUuid'];
+  final stateRaw = value['state'];
+  final fundingTxids = value['fundingTxids'];
+  final archivedAtRaw = value['archivedAt'];
+  final updatedAtRaw = value['updatedAt'];
+  if (linkRaw is! String ||
+      sourceAccountUuid is! String ||
+      sourceAccountUuid.isEmpty ||
+      stateRaw is! String ||
+      (fundingTxids != null && fundingTxids is! String) ||
+      (archivedAtRaw != null && archivedAtRaw is! String) ||
+      updatedAtRaw is! String) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record fields are invalid.',
+    );
+  }
+  final updatedAt = DateTime.tryParse(updatedAtRaw);
+  if (updatedAt == null) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record timestamp is invalid.',
+    );
+  }
+  final archivedAt = archivedAtRaw == null
+      ? null
+      : DateTime.tryParse(archivedAtRaw);
+  if (archivedAtRaw != null && archivedAt == null) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record archive timestamp is invalid.',
+    );
+  }
+  late final PaymentLinkRecoveryState state;
+  try {
+    state = PaymentLinkRecoveryState.values.byName(stateRaw);
+  } on ArgumentError {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record state is invalid.',
+    );
+  }
+
+  return PaymentLinkRecoveryRecord(
+    link: VizorPaymentLink.decode(linkRaw),
+    sourceAccountUuid: sourceAccountUuid,
+    state: state,
+    fundingTxids: fundingTxids as String?,
+    archivedAt: archivedAt?.toUtc(),
+    updatedAt: updatedAt.toUtc(),
+  );
+}

--- a/lib/src/features/payment_links/services/payment_link_recovery_store.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_store.dart
@@ -7,6 +7,7 @@ import '../../../core/storage/app_secure_store.dart';
 import '../models/vizor_payment_link.dart';
 
 const _storageVersion = 1;
+const _fundingMetadataWriteAttempts = 2;
 
 final paymentLinkRecoveryStoreProvider = Provider<PaymentLinkRecoveryStore>((
   ref,
@@ -262,12 +263,26 @@ class PaymentLinkRecoveryStore {
   }
 }
 
+class PaymentLinkFundingRecoveryResult<T> {
+  const PaymentLinkFundingRecoveryResult({
+    required this.transaction,
+    this.recoveryError,
+    this.recoveryStackTrace,
+  });
+
+  final T transaction;
+  final Object? recoveryError;
+  final StackTrace? recoveryStackTrace;
+
+  bool get fundingMetadataSaved => recoveryError == null;
+}
+
 class PaymentLinkFundingRecovery {
   const PaymentLinkFundingRecovery(this._store);
 
   final PaymentLinkRecoveryStore _store;
 
-  Future<T> fund<T>({
+  Future<PaymentLinkFundingRecoveryResult<T>> fund<T>({
     required VizorPaymentLink link,
     required String sourceAccountUuid,
     required Future<T> Function() createTransaction,
@@ -275,11 +290,23 @@ class PaymentLinkFundingRecovery {
   }) async {
     await _store.saveDraft(link: link, sourceAccountUuid: sourceAccountUuid);
     final result = await createTransaction();
-    await _store.markFunded(
-      address: link.address,
-      fundingTxids: fundingTxids(result),
+    final txids = fundingTxids(result);
+    Object? recoveryError;
+    StackTrace? recoveryStackTrace;
+    for (var attempt = 0; attempt < _fundingMetadataWriteAttempts; attempt++) {
+      try {
+        await _store.markFunded(address: link.address, fundingTxids: txids);
+        return PaymentLinkFundingRecoveryResult(transaction: result);
+      } catch (error, stackTrace) {
+        recoveryError = error;
+        recoveryStackTrace = stackTrace;
+      }
+    }
+    return PaymentLinkFundingRecoveryResult(
+      transaction: result,
+      recoveryError: recoveryError,
+      recoveryStackTrace: recoveryStackTrace,
     );
-    return result;
   }
 }
 

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -1,0 +1,693 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/storage/wallet_paths.dart';
+import '../../../providers/account_provider.dart';
+import '../../../providers/app_security_provider.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../providers/sync_provider.dart';
+import '../../../rust/api/sync.dart' as rust_sync;
+import '../../../rust/api/wallet.dart' as rust_wallet;
+import '../../send/services/sapling_params.dart';
+import '../models/vizor_payment_link.dart';
+import 'payment_link_recovery_store.dart';
+
+final paymentLinkServiceProvider = Provider<PaymentLinkService>((ref) {
+  return PaymentLinkService(ref, ref.read(paymentLinkRecoveryStoreProvider));
+});
+
+const kPaymentLinkMaxClaimLookbackBlocks = 100000;
+
+/// The ZIP-317 fee for the payment link's expected one-input, one-output
+/// shielded claim transaction.
+const kPaymentLinkClaimFeeReserveZatoshi = 10000;
+
+BigInt paymentLinkFundingAmountZatoshi(BigInt recipientAmountZatoshi) {
+  if (recipientAmountZatoshi <= BigInt.zero) {
+    throw ArgumentError.value(
+      recipientAmountZatoshi,
+      'recipientAmountZatoshi',
+      'Payment link amount must be positive.',
+    );
+  }
+  return recipientAmountZatoshi +
+      BigInt.from(kPaymentLinkClaimFeeReserveZatoshi);
+}
+
+@visibleForTesting
+BigInt paymentLinkClaimableAmountZatoshi({
+  required BigInt recipientAmountZatoshi,
+  required BigInt maxSpendableZatoshi,
+}) {
+  return maxSpendableZatoshi >= recipientAmountZatoshi
+      ? recipientAmountZatoshi
+      : BigInt.zero;
+}
+
+class PaymentLinkClaimSession {
+  const PaymentLinkClaimSession({
+    required this.link,
+    required this.destinationAddress,
+    required this.directory,
+    required this.dbPath,
+    required this.accountUuid,
+    required this.totalZatoshi,
+    required this.claimableZatoshi,
+    required this.feeZatoshi,
+  });
+
+  final VizorPaymentLink link;
+  final String destinationAddress;
+  final Directory directory;
+  final String dbPath;
+  final String accountUuid;
+  final BigInt totalZatoshi;
+  final BigInt claimableZatoshi;
+  final BigInt feeZatoshi;
+
+  bool get canClaim => claimableZatoshi > BigInt.zero;
+}
+
+enum PaymentLinkClaimBroadcastStatus {
+  broadcasted,
+  pendingBroadcast,
+  partialBroadcast,
+}
+
+@visibleForTesting
+PaymentLinkClaimBroadcastStatus paymentLinkClaimBroadcastStatusFromWire(
+  String status,
+) {
+  return switch (status) {
+    'broadcasted' => PaymentLinkClaimBroadcastStatus.broadcasted,
+    'pending_broadcast' => PaymentLinkClaimBroadcastStatus.pendingBroadcast,
+    'partial_broadcast' => PaymentLinkClaimBroadcastStatus.partialBroadcast,
+    _ => throw StateError('Unknown payment link broadcast status: $status'),
+  };
+}
+
+@visibleForTesting
+bool shouldRetainPaymentLinkClaimWallet(
+  PaymentLinkClaimBroadcastStatus status,
+) {
+  return status != PaymentLinkClaimBroadcastStatus.broadcasted;
+}
+
+@visibleForTesting
+bool shouldRecreatePaymentLinkClaimWallet({
+  required List<String> accountAddresses,
+  required String expectedAddress,
+}) {
+  return accountAddresses.length != 1 ||
+      accountAddresses.single != expectedAddress;
+}
+
+@visibleForTesting
+void requireUnlockedPaymentLinkWallet({required bool requiresUnlock}) {
+  if (requiresUnlock) {
+    throw StateError('Wallet is locked.');
+  }
+}
+
+@visibleForTesting
+int validatePaymentLinkClaimBirthday({
+  required int advertisedBirthdayHeight,
+  required int currentTipHeight,
+}) {
+  if (currentTipHeight <= 0) {
+    throw StateError('Current chain tip is unavailable.');
+  }
+  if (advertisedBirthdayHeight > currentTipHeight) {
+    throw const FormatException(
+      'Payment link birthday is ahead of the current chain tip.',
+    );
+  }
+  final earliestSupportedHeight = max(
+    1,
+    currentTipHeight - kPaymentLinkMaxClaimLookbackBlocks,
+  );
+  if (advertisedBirthdayHeight < earliestSupportedHeight) {
+    throw const FormatException(
+      'Payment link birthday is outside the supported claim window.',
+    );
+  }
+  return advertisedBirthdayHeight;
+}
+
+@visibleForTesting
+String paymentLinkClaimWalletDirectoryName(VizorPaymentLink link) {
+  final identity = sha256
+      .convert(utf8.encode('${link.network}:${link.address}:${link.mnemonic}'))
+      .toString();
+  return '$kPaymentLinkClaimWalletDirectoryPrefix$identity';
+}
+
+class PaymentLinkClaimResult {
+  const PaymentLinkClaimResult({required this.txids, required this.status});
+
+  final String txids;
+  final PaymentLinkClaimBroadcastStatus status;
+
+  bool get isBroadcasted =>
+      status == PaymentLinkClaimBroadcastStatus.broadcasted;
+}
+
+class PaymentLinkBroadcastPendingException implements Exception {
+  const PaymentLinkBroadcastPendingException({
+    required this.txids,
+    required this.status,
+    required this.message,
+  });
+
+  final String txids;
+  final String status;
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class PaymentLinkService {
+  PaymentLinkService(this._ref, this._recoveryStore);
+
+  final Ref _ref;
+  final PaymentLinkRecoveryStore _recoveryStore;
+
+  Future<VizorPaymentLink> createFundedLink({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+    PaymentLinkPresentation? presentation,
+  }) async {
+    if (sourceAccountUuid.isEmpty) {
+      throw StateError('No active account.');
+    }
+    if (amountZatoshi <= BigInt.zero) {
+      throw ArgumentError.value(
+        amountZatoshi,
+        'amountZatoshi',
+        'Payment link amount must be positive.',
+      );
+    }
+    if (_ref
+        .read(accountProvider.notifier)
+        .isHardwareAccount(sourceAccountUuid)) {
+      throw StateError(
+        'Keystone payment links require the hardware signing flow.',
+      );
+    }
+
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    final paymentAccount = await rust_wallet.previewNewSoftwareAccount(
+      network: endpoint.networkName,
+    );
+    final ephemeralAddress = paymentAccount.unifiedAddress;
+    if (ephemeralAddress.isEmpty) {
+      throw StateError('Payment link account was created without an address.');
+    }
+
+    final birthdayHeight = await _ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .getLatestBlockHeight();
+    final link = VizorPaymentLink(
+      network: endpoint.networkName,
+      address: ephemeralAddress,
+      amountZatoshi: amountZatoshi,
+      mnemonic: paymentAccount.mnemonic,
+      birthdayHeight: birthdayHeight.toInt(),
+      label: 'Payment link',
+      createdAt: DateTime.now(),
+      presentation: presentation,
+    );
+
+    final fundingResult = await PaymentLinkFundingRecovery(_recoveryStore)
+        .fund<rust_sync.ExecuteProposalResult>(
+          link: link,
+          sourceAccountUuid: sourceAccountUuid,
+          createTransaction: () {
+            return _sendShielded(
+              fromAccountUuid: sourceAccountUuid,
+              toAddress: ephemeralAddress,
+              amountZatoshi: paymentLinkFundingAmountZatoshi(amountZatoshi),
+              memo: null,
+            );
+          },
+          fundingTxids: (result) => result.txids,
+        );
+
+    unawaited(_ref.read(syncProvider.notifier).refreshAfterSend());
+    _requireFullyBroadcasted(fundingResult);
+    return link;
+  }
+
+  Future<List<PaymentLinkRecoveryRecord>> loadCreatedLinkRecoveries() {
+    return _recoveryStore.load();
+  }
+
+  Future<PaymentLinkRecoveryRecord> markCreatedLinkShared(
+    VizorPaymentLink link,
+  ) {
+    return _recoveryStore.markShared(address: link.address);
+  }
+
+  Future<PaymentLinkRecoveryRecord> setCreatedLinkArchived(
+    VizorPaymentLink link, {
+    required bool archived,
+  }) {
+    return _recoveryStore.setArchived(
+      address: link.address,
+      archived: archived,
+    );
+  }
+
+  Future<PaymentLinkClaimSession> prepareClaim(VizorPaymentLink link) async {
+    final receiverState = _ref.read(accountProvider).value;
+    final receiverAddress = receiverState?.activeAddress;
+    if (receiverState?.activeAccountUuid == null ||
+        receiverAddress == null ||
+        receiverAddress.isEmpty) {
+      throw StateError('No active receive account.');
+    }
+    return _prepareSpend(link: link, destinationAddress: receiverAddress);
+  }
+
+  Future<PaymentLinkClaimSession> _prepareSpend({
+    required VizorPaymentLink link,
+    required String destinationAddress,
+  }) async {
+    await _requireShieldedAddress(destinationAddress);
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    if (link.network != endpoint.networkName) {
+      throw StateError(
+        'Payment link is for ${link.network}, but this wallet is using '
+        '${endpoint.networkName}.',
+      );
+    }
+
+    final currentTipHeight = await _ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .getLatestBlockHeight();
+    final claimBirthdayHeight = validatePaymentLinkClaimBirthday(
+      advertisedBirthdayHeight: link.birthdayHeight,
+      currentTipHeight: currentTipHeight.toInt(),
+    );
+
+    final tempWallet = await _createOrOpenTemporaryWalletDb(link);
+    var deleteOnError = !tempWallet.existed;
+    try {
+      final String importedAddress;
+      final String importedAccountUuid;
+      if (tempWallet.existed) {
+        List<rust_wallet.AccountInfo>? accounts;
+        try {
+          accounts = await rust_wallet.listAccounts(
+            dbPath: tempWallet.dbPath,
+            network: endpoint.networkName,
+          );
+        } catch (e, st) {
+          log(
+            'PaymentLinkService: reopening payment-link claim wallet failed; '
+            'recreating it: $e\n$st',
+          );
+        }
+        if (accounts == null ||
+            shouldRecreatePaymentLinkClaimWallet(
+              accountAddresses: [
+                for (final account in accounts) account.unifiedAddress,
+              ],
+              expectedAddress: link.address,
+            )) {
+          if (accounts != null) {
+            log(
+              'PaymentLinkService: recreating incomplete payment-link claim '
+              'wallet with ${accounts.length} account(s)',
+            );
+          }
+          deleteOnError = true;
+          await _resetTemporaryWalletDb(tempWallet.directory);
+          final imported = await _importPaymentLinkClaimAccount(
+            link: link,
+            birthdayHeight: claimBirthdayHeight,
+            dbPath: tempWallet.dbPath,
+            network: endpoint.networkName,
+          );
+          importedAddress = imported.address;
+          importedAccountUuid = imported.accountUuid;
+        } else {
+          importedAddress = accounts.single.unifiedAddress;
+          importedAccountUuid = accounts.single.uuid;
+        }
+      } else {
+        final imported = await _importPaymentLinkClaimAccount(
+          link: link,
+          birthdayHeight: claimBirthdayHeight,
+          dbPath: tempWallet.dbPath,
+          network: endpoint.networkName,
+        );
+        importedAddress = imported.address;
+        importedAccountUuid = imported.accountUuid;
+      }
+      if (importedAddress != link.address) {
+        throw const FormatException(
+          'Payment link address does not match its recovery phrase.',
+        );
+      }
+
+      await _runBlockingSync(dbPath: tempWallet.dbPath);
+      final balance = await rust_sync.getBalance(
+        dbPath: tempWallet.dbPath,
+        network: endpoint.networkName,
+        accountUuid: importedAccountUuid,
+      );
+      var claimableZatoshi = BigInt.zero;
+      var feeZatoshi = BigInt.zero;
+      try {
+        final estimate = await rust_sync.estimateSendMaxMinConfirmations(
+          dbPath: tempWallet.dbPath,
+          network: endpoint.networkName,
+          accountUuid: importedAccountUuid,
+          toAddress: destinationAddress,
+        );
+        claimableZatoshi = paymentLinkClaimableAmountZatoshi(
+          recipientAmountZatoshi: link.amountZatoshi,
+          maxSpendableZatoshi: estimate.amountZatoshi,
+        );
+        feeZatoshi = estimate.feeZatoshi;
+      } catch (e) {
+        final message = e.toString().toLowerCase();
+        if (!message.contains('insufficient balance')) {
+          rethrow;
+        }
+      }
+
+      return PaymentLinkClaimSession(
+        link: link,
+        destinationAddress: destinationAddress,
+        directory: tempWallet.directory,
+        dbPath: tempWallet.dbPath,
+        accountUuid: importedAccountUuid,
+        totalZatoshi: balance.total,
+        claimableZatoshi: claimableZatoshi,
+        feeZatoshi: feeZatoshi,
+      );
+    } catch (_) {
+      if (deleteOnError) {
+        await _deleteTemporaryWalletDb(tempWallet.directory);
+      }
+      rethrow;
+    }
+  }
+
+  Future<PaymentLinkClaimResult> claimPreparedLink(
+    PaymentLinkClaimSession session,
+  ) async {
+    return _broadcastPreparedSpend(session);
+  }
+
+  Future<PaymentLinkClaimResult> _broadcastPreparedSpend(
+    PaymentLinkClaimSession session,
+  ) async {
+    if (!session.canClaim) {
+      throw StateError('Payment link has no spendable shielded balance yet.');
+    }
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    if (session.link.network != endpoint.networkName) {
+      throw StateError(
+        'Payment link is for ${session.link.network}, but this wallet is '
+        'using ${endpoint.networkName}.',
+      );
+    }
+    final estimate = await rust_sync.estimateSendMaxMinConfirmations(
+      dbPath: session.dbPath,
+      network: endpoint.networkName,
+      accountUuid: session.accountUuid,
+      toAddress: session.destinationAddress,
+    );
+    if (estimate.amountZatoshi < session.link.amountZatoshi) {
+      throw StateError(
+        'Payment link does not yet have enough spendable shielded balance.',
+      );
+    }
+
+    _requireWalletUnlocked();
+    final sendResult = await _sendShielded(
+      dbPath: session.dbPath,
+      fromAccountUuid: session.accountUuid,
+      toAddress: session.destinationAddress,
+      amountZatoshi: session.link.amountZatoshi,
+      memo: null,
+      mnemonic: session.link.mnemonic,
+      useMinConfirmations: true,
+    );
+    final claimResult = PaymentLinkClaimResult(
+      txids: sendResult.txids,
+      status: paymentLinkClaimBroadcastStatusFromWire(sendResult.status),
+    );
+    if (!shouldRetainPaymentLinkClaimWallet(claimResult.status)) {
+      await discardClaimSession(session);
+    }
+    unawaited(_ref.read(syncProvider.notifier).refreshAfterSend());
+    return claimResult;
+  }
+
+  Future<PaymentLinkClaimResult> claimLink(VizorPaymentLink link) async {
+    final session = await prepareClaim(link);
+    return claimPreparedLink(session);
+  }
+
+  Future<void> discardClaimSession(PaymentLinkClaimSession session) =>
+      _deleteTemporaryWalletDb(session.directory);
+
+  Future<rust_sync.ExecuteProposalResult> _sendShielded({
+    String? dbPath,
+    required String fromAccountUuid,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+    String? mnemonic,
+    bool useMinConfirmations = false,
+  }) async {
+    await _requireShieldedAddress(toAddress);
+    final walletDbPath = dbPath ?? await getWalletDbPath();
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    final sendFlowId = _newSendFlowId();
+    final proposal = useMinConfirmations
+        ? await rust_sync.proposeSendMinConfirmations(
+            dbPath: walletDbPath,
+            network: endpoint.networkName,
+            accountUuid: fromAccountUuid,
+            sendFlowId: sendFlowId,
+            toAddress: toAddress,
+            amountZatoshi: amountZatoshi,
+            memo: memo,
+          )
+        : await rust_sync.proposeSend(
+            dbPath: walletDbPath,
+            network: endpoint.networkName,
+            accountUuid: fromAccountUuid,
+            sendFlowId: sendFlowId,
+            toAddress: toAddress,
+            amountZatoshi: amountZatoshi,
+            memo: memo,
+          );
+
+    try {
+      final result = await _executeProposal(
+        dbPath: walletDbPath,
+        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        accountUuid: fromAccountUuid,
+        proposalId: proposal.proposalId,
+        sendFlowId: sendFlowId,
+        needsSaplingParams: proposal.needsSaplingParams,
+        mnemonic: mnemonic,
+      );
+      paymentLinkClaimBroadcastStatusFromWire(result.status);
+      return result;
+    } catch (e) {
+      try {
+        await rust_sync.discardProposal(
+          proposalId: proposal.proposalId,
+          sendFlowId: sendFlowId,
+        );
+      } catch (discardError) {
+        log('PaymentLinkService: discardProposal failed: $discardError');
+      }
+      rethrow;
+    }
+  }
+
+  Future<rust_sync.ExecuteProposalResult> _executeProposal({
+    required String dbPath,
+    required String lightwalletdUrl,
+    required String accountUuid,
+    required BigInt proposalId,
+    required String sendFlowId,
+    required bool needsSaplingParams,
+    String? mnemonic,
+  }) async {
+    var saplingParams = await loadSaplingParamsStatus();
+    if (needsSaplingParams && !saplingParams.complete) {
+      await downloadMissingSaplingParams(
+        saplingParams,
+        log: (message) => log('PaymentLinkService: $message'),
+      );
+      saplingParams = await loadSaplingParamsStatus();
+    }
+
+    _requireWalletUnlocked();
+
+    if (Platform.isMacOS && mnemonic == null) {
+      final password = _ref
+          .read(appSecurityProvider.notifier)
+          .requireSessionPasswordForNativeSecretUse();
+      return rust_sync.executeProposalWithMacosStoredMnemonic(
+        dbPath: dbPath,
+        lightwalletdUrl: lightwalletdUrl,
+        proposalId: proposalId,
+        sendFlowId: sendFlowId,
+        password: password,
+        spendParamsPath: needsSaplingParams ? saplingParams.spendPath : null,
+        outputParamsPath: needsSaplingParams ? saplingParams.outputPath : null,
+      );
+    }
+
+    final mnemonicBytes = mnemonic == null
+        ? await _ref
+              .read(accountProvider.notifier)
+              .getMnemonicBytesForAccount(accountUuid)
+        : Uint8List.fromList(utf8.encode(mnemonic));
+    if (mnemonicBytes == null || mnemonicBytes.isEmpty) {
+      throw StateError('Mnemonic not found for payment link account.');
+    }
+    late final Future<rust_sync.ExecuteProposalResult> result;
+    try {
+      result = rust_sync.executeProposal(
+        dbPath: dbPath,
+        lightwalletdUrl: lightwalletdUrl,
+        proposalId: proposalId,
+        sendFlowId: sendFlowId,
+        mnemonicBytes: mnemonicBytes,
+        spendParamsPath: needsSaplingParams ? saplingParams.spendPath : null,
+        outputParamsPath: needsSaplingParams ? saplingParams.outputPath : null,
+      );
+    } finally {
+      _zeroize(mnemonicBytes);
+    }
+    return result;
+  }
+
+  Future<void> _runBlockingSync({required String dbPath}) async {
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    await _ref
+        .read(syncProvider.notifier)
+        .runWithExclusiveRustSync(
+          () => rust_sync.runFullSyncBlocking(
+            dbPath: dbPath,
+            lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+            network: endpoint.networkName,
+            mode: 1,
+          ),
+        );
+  }
+
+  Future<({Directory directory, String dbPath, bool existed})>
+  _createOrOpenTemporaryWalletDb(VizorPaymentLink link) async {
+    final supportDir = await getWalletSupportDirectory();
+    final separator = Platform.pathSeparator;
+    final directory = Directory(
+      '${supportDir.path}$separator${paymentLinkClaimWalletDirectoryName(link)}',
+    );
+    final dbPath = '${directory.path}${separator}zcash_wallet.db';
+    final existed = await File(dbPath).exists();
+    await directory.create(recursive: true);
+    return (directory: directory, dbPath: dbPath, existed: existed);
+  }
+
+  Future<({String address, String accountUuid})>
+  _importPaymentLinkClaimAccount({
+    required VizorPaymentLink link,
+    required int birthdayHeight,
+    required String dbPath,
+    required String network,
+  }) async {
+    final imported = await rust_wallet.importWallet(
+      mnemonic: link.mnemonic,
+      bip39Passphrase: '',
+      birthdayHeight: BigInt.from(birthdayHeight),
+      network: network,
+      dbPath: dbPath,
+      accountName: 'Payment link claim',
+    );
+    return (
+      address: imported.unifiedAddress,
+      accountUuid: imported.accountUuid,
+    );
+  }
+
+  Future<void> _resetTemporaryWalletDb(Directory directory) async {
+    if (await directory.exists()) {
+      await directory.delete(recursive: true);
+    }
+    await directory.create(recursive: true);
+  }
+
+  void _requireFullyBroadcasted(rust_sync.ExecuteProposalResult result) {
+    if (paymentLinkClaimBroadcastStatusFromWire(result.status) ==
+        PaymentLinkClaimBroadcastStatus.broadcasted) {
+      return;
+    }
+    throw PaymentLinkBroadcastPendingException(
+      txids: result.txids,
+      status: result.status,
+      message:
+          result.message ??
+          'Payment link funding transaction is waiting to be broadcast.',
+    );
+  }
+
+  Future<void> _deleteTemporaryWalletDb(Directory directory) async {
+    try {
+      if (await directory.exists()) {
+        await directory.delete(recursive: true);
+      }
+    } catch (e, st) {
+      log(
+        'PaymentLinkService: failed to delete temporary payment-link DB '
+        '${directory.path}: $e\n$st',
+      );
+    }
+  }
+
+  Future<void> _requireShieldedAddress(String address) async {
+    final validation = await rust_sync.validateAddress(address: address);
+    if (!validation.isValid ||
+        (validation.addressType != 'unified' &&
+            validation.addressType != 'sapling')) {
+      throw StateError('Payment links only support shielded addresses.');
+    }
+  }
+
+  void _requireWalletUnlocked() {
+    requireUnlockedPaymentLinkWallet(
+      requiresUnlock: _ref.read(appSecurityProvider).requiresUnlock,
+    );
+  }
+
+  String _newSendFlowId() {
+    final random = Random.secure();
+    return List<int>.generate(
+      16,
+      (_) => random.nextInt(256),
+    ).map((byte) => byte.toRadixString(16).padLeft(2, '0')).join();
+  }
+
+  void _zeroize(Uint8List bytes) {
+    bytes.fillRange(0, bytes.length, 0);
+  }
+}

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -204,7 +204,7 @@ class PaymentLinkService {
     }
 
     final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
-    final paymentAccount = await rust_wallet.previewNewSoftwareAccount(
+    final paymentAccount = await rust_wallet.generateSoftwareAccount(
       network: endpoint.networkName,
     );
     final ephemeralAddress = paymentAccount.unifiedAddress;
@@ -241,7 +241,7 @@ class PaymentLinkService {
           fundingTxids: (result) => result.txids,
         );
 
-    unawaited(_ref.read(syncProvider.notifier).refreshAfterSend());
+    unawaited(_refreshMainWalletAfterSend());
     _requireFullyBroadcasted(fundingResult);
     return link;
   }
@@ -368,7 +368,7 @@ class PaymentLinkService {
       var claimableZatoshi = BigInt.zero;
       var feeZatoshi = BigInt.zero;
       try {
-        final estimate = await rust_sync.estimateSendMaxMinConfirmations(
+        final estimate = await rust_sync.estimateSendMax(
           dbPath: tempWallet.dbPath,
           network: endpoint.networkName,
           accountUuid: importedAccountUuid,
@@ -423,7 +423,7 @@ class PaymentLinkService {
         'using ${endpoint.networkName}.',
       );
     }
-    final estimate = await rust_sync.estimateSendMaxMinConfirmations(
+    final estimate = await rust_sync.estimateSendMax(
       dbPath: session.dbPath,
       network: endpoint.networkName,
       accountUuid: session.accountUuid,
@@ -443,7 +443,6 @@ class PaymentLinkService {
       amountZatoshi: session.link.amountZatoshi,
       memo: null,
       mnemonic: session.link.mnemonic,
-      useMinConfirmations: true,
     );
     final claimResult = PaymentLinkClaimResult(
       txids: sendResult.txids,
@@ -452,7 +451,7 @@ class PaymentLinkService {
     if (!shouldRetainPaymentLinkClaimWallet(claimResult.status)) {
       await discardClaimSession(session);
     }
-    unawaited(_ref.read(syncProvider.notifier).refreshAfterSend());
+    unawaited(_refreshMainWalletAfterSend());
     return claimResult;
   }
 
@@ -464,6 +463,17 @@ class PaymentLinkService {
   Future<void> discardClaimSession(PaymentLinkClaimSession session) =>
       _deleteTemporaryWalletDb(session.directory);
 
+  Future<void> _refreshMainWalletAfterSend() async {
+    try {
+      await _ref.read(syncProvider.notifier).refreshAfterSend();
+    } catch (e, stackTrace) {
+      log(
+        'PaymentLinkService: refreshAfterSend failed (non-critical): $e\n'
+        '$stackTrace',
+      );
+    }
+  }
+
   Future<rust_sync.ExecuteProposalResult> _sendShielded({
     String? dbPath,
     required String fromAccountUuid,
@@ -471,31 +481,20 @@ class PaymentLinkService {
     required BigInt amountZatoshi,
     String? memo,
     String? mnemonic,
-    bool useMinConfirmations = false,
   }) async {
     await _requireShieldedAddress(toAddress);
     final walletDbPath = dbPath ?? await getWalletDbPath();
     final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
     final sendFlowId = _newSendFlowId();
-    final proposal = useMinConfirmations
-        ? await rust_sync.proposeSendMinConfirmations(
-            dbPath: walletDbPath,
-            network: endpoint.networkName,
-            accountUuid: fromAccountUuid,
-            sendFlowId: sendFlowId,
-            toAddress: toAddress,
-            amountZatoshi: amountZatoshi,
-            memo: memo,
-          )
-        : await rust_sync.proposeSend(
-            dbPath: walletDbPath,
-            network: endpoint.networkName,
-            accountUuid: fromAccountUuid,
-            sendFlowId: sendFlowId,
-            toAddress: toAddress,
-            amountZatoshi: amountZatoshi,
-            memo: memo,
-          );
+    final proposal = await rust_sync.proposeSend(
+      dbPath: walletDbPath,
+      network: endpoint.networkName,
+      accountUuid: fromAccountUuid,
+      sendFlowId: sendFlowId,
+      toAddress: toAddress,
+      amountZatoshi: amountZatoshi,
+      memo: memo,
+    );
 
     try {
       final result = await _executeProposal(

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -159,6 +159,26 @@ class PaymentLinkClaimResult {
       status == PaymentLinkClaimBroadcastStatus.broadcasted;
 }
 
+/// A fully broadcast payment-link funding result.
+///
+/// When [fundingMetadataSaved] is false, the durable draft still preserves the
+/// bearer secret, but callers must not offer another funding attempt as the
+/// transaction already reached the network.
+class PaymentLinkFundingResult {
+  const PaymentLinkFundingResult({
+    required this.link,
+    required this.txids,
+    required this.fundingMetadataSaved,
+  });
+
+  final VizorPaymentLink link;
+  final String txids;
+
+  /// Whether the durable recovery record advanced from draft to funded.
+  /// The link remains recoverable from its draft when this is false.
+  final bool fundingMetadataSaved;
+}
+
 class PaymentLinkBroadcastPendingException implements Exception {
   const PaymentLinkBroadcastPendingException({
     required this.txids,
@@ -180,7 +200,7 @@ class PaymentLinkService {
   final Ref _ref;
   final PaymentLinkRecoveryStore _recoveryStore;
 
-  Future<VizorPaymentLink> createFundedLink({
+  Future<PaymentLinkFundingResult> createFundedLink({
     required BigInt amountZatoshi,
     required String sourceAccountUuid,
     PaymentLinkPresentation? presentation,
@@ -226,7 +246,7 @@ class PaymentLinkService {
       presentation: presentation,
     );
 
-    final fundingResult = await PaymentLinkFundingRecovery(_recoveryStore)
+    final funding = await PaymentLinkFundingRecovery(_recoveryStore)
         .fund<rust_sync.ExecuteProposalResult>(
           link: link,
           sourceAccountUuid: sourceAccountUuid,
@@ -240,10 +260,22 @@ class PaymentLinkService {
           },
           fundingTxids: (result) => result.txids,
         );
+    final fundingResult = funding.transaction;
+    if (!funding.fundingMetadataSaved) {
+      log(
+        'PaymentLinkService: funding was submitted but recovery metadata '
+        'could not be saved after retry: ${funding.recoveryError}\n'
+        '${funding.recoveryStackTrace}',
+      );
+    }
 
     unawaited(_refreshMainWalletAfterSend());
     _requireFullyBroadcasted(fundingResult);
-    return link;
+    return PaymentLinkFundingResult(
+      link: link,
+      txids: fundingResult.txids,
+      fundingMetadataSaved: funding.fundingMetadataSaved,
+    );
   }
 
   Future<List<PaymentLinkRecoveryRecord>> loadCreatedLinkRecoveries() {

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -824,6 +824,11 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         log('resetWallet: failed to evict wallet summary cache: $e\n$st');
       }
       try {
+        await deletePaymentLinkClaimWalletDirectories();
+      } catch (e, st) {
+        recordError('payment-link claim db deletion', e, st);
+      }
+      try {
         await _storage.deleteAll();
       } catch (e, st) {
         recordError('secure storage wipe', e, st);

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -823,11 +823,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         // and must not prevent the secure-storage wipe from completing.
         log('resetWallet: failed to evict wallet summary cache: $e\n$st');
       }
-      try {
-        await deletePaymentLinkClaimWalletDirectories();
-      } catch (e, st) {
-        recordError('payment-link claim db deletion', e, st);
-      }
+      await clearPaymentLinkClaimWalletsForReset();
       try {
         await _storage.deleteAll();
       } catch (e, st) {
@@ -1417,6 +1413,27 @@ String _normalizedExceptionMessage(Object error) {
 final accountProvider = AsyncNotifierProvider<AccountNotifier, AccountState>(
   AccountNotifier.new,
 );
+
+/// Best-effort cleanup for isolated payment-link claim databases.
+///
+/// A wallet reset that already deleted its primary database must still clear
+/// account/security state and route to onboarding when this ancillary cleanup
+/// fails.
+@visibleForTesting
+Future<void> clearPaymentLinkClaimWalletsForReset({
+  Future<void> Function() deleteDirectories =
+      deletePaymentLinkClaimWalletDirectories,
+  void Function(String message) reportError = log,
+}) async {
+  try {
+    await deleteDirectories();
+  } catch (error, stackTrace) {
+    reportError(
+      'resetWallet: payment-link claim db cleanup failed (non-critical): '
+      '$error\n$stackTrace',
+    );
+  }
+}
 
 @visibleForTesting
 String? resolveNextActiveAccountUuidAfterRemoval({

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -680,6 +680,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   int _authoritativeBalanceVersion = 0;
   Future<void>? _authoritativeBalanceRecovery;
   int _authoritativeSpendableOperationCount = 0;
+  Future<void> _exclusiveRustSyncTail = Future<void>.value();
   bool _syncStartDeferred = false;
   int? _deferredSyncLatestTipHeight;
   // Mempool observer subscription. Started in `startSync` and
@@ -1635,12 +1636,43 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   void resumeAfterWalletMutation(WalletMutationSyncPause pause) {
     if (_requiresUnlock) return;
 
-    if (pause.hadActiveSync) {
-      log('SyncNotifier: resuming sync after wallet DB mutation');
+    if (pause.hadActiveSync || pause.hadMempoolObserver) {
+      log('SyncNotifier: resuming sync and mempool observation after pause');
       startSync();
     }
     if (pause.hadPolling || pause.hadActiveSync) {
       _startPolling();
+    }
+  }
+
+  /// Serializes a non-wallet foreground sync against the process-global Rust
+  /// sync engine. New foreground starts stay deferred until the operation has
+  /// completed and any previously active wallet sync can be resumed.
+  Future<T> runWithExclusiveRustSync<T>(Future<T> Function() operation) {
+    final result = _exclusiveRustSyncTail.then(
+      (_) => _runWithExclusiveRustSync(operation),
+    );
+    _exclusiveRustSyncTail = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+
+  Future<T> _runWithExclusiveRustSync<T>(Future<T> Function() operation) async {
+    if (_requiresUnlock) {
+      throw StateError('Wallet is locked.');
+    }
+    _authoritativeSpendableOperationCount++;
+    WalletMutationSyncPause? pause;
+    try {
+      pause = await pauseForWalletMutation();
+      if (_requiresUnlock) {
+        throw StateError('Wallet is locked.');
+      }
+      return await operation();
+    } finally {
+      if (pause != null) {
+        resumeAfterWalletMutation(pause);
+      }
+      _releaseForegroundSyncLease();
     }
   }
 
@@ -2538,16 +2570,21 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       await waitForAuthoritativeSpendable(accountUuid: accountUuid);
       return await operation();
     } finally {
-      _authoritativeSpendableOperationCount--;
-      if (_authoritativeSpendableOperationCount == 0 &&
-          _syncStartDeferred &&
-          ref.mounted &&
-          !_requiresUnlock) {
-        final latestTipHeight = _deferredSyncLatestTipHeight;
-        _syncStartDeferred = false;
-        _deferredSyncLatestTipHeight = null;
-        startSync(latestTipHeight: latestTipHeight);
-      }
+      _releaseForegroundSyncLease();
+    }
+  }
+
+  void _releaseForegroundSyncLease() {
+    assert(_authoritativeSpendableOperationCount > 0);
+    _authoritativeSpendableOperationCount--;
+    if (_authoritativeSpendableOperationCount == 0 &&
+        _syncStartDeferred &&
+        ref.mounted &&
+        !_requiresUnlock) {
+      final latestTipHeight = _deferredSyncLatestTipHeight;
+      _syncStartDeferred = false;
+      _deferredSyncLatestTipHeight = null;
+      startSync(latestTipHeight: latestTipHeight);
     }
   }
 

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -231,28 +231,6 @@ Future<ProposalResult> proposeSend({
   memo: memo,
 );
 
-/// Propose a transfer using the minimum shielded confirmation policy.
-///
-/// Payment-link claims sweep a freshly funded one-time account after one
-/// confirmation, while normal wallet sends keep the default policy.
-Future<ProposalResult> proposeSendMinConfirmations({
-  required String dbPath,
-  required String network,
-  required String accountUuid,
-  required String sendFlowId,
-  required String toAddress,
-  required BigInt amountZatoshi,
-  String? memo,
-}) => RustLib.instance.api.crateApiSyncProposeSendMinConfirmations(
-  dbPath: dbPath,
-  network: network,
-  accountUuid: accountUuid,
-  sendFlowId: sendFlowId,
-  toAddress: toAddress,
-  amountZatoshi: amountZatoshi,
-  memo: memo,
-);
-
 /// Estimate the fee for a transfer without storing a proposal.
 Future<BigInt> estimateFee({
   required String dbPath,
@@ -278,24 +256,6 @@ Future<SendMaxEstimateResult> estimateSendMax({
   required String toAddress,
   String? memo,
 }) => RustLib.instance.api.crateApiSyncEstimateSendMax(
-  dbPath: dbPath,
-  network: network,
-  accountUuid: accountUuid,
-  toAddress: toAddress,
-  memo: memo,
-);
-
-/// Estimate max send using the minimum shielded confirmation policy.
-///
-/// Payment-link claims use this before `propose_send_min_confirmations` so the
-/// estimate and stored proposal agree on one-confirmation spendability.
-Future<SendMaxEstimateResult> estimateSendMaxMinConfirmations({
-  required String dbPath,
-  required String network,
-  required String accountUuid,
-  required String toAddress,
-  String? memo,
-}) => RustLib.instance.api.crateApiSyncEstimateSendMaxMinConfirmations(
   dbPath: dbPath,
   network: network,
   accountUuid: accountUuid,

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -231,6 +231,28 @@ Future<ProposalResult> proposeSend({
   memo: memo,
 );
 
+/// Propose a transfer using the minimum shielded confirmation policy.
+///
+/// Payment-link claims sweep a freshly funded one-time account after one
+/// confirmation, while normal wallet sends keep the default policy.
+Future<ProposalResult> proposeSendMinConfirmations({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+  required String sendFlowId,
+  required String toAddress,
+  required BigInt amountZatoshi,
+  String? memo,
+}) => RustLib.instance.api.crateApiSyncProposeSendMinConfirmations(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  sendFlowId: sendFlowId,
+  toAddress: toAddress,
+  amountZatoshi: amountZatoshi,
+  memo: memo,
+);
+
 /// Estimate the fee for a transfer without storing a proposal.
 Future<BigInt> estimateFee({
   required String dbPath,
@@ -256,6 +278,24 @@ Future<SendMaxEstimateResult> estimateSendMax({
   required String toAddress,
   String? memo,
 }) => RustLib.instance.api.crateApiSyncEstimateSendMax(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  toAddress: toAddress,
+  memo: memo,
+);
+
+/// Estimate max send using the minimum shielded confirmation policy.
+///
+/// Payment-link claims use this before `propose_send_min_confirmations` so the
+/// estimate and stored proposal agree on one-confirmation spendability.
+Future<SendMaxEstimateResult> estimateSendMaxMinConfirmations({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+  required String toAddress,
+  String? memo,
+}) => RustLib.instance.api.crateApiSyncEstimateSendMaxMinConfirmations(
   dbPath: dbPath,
   network: network,
   accountUuid: accountUuid,

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -89,9 +89,9 @@ Future<AccountCreationResult> addAccount({
 /// Generate a software account mnemonic and shielded address without touching
 /// the wallet DB. Used for an external one-time recipient controlled by a
 /// fresh seed, such as payment-link funding.
-Future<SoftwareAccountPreviewResult> previewNewSoftwareAccount({
+Future<GeneratedSoftwareAccount> generateSoftwareAccount({
   required String network,
-}) => RustLib.instance.api.crateApiWalletPreviewNewSoftwareAccount(
+}) => RustLib.instance.api.crateApiWalletGenerateSoftwareAccount(
   network: network,
 );
 
@@ -509,12 +509,12 @@ class ChainUpgradeStatus {
           endpointMatchesNetwork == other.endpointMatchesNetwork;
 }
 
-/// Result of deriving a software account without importing it into the wallet DB.
-class SoftwareAccountPreviewResult {
+/// A generated software account that has not been imported into the wallet DB.
+class GeneratedSoftwareAccount {
   final String mnemonic;
   final String unifiedAddress;
 
-  const SoftwareAccountPreviewResult({
+  const GeneratedSoftwareAccount({
     required this.mnemonic,
     required this.unifiedAddress,
   });
@@ -525,7 +525,7 @@ class SoftwareAccountPreviewResult {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is SoftwareAccountPreviewResult &&
+      other is GeneratedSoftwareAccount &&
           runtimeType == other.runtimeType &&
           mnemonic == other.mnemonic &&
           unifiedAddress == other.unifiedAddress;

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -86,6 +86,15 @@ Future<AccountCreationResult> addAccount({
   birthdayHeight: birthdayHeight,
 );
 
+/// Generate a software account mnemonic and shielded address without touching
+/// the wallet DB. Used for an external one-time recipient controlled by a
+/// fresh seed, such as payment-link funding.
+Future<SoftwareAccountPreviewResult> previewNewSoftwareAccount({
+  required String network,
+}) => RustLib.instance.api.crateApiWalletPreviewNewSoftwareAccount(
+  network: network,
+);
+
 /// Discover higher ZIP32 software accounts with transparent history that are
 /// not already present in the wallet DB for this mnemonic.
 Future<SoftwareWalletImportDiscoveryResult>
@@ -498,6 +507,28 @@ class ChainUpgradeStatus {
           nu63ActivationHeight == other.nu63ActivationHeight &&
           ironwoodActiveAtTip == other.ironwoodActiveAtTip &&
           endpointMatchesNetwork == other.endpointMatchesNetwork;
+}
+
+/// Result of deriving a software account without importing it into the wallet DB.
+class SoftwareAccountPreviewResult {
+  final String mnemonic;
+  final String unifiedAddress;
+
+  const SoftwareAccountPreviewResult({
+    required this.mnemonic,
+    required this.unifiedAddress,
+  });
+
+  @override
+  int get hashCode => mnemonic.hashCode ^ unifiedAddress.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SoftwareAccountPreviewResult &&
+          runtimeType == other.runtimeType &&
+          mnemonic == other.mnemonic &&
+          unifiedAddress == other.unifiedAddress;
 }
 
 /// A higher ZIP32 software account that can be imported by user choice.

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -80,7 +80,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 582226879;
+  int get rustContentHash => 1816387528;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -443,6 +443,14 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<SendMaxEstimateResult> crateApiSyncEstimateSendMax({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String toAddress,
+    String? memo,
+  });
+
+  Future<SendMaxEstimateResult> crateApiSyncEstimateSendMaxMinConfirmations({
     required String dbPath,
     required String network,
     required String accountUuid,
@@ -904,6 +912,10 @@ abstract class RustLibApi extends BaseApi {
     required bool spacePreparationBroadcasts,
   });
 
+  Future<SoftwareAccountPreviewResult> crateApiWalletPreviewNewSoftwareAccount({
+    required String network,
+  });
+
   Future<BigInt> crateApiWalletPreviewSoftwareAccountTransparentBalance({
     required String mnemonic,
     required String bip39Passphrase,
@@ -913,6 +925,16 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<ProposalResult> crateApiSyncProposeSend({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String sendFlowId,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+  });
+
+  Future<ProposalResult> crateApiSyncProposeSendMinConfirmations({
     required String dbPath,
     required String network,
     required String accountUuid,
@@ -3613,6 +3635,47 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<SendMaxEstimateResult> crateApiSyncEstimateSendMaxMinConfirmations({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String toAddress,
+    String? memo,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
+          sse_encode_String(toAddress, serializer);
+          sse_encode_opt_String(memo, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 55,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_send_max_estimate_result,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncEstimateSendMaxMinConfirmationsConstMeta,
+        argValues: [dbPath, network, accountUuid, toAddress, memo],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncEstimateSendMaxMinConfirmationsConstMeta =>
+      const TaskConstMeta(
+        debugName: "estimate_send_max_min_confirmations",
+        argNames: ["dbPath", "network", "accountUuid", "toAddress", "memo"],
+      );
+
+  @override
   Future<void> crateApiWalletEvictWalletSummaryCache({required String dbPath}) {
     return handler.executeNormal(
       NormalTask(
@@ -3622,7 +3685,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -3667,7 +3730,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 57,
             port: port_,
           );
         },
@@ -3729,7 +3792,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -3787,7 +3850,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -3838,7 +3901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -3881,7 +3944,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3917,7 +3980,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 62,
             port: port_,
           );
         },
@@ -3956,7 +4019,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 63,
             port: port_,
           );
         },
@@ -3993,7 +4056,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 64,
             port: port_,
           );
         },
@@ -4030,7 +4093,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 65,
             port: port_,
           );
         },
@@ -4067,7 +4130,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 66,
             port: port_,
           );
         },
@@ -4101,7 +4164,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 67,
             port: port_,
           );
         },
@@ -4128,7 +4191,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4158,7 +4221,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 69,
             port: port_,
           );
         },
@@ -4194,7 +4257,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 70,
             port: port_,
           );
         },
@@ -4231,7 +4294,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 71,
             port: port_,
           );
         },
@@ -4267,7 +4330,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 72,
             port: port_,
           );
         },
@@ -4304,7 +4367,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 73,
             port: port_,
           );
         },
@@ -4337,7 +4400,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 74,
             port: port_,
           );
         },
@@ -4370,7 +4433,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 75,
             port: port_,
           );
         },
@@ -4397,7 +4460,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 76)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_network_privacy_status,
@@ -4434,7 +4497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 77,
             port: port_,
           );
         },
@@ -4469,7 +4532,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 78,
             port: port_,
           );
         },
@@ -4507,7 +4570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 79,
             port: port_,
           );
         },
@@ -4548,7 +4611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 80,
             port: port_,
           );
         },
@@ -4591,7 +4654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 81,
             port: port_,
           );
         },
@@ -4628,7 +4691,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 82,
             port: port_,
           );
         },
@@ -4667,7 +4730,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 83,
             port: port_,
           );
         },
@@ -4707,7 +4770,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 84,
             port: port_,
           );
         },
@@ -4747,7 +4810,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4783,7 +4846,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 86,
             port: port_,
           );
         },
@@ -4820,7 +4883,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 87,
             port: port_,
           );
         },
@@ -4847,7 +4910,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -4877,7 +4940,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 89,
             port: port_,
           );
         },
@@ -4911,7 +4974,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4952,7 +5015,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4991,7 +5054,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 92,
             port: port_,
           );
         },
@@ -5028,7 +5091,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -5065,7 +5128,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 94,
             port: port_,
           );
         },
@@ -5093,7 +5156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -5133,7 +5196,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -5197,7 +5260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -5265,7 +5328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 98,
             port: port_,
           );
         },
@@ -5331,7 +5394,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 99,
             port: port_,
           );
         },
@@ -5374,7 +5437,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 100,
             port: port_,
           );
         },
@@ -5408,7 +5471,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
           )!;
         },
         codec: SseCodec(
@@ -5436,7 +5499,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 102,
           )!;
         },
         codec: SseCodec(
@@ -5476,7 +5539,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 103,
             port: port_,
           );
         },
@@ -5519,7 +5582,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 104,
           )!;
         },
         codec: SseCodec(
@@ -5545,7 +5608,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 105,
           )!;
         },
         codec: SseCodec(
@@ -5571,7 +5634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 106,
           )!;
         },
         codec: SseCodec(
@@ -5599,7 +5662,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 107,
             port: port_,
           );
         },
@@ -5634,7 +5697,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 108,
           )!;
         },
         codec: SseCodec(
@@ -5668,7 +5731,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 109,
             port: port_,
           );
         },
@@ -5702,7 +5765,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5743,7 +5806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5786,7 +5849,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5843,7 +5906,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5909,7 +5972,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
             port: port_,
           );
         },
@@ -5979,7 +6042,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -6050,7 +6113,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
             port: port_,
           );
         },
@@ -6100,7 +6163,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
           )!;
         },
         codec: SseCodec(
@@ -6131,7 +6194,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
             port: port_,
           );
         },
@@ -6164,7 +6227,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 119,
             port: port_,
           );
         },
@@ -6207,7 +6270,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 120,
             port: port_,
           );
         },
@@ -6261,7 +6324,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 121,
             port: port_,
           );
         },
@@ -6299,7 +6362,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 122,
             port: port_,
           );
         },
@@ -6344,7 +6407,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 123,
             port: port_,
           );
         },
@@ -6404,7 +6467,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 124,
             port: port_,
           );
         },
@@ -6464,7 +6527,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 125,
             port: port_,
           );
         },
@@ -6523,7 +6586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6557,6 +6620,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<SoftwareAccountPreviewResult> crateApiWalletPreviewNewSoftwareAccount({
+    required String network,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(network, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 127,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_software_account_preview_result,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletPreviewNewSoftwareAccountConstMeta,
+        argValues: [network],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletPreviewNewSoftwareAccountConstMeta =>
+      const TaskConstMeta(
+        debugName: "preview_new_software_account",
+        argNames: ["network"],
+      );
+
+  @override
   Future<BigInt> crateApiWalletPreviewSoftwareAccountTransparentBalance({
     required String mnemonic,
     required String bip39Passphrase,
@@ -6576,7 +6672,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6635,7 +6731,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6672,6 +6768,67 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<ProposalResult> crateApiSyncProposeSendMinConfirmations({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String sendFlowId,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
+          sse_encode_String(sendFlowId, serializer);
+          sse_encode_String(toAddress, serializer);
+          sse_encode_u_64(amountZatoshi, serializer);
+          sse_encode_opt_String(memo, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 130,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_proposal_result,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncProposeSendMinConfirmationsConstMeta,
+        argValues: [
+          dbPath,
+          network,
+          accountUuid,
+          sendFlowId,
+          toAddress,
+          amountZatoshi,
+          memo,
+        ],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncProposeSendMinConfirmationsConstMeta =>
+      const TaskConstMeta(
+        debugName: "propose_send_min_confirmations",
+        argNames: [
+          "dbPath",
+          "network",
+          "accountUuid",
+          "sendFlowId",
+          "toAddress",
+          "amountZatoshi",
+          "memo",
+        ],
+      );
+
+  @override
   Future<void> crateApiSyncPutSubtreeRoots({
     required String dbPath,
     required String network,
@@ -6697,7 +6854,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6745,7 +6902,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6804,7 +6961,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6874,7 +7031,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 134,
             port: port_,
           );
         },
@@ -6933,7 +7090,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 135,
             port: port_,
           );
         },
@@ -6980,7 +7137,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 136,
             port: port_,
           );
         },
@@ -7025,7 +7182,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 137,
             port: port_,
           );
         },
@@ -7055,7 +7212,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 138,
           )!;
         },
         codec: SseCodec(
@@ -7088,7 +7245,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7125,7 +7282,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7160,7 +7317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7202,7 +7359,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7237,7 +7394,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7278,7 +7435,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 144,
             port: port_,
           );
         },
@@ -7327,7 +7484,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7365,7 +7522,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 146,
             port: port_,
           );
         },
@@ -7420,7 +7577,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7476,7 +7633,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 148,
           )!;
         },
         codec: SseCodec(
@@ -7520,7 +7677,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7567,7 +7724,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 150,
           )!;
         },
         codec: SseCodec(
@@ -7597,7 +7754,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 151,
           )!;
         },
         codec: SseCodec(
@@ -7632,7 +7789,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7665,7 +7822,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7700,7 +7857,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7740,7 +7897,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 155,
             port: port_,
           );
         },
@@ -7781,7 +7938,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7835,7 +7992,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 157,
             port: port_,
           );
         },
@@ -7885,7 +8042,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 155,
+              funcId: 158,
               port: port_,
             );
           },
@@ -7926,7 +8083,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 156,
+              funcId: 159,
               port: port_,
             );
           },
@@ -7958,7 +8115,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 160,
             port: port_,
           );
         },
@@ -7985,7 +8142,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 161,
           )!;
         },
         codec: SseCodec(
@@ -8011,7 +8168,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8053,7 +8210,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8109,7 +8266,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8144,7 +8301,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8183,7 +8340,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 166,
             port: port_,
           );
         },
@@ -8219,7 +8376,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8254,7 +8411,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8291,7 +8448,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8335,7 +8492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8385,7 +8542,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 171,
             port: port_,
           );
         },
@@ -8417,7 +8574,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8445,7 +8602,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 173,
           )!;
         },
         codec: SseCodec(
@@ -8477,7 +8634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 174,
             port: port_,
           );
         },
@@ -8514,7 +8671,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 175,
             port: port_,
           );
         },
@@ -8545,7 +8702,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 176,
           )!;
         },
         codec: SseCodec(
@@ -8576,7 +8733,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 177,
             port: port_,
           );
         },
@@ -8613,7 +8770,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 178,
             port: port_,
           );
         },
@@ -10646,6 +10803,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return SignedVoteCommitmentsView(
       bundleIndex: dco_decode_u_32(arr[0]),
       commitments: dco_decode_list_signed_vote_commitment_view(arr[1]),
+    );
+  }
+
+  @protected
+  SoftwareAccountPreviewResult dco_decode_software_account_preview_result(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return SoftwareAccountPreviewResult(
+      mnemonic: dco_decode_String(arr[0]),
+      unifiedAddress: dco_decode_String(arr[1]),
     );
   }
 
@@ -13824,6 +13995,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  SoftwareAccountPreviewResult sse_decode_software_account_preview_result(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_mnemonic = sse_decode_String(deserializer);
+    var var_unifiedAddress = sse_decode_String(deserializer);
+    return SoftwareAccountPreviewResult(
+      mnemonic: var_mnemonic,
+      unifiedAddress: var_unifiedAddress,
+    );
+  }
+
+  @protected
   SoftwareWalletDiscoveredAccount sse_decode_software_wallet_discovered_account(
     SseDeserializer deserializer,
   ) {
@@ -16580,6 +16764,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_32(self.bundleIndex, serializer);
     sse_encode_list_signed_vote_commitment_view(self.commitments, serializer);
+  }
+
+  @protected
+  void sse_encode_software_account_preview_result(
+    SoftwareAccountPreviewResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.mnemonic, serializer);
+    sse_encode_String(self.unifiedAddress, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -80,7 +80,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1816387528;
+  int get rustContentHash => 221668710;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -450,14 +450,6 @@ abstract class RustLibApi extends BaseApi {
     String? memo,
   });
 
-  Future<SendMaxEstimateResult> crateApiSyncEstimateSendMaxMinConfirmations({
-    required String dbPath,
-    required String network,
-    required String accountUuid,
-    required String toAddress,
-    String? memo,
-  });
-
   Future<void> crateApiWalletEvictWalletSummaryCache({required String dbPath});
 
   Future<ExecuteProposalResult> crateApiSyncExecuteProposal({
@@ -500,6 +492,10 @@ abstract class RustLibApi extends BaseApi {
   });
 
   String crateApiWalletGenerateMnemonic();
+
+  Future<GeneratedSoftwareAccount> crateApiWalletGenerateSoftwareAccount({
+    required String network,
+  });
 
   Future<VanWitness> crateApiVotingGenerateVanWitness({
     required String dbPath,
@@ -912,10 +908,6 @@ abstract class RustLibApi extends BaseApi {
     required bool spacePreparationBroadcasts,
   });
 
-  Future<SoftwareAccountPreviewResult> crateApiWalletPreviewNewSoftwareAccount({
-    required String network,
-  });
-
   Future<BigInt> crateApiWalletPreviewSoftwareAccountTransparentBalance({
     required String mnemonic,
     required String bip39Passphrase,
@@ -925,16 +917,6 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<ProposalResult> crateApiSyncProposeSend({
-    required String dbPath,
-    required String network,
-    required String accountUuid,
-    required String sendFlowId,
-    required String toAddress,
-    required BigInt amountZatoshi,
-    String? memo,
-  });
-
-  Future<ProposalResult> crateApiSyncProposeSendMinConfirmations({
     required String dbPath,
     required String network,
     required String accountUuid,
@@ -3635,47 +3617,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<SendMaxEstimateResult> crateApiSyncEstimateSendMaxMinConfirmations({
-    required String dbPath,
-    required String network,
-    required String accountUuid,
-    required String toAddress,
-    String? memo,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(dbPath, serializer);
-          sse_encode_String(network, serializer);
-          sse_encode_String(accountUuid, serializer);
-          sse_encode_String(toAddress, serializer);
-          sse_encode_opt_String(memo, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 55,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_send_max_estimate_result,
-          decodeErrorData: sse_decode_String,
-        ),
-        constMeta: kCrateApiSyncEstimateSendMaxMinConfirmationsConstMeta,
-        argValues: [dbPath, network, accountUuid, toAddress, memo],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiSyncEstimateSendMaxMinConfirmationsConstMeta =>
-      const TaskConstMeta(
-        debugName: "estimate_send_max_min_confirmations",
-        argNames: ["dbPath", "network", "accountUuid", "toAddress", "memo"],
-      );
-
-  @override
   Future<void> crateApiWalletEvictWalletSummaryCache({required String dbPath}) {
     return handler.executeNormal(
       NormalTask(
@@ -3685,7 +3626,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 55,
             port: port_,
           );
         },
@@ -3730,7 +3671,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 56,
             port: port_,
           );
         },
@@ -3792,7 +3733,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 57,
             port: port_,
           );
         },
@@ -3850,7 +3791,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 58,
             port: port_,
           );
         },
@@ -3901,7 +3842,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 59,
             port: port_,
           );
         },
@@ -3944,7 +3885,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3959,6 +3900,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiWalletGenerateMnemonicConstMeta =>
       const TaskConstMeta(debugName: "generate_mnemonic", argNames: []);
+
+  @override
+  Future<GeneratedSoftwareAccount> crateApiWalletGenerateSoftwareAccount({
+    required String network,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(network, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 61,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_generated_software_account,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletGenerateSoftwareAccountConstMeta,
+        argValues: [network],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletGenerateSoftwareAccountConstMeta =>
+      const TaskConstMeta(
+        debugName: "generate_software_account",
+        argNames: ["network"],
+      );
 
   @override
   Future<VanWitness> crateApiVotingGenerateVanWitness({
@@ -6620,39 +6594,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<SoftwareAccountPreviewResult> crateApiWalletPreviewNewSoftwareAccount({
-    required String network,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(network, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 127,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_software_account_preview_result,
-          decodeErrorData: sse_decode_String,
-        ),
-        constMeta: kCrateApiWalletPreviewNewSoftwareAccountConstMeta,
-        argValues: [network],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiWalletPreviewNewSoftwareAccountConstMeta =>
-      const TaskConstMeta(
-        debugName: "preview_new_software_account",
-        argNames: ["network"],
-      );
-
-  @override
   Future<BigInt> crateApiWalletPreviewSoftwareAccountTransparentBalance({
     required String mnemonic,
     required String bip39Passphrase,
@@ -6672,7 +6613,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6731,7 +6672,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6768,67 +6709,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
-  Future<ProposalResult> crateApiSyncProposeSendMinConfirmations({
-    required String dbPath,
-    required String network,
-    required String accountUuid,
-    required String sendFlowId,
-    required String toAddress,
-    required BigInt amountZatoshi,
-    String? memo,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(dbPath, serializer);
-          sse_encode_String(network, serializer);
-          sse_encode_String(accountUuid, serializer);
-          sse_encode_String(sendFlowId, serializer);
-          sse_encode_String(toAddress, serializer);
-          sse_encode_u_64(amountZatoshi, serializer);
-          sse_encode_opt_String(memo, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 130,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_proposal_result,
-          decodeErrorData: sse_decode_String,
-        ),
-        constMeta: kCrateApiSyncProposeSendMinConfirmationsConstMeta,
-        argValues: [
-          dbPath,
-          network,
-          accountUuid,
-          sendFlowId,
-          toAddress,
-          amountZatoshi,
-          memo,
-        ],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiSyncProposeSendMinConfirmationsConstMeta =>
-      const TaskConstMeta(
-        debugName: "propose_send_min_confirmations",
-        argNames: [
-          "dbPath",
-          "network",
-          "accountUuid",
-          "sendFlowId",
-          "toAddress",
-          "amountZatoshi",
-          "memo",
-        ],
-      );
-
-  @override
   Future<void> crateApiSyncPutSubtreeRoots({
     required String dbPath,
     required String network,
@@ -6854,7 +6734,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6902,7 +6782,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6961,7 +6841,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 131,
             port: port_,
           );
         },
@@ -7031,7 +6911,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 132,
             port: port_,
           );
         },
@@ -7090,7 +6970,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 133,
             port: port_,
           );
         },
@@ -7137,7 +7017,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 134,
             port: port_,
           );
         },
@@ -7182,7 +7062,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 135,
             port: port_,
           );
         },
@@ -7212,7 +7092,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 136,
           )!;
         },
         codec: SseCodec(
@@ -7245,7 +7125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 137,
             port: port_,
           );
         },
@@ -7282,7 +7162,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 138,
             port: port_,
           );
         },
@@ -7317,7 +7197,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7359,7 +7239,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7394,7 +7274,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7435,7 +7315,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7484,7 +7364,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7522,7 +7402,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 144,
             port: port_,
           );
         },
@@ -7577,7 +7457,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7633,7 +7513,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 146,
           )!;
         },
         codec: SseCodec(
@@ -7677,7 +7557,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7724,7 +7604,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 148,
           )!;
         },
         codec: SseCodec(
@@ -7754,7 +7634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 149,
           )!;
         },
         codec: SseCodec(
@@ -7789,7 +7669,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7822,7 +7702,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 151,
             port: port_,
           );
         },
@@ -7857,7 +7737,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7897,7 +7777,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7938,7 +7818,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7992,7 +7872,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 155,
             port: port_,
           );
         },
@@ -8042,7 +7922,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 158,
+              funcId: 156,
               port: port_,
             );
           },
@@ -8083,7 +7963,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 159,
+              funcId: 157,
               port: port_,
             );
           },
@@ -8115,7 +7995,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 158,
             port: port_,
           );
         },
@@ -8142,7 +8022,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 159,
           )!;
         },
         codec: SseCodec(
@@ -8168,7 +8048,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8210,7 +8090,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 161,
             port: port_,
           );
         },
@@ -8266,7 +8146,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8301,7 +8181,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8340,7 +8220,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8376,7 +8256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8411,7 +8291,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 166,
             port: port_,
           );
         },
@@ -8448,7 +8328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8492,7 +8372,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8542,7 +8422,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8574,7 +8454,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8602,7 +8482,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 171,
           )!;
         },
         codec: SseCodec(
@@ -8634,7 +8514,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8671,7 +8551,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 173,
             port: port_,
           );
         },
@@ -8702,7 +8582,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 174,
           )!;
         },
         codec: SseCodec(
@@ -8733,7 +8613,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 175,
             port: port_,
           );
         },
@@ -8770,7 +8650,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 178,
+            funcId: 176,
             port: port_,
           );
         },
@@ -9441,6 +9321,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   double dco_decode_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as double;
+  }
+
+  @protected
+  GeneratedSoftwareAccount dco_decode_generated_software_account(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return GeneratedSoftwareAccount(
+      mnemonic: dco_decode_String(arr[0]),
+      unifiedAddress: dco_decode_String(arr[1]),
+    );
   }
 
   @protected
@@ -10807,20 +10699,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  SoftwareAccountPreviewResult dco_decode_software_account_preview_result(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return SoftwareAccountPreviewResult(
-      mnemonic: dco_decode_String(arr[0]),
-      unifiedAddress: dco_decode_String(arr[1]),
-    );
-  }
-
-  @protected
   SoftwareWalletDiscoveredAccount dco_decode_software_wallet_discovered_account(
     dynamic raw,
   ) {
@@ -12038,6 +11916,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   double sse_decode_f_64(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getFloat64();
+  }
+
+  @protected
+  GeneratedSoftwareAccount sse_decode_generated_software_account(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_mnemonic = sse_decode_String(deserializer);
+    var var_unifiedAddress = sse_decode_String(deserializer);
+    return GeneratedSoftwareAccount(
+      mnemonic: var_mnemonic,
+      unifiedAddress: var_unifiedAddress,
+    );
   }
 
   @protected
@@ -13995,19 +13886,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  SoftwareAccountPreviewResult sse_decode_software_account_preview_result(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_mnemonic = sse_decode_String(deserializer);
-    var var_unifiedAddress = sse_decode_String(deserializer);
-    return SoftwareAccountPreviewResult(
-      mnemonic: var_mnemonic,
-      unifiedAddress: var_unifiedAddress,
-    );
-  }
-
-  @protected
   SoftwareWalletDiscoveredAccount sse_decode_software_wallet_discovered_account(
     SseDeserializer deserializer,
   ) {
@@ -15208,6 +15086,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_f_64(double self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putFloat64(self);
+  }
+
+  @protected
+  void sse_encode_generated_software_account(
+    GeneratedSoftwareAccount self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.mnemonic, serializer);
+    sse_encode_String(self.unifiedAddress, serializer);
   }
 
   @protected
@@ -16764,16 +16652,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_32(self.bundleIndex, serializer);
     sse_encode_list_signed_vote_commitment_view(self.commitments, serializer);
-  }
-
-  @protected
-  void sse_encode_software_account_preview_result(
-    SoftwareAccountPreviewResult self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.mnemonic, serializer);
-    sse_encode_String(self.unifiedAddress, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -699,6 +699,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  SoftwareAccountPreviewResult dco_decode_software_account_preview_result(
+    dynamic raw,
+  );
+
+  @protected
   SoftwareWalletDiscoveredAccount dco_decode_software_wallet_discovered_account(
     dynamic raw,
   );
@@ -1646,6 +1651,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SignedVoteCommitmentsView sse_decode_signed_vote_commitments_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SoftwareAccountPreviewResult sse_decode_software_account_preview_result(
     SseDeserializer deserializer,
   );
 
@@ -2805,6 +2815,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_signed_vote_commitments_view(
     SignedVoteCommitmentsView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_software_account_preview_result(
+    SoftwareAccountPreviewResult self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -241,6 +241,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double dco_decode_f_64(dynamic raw);
 
   @protected
+  GeneratedSoftwareAccount dco_decode_generated_software_account(dynamic raw);
+
+  @protected
   int dco_decode_i_32(dynamic raw);
 
   @protected
@@ -699,11 +702,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  SoftwareAccountPreviewResult dco_decode_software_account_preview_result(
-    dynamic raw,
-  );
-
-  @protected
   SoftwareWalletDiscoveredAccount dco_decode_software_wallet_discovered_account(
     dynamic raw,
   );
@@ -1081,6 +1079,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double sse_decode_f_64(SseDeserializer deserializer);
+
+  @protected
+  GeneratedSoftwareAccount sse_decode_generated_software_account(
+    SseDeserializer deserializer,
+  );
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
@@ -1655,11 +1658,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  SoftwareAccountPreviewResult sse_decode_software_account_preview_result(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   SoftwareWalletDiscoveredAccount sse_decode_software_wallet_discovered_account(
     SseDeserializer deserializer,
   );
@@ -2121,6 +2119,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_generated_software_account(
+    GeneratedSoftwareAccount self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
@@ -2815,12 +2819,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_signed_vote_commitments_view(
     SignedVoteCommitmentsView self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_software_account_preview_result(
-    SoftwareAccountPreviewResult self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -243,6 +243,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double dco_decode_f_64(dynamic raw);
 
   @protected
+  GeneratedSoftwareAccount dco_decode_generated_software_account(dynamic raw);
+
+  @protected
   int dco_decode_i_32(dynamic raw);
 
   @protected
@@ -701,11 +704,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  SoftwareAccountPreviewResult dco_decode_software_account_preview_result(
-    dynamic raw,
-  );
-
-  @protected
   SoftwareWalletDiscoveredAccount dco_decode_software_wallet_discovered_account(
     dynamic raw,
   );
@@ -1083,6 +1081,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double sse_decode_f_64(SseDeserializer deserializer);
+
+  @protected
+  GeneratedSoftwareAccount sse_decode_generated_software_account(
+    SseDeserializer deserializer,
+  );
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
@@ -1657,11 +1660,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  SoftwareAccountPreviewResult sse_decode_software_account_preview_result(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   SoftwareWalletDiscoveredAccount sse_decode_software_wallet_discovered_account(
     SseDeserializer deserializer,
   );
@@ -2123,6 +2121,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_generated_software_account(
+    GeneratedSoftwareAccount self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
@@ -2817,12 +2821,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_signed_vote_commitments_view(
     SignedVoteCommitmentsView self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_software_account_preview_result(
-    SoftwareAccountPreviewResult self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -701,6 +701,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  SoftwareAccountPreviewResult dco_decode_software_account_preview_result(
+    dynamic raw,
+  );
+
+  @protected
   SoftwareWalletDiscoveredAccount dco_decode_software_wallet_discovered_account(
     dynamic raw,
   );
@@ -1648,6 +1653,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SignedVoteCommitmentsView sse_decode_signed_vote_commitments_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SoftwareAccountPreviewResult sse_decode_software_account_preview_result(
     SseDeserializer deserializer,
   );
 
@@ -2807,6 +2817,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_signed_vote_commitments_view(
     SignedVoteCommitmentsView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_software_account_preview_result(
+    SoftwareAccountPreviewResult self,
     SseSerializer serializer,
   );
 

--- a/lib/src/services/incoming_uri_service.dart
+++ b/lib/src/services/incoming_uri_service.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+const kIncomingUriChannelName = 'com.zcash.wallet/payment_uri';
+
+final incomingUriServiceProvider = Provider<IncomingUriService>((ref) {
+  final service = IncomingUriService();
+  ref.onDispose(service.dispose);
+  return service;
+});
+
+/// Shared native-to-Dart URI intake. Scheme-specific parsing belongs to
+/// subscribers so `zcash:` ZIP-321 requests and `vizor:` bearer links can use
+/// one OS channel without competing MethodChannel handlers.
+class IncomingUriService {
+  IncomingUriService({MethodChannel? channel})
+    : _channel = channel ?? const MethodChannel(kIncomingUriChannelName);
+
+  final MethodChannel _channel;
+  final StreamController<String> _controller =
+      StreamController<String>.broadcast();
+  bool _initialized = false;
+  bool _disposed = false;
+
+  Stream<String> get uriStream => _controller.stream;
+
+  Future<void> initialize() async {
+    if (_initialized || _disposed || !_isSupportedPlatform) return;
+    _initialized = true;
+
+    _channel.setMethodCallHandler((call) async {
+      switch (call.method) {
+        case 'onUris':
+          _addUris(call.arguments);
+        default:
+          throw MissingPluginException('Unknown method ${call.method}');
+      }
+    });
+
+    try {
+      final pending = await _channel.invokeMethod<List<dynamic>>(
+        'takePendingUris',
+      );
+      _addUris(pending);
+      await _channel.invokeMethod<void>('ready');
+    } on MissingPluginException {
+      // A runner without the native channel leaves URI intake inert.
+    }
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    _channel.setMethodCallHandler(null);
+    await _controller.close();
+  }
+
+  bool get _isSupportedPlatform {
+    if (kIsWeb) return false;
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.android ||
+      TargetPlatform.iOS ||
+      TargetPlatform.linux ||
+      TargetPlatform.macOS ||
+      TargetPlatform.windows => true,
+      _ => false,
+    };
+  }
+
+  void _addUris(Object? arguments) {
+    if (_disposed) return;
+    if (arguments is String) {
+      _controller.add(arguments);
+      return;
+    }
+    if (arguments is Iterable) {
+      for (final item in arguments) {
+        if (item is String) _controller.add(item);
+      }
+    }
+  }
+}

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -5,14 +5,23 @@
 #include <gdk/gdkx.h>
 #endif
 
+#include <cstring>
+
 #include "flutter/generated_plugin_registrant.h"
 
 struct _MyApplication {
   GtkApplication parent_instance;
   char** dart_entrypoint_arguments;
+  GtkWindow* main_window;
+  FlMethodChannel* incoming_uri_channel;
+  GPtrArray* pending_incoming_uris;
+  gboolean incoming_uri_dart_ready;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+static constexpr gsize kMaxIncomingUriBytes = 16 * 1024;
+static constexpr guint kMaxPendingIncomingUris = 16;
 
 // Called when first Flutter frame received.
 static void first_frame_cb(MyApplication* self, FlView* view) {
@@ -37,15 +46,104 @@ static void register_icon_theme_paths() {
   }
 }
 
+static gboolean is_payment_link_uri(const gchar* value) {
+  return value != nullptr &&
+         g_ascii_strncasecmp(value, "vizor://payment-link", 20) == 0;
+}
+
+static gboolean add_bounded_payment_link(GPtrArray* uris,
+                                         const gchar* value) {
+  if (!is_payment_link_uri(value) ||
+      std::strlen(value) > kMaxIncomingUriBytes ||
+      uris->len >= kMaxPendingIncomingUris) {
+    return FALSE;
+  }
+  for (guint i = 0; i < uris->len; ++i) {
+    const gchar* existing =
+        static_cast<const gchar*>(g_ptr_array_index(uris, i));
+    if (g_strcmp0(existing, value) == 0) {
+      return FALSE;
+    }
+  }
+  g_ptr_array_add(uris, g_strdup(value));
+  return TRUE;
+}
+
+static void add_pending_incoming_uri(MyApplication* self, const gchar* value) {
+  add_bounded_payment_link(self->pending_incoming_uris, value);
+}
+
+static FlValue* take_pending_incoming_uris(MyApplication* self) {
+  FlValue* uris = fl_value_new_list();
+  for (guint i = 0; i < self->pending_incoming_uris->len; ++i) {
+    const gchar* uri = static_cast<const gchar*>(
+        g_ptr_array_index(self->pending_incoming_uris, i));
+    fl_value_append_take(uris, fl_value_new_string(uri));
+  }
+  g_ptr_array_set_size(self->pending_incoming_uris, 0);
+  return uris;
+}
+
+static void flush_pending_incoming_uris(MyApplication* self) {
+  if (!self->incoming_uri_dart_ready || self->incoming_uri_channel == nullptr ||
+      self->pending_incoming_uris->len == 0) {
+    return;
+  }
+
+  g_autoptr(FlValue) uris = take_pending_incoming_uris(self);
+  fl_method_channel_invoke_method(self->incoming_uri_channel, "onUris", uris,
+                                  nullptr, nullptr, nullptr);
+}
+
+static void incoming_uri_method_call_cb(FlMethodChannel* /*channel*/,
+                                        FlMethodCall* method_call,
+                                        gpointer user_data) {
+  MyApplication* self = MY_APPLICATION(user_data);
+  const gchar* method = fl_method_call_get_name(method_call);
+  g_autoptr(FlMethodResponse) response = nullptr;
+
+  if (std::strcmp(method, "takePendingUris") == 0) {
+    g_autoptr(FlValue) uris = take_pending_incoming_uris(self);
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(uris));
+  } else if (std::strcmp(method, "ready") == 0) {
+    self->incoming_uri_dart_ready = TRUE;
+    flush_pending_incoming_uris(self);
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+  } else {
+    response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  }
+
+  fl_method_call_respond(method_call, response, nullptr);
+}
+
+static void register_incoming_uri_channel(MyApplication* self, FlView* view) {
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  FlEngine* engine = fl_view_get_engine(view);
+  self->incoming_uri_channel = fl_method_channel_new(
+      fl_engine_get_binary_messenger(engine), "com.zcash.wallet/payment_uri",
+      FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(self->incoming_uri_channel,
+                                            incoming_uri_method_call_cb, self,
+                                            nullptr);
+}
+
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
   register_icon_theme_paths();
   gtk_window_set_default_icon_name(APP_ICON_NAME);
 
+  if (self->main_window != nullptr) {
+    gtk_window_present(self->main_window);
+    return;
+  }
+
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
   gtk_window_set_icon_name(window, APP_ICON_NAME);
+  self->main_window = window;
+  g_object_add_weak_pointer(G_OBJECT(window),
+                            reinterpret_cast<gpointer*>(&self->main_window));
 
   // Use a header bar when running in GNOME as this is the common style used
   // by applications and is the setup most users will be using (e.g. Ubuntu
@@ -96,8 +194,21 @@ static void my_application_activate(GApplication* application) {
   gtk_widget_realize(GTK_WIDGET(view));
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+  register_incoming_uri_channel(self, view);
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Reached on the primary process when a warm URI is forwarded over D-Bus.
+static void my_application_open(GApplication* application, GFile** files,
+                                gint n_files, const gchar* /*hint*/) {
+  MyApplication* self = MY_APPLICATION(application);
+  for (gint i = 0; i < n_files; ++i) {
+    g_autofree gchar* uri = g_file_get_uri(files[i]);
+    add_pending_incoming_uri(self, uri);
+  }
+  flush_pending_incoming_uris(self);
+  g_application_activate(application);
 }
 
 // Implements GApplication::local_command_line.
@@ -106,7 +217,22 @@ static gboolean my_application_local_command_line(GApplication* application,
                                                   int* exit_status) {
   MyApplication* self = MY_APPLICATION(application);
   // Strip out the first argument as it is the binary name.
-  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  const gsize argument_count = g_strv_length(*arguments + 1);
+  self->dart_entrypoint_arguments = g_new0(gchar*, argument_count + 1);
+  g_autoptr(GPtrArray) incoming_uris =
+      g_ptr_array_new_with_free_func(g_free);
+  gsize dart_argument_index = 0;
+  for (gchar** argument = *arguments + 1;
+       argument != nullptr && *argument != nullptr; ++argument) {
+    if (is_payment_link_uri(*argument)) {
+      add_bounded_payment_link(incoming_uris, *argument);
+      std::memset(*argument, 0, std::strlen(*argument));
+      continue;
+    }
+    self->dart_entrypoint_arguments[dart_argument_index++] =
+        g_strdup(*argument);
+  }
 
   g_autoptr(GError) error = nullptr;
   if (!g_application_register(application, nullptr, &error)) {
@@ -115,6 +241,28 @@ static gboolean my_application_local_command_line(GApplication* application,
     return TRUE;
   }
 
+  if (g_application_get_is_remote(application)) {
+    g_autoptr(GPtrArray) files = g_ptr_array_new_with_free_func(g_object_unref);
+    for (guint i = 0; i < incoming_uris->len; ++i) {
+      const gchar* uri =
+          static_cast<const gchar*>(g_ptr_array_index(incoming_uris, i));
+      g_ptr_array_add(files, g_file_new_for_uri(uri));
+    }
+    if (files->len > 0) {
+      g_application_open(application, reinterpret_cast<GFile**>(files->pdata),
+                         static_cast<gint>(files->len), "");
+    } else {
+      g_application_activate(application);
+    }
+    *exit_status = 0;
+    return TRUE;
+  }
+
+  for (guint i = 0; i < incoming_uris->len; ++i) {
+    const gchar* uri =
+        static_cast<const gchar*>(g_ptr_array_index(incoming_uris, i));
+    add_pending_incoming_uri(self, uri);
+  }
   g_application_activate(application);
   *exit_status = 0;
 
@@ -142,12 +290,15 @@ static void my_application_shutdown(GApplication* application) {
 // Implements GObject::dispose.
 static void my_application_dispose(GObject* object) {
   MyApplication* self = MY_APPLICATION(object);
+  g_clear_object(&self->incoming_uri_channel);
+  g_clear_pointer(&self->pending_incoming_uris, g_ptr_array_unref);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
 }
 
 static void my_application_class_init(MyApplicationClass* klass) {
   G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->open = my_application_open;
   G_APPLICATION_CLASS(klass)->local_command_line =
       my_application_local_command_line;
   G_APPLICATION_CLASS(klass)->startup = my_application_startup;
@@ -155,7 +306,11 @@ static void my_application_class_init(MyApplicationClass* klass) {
   G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
 }
 
-static void my_application_init(MyApplication* self) {}
+static void my_application_init(MyApplication* self) {
+  self->main_window = nullptr;
+  self->pending_incoming_uris = g_ptr_array_new_with_free_func(g_free);
+  self->incoming_uri_dart_ready = FALSE;
+}
 
 MyApplication* my_application_new() {
   // Set the program name to the application ID, which helps various systems
@@ -166,5 +321,5 @@ MyApplication* my_application_new() {
 
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID, "flags",
-                                     G_APPLICATION_NON_UNIQUE, nullptr));
+                                     G_APPLICATION_HANDLES_OPEN, nullptr));
 }

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -47,8 +47,15 @@ static void register_icon_theme_paths() {
 }
 
 static gboolean is_payment_link_uri(const gchar* value) {
-  return value != nullptr &&
-         g_ascii_strncasecmp(value, "vizor://payment-link", 20) == 0;
+  static constexpr gchar prefix[] = "vizor://payment-link";
+  static constexpr gsize prefix_length = sizeof(prefix) - 1;
+  if (value == nullptr ||
+      g_ascii_strncasecmp(value, prefix, prefix_length) != 0) {
+    return FALSE;
+  }
+  const gchar boundary = value[prefix_length];
+  return boundary == '\0' || boundary == '?' || boundary == '/' ||
+         boundary == '#';
 }
 
 static gboolean add_bounded_payment_link(GPtrArray* uris,

--- a/linux/vizor.desktop.in
+++ b/linux/vizor.desktop.in
@@ -2,8 +2,9 @@
 Type=Application
 Name=@APP_DISPLAY_NAME@
 Comment=Self-custody Zcash wallet
-Exec=@BINARY_NAME@
+Exec=@BINARY_NAME@ %u
 Icon=@APPLICATION_ID@
 Terminal=false
 Categories=Office;Finance;
+MimeType=x-scheme-handler/vizor;
 StartupWMClass=@APPLICATION_ID@

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -399,6 +399,10 @@ class AppDelegate: FlutterAppDelegate {
 #endif
   }
 
+  override func application(_ application: NSApplication, open urls: [URL]) {
+    IncomingUriChannel.handle(urls: urls)
+  }
+
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true
   }

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -10,6 +10,19 @@
 	<string>$(MACOS_APP_ICON_FILE)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER).payment-link</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>vizor</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -948,6 +948,83 @@ final class DeviceOwnerAuthChannel {
   }
 }
 
+final class IncomingUriChannel {
+  private static let maxIncomingUriBytes = 16 * 1024
+  private static let maxPendingURLs = 16
+  private static var channel: FlutterMethodChannel?
+  private static var pendingURLs: [String] = []
+  private static var dartReady = false
+
+  static func register(messenger: FlutterBinaryMessenger) {
+    let methodChannel = FlutterMethodChannel(
+      name: "com.zcash.wallet/payment_uri",
+      binaryMessenger: messenger
+    )
+    channel = methodChannel
+    dartReady = false
+    methodChannel.setMethodCallHandler { call, result in
+      switch call.method {
+      case "takePendingUris":
+        let urls = pendingURLs
+        pendingURLs.removeAll()
+        result(urls)
+      case "ready":
+        dartReady = true
+        flushPendingURLs()
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  static func handle(urls: [URL]) {
+    var handledPaymentLink = false
+    for url in urls {
+      guard
+        url.scheme?.lowercased() == "vizor",
+        url.host?.lowercased() == "payment-link"
+      else {
+        continue
+      }
+      handledPaymentLink = true
+      let uri = url.absoluteString
+      guard
+        uri.utf8.count <= maxIncomingUriBytes,
+        pendingURLs.count < maxPendingURLs,
+        !pendingURLs.contains(uri)
+      else {
+        continue
+      }
+      pendingURLs.append(uri)
+    }
+    guard handledPaymentLink else { return }
+    flushPendingURLs()
+    presentMainWindow()
+  }
+
+  private static func flushPendingURLs() {
+    guard dartReady, let channel, !pendingURLs.isEmpty else { return }
+    let urls = pendingURLs
+    pendingURLs.removeAll()
+    channel.invokeMethod("onUris", arguments: urls)
+  }
+
+  private static func presentMainWindow() {
+    NSApp.activate(ignoringOtherApps: true)
+    guard let window = NSApp.windows.first(where: { $0 is MainFlutterWindow })
+      ?? NSApp.mainWindow
+      ?? NSApp.keyWindow
+    else {
+      return
+    }
+    if window.isMiniaturized {
+      window.deminiaturize(nil)
+    }
+    window.makeKeyAndOrderFront(nil)
+  }
+}
+
 class MainFlutterWindow: NSWindow {
   private let vizorWindowToolbarDelegate = VizorWindowToolbarDelegate()
   private var vizorWindowToolbar: NSToolbar?
@@ -991,6 +1068,9 @@ class MainFlutterWindow: NSWindow {
       messenger: flutterViewController.engine.binaryMessenger
     )
     NativeUpdatePrivacyChannel.register(
+      messenger: flutterViewController.engine.binaryMessenger
+    )
+    IncomingUriChannel.register(
       messenger: flutterViewController.engine.binaryMessenger
     )
     RegisterGeneratedPlugins(registry: flutterViewController)

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -1012,38 +1012,6 @@ pub fn propose_send(
     })
 }
 
-/// Propose a transfer using the minimum shielded confirmation policy.
-///
-/// Payment-link claims sweep a freshly funded one-time account after one
-/// confirmation, while normal wallet sends keep the default policy.
-pub fn propose_send_min_confirmations(
-    db_path: String,
-    network: String,
-    account_uuid: String,
-    send_flow_id: String,
-    to_address: String,
-    amount_zatoshi: u64,
-    memo: Option<String>,
-) -> Result<ProposalResult, String> {
-    catch(|| {
-        let network = parse_network_and_migrate(&db_path, &network)?;
-        let r = wallet_sync::propose_send_min_confirmations(
-            &db_path,
-            network,
-            &account_uuid,
-            &send_flow_id,
-            &to_address,
-            amount_zatoshi,
-            memo.as_deref(),
-        )?;
-        Ok(ProposalResult {
-            proposal_id: r.proposal_id,
-            needs_sapling_params: r.needs_sapling_params,
-            fee_zatoshi: r.fee_zatoshi,
-        })
-    })
-}
-
 /// Estimate the fee for a transfer without storing a proposal.
 pub fn estimate_fee(
     db_path: String,
@@ -1077,34 +1045,6 @@ pub fn estimate_send_max(
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
         let r = wallet_sync::estimate_send_max(
-            &db_path,
-            network,
-            &account_uuid,
-            &to_address,
-            memo.as_deref(),
-        )?;
-        Ok(SendMaxEstimateResult {
-            amount_zatoshi: r.amount_zatoshi,
-            fee_zatoshi: r.fee_zatoshi,
-            needs_sapling_params: r.needs_sapling_params,
-        })
-    })
-}
-
-/// Estimate max send using the minimum shielded confirmation policy.
-///
-/// Payment-link claims use this before `propose_send_min_confirmations` so the
-/// estimate and stored proposal agree on one-confirmation spendability.
-pub fn estimate_send_max_min_confirmations(
-    db_path: String,
-    network: String,
-    account_uuid: String,
-    to_address: String,
-    memo: Option<String>,
-) -> Result<SendMaxEstimateResult, String> {
-    catch(|| {
-        let network = parse_network_and_migrate(&db_path, &network)?;
-        let r = wallet_sync::estimate_send_max_min_confirmations(
             &db_path,
             network,
             &account_uuid,

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -1012,6 +1012,38 @@ pub fn propose_send(
     })
 }
 
+/// Propose a transfer using the minimum shielded confirmation policy.
+///
+/// Payment-link claims sweep a freshly funded one-time account after one
+/// confirmation, while normal wallet sends keep the default policy.
+pub fn propose_send_min_confirmations(
+    db_path: String,
+    network: String,
+    account_uuid: String,
+    send_flow_id: String,
+    to_address: String,
+    amount_zatoshi: u64,
+    memo: Option<String>,
+) -> Result<ProposalResult, String> {
+    catch(|| {
+        let network = parse_network_and_migrate(&db_path, &network)?;
+        let r = wallet_sync::propose_send_min_confirmations(
+            &db_path,
+            network,
+            &account_uuid,
+            &send_flow_id,
+            &to_address,
+            amount_zatoshi,
+            memo.as_deref(),
+        )?;
+        Ok(ProposalResult {
+            proposal_id: r.proposal_id,
+            needs_sapling_params: r.needs_sapling_params,
+            fee_zatoshi: r.fee_zatoshi,
+        })
+    })
+}
+
 /// Estimate the fee for a transfer without storing a proposal.
 pub fn estimate_fee(
     db_path: String,
@@ -1045,6 +1077,34 @@ pub fn estimate_send_max(
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
         let r = wallet_sync::estimate_send_max(
+            &db_path,
+            network,
+            &account_uuid,
+            &to_address,
+            memo.as_deref(),
+        )?;
+        Ok(SendMaxEstimateResult {
+            amount_zatoshi: r.amount_zatoshi,
+            fee_zatoshi: r.fee_zatoshi,
+            needs_sapling_params: r.needs_sapling_params,
+        })
+    })
+}
+
+/// Estimate max send using the minimum shielded confirmation policy.
+///
+/// Payment-link claims use this before `propose_send_min_confirmations` so the
+/// estimate and stored proposal agree on one-confirmation spendability.
+pub fn estimate_send_max_min_confirmations(
+    db_path: String,
+    network: String,
+    account_uuid: String,
+    to_address: String,
+    memo: Option<String>,
+) -> Result<SendMaxEstimateResult, String> {
+    catch(|| {
+        let network = parse_network_and_migrate(&db_path, &network)?;
+        let r = wallet_sync::estimate_send_max_min_confirmations(
             &db_path,
             network,
             &account_uuid,

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -30,8 +30,8 @@ pub struct AccountCreationResult {
     pub unified_address: String,
 }
 
-/// Result of deriving a software account without importing it into the wallet DB.
-pub struct SoftwareAccountPreviewResult {
+/// A generated software account that has not been imported into the wallet DB.
+pub struct GeneratedSoftwareAccount {
     pub mnemonic: String,
     pub unified_address: String,
 }
@@ -327,16 +327,14 @@ pub fn add_account(
 /// Generate a software account mnemonic and shielded address without touching
 /// the wallet DB. Used for an external one-time recipient controlled by a
 /// fresh seed, such as payment-link funding.
-pub fn preview_new_software_account(
-    network: String,
-) -> Result<SoftwareAccountPreviewResult, String> {
+pub fn generate_software_account(network: String) -> Result<GeneratedSoftwareAccount, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
         let mnemonic = keys::generate_mnemonic();
         let seed = keys::mnemonic_to_seed(&mnemonic)?;
-        let unified_address = keys::software_account_unified_address(network, &seed, 0)?;
+        let unified_address = keys::derive_software_address(network, &seed, 0)?;
 
-        Ok(SoftwareAccountPreviewResult {
+        Ok(GeneratedSoftwareAccount {
             mnemonic,
             unified_address,
         })
@@ -1122,12 +1120,12 @@ mod tests {
     const BIP39_VECTOR_MAINNET_TADDR: &str = "t1eB9Q9aDobjEnazefA9hdGyx3ku7dHshw5";
 
     #[test]
-    fn payment_link_account_preview_is_valid_without_creating_a_database() {
-        let preview = preview_new_software_account("main".to_string()).unwrap();
+    fn generates_valid_software_account_without_creating_a_database() {
+        let account = generate_software_account("main".to_string()).unwrap();
 
-        assert_eq!(preview.mnemonic.split_whitespace().count(), 24);
-        assert!(validate_mnemonic(preview.mnemonic.clone()));
-        assert!(preview.unified_address.starts_with("u1"));
+        assert_eq!(account.mnemonic.split_whitespace().count(), 24);
+        assert!(validate_mnemonic(account.mnemonic.clone()));
+        assert!(account.unified_address.starts_with("u1"));
     }
 
     #[test]

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -30,6 +30,12 @@ pub struct AccountCreationResult {
     pub unified_address: String,
 }
 
+/// Result of deriving a software account without importing it into the wallet DB.
+pub struct SoftwareAccountPreviewResult {
+    pub mnemonic: String,
+    pub unified_address: String,
+}
+
 /// Result of software mnemonic import with ZIP32 account discovery.
 pub struct SoftwareWalletImportWithDiscoveryResult {
     pub accounts: Vec<SoftwareWalletImportAccount>,
@@ -313,6 +319,25 @@ pub fn add_account(
 
         Ok(AccountCreationResult {
             account_uuid,
+            unified_address,
+        })
+    })
+}
+
+/// Generate a software account mnemonic and shielded address without touching
+/// the wallet DB. Used for an external one-time recipient controlled by a
+/// fresh seed, such as payment-link funding.
+pub fn preview_new_software_account(
+    network: String,
+) -> Result<SoftwareAccountPreviewResult, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        let mnemonic = keys::generate_mnemonic();
+        let seed = keys::mnemonic_to_seed(&mnemonic)?;
+        let unified_address = keys::software_account_unified_address(network, &seed, 0)?;
+
+        Ok(SoftwareAccountPreviewResult {
+            mnemonic,
             unified_address,
         })
     })
@@ -1095,6 +1120,15 @@ mod tests {
     const BIP39_VECTOR_MAINNET_UA: &str =
         "u1flce76a85e0zvdtrqaqj59mdk2mv35d074lafaeej5s09qjm4vflc9gndayyxt37v6tekfgram4p9209ygugkz7es438hc9gsujwmcm0trr7zt5lcz8xmpfg9rqyfyznc83ax697lc5ur3nem8wwyen732wemtxcg6lxr4n2agm437m2";
     const BIP39_VECTOR_MAINNET_TADDR: &str = "t1eB9Q9aDobjEnazefA9hdGyx3ku7dHshw5";
+
+    #[test]
+    fn payment_link_account_preview_is_valid_without_creating_a_database() {
+        let preview = preview_new_software_account("main".to_string()).unwrap();
+
+        assert_eq!(preview.mnemonic.split_whitespace().count(), 24);
+        assert!(validate_mnemonic(preview.mnemonic.clone()));
+        assert!(preview.unified_address.starts_with("u1"));
+    }
 
     #[test]
     fn bip39_passphrase_import_matches_independent_mainnet_address_vectors() {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 582226879;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1816387528;
 
 // Section: executor
 
@@ -2191,6 +2191,49 @@ fn wire__crate__api__sync__estimate_send_max_impl(
             move |context| {
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::api::sync::estimate_send_max(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                        api_to_address,
+                        api_memo,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__sync__estimate_send_max_min_confirmations_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "estimate_send_max_min_confirmations",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_to_address = <String>::sse_decode(&mut deserializer);
+            let api_memo = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::sync::estimate_send_max_min_confirmations(
                         api_db_path,
                         api_network,
                         api_account_uuid,
@@ -4987,6 +5030,39 @@ fn wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(
         },
     )
 }
+fn wire__crate__api__wallet__preview_new_software_account_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "preview_new_software_account",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::wallet::preview_new_software_account(api_network)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet__preview_software_account_transparent_balance_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -5064,6 +5140,53 @@ fn wire__crate__api__sync__propose_send_impl(
             move |context| {
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::api::sync::propose_send(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                        api_send_flow_id,
+                        api_to_address,
+                        api_amount_zatoshi,
+                        api_memo,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__sync__propose_send_min_confirmations_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "propose_send_min_confirmations",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_send_flow_id = <String>::sse_decode(&mut deserializer);
+            let api_to_address = <String>::sse_decode(&mut deserializer);
+            let api_amount_zatoshi = <u64>::sse_decode(&mut deserializer);
+            let api_memo = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::sync::propose_send_min_confirmations(
                         api_db_path,
                         api_network,
                         api_account_uuid,
@@ -9848,6 +9971,18 @@ impl SseDecode for zcash_voting::wire::SignedVoteCommitmentsView {
     }
 }
 
+impl SseDecode for crate::api::wallet::SoftwareAccountPreviewResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_mnemonic = <String>::sse_decode(deserializer);
+        let mut var_unifiedAddress = <String>::sse_decode(deserializer);
+        return crate::api::wallet::SoftwareAccountPreviewResult {
+            mnemonic: var_mnemonic,
+            unified_address: var_unifiedAddress,
+        };
+    }
+}
+
 impl SseDecode for crate::api::wallet::SoftwareWalletDiscoveredAccount {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -10469,108 +10604,111 @@ fn pde_ffi_dispatcher_primary_impl(
 52 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
 53 => wire__crate__api__network_privacy__estimate_import_birthday_height_impl(port, ptr, rust_vec_len, data_len),
 54 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
-55 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
-56 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-57 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-58 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-59 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
-61 => wire__crate__api__voting__generate_van_witness_impl(port, ptr, rust_vec_len, data_len),
-62 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
-63 => wire__crate__api__wallet__get_account_export_metadata_impl(port, ptr, rust_vec_len, data_len),
-64 => wire__crate__api__wallet__get_account_ufvk_impl(port, ptr, rust_vec_len, data_len),
-65 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-66 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
-68 => wire__crate__api__wallet__get_chain_upgrade_status_impl(port, ptr, rust_vec_len, data_len),
-69 => wire__crate__api__wallet__get_chain_upgrade_status_at_height_impl(port, ptr, rust_vec_len, data_len),
-70 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
-71 => wire__crate__api__network_privacy__get_import_birthday_metadata_impl(port, ptr, rust_vec_len, data_len),
-72 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
-73 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
-74 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
-76 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
-77 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
-78 => wire__crate__api__sync__get_orchard_migration_immediate_plan_impl(port, ptr, rust_vec_len, data_len),
-79 => wire__crate__api__sync__get_orchard_migration_private_plan_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__sync__get_orchard_migration_status_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__sync__get_orchard_migration_statuses_impl(port, ptr, rust_vec_len, data_len),
-82 => wire__crate__api__sync__get_previous_transaction_count_for_address_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__voting__get_round_recovery_state_impl(port, ptr, rust_vec_len, data_len),
-86 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
-93 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__wallet__import_software_account_at_index_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-99 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
-106 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-117 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
-119 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-172 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-174 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-175 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+55 => wire__crate__api__sync__estimate_send_max_min_confirmations_impl(port, ptr, rust_vec_len, data_len),
+56 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
+57 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+59 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+60 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__voting__generate_van_witness_impl(port, ptr, rust_vec_len, data_len),
+63 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
+64 => wire__crate__api__wallet__get_account_export_metadata_impl(port, ptr, rust_vec_len, data_len),
+65 => wire__crate__api__wallet__get_account_ufvk_impl(port, ptr, rust_vec_len, data_len),
+66 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+67 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
+69 => wire__crate__api__wallet__get_chain_upgrade_status_impl(port, ptr, rust_vec_len, data_len),
+70 => wire__crate__api__wallet__get_chain_upgrade_status_at_height_impl(port, ptr, rust_vec_len, data_len),
+71 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
+72 => wire__crate__api__network_privacy__get_import_birthday_metadata_impl(port, ptr, rust_vec_len, data_len),
+73 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
+74 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
+75 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
+77 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__sync__get_orchard_migration_immediate_plan_impl(port, ptr, rust_vec_len, data_len),
+80 => wire__crate__api__sync__get_orchard_migration_private_plan_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__sync__get_orchard_migration_status_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__sync__get_orchard_migration_statuses_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__sync__get_previous_transaction_count_for_address_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__voting__get_round_recovery_state_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__wallet__import_software_account_at_index_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
+116 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+118 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__wallet__preview_new_software_account_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__sync__propose_send_min_confirmations_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+136 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+146 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+174 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+175 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+177 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+178 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10589,37 +10727,37 @@ fn pde_ffi_dispatcher_sync_impl(
             data_len,
         ),
         12 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        75 => wire__crate__api__network_privacy__get_network_privacy_status_impl(
+        61 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        76 => wire__crate__api__network_privacy__get_network_privacy_status_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        87 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        94 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
-        101 => {
+        88 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        95 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        101 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
+        102 => {
             wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len)
         }
-        103 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        104 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        105 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
-        107 => {
+        104 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        105 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        106 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
+        108 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        116 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        135 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        145 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
-        147 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        117 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        138 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        148 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
+        150 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        148 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        158 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        170 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        173 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        151 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        161 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        173 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        176 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -12701,6 +12839,27 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::SignedVote
 {
     fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::SignedVoteCommitmentsView> {
         self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::wallet::SoftwareAccountPreviewResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.mnemonic.into_into_dart().into_dart(),
+            self.unified_address.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::wallet::SoftwareAccountPreviewResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::SoftwareAccountPreviewResult>
+    for crate::api::wallet::SoftwareAccountPreviewResult
+{
+    fn into_into_dart(self) -> crate::api::wallet::SoftwareAccountPreviewResult {
+        self
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -15205,6 +15364,14 @@ impl SseEncode for zcash_voting::wire::SignedVoteCommitmentsView {
             self.commitments,
             serializer,
         );
+    }
+}
+
+impl SseEncode for crate::api::wallet::SoftwareAccountPreviewResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.mnemonic, serializer);
+        <String>::sse_encode(self.unified_address, serializer);
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1816387528;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 221668710;
 
 // Section: executor
 
@@ -2203,49 +2203,6 @@ fn wire__crate__api__sync__estimate_send_max_impl(
         },
     )
 }
-fn wire__crate__api__sync__estimate_send_max_min_confirmations_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "estimate_send_max_min_confirmations",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_db_path = <String>::sse_decode(&mut deserializer);
-            let api_network = <String>::sse_decode(&mut deserializer);
-            let api_account_uuid = <String>::sse_decode(&mut deserializer);
-            let api_to_address = <String>::sse_decode(&mut deserializer);
-            let api_memo = <Option<String>>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| {
-                transform_result_sse::<_, String>((move || {
-                    let output_ok = crate::api::sync::estimate_send_max_min_confirmations(
-                        api_db_path,
-                        api_network,
-                        api_account_uuid,
-                        api_to_address,
-                        api_memo,
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
 fn wire__crate__api__wallet__evict_wallet_summary_cache_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2495,6 +2452,39 @@ fn wire__crate__api__wallet__generate_mnemonic_impl(
                 let output_ok = Result::<_, ()>::Ok(crate::api::wallet::generate_mnemonic())?;
                 Ok(output_ok)
             })())
+        },
+    )
+}
+fn wire__crate__api__wallet__generate_software_account_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "generate_software_account",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::wallet::generate_software_account(api_network)?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }
@@ -5030,39 +5020,6 @@ fn wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(
         },
     )
 }
-fn wire__crate__api__wallet__preview_new_software_account_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "preview_new_software_account",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_network = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| {
-                transform_result_sse::<_, String>((move || {
-                    let output_ok = crate::api::wallet::preview_new_software_account(api_network)?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
 fn wire__crate__api__wallet__preview_software_account_transparent_balance_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -5140,53 +5097,6 @@ fn wire__crate__api__sync__propose_send_impl(
             move |context| {
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::api::sync::propose_send(
-                        api_db_path,
-                        api_network,
-                        api_account_uuid,
-                        api_send_flow_id,
-                        api_to_address,
-                        api_amount_zatoshi,
-                        api_memo,
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
-fn wire__crate__api__sync__propose_send_min_confirmations_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "propose_send_min_confirmations",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_db_path = <String>::sse_decode(&mut deserializer);
-            let api_network = <String>::sse_decode(&mut deserializer);
-            let api_account_uuid = <String>::sse_decode(&mut deserializer);
-            let api_send_flow_id = <String>::sse_decode(&mut deserializer);
-            let api_to_address = <String>::sse_decode(&mut deserializer);
-            let api_amount_zatoshi = <u64>::sse_decode(&mut deserializer);
-            let api_memo = <Option<String>>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| {
-                transform_result_sse::<_, String>((move || {
-                    let output_ok = crate::api::sync::propose_send_min_confirmations(
                         api_db_path,
                         api_network,
                         api_account_uuid,
@@ -8074,6 +7984,18 @@ impl SseDecode for f64 {
     }
 }
 
+impl SseDecode for crate::api::wallet::GeneratedSoftwareAccount {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_mnemonic = <String>::sse_decode(deserializer);
+        let mut var_unifiedAddress = <String>::sse_decode(deserializer);
+        return crate::api::wallet::GeneratedSoftwareAccount {
+            mnemonic: var_mnemonic,
+            unified_address: var_unifiedAddress,
+        };
+    }
+}
+
 impl SseDecode for i32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -9971,18 +9893,6 @@ impl SseDecode for zcash_voting::wire::SignedVoteCommitmentsView {
     }
 }
 
-impl SseDecode for crate::api::wallet::SoftwareAccountPreviewResult {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_mnemonic = <String>::sse_decode(deserializer);
-        let mut var_unifiedAddress = <String>::sse_decode(deserializer);
-        return crate::api::wallet::SoftwareAccountPreviewResult {
-            mnemonic: var_mnemonic,
-            unified_address: var_unifiedAddress,
-        };
-    }
-}
-
 impl SseDecode for crate::api::wallet::SoftwareWalletDiscoveredAccount {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -10604,12 +10514,12 @@ fn pde_ffi_dispatcher_primary_impl(
 52 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
 53 => wire__crate__api__network_privacy__estimate_import_birthday_height_impl(port, ptr, rust_vec_len, data_len),
 54 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
-55 => wire__crate__api__sync__estimate_send_max_min_confirmations_impl(port, ptr, rust_vec_len, data_len),
-56 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
-57 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-58 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-59 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-60 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
+55 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
+56 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+57 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+59 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
+61 => wire__crate__api__wallet__generate_software_account_impl(port, ptr, rust_vec_len, data_len),
 62 => wire__crate__api__voting__generate_van_witness_impl(port, ptr, rust_vec_len, data_len),
 63 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
 64 => wire__crate__api__wallet__get_account_export_metadata_impl(port, ptr, rust_vec_len, data_len),
@@ -10664,51 +10574,49 @@ fn pde_ffi_dispatcher_primary_impl(
 124 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
 125 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
 126 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__wallet__preview_new_software_account_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__sync__propose_send_min_confirmations_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-135 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-145 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-172 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-174 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-175 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-177 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-178 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+175 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+176 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10727,7 +10635,7 @@ fn pde_ffi_dispatcher_sync_impl(
             data_len,
         ),
         12 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
         68 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
         76 => wire__crate__api__network_privacy__get_network_privacy_status_impl(
             ptr,
@@ -10747,17 +10655,17 @@ fn pde_ffi_dispatcher_sync_impl(
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
         117 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        138 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        148 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
-        150 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        136 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        146 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
+        148 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        151 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        161 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        173 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        176 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        149 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        159 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        171 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        174 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -11571,6 +11479,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ExtractAndBroadcastPczt
     for crate::api::sync::ExtractAndBroadcastPcztResult
 {
     fn into_into_dart(self) -> crate::api::sync::ExtractAndBroadcastPcztResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::wallet::GeneratedSoftwareAccount {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.mnemonic.into_into_dart().into_dart(),
+            self.unified_address.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::wallet::GeneratedSoftwareAccount
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::GeneratedSoftwareAccount>
+    for crate::api::wallet::GeneratedSoftwareAccount
+{
+    fn into_into_dart(self) -> crate::api::wallet::GeneratedSoftwareAccount {
         self
     }
 }
@@ -12842,27 +12771,6 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::SignedVote
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::wallet::SoftwareAccountPreviewResult {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.mnemonic.into_into_dart().into_dart(),
-            self.unified_address.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::wallet::SoftwareAccountPreviewResult
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::SoftwareAccountPreviewResult>
-    for crate::api::wallet::SoftwareAccountPreviewResult
-{
-    fn into_into_dart(self) -> crate::api::wallet::SoftwareAccountPreviewResult {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::wallet::SoftwareWalletDiscoveredAccount {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -14001,6 +13909,14 @@ impl SseEncode for f64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_f64::<NativeEndian>(self).unwrap();
+    }
+}
+
+impl SseEncode for crate::api::wallet::GeneratedSoftwareAccount {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.mnemonic, serializer);
+        <String>::sse_encode(self.unified_address, serializer);
     }
 }
 
@@ -15364,14 +15280,6 @@ impl SseEncode for zcash_voting::wire::SignedVoteCommitmentsView {
             self.commitments,
             serializer,
         );
-    }
-}
-
-impl SseEncode for crate::api::wallet::SoftwareAccountPreviewResult {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.mnemonic, serializer);
-        <String>::sse_encode(self.unified_address, serializer);
     }
 }
 

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -259,7 +259,7 @@ fn software_account_ufvk(
 
 /// Derive the default shielded Unified Address for a software account without
 /// importing it into the wallet database.
-pub fn software_account_unified_address(
+pub fn derive_software_address(
     network: WalletNetwork,
     seed: &SecretVec<u8>,
     account_index: u32,
@@ -1260,13 +1260,13 @@ mod tests {
     }
 
     #[test]
-    fn software_account_preview_address_is_deterministic_and_network_scoped() {
+    fn software_address_derivation_is_deterministic_and_network_scoped() {
         let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
         let seed = mnemonic_to_seed(phrase).unwrap();
 
-        let main = software_account_unified_address(WalletNetwork::Main, &seed, 0).unwrap();
-        let main_again = software_account_unified_address(WalletNetwork::Main, &seed, 0).unwrap();
-        let test = software_account_unified_address(WalletNetwork::Test, &seed, 0).unwrap();
+        let main = derive_software_address(WalletNetwork::Main, &seed, 0).unwrap();
+        let main_again = derive_software_address(WalletNetwork::Main, &seed, 0).unwrap();
+        let test = derive_software_address(WalletNetwork::Test, &seed, 0).unwrap();
 
         assert_eq!(main, main_again);
         assert!(main.starts_with("u1"));

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -257,6 +257,20 @@ fn software_account_ufvk(
     )
 }
 
+/// Derive the default shielded Unified Address for a software account without
+/// importing it into the wallet database.
+pub fn software_account_unified_address(
+    network: WalletNetwork,
+    seed: &SecretVec<u8>,
+    account_index: u32,
+) -> Result<String, String> {
+    let ufvk = software_account_ufvk(network, seed, account_index)?;
+    let (ua, _di) = ufvk
+        .default_address(shielded_address_request())
+        .map_err(|e| format!("Failed to derive address: {e}"))?;
+    Ok(ua.encode(&network))
+}
+
 /// Return the transparent receiver at `m/44'/coin_type'/account'/0/0`.
 pub fn software_account_first_external_transparent_address(
     network: WalletNetwork,
@@ -1243,6 +1257,21 @@ mod tests {
         let phrase = generate_mnemonic();
         let seed = mnemonic_to_seed(&phrase).unwrap();
         assert_eq!(seed.expose_secret().len(), 64);
+    }
+
+    #[test]
+    fn software_account_preview_address_is_deterministic_and_network_scoped() {
+        let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let seed = mnemonic_to_seed(phrase).unwrap();
+
+        let main = software_account_unified_address(WalletNetwork::Main, &seed, 0).unwrap();
+        let main_again = software_account_unified_address(WalletNetwork::Main, &seed, 0).unwrap();
+        let test = software_account_unified_address(WalletNetwork::Test, &seed, 0).unwrap();
+
+        assert_eq!(main, main_again);
+        assert!(main.starts_with("u1"));
+        assert!(test.starts_with("utest1"));
+        assert_ne!(main, test);
     }
 
     #[test]

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -53,6 +53,8 @@ pub use pczt::{
     redact_pczt_for_signer, retain_proposal_lock_until_expiry, ExtractAndBroadcastPcztResult,
 };
 pub(crate) use proposal_locks::recover_previous_process as recover_orphaned_send_locks;
+pub(crate) use send::estimate_send_max;
+pub(crate) use send::propose_send;
 pub(crate) use send::{
     abandon_orchard_migration, advance_orchard_migration_preparation_for_run,
     complete_orchard_migration_batch_pczt, complete_orchard_migration_denominations_pczt,
@@ -75,10 +77,6 @@ pub use send::{
 };
 pub(crate) use send::{
     create_shield_transparent_pczt, get_shield_transparent_status, shield_transparent_balance,
-};
-pub(crate) use send::{
-    estimate_send_max, estimate_send_max_min_confirmations, propose_send,
-    propose_send_min_confirmations,
 };
 pub(crate) use send::{get_orchard_migration_immediate_plan, get_orchard_migration_private_plan};
 // Internal-only re-export for `sync_engine::run_sync_impl`'s

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -53,8 +53,6 @@ pub use pczt::{
     redact_pczt_for_signer, retain_proposal_lock_until_expiry, ExtractAndBroadcastPcztResult,
 };
 pub(crate) use proposal_locks::recover_previous_process as recover_orphaned_send_locks;
-pub(crate) use send::estimate_send_max;
-pub(crate) use send::propose_send;
 pub(crate) use send::{
     abandon_orchard_migration, advance_orchard_migration_preparation_for_run,
     complete_orchard_migration_batch_pczt, complete_orchard_migration_denominations_pczt,
@@ -77,6 +75,10 @@ pub use send::{
 };
 pub(crate) use send::{
     create_shield_transparent_pczt, get_shield_transparent_status, shield_transparent_balance,
+};
+pub(crate) use send::{
+    estimate_send_max, estimate_send_max_min_confirmations, propose_send,
+    propose_send_min_confirmations,
 };
 pub(crate) use send::{get_orchard_migration_immediate_plan, get_orchard_migration_private_plan};
 // Internal-only re-export for `sync_engine::run_sync_impl`'s

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -765,6 +765,50 @@ pub(crate) fn propose_send(
     amount_zatoshi: u64,
     memo_str: Option<&str>,
 ) -> Result<ProposalResult, String> {
+    propose_send_with_confirmations_policy(
+        db_path,
+        network,
+        account_uuid,
+        send_flow_id,
+        to_address,
+        amount_zatoshi,
+        memo_str,
+        confirmations_policy(),
+    )
+}
+
+pub(crate) fn propose_send_min_confirmations(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    send_flow_id: &str,
+    to_address: &str,
+    amount_zatoshi: u64,
+    memo_str: Option<&str>,
+) -> Result<ProposalResult, String> {
+    propose_send_with_confirmations_policy(
+        db_path,
+        network,
+        account_uuid,
+        send_flow_id,
+        to_address,
+        amount_zatoshi,
+        memo_str,
+        ConfirmationsPolicy::MIN,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn propose_send_with_confirmations_policy(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    send_flow_id: &str,
+    to_address: &str,
+    amount_zatoshi: u64,
+    memo_str: Option<&str>,
+    confirmations_policy: ConfirmationsPolicy,
+) -> Result<ProposalResult, String> {
     use zcash_protocol::{PoolType, ShieldedPool as SP};
 
     if send_flow_id.is_empty() {
@@ -774,8 +818,12 @@ pub(crate) fn propose_send(
     with_wallet_db_write_lock("send.propose_send", || {
         let mut db = open_wallet_db(db_path, network)?;
         let account_id = parse_account_uuid(account_uuid)?;
-        let proposed_tx_version =
-            proposed_tx_version_for_wallet_db(&db, network, "creating a send")?;
+        let proposed_tx_version = proposed_tx_version_for_wallet_db(
+            &db,
+            network,
+            confirmations_policy,
+            "creating a send",
+        )?;
         let request = build_send_request(to_address, amount_zatoshi, memo_str)?;
         let migration_locks = super::migration::locked_migration_note_refs(db_path, account_uuid)?;
         let spend_policy = ordinary_send_spend_policy(
@@ -790,6 +838,7 @@ pub(crate) fn propose_send(
             &migration_locks,
             &spend_policy,
             proposed_tx_version,
+            confirmations_policy,
         )?;
         let (proposal, stored_tx_version) = propose_with_note_version_downgrade(
             pass1_proposal,
@@ -805,6 +854,7 @@ pub(crate) fn propose_send(
                     &migration_locks,
                     &spend_policy,
                     tx_version,
+                    confirmations_policy,
                 )
             },
         );
@@ -908,8 +958,13 @@ pub fn estimate_fee(
 ) -> Result<u64, String> {
     let db = open_wallet_db_for_read(db_path, network)?;
     let account_id = parse_account_uuid(account_uuid)?;
-    let proposed_tx_version =
-        proposed_tx_version_for_wallet_db(&db, network, "estimating a send fee")?;
+    let confirmations_policy = confirmations_policy();
+    let proposed_tx_version = proposed_tx_version_for_wallet_db(
+        &db,
+        network,
+        confirmations_policy,
+        "estimating a send fee",
+    )?;
     let request = build_send_request(to_address, amount_zatoshi, memo_str)?;
     let migration_locks = super::migration::locked_migration_note_refs(db_path, account_uuid)?;
     let spend_policy = ordinary_send_spend_policy(
@@ -924,6 +979,7 @@ pub fn estimate_fee(
         &migration_locks,
         &spend_policy,
         proposed_tx_version,
+        confirmations_policy,
     )?;
     // Same two-pass rule as `propose_send`, so the displayed estimate equals
     // the stored proposal's fee.
@@ -939,6 +995,7 @@ pub fn estimate_fee(
                 &migration_locks,
                 &spend_policy,
                 tx_version,
+                confirmations_policy,
             )
         });
 
@@ -958,6 +1015,41 @@ pub(crate) fn estimate_send_max(
     to_address: &str,
     memo_str: Option<&str>,
 ) -> Result<SendMaxEstimateResult, String> {
+    estimate_send_max_with_confirmations_policy(
+        db_path,
+        network,
+        account_uuid,
+        to_address,
+        memo_str,
+        confirmations_policy(),
+    )
+}
+
+pub(crate) fn estimate_send_max_min_confirmations(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    to_address: &str,
+    memo_str: Option<&str>,
+) -> Result<SendMaxEstimateResult, String> {
+    estimate_send_max_with_confirmations_policy(
+        db_path,
+        network,
+        account_uuid,
+        to_address,
+        memo_str,
+        ConfirmationsPolicy::MIN,
+    )
+}
+
+fn estimate_send_max_with_confirmations_policy(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    to_address: &str,
+    memo_str: Option<&str>,
+    confirmations_policy: ConfirmationsPolicy,
+) -> Result<SendMaxEstimateResult, String> {
     let mut db = open_wallet_db_for_read(db_path, network)?;
     let account_id = parse_account_uuid(account_uuid)?;
     // librustzcash's max-spend proposal path no longer takes a proposed tx
@@ -973,6 +1065,7 @@ pub(crate) fn estimate_send_max(
         to_address,
         memo_str,
         &spend_pools,
+        confirmations_policy,
     )?;
     summarize_send_max_proposal(&proposal)
 }
@@ -3339,8 +3432,8 @@ fn propose_send_with_reserved_notes(
     migration_locks: &BTreeSet<(String, u32)>,
     spend_policy: &SpendPolicy,
     proposed_tx_version: Option<TxVersion>,
+    confirmations_policy: ConfirmationsPolicy,
 ) -> Result<Proposal<WalletFeeRule, ReceivedNoteId>, String> {
-    let confirmations_policy = confirmations_policy();
     let (target_height, anchor_height) = db
         .get_target_and_anchor_heights(confirmations_policy.trusted())
         .map_err(|e| format!("Read chain state for proposal: {e}"))?
@@ -3751,6 +3844,7 @@ fn build_send_max_proposal(
     to_address: &str,
     memo_str: Option<&str>,
     spend_pools: &[ShieldedPool],
+    confirmations_policy: ConfirmationsPolicy,
 ) -> Result<Proposal<WalletFeeRule, <WalletDatabase as InputSource>::NoteRef>, String> {
     let to: zcash_address::ZcashAddress = to_address
         .parse()
@@ -3779,6 +3873,7 @@ fn build_send_max_proposal(
             memo_bytes,
             fee_rule,
             spend_pools,
+            confirmations_policy,
         );
     }
 
@@ -3791,7 +3886,7 @@ fn build_send_max_proposal(
         to,
         memo_bytes,
         MaxSpendMode::MaxSpendable,
-        confirmations_policy(),
+        confirmations_policy,
         &LockedInputPolicy::Exclude,
         None,
     )
@@ -3804,9 +3899,9 @@ fn build_send_max_proposal(
 fn proposed_tx_version_for_wallet_db(
     db: &WalletDatabase,
     network: WalletNetwork,
+    confirmations_policy: ConfirmationsPolicy,
     context: &str,
 ) -> Result<Option<TxVersion>, String> {
-    let confirmations_policy = confirmations_policy();
     let (target_height, _) = db
         .get_target_and_anchor_heights(confirmations_policy.trusted())
         .map_err(|e| format!("Read chain state for {context}: {e}"))?
@@ -3839,8 +3934,8 @@ fn build_transparent_recipient_send_max_proposal(
     memo_bytes: Option<MemoBytes>,
     fee_rule: WalletFeeRule,
     spend_pools: &[ShieldedPool],
+    confirmations_policy: ConfirmationsPolicy,
 ) -> Result<Proposal<WalletFeeRule, <WalletDatabase as InputSource>::NoteRef>, String> {
-    let confirmations_policy = confirmations_policy();
     let (target_height, anchor_height) = db
         .get_target_and_anchor_heights(confirmations_policy.trusted())
         .map_err(|e| format!("Failed to read target height: {e}"))?

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -765,50 +765,6 @@ pub(crate) fn propose_send(
     amount_zatoshi: u64,
     memo_str: Option<&str>,
 ) -> Result<ProposalResult, String> {
-    propose_send_with_confirmations_policy(
-        db_path,
-        network,
-        account_uuid,
-        send_flow_id,
-        to_address,
-        amount_zatoshi,
-        memo_str,
-        confirmations_policy(),
-    )
-}
-
-pub(crate) fn propose_send_min_confirmations(
-    db_path: &str,
-    network: WalletNetwork,
-    account_uuid: &str,
-    send_flow_id: &str,
-    to_address: &str,
-    amount_zatoshi: u64,
-    memo_str: Option<&str>,
-) -> Result<ProposalResult, String> {
-    propose_send_with_confirmations_policy(
-        db_path,
-        network,
-        account_uuid,
-        send_flow_id,
-        to_address,
-        amount_zatoshi,
-        memo_str,
-        ConfirmationsPolicy::MIN,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn propose_send_with_confirmations_policy(
-    db_path: &str,
-    network: WalletNetwork,
-    account_uuid: &str,
-    send_flow_id: &str,
-    to_address: &str,
-    amount_zatoshi: u64,
-    memo_str: Option<&str>,
-    confirmations_policy: ConfirmationsPolicy,
-) -> Result<ProposalResult, String> {
     use zcash_protocol::{PoolType, ShieldedPool as SP};
 
     if send_flow_id.is_empty() {
@@ -818,12 +774,8 @@ fn propose_send_with_confirmations_policy(
     with_wallet_db_write_lock("send.propose_send", || {
         let mut db = open_wallet_db(db_path, network)?;
         let account_id = parse_account_uuid(account_uuid)?;
-        let proposed_tx_version = proposed_tx_version_for_wallet_db(
-            &db,
-            network,
-            confirmations_policy,
-            "creating a send",
-        )?;
+        let proposed_tx_version =
+            proposed_tx_version_for_wallet_db(&db, network, "creating a send")?;
         let request = build_send_request(to_address, amount_zatoshi, memo_str)?;
         let migration_locks = super::migration::locked_migration_note_refs(db_path, account_uuid)?;
         let spend_policy = ordinary_send_spend_policy(
@@ -838,7 +790,6 @@ fn propose_send_with_confirmations_policy(
             &migration_locks,
             &spend_policy,
             proposed_tx_version,
-            confirmations_policy,
         )?;
         let (proposal, stored_tx_version) = propose_with_note_version_downgrade(
             pass1_proposal,
@@ -854,7 +805,6 @@ fn propose_send_with_confirmations_policy(
                     &migration_locks,
                     &spend_policy,
                     tx_version,
-                    confirmations_policy,
                 )
             },
         );
@@ -958,13 +908,8 @@ pub fn estimate_fee(
 ) -> Result<u64, String> {
     let db = open_wallet_db_for_read(db_path, network)?;
     let account_id = parse_account_uuid(account_uuid)?;
-    let confirmations_policy = confirmations_policy();
-    let proposed_tx_version = proposed_tx_version_for_wallet_db(
-        &db,
-        network,
-        confirmations_policy,
-        "estimating a send fee",
-    )?;
+    let proposed_tx_version =
+        proposed_tx_version_for_wallet_db(&db, network, "estimating a send fee")?;
     let request = build_send_request(to_address, amount_zatoshi, memo_str)?;
     let migration_locks = super::migration::locked_migration_note_refs(db_path, account_uuid)?;
     let spend_policy = ordinary_send_spend_policy(
@@ -979,7 +924,6 @@ pub fn estimate_fee(
         &migration_locks,
         &spend_policy,
         proposed_tx_version,
-        confirmations_policy,
     )?;
     // Same two-pass rule as `propose_send`, so the displayed estimate equals
     // the stored proposal's fee.
@@ -995,7 +939,6 @@ pub fn estimate_fee(
                 &migration_locks,
                 &spend_policy,
                 tx_version,
-                confirmations_policy,
             )
         });
 
@@ -1015,41 +958,6 @@ pub(crate) fn estimate_send_max(
     to_address: &str,
     memo_str: Option<&str>,
 ) -> Result<SendMaxEstimateResult, String> {
-    estimate_send_max_with_confirmations_policy(
-        db_path,
-        network,
-        account_uuid,
-        to_address,
-        memo_str,
-        confirmations_policy(),
-    )
-}
-
-pub(crate) fn estimate_send_max_min_confirmations(
-    db_path: &str,
-    network: WalletNetwork,
-    account_uuid: &str,
-    to_address: &str,
-    memo_str: Option<&str>,
-) -> Result<SendMaxEstimateResult, String> {
-    estimate_send_max_with_confirmations_policy(
-        db_path,
-        network,
-        account_uuid,
-        to_address,
-        memo_str,
-        ConfirmationsPolicy::MIN,
-    )
-}
-
-fn estimate_send_max_with_confirmations_policy(
-    db_path: &str,
-    network: WalletNetwork,
-    account_uuid: &str,
-    to_address: &str,
-    memo_str: Option<&str>,
-    confirmations_policy: ConfirmationsPolicy,
-) -> Result<SendMaxEstimateResult, String> {
     let mut db = open_wallet_db_for_read(db_path, network)?;
     let account_id = parse_account_uuid(account_uuid)?;
     // librustzcash's max-spend proposal path no longer takes a proposed tx
@@ -1065,7 +973,6 @@ fn estimate_send_max_with_confirmations_policy(
         to_address,
         memo_str,
         &spend_pools,
-        confirmations_policy,
     )?;
     summarize_send_max_proposal(&proposal)
 }
@@ -3432,8 +3339,8 @@ fn propose_send_with_reserved_notes(
     migration_locks: &BTreeSet<(String, u32)>,
     spend_policy: &SpendPolicy,
     proposed_tx_version: Option<TxVersion>,
-    confirmations_policy: ConfirmationsPolicy,
 ) -> Result<Proposal<WalletFeeRule, ReceivedNoteId>, String> {
+    let confirmations_policy = confirmations_policy();
     let (target_height, anchor_height) = db
         .get_target_and_anchor_heights(confirmations_policy.trusted())
         .map_err(|e| format!("Read chain state for proposal: {e}"))?
@@ -3844,7 +3751,6 @@ fn build_send_max_proposal(
     to_address: &str,
     memo_str: Option<&str>,
     spend_pools: &[ShieldedPool],
-    confirmations_policy: ConfirmationsPolicy,
 ) -> Result<Proposal<WalletFeeRule, <WalletDatabase as InputSource>::NoteRef>, String> {
     let to: zcash_address::ZcashAddress = to_address
         .parse()
@@ -3873,7 +3779,6 @@ fn build_send_max_proposal(
             memo_bytes,
             fee_rule,
             spend_pools,
-            confirmations_policy,
         );
     }
 
@@ -3886,7 +3791,7 @@ fn build_send_max_proposal(
         to,
         memo_bytes,
         MaxSpendMode::MaxSpendable,
-        confirmations_policy,
+        confirmations_policy(),
         &LockedInputPolicy::Exclude,
         None,
     )
@@ -3899,9 +3804,9 @@ fn build_send_max_proposal(
 fn proposed_tx_version_for_wallet_db(
     db: &WalletDatabase,
     network: WalletNetwork,
-    confirmations_policy: ConfirmationsPolicy,
     context: &str,
 ) -> Result<Option<TxVersion>, String> {
+    let confirmations_policy = confirmations_policy();
     let (target_height, _) = db
         .get_target_and_anchor_heights(confirmations_policy.trusted())
         .map_err(|e| format!("Read chain state for {context}: {e}"))?
@@ -3934,8 +3839,8 @@ fn build_transparent_recipient_send_max_proposal(
     memo_bytes: Option<MemoBytes>,
     fee_rule: WalletFeeRule,
     spend_pools: &[ShieldedPool],
-    confirmations_policy: ConfirmationsPolicy,
 ) -> Result<Proposal<WalletFeeRule, <WalletDatabase as InputSource>::NoteRef>, String> {
+    let confirmations_policy = confirmations_policy();
     let (target_height, anchor_height) = db
         .get_target_and_anchor_heights(confirmations_policy.trusted())
         .map_err(|e| format!("Failed to read target height: {e}"))?

--- a/scripts/package-linux-appimage.sh
+++ b/scripts/package-linux-appimage.sh
@@ -164,7 +164,7 @@ DESKTOP_FILE="$APPDIR/$APP_ID.desktop"
 cp "$BUNDLE_DIR/data/applications/$APP_ID.desktop" "$DESKTOP_FILE"
 sed -i \
   -e "s/^Name=.*/Name=$APP_NAME/" \
-  -e "s/^Exec=.*/Exec=$BINARY_NAME/" \
+  -e "s/^Exec=.*/Exec=$BINARY_NAME %u/" \
   -e "s/^Icon=.*/Icon=$APP_ID/" \
   -e "s/^Categories=.*/Categories=Office;Finance;/" \
   -e "s/^StartupWMClass=.*/StartupWMClass=$APP_ID/" \
@@ -177,7 +177,7 @@ set_desktop_exec() {
   local file
   for file in "$DESKTOP_FILE" "$APPDIR_APPLICATIONS_DIR/$APP_ID.desktop"; do
     if [[ -e "$file" ]]; then
-      sed -i -e "s/^Exec=.*/Exec=$exec_name/" "$file"
+      sed -i -e "s/^Exec=.*/Exec=$exec_name %u/" "$file"
     fi
   done
 }

--- a/scripts/package-windows-velopack.ps1
+++ b/scripts/package-windows-velopack.ps1
@@ -5,6 +5,7 @@ param(
   [string]$Network = "mainnet",
   [string]$PackId = "",
   [string]$PackTitle = "",
+  [string]$WindowsStoragePrefix = "",
   [string]$Channel = "",
   [string]$OutputDir = "",
   [string]$UpdateFeedSigningKey = $env:VIZOR_UPDATE_FEED_SIGNING_KEY_B64,
@@ -285,7 +286,9 @@ if ($Network -eq "mainnet") {
     $OutputDir = "build\velopack\mainnet"
   }
   $NetworkDartDefine = "main"
-  $WindowsStoragePrefix = "Vizor"
+  if ([string]::IsNullOrWhiteSpace($WindowsStoragePrefix)) {
+    $WindowsStoragePrefix = "Vizor"
+  }
 } else {
   if ([string]::IsNullOrWhiteSpace($PackId)) {
     $PackId = "com.keplr.vizor.testnet"
@@ -300,7 +303,9 @@ if ($Network -eq "mainnet") {
     $OutputDir = "build\velopack\testnet"
   }
   $NetworkDartDefine = "test"
-  $WindowsStoragePrefix = "VizorTestnet"
+  if ([string]::IsNullOrWhiteSpace($WindowsStoragePrefix)) {
+    $WindowsStoragePrefix = "VizorTestnet"
+  }
 }
 
 $env:VIZOR_WINDOWS_COMPANY_NAME = "com.keplr"

--- a/scripts/package-windows-velopack.ps1
+++ b/scripts/package-windows-velopack.ps1
@@ -315,6 +315,24 @@ $env:VIZOR_WINDOWS_LEGAL_COPYRIGHT = "Copyright (C) 2026 com.keplr. All rights r
 $env:VIZOR_WINDOWS_ORIGINAL_FILENAME = "Vizor.exe"
 $env:VIZOR_WINDOWS_PRODUCT_NAME = $PackTitle
 $env:VIZOR_WINDOWS_STORAGE_PREFIX = $WindowsStoragePrefix
+$env:VIZOR_WINDOWS_PAYMENT_URI_OWNER = "0"
+$isOfficialPackageId = [string]::Equals(
+  $PackId,
+  "com.keplr.vizor",
+  [System.StringComparison]::Ordinal
+)
+$isProductionStorage = [string]::Equals(
+  $WindowsStoragePrefix,
+  "Vizor",
+  [System.StringComparison]::Ordinal
+)
+if (
+  $Network -eq "mainnet" -and
+  $isOfficialPackageId -and
+  $isProductionStorage
+) {
+  $env:VIZOR_WINDOWS_PAYMENT_URI_OWNER = "1"
+}
 
 if (-not [string]::IsNullOrWhiteSpace($UpdateFeedSigningKey)) {
   $env:VIZOR_UPDATE_FEED_SIGNING_KEY_B64 = $UpdateFeedSigningKey.Trim()

--- a/scripts/windows-single-instance-smoke.ps1
+++ b/scripts/windows-single-instance-smoke.ps1
@@ -6,13 +6,13 @@ Build an isolated executable before running this destructive smoke test:
     -Network mainnet `
     -PackId com.keplr.vizor.single-instance-smoke `
     -PackTitle "Vizor Single Instance Smoke" `
+    -WindowsStoragePrefix VizorSingleInstanceSmoke `
     -Channel win-x64-single-instance-smoke `
     -OutputDir build\velopack\single-instance-smoke
 
-The PackTitle sets the executable's VERSIONINFO ProductName, which determines
-the Windows application-support directory used by the wallet database and
-flutter_secure_storage. Changing only VIZOR_WINDOWS_STORAGE_PREFIX does not
-isolate those files.
+The PackTitle isolates the application-support directory used by the wallet
+database and flutter_secure_storage. WindowsStoragePrefix separately isolates
+the single-instance lock. Both values are required for this destructive smoke.
 #>
 
 param(
@@ -26,6 +26,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 $requiredProductName = "Vizor Single Instance Smoke"
+$requiredStoragePrefix = "VizorSingleInstanceSmoke"
 
 function Wait-ForMainWindow {
   param(
@@ -75,16 +76,65 @@ if (-not [string]::Equals(
   throw "Executable ProductName '$actualProductName' does not match required smoke ProductName '$requiredProductName'."
 }
 if (-not $ConfirmIsolatedStorage) {
-  throw "This smoke test forcibly terminates Vizor. ProductName '$actualProductName' is storage-isolated; pass -ConfirmIsolatedStorage to continue."
+  throw "This smoke test forcibly terminates Vizor. ProductName '$actualProductName' and storage prefix '$requiredStoragePrefix' must be isolated; pass -ConfirmIsolatedStorage to continue."
 }
 
 Write-Host "Verified isolated ProductName: $actualProductName"
+Write-Host "Using isolated storage prefix: $requiredStoragePrefix"
 
 $primary = $null
 $secondary = $null
 $replacement = $null
+$delayedRelay = $null
+$delayedPrimary = $null
+$delayedLockStream = $null
+$delayedLockHeld = $false
 
 try {
+  $lockDirectory = Join-Path $env:LOCALAPPDATA "com.keplr\VizorInstanceLocks"
+  New-Item -ItemType Directory -Path $lockDirectory -Force | Out-Null
+  $lockPath = Join-Path $lockDirectory "$requiredStoragePrefix.lock"
+  $delayedLockStream = [System.IO.File]::Open(
+    $lockPath,
+    [System.IO.FileMode]::OpenOrCreate,
+    [System.IO.FileAccess]::ReadWrite,
+    [System.IO.FileShare]::ReadWrite
+  )
+  $delayedLockStream.Lock(0, 1)
+  $delayedLockHeld = $true
+
+  Write-Host "Starting payment-link relay while the primary window is delayed"
+  $delayedRelay = Start-Process `
+    -FilePath $resolvedExecutable `
+    -ArgumentList "vizor://payment-link?payload=single-instance-smoke" `
+    -PassThru
+  Start-Sleep -Milliseconds 2500
+  $delayedRelay.Refresh()
+  if ($delayedRelay.HasExited) {
+    throw "Payment-link relay exited before the delayed lock was released."
+  }
+
+  $delayedLockStream.Unlock(0, 1)
+  $delayedLockHeld = $false
+  $delayedLockStream.Dispose()
+  $delayedLockStream = $null
+
+  $delayedPrimary = Start-Process -FilePath $resolvedExecutable -PassThru
+  Wait-ForMainWindow `
+    -Process $delayedPrimary `
+    -TimeoutSeconds $StartupTimeoutSeconds
+  if (-not $delayedRelay.WaitForExit($SecondaryExitTimeoutSeconds * 1000)) {
+    throw "Payment-link relay did not exit after the delayed primary created its window."
+  }
+  if ($delayedRelay.ExitCode -ne 0) {
+    throw "Payment-link relay exited with code $($delayedRelay.ExitCode) after delayed primary startup."
+  }
+  if ($delayedPrimary.HasExited) {
+    throw "Delayed primary exited while receiving the payment link."
+  }
+  Stop-OwnedProcess -Process $delayedPrimary
+  $delayedPrimary = $null
+
   Write-Host "Starting primary: $resolvedExecutable"
   $primary = Start-Process -FilePath $resolvedExecutable -PassThru
   Wait-ForMainWindow -Process $primary -TimeoutSeconds $StartupTimeoutSeconds
@@ -108,9 +158,33 @@ try {
   $replacement = Start-Process -FilePath $resolvedExecutable -PassThru
   Wait-ForMainWindow -Process $replacement -TimeoutSeconds $StartupTimeoutSeconds
 
-  Write-Host "PASS: secondary execution was blocked and the lock recovered after termination."
+  Write-Host "PASS: delayed payment-link relay, secondary blocking, and lock recovery succeeded."
 } finally {
-  Stop-OwnedProcess -Process $secondary
-  Stop-OwnedProcess -Process $primary
-  Stop-OwnedProcess -Process $replacement
+  if ($delayedLockHeld -and $null -ne $delayedLockStream) {
+    try {
+      $delayedLockStream.Unlock(0, 1)
+    } catch {
+      Write-Warning "Could not release delayed-start lock: $_"
+    }
+  }
+  if ($null -ne $delayedLockStream) {
+    try {
+      $delayedLockStream.Dispose()
+    } catch {
+      Write-Warning "Could not dispose delayed-start lock stream: $_"
+    }
+  }
+  foreach ($ownedProcess in @(
+      $delayedRelay,
+      $delayedPrimary,
+      $secondary,
+      $primary,
+      $replacement
+    )) {
+    try {
+      Stop-OwnedProcess -Process $ownedProcess
+    } catch {
+      Write-Warning "Could not stop an owned smoke-test process: $_"
+    }
+  }
 }

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -105,6 +105,40 @@ void main() {
     expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
   });
 
+  test(
+    'payment-link recovery stays encrypted across password rotation',
+    () async {
+      const recoveryPayload =
+          '{"link":"vizor://payment-link?p=secret-mnemonic-payload"}';
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(
+        kPaymentLinkRecoveryStorageKey,
+        recoveryPayload,
+      );
+
+      final storedBeforeRotation = await store.readPlain(
+        kPaymentLinkRecoveryStorageKey,
+      );
+      expect(storedBeforeRotation, isNot(contains('secret-mnemonic-payload')));
+
+      final didChange = await store.changePassword(
+        currentPassword: _oldPassword,
+        newPassword: _newPassword,
+      );
+
+      expect(didChange, isTrue);
+      store.clearSessionPassword();
+      expect(await store.verifyPassword(_newPassword), isTrue);
+      expect(
+        await store.readSecretStringWithOptions(
+          kPaymentLinkRecoveryStorageKey,
+          requireUnlockedSession: true,
+        ),
+        recoveryPayload,
+      );
+    },
+  );
+
   test('readAccountMnemonicBytes returns mutable mnemonic bytes', () async {
     await store.configurePassword(_oldPassword);
     await store.writeAccountMnemonic(_accountUuid, _mnemonic);

--- a/test/features/payment_links/payment_link_intake_provider_test.dart
+++ b/test/features/payment_links/payment_link_intake_provider_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_intake_provider.dart';
+
+void main() {
+  test('accepts and exposes a valid Vizor payment link', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final link = _link();
+
+    final result = container
+        .read(paymentLinkIntakeProvider.notifier)
+        .ingest(link.encode());
+
+    expect(result, PaymentLinkIntakeResult.accepted);
+    expect(
+      container.read(paymentLinkIntakeProvider).pendingLink?.address,
+      link.address,
+    );
+    expect(container.read(paymentLinkIntakeProvider).errorMessage, isNull);
+  });
+
+  test('ignores other URI schemes so ZIP-321 can share the channel', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final result = container
+        .read(paymentLinkIntakeProvider.notifier)
+        .ingest('zcash:u1recipient?amount=1');
+
+    expect(result, PaymentLinkIntakeResult.ignored);
+    expect(container.read(paymentLinkIntakeProvider).pendingLink, isNull);
+  });
+
+  test('rejects malformed Vizor links without clearing an earlier secret', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final link = _link();
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    notifier.ingest(link.encode());
+
+    final result = notifier.ingest('vizor://payment-link?p=not-base64');
+
+    expect(result, PaymentLinkIntakeResult.rejected);
+    final state = container.read(paymentLinkIntakeProvider);
+    expect(state.pendingLink?.address, link.address);
+    expect(state.errorMessage, isNotNull);
+    expect(state.errorMessage, isNot(contains('not-base64')));
+  });
+
+  test('takePending removes the link from memory', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    final link = _link();
+    notifier.ingest(link.encode());
+
+    final taken = notifier.takePending();
+
+    expect(taken?.address, link.address);
+    expect(container.read(paymentLinkIntakeProvider).pendingLink, isNull);
+  });
+
+  test('queues multiple accepted links in arrival order', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    final first = _link();
+    final second = VizorPaymentLink(
+      network: first.network,
+      address: 'u1secondpaymentlinkaddress',
+      amountZatoshi: BigInt.from(200000),
+      mnemonic: first.mnemonic,
+      birthdayHeight: first.birthdayHeight,
+      label: first.label,
+      createdAt: first.createdAt.add(const Duration(minutes: 1)),
+    );
+
+    notifier.ingest(first.encode());
+    notifier.ingest(second.encode());
+
+    expect(notifier.takePending()?.address, first.address);
+    expect(notifier.takePending()?.address, second.address);
+    expect(notifier.takePending(), isNull);
+  });
+
+  test('coalesces duplicate links without growing the queue', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    final link = _link();
+
+    expect(notifier.ingest(link.encode()), PaymentLinkIntakeResult.accepted);
+    expect(notifier.ingest(link.encode()), PaymentLinkIntakeResult.accepted);
+
+    expect(
+      container.read(paymentLinkIntakeProvider).pendingLinks,
+      hasLength(1),
+    );
+  });
+
+  test('rejects unique links beyond the bounded intake queue', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+
+    for (var i = 0; i < kPaymentLinkIntakeQueueCapacity; i++) {
+      expect(
+        notifier.ingest(_link(address: 'u1paymentlinkaddress$i').encode()),
+        PaymentLinkIntakeResult.accepted,
+      );
+    }
+
+    expect(
+      notifier.ingest(_link(address: 'u1paymentlinkoverflow').encode()),
+      PaymentLinkIntakeResult.rejected,
+    );
+    final state = container.read(paymentLinkIntakeProvider);
+    expect(state.pendingLinks, hasLength(kPaymentLinkIntakeQueueCapacity));
+    expect(state.errorMessage, 'Too many payment links are waiting to open.');
+  });
+}
+
+VizorPaymentLink _link({String address = 'u1paymentlinkaddress'}) {
+  return VizorPaymentLink(
+    network: 'main',
+    address: address,
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 3_456_789,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 8, 5, 12),
+  );
+}

--- a/test/features/payment_links/payment_link_recovery_store_test.dart
+++ b/test/features/payment_links/payment_link_recovery_store_test.dart
@@ -1,0 +1,206 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
+
+void main() {
+  group('PaymentLinkRecoveryStore', () {
+    test(
+      'persists the secret before broadcast and records funding success',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage();
+        final store = PaymentLinkRecoveryStore(storage);
+        final link = _link();
+
+        final fundingTxid = await PaymentLinkFundingRecovery(store).fund(
+          link: link,
+          sourceAccountUuid: 'source-account',
+          createTransaction: () async {
+            final restartedRecords = await PaymentLinkRecoveryStore(
+              storage,
+            ).load();
+            expect(restartedRecords, hasLength(1));
+            expect(
+              restartedRecords.single.state,
+              PaymentLinkRecoveryState.draft,
+            );
+            expect(restartedRecords.single.link.mnemonic, link.mnemonic);
+            return 'funding-txid';
+          },
+          fundingTxids: (txid) => txid,
+        );
+
+        expect(fundingTxid, 'funding-txid');
+        final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+        expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
+        expect(restartedRecords.single.fundingTxids, 'funding-txid');
+      },
+    );
+
+    test(
+      'transaction failure leaves the draft recoverable after restart',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage();
+        final link = _link();
+
+        await expectLater(
+          PaymentLinkFundingRecovery(
+            PaymentLinkRecoveryStore(storage),
+          ).fund<String>(
+            link: link,
+            sourceAccountUuid: 'source-account',
+            createTransaction: () => throw StateError('transaction failed'),
+            fundingTxids: (txid) => txid,
+          ),
+          throwsStateError,
+        );
+
+        final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+        expect(restartedRecords, hasLength(1));
+        expect(restartedRecords.single.state, PaymentLinkRecoveryState.draft);
+        expect(restartedRecords.single.link.encode(), link.encode());
+      },
+    );
+
+    test(
+      'funding metadata failure still preserves the earlier draft',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage(failOnWrite: 2);
+        final link = _link();
+
+        await expectLater(
+          PaymentLinkFundingRecovery(PaymentLinkRecoveryStore(storage)).fund(
+            link: link,
+            sourceAccountUuid: 'source-account',
+            createTransaction: () async => 'funding-txid',
+            fundingTxids: (txid) => txid,
+          ),
+          throwsStateError,
+        );
+
+        final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+        expect(restartedRecords.single.state, PaymentLinkRecoveryState.draft);
+        expect(restartedRecords.single.link.mnemonic, link.mnemonic);
+      },
+    );
+
+    test('records pending transaction ids before status handling', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+
+      final result = await PaymentLinkFundingRecovery(store).fund(
+        link: link,
+        sourceAccountUuid: 'source-account',
+        createTransaction: () async =>
+            (txids: 'pending-funding-txid', status: 'pending_broadcast'),
+        fundingTxids: (result) => result.txids,
+      );
+
+      expect(result.status, 'pending_broadcast');
+      final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+      expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
+      expect(restartedRecords.single.fundingTxids, 'pending-funding-txid');
+    });
+
+    test('archiving a shared record keeps its recovery secret', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+
+      await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+      await store.markFunded(
+        address: link.address,
+        fundingTxids: 'funding-txid',
+      );
+      await store.markShared(address: link.address);
+      await store.setArchived(address: link.address, archived: true);
+
+      final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+      expect(restartedRecords.single.state, PaymentLinkRecoveryState.shared);
+      expect(restartedRecords.single.fundingTxids, 'funding-txid');
+      expect(restartedRecords.single.isArchived, isTrue);
+      expect(restartedRecords.single.archivedAt, isNotNull);
+      expect(restartedRecords.single.link.mnemonic, link.mnemonic);
+
+      await PaymentLinkRecoveryStore(
+        storage,
+      ).setArchived(address: link.address, archived: false);
+      final restored = await PaymentLinkRecoveryStore(storage).load();
+      expect(restored.single.isArchived, isFalse);
+      expect(restored.single.archivedAt, isNull);
+      expect(restored.single.link.mnemonic, link.mnemonic);
+    });
+
+    test('rejects recovery states outside the v1 schema', () async {
+      final link = _link();
+      final storage = _FakePaymentLinkRecoveryStorage()
+        ..value = jsonEncode({
+          'version': 1,
+          'records': [
+            {
+              'link': link.encode(),
+              'sourceAccountUuid': 'source-account',
+              'state': 'unsupported',
+              'fundingTxids': 'funding-txid',
+              'archivedAt': null,
+              'updatedAt': DateTime.utc(2026, 8, 5).toIso8601String(),
+            },
+          ],
+        });
+
+      await expectLater(
+        PaymentLinkRecoveryStore(storage).load(),
+        throwsA(isA<PaymentLinkRecoveryStoreFormatException>()),
+      );
+    });
+
+    test('fails loud instead of hiding corrupted recovery data', () async {
+      final storage = _FakePaymentLinkRecoveryStorage()..value = '{not-json';
+
+      await expectLater(
+        PaymentLinkRecoveryStore(storage).load(),
+        throwsA(isA<PaymentLinkRecoveryStoreFormatException>()),
+      );
+    });
+  });
+}
+
+VizorPaymentLink _link() {
+  return VizorPaymentLink(
+    network: 'main',
+    address: 'u1paymentlinkaddress',
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 3_456_789,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 8, 5, 12),
+  );
+}
+
+class _FakePaymentLinkRecoveryStorage implements PaymentLinkRecoveryStorage {
+  _FakePaymentLinkRecoveryStorage({this.failOnWrite});
+
+  final int? failOnWrite;
+  String? value;
+  int _writeCount = 0;
+
+  @override
+  Future<void> delete() async {
+    value = null;
+  }
+
+  @override
+  Future<String?> read() async => value;
+
+  @override
+  Future<void> write(String nextValue) async {
+    _writeCount += 1;
+    if (_writeCount == failOnWrite) {
+      throw StateError('storage write failed');
+    }
+    value = nextValue;
+  }
+}

--- a/test/features/payment_links/payment_link_recovery_store_test.dart
+++ b/test/features/payment_links/payment_link_recovery_store_test.dart
@@ -13,7 +13,7 @@ void main() {
         final store = PaymentLinkRecoveryStore(storage);
         final link = _link();
 
-        final fundingTxid = await PaymentLinkFundingRecovery(store).fund(
+        final funding = await PaymentLinkFundingRecovery(store).fund(
           link: link,
           sourceAccountUuid: 'source-account',
           createTransaction: () async {
@@ -31,7 +31,8 @@ void main() {
           fundingTxids: (txid) => txid,
         );
 
-        expect(fundingTxid, 'funding-txid');
+        expect(funding.transaction, 'funding-txid');
+        expect(funding.recoveryError, isNull);
         final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
         expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
         expect(restartedRecords.single.fundingTxids, 'funding-txid');
@@ -63,22 +64,51 @@ void main() {
       },
     );
 
-    test(
-      'funding metadata failure still preserves the earlier draft',
-      () async {
-        final storage = _FakePaymentLinkRecoveryStorage(failOnWrite: 2);
-        final link = _link();
+    test('retries a transient funding metadata write failure', () async {
+      final storage = _FakePaymentLinkRecoveryStorage(failOnWrites: {2});
+      final link = _link();
 
-        await expectLater(
-          PaymentLinkFundingRecovery(PaymentLinkRecoveryStore(storage)).fund(
-            link: link,
-            sourceAccountUuid: 'source-account',
-            createTransaction: () async => 'funding-txid',
-            fundingTxids: (txid) => txid,
-          ),
-          throwsStateError,
+      final funding = await PaymentLinkFundingRecovery(
+        PaymentLinkRecoveryStore(storage),
+      ).fund(
+        link: link,
+        sourceAccountUuid: 'source-account',
+        createTransaction: () async => 'funding-txid',
+        fundingTxids: (txid) => txid,
+      );
+
+      expect(funding.transaction, 'funding-txid');
+      expect(funding.recoveryError, isNull);
+      final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+      expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
+      expect(restartedRecords.single.fundingTxids, 'funding-txid');
+    });
+
+    test(
+      'returns the broadcast result when funding metadata cannot be updated',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage(
+          failOnWrites: {2, 3},
+        );
+        final link = _link();
+        var transactionCount = 0;
+
+        final funding = await PaymentLinkFundingRecovery(
+          PaymentLinkRecoveryStore(storage),
+        ).fund(
+          link: link,
+          sourceAccountUuid: 'source-account',
+          createTransaction: () async {
+            transactionCount += 1;
+            return 'funding-txid';
+          },
+          fundingTxids: (txid) => txid,
         );
 
+        expect(funding.transaction, 'funding-txid');
+        expect(funding.recoveryError, isA<StateError>());
+        expect(funding.recoveryStackTrace, isNotNull);
+        expect(transactionCount, 1);
         final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
         expect(restartedRecords.single.state, PaymentLinkRecoveryState.draft);
         expect(restartedRecords.single.link.mnemonic, link.mnemonic);
@@ -90,7 +120,7 @@ void main() {
       final store = PaymentLinkRecoveryStore(storage);
       final link = _link();
 
-      final result = await PaymentLinkFundingRecovery(store).fund(
+      final funding = await PaymentLinkFundingRecovery(store).fund(
         link: link,
         sourceAccountUuid: 'source-account',
         createTransaction: () async =>
@@ -98,7 +128,8 @@ void main() {
         fundingTxids: (result) => result.txids,
       );
 
-      expect(result.status, 'pending_broadcast');
+      expect(funding.transaction.status, 'pending_broadcast');
+      expect(funding.recoveryError, isNull);
       final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
       expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
       expect(restartedRecords.single.fundingTxids, 'pending-funding-txid');
@@ -181,9 +212,9 @@ VizorPaymentLink _link() {
 }
 
 class _FakePaymentLinkRecoveryStorage implements PaymentLinkRecoveryStorage {
-  _FakePaymentLinkRecoveryStorage({this.failOnWrite});
+  _FakePaymentLinkRecoveryStorage({this.failOnWrites = const {}});
 
-  final int? failOnWrite;
+  final Set<int> failOnWrites;
   String? value;
   int _writeCount = 0;
 
@@ -198,7 +229,7 @@ class _FakePaymentLinkRecoveryStorage implements PaymentLinkRecoveryStorage {
   @override
   Future<void> write(String nextValue) async {
     _writeCount += 1;
-    if (_writeCount == failOnWrite) {
+    if (failOnWrites.contains(_writeCount)) {
       throw StateError('storage write failed');
     }
     value = nextValue;

--- a/test/features/payment_links/payment_link_service_test.dart
+++ b/test/features/payment_links/payment_link_service_test.dart
@@ -1,0 +1,242 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_service.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+
+void main() {
+  test('funding covers the exact recipient amount and claim fee', () {
+    final recipientAmount = BigInt.from(100000000);
+
+    expect(
+      paymentLinkFundingAmountZatoshi(recipientAmount),
+      BigInt.from(100010000),
+    );
+    expect(
+      () => paymentLinkFundingAmountZatoshi(BigInt.zero),
+      throwsArgumentError,
+    );
+  });
+
+  test('claim exposes only the amount promised by the link', () {
+    final recipientAmount = BigInt.from(100000000);
+
+    expect(
+      paymentLinkClaimableAmountZatoshi(
+        recipientAmountZatoshi: recipientAmount,
+        maxSpendableZatoshi: BigInt.from(100000000),
+      ),
+      recipientAmount,
+    );
+    expect(
+      paymentLinkClaimableAmountZatoshi(
+        recipientAmountZatoshi: recipientAmount,
+        maxSpendableZatoshi: BigInt.from(120000000),
+      ),
+      recipientAmount,
+    );
+    expect(
+      paymentLinkClaimableAmountZatoshi(
+        recipientAmountZatoshi: recipientAmount,
+        maxSpendableZatoshi: BigInt.from(99999999),
+      ),
+      BigInt.zero,
+    );
+  });
+
+  test('pending and partial claim broadcasts retain their wallet DB', () {
+    expect(
+      shouldRetainPaymentLinkClaimWallet(
+        paymentLinkClaimBroadcastStatusFromWire('pending_broadcast'),
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRetainPaymentLinkClaimWallet(
+        paymentLinkClaimBroadcastStatusFromWire('partial_broadcast'),
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRetainPaymentLinkClaimWallet(
+        paymentLinkClaimBroadcastStatusFromWire('broadcasted'),
+      ),
+      isFalse,
+    );
+    expect(
+      () => paymentLinkClaimBroadcastStatusFromWire('unexpected'),
+      throwsStateError,
+    );
+  });
+
+  test('only reuses a complete claim wallet for the expected address', () {
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const [],
+        expectedAddress: 'u1expected',
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const ['u1expected', 'u1unexpected'],
+        expectedAddress: 'u1expected',
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const ['u1unexpected'],
+        expectedAddress: 'u1expected',
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const ['u1expected'],
+        expectedAddress: 'u1expected',
+      ),
+      isFalse,
+    );
+  });
+
+  test('claim broadcast stops when the wallet locks', () {
+    expect(
+      () => requireUnlockedPaymentLinkWallet(requiresUnlock: true),
+      throwsStateError,
+    );
+    expect(
+      () => requireUnlockedPaymentLinkWallet(requiresUnlock: false),
+      returnsNormally,
+    );
+  });
+
+  test('bounds claim birthdays to a recent chain-tip window', () {
+    const currentTip = 3500000;
+    expect(
+      validatePaymentLinkClaimBirthday(
+        advertisedBirthdayHeight:
+            currentTip - kPaymentLinkMaxClaimLookbackBlocks,
+        currentTipHeight: currentTip,
+      ),
+      currentTip - kPaymentLinkMaxClaimLookbackBlocks,
+    );
+    expect(
+      () => validatePaymentLinkClaimBirthday(
+        advertisedBirthdayHeight:
+            currentTip - kPaymentLinkMaxClaimLookbackBlocks - 1,
+        currentTipHeight: currentTip,
+      ),
+      throwsFormatException,
+    );
+    expect(
+      () => validatePaymentLinkClaimBirthday(
+        advertisedBirthdayHeight: currentTip + 1,
+        currentTipHeight: currentTip,
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('claim wallet directory is deterministic without exposing its secret', () {
+    final link = _link();
+    final sameLinkName = paymentLinkClaimWalletDirectoryName(link);
+    final differentSecretName = paymentLinkClaimWalletDirectoryName(
+      VizorPaymentLink(
+        network: link.network,
+        address: link.address,
+        amountZatoshi: link.amountZatoshi,
+        mnemonic:
+            'legal winner thank year wave sausage worth useful legal winner thank yellow',
+        birthdayHeight: link.birthdayHeight,
+        label: link.label,
+        createdAt: link.createdAt,
+      ),
+    );
+
+    expect(paymentLinkClaimWalletDirectoryName(link), sameLinkName);
+    expect(differentSecretName, isNot(sameLinkName));
+    expect(sameLinkName, isNot(contains(link.address)));
+    expect(sameLinkName, isNot(contains('abandon')));
+  });
+
+  test(
+    'hardware funding is rejected before creating a recovery draft',
+    () async {
+      final storage = _RecordingPaymentLinkRecoveryStorage();
+      final container = ProviderContainer(
+        overrides: [
+          accountProvider.overrideWith(_HardwareAccountNotifier.new),
+          paymentLinkRecoveryStoreProvider.overrideWithValue(
+            PaymentLinkRecoveryStore(storage),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(accountProvider.future);
+
+      await expectLater(
+        container
+            .read(paymentLinkServiceProvider)
+            .createFundedLink(
+              amountZatoshi: BigInt.from(100000),
+              sourceAccountUuid: 'hardware-account',
+            ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'Keystone payment links require the hardware signing flow.',
+          ),
+        ),
+      );
+      expect(storage.writeCount, 0);
+    },
+  );
+}
+
+class _HardwareAccountNotifier extends AccountNotifier {
+  @override
+  AccountState build() => const AccountState(
+    accounts: [
+      AccountInfo(
+        uuid: 'hardware-account',
+        name: 'Keystone',
+        order: 0,
+        isHardware: true,
+      ),
+    ],
+    activeAccountUuid: 'hardware-account',
+    activeAddress: 'u1hardwareaddress',
+  );
+}
+
+class _RecordingPaymentLinkRecoveryStorage
+    implements PaymentLinkRecoveryStorage {
+  int writeCount = 0;
+
+  @override
+  Future<void> delete() async {}
+
+  @override
+  Future<String?> read() async => null;
+
+  @override
+  Future<void> write(String value) async {
+    writeCount += 1;
+  }
+}
+
+VizorPaymentLink _link() {
+  return VizorPaymentLink(
+    network: 'main',
+    address: 'u1paymentlinkaddress',
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 3_456_789,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 8, 5, 12),
+  );
+}

--- a/test/features/payment_links/vizor_payment_link_test.dart
+++ b/test/features/payment_links/vizor_payment_link_test.dart
@@ -1,0 +1,185 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+
+void main() {
+  group('VizorPaymentLink', () {
+    test('round trips a payment link payload', () {
+      final link = _link(
+        presentation: const PaymentLinkPresentation(
+          artworkId: 'celebration_03',
+          message: '축하해! 🎉',
+        ),
+      );
+
+      final encoded = link.encode();
+      final decoded = VizorPaymentLink.decode(encoded);
+      final payload =
+          jsonDecode(
+                utf8.decode(
+                  base64Url.decode(
+                    base64Url.normalize(
+                      Uri.parse(encoded).queryParameters['p']!,
+                    ),
+                  ),
+                ),
+              )
+              as Map<String, Object?>;
+
+      expect(encoded, startsWith('vizor://payment-link?p='));
+      expect(decoded.network, 'main');
+      expect(decoded.address, link.address);
+      expect(decoded.amountZatoshi, BigInt.from(123456789));
+      expect(decoded.mnemonic, link.mnemonic);
+      expect(decoded.birthdayHeight, 3_456_789);
+      expect(decoded.label, link.label);
+      expect(decoded.createdAt, link.createdAt);
+      expect(decoded.presentation?.artworkId, 'celebration_03');
+      expect(decoded.presentation?.message, '축하해! 🎉');
+      expect(payload['presentation'], {
+        'artworkId': 'celebration_03',
+        'message': '축하해! 🎉',
+      });
+    });
+
+    test('omits an empty presentation payload', () {
+      final encoded = _link(
+        presentation: const PaymentLinkPresentation(
+          artworkId: '  ',
+          message: '  ',
+        ),
+      ).encode();
+      final payload =
+          jsonDecode(
+                utf8.decode(
+                  base64Url.decode(
+                    base64Url.normalize(
+                      Uri.parse(encoded).queryParameters['p']!,
+                    ),
+                  ),
+                ),
+              )
+              as Map<String, Object?>;
+
+      expect(payload, isNot(contains('presentation')));
+      expect(VizorPaymentLink.decode(encoded).presentation, isNull);
+    });
+
+    test('rejects invalid presentation values', () {
+      final maxSimpleEmojiMessage = List.filled(128, '🎉').join();
+      expect(
+        PaymentLinkPresentation(
+          message: maxSimpleEmojiMessage,
+        ).toPayload()?['message'],
+        maxSimpleEmojiMessage,
+      );
+      expect(
+        () => _link(
+          presentation: const PaymentLinkPresentation(
+            artworkId: 'not an artwork id',
+          ),
+        ).encode(),
+        throwsFormatException,
+      );
+      expect(
+        () => _link(
+          presentation: PaymentLinkPresentation(
+            message: List.filled(129, 'a').join(),
+          ),
+        ).encode(),
+        throwsFormatException,
+      );
+      expect(
+        () => _link(
+          presentation: PaymentLinkPresentation(
+            message: List.filled(25, '👨‍👩‍👧‍👦').join(),
+          ),
+        ).encode(),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects links without Vizor payment-link scheme', () {
+      expect(
+        () => VizorPaymentLink.decode('https://example.com/pay'),
+        throwsFormatException,
+      );
+    });
+
+    test('accepts the scheme and host case-insensitively', () {
+      final link = _link();
+      final uppercaseLink = link.encode().replaceFirst(
+        'vizor://payment-link',
+        'VIZOR://PAYMENT-LINK',
+      );
+
+      final decoded = VizorPaymentLink.decode(uppercaseLink);
+
+      expect(decoded.address, link.address);
+      expect(decoded.mnemonic, link.mnemonic);
+    });
+
+    test('rejects malformed payloads', () {
+      expect(
+        () => VizorPaymentLink.decode('vizor://payment-link?p=not-base64'),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects oversized inbound links before decoding', () {
+      expect(
+        () => VizorPaymentLink.decode(
+          'vizor://payment-link?p=${'a' * VizorPaymentLink.maxEncodedLength}',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects unsupported versions', () {
+      final encoded = Uri(
+        scheme: 'vizor',
+        host: 'payment-link',
+        queryParameters: {'p': 'eyJ2IjoyfQ=='},
+      ).toString();
+
+      expect(() => VizorPaymentLink.decode(encoded), throwsFormatException);
+    });
+
+    test('rejects links without network', () {
+      final payload = {
+        'v': 1,
+        'address': 'u1exampleaddress',
+        'amountZatoshi': '1',
+        'mnemonic':
+            'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+        'birthdayHeight': 1,
+        'label': 'Demo link',
+        'createdAt': DateTime.utc(2026, 6, 21).toIso8601String(),
+      };
+      final encoded = Uri(
+        scheme: VizorPaymentLink.scheme,
+        host: VizorPaymentLink.host,
+        queryParameters: {
+          'p': base64UrlEncode(utf8.encode(jsonEncode(payload))),
+        },
+      ).toString();
+
+      expect(() => VizorPaymentLink.decode(encoded), throwsFormatException);
+    });
+  });
+}
+
+VizorPaymentLink _link({PaymentLinkPresentation? presentation}) {
+  return VizorPaymentLink(
+    network: 'main',
+    address: 'u1exampleaddress',
+    amountZatoshi: BigInt.from(123456789),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 3_456_789,
+    label: 'Demo link',
+    createdAt: DateTime.utc(2026, 6, 21, 12),
+    presentation: presentation,
+  );
+}

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -89,6 +89,23 @@ void main() {
   );
 
   test(
+    'wallet reset treats payment-link claim cleanup as best effort',
+    () async {
+      final loggedMessages = <String>[];
+
+      await clearPaymentLinkClaimWalletsForReset(
+        deleteDirectories: () async {
+          throw StateError('claim cleanup failed');
+        },
+        reportError: loggedMessages.add,
+      );
+
+      expect(loggedMessages, hasLength(1));
+      expect(loggedMessages.single, contains('claim cleanup failed'));
+    },
+  );
+
+  test(
     'wallet reset clears the tor data directory and route preference',
     () async {
       SharedPreferences.setMockInitialValues({kTorEnabledPreferenceKey: true});

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
 import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
@@ -57,6 +58,35 @@ void main() {
       '.receive.redb',
     ]);
   });
+
+  test(
+    'wallet reset cleanup removes only payment-link claim directories',
+    () async {
+      final supportDirectory = Directory.systemTemp.createTempSync(
+        'vizor-payment-link-reset',
+      );
+      addTearDown(() {
+        if (supportDirectory.existsSync()) {
+          supportDirectory.deleteSync(recursive: true);
+        }
+      });
+      final claimDirectory = Directory(
+        '${supportDirectory.path}${Platform.pathSeparator}'
+        '$kPaymentLinkClaimWalletDirectoryPrefix${List.filled(64, 'a').join()}',
+      )..createSync();
+      final unrelatedDirectory = Directory(
+        '${supportDirectory.path}${Platform.pathSeparator}'
+        '${kPaymentLinkClaimWalletDirectoryPrefix}draft',
+      )..createSync();
+
+      await deletePaymentLinkClaimWalletDirectories(
+        resolveSupportDirectory: () async => supportDirectory,
+      );
+
+      expect(claimDirectory.existsSync(), isFalse);
+      expect(unrelatedDirectory.existsSync(), isTrue);
+    },
+  );
 
   test(
     'wallet reset clears the tor data directory and route preference',

--- a/test/providers/sync_provider_test.dart
+++ b/test/providers/sync_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/formatting/sync_status_label.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_failure.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
@@ -89,6 +90,86 @@ void main() {
       expect(resolveCount, 2);
     },
   );
+
+  test('exclusive Rust sync operations are serialized and bracketed', () async {
+    late _ExclusiveRustSyncTestNotifier notifier;
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+        syncProvider.overrideWith(
+          () => notifier = _ExclusiveRustSyncTestNotifier(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.listen(syncProvider, (_, _) {});
+    await container.read(syncProvider.future);
+
+    final firstRelease = Completer<void>();
+    final firstStarted = Completer<void>();
+    var secondStarted = false;
+    final first = notifier.runWithExclusiveRustSync(() async {
+      firstStarted.complete();
+      await firstRelease.future;
+      return 'first';
+    });
+    await firstStarted.future;
+    final second = notifier.runWithExclusiveRustSync(() async {
+      secondStarted = true;
+      return 'second';
+    });
+
+    await Future<void>.delayed(Duration.zero);
+    expect(secondStarted, isFalse);
+    firstRelease.complete();
+
+    expect(await Future.wait([first, second]), ['first', 'second']);
+    expect(notifier.pauseCount, 2);
+    expect(notifier.resumeCount, 2);
+  });
+
+  test('queued exclusive Rust sync aborts when the wallet locks', () async {
+    late _ExclusiveRustSyncTestNotifier notifier;
+    late _MutableSecurityNotifier security;
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+        appSecurityProvider.overrideWith(
+          () => security = _MutableSecurityNotifier(),
+        ),
+        syncProvider.overrideWith(
+          () => notifier = _ExclusiveRustSyncTestNotifier(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.listen(syncProvider, (_, _) {});
+    await container.read(syncProvider.future);
+    container.read(appSecurityProvider);
+
+    final firstRelease = Completer<void>();
+    final firstStarted = Completer<void>();
+    var secondStarted = false;
+    final first = notifier.runWithExclusiveRustSync(() async {
+      firstStarted.complete();
+      await firstRelease.future;
+      return 'first';
+    });
+    await firstStarted.future;
+    final second = notifier.runWithExclusiveRustSync(() async {
+      secondStarted = true;
+      return 'second';
+    });
+    final secondExpectation = expectLater(second, throwsStateError);
+
+    security.lock();
+    firstRelease.complete();
+
+    expect(await first, 'first');
+    await secondExpectation;
+    expect(secondStarted, isFalse);
+    expect(notifier.pauseCount, 1);
+  });
 
   test('refreshAfterUnlock propagates DB path resolution failures', () async {
     final container = ProviderContainer(
@@ -529,6 +610,49 @@ class _LifecycleTestSyncNotifier extends SyncNotifier {
 
   void replaceState(SyncState next) {
     state = AsyncData(next);
+  }
+}
+
+class _ExclusiveRustSyncTestNotifier extends SyncNotifier {
+  _ExclusiveRustSyncTestNotifier()
+    : super(walletDbPathResolver: () async => 'wallet.db');
+
+  var pauseCount = 0;
+  var resumeCount = 0;
+
+  @override
+  Future<SyncState> build() async => SyncState();
+
+  @override
+  Future<WalletMutationSyncPause> pauseForWalletMutation({
+    FutureOr<void> Function()? onStoppingSync,
+  }) async {
+    pauseCount++;
+    await onStoppingSync?.call();
+    return const WalletMutationSyncPause(
+      hadActiveSync: false,
+      hadPolling: false,
+      hadMempoolObserver: false,
+    );
+  }
+
+  @override
+  void resumeAfterWalletMutation(WalletMutationSyncPause pause) {
+    resumeCount++;
+  }
+}
+
+class _MutableSecurityNotifier extends AppSecurityNotifier {
+  @override
+  AppSecurityState build() =>
+      const AppSecurityState(isPasswordConfigured: true, isUnlocked: true);
+
+  @override
+  void lock() {
+    state = const AppSecurityState(
+      isPasswordConfigured: true,
+      isUnlocked: false,
+    );
   }
 }
 

--- a/test/services/incoming_uri_service_test.dart
+++ b/test/services/incoming_uri_service_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/services/incoming_uri_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel(kIncomingUriChannelName);
+  late List<String> nativeCalls;
+
+  setUp(() {
+    nativeCalls = [];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          nativeCalls.add(call.method);
+          return switch (call.method) {
+            'takePendingUris' => <String>['vizor://payment-link?p=cold'],
+            'ready' => null,
+            _ => throw MissingPluginException(),
+          };
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('drains cold-start URIs before announcing readiness', () async {
+    final service = IncomingUriService(channel: channel);
+    final received = <String>[];
+    final subscription = service.uriStream.listen(received.add);
+    addTearDown(() async {
+      await subscription.cancel();
+      await service.dispose();
+    });
+
+    await service.initialize();
+
+    expect(nativeCalls, ['takePendingUris', 'ready']);
+    expect(received, ['vizor://payment-link?p=cold']);
+  });
+
+  test('forwards warm URIs after initialization', () async {
+    final service = IncomingUriService(channel: channel);
+    final received = <String>[];
+    final subscription = service.uriStream.listen(received.add);
+    addTearDown(() async {
+      await subscription.cancel();
+      await service.dispose();
+    });
+    await service.initialize();
+
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+          kIncomingUriChannelName,
+          const StandardMethodCodec().encodeMethodCall(
+            const MethodCall('onUris', <String>['vizor://payment-link?p=warm']),
+          ),
+          (_) {},
+        );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(received.last, 'vizor://payment-link?p=warm');
+  });
+}

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -13,6 +13,15 @@ else()
 endif()
 set(STORAGE_PREFIX "${VIZOR_WINDOWS_STORAGE_PREFIX}")
 
+if(
+  DEFINED ENV{VIZOR_WINDOWS_PAYMENT_URI_OWNER}
+  AND "$ENV{VIZOR_WINDOWS_PAYMENT_URI_OWNER}" STREQUAL "1"
+)
+  set(VIZOR_WINDOWS_PAYMENT_URI_OWNER 1)
+else()
+  set(VIZOR_WINDOWS_PAYMENT_URI_OWNER 0)
+endif()
+
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.
 cmake_policy(VERSION 3.14...3.25)

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -10,6 +10,8 @@ add_executable(${BINARY_NAME} WIN32
   "flutter_window.cpp"
   "main.cpp"
   "single_instance.cpp"
+  "payment_uri_handoff.cpp"
+  "payment_uri_protocol.cpp"
   "utils.cpp"
   "velopack_uninstall.cpp"
   "velopack_update.cpp"

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -63,6 +63,7 @@ target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_BUILD=${FLUTT
 # Disable Windows macros that collide with C++ standard library functions.
 target_compile_definitions(${BINARY_NAME} PRIVATE "NOMINMAX")
 target_compile_definitions(${BINARY_NAME} PRIVATE "VIZOR_WINDOWS_STORAGE_PREFIX=\"${VIZOR_WINDOWS_STORAGE_PREFIX}\"")
+target_compile_definitions(${BINARY_NAME} PRIVATE "VIZOR_WINDOWS_PAYMENT_URI_OWNER=${VIZOR_WINDOWS_PAYMENT_URI_OWNER}")
 
 if(DEFINED ENV{VIZOR_UPDATE_FEED_PUBLIC_KEY_B64})
   target_compile_definitions(${BINARY_NAME} PRIVATE "VIZOR_UPDATE_FEED_PUBLIC_KEY_B64=\"$ENV{VIZOR_UPDATE_FEED_PUBLIC_KEY_B64}\"")

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -12,9 +12,11 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "flutter/generated_plugin_registrant.h"
+#include "payment_uri_handoff.h"
 #include "single_instance.h"
 #include "utils.h"
 #include "velopack_update.h"
@@ -24,6 +26,15 @@ namespace {
 namespace credentials_ui = ABI::Windows::Security::Credentials::UI;
 namespace foundation = ABI::Windows::Foundation;
 namespace wrl = Microsoft::WRL;
+
+void PresentWindowForPaymentLink(HWND window) {
+  if (::IsIconic(window)) {
+    ::ShowWindow(window, SW_RESTORE);
+  } else {
+    ::ShowWindow(window, SW_SHOW);
+  }
+  ::SetForegroundWindow(window);
+}
 
 std::wstring StringArg(const flutter::EncodableValue* arguments,
                        const char* key) {
@@ -434,6 +445,25 @@ bool FlutterWindow::OnCreate() {
       });
   velopack_update_channel_ =
       CreateVelopackUpdateChannel(flutter_controller_->engine()->messenger());
+  incoming_uri_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          flutter_controller_->engine()->messenger(),
+          "com.zcash.wallet/payment_uri",
+          &flutter::StandardMethodCodec::GetInstance());
+  incoming_uri_channel_->SetMethodCallHandler(
+      [this](const auto& call, auto result) {
+        if (call.method_name() == "takePendingUris") {
+          result->Success(TakePendingPaymentLinks());
+          return;
+        }
+        if (call.method_name() == "ready") {
+          incoming_uri_dart_ready_ = true;
+          FlushPendingPaymentLinks();
+          result->Success();
+          return;
+        }
+        result->NotImplemented();
+      });
 
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
@@ -454,6 +484,7 @@ void FlutterWindow::OnDestroy() {
     camera_permission_channel_.reset();
     device_owner_auth_channel_.reset();
     velopack_update_channel_.reset();
+    incoming_uri_channel_.reset();
     flutter_controller_ = nullptr;
   }
 
@@ -482,6 +513,17 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
     return kSingleInstanceActivationAcknowledged;
   }
 
+  if (message == WM_COPYDATA) {
+    std::string payment_link;
+    if (TryReadPaymentLinkCopyData(lparam, &payment_link)) {
+      AppendPaymentLinkIfAccepted(&pending_payment_links_,
+                                  std::move(payment_link));
+      PresentWindowForPaymentLink(hwnd);
+      FlushPendingPaymentLinks();
+      return TRUE;
+    }
+  }
+
   // Give Flutter, including plugins, an opportunity to handle window messages.
   if (flutter_controller_) {
     std::optional<LRESULT> result =
@@ -499,4 +541,24 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
   }
 
   return Win32Window::MessageHandler(hwnd, message, wparam, lparam);
+}
+
+flutter::EncodableValue FlutterWindow::TakePendingPaymentLinks() {
+  flutter::EncodableList uris;
+  uris.reserve(pending_payment_links_.size());
+  for (const auto& uri : pending_payment_links_) {
+    uris.emplace_back(uri);
+  }
+  pending_payment_links_.clear();
+  return flutter::EncodableValue(uris);
+}
+
+void FlutterWindow::FlushPendingPaymentLinks() {
+  if (!incoming_uri_dart_ready_ || !incoming_uri_channel_ ||
+      pending_payment_links_.empty()) {
+    return;
+  }
+  incoming_uri_channel_->InvokeMethod(
+      "onUris", std::make_unique<flutter::EncodableValue>(
+                    TakePendingPaymentLinks()));
 }

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -6,6 +6,8 @@
 #include <flutter/method_channel.h>
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "win32_window.h"
 
@@ -40,6 +42,13 @@ class FlutterWindow : public Win32Window {
   // Registered Windows message used by a secondary process to restore this
   // primary window. The message name is scoped to the storage prefix.
   UINT activation_message_ = 0;
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      incoming_uri_channel_;
+  std::vector<std::string> pending_payment_links_;
+  bool incoming_uri_dart_ready_ = false;
+
+  flutter::EncodableValue TakePendingPaymentLinks();
+  void FlushPendingPaymentLinks();
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -4,20 +4,69 @@
 #include <windows.h>
 
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "flutter_window.h"
+#include "payment_uri_handoff.h"
+#include "payment_uri_protocol.h"
 #include "single_instance.h"
 #include "utils.h"
 #include "velopack_uninstall.h"
+
+namespace {
+
+constexpr DWORD kNormalActivationRetryWindowMs = 2'000;
+constexpr DWORD kPaymentLinkActivationRetryWindowMs = 15'000;
+
+}  // namespace
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
   RunVelopackHooks();
 
+  std::vector<std::string> command_line_arguments =
+      GetCommandLineArguments();
+  bool had_payment_link_argument = false;
+  std::vector<std::string> payment_links =
+      ExtractPaymentLinkUriArguments(&command_line_arguments,
+                                     &had_payment_link_argument);
+  if (had_payment_link_argument) {
+    if (payment_links.empty()) {
+      return EXIT_FAILURE;
+    }
+
+    bool delivered = false;
+    bool launch_clean_instance = false;
+    {
+      SingleInstanceGuard relay_probe;
+      const SingleInstanceAcquireResult relay_result = relay_probe.Acquire();
+      if (relay_result == SingleInstanceAcquireResult::kSecondary) {
+        delivered = ForwardPaymentLinksToRunningInstance(payment_links);
+        if (!delivered &&
+            ActivateExistingInstance(
+                relay_probe.activation_message(),
+                kPaymentLinkActivationRetryWindowMs)) {
+          delivered = ForwardPaymentLinksToRunningInstance(payment_links);
+        }
+      } else if (relay_result == SingleInstanceAcquireResult::kPrimary) {
+        launch_clean_instance = true;
+      } else {
+        return EXIT_FAILURE;
+      }
+    }
+
+    if (!delivered && launch_clean_instance) {
+      delivered = LaunchCleanInstanceAndForwardPaymentLinks(payment_links);
+    }
+    return delivered ? EXIT_SUCCESS : EXIT_FAILURE;
+  }
+
   SingleInstanceGuard single_instance;
   const SingleInstanceAcquireResult instance_result = single_instance.Acquire();
   if (instance_result == SingleInstanceAcquireResult::kSecondary) {
-    if (!ActivateExistingInstance(single_instance.activation_message())) {
+    if (!ActivateExistingInstance(single_instance.activation_message(),
+                                  kNormalActivationRetryWindowMs)) {
       ::MessageBoxW(
           nullptr,
           L"Vizor is already running. It may be starting, not responding, or "
@@ -46,11 +95,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   // plugins.
   const HRESULT ro_init = ::RoInitialize(RO_INIT_SINGLETHREADED);
   const bool ro_initialized = SUCCEEDED(ro_init);
+  RegisterVizorProtocolHandlerIfUnclaimed();
 
   flutter::DartProject project(L"data");
-
-  std::vector<std::string> command_line_arguments =
-      GetCommandLineArguments();
 
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 

--- a/windows/runner/payment_uri_handoff.cpp
+++ b/windows/runner/payment_uri_handoff.cpp
@@ -1,0 +1,233 @@
+#include "payment_uri_handoff.h"
+
+#include <algorithm>
+#include <cwctype>
+#include <string>
+
+#include "utils.h"
+
+namespace {
+
+constexpr wchar_t kFlutterWindowClassName[] = L"FLUTTER_RUNNER_WIN32_WINDOW";
+constexpr ULONG_PTR kPaymentLinkCopyDataId = 0x565A504C;  // "VZPL"
+constexpr ULONGLONG kCleanLaunchForwardTimeoutMs = 15'000;
+
+struct ScopedProcessInformation {
+  PROCESS_INFORMATION value{};
+
+  ~ScopedProcessInformation() {
+    if (value.hThread != nullptr) {
+      ::CloseHandle(value.hThread);
+    }
+    if (value.hProcess != nullptr) {
+      ::CloseHandle(value.hProcess);
+    }
+  }
+};
+
+std::wstring ToLower(std::wstring value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](wchar_t ch) { return static_cast<wchar_t>(towlower(ch)); });
+  return value;
+}
+
+std::wstring ModuleFileName() {
+  std::wstring file_name(MAX_PATH, L'\0');
+  while (true) {
+    const DWORD length = ::GetModuleFileNameW(
+        nullptr, file_name.data(), static_cast<DWORD>(file_name.size()));
+    if (length == 0) {
+      return L"";
+    }
+    if (length < file_name.size() - 1) {
+      file_name.resize(length);
+      return file_name;
+    }
+    file_name.resize(file_name.size() * 2);
+  }
+}
+
+std::wstring ProcessImagePath(DWORD process_id) {
+  HANDLE process = ::OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE,
+                                 process_id);
+  if (process == nullptr) {
+    return L"";
+  }
+
+  std::wstring image_path(MAX_PATH, L'\0');
+  DWORD length = static_cast<DWORD>(image_path.size());
+  while (true) {
+    if (::QueryFullProcessImageNameW(process, 0, image_path.data(), &length)) {
+      ::CloseHandle(process);
+      image_path.resize(length);
+      return image_path;
+    }
+    if (::GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+      ::CloseHandle(process);
+      return L"";
+    }
+    image_path.resize(image_path.size() * 2);
+    length = static_cast<DWORD>(image_path.size());
+  }
+}
+
+bool IsFlutterRunnerWindow(HWND window) {
+  wchar_t class_name[256];
+  const int length = ::GetClassNameW(window, class_name, 256);
+  return length > 0 &&
+         std::wstring(class_name, length) == kFlutterWindowClassName;
+}
+
+bool SendPaymentLink(HWND window, const std::string& uri) {
+  if (!IsPaymentLinkUri(uri)) {
+    return false;
+  }
+  COPYDATASTRUCT copy_data;
+  copy_data.dwData = kPaymentLinkCopyDataId;
+  copy_data.cbData = static_cast<DWORD>(uri.size() + 1);
+  copy_data.lpData = const_cast<char*>(uri.c_str());
+  DWORD_PTR result = 0;
+  return ::SendMessageTimeoutW(window, WM_COPYDATA, 0,
+                               reinterpret_cast<LPARAM>(&copy_data),
+                               SMTO_ABORTIFHUNG, 3000, &result) != 0;
+}
+
+struct ForwardContext {
+  std::wstring module_path;
+  const std::vector<std::string>* uris;
+  bool delivered = false;
+};
+
+bool SendAllPaymentLinks(HWND window,
+                         const std::vector<std::string>& uris) {
+  bool delivered = true;
+  for (const auto& uri : uris) {
+    delivered = SendPaymentLink(window, uri) && delivered;
+  }
+  return delivered;
+}
+
+BOOL CALLBACK ForwardToMatchingWindow(HWND window, LPARAM lparam) {
+  auto* context = reinterpret_cast<ForwardContext*>(lparam);
+  if (!IsFlutterRunnerWindow(window)) {
+    return TRUE;
+  }
+
+  DWORD process_id = 0;
+  ::GetWindowThreadProcessId(window, &process_id);
+  if (process_id == 0 || process_id == ::GetCurrentProcessId()) {
+    return TRUE;
+  }
+  const std::wstring process_path = ToLower(ProcessImagePath(process_id));
+  if (process_path.empty() || process_path != context->module_path) {
+    return TRUE;
+  }
+
+  ::AllowSetForegroundWindow(process_id);
+  context->delivered = SendAllPaymentLinks(window, *context->uris);
+  return context->delivered ? FALSE : TRUE;
+}
+
+struct ProcessForwardContext {
+  DWORD process_id;
+  const std::vector<std::string>* uris;
+  bool delivered = false;
+};
+
+BOOL CALLBACK ForwardToProcessWindow(HWND window, LPARAM lparam) {
+  auto* context = reinterpret_cast<ProcessForwardContext*>(lparam);
+  if (!IsFlutterRunnerWindow(window)) {
+    return TRUE;
+  }
+  DWORD process_id = 0;
+  ::GetWindowThreadProcessId(window, &process_id);
+  if (process_id != context->process_id) {
+    return TRUE;
+  }
+  ::AllowSetForegroundWindow(process_id);
+  context->delivered = SendAllPaymentLinks(window, *context->uris);
+  return context->delivered ? FALSE : TRUE;
+}
+
+bool ForwardPaymentLinksToProcess(DWORD process_id,
+                                  const std::vector<std::string>& uris) {
+  ProcessForwardContext context{process_id, &uris};
+  ::EnumWindows(ForwardToProcessWindow, reinterpret_cast<LPARAM>(&context));
+  return context.delivered;
+}
+
+}  // namespace
+
+bool ForwardPaymentLinksToRunningInstance(
+    const std::vector<std::string>& uris) {
+  if (uris.empty()) {
+    return false;
+  }
+  ForwardContext context;
+  context.module_path = ToLower(ModuleFileName());
+  context.uris = &uris;
+  if (context.module_path.empty()) {
+    return false;
+  }
+  ::EnumWindows(ForwardToMatchingWindow, reinterpret_cast<LPARAM>(&context));
+  return context.delivered;
+}
+
+bool LaunchCleanInstanceAndForwardPaymentLinks(
+    const std::vector<std::string>& uris) {
+  if (uris.empty()) {
+    return false;
+  }
+  const std::wstring module_path = ModuleFileName();
+  if (module_path.empty()) {
+    return false;
+  }
+
+  std::wstring command_line = L"\"" + module_path + L"\"";
+  std::vector<wchar_t> command_line_buffer(command_line.begin(),
+                                            command_line.end());
+  command_line_buffer.push_back(L'\0');
+  STARTUPINFOW startup_info{};
+  startup_info.cb = sizeof(startup_info);
+  ScopedProcessInformation process_info;
+  if (!::CreateProcessW(module_path.c_str(), command_line_buffer.data(),
+                        nullptr, nullptr, FALSE, 0, nullptr, nullptr,
+                        &startup_info, &process_info.value)) {
+    return false;
+  }
+
+  const ULONGLONG deadline =
+      ::GetTickCount64() + kCleanLaunchForwardTimeoutMs;
+  while (::GetTickCount64() < deadline) {
+    if (ForwardPaymentLinksToProcess(process_info.value.dwProcessId, uris)) {
+      return true;
+    }
+    if (::WaitForSingleObject(process_info.value.hProcess, 100) ==
+        WAIT_OBJECT_0) {
+      return false;
+    }
+  }
+  return false;
+}
+
+bool TryReadPaymentLinkCopyData(LPARAM lparam, std::string* uri) {
+  if (uri == nullptr) {
+    return false;
+  }
+  const auto* copy_data = reinterpret_cast<const COPYDATASTRUCT*>(lparam);
+  if (copy_data == nullptr || copy_data->dwData != kPaymentLinkCopyDataId ||
+      copy_data->lpData == nullptr || copy_data->cbData == 0 ||
+      copy_data->cbData > kMaxIncomingUriBytes + 1) {
+    return false;
+  }
+  const auto* raw = static_cast<const char*>(copy_data->lpData);
+  if (raw[copy_data->cbData - 1] != '\0') {
+    return false;
+  }
+  std::string value(raw, copy_data->cbData - 1);
+  if (!IsPaymentLinkUri(value)) {
+    return false;
+  }
+  *uri = std::move(value);
+  return true;
+}

--- a/windows/runner/payment_uri_handoff.cpp
+++ b/windows/runner/payment_uri_handoff.cpp
@@ -198,13 +198,20 @@ bool LaunchCleanInstanceAndForwardPaymentLinks(
 
   const ULONGLONG deadline =
       ::GetTickCount64() + kCleanLaunchForwardTimeoutMs;
+  bool child_exited = false;
   while (::GetTickCount64() < deadline) {
-    if (ForwardPaymentLinksToProcess(process_info.value.dwProcessId, uris)) {
+    if (!child_exited &&
+        ForwardPaymentLinksToProcess(process_info.value.dwProcessId, uris)) {
       return true;
     }
-    if (::WaitForSingleObject(process_info.value.hProcess, 100) ==
-        WAIT_OBJECT_0) {
-      return false;
+    if (ForwardPaymentLinksToRunningInstance(uris)) {
+      return true;
+    }
+    if (child_exited) {
+      ::Sleep(100);
+    } else if (::WaitForSingleObject(process_info.value.hProcess, 100) ==
+               WAIT_OBJECT_0) {
+      child_exited = true;
     }
   }
   return false;

--- a/windows/runner/payment_uri_handoff.h
+++ b/windows/runner/payment_uri_handoff.h
@@ -1,0 +1,15 @@
+#ifndef RUNNER_PAYMENT_URI_HANDOFF_H_
+#define RUNNER_PAYMENT_URI_HANDOFF_H_
+
+#include <windows.h>
+
+#include <string>
+#include <vector>
+
+bool ForwardPaymentLinksToRunningInstance(
+    const std::vector<std::string>& uris);
+bool LaunchCleanInstanceAndForwardPaymentLinks(
+    const std::vector<std::string>& uris);
+bool TryReadPaymentLinkCopyData(LPARAM lparam, std::string* uri);
+
+#endif  // RUNNER_PAYMENT_URI_HANDOFF_H_

--- a/windows/runner/payment_uri_protocol.cpp
+++ b/windows/runner/payment_uri_protocol.cpp
@@ -1,0 +1,140 @@
+#include "payment_uri_protocol.h"
+
+#include <windows.h>
+
+#include <shellapi.h>
+#include <shlobj.h>
+
+#include <algorithm>
+#include <cwctype>
+#include <string>
+
+namespace {
+
+constexpr wchar_t kProtocolKeyPath[] = L"Software\\Classes\\vizor";
+constexpr wchar_t kProtocolCommandKeyPath[] =
+    L"Software\\Classes\\vizor\\shell\\open\\command";
+constexpr wchar_t kEffectiveProtocolCommandKeyPath[] =
+    L"vizor\\shell\\open\\command";
+
+struct RegistryKey {
+  HKEY value = nullptr;
+
+  ~RegistryKey() {
+    if (value != nullptr) {
+      ::RegCloseKey(value);
+    }
+  }
+};
+
+std::wstring ToLower(std::wstring value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](wchar_t ch) { return static_cast<wchar_t>(towlower(ch)); });
+  return value;
+}
+
+std::wstring ModuleFileName() {
+  std::wstring file_name(MAX_PATH, L'\0');
+  while (true) {
+    const DWORD length = ::GetModuleFileNameW(
+        nullptr, file_name.data(), static_cast<DWORD>(file_name.size()));
+    if (length == 0) {
+      return L"";
+    }
+    if (length < file_name.size() - 1) {
+      file_name.resize(length);
+      return file_name;
+    }
+    file_name.resize(file_name.size() * 2);
+  }
+}
+
+bool CreateCurrentUserKey(const wchar_t* key_path, RegistryKey* key) {
+  return ::RegCreateKeyExW(HKEY_CURRENT_USER, key_path, 0, nullptr, 0,
+                           KEY_SET_VALUE, nullptr, &key->value,
+                           nullptr) == ERROR_SUCCESS;
+}
+
+void SetStringValue(HKEY key, const wchar_t* name, const std::wstring& value) {
+  ::RegSetValueExW(
+      key, name, 0, REG_SZ, reinterpret_cast<const BYTE*>(value.c_str()),
+      static_cast<DWORD>((value.size() + 1) * sizeof(wchar_t)));
+}
+
+std::wstring ReadDefaultCommand() {
+  DWORD type = 0;
+  DWORD size = 0;
+  if (::RegGetValueW(HKEY_CLASSES_ROOT, kEffectiveProtocolCommandKeyPath,
+                     nullptr, RRF_RT_REG_SZ, &type, nullptr, &size) !=
+          ERROR_SUCCESS ||
+      size == 0) {
+    return L"";
+  }
+
+  std::wstring value(size / sizeof(wchar_t), L'\0');
+  if (::RegGetValueW(HKEY_CLASSES_ROOT, kEffectiveProtocolCommandKeyPath,
+                     nullptr, RRF_RT_REG_SZ, &type, value.data(), &size) !=
+      ERROR_SUCCESS) {
+    return L"";
+  }
+  while (!value.empty() && value.back() == L'\0') {
+    value.pop_back();
+  }
+  return value;
+}
+
+void NotifyAssociationChanged() {
+  ::SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
+}
+
+}  // namespace
+
+void RegisterVizorProtocolHandler() {
+  const std::wstring module_path = ModuleFileName();
+  if (module_path.empty()) {
+    return;
+  }
+
+  RegistryKey protocol_key;
+  if (!CreateCurrentUserKey(kProtocolKeyPath, &protocol_key)) {
+    return;
+  }
+  SetStringValue(protocol_key.value, nullptr, L"URL:Vizor Payment Link");
+  SetStringValue(protocol_key.value, L"URL Protocol", L"");
+
+  RegistryKey icon_key;
+  if (CreateCurrentUserKey(L"Software\\Classes\\vizor\\DefaultIcon",
+                           &icon_key)) {
+    SetStringValue(icon_key.value, nullptr, L"\"" + module_path + L"\",0");
+  }
+
+  RegistryKey command_key;
+  if (!CreateCurrentUserKey(kProtocolCommandKeyPath, &command_key)) {
+    return;
+  }
+  SetStringValue(command_key.value, nullptr,
+                 L"\"" + module_path + L"\" \"%1\"");
+  NotifyAssociationChanged();
+}
+
+void RegisterVizorProtocolHandlerIfUnclaimed() {
+  const std::wstring module_path = ToLower(ModuleFileName());
+  if (module_path.empty()) {
+    return;
+  }
+  const std::wstring command = ToLower(ReadDefaultCommand());
+  if (!command.empty() && command.find(module_path) == std::wstring::npos) {
+    return;
+  }
+  RegisterVizorProtocolHandler();
+}
+
+void UnregisterVizorProtocolHandler() {
+  const std::wstring module_path = ToLower(ModuleFileName());
+  const std::wstring command = ToLower(ReadDefaultCommand());
+  if (module_path.empty() || command.find(module_path) == std::wstring::npos) {
+    return;
+  }
+  ::RegDeleteTreeW(HKEY_CURRENT_USER, kProtocolKeyPath);
+  NotifyAssociationChanged();
+}

--- a/windows/runner/payment_uri_protocol.cpp
+++ b/windows/runner/payment_uri_protocol.cpp
@@ -11,6 +11,12 @@
 
 namespace {
 
+#ifndef VIZOR_WINDOWS_PAYMENT_URI_OWNER
+#define VIZOR_WINDOWS_PAYMENT_URI_OWNER 0
+#endif
+
+constexpr bool kOwnsPaymentUriScheme =
+    VIZOR_WINDOWS_PAYMENT_URI_OWNER == 1;
 constexpr wchar_t kProtocolKeyPath[] = L"Software\\Classes\\vizor";
 constexpr wchar_t kProtocolCommandKeyPath[] =
     L"Software\\Classes\\vizor\\shell\\open\\command";
@@ -90,6 +96,9 @@ void NotifyAssociationChanged() {
 }  // namespace
 
 void RegisterVizorProtocolHandler() {
+  if (!kOwnsPaymentUriScheme) {
+    return;
+  }
   const std::wstring module_path = ModuleFileName();
   if (module_path.empty()) {
     return;
@@ -118,6 +127,9 @@ void RegisterVizorProtocolHandler() {
 }
 
 void RegisterVizorProtocolHandlerIfUnclaimed() {
+  if (!kOwnsPaymentUriScheme) {
+    return;
+  }
   const std::wstring module_path = ToLower(ModuleFileName());
   if (module_path.empty()) {
     return;
@@ -130,6 +142,9 @@ void RegisterVizorProtocolHandlerIfUnclaimed() {
 }
 
 void UnregisterVizorProtocolHandler() {
+  if (!kOwnsPaymentUriScheme) {
+    return;
+  }
   const std::wstring module_path = ToLower(ModuleFileName());
   const std::wstring command = ToLower(ReadDefaultCommand());
   if (module_path.empty() || command.find(module_path) == std::wstring::npos) {

--- a/windows/runner/payment_uri_protocol.h
+++ b/windows/runner/payment_uri_protocol.h
@@ -1,0 +1,8 @@
+#ifndef RUNNER_PAYMENT_URI_PROTOCOL_H_
+#define RUNNER_PAYMENT_URI_PROTOCOL_H_
+
+void RegisterVizorProtocolHandler();
+void RegisterVizorProtocolHandlerIfUnclaimed();
+void UnregisterVizorProtocolHandler();
+
+#endif  // RUNNER_PAYMENT_URI_PROTOCOL_H_

--- a/windows/runner/single_instance.cpp
+++ b/windows/runner/single_instance.cpp
@@ -22,7 +22,6 @@ namespace {
 #define VIZOR_WIDEN(value) VIZOR_WIDEN2(value)
 
 constexpr wchar_t kLockDirectoryName[] = L"VizorInstanceLocks";
-constexpr DWORD kActivationRetryWindowMs = 2000;
 constexpr DWORD kActivationRetryDelayMs = 50;
 constexpr UINT kActivationMessageTimeoutMs = 100;
 
@@ -186,12 +185,13 @@ SingleInstanceAcquireResult SingleInstanceGuard::Acquire() {
   return SingleInstanceAcquireResult::kError;
 }
 
-bool ActivateExistingInstance(UINT activation_message) {
+bool ActivateExistingInstance(UINT activation_message,
+                              DWORD retry_window_ms) {
   if (activation_message == 0) {
     return false;
   }
 
-  const ULONGLONG deadline = ::GetTickCount64() + kActivationRetryWindowMs;
+  const ULONGLONG deadline = ::GetTickCount64() + retry_window_ms;
   do {
     ActivationContext context{activation_message, false};
     ::EnumWindows(SendActivationMessage,

--- a/windows/runner/single_instance.h
+++ b/windows/runner/single_instance.h
@@ -40,10 +40,12 @@ class SingleInstanceGuard {
 // Result returned by the matching primary window for an activation message.
 constexpr LRESULT kSingleInstanceActivationAcknowledged = 0x56495A4F;
 
-// Tries briefly to find the primary window in the current interactive session
-// and asks it to restore and activate itself. Returns false when the primary is
-// still starting, hung, elevated beyond the caller, or running in another
-// Windows session. Process exclusion remains enforced by the file lock.
-bool ActivateExistingInstance(UINT activation_message);
+// Tries for |retry_window_ms| to find the primary window in the current
+// interactive session and asks it to restore and activate itself. Returns
+// false when the primary is still starting, hung, elevated beyond the caller,
+// or running in another Windows session. Process exclusion remains enforced by
+// the file lock.
+bool ActivateExistingInstance(UINT activation_message,
+                              DWORD retry_window_ms);
 
 #endif  // RUNNER_SINGLE_INSTANCE_H_

--- a/windows/runner/utils.cpp
+++ b/windows/runner/utils.cpp
@@ -5,7 +5,42 @@
 #include <stdio.h>
 #include <windows.h>
 
+#include <algorithm>
+#include <cctype>
 #include <iostream>
+#include <utility>
+
+bool HasPaymentLinkUriPrefix(const std::string& value) {
+  constexpr char prefix[] = "vizor://payment-link";
+  constexpr size_t prefix_length = sizeof(prefix) - 1;
+  if (value.size() < prefix_length) {
+    return false;
+  }
+  for (size_t i = 0; i < prefix_length; ++i) {
+    const auto actual = static_cast<unsigned char>(value[i]);
+    const auto expected = static_cast<unsigned char>(prefix[i]);
+    if (std::tolower(actual) != std::tolower(expected)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IsPaymentLinkUri(const std::string& value) {
+  return value.size() <= kMaxIncomingUriBytes &&
+         HasPaymentLinkUriPrefix(value);
+}
+
+bool AppendPaymentLinkIfAccepted(std::vector<std::string>* uris,
+                                 std::string value) {
+  if (uris == nullptr || !IsPaymentLinkUri(value) ||
+      uris->size() >= kMaxPendingIncomingUris ||
+      std::find(uris->begin(), uris->end(), value) != uris->end()) {
+    return false;
+  }
+  uris->push_back(std::move(value));
+  return true;
+}
 
 void CreateAndAttachConsole() {
   if (::AllocConsole()) {
@@ -39,6 +74,31 @@ std::vector<std::string> GetCommandLineArguments() {
   ::LocalFree(argv);
 
   return command_line_arguments;
+}
+
+std::vector<std::string> ExtractPaymentLinkUriArguments(
+    std::vector<std::string>* arguments, bool* had_payment_link_argument) {
+  std::vector<std::string> uris;
+  if (had_payment_link_argument != nullptr) {
+    *had_payment_link_argument = false;
+  }
+  if (arguments == nullptr) {
+    return uris;
+  }
+  std::vector<std::string> remaining_arguments;
+  remaining_arguments.reserve(arguments->size());
+  for (auto& argument : *arguments) {
+    if (HasPaymentLinkUriPrefix(argument)) {
+      if (had_payment_link_argument != nullptr) {
+        *had_payment_link_argument = true;
+      }
+      AppendPaymentLinkIfAccepted(&uris, std::move(argument));
+      continue;
+    }
+    remaining_arguments.push_back(std::move(argument));
+  }
+  *arguments = std::move(remaining_arguments);
+  return uris;
 }
 
 std::string Utf8FromUtf16(const wchar_t* utf16_string) {

--- a/windows/runner/utils.cpp
+++ b/windows/runner/utils.cpp
@@ -10,7 +10,9 @@
 #include <iostream>
 #include <utility>
 
-bool HasPaymentLinkUriPrefix(const std::string& value) {
+namespace {
+
+bool MatchesPaymentLinkTarget(const std::string& value) {
   constexpr char prefix[] = "vizor://payment-link";
   constexpr size_t prefix_length = sizeof(prefix) - 1;
   if (value.size() < prefix_length) {
@@ -23,12 +25,18 @@ bool HasPaymentLinkUriPrefix(const std::string& value) {
       return false;
     }
   }
-  return true;
+  if (value.size() == prefix_length) {
+    return true;
+  }
+  const char boundary = value[prefix_length];
+  return boundary == '?' || boundary == '/' || boundary == '#';
 }
+
+}  // namespace
 
 bool IsPaymentLinkUri(const std::string& value) {
   return value.size() <= kMaxIncomingUriBytes &&
-         HasPaymentLinkUriPrefix(value);
+         MatchesPaymentLinkTarget(value);
 }
 
 bool AppendPaymentLinkIfAccepted(std::vector<std::string>* uris,
@@ -88,7 +96,7 @@ std::vector<std::string> ExtractPaymentLinkUriArguments(
   std::vector<std::string> remaining_arguments;
   remaining_arguments.reserve(arguments->size());
   for (auto& argument : *arguments) {
-    if (HasPaymentLinkUriPrefix(argument)) {
+    if (MatchesPaymentLinkTarget(argument)) {
       if (had_payment_link_argument != nullptr) {
         *had_payment_link_argument = true;
       }

--- a/windows/runner/utils.h
+++ b/windows/runner/utils.h
@@ -1,8 +1,12 @@
 #ifndef RUNNER_UTILS_H_
 #define RUNNER_UTILS_H_
 
+#include <cstddef>
 #include <string>
 #include <vector>
+
+constexpr size_t kMaxIncomingUriBytes = 16 * 1024;
+constexpr size_t kMaxPendingIncomingUris = 16;
 
 // Creates a console for the process, and redirects stdout and stderr to
 // it for both the runner and the Flutter library.
@@ -19,5 +23,12 @@ std::wstring Utf16FromUtf8(const std::string& utf8_string);
 // Gets the command line arguments passed in as a std::vector<std::string>,
 // encoded in UTF-8. Returns an empty std::vector<std::string> on failure.
 std::vector<std::string> GetCommandLineArguments();
+
+std::vector<std::string> ExtractPaymentLinkUriArguments(
+    std::vector<std::string>* arguments, bool* had_payment_link_argument);
+bool AppendPaymentLinkIfAccepted(std::vector<std::string>* uris,
+                                 std::string value);
+bool HasPaymentLinkUriPrefix(const std::string& value);
+bool IsPaymentLinkUri(const std::string& value);
 
 #endif  // RUNNER_UTILS_H_

--- a/windows/runner/utils.h
+++ b/windows/runner/utils.h
@@ -28,7 +28,6 @@ std::vector<std::string> ExtractPaymentLinkUriArguments(
     std::vector<std::string>* arguments, bool* had_payment_link_argument);
 bool AppendPaymentLinkIfAccepted(std::vector<std::string>* uris,
                                  std::string value);
-bool HasPaymentLinkUriPrefix(const std::string& value);
 bool IsPaymentLinkUri(const std::string& value);
 
 #endif  // RUNNER_UTILS_H_

--- a/windows/runner/velopack_uninstall.cpp
+++ b/windows/runner/velopack_uninstall.cpp
@@ -1,5 +1,7 @@
 #include "velopack_uninstall.h"
 
+#include "payment_uri_protocol.h"
+
 #include <windows.h>
 
 #include <knownfolders.h>
@@ -213,13 +215,22 @@ void DeleteUserData() {
 }
 
 void BeforeUninstallHook(void* user_data, const char* app_version) {
+  UnregisterVizorProtocolHandler();
   DeleteUserData();
+}
+
+void RegisterProtocolHook(void* user_data, const char* app_version) {
+  RegisterVizorProtocolHandler();
 }
 
 }  // namespace
 
 void RunVelopackHooks() {
   vpkc_app_set_auto_apply_on_startup(false);
+  vpkc_app_set_hook_after_install(RegisterProtocolHook);
+  vpkc_app_set_hook_after_update(RegisterProtocolHook);
   vpkc_app_set_hook_before_uninstall(BeforeUninstallHook);
+  vpkc_app_set_hook_first_run(RegisterProtocolHook);
+  vpkc_app_set_hook_restarted(RegisterProtocolHook);
   vpkc_app_run(nullptr);
 }


### PR DESCRIPTION
## Problem

Each supported OS delivers custom URIs differently across cold start, warm start, and single-instance handoff. This platform transport should be reviewed separately from payment-link business logic, with bounded buffering and strict URI filtering at the native boundary.

## Solution

- Register the Vizor payment-link URI on Android, iOS, macOS, Linux, and Windows.
- Buffer accepted links until the Dart method channel is ready, with per-platform bounds and scheme/host validation.
- Connect native delivery to the Dart intake host.
- Preserve Linux AppImage arguments and Windows single-instance/startup relay behavior.
- Include the Windows startup relay fix that existed only on the closed PR head.

## Verification

- Focused Dart analysis for app and incoming URI service: no issues.
- Incoming URI service tests: 2 passed.
- iOS/macOS plist validation: passed.
- Android manifest XML validation: passed.
- Linux packaging script syntax validation: passed.

## Not run

- Platform integration builds were intentionally not run as part of the focused split validation.
- PowerShell parser validation was skipped because pwsh is not installed locally.

Depends on #552.