### PR TITLE
fix(voting): allow answers while voting power loads

### DIFF
--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -205,6 +205,11 @@ class _VotingProposalDetailViewState
               : state.eligibleWeightZatoshi,
           votingPowerPreparing: votingPowerPreparing,
           votingEligibilityConfirmed: hasConfirmedVotingEligibility,
+          // Drafting answers only writes local state, so it stays open while
+          // voting power is still being calculated. Only a resolved
+          // ineligibility (or another eligibility failure) locks the options.
+          answersEditable:
+              hasConfirmedVotingEligibility || isVotingEligibilityPending,
           votingEligibilityMessage: votingEligibilityError
               ? null
               : votingEligibilityMessage,
@@ -217,7 +222,10 @@ class _VotingProposalDetailViewState
           onChoice: draftKey == null
               ? (_, _) {}
               : (proposalId, choice) {
-                  if (!hasConfirmedVotingEligibility) return;
+                  if (!hasConfirmedVotingEligibility &&
+                      !isVotingEligibilityPending) {
+                    return;
+                  }
                   final notifier = ref.read(
                     votingDraftProvider(draftKey).notifier,
                   );
@@ -395,6 +403,7 @@ class _ActivePollContent extends StatefulWidget {
     required this.votingPowerZatoshi,
     required this.votingPowerPreparing,
     required this.votingEligibilityConfirmed,
+    required this.answersEditable,
     required this.votingEligibilityMessage,
     required this.votingEligibilityErrorMessage,
     required this.onVotingEligibilityRetry,
@@ -413,6 +422,11 @@ class _ActivePollContent extends StatefulWidget {
   final BigInt? votingPowerZatoshi;
   final bool votingPowerPreparing;
   final bool votingEligibilityConfirmed;
+
+  /// Whether the user may still pick answers. Broader than
+  /// [votingEligibilityConfirmed]: it also covers the window where voting
+  /// power is still being calculated.
+  final bool answersEditable;
   final String? votingEligibilityMessage;
   final String? votingEligibilityErrorMessage;
   final VoidCallback onVotingEligibilityRetry;
@@ -540,10 +554,10 @@ class _ActivePollContentState extends State<_ActivePollContent> {
                         widget.votingEligibilityErrorMessage != null;
                     return VotingProposalCard(
                       proposal: proposal,
-                      selectedChoice: widget.votingEligibilityConfirmed
+                      selectedChoice: widget.answersEditable
                           ? widget.draft.choices[proposal.id]
                           : null,
-                      enabled: widget.votingEligibilityConfirmed,
+                      enabled: widget.answersEditable,
                       onDisabledOptionTap: isIneligible
                           ? _showIneligibleDialog
                           : null,

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1858,6 +1858,49 @@ void main() {
     expect(find.text('Review answers'), findsOneWidget);
   });
 
+  testWidgets('proposal detail accepts answers while voting power loads', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final recoveryApi = _MutableVotingRecoveryApi();
+    final rust = _PendingVotingEligibilityRustApi(recoveryApi);
+    addTearDown(rust.completeEligible);
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: rust,
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await _pumpUntilFound(tester, find.text('Preparing voting power'));
+
+    await tester.tap(find.text('Yes'));
+    await tester.pump();
+
+    // The choice is local state, so it must land while the eligibility check
+    // is still outstanding.
+    expect(container.read(votingDraftProvider(_draftKey)).choices, {1: 0});
+    expect(find.text('Preparing voting power'), findsOneWidget);
+    expect(_reviewAnswersButton(tester).onPressed, isNull);
+
+    rust.completeEligible();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Preparing voting power'), findsNothing);
+    expect(container.read(votingDraftProvider(_draftKey)).choices, {1: 0});
+    expect(_reviewAnswersButton(tester).onPressed, isNotNull);
+  });
+
   testWidgets(
     'proposal detail shows read-only options when eligibility fails',
     (tester) async {
@@ -3430,6 +3473,15 @@ Future<void> _pumpUntilCondition(
     await tester.pump(const Duration(milliseconds: 100));
     if (condition()) return;
   }
+}
+
+AppButton _reviewAnswersButton(WidgetTester tester) {
+  return tester.widget<AppButton>(
+    find.descendant(
+      of: find.byKey(const ValueKey('voting_review_answers_button')),
+      matching: find.byType(AppButton),
+    ),
+  );
 }
 
 ProviderContainer _statusContainer({


### PR DESCRIPTION
## Summary

Opening a voting round left every question unselectable until the voting-power calculation finished.

`VotingProposalDetailView` used a single flag, `hasConfirmedVotingEligibility`, for two different decisions. That getter requires a non-null `eligibleWeightZatoshi`, so the window where `checkVotingEligibility` is still in flight was indistinguishable from a resolved ineligibility: the option rows were disabled (`InkWell.onTap` null) and the parent `onChoice` callback dropped the write. Unlike the ineligible path, the pending state has no explanatory dialog, so taps did nothing at all.

Answer drafting only writes local `votingDraftProvider` state, so it no longer waits on the weight. A new `answersEditable` condition (confirmed **or** pending eligibility) drives option enablement, selected-choice display, and the draft write.

Unchanged on purpose:

- "Review answers" and submission still require confirmed eligibility, so nobody can advance before the weight is known.
- A resolved ineligibility still disables the options and shows the "Not eligible" dialog on tap.
- The eligibility-error state still locks the options behind "Retry eligibility".

## Test plan

- [x] New widget test `proposal detail accepts answers while voting power loads` taps an option while "Preparing voting power" is on screen, asserts the draft records the choice with the review button still disabled, then completes eligibility and asserts the choice survived and review became enabled.
- [x] `fvm flutter test test/features/voting/` — 109 passing, 2 skipped, no failures.
- [x] `fvm flutter analyze` clean on both touched files.