### PR TITLE
VZR-138 Enable wallet actions before Ironwood migration

### DIFF
--- a/integration_test/regtest_ironwood_pre_migration_send_test.dart
+++ b/integration_test/regtest_ironwood_pre_migration_send_test.dart
@@ -1,0 +1,276 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
+import 'package:zcash_wallet/src/providers/chain_upgrade_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import 'support/desktop_regtest_flow.dart';
+
+const _driverUrl = String.fromEnvironment(
+  'ZCASH_E2E_DRIVER_URL',
+  defaultValue: 'http://127.0.0.1:39078',
+);
+const _recipientAddress = String.fromEnvironment(
+  'ZCASH_E2E_SEND_RECIPIENT_ADDRESS',
+);
+const _network = 'regtest';
+final _fundedAmount = BigInt.from(1_100_000);
+final _sendAmount = BigInt.from(100_000);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(initializeZcashWalletRuntime);
+
+  testWidgets(
+    'sends Orchard funds before starting the required Ironwood migration',
+    (tester) async {
+      if (_recipientAddress.isEmpty) {
+        fail('ZCASH_E2E_SEND_RECIPIENT_ADDRESS is required.');
+      }
+
+      addTearDown(cleanupDesktopRegtestWallet);
+      await cleanupDesktopRegtestWallet();
+
+      final initialChain = await ironwoodDriverGet(_driverUrl, '/status');
+      expect(initialChain['ironwoodActive'], isFalse);
+
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+      await importDesktopRegtestWallet(tester);
+      await pumpUntil(
+        tester,
+        () =>
+            textForKey(
+              tester,
+              const ValueKey('home_desktop_balance_amount_text'),
+            ) ==
+            '0.011',
+        description: 'pre-Ironwood Orchard balance',
+        timeout: const Duration(minutes: 5),
+      );
+
+      e2eLog('activating Ironwood without starting migration');
+      await ironwoodDriverPost(_driverUrl, '/activate');
+
+      final providerContainer = ProviderScope.containerOf(
+        tester.element(
+          find.byKey(const ValueKey('home_desktop_balance_amount_text')),
+        ),
+      );
+      await pumpUntil(
+        tester,
+        () {
+          final chain = providerContainer
+              .read(chainUpgradeStatusProvider)
+              .value;
+          final sync = providerContainer.read(syncProvider).value;
+          final migration = providerContainer
+              .read(ironwoodPostMigrationStateProvider)
+              .value;
+          return chain?.ironwoodActiveAtTip == true &&
+              sync?.isSyncing == false &&
+              sync?.isSyncComplete == true &&
+              migration?.mode == IronwoodPostMigrationMode.required;
+        },
+        description: 'required Ironwood migration state',
+        timeout: const Duration(minutes: 5),
+      );
+      await pumpUntil(
+        tester,
+        () => tester.any(
+          find.byKey(const ValueKey('ironwood_migration_announcement_modal')),
+        ),
+        description: 'Ironwood migration announcement',
+      );
+      await dismissIronwoodAnnouncement(tester);
+
+      final accountUuid = await firstDesktopRegtestAccountUuid();
+      final dbPath = await getWalletDbPath();
+      final before = await rust_sync.getBalance(
+        dbPath: dbPath,
+        network: _network,
+        accountUuid: accountUuid,
+      );
+      expect(before.orchard, _fundedAmount);
+      expect(before.ironwood, BigInt.zero);
+      final migrationBefore = await desktopRegtestMigrationStatus(accountUuid);
+      expect(migrationBefore.activeRunId, isNull);
+
+      final validation = await rust_sync.validateAddress(
+        address: _recipientAddress,
+      );
+      expect(validation.isValid, isTrue);
+      expect(_recipientAddress, startsWith('uregtest1'));
+      final expectedFee = await rust_sync.estimateFee(
+        dbPath: dbPath,
+        network: _network,
+        accountUuid: accountUuid,
+        toAddress: _recipientAddress,
+        amountZatoshi: _sendAmount,
+      );
+
+      expect(
+        find.byKey(
+          const ValueKey('home_desktop_ironwood_migration_cta_button'),
+        ),
+        findsOneWidget,
+      );
+      await _sendBeforeMigration(tester);
+      await _waitForSentHistory(
+        tester,
+        dbPath: dbPath,
+        accountUuid: accountUuid,
+        pending: true,
+      );
+      final mempool = await ironwoodDriverGet(_driverUrl, '/mempool');
+      expect(mempool['size'], greaterThanOrEqualTo(1));
+      final migrationAfterBroadcast = await desktopRegtestMigrationStatus(
+        accountUuid,
+      );
+      expect(migrationAfterBroadcast.activeRunId, isNull);
+
+      e2eLog('confirming the pre-migration send');
+      await ironwoodDriverPost(
+        _driverUrl,
+        '/mine',
+        payload: const {'blocks': 11},
+      );
+      await _waitForConfirmedOrchardChange(
+        tester,
+        dbPath: dbPath,
+        accountUuid: accountUuid,
+        expectedOrchard: _fundedAmount - _sendAmount - expectedFee,
+      );
+
+      final migrationAfterConfirmation = await desktopRegtestMigrationStatus(
+        accountUuid,
+      );
+      expect(migrationAfterConfirmation.activeRunId, isNull);
+      await pumpUntil(
+        tester,
+        () =>
+            providerContainer
+                .read(ironwoodPostMigrationStateProvider)
+                .value
+                ?.mode ==
+            IronwoodPostMigrationMode.notNeeded,
+        description: 'migration no longer needed after legacy note spend',
+        timeout: const Duration(minutes: 3),
+      );
+      expect(
+        find.byKey(
+          const ValueKey('home_desktop_ironwood_migration_cta_button'),
+        ),
+        findsNothing,
+      );
+      e2eLog(
+        'pre-migration Orchard send confirmed; migration is no longer needed',
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 12)),
+  );
+}
+
+Future<void> _sendBeforeMigration(WidgetTester tester) async {
+  await tapAppWidget(tester, const ValueKey('home_desktop_send_button'));
+  await enterAppText(
+    tester,
+    const ValueKey('send_address_field'),
+    _recipientAddress,
+  );
+  await enterAppText(tester, const ValueKey('send_amount_field'), '0.001');
+  await tapAppButton(tester, const ValueKey('send_review_button'));
+  await tapAppButton(tester, const ValueKey('send_confirm_button'));
+  await pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('send_status_completed'))),
+    description: 'pre-migration send broadcast',
+    timeout: const Duration(minutes: 4),
+  );
+}
+
+Future<void> _waitForSentHistory(
+  WidgetTester tester, {
+  required String dbPath,
+  required String accountUuid,
+  required bool pending,
+  Duration timeout = const Duration(minutes: 3),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  var lastHistory = '<not read>';
+  while (DateTime.now().isBefore(deadline)) {
+    final history = await rust_sync.getTransactionHistory(
+      dbPath: dbPath,
+      network: _network,
+      limit: 20,
+      accountUuid: accountUuid,
+    );
+    lastHistory = history
+        .map(
+          (tx) =>
+              '${tx.txidHex}:${tx.txKind}:${tx.displayAmount}:${tx.minedHeight}',
+        )
+        .join(', ');
+    if (history.any(
+      (tx) =>
+          tx.txKind == 'sent' &&
+          tx.displayAmount == _sendAmount &&
+          (tx.minedHeight == BigInt.zero) == pending &&
+          !tx.expiredUnmined,
+    )) {
+      return;
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+  }
+  fail(
+    'Timed out waiting for pending=$pending sent history. Last: $lastHistory',
+  );
+}
+
+Future<void> _waitForConfirmedOrchardChange(
+  WidgetTester tester, {
+  required String dbPath,
+  required String accountUuid,
+  required BigInt expectedOrchard,
+  Duration timeout = const Duration(minutes: 5),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  rust_sync.WalletBalance? lastBalance;
+  while (DateTime.now().isBefore(deadline)) {
+    lastBalance = await rust_sync.getBalance(
+      dbPath: dbPath,
+      network: _network,
+      accountUuid: accountUuid,
+    );
+    final history = await rust_sync.getTransactionHistory(
+      dbPath: dbPath,
+      network: _network,
+      limit: 20,
+      accountUuid: accountUuid,
+    );
+    final confirmed = history.any(
+      (tx) =>
+          tx.txKind == 'sent' &&
+          tx.displayAmount == _sendAmount &&
+          tx.minedHeight > BigInt.zero &&
+          !tx.expiredUnmined,
+    );
+    if (confirmed &&
+        lastBalance.orchard == expectedOrchard &&
+        lastBalance.ironwood == BigInt.zero) {
+      return;
+    }
+    await tester.pump(const Duration(milliseconds: 150));
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+  }
+  fail(
+    'Timed out waiting for confirmed Orchard change. '
+    'Expected Orchard $expectedOrchard, last balance: $lastBalance',
+  );
+}

--- a/integration_test/regtest_mobile_ironwood_pre_migration_send_test.dart
+++ b/integration_test/regtest_mobile_ironwood_pre_migration_send_test.dart
@@ -1,0 +1,275 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
+import 'package:zcash_wallet/src/providers/chain_upgrade_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import 'support/mobile_regtest_flow.dart';
+
+const _recipientAddress = String.fromEnvironment(
+  'ZCASH_E2E_SEND_RECIPIENT_ADDRESS',
+);
+final _fundedAmount = BigInt.from(1_095_000);
+final _sendAmount = BigInt.from(100_000);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(initializeZcashWalletRuntime);
+
+  testWidgets(
+    'sends Orchard funds on iOS before starting the required migration',
+    (tester) async {
+      tolerateRenderOverflows();
+      if (_recipientAddress.isEmpty) {
+        fail('ZCASH_E2E_SEND_RECIPIENT_ADDRESS is required.');
+      }
+
+      addTearDown(cleanupE2eWalletState);
+      await cleanupE2eWalletState();
+
+      final initialChain = await getDriver('/status');
+      expect(initialChain['ironwoodActive'], isFalse);
+
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+      await importWalletViaPaste(
+        tester,
+        mnemonic: mobileIronwoodE2eMnemonic,
+        birthdayHeight: 1,
+        isFirstWallet: true,
+      );
+      await waitForShieldedBalance(tester, '0.01095 $mobileE2eTicker');
+
+      final container = ProviderScope.containerOf(
+        tester.element(
+          find.byKey(const ValueKey('mobile_home_shielded_balance')),
+        ),
+      );
+      await _waitForIdleSync(
+        tester,
+        container,
+        (initialChain['zcashdHeight'] as num).toInt(),
+      );
+
+      logE2e('activating Ironwood without starting migration');
+      await postDriver('/activate', const {});
+      await pumpUntil(
+        tester,
+        () {
+          final chain = container.read(chainUpgradeStatusProvider).value;
+          final sync = container.read(syncProvider).value;
+          final migration = container
+              .read(ironwoodPostMigrationStateProvider)
+              .value;
+          return chain?.ironwoodActiveAtTip == true &&
+              sync?.isSyncing == false &&
+              sync?.isSyncComplete == true &&
+              migration?.mode == IronwoodPostMigrationMode.required;
+        },
+        description: 'required mobile Ironwood migration state',
+        timeout: const Duration(minutes: 5),
+      );
+      await pumpUntil(
+        tester,
+        () => tester.any(
+          find.byKey(const ValueKey('mobile_ironwood_announcement_sheet')),
+        ),
+        description: 'mobile Ironwood migration announcement',
+      );
+      await tapWidget(
+        tester,
+        const ValueKey('mobile_ironwood_announcement_close_button'),
+      );
+      await pumpUntil(
+        tester,
+        () => tester.any(
+          find.byKey(
+            const ValueKey('mobile_home_ironwood_migration_required_pill'),
+          ),
+        ),
+        description: 'mobile Ironwood migration CTA',
+      );
+
+      final accountUuid = await accountUuidAtOrder(0);
+      final dbPath = await getWalletDbPath();
+      final before = await rust_sync.getBalance(
+        dbPath: dbPath,
+        network: mobileE2eNetwork,
+        accountUuid: accountUuid,
+      );
+      expect(before.orchard, _fundedAmount);
+      expect(before.ironwood, BigInt.zero);
+      expect(
+        (await mobileRegtestMigrationStatus(accountUuid)).activeRunId,
+        isNull,
+      );
+
+      final validation = await rust_sync.validateAddress(
+        address: _recipientAddress,
+      );
+      expect(validation.isValid, isTrue);
+      expect(_recipientAddress, startsWith('uregtest1'));
+      final expectedFee = await rust_sync.estimateFee(
+        dbPath: dbPath,
+        network: mobileE2eNetwork,
+        accountUuid: accountUuid,
+        toAddress: _recipientAddress,
+        amountZatoshi: _sendAmount,
+      );
+
+      await sendViaWizard(
+        tester,
+        address: _recipientAddress,
+        amountDigits: '0.001',
+      );
+      await _waitForSentHistory(
+        tester,
+        dbPath: dbPath,
+        accountUuid: accountUuid,
+        pending: true,
+      );
+      final mempool = await getDriver('/mempool');
+      expect(mempool['size'], greaterThanOrEqualTo(1));
+      expect(
+        (await mobileRegtestMigrationStatus(accountUuid)).activeRunId,
+        isNull,
+      );
+
+      logE2e('confirming the iOS pre-migration send');
+      await postDriver('/mine', const {'blocks': 11});
+      await _waitForConfirmedOrchardChange(
+        tester,
+        dbPath: dbPath,
+        accountUuid: accountUuid,
+        expectedOrchard: _fundedAmount - _sendAmount - expectedFee,
+      );
+
+      expect(
+        (await mobileRegtestMigrationStatus(accountUuid)).activeRunId,
+        isNull,
+      );
+      await pumpUntil(
+        tester,
+        () =>
+            container.read(ironwoodPostMigrationStateProvider).value?.mode ==
+            IronwoodPostMigrationMode.notNeeded,
+        description: 'mobile migration no longer needed after legacy spend',
+        timeout: const Duration(minutes: 3),
+      );
+      expect(
+        find.byKey(
+          const ValueKey('mobile_home_ironwood_migration_required_pill'),
+        ),
+        findsNothing,
+      );
+      logE2e(
+        'iOS pre-migration Orchard send confirmed; migration is not needed',
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 15)),
+  );
+}
+
+Future<void> _waitForIdleSync(
+  WidgetTester tester,
+  ProviderContainer container,
+  int targetHeight,
+) {
+  return pumpUntil(
+    tester,
+    () {
+      final sync = container.read(syncProvider).value;
+      return sync?.isSyncing == false &&
+          sync?.isSyncComplete == true &&
+          (sync?.scannedHeight ?? 0) >= targetHeight;
+    },
+    description: 'idle mobile wallet sync at $targetHeight',
+    timeout: const Duration(minutes: 5),
+  );
+}
+
+Future<void> _waitForSentHistory(
+  WidgetTester tester, {
+  required String dbPath,
+  required String accountUuid,
+  required bool pending,
+  Duration timeout = const Duration(minutes: 3),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  var lastHistory = '<not read>';
+  while (DateTime.now().isBefore(deadline)) {
+    final history = await rust_sync.getTransactionHistory(
+      dbPath: dbPath,
+      network: mobileE2eNetwork,
+      limit: 20,
+      accountUuid: accountUuid,
+    );
+    lastHistory = history
+        .map(
+          (tx) =>
+              '${tx.txidHex}:${tx.txKind}:${tx.displayAmount}:${tx.minedHeight}',
+        )
+        .join(', ');
+    if (history.any(
+      (tx) =>
+          tx.txKind == 'sent' &&
+          tx.displayAmount == _sendAmount &&
+          (tx.minedHeight == BigInt.zero) == pending &&
+          !tx.expiredUnmined,
+    )) {
+      return;
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+  }
+  fail(
+    'Timed out waiting for pending=$pending sent history. Last: $lastHistory',
+  );
+}
+
+Future<void> _waitForConfirmedOrchardChange(
+  WidgetTester tester, {
+  required String dbPath,
+  required String accountUuid,
+  required BigInt expectedOrchard,
+  Duration timeout = const Duration(minutes: 5),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  rust_sync.WalletBalance? lastBalance;
+  while (DateTime.now().isBefore(deadline)) {
+    lastBalance = await rust_sync.getBalance(
+      dbPath: dbPath,
+      network: mobileE2eNetwork,
+      accountUuid: accountUuid,
+    );
+    final history = await rust_sync.getTransactionHistory(
+      dbPath: dbPath,
+      network: mobileE2eNetwork,
+      limit: 20,
+      accountUuid: accountUuid,
+    );
+    final confirmed = history.any(
+      (tx) =>
+          tx.txKind == 'sent' &&
+          tx.displayAmount == _sendAmount &&
+          tx.minedHeight > BigInt.zero &&
+          !tx.expiredUnmined,
+    );
+    if (confirmed &&
+        lastBalance.orchard == expectedOrchard &&
+        lastBalance.ironwood == BigInt.zero) {
+      return;
+    }
+    await tester.pump(const Duration(milliseconds: 150));
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+  }
+  fail(
+    'Timed out waiting for confirmed Orchard change. '
+    'Expected Orchard $expectedOrchard, last balance: $lastBalance',
+  );
+}

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -31,7 +31,6 @@ import 'src/features/activity/screens/swap_activity_detail_screen.dart';
 import 'src/features/accounts/screens/accounts_screen.dart';
 import 'src/features/address_book/screens/address_book_screen.dart';
 import 'src/features/home/screens/home_screen.dart';
-import 'src/features/migration/providers/ironwood_migration_announcement_provider.dart';
 import 'src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
 import 'src/features/migration/screens/ironwood_migration_flow_screen.dart';
 import 'src/features/migration/widgets/ironwood_migration_privacy_lock_host.dart';
@@ -230,12 +229,6 @@ final _routerProvider = Provider<_AppRouter>((ref) {
   ref.listen(swapFeatureEnabledProvider, (_, _) {
     refresh.requestRefresh();
   });
-  ref.listen(ironwoodPostMigrationStateProvider, (_, _) {
-    final path = router.routerDelegate.currentConfiguration.uri.path;
-    if (_isIronwoodMigrationRestrictedRoute(path)) {
-      refresh.requestRefresh();
-    }
-  });
   log('router: initialized');
 
   final navigatorKey = GlobalKey<NavigatorState>();
@@ -387,29 +380,8 @@ String? appRedirect({
   if (hasWallet && state.matchedLocation == '/welcome') {
     return requiresUnlock ? '/unlock' : '/home';
   }
-  final locksIronwoodNavigation = kAppFormFactor == AppFormFactor.mobile
-      ? ref.read(ironwoodHomeMigrationPresentationProvider).mode ==
-            IronwoodHomeMigrationCtaMode.start
-      : ref.read(ironwoodPostMigrationStateProvider).value?.locksNavigation ==
-            true;
-  if (locksIronwoodNavigation &&
-      _isIronwoodMigrationRestrictedRoute(state.matchedLocation)) {
-    return '/migration';
-  }
   if (!swapFeatureEnabled && isSwap) return '/home';
   return null;
-}
-
-bool _isIronwoodMigrationRestrictedRoute(String matchedLocation) {
-  return _matchesRoutePrefix(matchedLocation, '/send') ||
-      _matchesRoutePrefix(matchedLocation, '/receive') ||
-      _matchesRoutePrefix(matchedLocation, '/pay') ||
-      _matchesRoutePrefix(matchedLocation, '/swap');
-}
-
-bool _matchesRoutePrefix(String matchedLocation, String routePath) {
-  return matchedLocation == routePath ||
-      matchedLocation.startsWith('$routePath/');
 }
 
 /// Entry, onboarding, and auth routes shared by the desktop and mobile

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -429,15 +429,14 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
     final ironwoodPostMigrationState = ref
         .watch(ironwoodPostMigrationStateProvider)
         .value;
-    final ironwoodMigrationNavigationLocked =
+    final ironwoodVoteNavigationLocked =
         ironwoodPostMigrationState?.locksNavigation ??
         (ironwoodHomeMigrationPresentation.mode ==
             IronwoodHomeMigrationCtaMode.start);
     final payNavigationLocked =
-        ironwoodMigrationNavigationLocked ||
-        (ironwoodHomeMigrationPresentation.mode ==
-                IronwoodHomeMigrationCtaMode.resume &&
-            accountSync.ironwoodBalance <= BigInt.zero);
+        ironwoodHomeMigrationPresentation.mode ==
+            IronwoodHomeMigrationCtaMode.resume &&
+        accountSync.ironwoodBalance <= BigInt.zero;
     final migrationCoordinator = ref.watch(
       ironwoodMigrationCoordinatorProvider,
     );
@@ -529,8 +528,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                         active: _matches('/swap'),
                         onTap:
                             isImporting ||
-                                widget.disabledRoutePaths.contains('/swap') ||
-                                ironwoodMigrationNavigationLocked
+                                widget.disabledRoutePaths.contains('/swap')
                             ? null
                             : () => _navigateTo('/swap'),
                       ),
@@ -559,7 +557,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                       onTap:
                           isImporting ||
                               widget.disabledRoutePaths.contains('/voting') ||
-                              ironwoodMigrationNavigationLocked
+                              ironwoodVoteNavigationLocked
                           ? null
                           : () => _navigateTo('/voting'),
                     ),

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -611,11 +611,8 @@ class _HomePaneState extends ConsumerState<_HomePane> {
     final swapFeatureEnabled = ref.watch(swapFeatureEnabledProvider);
     final migrationInProgress =
         widget.ironwoodMigrationCta.mode == IronwoodHomeMigrationCtaMode.resume;
-    final migrationRequired =
-        widget.ironwoodMigrationCta.mode == IronwoodHomeMigrationCtaMode.start;
     final payAvailable =
         swapFeatureEnabled &&
-        !migrationRequired &&
         (!migrationInProgress || widget.sync.ironwoodBalance > BigInt.zero);
     final animateMigrationCta = ref.watch(
       homeMigrationCtaPulseMotionEnabledProvider,
@@ -1704,7 +1701,7 @@ class _HomeDesktopBalanceCardState extends State<_HomeDesktopBalanceCard> {
                     key: const ValueKey('home_desktop_send_button'),
                     icon: AppIcons.plane,
                     label: 'Send',
-                    onTap: migrationRequired ? null : widget.onSend,
+                    onTap: widget.onSend,
                     primary: true,
                   ),
                 ),

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -970,8 +970,7 @@ class _HomeContentState extends ConsumerState<_HomeContent> {
     final migrationInProgress =
         widget.ironwoodMigrationCta.mode == IronwoodHomeMigrationCtaMode.resume;
     final sendDisabled =
-        migrationRequired ||
-        (migrationInProgress && sync.ironwoodBalance <= BigInt.zero);
+        migrationInProgress && sync.ironwoodBalance <= BigInt.zero;
     final shieldedBalance = migrationRequired
         ? sync.orchardBalance + sync.orchardPendingBalance
         : sync.saplingBalance +
@@ -997,7 +996,6 @@ class _HomeContentState extends ConsumerState<_HomeContent> {
     final payEnabled = ref.watch(swapFeatureEnabledProvider);
     final showPayEntry =
         payEnabled &&
-        !migrationRequired &&
         (!migrationInProgress || sync.ironwoodBalance > BigInt.zero);
     final migrationAttention = mobileIronwoodMigrationAttention(
       widget.ironwoodMigrationCta.status,

--- a/scripts/e2e/flutter-ios-regtest-mobile-full.sh
+++ b/scripts/e2e/flutter-ios-regtest-mobile-full.sh
@@ -44,49 +44,52 @@ cd "$ROOT_DIR"
 # Desktop scenarios without a mobile counterpart yet (feature gaps):
 # custom-endpoint privacy (no mobile endpoint settings UI) and
 # shield-transparent ×2 (no mobile transparent balance / shield UI).
-run_test "1/15 create wallet via passcode onboarding and sync" \
+run_test "1/16 create wallet via passcode onboarding and sync" \
   "scripts/e2e/flutter-ios-regtest-mobile-create-sync.sh"
 
-run_test "2/15 import funded wallet and sync balance" \
+run_test "2/16 import funded wallet and sync balance" \
   "scripts/e2e/flutter-ios-regtest-mobile-import-sync.sh"
 
-run_test "3/15 manage accounts and rotate the passcode" \
+run_test "3/16 manage accounts and rotate the passcode" \
   "scripts/e2e/flutter-ios-regtest-mobile-account-management.sh"
 
-run_test "4/15 import two accounts and send shielded funds" \
+run_test "4/16 import two accounts and send shielded funds" \
   "scripts/e2e/flutter-ios-regtest-mobile-multi-account-send.sh"
 
-run_test "5/15 show mempool receives in activity" \
+run_test "5/16 show mempool receives in activity" \
   "scripts/e2e/flutter-ios-regtest-mobile-mempool-receive.sh"
 
-run_test "6/15 fall back from unavailable endpoint" \
+run_test "6/16 fall back from unavailable endpoint" \
   "scripts/e2e/flutter-ios-regtest-mobile-fallback-endpoint.sh"
 
-run_test "7/15 fall back from slow-height primary and recover" \
+run_test "7/16 fall back from slow-height primary and recover" \
   "scripts/e2e/flutter-ios-regtest-mobile-slow-height-fallback.sh"
 
-run_test "8/15 migrate the minimum viable Orchard balance to Ironwood" \
+run_test "8/16 send Orchard funds before starting Ironwood migration" \
+  "scripts/e2e/flutter-ios-regtest-mobile-ironwood-pre-migration-send.sh"
+
+run_test "9/16 migrate the minimum viable Orchard balance to Ironwood" \
   "scripts/e2e/flutter-ios-regtest-mobile-ironwood-migration.sh"
 
-run_test "9/15 migrate twenty Orchard notes through two split stages" \
+run_test "10/16 migrate twenty Orchard notes through two split stages" \
   "scripts/e2e/flutter-ios-regtest-mobile-ironwood-migration-many-notes.sh"
 
-run_test "10/15 isolate an Ironwood migration across two accounts" \
+run_test "11/16 isolate an Ironwood migration across two accounts" \
   "scripts/e2e/flutter-ios-regtest-mobile-ironwood-migration-multi-account.sh"
 
-run_test "11/15 rebuild an Ironwood migration after a chain reorg" \
+run_test "12/16 rebuild an Ironwood migration after a chain reorg" \
   "scripts/e2e/flutter-ios-regtest-mobile-ironwood-migration-reorg.sh"
 
-run_test "12/15 resume an Ironwood migration after process restart" \
+run_test "13/16 resume an Ironwood migration after process restart" \
   "scripts/e2e/flutter-ios-regtest-mobile-ironwood-migration-restart.sh"
 
-run_test "13/15 resume an Ironwood migration after network recovery" \
+run_test "14/16 resume an Ironwood migration after network recovery" \
   "scripts/e2e/flutter-ios-regtest-mobile-ironwood-migration-network-recovery.sh"
 
-run_test "14/15 advance Ironwood migration through native background wakes" \
+run_test "15/16 advance Ironwood migration through native background wakes" \
   "scripts/e2e/flutter-ios-regtest-mobile-ironwood-background-migration.sh"
 
-run_test "15/15 resume a persisted Ironwood proof after process restart" \
+run_test "16/16 resume a persisted Ironwood proof after process restart" \
   "scripts/e2e/flutter-ios-regtest-mobile-ironwood-background-restart.sh"
 
 if [[ "$INCLUDE_ACCOUNT_REIMPORT_MIGRATION" == "1" ]]; then

--- a/scripts/e2e/flutter-ios-regtest-mobile-ironwood-migration.sh
+++ b/scripts/e2e/flutter-ios-regtest-mobile-ironwood-migration.sh
@@ -17,6 +17,6 @@ UDID="$(pick_simulator)"
 FLUTTER_DEVICE="$UDID" \
 VIZOR_FORM_FACTOR=mobile \
 E2E_DRIVER_PORT="${E2E_DRIVER_PORT:-39084}" \
-E2E_TEST_FILE=integration_test/regtest_mobile_ironwood_migration_test.dart \
+E2E_TEST_FILE="${E2E_TEST_FILE:-integration_test/regtest_mobile_ironwood_migration_test.dart}" \
 E2E_ORCHARD_FUNDING_AMOUNT="${E2E_ORCHARD_FUNDING_AMOUNT:-0.01095}" \
   exec "$ROOT_DIR/scripts/e2e/flutter-macos-ironwood-migration.sh"

--- a/scripts/e2e/flutter-ios-regtest-mobile-ironwood-pre-migration-send.sh
+++ b/scripts/e2e/flutter-ios-regtest-mobile-ironwood-pre-migration-send.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RECEIVER_MNEMONIC="return try reason flat civil wolf dwarf announce toddler uphold equip range neck proof gauge east rifle swim tray twin venue fossil will version"
+
+cd "$ROOT_DIR"
+
+receiver_addresses_json="$(
+  cd rust
+  cargo run --quiet --example regtest_wallet_addresses -- "$RECEIVER_MNEMONIC"
+)"
+recipient_address="$(
+  python3 -c 'import json, sys; print(json.load(sys.stdin)["unifiedAddress"])' \
+    <<<"$receiver_addresses_json"
+)"
+
+export E2E_TEST_FILE="integration_test/regtest_mobile_ironwood_pre_migration_send_test.dart"
+export E2E_DRIVER_PORT="${E2E_DRIVER_PORT:-39089}"
+export E2E_SEND_RECIPIENT_ADDRESS="$recipient_address"
+exec scripts/e2e/flutter-ios-regtest-mobile-ironwood-migration.sh

--- a/scripts/e2e/flutter-macos-ironwood-migration.sh
+++ b/scripts/e2e/flutter-macos-ironwood-migration.sh
@@ -176,6 +176,11 @@ scenario_define_args=(
   --dart-define=ZCASH_E2E_ORCHARD_FUNDING_NOTE_COUNT="$FUNDING_NOTE_COUNT"
   --dart-define=ZCASH_FAST_TESTNET_MIGRATION="${E2E_FAST_TESTNET_MIGRATION:-false}"
 )
+if [[ -n "${E2E_SEND_RECIPIENT_ADDRESS:-}" ]]; then
+  scenario_define_args+=(
+    --dart-define=ZCASH_E2E_SEND_RECIPIENT_ADDRESS="$E2E_SEND_RECIPIENT_ADDRESS"
+  )
+fi
 if [[ -n "${E2E_ORCHARD_FUNDING_ZATOSHI:-}" ]]; then
   scenario_define_args+=(
     --dart-define=ZCASH_E2E_ORCHARD_FUNDING_ZATOSHI="$E2E_ORCHARD_FUNDING_ZATOSHI"

--- a/scripts/e2e/flutter-macos-ironwood-pre-migration-send.sh
+++ b/scripts/e2e/flutter-macos-ironwood-pre-migration-send.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RECEIVER_MNEMONIC="return try reason flat civil wolf dwarf announce toddler uphold equip range neck proof gauge east rifle swim tray twin venue fossil will version"
+
+cd "$ROOT_DIR"
+
+receiver_addresses_json="$(
+  cd rust
+  cargo run --quiet --example regtest_wallet_addresses -- "$RECEIVER_MNEMONIC"
+)"
+recipient_address="$(
+  python3 -c 'import json, sys; print(json.load(sys.stdin)["unifiedAddress"])' \
+    <<<"$receiver_addresses_json"
+)"
+
+export E2E_TEST_FILE="integration_test/regtest_ironwood_pre_migration_send_test.dart"
+export E2E_DRIVER_PORT="${E2E_DRIVER_PORT:-39088}"
+export E2E_SEND_RECIPIENT_ADDRESS="$recipient_address"
+exec scripts/e2e/flutter-macos-ironwood-migration.sh

--- a/scripts/ironwood-regtest/README.md
+++ b/scripts/ironwood-regtest/README.md
@@ -53,6 +53,12 @@ the desktop UI, and confirms the transaction without creating a migration run.
 Once the legacy Orchard note is spent, only post-activation Orchard change
 remains, so the migration becomes unnecessary and the CTA disappears.
 
+Run the equivalent mobile flow on an iOS Simulator:
+
+```bash
+scripts/e2e/flutter-ios-regtest-mobile-ironwood-pre-migration-send.sh
+```
+
 Test recovery across a real Flutter process restart and a lightwalletd outage:
 
 ```bash

--- a/scripts/ironwood-regtest/README.md
+++ b/scripts/ironwood-regtest/README.md
@@ -41,6 +41,18 @@ test on the macOS device. It verifies all of the following through the app UI:
 - confirmation completes the run, creates spendable Ironwood funds, and removes
   the home migration CTA.
 
+Verify that a required migration does not block an ordinary Orchard-funded
+send before the migration run starts:
+
+```bash
+scripts/e2e/flutter-macos-ironwood-pre-migration-send.sh
+```
+
+This activates Ironwood, verifies the migration CTA is pending, sends through
+the desktop UI, and confirms the transaction without creating a migration run.
+Once the legacy Orchard note is spent, only post-activation Orchard change
+remains, so the migration becomes unnecessary and the CTA disappears.
+
 Test recovery across a real Flutter process restart and a lightwalletd outage:
 
 ```bash

--- a/test/app_main_sidebar_test.dart
+++ b/test/app_main_sidebar_test.dart
@@ -715,7 +715,7 @@ void main() {
   });
 
   testWidgets(
-    'sidebar disables Swap, Pay, and Vote while Ironwood migration is required',
+    'sidebar enables Swap and Pay but keeps Vote disabled while Ironwood migration is required',
     (tester) async {
       await tester.pumpWidget(
         _sidebarHarness(
@@ -739,22 +739,20 @@ void main() {
       final activity = _sidebarItemWithLabel(tester, 'Activity');
       final settings = _sidebarItemWithLabel(tester, 'Settings');
 
-      expect(swap.onTap, isNull);
-      expect(pay.onTap, isNull);
+      expect(swap.onTap, isNotNull);
+      expect(pay.onTap, isNotNull);
       expect(vote.onTap, isNull);
       expect(activity.onTap, isNotNull);
       expect(settings.onTap, isNotNull);
-      expect(_opacityForText(tester, 'Swap'), 0.5);
-      expect(_opacityForText(tester, 'Pay'), 0.5);
       expect(_opacityForText(tester, 'Vote'), 0.5);
 
       await tester.tap(find.text('Swap'));
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(find.text('swap'), findsNothing);
+      await tester.pumpAndSettle();
+      expect(find.text('swap'), findsOneWidget);
 
       await tester.tap(find.text('Pay'));
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(find.text('pay'), findsNothing);
+      await tester.pumpAndSettle();
+      expect(find.text('pay'), findsOneWidget);
 
       await tester.tap(find.text('Vote'));
       await tester.pump(const Duration(milliseconds: 50));

--- a/test/app_swap_feature_test.dart
+++ b/test/app_swap_feature_test.dart
@@ -14,6 +14,9 @@ import 'package:zcash_wallet/src/features/home/screens/home_screen.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
 import 'package:zcash_wallet/src/features/migration/screens/ironwood_migration_flow_screen.dart';
 import 'package:zcash_wallet/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart';
+import 'package:zcash_wallet/src/features/pay/screens/pay_screen.dart';
+import 'package:zcash_wallet/src/features/receive/screens/receive_screen.dart';
+import 'package:zcash_wallet/src/features/send/screens/mobile/mobile_send_screen.dart';
 import 'package:zcash_wallet/src/features/send/screens/send_screen.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_activity_store.dart';
@@ -36,23 +39,18 @@ final _migrationFlowData = IronwoodMigrationFlowData(
 );
 
 void main() {
-  for (final location in [
-    '/send',
-    '/send/review',
-    '/send/keystone/scan',
-    '/send/status',
-    '/receive',
-    '/pay',
-    '/pay/review',
-    '/swap',
-    '/swap/review',
+  for (final route in [
+    (location: '/send', screenType: SendScreen),
+    (location: '/receive', screenType: ReceiveScreen),
+    (location: '/pay', screenType: PayScreen),
+    (location: '/swap', screenType: SwapScreen),
   ]) {
     testWidgets(
-      'Ironwood migration lock redirects $location to migration intro',
+      'required Ironwood migration leaves ${route.location} accessible',
       (tester) async {
         await tester.pumpWidget(
           _appHarness(
-            location,
+            route.location,
             ironwoodPostMigrationState:
                 const IronwoodPostMigrationState.required(
                   network: 'main',
@@ -68,21 +66,17 @@ void main() {
           ),
         );
 
-        await _pumpUntilPresent(
-          tester,
-          find.byType(IronwoodMigrationFlowScreen),
-        );
+        await _pumpUntilPresent(tester, find.byType(route.screenType));
 
-        expect(find.byType(IronwoodMigrationFlowScreen), findsOneWidget);
-        expect(find.byType(SendScreen), findsNothing);
-        expect(find.byType(SwapScreen), findsNothing);
+        expect(find.byType(route.screenType), findsOneWidget);
+        expect(find.byType(IronwoodMigrationFlowScreen), findsNothing);
         expect(find.byType(HomeScreen), findsNothing);
       },
     );
   }
 
   testWidgets(
-    'mobile migration presentation lock survives unavailable raw state',
+    'mobile required migration presentation leaves send accessible',
     (tester) async {
       await tester.pumpWidget(
         _appHarness(
@@ -100,8 +94,8 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.byType(MobileIronwoodMigrationFlowScreen), findsOneWidget);
-      expect(find.byType(SendScreen), findsNothing);
+      expect(find.byType(MobileSendScreen), findsOneWidget);
+      expect(find.byType(MobileIronwoodMigrationFlowScreen), findsNothing);
     },
     tags: 'mobile',
   );

--- a/test/features/home/home_desktop_screen_test.dart
+++ b/test/features/home/home_desktop_screen_test.dart
@@ -308,7 +308,7 @@ void main() {
   });
 
   testWidgets(
-    'home desktop disables send and shielding while migration is required',
+    'home desktop enables wallet actions but keeps shielding disabled while migration is required',
     (tester) async {
       await tester.pumpWidget(
         _appHarness(
@@ -360,11 +360,8 @@ void main() {
       );
       expect(
         find.byKey(const ValueKey('home_desktop_pay_button')),
-        findsNothing,
+        findsOneWidget,
       );
-      await tester.tap(find.byKey(const ValueKey('home_desktop_send_button')));
-      await tester.pump();
-      expect(find.byType(SendScreen), findsNothing);
       final shieldSemantics = tester.widget<Semantics>(
         find.byKey(const ValueKey('home_shield_balance_button')),
       );
@@ -378,6 +375,9 @@ void main() {
             ?.color,
         AppThemeData.light.colors.text.disabled,
       );
+      await tester.tap(find.byKey(const ValueKey('home_desktop_send_button')));
+      await _pumpUntilPresent(tester, find.byType(SendScreen));
+      expect(find.byType(SendScreen), findsOneWidget);
     },
   );
 

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -995,7 +995,7 @@ void main() {
       tester
           .widget<AppButton>(find.byKey(const ValueKey('mobile_home_send')))
           .onPressed,
-      isNull,
+      isNotNull,
     );
     expect(find.text('Receive'), findsOneWidget);
     expect(
@@ -1118,7 +1118,7 @@ void main() {
     expect(find.text('migration complete route'), findsNothing);
   });
 
-  testWidgets('keeps the required migration lock while the raw CTA is hidden', (
+  testWidgets('keeps wallet actions available while migration is required', (
     tester,
   ) async {
     const requiredCta = IronwoodHomeMigrationCtaState.start(
@@ -1138,8 +1138,13 @@ void main() {
       tester
           .widget<AppButton>(find.byKey(const ValueKey('mobile_home_send')))
           .onPressed,
-      isNull,
+      isNotNull,
     );
+    expect(find.byKey(const ValueKey('mobile_home_pay')), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_home_send')));
+    await tester.pumpAndSettle();
+    expect(find.text('send route'), findsOneWidget);
   });
 
   testWidgets('shows total balance and remaining amount while migrating', (


### PR DESCRIPTION
## Summary

- allow Send, Receive, Pay, and Swap navigation while Ironwood migration is required
- keep active-migration restrictions and the existing Sapling Pay/Swap limitation
- enable the corresponding desktop and mobile home/sidebar entry points
- add desktop and iOS regtest E2E coverage proving an Orchard-funded Send succeeds before migration starts

## Verification

- `fvm flutter test`: 2419 passed, 87 skipped
- mobile relevant tests: 52 passed
- `fvm flutter analyze`: clean
- desktop Ironwood pre-migration Send regtest E2E: passed
- iOS Simulator Ironwood pre-migration Send regtest E2E: passed
- iterative review/fix cycle: clean after two review passes

## Notes

A normal Send consumes the legacy Orchard note without starting a migration run. After confirmation, the post-activation Orchard change remains spendable and the migration state transitions from `required` to `notNeeded`.