### PR TITLE
Show full mobile voting option copy

### DIFF
--- a/lib/src/features/voting/screens/voting_results_screen.dart
+++ b/lib/src/features/voting/screens/voting_results_screen.dart
@@ -520,33 +520,36 @@ class _MobileTallyRow extends StatelessWidget {
     final progress = total <= 0
         ? 0.0
         : (amount / total).clamp(0.0, 1.0).toDouble();
-    return SizedBox(
-      height: 48,
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: 48),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(AppRadii.medium),
         child: Stack(
-          fit: StackFit.expand,
+          alignment: Alignment.center,
           children: [
-            ColoredBox(color: colors.background.base),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: FractionallySizedBox(
-                widthFactor: progress,
-                heightFactor: 1,
-                child: ColoredBox(
-                  color: colors.background.neutralSubtleOpacity,
+            Positioned.fill(child: ColoredBox(color: colors.background.base)),
+            Positioned.fill(
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: FractionallySizedBox(
+                  widthFactor: progress,
+                  heightFactor: 1,
+                  child: ColoredBox(
+                    color: colors.background.neutralSubtleOpacity,
+                  ),
                 ),
               ),
             ),
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.s,
+                vertical: AppSpacing.xs,
+              ),
               child: Row(
                 children: [
                   Expanded(
                     child: Text(
                       selected ? '${option.label} (your vote)' : option.label,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
                       style: AppTypography.bodySmall.copyWith(
                         color: colors.text.accent,
                         fontWeight: FontWeight.w500,

--- a/lib/src/features/voting/widgets/voting_metadata_widgets.dart
+++ b/lib/src/features/voting/widgets/voting_metadata_widgets.dart
@@ -498,7 +498,7 @@ class _MobileVotingProposalOption extends StatelessWidget {
             ? null
             : onDisabledTap,
         child: Container(
-          height: description.isEmpty ? 48 : 94,
+          constraints: BoxConstraints(minHeight: description.isEmpty ? 48 : 94),
           padding: const EdgeInsets.all(10),
           decoration: BoxDecoration(
             color: colors.background.base,
@@ -516,8 +516,6 @@ class _MobileVotingProposalOption extends StatelessWidget {
                   Expanded(
                     child: Text(
                       option.label,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
                       style: AppTypography.bodySmall.copyWith(
                         color: colors.text.accent,
                         fontWeight: FontWeight.w500,
@@ -546,8 +544,6 @@ class _MobileVotingProposalOption extends StatelessWidget {
                 const SizedBox(height: AppSpacing.xxs),
                 Text(
                   description,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
                   style: AppTypography.bodySmall.copyWith(
                     color: colors.text.primary,
                     height: 21 / 14,

--- a/test/features/voting/mobile_voting_design_test.dart
+++ b/test/features/voting/mobile_voting_design_test.dart
@@ -99,12 +99,60 @@ void main() {
     expect(find.text('490.36 ZEC'), findsWidgets);
   });
 
-  testWidgets('long mobile metadata and option labels stay within the card', (
+  testWidgets('long mobile result labels remain fully visible', (tester) async {
+    const optionLabel =
+        'Ship NU7 as soon as possible, removing any feature that is not '
+        'implemented by the September 30th deadline.';
+    const displayedOptionLabel = '$optionLabel (your vote)';
+    await _pumpMobileFixture(
+      tester,
+      (_) => const MobileVotingScaffold(
+        title: 'Voting results',
+        child: SingleChildScrollView(
+          padding: EdgeInsets.fromLTRB(16, 12, 16, 24),
+          child: VotingResultCard(
+            proposal: VotingProposalView(
+              id: 98,
+              title: 'NU7 Scope and Readiness',
+              description:
+                  'How should features that are not ready by the deadline be '
+                  'handled?',
+              options: [VotingOptionView(index: 1, label: optionLabel)],
+            ),
+            tally: {1: 2.75},
+            selectedChoice: 1,
+          ),
+        ),
+      ),
+    );
+
+    final option = tester.widget<Text>(find.text(displayedOptionLabel));
+    final row = find.ancestor(
+      of: find.text(displayedOptionLabel),
+      matching: find.byType(ClipRRect),
+    );
+    expect(option.maxLines, isNull);
+    expect(option.overflow, isNull);
+    expect(row, findsOneWidget);
+    expect(tester.getSize(row).height, greaterThan(48));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('long mobile question and option copy remains fully visible', (
     tester,
   ) async {
-    const title = 'A proposal with constrained mobile metadata';
+    const title =
+        'A proposal title that wraps across multiple lines on a mobile screen';
+    const proposalDescription =
+        'A proposal description that must remain fully visible even when it '
+        'takes several lines to explain the question to the voter.';
     const optionLabel =
-        'A very long option label that must remain on a single line';
+        'Ship NU7 as soon as possible, removing any feature that is not '
+        'implemented by the September 30th deadline.';
+    const optionDescription =
+        'This option description is intentionally long enough to exceed two '
+        'lines so the complete explanation remains available before voting.';
+    const optionKey = ValueKey('voting_proposal_99_option_1');
     await _pumpMobileFixture(
       tester,
       (_) => MobileVotingScaffold(
@@ -115,15 +163,14 @@ void main() {
             proposal: const VotingProposalView(
               id: 99,
               title: title,
-              description: 'Description',
+              description: proposalDescription,
               zipNumber:
                   'ZIP-1000 ZIP-2000 ZIP-3000 ZIP-4000 ZIP-5000 ZIP-6000',
               options: [
                 VotingOptionView(
                   index: 1,
                   label: optionLabel,
-                  description:
-                      'A description that occupies the supported two lines.',
+                  description: optionDescription,
                 ),
               ],
             ),
@@ -134,14 +181,26 @@ void main() {
     );
 
     final metadata = find.textContaining('ZIP-1000');
+    final proposalTitle = tester.widget<Text>(find.text(title));
+    final description = tester.widget<Text>(find.text(proposalDescription));
     final option = tester.widget<Text>(find.text(optionLabel));
+    final optionDescriptionText = tester.widget<Text>(
+      find.text(optionDescription),
+    );
     expect(metadata, findsOneWidget);
     expect(
       tester.getBottomLeft(metadata).dy,
       lessThanOrEqualTo(tester.getTopLeft(find.text(title)).dy),
     );
-    expect(option.maxLines, 1);
-    expect(option.overflow, TextOverflow.ellipsis);
+    expect(proposalTitle.maxLines, isNull);
+    expect(proposalTitle.overflow, isNull);
+    expect(description.maxLines, isNull);
+    expect(description.overflow, isNull);
+    expect(option.maxLines, isNull);
+    expect(option.overflow, isNull);
+    expect(optionDescriptionText.maxLines, isNull);
+    expect(optionDescriptionText.overflow, isNull);
+    expect(tester.getSize(find.byKey(optionKey)).height, greaterThan(94));
     expect(tester.getSize(find.byType(VotingForumLinkButton)).height, 24);
     expect(tester.takeException(), isNull);
   });


### PR DESCRIPTION
Mobile voting question and result rows used fixed heights and ellipsized long option text. They now keep the designed minimum heights while expanding to show the complete label and description.\n\nRegression coverage uses the long NU7 readiness answer from the reported screen.