### PR TITLE
Show vote share submission status

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -42,8 +42,9 @@ class FigmaCompareScenario {
 const figmaCompareScenarios = <FigmaCompareScenario>[
   FigmaCompareScenario(
     id: 'voting-share-status',
-    description: 'Desktop encrypted vote-share progress',
-    builder: buildVotingShareStatusUseCase,
+    description: 'Desktop completed vote with shares still submitting',
+    builder: buildDesktopVotingVotedUseCase,
+    scrollToEnd: true,
   ),
   FigmaCompareScenario(
     id: 'mobile-voting-share-in-progress',

--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -23,6 +23,7 @@ class FigmaCompareScenario {
     required this.builder,
     this.desktop = true,
     this.mobile = false,
+    this.scrollToEnd = false,
   });
 
   final String id;
@@ -30,6 +31,7 @@ class FigmaCompareScenario {
   final FigmaCompareScenarioBuilder builder;
   final bool desktop;
   final bool mobile;
+  final bool scrollToEnd;
 }
 
 /// Deterministic previews for the screens changed on the current branch.
@@ -38,6 +40,25 @@ class FigmaCompareScenario {
 /// storage, network, wallet, and Rust state. Widgetbook fixtures are preferred
 /// because they are already used to review the same UI states.
 const figmaCompareScenarios = <FigmaCompareScenario>[
+  FigmaCompareScenario(
+    id: 'voting-share-status',
+    description: 'Desktop encrypted vote-share progress',
+    builder: buildVotingShareStatusUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-voting-share-in-progress',
+    description: 'Mobile encrypted vote shares while submission is in progress',
+    builder: buildVotingShareStatusUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-voting-share-complete',
+    description: 'Mobile encrypted vote shares after submission completes',
+    builder: buildVotingShareStatusCompleteUseCase,
+    desktop: false,
+    mobile: true,
+  ),
   FigmaCompareScenario(
     id: 'donation-zec-empty',
     description: 'Desktop donation composer with an empty ZEC amount',
@@ -338,10 +359,19 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
   ),
   FigmaCompareScenario(
     id: 'mobile-voting-voted',
-    description: 'Mobile completed coinholder vote detail',
+    description: 'Mobile completed vote detail with shares still submitting',
     builder: buildMobileVotingVotedUseCase,
     desktop: false,
     mobile: true,
+    scrollToEnd: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-voting-voted-complete',
+    description: 'Mobile completed vote detail with every share submitted',
+    builder: buildMobileVotingVotedCompleteUseCase,
+    desktop: false,
+    mobile: true,
+    scrollToEnd: true,
   ),
   FigmaCompareScenario(
     id: 'mobile-voting-proposal-default',

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -15,6 +15,7 @@ import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/voting/voting_pir_warmup_provider.dart';
 import '../../../providers/voting/voting_session_provider.dart';
+import '../../../providers/voting/voting_submission_job_provider.dart';
 import '../../../providers/voting/voting_tree_sync_provider.dart';
 import '../../../providers/voting/voting_state.dart';
 import '../../../rust/third_party/zcash_voting/wire.dart' as rust_wire;
@@ -27,6 +28,7 @@ import '../voting_resume_plan.dart';
 import '../voting_routes.dart';
 import '../widgets/voting_metadata_widgets.dart';
 import '../widgets/voting_pane_scroll_area.dart';
+import '../widgets/voting_share_status_card.dart';
 
 class VotingProposalDetailScreen extends StatelessWidget {
   const VotingProposalDetailScreen({super.key, required this.roundId});
@@ -72,6 +74,9 @@ class _VotingProposalDetailViewState
   String? _votingPowerPreparationKey;
   String? _snapshotBundlePrecomputeKey;
   String? _resultsRedirectRoundId;
+  Timer? _shareStatusDeadlineTimer;
+  DateTime? _shareStatusDeadline;
+  bool _shareStatusDeadlinePassed = false;
 
   @override
   void initState() {
@@ -94,14 +99,45 @@ class _VotingProposalDetailViewState
       _votingPowerPreparationKey = null;
       _snapshotBundlePrecomputeKey = null;
       _resultsRedirectRoundId = null;
+      _clearShareStatusDeadline();
     }
+  }
+
+  @override
+  void dispose() {
+    _shareStatusDeadlineTimer?.cancel();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final roundId = widget.roundId;
-    final session = ref.watch(votingSessionProvider(roundId));
-    return session.when(
+    final roundSession = ref.watch(votingSessionProvider(roundId));
+    final roundState = roundSession.value;
+    final accountUuid = roundState?.accountUuid;
+    final round = roundState?.round;
+    final hasPersistedShares =
+        roundState?.resumePlan?.shareDelegations.isNotEmpty ?? false;
+    final shareTrackingOpen =
+        round != null && shouldTrackPendingVotingShares(round);
+    _syncShareStatusDeadline(
+      shareTrackingOpen && hasPersistedShares ? round.voteEndTime : null,
+    );
+    final hasShareStatus =
+        shareTrackingOpen && !_shareStatusDeadlinePassed && hasPersistedShares;
+    final trackedSession = accountUuid == null || !hasShareStatus
+        ? null
+        : ref.watch(
+            votingSubmissionJobSessionProvider(
+              VotingSessionKey(roundId: roundId, accountUuid: accountUuid),
+            ),
+          );
+    // The submission session owns background share tracking, but its other
+    // fields can carry an unrelated transient error. Keep the round session
+    // authoritative for this screen and project only the live share records.
+    final trackedShareDelegations =
+        trackedSession?.value?.resumePlan?.shareDelegations;
+    return roundSession.when(
       skipLoadingOnRefresh: false,
       loading: () => _stateView(const VotingPaneLoading()),
       error: (error, _) => _stateView(
@@ -168,6 +204,11 @@ class _VotingProposalDetailViewState
             votedAt: completedVote.votedAt,
             proposals: proposals,
             choicesByProposalId: completedVote.choicesByProposalId,
+            shareDelegations: hasShareStatus
+                ? trackedShareDelegations ??
+                      state.resumePlan?.shareDelegations ??
+                      const []
+                : const [],
           );
         }
         if (pendingVote != null && hasConfirmedVotingEligibility) {
@@ -254,6 +295,39 @@ class _VotingProposalDetailViewState
         );
       },
     );
+  }
+
+  void _syncShareStatusDeadline(DateTime? deadline) {
+    if (deadline == null) {
+      _clearShareStatusDeadline();
+      return;
+    }
+    if (_shareStatusDeadline == deadline) return;
+
+    _shareStatusDeadlineTimer?.cancel();
+    _shareStatusDeadline = deadline;
+    final delay = deadline.difference(DateTime.now());
+    if (delay <= Duration.zero) {
+      _shareStatusDeadlineTimer = null;
+      _shareStatusDeadlinePassed = true;
+      return;
+    }
+
+    _shareStatusDeadlinePassed = false;
+    _shareStatusDeadlineTimer = Timer(delay, () {
+      if (!mounted || _shareStatusDeadline != deadline) return;
+      _shareStatusDeadlineTimer = null;
+      setState(() {
+        _shareStatusDeadlinePassed = true;
+      });
+    });
+  }
+
+  void _clearShareStatusDeadline() {
+    _shareStatusDeadlineTimer?.cancel();
+    _shareStatusDeadlineTimer = null;
+    _shareStatusDeadline = null;
+    _shareStatusDeadlinePassed = false;
   }
 
   Widget _stateView(Widget child) {
@@ -1336,6 +1410,8 @@ class VotingVotedPollContent extends StatelessWidget {
     required this.votedAt,
     required this.proposals,
     required this.choicesByProposalId,
+    this.shareDelegations = const [],
+    this.shareStatusNow,
   });
 
   final bool showDesktopToolbar;
@@ -1348,9 +1424,15 @@ class VotingVotedPollContent extends StatelessWidget {
   final DateTime? votedAt;
   final List<VotingProposalView> proposals;
   final Map<int, int?> choicesByProposalId;
+  final List<rust_wire.ShareDelegationRecordView> shareDelegations;
+
+  /// Fixed current time for deterministic vote-share previews.
+  final DateTime? shareStatusNow;
 
   @override
   Widget build(BuildContext context) {
+    final shareStatusOffset = shareDelegations.isEmpty ? 0 : 1;
+    final itemCount = proposals.length + shareStatusOffset;
     if (kAppFormFactor == AppFormFactor.desktop) {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -1379,7 +1461,7 @@ class VotingVotedPollContent extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.md),
           Expanded(
-            child: proposals.isEmpty
+            child: itemCount == 0
                 ? const _Message(
                     title: 'No proposals',
                     message:
@@ -1393,10 +1475,16 @@ class VotingVotedPollContent extends StatelessWidget {
                       showDesktopToolbar ? AppSpacing.md : AppSpacing.sm,
                       AppSpacing.md,
                     ),
-                    itemCount: proposals.length,
+                    itemCount: itemCount,
                     separatorBuilder: (_, _) =>
                         const SizedBox(height: AppSpacing.s),
                     itemBuilder: (context, index) {
+                      if (index == proposals.length) {
+                        return VotingShareStatusCard(
+                          records: shareDelegations,
+                          now: shareStatusNow,
+                        );
+                      }
                       final proposal = proposals[index];
                       final choice = choicesByProposalId[proposal.id];
                       return VotingProposalCard(
@@ -1459,6 +1547,13 @@ class VotingVotedPollContent extends StatelessWidget {
                     if (index < proposals.length - 1)
                       const SizedBox(height: AppSpacing.md),
                   ],
+                if (shareDelegations.isNotEmpty) ...[
+                  const SizedBox(height: AppSpacing.md),
+                  VotingShareStatusCard(
+                    records: shareDelegations,
+                    now: shareStatusNow,
+                  ),
+                ],
               ],
             ),
           ),

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -68,7 +68,8 @@ class VotingProposalDetailView extends ConsumerStatefulWidget {
 }
 
 class _VotingProposalDetailViewState
-    extends ConsumerState<VotingProposalDetailView> {
+    extends ConsumerState<VotingProposalDetailView>
+    with WidgetsBindingObserver {
   bool _votingPowerPreparationStarted = false;
   bool _votingPowerPreparationInFlight = false;
   String? _votingPowerPreparationKey;
@@ -77,10 +78,16 @@ class _VotingProposalDetailViewState
   Timer? _shareStatusDeadlineTimer;
   DateTime? _shareStatusDeadline;
   bool _shareStatusDeadlinePassed = false;
+  ProviderSubscription<AsyncValue<VotingSessionState>>?
+  _visibleRoundSubscription;
+  VotingSessionKey? _visibleShareRefreshKey;
+  ModalRoute<dynamic>? _modalRoute;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _listenForVisibleShareRefresh();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       // Second entry point for the background nullifier-proof warm-up, for
@@ -99,14 +106,83 @@ class _VotingProposalDetailViewState
       _votingPowerPreparationKey = null;
       _snapshotBundlePrecomputeKey = null;
       _resultsRedirectRoundId = null;
+      _visibleShareRefreshKey = null;
+      _listenForVisibleShareRefresh();
       _clearShareStatusDeadline();
     }
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _modalRoute = ModalRoute.of(context);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    _visibleShareRefreshKey = null;
+    final session = ref.read(votingSessionProvider(widget.roundId)).value;
+    if (session != null) _maybeRefreshVisibleShareStatus(session);
+  }
+
+  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _visibleRoundSubscription?.close();
     _shareStatusDeadlineTimer?.cancel();
     super.dispose();
+  }
+
+  void _listenForVisibleShareRefresh() {
+    _visibleRoundSubscription?.close();
+    _visibleRoundSubscription = ref.listenManual(
+      votingSessionProvider(widget.roundId),
+      (_, next) => next.whenData(_maybeRefreshVisibleShareStatus),
+      fireImmediately: true,
+    );
+  }
+
+  void _maybeRefreshVisibleShareStatus(VotingSessionState session) {
+    final accountUuid = session.accountUuid;
+    final round = session.round;
+    final hasUnconfirmedShares =
+        session.resumePlan?.unconfirmedShareDelegations.isNotEmpty ?? false;
+    final lifecycleState = WidgetsBinding.instance.lifecycleState;
+    if (!mounted ||
+        (lifecycleState != null &&
+            lifecycleState != AppLifecycleState.resumed) ||
+        (_modalRoute != null && !_modalRoute!.isCurrent) ||
+        accountUuid == null ||
+        round == null ||
+        !hasUnconfirmedShares ||
+        !shouldTrackPendingVotingShares(round)) {
+      return;
+    }
+
+    final key = VotingSessionKey(
+      roundId: widget.roundId,
+      accountUuid: accountUuid,
+    );
+    if (_visibleShareRefreshKey == key) return;
+    _visibleShareRefreshKey = key;
+    unawaited(_refreshVisibleShareStatus(key));
+  }
+
+  Future<void> _refreshVisibleShareStatus(VotingSessionKey key) async {
+    try {
+      await ref.read(votingSubmissionSessionProvider(key).future);
+      if (!mounted || _visibleShareRefreshKey != key) return;
+      await ref
+          .read(votingSubmissionSessionProvider(key).notifier)
+          .runShareTrackingPassIfStale();
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[zcash] Voting: visible share status refresh failed '
+        'round=${key.roundId} account=${key.accountUuid} '
+        'error=$error\n$stackTrace',
+      );
+    }
   }
 
   @override
@@ -118,25 +194,32 @@ class _VotingProposalDetailViewState
     final round = roundState?.round;
     final hasPersistedShares =
         roundState?.resumePlan?.shareDelegations.isNotEmpty ?? false;
-    final shareTrackingOpen =
+    final hasUnconfirmedShares =
+        roundState?.resumePlan?.unconfirmedShareDelegations.isNotEmpty ?? false;
+    final cachedRoundTrackingOpen =
         round != null && shouldTrackPendingVotingShares(round);
-    _syncShareStatusDeadline(
-      shareTrackingOpen && hasPersistedShares ? round.voteEndTime : null,
-    );
-    final hasShareStatus =
-        shareTrackingOpen && !_shareStatusDeadlinePassed && hasPersistedShares;
-    final trackedSession = accountUuid == null || !hasShareStatus
+    final shouldWatchTrackedSession =
+        hasPersistedShares && (cachedRoundTrackingOpen || hasUnconfirmedShares);
+    final trackedSession = accountUuid == null || !shouldWatchTrackedSession
         ? null
         : ref.watch(
             votingSubmissionJobSessionProvider(
               VotingSessionKey(roundId: roundId, accountUuid: accountUuid),
             ),
           );
-    // The submission session owns background share tracking, but its other
-    // fields can carry an unrelated transient error. Keep the round session
-    // authoritative for this screen and project only the live share records.
-    final trackedShareDelegations =
-        trackedSession?.value?.resumePlan?.shareDelegations;
+    final trackedState = trackedSession?.value;
+    final trackedRound = trackedState?.round ?? round;
+    final shareTrackingOpen =
+        trackedRound != null && shouldTrackPendingVotingShares(trackedRound);
+    _syncShareStatusDeadline(
+      shareTrackingOpen && hasPersistedShares ? trackedRound.voteEndTime : null,
+    );
+    final hasShareStatus =
+        shareTrackingOpen && !_shareStatusDeadlinePassed && hasPersistedShares;
+    // The round session remains authoritative for the screen, while the
+    // submission session supplies live tracking metadata: share records plus
+    // the round status/deadline that controls their visibility.
+    final trackedShareDelegations = trackedState?.resumePlan?.shareDelegations;
     return roundSession.when(
       skipLoadingOnRefresh: false,
       loading: () => _stateView(const VotingPaneLoading()),

--- a/lib/src/features/voting/voting_share_status.dart
+++ b/lib/src/features/voting/voting_share_status.dart
@@ -1,0 +1,151 @@
+import '../../rust/third_party/zcash_voting/wire.dart' as rust_wire;
+
+const _shareTrackingRoundStatuses = {
+  'active',
+  'open',
+  '1',
+  'session_status_active',
+};
+
+/// Whether Vizor may still check or retry pending encrypted vote shares.
+bool isVotingShareTrackingOpen({
+  required String roundStatus,
+  required DateTime? voteEndTime,
+  required DateTime now,
+}) {
+  final status = roundStatus.trim().toLowerCase();
+  return _shareTrackingRoundStatuses.contains(status) &&
+      voteEndTime != null &&
+      now.isBefore(voteEndTime);
+}
+
+/// A compact projection of the persisted encrypted-share submission state.
+class VotingShareStatusSummary {
+  const VotingShareStatusSummary({
+    required this.totalCount,
+    required this.confirmedCount,
+    required this.latestPendingDueAtSeconds,
+    required this.usesStaggeredSubmission,
+  });
+
+  /// Builds a summary without inventing state beyond the records persisted by
+  /// `zcash_voting`.
+  factory VotingShareStatusSummary.fromRecords(
+    Iterable<rust_wire.ShareDelegationRecordView> records,
+  ) {
+    var totalCount = 0;
+    var confirmedCount = 0;
+    BigInt? latestPendingDueAtSeconds;
+    var usesStaggeredSubmission = false;
+    final submitTimesByVote =
+        <({int bundleIndex, int proposalId}), Map<int, BigInt>>{};
+
+    for (final record in records) {
+      totalCount++;
+      final dueAt = record.submitAt > BigInt.zero
+          ? record.submitAt
+          : record.createdAt;
+      final voteKey = (
+        bundleIndex: record.bundleIndex,
+        proposalId: record.proposalId,
+      );
+      final submitTimes = submitTimesByVote.putIfAbsent(voteKey, () => {});
+      if (!usesStaggeredSubmission &&
+          submitTimes.entries.any(
+            (entry) =>
+                entry.key != record.shareIndex &&
+                entry.value != record.submitAt,
+          )) {
+        usesStaggeredSubmission = true;
+      }
+      submitTimes[record.shareIndex] = record.submitAt;
+
+      if (record.confirmed) {
+        confirmedCount++;
+      } else if (latestPendingDueAtSeconds == null ||
+          dueAt > latestPendingDueAtSeconds) {
+        latestPendingDueAtSeconds = dueAt;
+      }
+    }
+
+    return VotingShareStatusSummary(
+      totalCount: totalCount,
+      confirmedCount: confirmedCount,
+      latestPendingDueAtSeconds: latestPendingDueAtSeconds,
+      usesStaggeredSubmission: usesStaggeredSubmission,
+    );
+  }
+
+  final int totalCount;
+  final int confirmedCount;
+
+  /// Latest effective due time among shares that are not yet confirmed.
+  ///
+  /// Delayed shares use `submitAt`; immediate shares use `createdAt`.
+  final BigInt? latestPendingDueAtSeconds;
+
+  /// Whether at least one vote was split across planned submission times.
+  ///
+  /// Immediate shares all use `submitAt == 0`; their persistence timestamps do
+  /// not imply staggering.
+  final bool usesStaggeredSubmission;
+
+  int get pendingCount => totalCount - confirmedCount;
+
+  bool get allConfirmed => totalCount > 0 && pendingCount == 0;
+
+  double get confirmedFraction =>
+      totalCount == 0 ? 0 : (confirmedCount / totalCount).clamp(0.0, 1.0);
+}
+
+/// Formats the expected completion time from the last pending share due time.
+///
+/// The estimate intentionally uses only whole minutes, hours, or days. A due
+/// time that has already passed is awaiting submission or confirmation, so it
+/// is described as completing soon instead of showing a misleading zero
+/// duration.
+String? votingShareCompletionEstimateText(
+  VotingShareStatusSummary summary, {
+  required DateTime now,
+}) {
+  final latestDueAt = summary.latestPendingDueAtSeconds;
+  if (latestDueAt == null) return null;
+
+  final nowSeconds = BigInt.from(
+    now.toUtc().millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond,
+  );
+  final remainingSeconds = latestDueAt - nowSeconds;
+  if (remainingSeconds <= BigInt.zero) return 'Completing soon';
+
+  final minutes = _roundedDurationUnits(
+    remainingSeconds,
+    Duration.secondsPerMinute,
+  );
+  if (minutes < BigInt.from(Duration.minutesPerHour)) {
+    return 'Complete in about ${_durationUnit(minutes, 'minute')}';
+  }
+
+  final hours = _roundedDurationUnits(
+    remainingSeconds,
+    Duration.secondsPerMinute * Duration.minutesPerHour,
+  );
+  if (hours < BigInt.from(Duration.hoursPerDay)) {
+    return 'Complete in about ${_durationUnit(hours, 'hour')}';
+  }
+
+  final days = _roundedDurationUnits(
+    remainingSeconds,
+    Duration.secondsPerMinute * Duration.minutesPerHour * Duration.hoursPerDay,
+  );
+  return 'Complete in about ${_durationUnit(days, 'day')}';
+}
+
+BigInt _roundedDurationUnits(BigInt seconds, int unitSeconds) {
+  final unit = BigInt.from(unitSeconds);
+  final rounded = (seconds + BigInt.from(unitSeconds ~/ 2)) ~/ unit;
+  return rounded < BigInt.one ? BigInt.one : rounded;
+}
+
+String _durationUnit(BigInt count, String singular) {
+  return '$count $singular${count == BigInt.one ? '' : 's'}';
+}

--- a/lib/src/features/voting/widgets/voting_share_status_card.dart
+++ b/lib/src/features/voting/widgets/voting_share_status_card.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../rust/third_party/zcash_voting/wire.dart' as rust_wire;
+import '../voting_share_status.dart';
+
+const _staggeredSharePrivacyExplanation =
+    'To protect your privacy, Vizor splits your encrypted vote into shares '
+    'that are submitted at different times, making them harder to link.';
+const _shareSubmissionContinuesExplanation =
+    'You can close Vizor at any time while these servers submit your shares '
+    'for you.';
+
+/// High-level status for encrypted vote shares.
+///
+/// The records are the durable `zcash_voting` recovery records. They contain
+/// real delegated shares only, so dummy zero-value shares are not displayed.
+class VotingShareStatusCard extends StatefulWidget {
+  const VotingShareStatusCard({required this.records, this.now, super.key});
+
+  final List<rust_wire.ShareDelegationRecordView> records;
+
+  /// Fixed current time for deterministic previews and tests.
+  final DateTime? now;
+
+  @override
+  State<VotingShareStatusCard> createState() => _VotingShareStatusCardState();
+}
+
+class _VotingShareStatusCardState extends State<VotingShareStatusCard> {
+  static const _estimateRefreshInterval = Duration(minutes: 1);
+
+  Timer? _estimateRefreshTimer;
+  late DateTime _estimateNow;
+
+  @override
+  void initState() {
+    super.initState();
+    _estimateNow = widget.now ?? DateTime.now();
+    _syncEstimateRefreshTimer();
+  }
+
+  @override
+  void didUpdateWidget(covariant VotingShareStatusCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.now != null) {
+      _estimateNow = widget.now!;
+    } else {
+      final wallClockNow = DateTime.now();
+      if (wallClockNow.isAfter(_estimateNow)) {
+        _estimateNow = wallClockNow;
+      }
+    }
+    _syncEstimateRefreshTimer();
+  }
+
+  @override
+  void dispose() {
+    _estimateRefreshTimer?.cancel();
+    super.dispose();
+  }
+
+  void _syncEstimateRefreshTimer() {
+    _estimateRefreshTimer?.cancel();
+    _estimateRefreshTimer = null;
+    if (widget.now != null || widget.records.isEmpty) return;
+
+    final summary = VotingShareStatusSummary.fromRecords(widget.records);
+    final latestDueAt = summary.latestPendingDueAtSeconds;
+    if (summary.allConfirmed || latestDueAt == null) return;
+
+    final nowSeconds = BigInt.from(
+      _estimateNow.toUtc().millisecondsSinceEpoch ~/
+          Duration.millisecondsPerSecond,
+    );
+    final remainingSeconds = latestDueAt - nowSeconds;
+    if (remainingSeconds <= BigInt.zero) return;
+
+    final refreshSeconds =
+        remainingSeconds < BigInt.from(_estimateRefreshInterval.inSeconds)
+        ? remainingSeconds.toInt()
+        : _estimateRefreshInterval.inSeconds;
+    final delay = Duration(seconds: refreshSeconds);
+    final scheduledFor = _estimateNow.add(delay);
+    _estimateRefreshTimer = Timer(delay, () {
+      if (!mounted) return;
+      final wallClockNow = DateTime.now();
+      setState(() {
+        _estimateNow = wallClockNow.isAfter(scheduledFor)
+            ? wallClockNow
+            : scheduledFor;
+      });
+      _syncEstimateRefreshTimer();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.records.isEmpty) return const SizedBox.shrink();
+
+    final colors = context.colors;
+    final summary = VotingShareStatusSummary.fromRecords(widget.records);
+    final roundedPercent = (summary.confirmedFraction * 100).round();
+    final percent = summary.allConfirmed ? 100 : roundedPercent.clamp(0, 99);
+    final noun = summary.totalCount == 1 ? 'share' : 'shares';
+    const title = 'Submission status';
+    final countText =
+        '${summary.confirmedCount} of ${summary.totalCount} $noun submitted';
+    final showProgress = !summary.allConfirmed;
+    final completionEstimate = showProgress
+        ? votingShareCompletionEstimateText(summary, now: _estimateNow)
+        : null;
+    final privacyExplanation = summary.usesStaggeredSubmission
+        ? _staggeredSharePrivacyExplanation
+        : summary.totalCount == 1
+        ? 'Your encrypted vote is submitted as one encrypted share.'
+        : 'Your encrypted vote is submitted as encrypted shares.';
+    final explanation = showProgress
+        ? '$privacyExplanation $_shareSubmissionContinuesExplanation'
+        : privacyExplanation;
+    final statusIcon = summary.allConfirmed ? AppIcons.checkCircle : null;
+    final percentDescription = showProgress
+        ? '$percent percent complete'
+        : null;
+
+    return Semantics(
+      container: true,
+      label: [
+        title,
+        countText,
+        ?percentDescription,
+        ?completionEstimate,
+        explanation,
+      ].join('. '),
+      excludeSemantics: true,
+      child: Container(
+        key: const ValueKey('voting_share_status_card'),
+        padding: const EdgeInsets.all(AppSpacing.sm),
+        decoration: BoxDecoration(
+          color: colors.background.raised.withValues(alpha: 0.78),
+          borderRadius: BorderRadius.circular(AppRadii.medium),
+          border: Border.all(color: colors.border.subtle),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    title,
+                    style: AppTypography.bodyMediumStrong.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.s),
+                if (statusIcon != null)
+                  AppIcon(
+                    statusIcon,
+                    key: const ValueKey('voting_share_status_complete_icon'),
+                    size: 20,
+                    color: colors.icon.success,
+                  )
+                else
+                  Text(
+                    '$percent%',
+                    key: const ValueKey('voting_share_status_percent'),
+                    style: AppTypography.bodyMediumStrong.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xxs),
+            Text(
+              countText,
+              key: const ValueKey('voting_share_status_count'),
+              style: AppTypography.bodyMedium.copyWith(
+                color: colors.text.primary,
+              ),
+            ),
+            if (completionEstimate != null) ...[
+              const SizedBox(height: AppSpacing.xxs),
+              Text(
+                completionEstimate,
+                key: const ValueKey('voting_share_status_completion_estimate'),
+                style: AppTypography.bodyMediumStrong.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+            ],
+            if (showProgress) ...[
+              const SizedBox(height: AppSpacing.s),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(AppRadii.full),
+                child: LinearProgressIndicator(
+                  key: const ValueKey('voting_share_status_progress'),
+                  minHeight: 4,
+                  value: summary.confirmedFraction,
+                  color: colors.icon.brandCrimson,
+                  backgroundColor: colors.background.neutralSubtleOpacity,
+                ),
+              ),
+            ],
+            const SizedBox(height: AppSpacing.s),
+            Text(
+              explanation,
+              style: AppTypography.bodySmall.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -64,6 +64,21 @@ final votingShareTrackingFailureRetryDelayProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 15);
 });
 
+/// Coalesces user-visible and lifecycle restore triggers that arrive just
+/// after the same session completed a successful full tracking pass.
+/// Scheduled boundary and retry passes bypass this freshness window.
+final votingShareTrackingTriggerFreshnessProvider = Provider<Duration>((ref) {
+  return const Duration(seconds: 5);
+});
+
+/// Lightweight round-status heartbeat while the next share boundary is far
+/// away. This does not open the voting database or contact helper servers.
+final votingShareTrackingRoundRefreshIntervalProvider = Provider<Duration>((
+  ref,
+) {
+  return const Duration(minutes: 5);
+});
+
 /// Timeout for PIR `/root` probe requests.
 final votingPirProbeTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 10);

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -10,6 +10,7 @@ import '../../features/voting/voting_error_messages.dart';
 import '../../features/voting/voting_flow_models.dart';
 import '../../features/voting/voting_formatters.dart';
 import '../../features/voting/voting_resume_plan.dart';
+import '../../features/voting/voting_share_status.dart';
 import '../../rust/api/voting.dart' as rust_api;
 import '../../rust/third_party/zcash_voting/config.dart' as rust_config;
 import '../../rust/third_party/zcash_voting/delegate.dart' as rust_delegate;
@@ -59,17 +60,11 @@ const _shareTrackingCancellationPollInterval = Duration(milliseconds: 250);
 
 /// Whether an authenticated round is still safe for automatic share recovery.
 bool shouldTrackPendingVotingShares(VotingRoundDetails round, {DateTime? now}) {
-  final status = round.status.trim().toLowerCase();
-  if (!const {
-    'active',
-    'open',
-    '1',
-    'session_status_active',
-  }.contains(status)) {
-    return false;
-  }
-  final voteEnd = round.voteEndTime;
-  return voteEnd != null && (now ?? DateTime.now()).isBefore(voteEnd);
+  return isVotingShareTrackingOpen(
+    roundStatus: round.status,
+    voteEndTime: round.voteEndTime,
+    now: now ?? DateTime.now(),
+  );
 }
 
 /// Orchestrates one round's voting lifecycle for the UI.
@@ -3031,7 +3026,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       if (_isDisposed || !ref.mounted) return;
       final context = await _loadContext(_roundId);
       if (_shareTrackingCancelled(context)) {
-        _releaseAutomaticShareTrackingIfRoundExpired(context);
+        _releaseAutomaticShareTrackingIfRoundClosed(context);
         return;
       }
       _currentContext = context;
@@ -3106,7 +3101,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       }
 
       if (report.cancelled || _shareTrackingCancelled(context)) {
-        _releaseAutomaticShareTrackingIfRoundExpired(context);
+        _releaseAutomaticShareTrackingIfRoundClosed(context);
         return;
       }
       final refreshedPlan = await _loadResumePlan(context);
@@ -3293,10 +3288,13 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         !shouldTrackPendingVotingShares(context.round);
   }
 
-  void _releaseAutomaticShareTrackingIfRoundExpired(
+  void _releaseAutomaticShareTrackingIfRoundClosed(
     _VotingSessionContext context,
   ) {
     if (!shouldTrackPendingVotingShares(context.round)) {
+      if (_ownsAutomaticShareTracking && !_isDisposed && ref.mounted) {
+        ref.invalidate(votingSessionProvider(_roundId));
+      }
       _releaseAutomaticShareTracking();
     }
   }

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -3265,8 +3265,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
 
   Future<void> _scheduleShareTracking(
     _VotingSessionContext context,
-    VotingResumePlan plan,
-  ) async {
+    VotingResumePlan plan, {
+    DateTime? preservedFullPassAt,
+  }) async {
     if (!_ownsAutomaticShareTracking) {
       _shareTrackingTimer?.cancel();
       _shareTrackingTimer = null;
@@ -3292,39 +3293,54 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     // left to track.
     final scheduledContext = context.withResumePlan(plan);
 
-    final delaySeconds = await ref
-        .read(votingRustApiProvider)
-        .nextShareTrackingDelaySeconds(
-          shares: plan.unconfirmedShareDelegations,
-          nowSeconds: BigInt.from(
-            DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000,
-          ),
-        );
-    if (!_isCurrentContext(context) ||
-        scheduleEpoch != _shareTrackingScheduleEpoch) {
-      return;
-    }
-    if (delaySeconds == null) {
-      _releaseAutomaticShareTracking();
-      return;
+    // A status heartbeat is only an earlier observation point. Keep the
+    // protocol wake as an absolute instant so a slow/failed status request
+    // cannot restart its countdown and postpone helper/DB work.
+    final DateTime fullPassAt;
+    if (preservedFullPassAt != null) {
+      fullPassAt = preservedFullPassAt;
+    } else {
+      final delayCalculatedAt = DateTime.now();
+      final delaySeconds = await ref
+          .read(votingRustApiProvider)
+          .nextShareTrackingDelaySeconds(
+            shares: plan.unconfirmedShareDelegations,
+            nowSeconds: BigInt.from(
+              delayCalculatedAt.toUtc().millisecondsSinceEpoch ~/ 1000,
+            ),
+          );
+      if (!_isCurrentContext(context) ||
+          scheduleEpoch != _shareTrackingScheduleEpoch) {
+        return;
+      }
+      if (delaySeconds == null) {
+        _releaseAutomaticShareTracking();
+        return;
+      }
+      fullPassAt = delayCalculatedAt.add(
+        Duration(seconds: delaySeconds.toInt()),
+      );
     }
     // The status-only wake reads [_currentContext]. Publish the exact plan
     // used for this schedule so its next rearm cannot fall back to the plan
     // that existed before the preceding full pass completed.
     _currentContext = scheduledContext;
-    final remaining = scheduledContext.round.voteEndTime!.difference(
-      DateTime.now(),
-    );
+    final now = DateTime.now();
+    final remaining = scheduledContext.round.voteEndTime!.difference(now);
     if (remaining <= Duration.zero) {
       _armShareTrackingTimer(
         scheduledContext,
         Duration.zero,
         scheduleEpoch,
         _ShareTrackingWake.roundStatus,
+        fullPassAt,
       );
       return;
     }
-    final protocolDelay = Duration(seconds: delaySeconds.toInt());
+    final untilFullPass = fullPassAt.difference(now);
+    final protocolDelay = untilFullPass.isNegative
+        ? Duration.zero
+        : untilFullPass;
     var delay = protocolDelay;
     var wake = _ShareTrackingWake.fullPass;
     if (remaining <= delay) {
@@ -3338,7 +3354,13 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       delay = roundRefreshInterval;
       wake = _ShareTrackingWake.roundStatus;
     }
-    _armShareTrackingTimer(scheduledContext, delay, scheduleEpoch, wake);
+    _armShareTrackingTimer(
+      scheduledContext,
+      delay,
+      scheduleEpoch,
+      wake,
+      fullPassAt,
+    );
   }
 
   void _scheduleShareTrackingFailureRetry() {
@@ -3367,7 +3389,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     );
     final delay = configuredDelay.isNegative ? Duration.zero : configuredDelay;
     final scheduleEpoch = _cancelShareTrackingSchedule();
-    final remaining = context.round.voteEndTime!.difference(DateTime.now());
+    final now = DateTime.now();
+    final fullPassAt = now.add(delay);
+    final remaining = context.round.voteEndTime!.difference(now);
     final crossesCachedDeadline =
         remaining > Duration.zero && remaining <= delay;
     final wake = remaining <= Duration.zero || crossesCachedDeadline
@@ -3378,6 +3402,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       crossesCachedDeadline ? remaining : delay,
       scheduleEpoch,
       wake,
+      fullPassAt,
     );
   }
 
@@ -3393,6 +3418,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     Duration delay,
     int scheduleEpoch,
     _ShareTrackingWake wake,
+    DateTime fullPassAt,
   ) {
     if (scheduleEpoch != _shareTrackingScheduleEpoch) return;
     _shareTrackingTimer = Timer(delay, () {
@@ -3404,12 +3430,15 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       if (wake == _ShareTrackingWake.fullPass) {
         unawaited(_runShareTrackingPassInBackground());
       } else {
-        unawaited(_runShareTrackingRoundStatusRefreshInBackground());
+        unawaited(_runShareTrackingRoundStatusRefreshInBackground(fullPassAt));
       }
     });
   }
 
-  void _scheduleShareTrackingRoundStatusRetry(_VotingSessionContext context) {
+  void _scheduleShareTrackingRoundStatusRetry(
+    _VotingSessionContext context,
+    DateTime fullPassAt,
+  ) {
     if (_automaticShareTrackingStopped ||
         _shareTrackingRoundClosed ||
         _isDisposed ||
@@ -3423,17 +3452,35 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     final configuredDelay = ref.read(
       votingShareTrackingFailureRetryDelayProvider,
     );
-    final delay = configuredDelay.isNegative ? Duration.zero : configuredDelay;
+    final retryDelay = configuredDelay.isNegative
+        ? Duration.zero
+        : configuredDelay;
+    final now = DateTime.now();
+    final untilVoteEnd = context.round.voteEndTime!.difference(now);
+    final rawUntilFullPass = fullPassAt.difference(now);
+    final untilFullPass = rawUntilFullPass.isNegative
+        ? Duration.zero
+        : rawUntilFullPass;
+    var delay = retryDelay;
+    var wake = _ShareTrackingWake.roundStatus;
+    // Preserve the cached deadline as the hard round-status boundary, while
+    // allowing the already-planned full pass to win before that boundary.
+    if (untilVoteEnd > Duration.zero && untilVoteEnd < delay) {
+      delay = untilVoteEnd;
+    }
+    if (untilVoteEnd > Duration.zero &&
+        untilFullPass < untilVoteEnd &&
+        untilFullPass <= delay) {
+      delay = untilFullPass;
+      wake = _ShareTrackingWake.fullPass;
+    }
     final retryEpoch = _cancelShareTrackingSchedule();
-    _armShareTrackingTimer(
-      context,
-      delay,
-      retryEpoch,
-      _ShareTrackingWake.roundStatus,
-    );
+    _armShareTrackingTimer(context, delay, retryEpoch, wake, fullPassAt);
   }
 
-  Future<void> _runShareTrackingRoundStatusRefreshInBackground() async {
+  Future<void> _runShareTrackingRoundStatusRefreshInBackground(
+    DateTime fullPassAt,
+  ) async {
     await _enqueueShareTracking(() async {
       _cancelShareTrackingSchedule();
       final context = _currentContext;
@@ -3472,13 +3519,14 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         await _scheduleShareTracking(
           refreshedContext,
           refreshedContext.resumePlan,
+          preservedFullPassAt: fullPassAt,
         );
       } catch (error, stackTrace) {
         debugPrint(
           '[zcash] Voting: share tracking round refresh failed '
           'round=${context.round.roundId} error=$error\n$stackTrace',
         );
-        _scheduleShareTrackingRoundStatusRetry(context);
+        _scheduleShareTrackingRoundStatusRetry(context, fullPassAt);
       }
     });
   }

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -81,6 +81,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   bool _retainAutomaticShareTracking() => true;
 
   void _releaseAutomaticShareTracking() {
+    _cancelShareTrackingSchedule();
     _disposeHelperDeliveryContext();
   }
 
@@ -98,11 +99,14 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   final Set<String> _completedSnapshotBundlePrecomputes = {};
   final Map<String, Future<List<int>>> _hotkeyEnsures = {};
   Timer? _shareTrackingTimer;
+  int _shareTrackingScheduleEpoch = 0;
   Future<void>? _activeAutomaticShareTrackingPass;
   final Set<Future<void>> _activeShareTrackingPasses = {};
   VotingHelperDeliveryContext? _helperDeliveryContext;
   final Set<VotingShareTrackingPassHandle> _activeShareTrackingPassHandles = {};
+  final Set<String> _unrecoverableShareGenerations = {};
   bool _automaticShareTrackingStopped = false;
+  bool _shareTrackingRoundClosed = false;
   String? _sessionAccountUuid;
   bool? _sessionIsHardwareAccount;
   _VotingSessionContext? _currentContext;
@@ -2883,7 +2887,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   }
 
   Future<void> runShareTrackingPass() {
-    if (_automaticShareTrackingStopped) return Future.value();
+    if (_automaticShareTrackingStopped || _shareTrackingRoundClosed) {
+      return Future.value();
+    }
     final inFlight = _activeAutomaticShareTrackingPass;
     if (inFlight != null) return inFlight;
     if (_ownsAutomaticShareTracking && !_retainAutomaticShareTracking()) {
@@ -2900,6 +2906,36 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     _activeAutomaticShareTrackingPass = pass;
     _activeShareTrackingPasses.add(pass);
     return pass;
+  }
+
+  /// Runs an externally triggered pass unless this session just completed one.
+  ///
+  /// App-resume restoration and a visible proposal screen can independently
+  /// request the same refresh. In-flight work is already shared by
+  /// [runShareTrackingPass]; this also coalesces callers that arrive just after
+  /// that work settles. Timers and submission recovery continue to call
+  /// [runShareTrackingPass] directly so protocol deadlines are never delayed.
+  Future<void> runShareTrackingPassIfStale() {
+    if (_automaticShareTrackingStopped || _shareTrackingRoundClosed) {
+      return Future.value();
+    }
+    final inFlight = _activeAutomaticShareTrackingPass;
+    if (inFlight != null) return inFlight;
+
+    final context = _currentContext;
+    if (context != null) {
+      final key = VotingSessionKey(
+        accountUuid: context.accountUuid,
+        roundId: context.round.roundId,
+      );
+      final freshness = ref.read(votingShareTrackingTriggerFreshnessProvider);
+      if (ref
+          .read(votingShareTrackingRegistryProvider)
+          .hasFreshSuccessfulPass(key, freshness: freshness)) {
+        return Future.value();
+      }
+    }
+    return runShareTrackingPass();
   }
 
   /// Reconciles the designated immediate share without reopening recovery.
@@ -3019,8 +3055,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
 
   Future<void> _runShareTrackingPass() {
     return _enqueueShareTracking(() async {
-      _shareTrackingTimer?.cancel();
-      _shareTrackingTimer = null;
+      _cancelShareTrackingSchedule();
       if (_automaticShareTrackingStopped) return;
       final current = await future;
       if (_isDisposed || !ref.mounted) return;
@@ -3030,8 +3065,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         return;
       }
       _currentContext = context;
-      var plan = await _loadResumePlan(context);
-      var roundPlan = await _loadRoundPlan(context);
+      var plan = context.resumePlan;
+      var roundPlan = context.roundPlan;
       if (ref.read(appSecurityProvider).requiresUnlock ||
           !shouldTrackPendingVotingShares(context.round)) {
         _setStateForContext(
@@ -3077,25 +3112,81 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           context,
           passHandle,
         );
-        report = await rust.trackPendingShares(
-          passHandle: passHandle,
-          configuredHelperUrls: configuredHelperUrls,
-          nowSeconds: BigInt.from(nowSeconds),
-          voteEndTimeSeconds: voteEndSeconds == null
-              ? null
-              : BigInt.from(voteEndSeconds),
-        );
+        final unconfirmedShares = plan.unconfirmedShareDelegations;
+        final confirmationOnly =
+            unconfirmedShares.isNotEmpty &&
+            unconfirmedShares.every(
+              (share) => _unrecoverableShareGenerations.contains(
+                _shareGenerationKey(share),
+              ),
+            );
+        if (confirmationOnly) {
+          final confirmed = <rust_api.ApiShareKey>[];
+          var cancelled = false;
+          for (final share in unconfirmedShares) {
+            if (_shareTrackingCancelled(context)) {
+              cancelled = true;
+              break;
+            }
+            final didConfirm = await rust.confirmShareWithHelpers(
+              passHandle: passHandle,
+              configuredHelperUrls: configuredHelperUrls,
+              bundleIndex: share.bundleIndex,
+              proposalId: share.proposalId,
+              shareIndex: share.shareIndex,
+              nowSeconds: BigInt.from(nowSeconds),
+            );
+            if (didConfirm) {
+              confirmed.add(
+                rust_api.ApiShareKey(
+                  bundleIndex: share.bundleIndex,
+                  proposalId: share.proposalId,
+                  shareIndex: share.shareIndex,
+                ),
+              );
+            }
+          }
+          report = rust_api.ApiShareTrackingReport(
+            confirmed: confirmed,
+            resubmitted: const [],
+            ambiguous: const [],
+            unrecoverable: const [],
+            cancelled: cancelled,
+            nextDelaySeconds: null,
+          );
+        } else {
+          report = await rust.trackPendingShares(
+            passHandle: passHandle,
+            configuredHelperUrls: configuredHelperUrls,
+            nowSeconds: BigInt.from(nowSeconds),
+            voteEndTimeSeconds: voteEndSeconds == null
+                ? null
+                : BigInt.from(voteEndSeconds),
+          );
+        }
       } finally {
         cancellationWatchdog?.cancel();
         _activeShareTrackingPassHandles.remove(passHandle);
         passHandle.dispose();
       }
 
-      if (report.unrecoverable.isNotEmpty) {
-        // These cannot be repaired by retrying; log once per pass rather than
-        // spinning on them silently.
+      final newlyUnrecoverable = report.unrecoverable.where((key) {
+        for (final share in plan.unconfirmedShareDelegations) {
+          if (share.bundleIndex == key.bundleIndex &&
+              share.proposalId == key.proposalId &&
+              share.shareIndex == key.shareIndex) {
+            return _unrecoverableShareGenerations.add(
+              _shareGenerationKey(share),
+            );
+          }
+        }
+        return false;
+      }).length;
+      if (newlyUnrecoverable > 0) {
+        // These cannot be repaired by retrying. Log each durable share
+        // generation once, then use confirmation-only checks on later passes.
         debugPrint(
-          '[zcash] Voting: ${report.unrecoverable.length} share(s) missing '
+          '[zcash] Voting: $newlyUnrecoverable share(s) missing '
           'recovery material round=${context.round.roundId}',
         );
       }
@@ -3106,6 +3197,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       }
       final refreshedPlan = await _loadResumePlan(context);
       final refreshedRoundPlan = await _loadRoundPlan(context);
+      final liveShareGenerations = refreshedPlan.unconfirmedShareDelegations
+          .map(_shareGenerationKey)
+          .toSet();
+      _unrecoverableShareGenerations.retainAll(liveShareGenerations);
       final hasBlockingWork = hasBlockingRoundRecoveryWork(refreshedRoundPlan);
       if (!hasBlockingWork) {
         await _clearPersistedDraftChoices(context);
@@ -3119,7 +3214,23 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         ),
       );
       await _scheduleShareTracking(context, refreshedPlan);
+      ref
+          .read(votingShareTrackingRegistryProvider)
+          .recordSuccessfulPass(
+            VotingSessionKey(
+              accountUuid: context.accountUuid,
+              roundId: context.round.roundId,
+            ),
+          );
     });
+  }
+
+  static String _shareGenerationKey(rust_wire.ShareDelegationRecordView share) {
+    final nullifier = share.nullifier
+        .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
+        .join();
+    return '${share.bundleIndex}:${share.proposalId}:${share.shareIndex}:'
+        '$nullifier';
   }
 
   Future<void> stopAndDrainShareTracking() async {
@@ -3163,6 +3274,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       return;
     }
     if (_automaticShareTrackingStopped ||
+        _shareTrackingRoundClosed ||
         plan.unconfirmedShareDelegations.isEmpty ||
         !shouldTrackPendingVotingShares(context.round) ||
         ref.read(appSecurityProvider).requiresUnlock) {
@@ -3173,8 +3285,12 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     }
     if (!_isCurrentContext(context)) return;
     if (!_retainAutomaticShareTracking()) return;
-    _shareTrackingTimer?.cancel();
-    _shareTrackingTimer = null;
+    final scheduleEpoch = _cancelShareTrackingSchedule();
+    // The timer may outlive the action that loaded [context]. Capture the
+    // exact plan used for this schedule so a later round-deadline refresh does
+    // not fall back to an older snapshot and conclude that there are no shares
+    // left to track.
+    final scheduledContext = context.withResumePlan(plan);
 
     final delaySeconds = await ref
         .read(votingRustApiProvider)
@@ -3184,19 +3300,52 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000,
           ),
         );
+    if (!_isCurrentContext(context) ||
+        scheduleEpoch != _shareTrackingScheduleEpoch) {
+      return;
+    }
     if (delaySeconds == null) {
       _releaseAutomaticShareTracking();
       return;
     }
-    if (!_isCurrentContext(context)) return;
-    final delay = Duration(seconds: delaySeconds.toInt());
-    _armShareTrackingTimer(context, _delayCappedAtVoteEnd(context, delay));
+    // The status-only wake reads [_currentContext]. Publish the exact plan
+    // used for this schedule so its next rearm cannot fall back to the plan
+    // that existed before the preceding full pass completed.
+    _currentContext = scheduledContext;
+    final remaining = scheduledContext.round.voteEndTime!.difference(
+      DateTime.now(),
+    );
+    if (remaining <= Duration.zero) {
+      _armShareTrackingTimer(
+        scheduledContext,
+        Duration.zero,
+        scheduleEpoch,
+        _ShareTrackingWake.roundStatus,
+      );
+      return;
+    }
+    final protocolDelay = Duration(seconds: delaySeconds.toInt());
+    var delay = protocolDelay;
+    var wake = _ShareTrackingWake.fullPass;
+    if (remaining <= delay) {
+      delay = remaining;
+      wake = _ShareTrackingWake.roundStatus;
+    }
+    final roundRefreshInterval = ref.read(
+      votingShareTrackingRoundRefreshIntervalProvider,
+    );
+    if (roundRefreshInterval > Duration.zero && roundRefreshInterval < delay) {
+      delay = roundRefreshInterval;
+      wake = _ShareTrackingWake.roundStatus;
+    }
+    _armShareTrackingTimer(scheduledContext, delay, scheduleEpoch, wake);
   }
 
   void _scheduleShareTrackingFailureRetry() {
     if (_isDisposed ||
         !_ownsAutomaticShareTracking ||
         _automaticShareTrackingStopped ||
+        _shareTrackingRoundClosed ||
         ref.read(appSecurityProvider).requiresUnlock) {
       _releaseAutomaticShareTracking();
       return;
@@ -3209,7 +3358,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     final context = _currentContext;
     if (context == null ||
         !_isCurrentContext(context) ||
-        !shouldTrackPendingVotingShares(context.round) ||
         !_retainAutomaticShareTracking()) {
       _releaseAutomaticShareTracking();
       return;
@@ -3218,28 +3366,120 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       votingShareTrackingFailureRetryDelayProvider,
     );
     final delay = configuredDelay.isNegative ? Duration.zero : configuredDelay;
-    _armShareTrackingTimer(context, _delayCappedAtVoteEnd(context, delay));
+    final scheduleEpoch = _cancelShareTrackingSchedule();
+    final remaining = context.round.voteEndTime!.difference(DateTime.now());
+    final crossesCachedDeadline =
+        remaining > Duration.zero && remaining <= delay;
+    final wake = remaining <= Duration.zero || crossesCachedDeadline
+        ? _ShareTrackingWake.roundStatus
+        : _ShareTrackingWake.fullPass;
+    _armShareTrackingTimer(
+      context,
+      crossesCachedDeadline ? remaining : delay,
+      scheduleEpoch,
+      wake,
+    );
   }
 
-  Duration _delayCappedAtVoteEnd(
+  int _cancelShareTrackingSchedule() {
+    final scheduleEpoch = ++_shareTrackingScheduleEpoch;
+    _shareTrackingTimer?.cancel();
+    _shareTrackingTimer = null;
+    return scheduleEpoch;
+  }
+
+  void _armShareTrackingTimer(
     _VotingSessionContext context,
     Duration delay,
+    int scheduleEpoch,
+    _ShareTrackingWake wake,
   ) {
-    final remaining = context.round.voteEndTime!.difference(DateTime.now());
-    if (remaining.isNegative) return Duration.zero;
-    return delay < remaining ? delay : remaining;
-  }
-
-  void _armShareTrackingTimer(_VotingSessionContext context, Duration delay) {
-    _shareTrackingTimer?.cancel();
+    if (scheduleEpoch != _shareTrackingScheduleEpoch) return;
     _shareTrackingTimer = Timer(delay, () {
       _shareTrackingTimer = null;
-      if (!_isCurrentContext(context)) return;
-      if (!shouldTrackPendingVotingShares(context.round)) {
-        _releaseAutomaticShareTracking();
+      if (scheduleEpoch != _shareTrackingScheduleEpoch ||
+          !_isCurrentContext(context)) {
         return;
       }
-      unawaited(_runShareTrackingPassInBackground());
+      if (wake == _ShareTrackingWake.fullPass) {
+        unawaited(_runShareTrackingPassInBackground());
+      } else {
+        unawaited(_runShareTrackingRoundStatusRefreshInBackground());
+      }
+    });
+  }
+
+  void _scheduleShareTrackingRoundStatusRetry(_VotingSessionContext context) {
+    if (_automaticShareTrackingStopped ||
+        _shareTrackingRoundClosed ||
+        _isDisposed ||
+        !ref.mounted ||
+        !_isCurrentContext(context) ||
+        ref.read(appSecurityProvider).requiresUnlock ||
+        !_retainAutomaticShareTracking()) {
+      _releaseAutomaticShareTracking();
+      return;
+    }
+    final configuredDelay = ref.read(
+      votingShareTrackingFailureRetryDelayProvider,
+    );
+    final delay = configuredDelay.isNegative ? Duration.zero : configuredDelay;
+    final retryEpoch = _cancelShareTrackingSchedule();
+    _armShareTrackingTimer(
+      context,
+      delay,
+      retryEpoch,
+      _ShareTrackingWake.roundStatus,
+    );
+  }
+
+  Future<void> _runShareTrackingRoundStatusRefreshInBackground() async {
+    await _enqueueShareTracking(() async {
+      _cancelShareTrackingSchedule();
+      final context = _currentContext;
+      if (context == null ||
+          _automaticShareTrackingStopped ||
+          _shareTrackingRoundClosed ||
+          _isDisposed ||
+          !ref.mounted ||
+          !_isCurrentContext(context) ||
+          ref.read(appSecurityProvider).requiresUnlock) {
+        return;
+      }
+      try {
+        final api = ref.read(
+          votingApiClientProvider(context.config.apiServers),
+        );
+        final round = VotingRoundDetails.fromStatus(
+          await api.getRoundStatus(context.round.roundId),
+        );
+        if (_automaticShareTrackingStopped ||
+            _isDisposed ||
+            !ref.mounted ||
+            !_isCurrentContext(context) ||
+            ref.read(appSecurityProvider).requiresUnlock) {
+          return;
+        }
+        final refreshedContext = context.withRound(round);
+        _currentContext = refreshedContext;
+        final current = state.value ?? VotingSessionState(roundId: _roundId);
+        _setStateForContext(refreshedContext, current.copyWith(round: round));
+        if (!shouldTrackPendingVotingShares(round)) {
+          _shareTrackingRoundClosed = true;
+          _releaseAutomaticShareTrackingIfRoundClosed(refreshedContext);
+          return;
+        }
+        await _scheduleShareTracking(
+          refreshedContext,
+          refreshedContext.resumePlan,
+        );
+      } catch (error, stackTrace) {
+        debugPrint(
+          '[zcash] Voting: share tracking round refresh failed '
+          'round=${context.round.roundId} error=$error\n$stackTrace',
+        );
+        _scheduleShareTrackingRoundStatusRetry(context);
+      }
     });
   }
 
@@ -3280,7 +3520,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   }
 
   bool _shareTrackingCancelled(_VotingSessionContext context) {
-    if (_automaticShareTrackingStopped || _isDisposed || !ref.mounted) {
+    if (_automaticShareTrackingStopped ||
+        _shareTrackingRoundClosed ||
+        _isDisposed ||
+        !ref.mounted) {
       return true;
     }
     return !_isCurrentContext(context) ||
@@ -4941,7 +5184,41 @@ class _VotingSessionContext {
     required this.resumePlan,
     this.roundPlan,
   });
+
+  _VotingSessionContext withResumePlan(VotingResumePlan resumePlan) {
+    return _VotingSessionContext(
+      sessionGeneration: sessionGeneration,
+      dbPath: dbPath,
+      accountUuid: accountUuid,
+      isHardwareAccount: isHardwareAccount,
+      network: network,
+      lightwalletdUrl: lightwalletdUrl,
+      config: config,
+      round: round,
+      roundParams: roundParams,
+      resumePlan: resumePlan,
+      roundPlan: roundPlan,
+    );
+  }
+
+  _VotingSessionContext withRound(VotingRoundDetails round) {
+    return _VotingSessionContext(
+      sessionGeneration: sessionGeneration,
+      dbPath: dbPath,
+      accountUuid: accountUuid,
+      isHardwareAccount: isHardwareAccount,
+      network: network,
+      lightwalletdUrl: lightwalletdUrl,
+      config: config,
+      round: round,
+      roundParams: roundParams,
+      resumePlan: resumePlan,
+      roundPlan: roundPlan,
+    );
+  }
 }
+
+enum _ShareTrackingWake { fullPass, roundStatus }
 
 class _StaleVotingSessionAction implements Exception {
   const _StaleVotingSessionAction();

--- a/lib/src/providers/voting/voting_share_tracking_registry_provider.dart
+++ b/lib/src/providers/voting/voting_share_tracking_registry_provider.dart
@@ -10,6 +10,7 @@ typedef VotingShareTrackingDrain = Future<void> Function();
 class VotingShareTrackingRegistry {
   final Map<VotingSessionKey, _VotingShareTrackingRegistration> _registrations =
       {};
+  final Map<VotingSessionKey, Stopwatch> _successfulPassAges = {};
   final Map<Completer<void>, String?> _backgroundWork = {};
   final Set<VoidCallback> _restoreRequestListeners = {};
   final Map<String, int> _accountQuiescenceDepths = {};
@@ -76,6 +77,24 @@ class VotingShareTrackingRegistry {
   bool isQuiesced(String accountUuid) {
     return _globalQuiescenceDepth > 0 ||
         (_accountQuiescenceDepths[accountUuid] ?? 0) > 0;
+  }
+
+  /// Remembers a completed pass across auto-disposed notifier instances.
+  void recordSuccessfulPass(VotingSessionKey key) {
+    _successfulPassAges[key] = Stopwatch()..start();
+  }
+
+  /// Whether [key] completed a pass inside the caller's freshness window.
+  bool hasFreshSuccessfulPass(
+    VotingSessionKey key, {
+    required Duration freshness,
+  }) {
+    if (freshness <= Duration.zero) return false;
+    final age = _successfulPassAges[key];
+    if (age == null) return false;
+    if (age.elapsed < freshness) return true;
+    _successfulPassAges.remove(key);
+    return false;
   }
 
   /// Blocks matching background work until paired with [resume].

--- a/lib/src/providers/voting/voting_share_tracking_restorer_provider.dart
+++ b/lib/src/providers/voting/voting_share_tracking_restorer_provider.dart
@@ -115,15 +115,13 @@ class VotingShareTrackingRestorer {
       if (pending.isEmpty) return;
 
       final accountSet = accountUuids.toSet();
-      final now = DateTime.now().toUtc();
       final candidates = pending
-          .where((round) {
-            final voteEnd = votingSessionVoteEndTime(round.sessionJson);
-            return accountSet.contains(round.accountUuid) &&
+          .where(
+            (round) =>
+                accountSet.contains(round.accountUuid) &&
                 !registry.isQuiesced(round.accountUuid) &&
-                voteEnd != null &&
-                now.isBefore(voteEnd);
-          })
+                votingSessionVoteEndTime(round.sessionJson) != null,
+          )
           .toList(growable: false);
       if (candidates.isEmpty) return;
 
@@ -149,12 +147,21 @@ class VotingShareTrackingRestorer {
           fireImmediately: true,
         );
         try {
-          await _ref.read(provider.future);
+          final session = await _ref.read(provider.future);
           if (_ref.read(appSecurityProvider).requiresUnlock) break;
           if (registry.isQuiesced(round.accountUuid)) continue;
+          final liveRound = session.round;
+          // The sidecar session JSON is immutable after the round is first
+          // inserted, so its cached deadline may predate a server extension.
+          // Session initialization has just loaded authenticated live status;
+          // use that result as the recovery boundary and avoid any helper/DB
+          // tracking pass when the server says the round is closed.
+          if (liveRound == null || !shouldTrackPendingVotingShares(liveRound)) {
+            continue;
+          }
           final notifier = _ref.read(provider.notifier);
           notifier.resumeShareTracking();
-          await notifier.runShareTrackingPass();
+          await notifier.runShareTrackingPassIfStale();
         } catch (error, stackTrace) {
           failed = true;
           debugPrint(

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -247,6 +247,12 @@ Future<ApiShareBatchDeliveryReport> submitPreparedSharesToHelpers({
 );
 
 /// Return the next share-tracking delay in seconds using crate policy.
+///
+/// Vizor wakes the tracker when the next share reaches its status-check grace
+/// boundary. The SDK's default policy caps future waits for wallets that also
+/// use the tracking pass as a general heartbeat; Vizor refreshes round state
+/// separately with a lightweight heartbeat and whenever the voting UI becomes
+/// visible, so that cap would only cause redundant SQLite and helper passes.
 Future<BigInt?> nextShareTrackingDelaySeconds({
   required List<ShareDelegationRecordView> shares,
   required BigInt nowSeconds,

--- a/lib/widgetbook/voting_use_cases.dart
+++ b/lib/widgetbook/voting_use_cases.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: depend_on_referenced_packages
 
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -16,6 +18,7 @@ import '../src/features/voting/screens/voting_status_screen.dart';
 import '../src/features/voting/voting_flow_models.dart';
 import '../src/features/voting/widgets/voting_metadata_widgets.dart';
 import '../src/features/voting/widgets/mobile/mobile_voting_config_settings_sheet.dart';
+import '../src/features/voting/widgets/voting_share_status_card.dart';
 import '../src/providers/voting/voting_config_provider.dart';
 import '../src/providers/voting/voting_config_source_provider.dart';
 import '../src/providers/voting/voting_poll_eligibility_provider.dart';
@@ -24,8 +27,45 @@ import '../src/providers/voting/voting_rounds_provider.dart';
 import '../src/providers/voting/voting_state.dart';
 import '../src/providers/voting/voting_submission_job_provider.dart';
 import '../src/rust/third_party/zcash_voting/config.dart';
+import '../src/rust/third_party/zcash_voting/wire.dart' as rust_wire;
 import '../src/services/qr_scanner.dart';
 import '../src/services/voting/voting_config_loader.dart';
+
+Widget buildVotingShareStatusUseCase(BuildContext context) {
+  return _buildVotingShareStatusUseCase(
+    context,
+    records: _previewVotingShareRecords,
+  );
+}
+
+Widget buildVotingShareStatusCompleteUseCase(BuildContext context) {
+  return _buildVotingShareStatusUseCase(
+    context,
+    records: _previewVotingShareCompleteRecords,
+  );
+}
+
+Widget _buildVotingShareStatusUseCase(
+  BuildContext context, {
+  required List<rust_wire.ShareDelegationRecordView> records,
+}) {
+  return ColoredBox(
+    color: context.colors.background.ground,
+    child: SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: VotingShareStatusCard(
+            records: records,
+            now: _previewVotingShareNow,
+          ),
+        ),
+      ),
+    ),
+  );
+}
 
 Widget buildMobileVotingPollsUseCase(BuildContext context) {
   return ProviderScope(
@@ -118,6 +158,16 @@ Widget _buildMobileVotingConfigPreview(
 }
 
 Widget buildMobileVotingVotedUseCase(BuildContext context) {
+  return _buildMobileVotingVotedUseCase(_previewVotingShareRecords);
+}
+
+Widget buildMobileVotingVotedCompleteUseCase(BuildContext context) {
+  return _buildMobileVotingVotedUseCase(_previewVotingShareCompleteRecords);
+}
+
+Widget _buildMobileVotingVotedUseCase(
+  List<rust_wire.ShareDelegationRecordView> records,
+) {
   return MobileVotingScaffold(
     title: 'Voted',
     child: VotingVotedPollContent(
@@ -133,6 +183,8 @@ Widget buildMobileVotingVotedUseCase(BuildContext context) {
       votedAt: DateTime(2026, 8, 24),
       proposals: const [_previewSnackProposal],
       choicesByProposalId: const {1: 1},
+      shareDelegations: records,
+      shareStatusNow: _previewVotingShareNow,
     ),
   );
 }
@@ -465,6 +517,51 @@ void _previewNoop() {}
 
 const _previewVotingKeystoneUr =
     'ur:zcash-sign-batch/1-1/lpadaxcsfwdmfwfwhdcxhdcxfwcxhdcxhdcxfwcx';
+
+final _previewVotingShareNow = DateTime.utc(2026, 8, 23, 12);
+
+final _previewVotingShareRecords = [
+  _previewVotingShare(0, 1, confirmed: true),
+  _previewVotingShare(1, 1, hours: 3, minutes: 24),
+  _previewVotingShare(2, 1, hours: 29, minutes: 10),
+  _previewVotingShare(0, 2, confirmed: true),
+  _previewVotingShare(1, 2, hours: 51, minutes: 42),
+];
+
+final _previewVotingShareCompleteRecords = [
+  _previewVotingShare(0, 1, confirmed: true),
+  _previewVotingShare(1, 1, hours: 3, minutes: 24, confirmed: true),
+  _previewVotingShare(2, 1, hours: 29, minutes: 10, confirmed: true),
+  _previewVotingShare(0, 2, confirmed: true),
+  _previewVotingShare(1, 2, hours: 51, minutes: 42, confirmed: true),
+];
+
+rust_wire.ShareDelegationRecordView _previewVotingShare(
+  int shareIndex,
+  int proposalId, {
+  int hours = 0,
+  int minutes = 0,
+  bool confirmed = false,
+}) {
+  final scheduled = _previewVotingShareNow.add(
+    Duration(hours: hours, minutes: minutes),
+  );
+  final epoch = BigInt.from(
+    scheduled.millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond,
+  );
+  return rust_wire.ShareDelegationRecordView(
+    roundId: 'preview-round',
+    bundleIndex: 0,
+    proposalId: proposalId,
+    shareIndex: shareIndex,
+    sentToUrls: const ['https://helper.example'],
+    nullifier: Uint8List.fromList(List.filled(32, shareIndex)),
+    phase: confirmed ? 'confirmed' : 'submitted_share',
+    confirmed: confirmed,
+    submitAt: epoch,
+    createdAt: epoch,
+  );
+}
 
 class _PreviewVotingConfigNotifier extends VotingConfigNotifier {
   @override

--- a/lib/widgetbook/voting_use_cases.dart
+++ b/lib/widgetbook/voting_use_cases.dart
@@ -5,9 +5,12 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../src/core/layout/app_desktop_shell.dart';
 import '../src/core/layout/mobile/app_mobile_sheet.dart';
 import '../src/core/profile_pictures.dart';
 import '../src/core/theme/app_theme.dart';
+import '../src/core/widgets/app_back_link.dart';
+import '../src/core/widgets/app_icon.dart';
 import '../src/features/voting/screens/mobile/mobile_keystone_voting_signing_screen.dart';
 import '../src/features/voting/screens/mobile/mobile_voting_submitted_screen.dart';
 import '../src/features/voting/screens/mobile/mobile_voting_submission_progress_screen.dart';
@@ -42,6 +45,44 @@ Widget buildVotingShareStatusCompleteUseCase(BuildContext context) {
   return _buildVotingShareStatusUseCase(
     context,
     records: _previewVotingShareCompleteRecords,
+  );
+}
+
+Widget buildDesktopVotingVotedUseCase(BuildContext context) {
+  return AppDesktopShell(
+    sidebar: const _VotingPreviewSidebar(),
+    pane: AppDesktopPane(
+      padding: EdgeInsets.zero,
+      child: Column(
+        children: [
+          const AppPaneToolbar(
+            leading: AppBackLink(
+              label: 'Vote',
+              minWidth: 60,
+              onTap: _previewNoop,
+            ),
+          ),
+          Expanded(
+            child: VotingVotedPollContent(
+              showDesktopToolbar: false,
+              roundTitle: '[TEST] Very Serious Snack Governance 3',
+              snapshotHeight: 3543600,
+              description:
+                  'A silly sample round for testing the shielded vote builder '
+                  'without using real governance content.',
+              forumUri: null,
+              votingPowerZatoshi: BigInt.from(37500000),
+              votingPowerPreparing: false,
+              votedAt: DateTime(2026, 8, 24),
+              proposals: const [_previewSnackProposal],
+              choicesByProposalId: const {1: 1},
+              shareDelegations: _previewVotingShareRecords,
+              shareStatusNow: _previewVotingShareNow,
+            ),
+          ),
+        ],
+      ),
+    ),
   );
 }
 
@@ -521,30 +562,24 @@ const _previewVotingKeystoneUr =
 final _previewVotingShareNow = DateTime.utc(2026, 8, 23, 12);
 
 final _previewVotingShareRecords = [
-  _previewVotingShare(0, 1, confirmed: true),
-  _previewVotingShare(1, 1, hours: 3, minutes: 24),
-  _previewVotingShare(2, 1, hours: 29, minutes: 10),
-  _previewVotingShare(0, 2, confirmed: true),
-  _previewVotingShare(1, 2, hours: 51, minutes: 42),
+  for (var index = 0; index < 16; index++)
+    _previewVotingShare(index, confirmed: index < 5),
 ];
 
 final _previewVotingShareCompleteRecords = [
-  _previewVotingShare(0, 1, confirmed: true),
-  _previewVotingShare(1, 1, hours: 3, minutes: 24, confirmed: true),
-  _previewVotingShare(2, 1, hours: 29, minutes: 10, confirmed: true),
-  _previewVotingShare(0, 2, confirmed: true),
-  _previewVotingShare(1, 2, hours: 51, minutes: 42, confirmed: true),
+  for (var index = 0; index < 16; index++)
+    _previewVotingShare(index, confirmed: true),
 ];
 
 rust_wire.ShareDelegationRecordView _previewVotingShare(
-  int shareIndex,
-  int proposalId, {
-  int hours = 0,
-  int minutes = 0,
+  int shareIndex, {
   bool confirmed = false,
 }) {
-  final scheduled = _previewVotingShareNow.add(
-    Duration(hours: hours, minutes: minutes),
+  final delayMinutes = shareIndex == 0 ? 0 : (3102 * shareIndex) ~/ 15;
+  final scheduled = _previewVotingShareNow.add(Duration(minutes: delayMinutes));
+  final createdAt = BigInt.from(
+    _previewVotingShareNow.millisecondsSinceEpoch ~/
+        Duration.millisecondsPerSecond,
   );
   final epoch = BigInt.from(
     scheduled.millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond,
@@ -552,15 +587,86 @@ rust_wire.ShareDelegationRecordView _previewVotingShare(
   return rust_wire.ShareDelegationRecordView(
     roundId: 'preview-round',
     bundleIndex: 0,
-    proposalId: proposalId,
+    proposalId: 1,
     shareIndex: shareIndex,
-    sentToUrls: const ['https://helper.example'],
+    sentToUrls: confirmed
+        ? const ['https://helper-a.example', 'https://helper-b.example']
+        : const [],
+    ambiguousUrls: const [],
+    targetCount: 2,
     nullifier: Uint8List.fromList(List.filled(32, shareIndex)),
     phase: confirmed ? 'confirmed' : 'submitted_share',
     confirmed: confirmed,
-    submitAt: epoch,
-    createdAt: epoch,
+    submitAt: shareIndex == 0 ? BigInt.zero : epoch,
+    createdAt: createdAt,
   );
+}
+
+class _VotingPreviewSidebar extends StatelessWidget {
+  const _VotingPreviewSidebar();
+
+  @override
+  Widget build(BuildContext context) {
+    return AppDesktopSidebarSurface(
+      glass: true,
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xs),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const SizedBox(height: 40),
+            const AppSidebarItem(
+              label: 'Demo wallet',
+              iconName: AppIcons.user,
+              leadingGap: AppSpacing.xs,
+            ),
+            const SizedBox(height: AppSpacing.md),
+            AppSidebarItem(
+              label: 'Home',
+              iconName: AppIcons.home,
+              onTap: _previewNoop,
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            AppSidebarItem(
+              label: 'Swap',
+              iconName: AppIcons.swapArrows,
+              onTap: _previewNoop,
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            AppSidebarItem(
+              label: 'Pay',
+              iconName: AppIcons.paid,
+              onTap: _previewNoop,
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            const AppSidebarItem(
+              label: 'Vote',
+              iconName: AppIcons.vote,
+              active: true,
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            AppSidebarItem(
+              label: 'Activity',
+              iconName: AppIcons.history,
+              onTap: _previewNoop,
+            ),
+            const Spacer(),
+            AppSidebarItem(
+              label: 'Settings',
+              iconName: AppIcons.cog,
+              onTap: _previewNoop,
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            AppSidebarItem(
+              label: 'Sign out',
+              iconName: AppIcons.logOut,
+              onTap: _previewNoop,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _PreviewVotingConfigNotifier extends VotingConfigNotifier {

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -855,6 +855,12 @@ pub async fn submit_prepared_shares_to_helpers(
 }
 
 /// Return the next share-tracking delay in seconds using crate policy.
+///
+/// Vizor wakes the tracker when the next share reaches its status-check grace
+/// boundary. The SDK's default policy caps future waits for wallets that also
+/// use the tracking pass as a general heartbeat; Vizor refreshes round state
+/// separately with a lightweight heartbeat and whenever the voting UI becomes
+/// visible, so that cap would only cause redundant SQLite and helper passes.
 pub fn next_share_tracking_delay_seconds(
     shares: Vec<zcash_voting::wire::ShareDelegationRecordView>,
     now_seconds: u64,
@@ -862,11 +868,29 @@ pub fn next_share_tracking_delay_seconds(
     catch(|| {
         // Convert wire views into core records consumed by share policy.
         let shares = shares.into_iter().map(share_record).collect::<Vec<_>>();
-        Ok(zcash_voting::share::policy::next_tracking_delay_seconds(
-            &shares,
-            now_seconds,
-            zcash_voting::share::ShareTimingPolicy::default(),
-        ))
+        let mut policy = zcash_voting::share::ShareTimingPolicy::default();
+        let ready_delay = shares
+            .iter()
+            .any(|share| {
+                zcash_voting::share::policy::is_share_ready_for_status_check(
+                    share,
+                    now_seconds,
+                    policy,
+                )
+            })
+            .then_some(
+                policy
+                    .ready_poll_interval_seconds
+                    .max(policy.min_tracking_delay_seconds),
+            );
+        policy.future_check_max_delay_seconds = u64::MAX;
+        let next_delay =
+            zcash_voting::share::policy::next_tracking_delay_seconds(&shares, now_seconds, policy);
+        Ok(match (ready_delay, next_delay) {
+            (Some(ready), Some(next)) => Some(ready.min(next)),
+            (Some(ready), None) => Some(ready),
+            (None, next) => next,
+        })
     })
 }
 
@@ -2950,7 +2974,7 @@ mod tests {
     }
 
     #[test]
-    fn next_share_tracking_delay_uses_crate_ready_interval() {
+    fn next_share_tracking_delay_uses_earliest_ready_or_future_wakeup() {
         let ready = zcash_voting::wire::ShareDelegationRecordView {
             round_id: ROUND_ID.to_string(),
             bundle_index: 0,
@@ -2966,17 +2990,29 @@ mod tests {
             created_at: 50,
         };
         let future = zcash_voting::wire::ShareDelegationRecordView {
-            submit_at: 140,
+            submit_at: 1_000,
+            ..ready.clone()
+        };
+        let near_future = zcash_voting::wire::ShareDelegationRecordView {
+            submit_at: 115,
             ..ready.clone()
         };
 
         assert_eq!(
-            next_share_tracking_delay_seconds(vec![ready], 130).unwrap(),
+            next_share_tracking_delay_seconds(vec![ready.clone()], 130).unwrap(),
             Some(15)
         );
         assert_eq!(
-            next_share_tracking_delay_seconds(vec![future], 120).unwrap(),
-            Some(30)
+            next_share_tracking_delay_seconds(vec![future.clone()], 120).unwrap(),
+            Some(890)
+        );
+        assert_eq!(
+            next_share_tracking_delay_seconds(vec![ready.clone(), future], 120).unwrap(),
+            Some(15)
+        );
+        assert_eq!(
+            next_share_tracking_delay_seconds(vec![ready.clone(), near_future], 120).unwrap(),
+            Some(5)
         );
     }
 

--- a/rust/src/wallet/voting/README.md
+++ b/rust/src/wallet/voting/README.md
@@ -210,8 +210,11 @@ ambiguous.
 
 On launch, unlock, and resume, Vizor asks
 `zcash_voting::share::pending_rounds` for durable
-unconfirmed rounds and rejects expired or unauthenticated entries before
-restoring a session. A restored session checks only helpers still present in
+unconfirmed rounds and rejects malformed or unauthenticated entries before
+restoring a session. The persisted session deadline is only a discovery hint:
+because a server may extend an existing round after that immutable metadata was
+stored, the restored session verifies live round status before deciding whether
+recovery remains open. A restored session checks only helpers still present in
 the current config and retains itself while work remains. Overdue shares use
 the crate's randomized, health-aware recovery order and continue until the
 complete definite-placement deficit is filled, candidates are exhausted, or

--- a/test/features/voting/mobile_voting_share_status_test.dart
+++ b/test/features/voting/mobile_voting_share_status_test.dart
@@ -1,0 +1,78 @@
+@Tags(['mobile'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/voting/widgets/voting_share_status_card.dart';
+import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
+    as rust_wire;
+
+void main() {
+  testWidgets('high-level share progress fits on mobile', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final now = DateTime.utc(2026, 8, 25, 12);
+    final nowSeconds = now.millisecondsSinceEpoch ~/ 1000;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (context, child) =>
+            AppTheme(data: AppThemeData.light, child: child!),
+        home: Scaffold(
+          body: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: VotingShareStatusCard(
+              now: now,
+              records: [
+                for (var index = 0; index < 16; index++)
+                  _share(
+                    index,
+                    confirmed: index < 5,
+                    submitAt: BigInt.from(nowSeconds + index * 60 * 60),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('5 of 16 shares submitted'), findsOneWidget);
+    expect(find.text('31%'), findsOneWidget);
+    expect(find.text('Complete in about 15 hours'), findsOneWidget);
+    expect(
+      find.textContaining('shares that are submitted at different times'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('close Vizor at any time'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('voting_share_status_toggle')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
+  });
+}
+
+rust_wire.ShareDelegationRecordView _share(
+  int shareIndex, {
+  required bool confirmed,
+  required BigInt submitAt,
+}) {
+  return rust_wire.ShareDelegationRecordView(
+    roundId: 'round-1',
+    bundleIndex: 0,
+    proposalId: 7,
+    shareIndex: shareIndex,
+    sentToUrls: const ['https://helper.example'],
+    ambiguousUrls: const [],
+    targetCount: 1,
+    nullifier: Uint8List.fromList(List.filled(32, shareIndex)),
+    phase: confirmed ? 'confirmed' : 'submitted_share',
+    confirmed: confirmed,
+    submitAt: submitAt,
+    createdAt: submitAt,
+  );
+}

--- a/test/features/voting/voting_share_status_test.dart
+++ b/test/features/voting/voting_share_status_test.dart
@@ -1,0 +1,335 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/voting/voting_share_status.dart';
+import 'package:zcash_wallet/src/features/voting/widgets/voting_share_status_card.dart';
+import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
+    as rust_wire;
+
+void main() {
+  test('summarizes confirmed vote shares', () {
+    final summary = VotingShareStatusSummary.fromRecords([
+      _share(0, confirmed: true),
+      _share(1),
+      _share(2),
+    ]);
+
+    expect(summary.totalCount, 3);
+    expect(summary.confirmedCount, 1);
+    expect(summary.pendingCount, 2);
+    expect(summary.allConfirmed, isFalse);
+    expect(summary.confirmedFraction, closeTo(1 / 3, 0.0001));
+    expect(summary.latestPendingDueAtSeconds, BigInt.from(1_777_000_002));
+    expect(summary.usesStaggeredSubmission, isTrue);
+  });
+
+  test('formats the last pending share in minutes, hours, or days', () {
+    final now = DateTime.utc(2026, 8, 25, 12);
+    final nowSeconds = now.millisecondsSinceEpoch ~/ 1000;
+
+    VotingShareStatusSummary summaryAfter(Duration duration) {
+      return VotingShareStatusSummary.fromRecords([
+        _share(0, submitAt: BigInt.from(nowSeconds + duration.inSeconds)),
+      ]);
+    }
+
+    expect(
+      votingShareCompletionEstimateText(
+        summaryAfter(const Duration(seconds: 30)),
+        now: now,
+      ),
+      'Complete in about 1 minute',
+    );
+    expect(
+      votingShareCompletionEstimateText(
+        summaryAfter(const Duration(minutes: 17, seconds: 20)),
+        now: now,
+      ),
+      'Complete in about 17 minutes',
+    );
+    expect(
+      votingShareCompletionEstimateText(
+        summaryAfter(const Duration(hours: 2, minutes: 20)),
+        now: now,
+      ),
+      'Complete in about 2 hours',
+    );
+    expect(
+      votingShareCompletionEstimateText(
+        summaryAfter(const Duration(hours: 51, minutes: 42)),
+        now: now,
+      ),
+      'Complete in about 2 days',
+    );
+    expect(
+      votingShareCompletionEstimateText(
+        summaryAfter(const Duration(minutes: -1)),
+        now: now,
+      ),
+      'Completing soon',
+    );
+  });
+
+  test('does not infer staggering from immediate-share creation times', () {
+    final summary = VotingShareStatusSummary.fromRecords([
+      _share(0, submitAt: BigInt.zero, createdAt: BigInt.from(100)),
+      _share(1, submitAt: BigInt.zero, createdAt: BigInt.from(101)),
+    ]);
+
+    expect(summary.latestPendingDueAtSeconds, BigInt.from(101));
+    expect(summary.usesStaggeredSubmission, isFalse);
+  });
+
+  test('closes share tracking when the round or deadline closes', () {
+    final now = DateTime.utc(2026, 8, 23, 12);
+    final voteEndTime = now.add(const Duration(hours: 1));
+
+    expect(
+      isVotingShareTrackingOpen(
+        roundStatus: 'active',
+        voteEndTime: voteEndTime,
+        now: now,
+      ),
+      isTrue,
+    );
+    expect(
+      isVotingShareTrackingOpen(
+        roundStatus: 'complete',
+        voteEndTime: voteEndTime,
+        now: now,
+      ),
+      isFalse,
+    );
+    expect(
+      isVotingShareTrackingOpen(
+        roundStatus: 'active',
+        voteEndTime: now,
+        now: now,
+      ),
+      isFalse,
+    );
+  });
+
+  testWidgets(
+    'shows share progress, completion estimate, and handoff context',
+    (tester) async {
+      final now = DateTime.utc(2026, 8, 25, 12);
+      final nowSeconds = now.millisecondsSinceEpoch ~/ 1000;
+      await tester.pumpWidget(
+        _harness(
+          VotingShareStatusCard(
+            records: [
+              _share(0, confirmed: true),
+              _share(1, submitAt: BigInt.from(nowSeconds + 20 * 60)),
+              _share(
+                2,
+                submitAt: BigInt.from(nowSeconds + 2 * 60 * 60 + 20 * 60),
+              ),
+            ],
+            now: now,
+          ),
+        ),
+      );
+
+      expect(find.text('Submission status'), findsOneWidget);
+      expect(find.text('1 of 3 shares submitted'), findsOneWidget);
+      expect(find.text('33%'), findsOneWidget);
+      expect(find.text('Complete in about 2 hours'), findsOneWidget);
+      expect(
+        find.text(
+          'To protect your privacy, Vizor splits your encrypted vote into '
+          'shares that are submitted at different times, making them harder '
+          'to link. You can close Vizor at any time while these servers submit '
+          'your shares for you.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('seconds'), findsNothing);
+      expect(find.textContaining('Scheduled'), findsNothing);
+      expect(find.textContaining('Share 1'), findsNothing);
+      expect(
+        find.byKey(const ValueKey('voting_share_status_toggle')),
+        findsNothing,
+      );
+
+      final progress = tester.widget<LinearProgressIndicator>(
+        find.byKey(const ValueKey('voting_share_status_progress')),
+      );
+      expect(progress.value, closeTo(1 / 3, 0.0001));
+    },
+  );
+
+  testWidgets('refreshes the completion estimate while the card stays open', (
+    tester,
+  ) async {
+    final nowSeconds =
+        DateTime.now().millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond;
+    await tester.pumpWidget(
+      _harness(
+        VotingShareStatusCard(
+          records: [_share(0, submitAt: BigInt.from(nowSeconds + 180))],
+        ),
+      ),
+    );
+
+    expect(find.text('Complete in about 3 minutes'), findsOneWidget);
+
+    await tester.pump(const Duration(minutes: 1));
+
+    expect(find.text('Complete in about 2 minutes'), findsOneWidget);
+    expect(find.text('Complete in about 3 minutes'), findsNothing);
+  });
+
+  testWidgets('describes an immediate single share without claiming a split', (
+    tester,
+  ) async {
+    final now = DateTime.utc(2026, 8, 25, 12);
+    final nowSeconds = now.millisecondsSinceEpoch ~/ 1000;
+    await tester.pumpWidget(
+      _harness(
+        VotingShareStatusCard(
+          records: [
+            _share(
+              0,
+              submitAt: BigInt.zero,
+              createdAt: BigInt.from(nowSeconds),
+            ),
+          ],
+          now: now,
+        ),
+      ),
+    );
+
+    expect(find.text('Completing soon'), findsOneWidget);
+    expect(
+      find.text(
+        'Your encrypted vote is submitted as one encrypted share. You can '
+        'close Vizor at any time while these servers submit your shares for '
+        'you.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('submitted at different times'), findsNothing);
+  });
+
+  testWidgets('keeps incomplete share progress below 100 percent', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _harness(
+        VotingShareStatusCard(
+          records: [
+            for (var index = 0; index < 200; index++)
+              _share(index, confirmed: index < 199),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.text('199 of 200 shares submitted'), findsOneWidget);
+    expect(find.text('99%'), findsOneWidget);
+    expect(find.text('100%'), findsNothing);
+    final progress = tester.widget<LinearProgressIndicator>(
+      find.byKey(const ValueKey('voting_share_status_progress')),
+    );
+    expect(progress.value, closeTo(199 / 200, 0.0001));
+  });
+
+  testWidgets('shows a success icon after every share is submitted', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _harness(
+        VotingShareStatusCard(
+          records: [_share(0, confirmed: true), _share(1, confirmed: true)],
+        ),
+      ),
+    );
+
+    expect(find.text('2 of 2 shares submitted'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('voting_share_status_complete_icon')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('voting_share_status_percent')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('voting_share_status_progress')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('voting_share_status_completion_estimate')),
+      findsNothing,
+    );
+    expect(find.textContaining('submitted at different times'), findsOneWidget);
+    expect(find.textContaining('close Vizor'), findsNothing);
+  });
+
+  testWidgets('is informative but not interactive for assistive technology', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      _harness(VotingShareStatusCard(records: [_share(0)])),
+    );
+
+    final node = tester.getSemantics(
+      find.bySemanticsLabel(RegExp('0 of 1 share submitted')),
+    );
+    expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isFalse);
+    semantics.dispose();
+  });
+
+  testWidgets('does not render a card without persisted shares', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_harness(const VotingShareStatusCard(records: [])));
+
+    expect(
+      find.byKey(const ValueKey('voting_share_status_card')),
+      findsNothing,
+    );
+  });
+}
+
+rust_wire.ShareDelegationRecordView _share(
+  int shareIndex, {
+  bool confirmed = false,
+  BigInt? submitAt,
+  BigInt? createdAt,
+}) {
+  return rust_wire.ShareDelegationRecordView(
+    roundId: 'round-1',
+    bundleIndex: 0,
+    proposalId: 7,
+    shareIndex: shareIndex,
+    sentToUrls: const ['https://helper.example'],
+    ambiguousUrls: const [],
+    targetCount: 1,
+    nullifier: Uint8List.fromList(List.filled(32, shareIndex)),
+    phase: confirmed ? 'confirmed' : 'submitted_share',
+    confirmed: confirmed,
+    submitAt: submitAt ?? BigInt.from(1_777_000_000 + shareIndex),
+    createdAt: createdAt ?? BigInt.from(1_777_000_000 + shareIndex),
+  );
+}
+
+Widget _harness(Widget child) {
+  return MaterialApp(
+    builder: (context, appChild) =>
+        AppTheme(data: AppThemeData.light, child: appChild!),
+    home: Scaffold(
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: SizedBox(width: 420, child: child),
+        ),
+      ),
+    ),
+  );
+}

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -2263,12 +2263,13 @@ void main() {
     final trackedResumePlan = const VotingRecoveryService().buildResumePlan(
       _recoveryState(shareDelegations: [confirmedShare]),
     );
+    final rust = _VotingStatusRustApi(recoveryApi);
     const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
     final container = _statusContainer(
       http: http,
       accountOverride: _MnemonicAccountNotifier.new,
       recoveryApi: recoveryApi,
-      rust: _VotingStatusRustApi(recoveryApi),
+      rust: rust,
       overrides: [
         votingSubmissionJobSessionProvider(key).overrideWith((ref) {
           return ref
@@ -2286,6 +2287,9 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
+    // Exercise the cached-provider path where the manual listener fires from
+    // initState, before inherited route dependencies may be established.
+    await container.read(votingSessionProvider(_roundId).future);
 
     await tester.pumpWidget(
       UncontrolledProviderScope(
@@ -2294,6 +2298,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+    await _pumpUntilCondition(tester, () => rust.shareTrackingPassCalls == 1);
 
     expect(find.textContaining('Voted'), findsOneWidget);
     expect(find.text('Submission status'), findsOneWidget);
@@ -2315,6 +2320,16 @@ void main() {
       ),
     );
     expect(find.text('temporary eligibility refresh failed'), findsNothing);
+
+    // Rebuilds do not turn the user-initiated refresh into another poll loop.
+    await tester.pump();
+    expect(rust.shareTrackingPassCalls, 1);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    expect(rust.shareTrackingPassCalls, 1);
   });
 
   testWidgets('proposal detail removes share status when the deadline passes', (
@@ -2390,6 +2405,113 @@ void main() {
     await tester.pump(const Duration(seconds: 11));
 
     expect(find.textContaining('Voted'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('voting_share_status_card')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('proposal detail uses the tracked share deadline', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+    final nowSeconds =
+        DateTime.now().millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond;
+    final cachedDeadlineSeconds = nowSeconds + 2;
+    final trackedDeadlineSeconds = nowSeconds + 10;
+    final cachedRound = _roundStatusJson()
+      ..['vote_end_time'] = cachedDeadlineSeconds;
+    final trackedRound = Map<String, dynamic>.of(cachedRound)
+      ..['vote_end_time'] = trackedDeadlineSeconds;
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': cachedRound},
+    );
+    final share = rust_wire.ShareDelegationRecordView(
+      roundId: _roundId,
+      bundleIndex: 0,
+      proposalId: 1,
+      shareIndex: 0,
+      sentToUrls: const ['https://helper.example'],
+      ambiguousUrls: const [],
+      targetCount: 1,
+      nullifier: Uint8List(32),
+      phase: VotingWorkflowPhase.submittedShare,
+      confirmed: false,
+      submitAt: BigInt.from(trackedDeadlineSeconds),
+      createdAt: BigInt.one,
+    );
+    final recoveryState = _recoveryState(
+      shareDelegations: [share],
+      unconfirmedShareDelegations: [share],
+    );
+    final resumePlan = const VotingRecoveryService().buildResumePlan(
+      recoveryState,
+    );
+    final recoveryApi = _MutableVotingRecoveryApi()
+      ..state = recoveryState
+      ..roundPlan = apiRoundPlan(
+        roundId: _roundId,
+        pendingRecovery: true,
+        nextSteps: const [],
+        openProposals: Uint32List.fromList(const [1]),
+        allDecided: true,
+        completedVoteArtifact: true,
+        completedForDisplay: true,
+        completedVoteDisplay: rust_wire.CompletedVoteDisplayView(
+          choices: const [
+            rust_wire.CompletedVoteChoiceView(proposalId: 1, choice: 0),
+          ],
+          votedAt: BigInt.from(1717260000),
+        ),
+      );
+    const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _VotingStatusRustApi(recoveryApi),
+      overrides: [
+        votingSubmissionJobSessionProvider(key).overrideWithValue(
+          AsyncData(
+            VotingSessionState(
+              roundId: _roundId,
+              accountUuid: key.accountUuid,
+              round: VotingRoundDetails.fromStatus(
+                VotingRoundStatus.fromJson(trackedRound),
+              ),
+              resumePlan: resumePlan,
+              phase: VotingSessionPhase.done,
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('voting_share_status_card')),
+      findsOneWidget,
+    );
+
+    await tester.pump(const Duration(seconds: 3));
+    expect(
+      find.byKey(const ValueKey('voting_share_status_card')),
+      findsOneWidget,
+    );
+
+    await tester.pump(const Duration(seconds: 8));
     expect(
       find.byKey(const ValueKey('voting_share_status_card')),
       findsNothing,
@@ -5611,6 +5733,7 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
   int _persistedBundleCount;
   int setupDelegationBundleCalls = 0;
   int eligibilityCheckCalls = 0;
+  int shareTrackingPassCalls = 0;
 
   /// Raw note value the privacy trim withholds. Zero for every fixture that
   /// does not exercise the trim notice.
@@ -6090,6 +6213,7 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
     required BigInt nowSeconds,
     BigInt? voteEndTimeSeconds,
   }) async {
+    shareTrackingPassCalls++;
     final accountUuid = passHandle.accountUuid;
     final confirmed = <rust_api.ApiShareKey>[];
     final pending = List.of(recoveryApi.state.unconfirmedShareDelegations);

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -56,6 +56,7 @@ import 'package:zcash_wallet/src/rust/wallet/keystone.dart'
 import 'package:zcash_wallet/src/services/voting/voting_config_loader.dart';
 import 'package:zcash_wallet/src/services/voting/voting_http.dart';
 import 'package:zcash_wallet/src/services/voting/pir_snapshot_resolver.dart';
+import 'package:zcash_wallet/src/services/voting/voting_models.dart';
 
 import 'round_plan_test_utils.dart';
 import 'tx_event_json_test_utils.dart';
@@ -619,6 +620,81 @@ void main() {
     expect(find.text('Voting power'), findsOneWidget);
     expect(find.text('0.000001 ZEC'), findsOneWidget);
     expect(notifier.refreshCalls, 2);
+  });
+
+  testWidgets('submitted route leaves vote-share status in the poll menu', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+    final scheduled = DateTime.now().add(const Duration(hours: 3));
+    final share = rust_wire.ShareDelegationRecordView(
+      roundId: _roundId,
+      bundleIndex: 0,
+      proposalId: 1,
+      shareIndex: 0,
+      sentToUrls: const ['https://helper.example'],
+      ambiguousUrls: const [],
+      targetCount: 1,
+      nullifier: Uint8List(32),
+      phase: VotingWorkflowPhase.submittedShare,
+      confirmed: false,
+      submitAt: BigInt.from(
+        scheduled.millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond,
+      ),
+      createdAt: BigInt.one,
+    );
+    final completedRoundPlan = apiRoundPlan(
+      roundId: _roundId,
+      pendingRecovery: true,
+      nextSteps: const [],
+      openProposals: Uint32List(0),
+      allDecided: true,
+      completedVoteArtifact: true,
+      completedForDisplay: true,
+    );
+    final resumePlan = const VotingRecoveryService().buildResumePlan(
+      _recoveryState(
+        shareDelegations: [share],
+        unconfirmedShareDelegations: [share],
+      ),
+    );
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      overrides: [
+        votingSessionProvider(_roundId).overrideWith(
+          () => _StaticVotingSessionNotifier(
+            VotingSessionState(
+              roundId: _roundId,
+              accountUuid: 'account-1',
+              round: VotingRoundDetails.fromStatus(
+                VotingRoundStatus.fromJson(_roundStatusJson()),
+              ),
+              phase: VotingSessionPhase.done,
+              resumePlan: resumePlan,
+              roundPlan: completedRoundPlan,
+              eligibleWeightZatoshi: BigInt.from(100),
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _submissionHarness(),
+      ),
+    );
+    await _pumpUntilFound(tester, find.text('Submission confirmed!'));
+
+    expect(
+      find.byKey(const ValueKey('voting_share_status_card')),
+      findsNothing,
+    );
   });
 
   testWidgets(
@@ -2121,6 +2197,205 @@ void main() {
     expect(find.text('Review answers'), findsNothing);
   });
 
+  testWidgets('proposal detail keeps live status despite a stale error', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+    final round = _roundStatusJson();
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
+    );
+    final scheduled = DateTime.now().add(const Duration(hours: 4));
+    final share = rust_wire.ShareDelegationRecordView(
+      roundId: _roundId,
+      bundleIndex: 0,
+      proposalId: 1,
+      shareIndex: 0,
+      sentToUrls: const ['https://helper.example'],
+      ambiguousUrls: const [],
+      targetCount: 1,
+      nullifier: Uint8List(32),
+      phase: VotingWorkflowPhase.submittedShare,
+      confirmed: false,
+      submitAt: BigInt.from(
+        scheduled.millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond,
+      ),
+      createdAt: BigInt.one,
+    );
+    final recoveryApi = _MutableVotingRecoveryApi()
+      ..state = _recoveryState(
+        shareDelegations: [share],
+        unconfirmedShareDelegations: [share],
+      )
+      ..roundPlan = apiRoundPlan(
+        roundId: _roundId,
+        pendingRecovery: true,
+        nextSteps: const [],
+        openProposals: Uint32List.fromList(const [1]),
+        allDecided: true,
+        completedVoteArtifact: true,
+        completedForDisplay: true,
+        completedVoteDisplay: rust_wire.CompletedVoteDisplayView(
+          choices: const [
+            rust_wire.CompletedVoteChoiceView(proposalId: 1, choice: 0),
+          ],
+          votedAt: BigInt.from(1717260000),
+        ),
+      );
+    final confirmedShare = rust_wire.ShareDelegationRecordView(
+      roundId: share.roundId,
+      bundleIndex: share.bundleIndex,
+      proposalId: share.proposalId,
+      shareIndex: share.shareIndex,
+      sentToUrls: share.sentToUrls,
+      ambiguousUrls: share.ambiguousUrls,
+      targetCount: share.targetCount,
+      nullifier: share.nullifier,
+      phase: VotingWorkflowPhase.confirmed,
+      confirmed: true,
+      submitAt: share.submitAt,
+      createdAt: share.createdAt,
+    );
+    final trackedResumePlan = const VotingRecoveryService().buildResumePlan(
+      _recoveryState(shareDelegations: [confirmedShare]),
+    );
+    const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _VotingStatusRustApi(recoveryApi),
+      overrides: [
+        votingSubmissionJobSessionProvider(key).overrideWith((ref) {
+          return ref
+              .watch(votingSessionProvider(_roundId))
+              .whenData(
+                (state) => state.copyWith(
+                  phase: VotingSessionPhase.done,
+                  resumePlan: trackedResumePlan,
+                  error: const VotingSessionError(
+                    message: 'temporary eligibility refresh failed',
+                  ),
+                ),
+              );
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Voted'), findsOneWidget);
+    expect(find.text('Submission status'), findsOneWidget);
+    expect(find.text('1 of 1 share submitted'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('voting_share_status_complete_icon')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('voting_share_status_progress')),
+      findsNothing,
+    );
+    expect(
+      tester
+          .getTopLeft(find.byKey(const ValueKey('voting_share_status_card')))
+          .dy,
+      greaterThan(
+        tester.getBottomLeft(find.byType(VotingProposalCard).last).dy,
+      ),
+    );
+    expect(find.text('temporary eligibility refresh failed'), findsNothing);
+  });
+
+  testWidgets('proposal detail removes share status when the deadline passes', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+    final deadline = DateTime.now().add(const Duration(seconds: 10));
+    final deadlineSeconds =
+        deadline.millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond;
+    final round = _roundStatusJson()..['vote_end_time'] = deadlineSeconds;
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
+    );
+    final share = rust_wire.ShareDelegationRecordView(
+      roundId: _roundId,
+      bundleIndex: 0,
+      proposalId: 1,
+      shareIndex: 0,
+      sentToUrls: const ['https://helper.example'],
+      ambiguousUrls: const [],
+      targetCount: 1,
+      nullifier: Uint8List(32),
+      phase: VotingWorkflowPhase.submittedShare,
+      confirmed: false,
+      submitAt: BigInt.from(deadlineSeconds),
+      createdAt: BigInt.one,
+    );
+    final recoveryApi = _MutableVotingRecoveryApi()
+      ..state = _recoveryState(
+        shareDelegations: [share],
+        unconfirmedShareDelegations: [share],
+      )
+      ..roundPlan = apiRoundPlan(
+        roundId: _roundId,
+        pendingRecovery: true,
+        nextSteps: const [],
+        openProposals: Uint32List.fromList(const [1]),
+        allDecided: true,
+        completedVoteArtifact: true,
+        completedForDisplay: true,
+        completedVoteDisplay: rust_wire.CompletedVoteDisplayView(
+          choices: const [
+            rust_wire.CompletedVoteChoiceView(proposalId: 1, choice: 0),
+          ],
+          votedAt: BigInt.from(1717260000),
+        ),
+      );
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _VotingStatusRustApi(recoveryApi),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('voting_share_status_card')),
+      findsOneWidget,
+    );
+
+    await tester.pump(const Duration(seconds: 11));
+
+    expect(find.textContaining('Voted'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('voting_share_status_card')),
+      findsNothing,
+    );
+  });
+
   testWidgets('proposal detail shows long question descriptions in full', (
     tester,
   ) async {
@@ -2226,7 +2501,25 @@ void main() {
       responses: _votingHttpResponses()
         ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
     );
+    final share = rust_wire.ShareDelegationRecordView(
+      roundId: _roundId,
+      bundleIndex: 0,
+      proposalId: 1,
+      shareIndex: 0,
+      sentToUrls: const ['https://helper.example'],
+      ambiguousUrls: const [],
+      targetCount: 1,
+      nullifier: Uint8List(32),
+      phase: VotingWorkflowPhase.submittedShare,
+      confirmed: false,
+      submitAt: BigInt.one,
+      createdAt: BigInt.one,
+    );
     final recoveryApi = _MutableVotingRecoveryApi()
+      ..state = _recoveryState(
+        shareDelegations: [share],
+        unconfirmedShareDelegations: [share],
+      )
       ..roundPlan = apiRoundPlan(
         roundId: _roundId,
         pendingRecovery: false,
@@ -2263,6 +2556,10 @@ void main() {
 
     expect(find.textContaining('Voted'), findsOneWidget);
     expect(find.text('results route'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('voting_share_status_card')),
+      findsNothing,
+    );
   });
 
   testWidgets('proposal detail shows recovery before non-active redirect', (
@@ -2768,6 +3065,34 @@ void main() {
           ],
         },
     );
+    final confirmedTallyShare = rust_frb_types.ShareDelegationRecordView(
+      roundId: _roundId,
+      bundleIndex: 0,
+      proposalId: 1,
+      shareIndex: 0,
+      sentToUrls: const ['https://helper.example'],
+      ambiguousUrls: const [],
+      targetCount: 1,
+      nullifier: Uint8List(32),
+      phase: VotingWorkflowPhase.confirmed,
+      confirmed: true,
+      submitAt: BigInt.one,
+      createdAt: BigInt.one,
+    );
+    final missingTallyShare = rust_frb_types.ShareDelegationRecordView(
+      roundId: _roundId,
+      bundleIndex: 0,
+      proposalId: 1,
+      shareIndex: 1,
+      sentToUrls: const ['https://helper.example'],
+      ambiguousUrls: const [],
+      targetCount: 1,
+      nullifier: Uint8List.fromList(List.filled(32, 1)),
+      phase: VotingWorkflowPhase.submittedShare,
+      confirmed: false,
+      submitAt: BigInt.two,
+      createdAt: BigInt.two,
+    );
     final recoveryApi = _MutableVotingRecoveryApi()
       ..state = _recoveryState(
         votes: const [
@@ -2779,6 +3104,8 @@ void main() {
             hasCommitmentBundle: false,
           ),
         ],
+        shareDelegations: [confirmedTallyShare, missingTallyShare],
+        unconfirmedShareDelegations: [missingTallyShare],
       );
     final container = _statusContainer(
       http: http,
@@ -2828,6 +3155,11 @@ void main() {
       ),
       findsOneWidget,
     );
+    expect(
+      find.byKey(const ValueKey('voting_share_status_card')),
+      findsNothing,
+    );
+    expect(find.text('Vote shares'), findsNothing);
   });
 
   testWidgets('results screen keeps empty tallies visible as zero rows', (

--- a/test/figma_compare/figma_compare_capture_support.dart
+++ b/test/figma_compare/figma_compare_capture_support.dart
@@ -87,6 +87,14 @@ void runFigmaCompareCaptureTest({
     // intentionally looping home-screen illustration motion.
     await tester.pump(const Duration(milliseconds: 400));
 
+    if (scenario.scrollToEnd) {
+      final scrollable = find.byType(Scrollable);
+      expect(scrollable, findsOneWidget);
+      final state = tester.state<ScrollableState>(scrollable);
+      state.position.jumpTo(state.position.maxScrollExtent);
+      await tester.pump();
+    }
+
     if (configuration.outputPath.isEmpty) {
       expect(find.byKey(captureBoundaryKey), findsOneWidget);
       expect(tester.takeException(), isNull);

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -4886,6 +4886,173 @@ void main() {
     },
   );
 
+  test('failed heartbeat preserves an earlier full-pass wake', () async {
+    final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final activeRound = roundStatusJson(
+      roundId: kRoundId,
+      voteEnd: nowSeconds + 1000,
+    );
+    final pendingShare = rust_frb_types.ShareDelegationRecordView(
+      roundId: kRoundId,
+      bundleIndex: 0,
+      proposalId: 7,
+      shareIndex: 0,
+      sentToUrls: const ['https://helper-a.example'],
+      ambiguousUrls: const [],
+      targetCount: 1,
+      nullifier: Uint8List.fromList(List.filled(32, 1)),
+      phase: VotingWorkflowPhase.submittedShare,
+      confirmed: false,
+      submitAt: BigInt.from(nowSeconds + 100),
+      createdAt: BigInt.from(nowSeconds),
+    );
+    final rust = FakeVotingRustApi(nextShareTrackingDelayOverride: BigInt.one);
+    final http = FakeVotingHttpClient(
+      responses:
+          votingHttpResponses(
+              roundStatus: activeRound,
+              dynamicConfig: dynamicConfigJson(
+                voteServers: const [
+                  {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                ],
+              ),
+            )
+            ..['/shielded-vote/v1/round/$kRoundId'] =
+                SequentialVotingHttpResponses([
+                  {'round': activeRound},
+                  TimeoutException('round status unavailable'),
+                  {'round': activeRound},
+                ]),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: FakeVotingRecoveryApi(
+        state: recoveryState(
+          shareDelegations: [pendingShare],
+          unconfirmedShareDelegations: [pendingShare],
+        ),
+      ),
+      extraOverrides: [
+        votingApiReadRetryPolicyProvider.overrideWithValue(
+          VotingRetryPolicy.transientHttp(
+            name: 'test-voting-read',
+            delays: const [],
+          ),
+        ),
+        votingShareTrackingRoundRefreshIntervalProvider.overrideWithValue(
+          const Duration(milliseconds: 10),
+        ),
+        votingShareTrackingFailureRetryDelayProvider.overrideWithValue(
+          const Duration(seconds: 3),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    const trackingKey = VotingSessionKey(
+      accountUuid: 'account-1',
+      roundId: kRoundId,
+    );
+
+    await container.read(votingSubmissionSessionProvider(trackingKey).future);
+    for (var i = 0; i < 200 && rust.trackPendingSharesCalls.isEmpty; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+
+    expect(rust.trackPendingSharesCalls, [kRoundId]);
+  });
+
+  test(
+    'slow heartbeat runs an overdue full pass immediately after success',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final activeRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: nowSeconds + 1000,
+      );
+      final pendingShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        ambiguousUrls: const [],
+        targetCount: 1,
+        nullifier: Uint8List.fromList(List.filled(32, 2)),
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.from(nowSeconds + 100),
+        createdAt: BigInt.from(nowSeconds),
+      );
+      final delayedHeartbeat = Completer<VotingHttpResponse>();
+      addTearDown(() {
+        if (!delayedHeartbeat.isCompleted) {
+          delayedHeartbeat.complete(jsonResponse({'round': activeRound}));
+        }
+      });
+      final rust = FakeVotingRustApi(
+        nextShareTrackingDelayOverride: BigInt.one,
+      );
+      final http = FakeVotingHttpClient(
+        responses:
+            votingHttpResponses(
+                roundStatus: activeRound,
+                dynamicConfig: dynamicConfigJson(
+                  voteServers: const [
+                    {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                  ],
+                ),
+              )
+              ..['/shielded-vote/v1/round/$kRoundId'] =
+                  SequentialVotingHttpResponses([
+                    {'round': activeRound},
+                    delayedHeartbeat.future,
+                    {'round': activeRound},
+                  ]),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: FakeVotingRecoveryApi(
+          state: recoveryState(
+            shareDelegations: [pendingShare],
+            unconfirmedShareDelegations: [pendingShare],
+          ),
+        ),
+        extraOverrides: [
+          votingShareTrackingRoundRefreshIntervalProvider.overrideWithValue(
+            const Duration(milliseconds: 10),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      const trackingKey = VotingSessionKey(
+        accountUuid: 'account-1',
+        roundId: kRoundId,
+      );
+
+      await container.read(votingSubmissionSessionProvider(trackingKey).future);
+      for (var i = 0; i < 100; i++) {
+        final roundReads = http.requests
+            .where(
+              (request) =>
+                  request.method == 'GET' &&
+                  request.uri.path == '/shielded-vote/v1/round/$kRoundId',
+            )
+            .length;
+        if (roundReads >= 2) break;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 1100));
+      delayedHeartbeat.complete(jsonResponse({'round': activeRound}));
+      for (var i = 0; i < 50 && rust.trackPendingSharesCalls.isEmpty; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+
+      expect(rust.trackPendingSharesCalls, [kRoundId]);
+    },
+  );
+
   test(
     'deadline refresh preserves shares created after context load',
     () async {
@@ -12913,6 +13080,7 @@ class FakeVotingRustApi implements VotingRustApi {
     this.keystoneSignatureBatchFailuresRemaining = 0,
     this.shareResubmissionError,
     this.nextShareTrackingDelayGate,
+    this.nextShareTrackingDelayOverride,
     this.trackingPassPolicyGate,
     this.helperPreflightGate,
     this.focusedShareConfirmationGate,
@@ -12961,6 +13129,7 @@ class FakeVotingRustApi implements VotingRustApi {
   int keystoneSignatureBatchFailuresRemaining;
   final Object? shareResubmissionError;
   final Completer<void>? nextShareTrackingDelayGate;
+  final BigInt? nextShareTrackingDelayOverride;
   final Completer<void>? trackingPassPolicyGate;
   final Completer<void>? helperPreflightGate;
   final Completer<void>? focusedShareConfirmationGate;
@@ -14456,6 +14625,8 @@ class FakeVotingRustApi implements VotingRustApi {
       nextShareTrackingDelayStarted.complete();
     }
     await nextShareTrackingDelayGate?.future;
+    final override = nextShareTrackingDelayOverride;
+    if (override != null) return override;
     final now = nowSeconds.toInt();
     int? nextSecond;
     var hasUnconfirmed = false;

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -49,6 +49,7 @@ import 'package:zcash_wallet/src/services/voting/voting_config_loader.dart';
 import 'package:zcash_wallet/src/services/voting/voting_endpoint_mapper.dart';
 import 'package:zcash_wallet/src/services/voting/voting_http.dart';
 import 'package:zcash_wallet/src/services/voting/voting_models.dart';
+import 'package:zcash_wallet/src/services/voting/voting_retry.dart';
 
 import '../../features/voting/round_plan_test_utils.dart';
 import '../../features/voting/tx_event_json_test_utils.dart';
@@ -4053,6 +4054,59 @@ void main() {
     expect(rust.helperDeliveryContexts.single.isDisposed, isTrue);
   });
 
+  test(
+    'fresh external share tracking triggers reuse a successful pass',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final pendingShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        ambiguousUrls: const [],
+        targetCount: 1,
+        nullifier: Uint8List.fromList(List.filled(32, 3)),
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.from(nowSeconds + 100),
+        createdAt: BigInt.from(nowSeconds),
+      );
+      final rust = FakeVotingRustApi();
+      final container = _sessionContainer(
+        rust: rust,
+        recoveryApi: FakeVotingRecoveryApi(
+          state: recoveryState(
+            shareDelegations: [pendingShare],
+            unconfirmedShareDelegations: [pendingShare],
+          ),
+        ),
+        extraOverrides: [
+          votingShareTrackingTriggerFreshnessProvider.overrideWithValue(
+            const Duration(hours: 1),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      const key = VotingSessionKey(accountUuid: 'account-1', roundId: kRoundId);
+
+      await container.read(votingSubmissionSessionProvider(key).future);
+      final notifier = container.read(
+        votingSubmissionSessionProvider(key).notifier,
+      );
+
+      await notifier.runShareTrackingPassIfStale();
+      await notifier.runShareTrackingPassIfStale();
+
+      expect(rust.trackPendingSharesCalls, [kRoundId]);
+
+      // Protocol-owned timers and submission recovery use the forced entry
+      // point, so freshness never delays a scheduled boundary.
+      await notifier.runShareTrackingPass();
+      expect(rust.trackPendingSharesCalls, [kRoundId, kRoundId]);
+    },
+  );
+
   test('immediate share waits until two accepted helpers corroborate', () async {
     final fullTrackingGate = Completer<void>();
     addTearDown(() {
@@ -4609,15 +4663,16 @@ void main() {
   );
 
   test(
-    'background share tracking refreshes a round that closes early',
+    'round-status heartbeat serializes before a requested full pass',
     () async {
       final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       final activeRound = roundStatusJson(
         roundId: kRoundId,
         voteEnd: nowSeconds + 1000,
       );
-      final closedRound = Map<String, dynamic>.of(activeRound)
-        ..['status'] = 'closed';
+      final roundRefreshResponse = Completer<VotingHttpResponse>();
+      final trackingGate = Completer<void>();
+      final rust = FakeVotingRustApi()..trackPendingSharesGate = trackingGate;
       final pendingShare = rust_frb_types.ShareDelegationRecordView(
         roundId: kRoundId,
         bundleIndex: 0,
@@ -4646,18 +4701,24 @@ void main() {
                   SequentialVotingHttpResponses([
                     {'round': activeRound},
                     {'round': activeRound},
-                    {'round': closedRound},
-                    {'round': closedRound},
+                    roundRefreshResponse.future,
+                    {'round': activeRound},
                   ]),
       );
       final container = _sessionContainer(
         http: http,
+        rust: rust,
         recoveryApi: FakeVotingRecoveryApi(
           state: recoveryState(
             shareDelegations: [pendingShare],
             unconfirmedShareDelegations: [pendingShare],
           ),
         ),
+        extraOverrides: [
+          votingShareTrackingRoundRefreshIntervalProvider.overrideWithValue(
+            const Duration(milliseconds: 10),
+          ),
+        ],
       );
       addTearDown(container.dispose);
       final roundProvider = votingSessionProvider(kRoundId);
@@ -4676,17 +4737,714 @@ void main() {
       final initialRound = await container.read(roundProvider.future);
       expect(initialRound.round?.status, 'active');
       await container.read(votingSubmissionSessionProvider(trackingKey).future);
-
-      await container
+      for (var i = 0; i < 100; i++) {
+        final roundReads = http.requests
+            .where(
+              (request) =>
+                  request.method == 'GET' &&
+                  request.uri.path == '/shielded-vote/v1/round/$kRoundId',
+            )
+            .length;
+        if (roundReads >= 3) {
+          break;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      final trackingPass = container
           .read(votingSubmissionSessionProvider(trackingKey).notifier)
-          .submitPendingShares();
+          .runShareTrackingPass();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(rust.trackPendingSharesCalls, isEmpty);
+
+      roundRefreshResponse.complete(jsonResponse({'round': activeRound}));
+      await rust.trackPendingSharesStarted.future;
+      if (!trackingGate.isCompleted) trackingGate.complete();
+      await trackingPass;
       final refreshedRound = await container.read(roundProvider.future);
 
-      expect(refreshedRound.round?.status, 'closed');
+      expect(refreshedRound.round?.status, 'active');
       expect(
         container.read(votingShareTrackingRegistryProvider).registeredKeys,
-        isEmpty,
+        contains(trackingKey),
       );
+      expect(rust.trackPendingSharesCalls, [kRoundId]);
+    },
+  );
+
+  test(
+    'background share tracking re-arms when the vote deadline extends',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final originalVoteEndSeconds = nowSeconds + 2;
+      final extendedVoteEndSeconds = nowSeconds + 1000;
+      final originalRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: originalVoteEndSeconds,
+      );
+      final extendedRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: extendedVoteEndSeconds,
+      );
+      final pendingShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        ambiguousUrls: const [],
+        targetCount: 1,
+        nullifier: Uint8List.fromList(List.filled(32, 1)),
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.from(nowSeconds + 100),
+        createdAt: BigInt.from(nowSeconds),
+      );
+      final rust = FakeVotingRustApi();
+      final http = FakeVotingHttpClient(
+        responses:
+            votingHttpResponses(
+                roundStatus: originalRound,
+                dynamicConfig: dynamicConfigJson(
+                  voteServers: const [
+                    {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                  ],
+                ),
+              )
+              ..['/shielded-vote/v1/round/$kRoundId'] =
+                  SequentialVotingHttpResponses([
+                    {'round': originalRound},
+                    {'round': originalRound},
+                    {'round': extendedRound},
+                  ]),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: FakeVotingRecoveryApi(
+          state: recoveryState(
+            shareDelegations: [pendingShare],
+            unconfirmedShareDelegations: [pendingShare],
+          ),
+        ),
+        extraOverrides: [
+          votingShareTrackingRoundRefreshIntervalProvider.overrideWithValue(
+            const Duration(milliseconds: 50),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final roundProvider = votingSessionProvider(kRoundId);
+      final roundSubscription = container
+          .listen<AsyncValue<VotingSessionState>>(
+            roundProvider,
+            (_, _) {},
+            fireImmediately: true,
+          );
+      addTearDown(roundSubscription.close);
+      const trackingKey = VotingSessionKey(
+        accountUuid: 'account-1',
+        roundId: kRoundId,
+      );
+      final trackingProvider = votingSubmissionSessionProvider(trackingKey);
+
+      await container.read(roundProvider.future);
+      await container.read(trackingProvider.future);
+      for (var i = 0; i < 100; i++) {
+        final voteEnd = container
+            .read(trackingProvider)
+            .value
+            ?.round
+            ?.voteEndTime
+            ?.millisecondsSinceEpoch;
+        if (voteEnd == extendedVoteEndSeconds * 1000) break;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+
+      final waitUntilOriginalExpiry = DateTime.fromMillisecondsSinceEpoch(
+        originalVoteEndSeconds * 1000,
+      ).difference(DateTime.now());
+      if (waitUntilOriginalExpiry > Duration.zero) {
+        await Future<void>.delayed(
+          waitUntilOriginalExpiry + const Duration(milliseconds: 100),
+        );
+      }
+
+      expect(
+        container
+            .read(trackingProvider)
+            .value
+            ?.round
+            ?.voteEndTime
+            ?.millisecondsSinceEpoch,
+        extendedVoteEndSeconds * 1000,
+      );
+      expect(
+        container.read(votingShareTrackingRegistryProvider).registeredKeys,
+        contains(trackingKey),
+      );
+      expect(rust.trackPendingSharesCalls, isEmpty);
+    },
+  );
+
+  test(
+    'deadline refresh preserves shares created after context load',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final originalVoteEndSeconds = nowSeconds + 2;
+      final extendedVoteEndSeconds = nowSeconds + 1000;
+      final originalRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: originalVoteEndSeconds,
+      );
+      final extendedRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: extendedVoteEndSeconds,
+      );
+      final pendingShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        ambiguousUrls: const [],
+        targetCount: 1,
+        nullifier: Uint8List.fromList(List.filled(32, 1)),
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.from(nowSeconds + 100),
+        createdAt: BigInt.from(nowSeconds),
+      );
+      final emptyRecovery = recoveryState();
+      final pendingRecovery = recoveryState(
+        shareDelegations: [pendingShare],
+        unconfirmedShareDelegations: [pendingShare],
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: emptyRecovery,
+        stateSequence: [emptyRecovery, emptyRecovery, pendingRecovery],
+      );
+      final rust = FakeVotingRustApi();
+      final http = FakeVotingHttpClient(
+        responses:
+            votingHttpResponses(
+                roundStatus: originalRound,
+                dynamicConfig: dynamicConfigJson(
+                  voteServers: const [
+                    {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                  ],
+                ),
+              )
+              ..['/shielded-vote/v1/round/$kRoundId'] =
+                  SequentialVotingHttpResponses([
+                    {'round': originalRound},
+                    {'round': originalRound},
+                    {'round': extendedRound},
+                  ]),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+        extraOverrides: [
+          votingShareTrackingRoundRefreshIntervalProvider.overrideWithValue(
+            const Duration(milliseconds: 50),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      const trackingKey = VotingSessionKey(
+        accountUuid: 'account-1',
+        roundId: kRoundId,
+      );
+      final trackingProvider = votingSubmissionSessionProvider(trackingKey);
+
+      final initial = await container.read(trackingProvider.future);
+      expect(initial.resumePlan?.unconfirmedShareDelegations, isEmpty);
+
+      await container
+          .read(trackingProvider.notifier)
+          .castVotes(draftVotes: const []);
+      expect(
+        container
+            .read(trackingProvider)
+            .value
+            ?.resumePlan
+            ?.unconfirmedShareDelegations,
+        [pendingShare],
+      );
+
+      for (var i = 0; i < 100; i++) {
+        final voteEnd = container
+            .read(trackingProvider)
+            .value
+            ?.round
+            ?.voteEndTime
+            ?.millisecondsSinceEpoch;
+        if (voteEnd == extendedVoteEndSeconds * 1000) break;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+
+      expect(
+        container
+            .read(trackingProvider)
+            .value
+            ?.round
+            ?.voteEndTime
+            ?.millisecondsSinceEpoch,
+        extendedVoteEndSeconds * 1000,
+      );
+      expect(
+        container.read(votingShareTrackingRegistryProvider).registeredKeys,
+        contains(trackingKey),
+      );
+      expect(rust.trackPendingSharesCalls, isEmpty);
+    },
+  );
+
+  test(
+    'share tracking refreshes an extension at the cached deadline',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final originalVoteEndSeconds = nowSeconds + 2;
+      final extendedVoteEndSeconds = nowSeconds + 1000;
+      final originalRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: originalVoteEndSeconds,
+      );
+      final extendedRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: extendedVoteEndSeconds,
+      );
+      final pendingShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        ambiguousUrls: const [],
+        targetCount: 1,
+        nullifier: Uint8List.fromList(List.filled(32, 1)),
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.from(nowSeconds + 100),
+        createdAt: BigInt.from(nowSeconds),
+      );
+      final rust = FakeVotingRustApi();
+      final http = FakeVotingHttpClient(
+        responses:
+            votingHttpResponses(
+                roundStatus: originalRound,
+                dynamicConfig: dynamicConfigJson(
+                  voteServers: const [
+                    {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                  ],
+                ),
+              )
+              ..['/shielded-vote/v1/round/$kRoundId'] =
+                  SequentialVotingHttpResponses([
+                    {'round': originalRound},
+                    {'round': extendedRound},
+                  ]),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: FakeVotingRecoveryApi(
+          state: recoveryState(
+            shareDelegations: [pendingShare],
+            unconfirmedShareDelegations: [pendingShare],
+          ),
+        ),
+      );
+      addTearDown(container.dispose);
+      const trackingKey = VotingSessionKey(
+        accountUuid: 'account-1',
+        roundId: kRoundId,
+      );
+      final trackingProvider = votingSubmissionSessionProvider(trackingKey);
+
+      final initial = await container.read(trackingProvider.future);
+      expect(
+        initial.round?.voteEndTime?.millisecondsSinceEpoch,
+        originalVoteEndSeconds * 1000,
+      );
+      for (var i = 0; i < 300; i++) {
+        final voteEnd = container
+            .read(trackingProvider)
+            .value
+            ?.round
+            ?.voteEndTime
+            ?.millisecondsSinceEpoch;
+        if (voteEnd == extendedVoteEndSeconds * 1000) break;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+
+      expect(
+        container
+            .read(trackingProvider)
+            .value
+            ?.round
+            ?.voteEndTime
+            ?.millisecondsSinceEpoch,
+        extendedVoteEndSeconds * 1000,
+      );
+      expect(
+        container.read(votingShareTrackingRegistryProvider).registeredKeys,
+        contains(trackingKey),
+      );
+      expect(rust.trackPendingSharesCalls, isEmpty);
+      expect(
+        http.requests
+            .where(
+              (request) =>
+                  request.method == 'GET' &&
+                  request.uri.path == '/shielded-vote/v1/round/$kRoundId',
+            )
+            .length,
+        2,
+      );
+    },
+  );
+
+  test(
+    'failed cached-deadline refresh retries without releasing tracking',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final originalVoteEndSeconds = nowSeconds + 1;
+      final extendedVoteEndSeconds = nowSeconds + 1000;
+      final originalRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: originalVoteEndSeconds,
+      );
+      final extendedRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: extendedVoteEndSeconds,
+      );
+      final pendingShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        ambiguousUrls: const [],
+        targetCount: 1,
+        nullifier: Uint8List.fromList(List.filled(32, 1)),
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.from(nowSeconds + 100),
+        createdAt: BigInt.from(nowSeconds),
+      );
+      final rust = FakeVotingRustApi();
+      final http = FakeVotingHttpClient(
+        responses:
+            votingHttpResponses(
+                roundStatus: originalRound,
+                dynamicConfig: dynamicConfigJson(
+                  voteServers: const [
+                    {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                  ],
+                ),
+              )
+              ..['/shielded-vote/v1/round/$kRoundId'] =
+                  SequentialVotingHttpResponses([
+                    {'round': originalRound},
+                    TimeoutException('round status unavailable'),
+                    TimeoutException('round status unavailable'),
+                    TimeoutException('round status unavailable'),
+                    {'round': extendedRound},
+                  ]),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: FakeVotingRecoveryApi(
+          state: recoveryState(
+            shareDelegations: [pendingShare],
+            unconfirmedShareDelegations: [pendingShare],
+          ),
+        ),
+        extraOverrides: [
+          votingApiReadRetryPolicyProvider.overrideWithValue(
+            VotingRetryPolicy.transientHttp(
+              name: 'test-voting-read',
+              delays: const [Duration.zero, Duration.zero],
+            ),
+          ),
+          votingShareTrackingFailureRetryDelayProvider.overrideWithValue(
+            const Duration(milliseconds: 10),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      const trackingKey = VotingSessionKey(
+        accountUuid: 'account-1',
+        roundId: kRoundId,
+      );
+      final trackingProvider = votingSubmissionSessionProvider(trackingKey);
+
+      await container.read(trackingProvider.future);
+      for (var i = 0; i < 300; i++) {
+        final voteEnd = container
+            .read(trackingProvider)
+            .value
+            ?.round
+            ?.voteEndTime
+            ?.millisecondsSinceEpoch;
+        if (voteEnd == extendedVoteEndSeconds * 1000) break;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+
+      expect(
+        container
+            .read(trackingProvider)
+            .value
+            ?.round
+            ?.voteEndTime
+            ?.millisecondsSinceEpoch,
+        extendedVoteEndSeconds * 1000,
+      );
+      expect(
+        container.read(votingShareTrackingRegistryProvider).registeredKeys,
+        contains(trackingKey),
+      );
+      expect(rust.trackPendingSharesCalls, isEmpty);
+      expect(
+        http.requests
+            .where(
+              (request) =>
+                  request.method == 'GET' &&
+                  request.uri.path == '/shielded-vote/v1/round/$kRoundId',
+            )
+            .length,
+        5,
+      );
+    },
+  );
+
+  test(
+    'single heartbeat applies a deadline extension before the next wake',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final originalVoteEndSeconds = nowSeconds + 1;
+      final extendedVoteEndSeconds = nowSeconds + 1000;
+      final originalRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: originalVoteEndSeconds,
+      );
+      final extendedRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: extendedVoteEndSeconds,
+      );
+      final staleHeartbeat = Completer<VotingHttpResponse>();
+      addTearDown(() {
+        if (!staleHeartbeat.isCompleted) {
+          staleHeartbeat.complete(jsonResponse({'round': originalRound}));
+        }
+      });
+      final pendingShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        ambiguousUrls: const [],
+        targetCount: 1,
+        nullifier: Uint8List.fromList(List.filled(32, 1)),
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.from(nowSeconds + 100),
+        createdAt: BigInt.from(nowSeconds),
+      );
+      final rust = FakeVotingRustApi();
+      final http = FakeVotingHttpClient(
+        responses:
+            votingHttpResponses(
+                roundStatus: originalRound,
+                dynamicConfig: dynamicConfigJson(
+                  voteServers: const [
+                    {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                  ],
+                ),
+              )
+              ..['/shielded-vote/v1/round/$kRoundId'] =
+                  SequentialVotingHttpResponses([
+                    {'round': originalRound},
+                    staleHeartbeat.future,
+                    {'round': extendedRound},
+                  ]),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: FakeVotingRecoveryApi(
+          state: recoveryState(
+            shareDelegations: [pendingShare],
+            unconfirmedShareDelegations: [pendingShare],
+          ),
+        ),
+        extraOverrides: [
+          votingShareTrackingRoundRefreshIntervalProvider.overrideWithValue(
+            const Duration(milliseconds: 10),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      const trackingKey = VotingSessionKey(
+        accountUuid: 'account-1',
+        roundId: kRoundId,
+      );
+      final trackingProvider = votingSubmissionSessionProvider(trackingKey);
+
+      await container.read(trackingProvider.future);
+      staleHeartbeat.complete(jsonResponse({'round': extendedRound}));
+      for (var i = 0; i < 300; i++) {
+        final voteEnd = container
+            .read(trackingProvider)
+            .value
+            ?.round
+            ?.voteEndTime
+            ?.millisecondsSinceEpoch;
+        if (voteEnd == extendedVoteEndSeconds * 1000) break;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(
+        container
+            .read(trackingProvider)
+            .value
+            ?.round
+            ?.voteEndTime
+            ?.millisecondsSinceEpoch,
+        extendedVoteEndSeconds * 1000,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        container
+            .read(trackingProvider)
+            .value
+            ?.round
+            ?.voteEndTime
+            ?.millisecondsSinceEpoch,
+        extendedVoteEndSeconds * 1000,
+      );
+      expect(
+        container.read(votingShareTrackingRegistryProvider).registeredKeys,
+        contains(trackingKey),
+      );
+      expect(rust.trackPendingSharesCalls, isEmpty);
+    },
+  );
+
+  test(
+    'full pass starts after a serialized heartbeat applies an extension',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final originalVoteEndSeconds = nowSeconds + 1000;
+      final extendedVoteEndSeconds = nowSeconds + 2000;
+      final originalRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: originalVoteEndSeconds,
+      );
+      final extendedRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: extendedVoteEndSeconds,
+      );
+      final staleHeartbeat = Completer<VotingHttpResponse>();
+      final trackingGate = Completer<void>();
+      addTearDown(() {
+        if (!staleHeartbeat.isCompleted) {
+          staleHeartbeat.complete(jsonResponse({'round': originalRound}));
+        }
+        if (!trackingGate.isCompleted) trackingGate.complete();
+      });
+      final pendingShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        ambiguousUrls: const [],
+        targetCount: 1,
+        nullifier: Uint8List.fromList(List.filled(32, 1)),
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.from(nowSeconds + 100),
+        createdAt: BigInt.from(nowSeconds),
+      );
+      final rust = FakeVotingRustApi()..trackPendingSharesGate = trackingGate;
+      final http = FakeVotingHttpClient(
+        responses:
+            votingHttpResponses(
+                roundStatus: originalRound,
+                dynamicConfig: dynamicConfigJson(
+                  voteServers: const [
+                    {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                  ],
+                ),
+              )
+              ..['/shielded-vote/v1/round/$kRoundId'] =
+                  SequentialVotingHttpResponses([
+                    {'round': originalRound},
+                    staleHeartbeat.future,
+                    {'round': extendedRound},
+                  ]),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: FakeVotingRecoveryApi(
+          state: recoveryState(
+            shareDelegations: [pendingShare],
+            unconfirmedShareDelegations: [pendingShare],
+          ),
+        ),
+        extraOverrides: [
+          votingShareTrackingRoundRefreshIntervalProvider.overrideWithValue(
+            const Duration(milliseconds: 10),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      const trackingKey = VotingSessionKey(
+        accountUuid: 'account-1',
+        roundId: kRoundId,
+      );
+      final trackingProvider = votingSubmissionSessionProvider(trackingKey);
+
+      await container.read(trackingProvider.future);
+      for (var i = 0; i < 100; i++) {
+        final roundReads = http.requests
+            .where(
+              (request) =>
+                  request.method == 'GET' &&
+                  request.uri.path == '/shielded-vote/v1/round/$kRoundId',
+            )
+            .length;
+        if (roundReads >= 2) break;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+
+      staleHeartbeat.complete(jsonResponse({'round': extendedRound}));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      final trackingPass = container
+          .read(trackingProvider.notifier)
+          .runShareTrackingPass();
+      await rust.trackPendingSharesStarted.future;
+
+      expect(
+        container.read(votingShareTrackingRegistryProvider).registeredKeys,
+        contains(trackingKey),
+      );
+
+      trackingGate.complete();
+      await trackingPass;
+
+      expect(
+        container.read(votingShareTrackingRegistryProvider).registeredKeys,
+        contains(trackingKey),
+      );
+      expect(rust.trackPendingSharesCalls, [kRoundId]);
     },
   );
 
@@ -8300,31 +9058,54 @@ void main() {
     },
   );
 
-  test(
-    'expired persisted shares stop before config or round requests',
-    () async {
-      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-      final http = FakeVotingHttpClient();
-      final container = _sessionContainer(
-        http: http,
-        pendingShareRoundLoader:
-            ({required dbPath, required accountUuids}) async {
-              return [
-                rust_api.ApiPendingShareRound(
-                  accountUuid: 'account-1',
-                  roundId: kRoundId,
-                  sessionJson: jsonEncode({'vote_end_time': nowSeconds - 1}),
-                ),
-              ];
-            },
-      );
-      addTearDown(container.dispose);
+  test('expired persisted shares verify live status before stopping', () async {
+    final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final http = FakeVotingHttpClient(
+      responses: votingHttpResponses(
+        roundStatus: roundStatusJson(
+          roundId: kRoundId,
+          voteEnd: nowSeconds - 1,
+        ),
+      ),
+    );
+    final rust = FakeVotingRustApi();
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      pendingShareRoundLoader:
+          ({required dbPath, required accountUuids}) async {
+            return [
+              rust_api.ApiPendingShareRound(
+                accountUuid: 'account-1',
+                roundId: kRoundId,
+                sessionJson: jsonEncode({'vote_end_time': nowSeconds - 1}),
+              ),
+            ];
+          },
+    );
+    addTearDown(container.dispose);
 
-      await container.read(votingShareTrackingRestorerProvider).restore();
+    await container.read(votingShareTrackingRestorerProvider).restore();
 
-      expect(http.requests, isEmpty);
-    },
-  );
+    expect(
+      http.requests
+          .where(
+            (request) =>
+                request.uri.path == '/shielded-vote/v1/round/$kRoundId',
+          )
+          .length,
+      1,
+    );
+    expect(rust.trackPendingSharesCalls, isEmpty);
+    expect(
+      http.requests.where(
+        (request) =>
+            request.uri.path.contains('share-status') ||
+            request.uri.path == '/shielded-vote/v1/shares',
+      ),
+      isEmpty,
+    );
+  });
 
   test('active rounds without an end time do not track shares', () {
     final round = VotingRoundDetails.fromStatus(
@@ -8740,7 +9521,7 @@ void main() {
     registry.resume();
   });
 
-  test('restores persisted shares across async session loading', () async {
+  test('restores cached-expired share when live round is open', () async {
     final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     const unknownRoundId =
         'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
@@ -8780,6 +9561,7 @@ void main() {
         unconfirmedShareDelegations: [pendingShare],
       ),
     );
+    final rust = FakeVotingRustApi();
     final shareId = _hexFromBytes(pendingShare.nullifier);
     final http = _YieldingFakeVotingHttpClient(
       responses:
@@ -8795,12 +9577,19 @@ void main() {
               ],
             ),
           )..addAll({
+            '/shielded-vote/v1/round/$kOtherRoundId': {
+              'round': roundStatusJson(
+                roundId: kOtherRoundId,
+                voteEnd: nowSeconds - 1,
+              ),
+            },
             'https://helper-a.example/shielded-vote/v1/share-status/$kRoundId/$shareId':
                 {'status': 'pending'},
           }),
     );
     final container = _sessionContainer(
       http: http,
+      rust: rust,
       recoveryApi: recoveryApi,
       pendingShareRoundLoader:
           ({required dbPath, required accountUuids}) async {
@@ -8808,7 +9597,9 @@ void main() {
               rust_api.ApiPendingShareRound(
                 accountUuid: 'account-1',
                 roundId: kRoundId,
-                sessionJson: jsonEncode({'vote_end_time': nowSeconds + 1000}),
+                // The sidecar retains the original deadline even though the
+                // authenticated live response above has extended the round.
+                sessionJson: jsonEncode({'vote_end_time': nowSeconds - 1}),
               ),
               rust_api.ApiPendingShareRound(
                 accountUuid: 'account-1',
@@ -8839,15 +9630,21 @@ void main() {
     final roundRequests = http.requests.where(
       (request) => request.uri.path.contains('/shielded-vote/v1/round/'),
     );
-    expect(roundRequests, isNotEmpty);
-    expect(
-      roundRequests.every((request) => request.uri.path.endsWith(kRoundId)),
-      isTrue,
-    );
+    expect(roundRequests.map((request) => request.uri.path).toSet(), {
+      '/shielded-vote/v1/round/$kRoundId',
+      '/shielded-vote/v1/round/$kOtherRoundId',
+    });
     final registry = container.read(votingShareTrackingRegistryProvider);
     expect(registry.registeredKeys, {
       const VotingSessionKey(accountUuid: 'account-1', roundId: kRoundId),
     });
+    expect(rust.trackPendingSharesCalls, [kRoundId]);
+    expect(
+      roundRequests
+          .where((request) => request.uri.path.endsWith(kOtherRoundId))
+          .length,
+      1,
+    );
 
     await registry.quiesceAndDrain();
     expect(registry.registeredKeys, isEmpty);
@@ -9012,6 +9809,59 @@ void main() {
       expect(recoveryApi.addedSentServers, isEmpty);
     },
   );
+
+  test('unrecoverable shares switch to confirmation-only tracking', () async {
+    final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final pendingShare = rust_frb_types.ShareDelegationRecordView(
+      roundId: kRoundId,
+      bundleIndex: 0,
+      proposalId: 7,
+      shareIndex: 0,
+      sentToUrls: const ['https://helper-a.example'],
+      ambiguousUrls: const [],
+      targetCount: 1,
+      nullifier: Uint8List.fromList(List.filled(32, 4)),
+      phase: VotingWorkflowPhase.submittedShare,
+      confirmed: false,
+      submitAt: BigInt.from(nowSeconds - 100),
+      createdAt: BigInt.from(nowSeconds - 100),
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        shareDelegations: [pendingShare],
+        unconfirmedShareDelegations: [pendingShare],
+      ),
+    );
+    final rust = FakeVotingRustApi();
+    rust.trackPendingSharesResult = () => rust_api.ApiShareTrackingReport(
+      confirmed: const [],
+      resubmitted: const [],
+      ambiguous: const [],
+      unrecoverable: const [
+        rust_api.ApiShareKey(bundleIndex: 0, proposalId: 7, shareIndex: 0),
+      ],
+      cancelled: false,
+      nextDelaySeconds: null,
+    );
+    final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
+    addTearDown(container.dispose);
+    final provider = votingSessionProvider(kRoundId);
+
+    await container.read(provider.future);
+    final notifier = container.read(provider.notifier);
+    await notifier.runShareTrackingPass();
+
+    expect(rust.trackPendingSharesCalls, [kRoundId]);
+    // Initial load, one pre-pass context refresh, and one post-pass refresh.
+    // The pass does not reload either plan again before entering Rust.
+    expect(recoveryApi.walletIds, hasLength(3));
+    expect(recoveryApi.roundPlanProposalIds, hasLength(3));
+
+    await notifier.runShareTrackingPass();
+
+    expect(rust.trackPendingSharesCalls, [kRoundId]);
+    expect(rust.focusedShareConfirmationCalls, ['0:7:0']);
+  });
 
   test('pending share recovery resubmits helpers missed initially', () async {
     final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -9762,11 +10612,11 @@ void main() {
     final registry = container.read(votingShareTrackingRegistryProvider);
     addTearDown(() => registry.resume(accountUuid: 'account-1'));
     var drained = false;
-    final drain = registry
-        .quiesceAndDrain(accountUuid: 'account-1')
-        .then<void>((_) {
-          drained = true;
-        });
+    final drain = registry.quiesceAndDrain(accountUuid: 'account-1').then<void>(
+      (_) {
+        drained = true;
+      },
+    );
     await Future<void>.delayed(Duration.zero);
     expect(drained, isFalse);
 
@@ -11207,6 +12057,7 @@ VotingKeystoneBatchSignature _keystoneBatchSignature(int bundleIndex) {
 
 class FakeVotingRecoveryApi implements VotingRecoveryApi {
   rust_frb_types.RoundRecoveryStateView state;
+  final List<rust_frb_types.RoundRecoveryStateView>? stateSequence;
   rust_wire.RoundPlanView? roundPlan;
   final List<rust_wire.RoundPlanView>? roundPlanSequence;
   final walletIds = <String>[];
@@ -11214,10 +12065,12 @@ class FakeVotingRecoveryApi implements VotingRecoveryApi {
   final ballotIntents = <String>[];
   final roundPlanProposalIds = <List<int>>[];
   final Object? setBallotIntentError;
+  var _stateCallCount = 0;
   var _roundPlanCallCount = 0;
 
   FakeVotingRecoveryApi({
     required this.state,
+    this.stateSequence,
     this.roundPlan,
     this.roundPlanSequence,
     this.setBallotIntentError,
@@ -11244,6 +12097,13 @@ class FakeVotingRecoveryApi implements VotingRecoveryApi {
     required String roundId,
   }) async {
     walletIds.add(accountUuid);
+    final sequence = stateSequence;
+    if (sequence != null && sequence.isNotEmpty) {
+      var index = _stateCallCount;
+      _stateCallCount++;
+      if (index >= sequence.length) index = sequence.length - 1;
+      state = sequence[index];
+    }
     return state;
   }
 
@@ -13599,6 +14459,7 @@ class FakeVotingRustApi implements VotingRustApi {
     final now = nowSeconds.toInt();
     int? nextSecond;
     var hasUnconfirmed = false;
+    var hasReady = false;
     for (final share in shares.where((share) => !share.confirmed)) {
       hasUnconfirmed = true;
       final base = share.submitAt > BigInt.zero
@@ -13607,12 +14468,12 @@ class FakeVotingRustApi implements VotingRustApi {
       final checkAt = base + 10;
       if (checkAt > now && (nextSecond == null || checkAt < nextSecond)) {
         nextSecond = checkAt;
+      } else if (checkAt <= now) {
+        hasReady = true;
       }
     }
     if (!hasUnconfirmed) return null;
-    final delay = nextSecond == null
-        ? 15
-        : (nextSecond - now).clamp(0, 30).toInt();
+    final delay = hasReady || nextSecond == null ? 15 : nextSecond - now;
     return BigInt.from(delay < 3 ? 3 : delay);
   }
 

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -4608,6 +4608,88 @@ void main() {
     },
   );
 
+  test(
+    'background share tracking refreshes a round that closes early',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final activeRound = roundStatusJson(
+        roundId: kRoundId,
+        voteEnd: nowSeconds + 1000,
+      );
+      final closedRound = Map<String, dynamic>.of(activeRound)
+        ..['status'] = 'closed';
+      final pendingShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        ambiguousUrls: const [],
+        targetCount: 1,
+        nullifier: Uint8List.fromList(List.filled(32, 1)),
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.from(nowSeconds + 100),
+        createdAt: BigInt.from(nowSeconds),
+      );
+      final http = FakeVotingHttpClient(
+        responses:
+            votingHttpResponses(
+                roundStatus: activeRound,
+                dynamicConfig: dynamicConfigJson(
+                  voteServers: const [
+                    {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                  ],
+                ),
+              )
+              ..['/shielded-vote/v1/round/$kRoundId'] =
+                  SequentialVotingHttpResponses([
+                    {'round': activeRound},
+                    {'round': activeRound},
+                    {'round': closedRound},
+                    {'round': closedRound},
+                  ]),
+      );
+      final container = _sessionContainer(
+        http: http,
+        recoveryApi: FakeVotingRecoveryApi(
+          state: recoveryState(
+            shareDelegations: [pendingShare],
+            unconfirmedShareDelegations: [pendingShare],
+          ),
+        ),
+      );
+      addTearDown(container.dispose);
+      final roundProvider = votingSessionProvider(kRoundId);
+      final roundSubscription = container
+          .listen<AsyncValue<VotingSessionState>>(
+            roundProvider,
+            (_, _) {},
+            fireImmediately: true,
+          );
+      addTearDown(roundSubscription.close);
+      const trackingKey = VotingSessionKey(
+        accountUuid: 'account-1',
+        roundId: kRoundId,
+      );
+
+      final initialRound = await container.read(roundProvider.future);
+      expect(initialRound.round?.status, 'active');
+      await container.read(votingSubmissionSessionProvider(trackingKey).future);
+
+      await container
+          .read(votingSubmissionSessionProvider(trackingKey).notifier)
+          .submitPendingShares();
+      final refreshedRound = await container.read(roundProvider.future);
+
+      expect(refreshedRound.round?.status, 'closed');
+      expect(
+        container.read(votingShareTrackingRegistryProvider).registeredKeys,
+        isEmpty,
+      );
+    },
+  );
+
   test('share tracking failure fails the job and releases its guard', () async {
     final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final pendingShare = rust_frb_types.ShareDelegationRecordView(


### PR DESCRIPTION
After a vote is locked in, Vizor shows a non-interactive Submission status tile at the bottom of the voted poll detail while the voting window remains active. It shows the submitted count and, while shares remain, a percentage, progress bar, and approximate completion time rounded to minutes, hours, or days. The explanation reflects whether the vote actually uses staggered shares and makes clear that configured servers continue submitting after Vizor closes.

Once all shares are submitted, the estimate, percentage, and bar give way to a green check. The tile is hidden after the active voting window closes; finalized results do not claim share inclusion until post-tally nullifier reconciliation is implemented.