### PR TITLE
Update scan order to prioritize Ironwood

### DIFF
--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -229,7 +229,7 @@ final votingWalletSyncMaxWaitProvider = Provider<Duration>((ref) {
   return const Duration(minutes: 3);
 });
 
-/// Checks whether wallet scan progress has reached a voting snapshot height.
+/// Checks whether the wallet has enough scan coverage for a voting snapshot.
 final votingWalletSyncReadinessCheckerProvider =
     Provider<VotingWalletSyncReadinessChecker>((ref) {
       return const FrbVotingWalletSyncReadinessChecker();
@@ -240,15 +240,19 @@ class VotingWalletSyncReadiness {
     required this.scannedHeight,
     required this.snapshotHeight,
     required this.chainTipHeight,
+    this.hasIronwoodSnapshotCoverage = false,
   });
 
   final int scannedHeight;
   final int snapshotHeight;
   final int chainTipHeight;
+  final bool hasIronwoodSnapshotCoverage;
 
-  bool get isReady => scannedHeight >= snapshotHeight;
+  bool get isReady =>
+      scannedHeight >= snapshotHeight || hasIronwoodSnapshotCoverage;
 
   int get blocksRemaining {
+    if (isReady) return 0;
     final remaining = snapshotHeight - scannedHeight;
     return remaining > 0 ? remaining : 0;
   }
@@ -276,10 +280,17 @@ class FrbVotingWalletSyncReadinessChecker
       dbPath: dbPath,
       network: network,
     );
+    final hasIronwoodSnapshotCoverage = await rust_api
+        .isWalletScannedToVotingSnapshot(
+          dbPath: dbPath,
+          network: network,
+          snapshotHeight: BigInt.from(snapshotHeight),
+        );
     return VotingWalletSyncReadiness(
       scannedHeight: status.scannedHeight.toInt(),
       snapshotHeight: snapshotHeight,
       chainTipHeight: status.chainTipHeight.toInt(),
+      hasIronwoodSnapshotCoverage: hasIronwoodSnapshotCoverage,
     );
   }
 }

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -215,6 +215,22 @@ Future<ApiVotingEligibility> checkVotingEligibility({
   required ApiVotingRoundContext ctx,
 }) => RustLib.instance.api.crateApiVotingCheckVotingEligibility(ctx: ctx);
 
+/// Return whether the wallet has scanned every required Ironwood block through
+/// the voting snapshot.
+///
+/// Unlike the wallet's contiguous fully-scanned height, this becomes true
+/// after the prioritized Ironwood window completes even while older history is
+/// still being backfilled.
+Future<bool> isWalletScannedToVotingSnapshot({
+  required String dbPath,
+  required String network,
+  required BigInt snapshotHeight,
+}) => RustLib.instance.api.crateApiVotingIsWalletScannedToVotingSnapshot(
+  dbPath: dbPath,
+  network: network,
+  snapshotHeight: snapshotHeight,
+);
+
 /// Persist the snapshot-stable bundle plan and warm all bundle PIR inputs.
 ///
 /// This is the vote-screen warm-up path. It requires an initialized round and
@@ -570,8 +586,10 @@ Future<void> resetVotingSessionState({
 ///
 /// This removes every persisted round scoped to `account_uuid`, relying on the
 /// `zcash_voting` round deletion cascade for bundles, recovery rows, share
-/// history, ballot intent, and cached tree state. Use this only at account
-/// deletion boundaries, not for ordinary voting-session retries.
+/// history, ballot intent, and cached tree state. It also deletes
+/// round-independent `pir_proof_cache` rows for the same wallet id — browse-
+/// only warm-up can persist those without ever creating a round. Use this only
+/// at account deletion boundaries, not for ordinary voting-session retries.
 Future<int> deleteVotingAccountState({
   required String dbPath,
   required String accountUuid,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -80,7 +80,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -339890453;
+  int get rustContentHash => -1242470621;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -757,6 +757,12 @@ abstract class RustLibApi extends BaseApi {
   bool crateApiSyncIsSyncRunning();
 
   bool crateApiNetworkPrivacyIsTorEnabled();
+
+  Future<bool> crateApiVotingIsWalletScannedToVotingSnapshot({
+    required String dbPath,
+    required String network,
+    required BigInt snapshotHeight,
+  });
 
   Future<KeystoneMigrationProofStatus>
   crateApiSyncKeystoneMigrationProofStatus({required String requestId});
@@ -5676,6 +5682,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "is_tor_enabled", argNames: []);
 
   @override
+  Future<bool> crateApiVotingIsWalletScannedToVotingSnapshot({
+    required String dbPath,
+    required String network,
+    required BigInt snapshotHeight,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_u_64(snapshotHeight, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 107,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_bool,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiVotingIsWalletScannedToVotingSnapshotConstMeta,
+        argValues: [dbPath, network, snapshotHeight],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVotingIsWalletScannedToVotingSnapshotConstMeta =>
+      const TaskConstMeta(
+        debugName: "is_wallet_scanned_to_voting_snapshot",
+        argNames: ["dbPath", "network", "snapshotHeight"],
+      );
+
+  @override
   Future<KeystoneMigrationProofStatus>
   crateApiSyncKeystoneMigrationProofStatus({required String requestId}) {
     return handler.executeNormal(
@@ -5686,7 +5729,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 108,
             port: port_,
           );
         },
@@ -5721,7 +5764,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 109,
           )!;
         },
         codec: SseCodec(
@@ -5755,7 +5798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5789,7 +5832,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5830,7 +5873,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5873,7 +5916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5930,7 +5973,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
             port: port_,
           );
         },
@@ -5996,7 +6039,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -6066,7 +6109,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
             port: port_,
           );
         },
@@ -6137,7 +6180,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
             port: port_,
           );
         },
@@ -6187,7 +6230,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
           )!;
         },
         codec: SseCodec(
@@ -6218,7 +6261,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 119,
             port: port_,
           );
         },
@@ -6251,7 +6294,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 120,
             port: port_,
           );
         },
@@ -6294,7 +6337,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 121,
             port: port_,
           );
         },
@@ -6348,7 +6391,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 122,
             port: port_,
           );
         },
@@ -6384,7 +6427,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 123,
             port: port_,
           );
         },
@@ -6422,7 +6465,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 124,
             port: port_,
           );
         },
@@ -6467,7 +6510,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 125,
             port: port_,
           );
         },
@@ -6527,7 +6570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6587,7 +6630,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6646,7 +6689,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6699,7 +6742,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6758,7 +6801,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6820,7 +6863,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6868,7 +6911,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6927,7 +6970,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6997,7 +7040,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 134,
             port: port_,
           );
         },
@@ -7056,7 +7099,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 135,
             port: port_,
           );
         },
@@ -7103,7 +7146,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 136,
             port: port_,
           );
         },
@@ -7148,7 +7191,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 137,
             port: port_,
           );
         },
@@ -7178,7 +7221,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 138,
           )!;
         },
         codec: SseCodec(
@@ -7211,7 +7254,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7248,7 +7291,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7283,7 +7326,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7325,7 +7368,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7360,7 +7403,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7401,7 +7444,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 144,
             port: port_,
           );
         },
@@ -7450,7 +7493,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7488,7 +7531,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
             port: port_,
           );
         },
@@ -7543,7 +7586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7599,7 +7642,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
           )!;
         },
         codec: SseCodec(
@@ -7643,7 +7686,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7690,7 +7733,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
           )!;
         },
         codec: SseCodec(
@@ -7720,7 +7763,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
           )!;
         },
         codec: SseCodec(
@@ -7755,7 +7798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7788,7 +7831,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7823,7 +7866,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7863,7 +7906,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
             port: port_,
           );
         },
@@ -7904,7 +7947,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7958,7 +8001,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 157,
             port: port_,
           );
         },
@@ -8008,7 +8051,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 157,
+              funcId: 158,
               port: port_,
             );
           },
@@ -8049,7 +8092,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 158,
+              funcId: 159,
               port: port_,
             );
           },
@@ -8081,7 +8124,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8108,7 +8151,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
           )!;
         },
         codec: SseCodec(
@@ -8134,7 +8177,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8181,7 +8224,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8248,7 +8291,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8304,7 +8347,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8339,7 +8382,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
             port: port_,
           );
         },
@@ -8378,7 +8421,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8414,7 +8457,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8449,7 +8492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8486,7 +8529,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8530,7 +8573,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 171,
             port: port_,
           );
         },
@@ -8580,7 +8623,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8612,7 +8655,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 173,
             port: port_,
           );
         },
@@ -8640,7 +8683,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 174,
           )!;
         },
         codec: SseCodec(
@@ -8672,7 +8715,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 175,
             port: port_,
           );
         },
@@ -8709,7 +8752,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 176,
             port: port_,
           );
         },
@@ -8740,7 +8783,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 177,
           )!;
         },
         codec: SseCodec(
@@ -8783,7 +8826,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 178,
             port: port_,
           );
         },
@@ -8831,7 +8874,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 178,
+            funcId: 179,
           )!;
         },
         codec: SseCodec(
@@ -8865,7 +8908,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 179,
+            funcId: 180,
             port: port_,
           );
         },
@@ -8902,7 +8945,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 180,
+            funcId: 181,
             port: port_,
           );
         },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4621,7 +4621,7 @@ dependencies = [
  "ur-registry",
  "url",
  "uuid",
- "vote-commitment-tree 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vote-commitment-tree",
  "voting-crypto-deps",
  "zakura-bls12-381",
  "zakura-client-backend",
@@ -7105,22 +7105,6 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f5f6190045301a6f713015b698bc43881786ab3f30973429630ea71aa04d17"
-dependencies = [
- "anyhow",
- "imt-tree",
- "incrementalmerkletree",
- "lazy_static",
- "libc",
- "shardtree",
- "voting-crypto-deps",
-]
-
-[[package]]
-name = "vote-commitment-tree"
-version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=f02ffe030376126b3606e667d957bb6b0053c247#f02ffe030376126b3606e667d957bb6b0053c247"
 dependencies = [
  "anyhow",
  "imt-tree",
@@ -7134,14 +7118,13 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.7.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=f02ffe030376126b3606e667d957bb6b0053c247#f02ffe030376126b3606e667d957bb6b0053c247"
 dependencies = [
  "base64",
  "hex",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "vote-commitment-tree 0.5.2 (git+https://github.com/valargroup/zcash_voting.git?rev=f02ffe030376126b3606e667d957bb6b0053c247)",
+ "vote-commitment-tree",
  "voting-crypto-deps",
 ]
 
@@ -7780,8 +7763,6 @@ dependencies = [
 [[package]]
 name = "zakura-client-backend"
 version = "0.1.0-rc2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a042cb0d6f6a22d976ed5dda9de3c9c51abe868324bc186ba5064be8f22756c"
 dependencies = [
  "arti-client",
  "async-trait",
@@ -7849,8 +7830,6 @@ dependencies = [
 [[package]]
 name = "zakura-client-sqlite"
 version = "0.1.0-rc2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47a7238ca986c3caec99ffe409fa49226cfe9fb5a0583ae2a5bb32466a12624"
 dependencies = [
  "bip32",
  "bitflags 2.13.1",
@@ -8059,8 +8038,6 @@ dependencies = [
 [[package]]
 name = "zakura-pczt"
 version = "0.1.0-rc1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226558d15d544c890bdb0cfaa935402b6697d1edf78ec0b541c4fd7e8033ce52"
 dependencies = [
  "blake2b_simd",
  "document-features",
@@ -8220,8 +8197,6 @@ dependencies = [
 [[package]]
 name = "zakura-wallet-lib"
 version = "0.1.0-rc2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b53acd746f74acdbdd39401cba4ad1516c8e82d54da461a8de6dbb2da47ff4"
 dependencies = [
  "zakura-client-backend",
  "zakura-client-sqlite",
@@ -8510,7 +8485,6 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "3.1.0-rc.9"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=f02ffe030376126b3606e667d957bb6b0053c247#f02ffe030376126b3606e667d957bb6b0053c247"
 dependencies = [
  "anyhow",
  "base64",
@@ -8542,7 +8516,7 @@ dependencies = [
  "uuid",
  "valar-spiral-rs",
  "valar-ypir",
- "vote-commitment-tree 0.5.2 (git+https://github.com/valargroup/zcash_voting.git?rev=f02ffe030376126b3606e667d957bb6b0053c247)",
+ "vote-commitment-tree",
  "vote-commitment-tree-client",
  "voting-circuits",
  "voting-crypto-deps",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -115,9 +115,11 @@ package = "zakura-client-sqlite"
 version = "0.1.0-rc2"
 features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
+# LOCAL REPLACE — point back at the git pin before committing.
+# zcash_voting: /Users/roman/projects-copy/zcash_voting (cheap-scanned-height)
+# wallet-libraries: /Users/roman/projects/wallet-libraries (feat/ironwood-first-scan-priority)
 [dependencies.zcash_voting]
-git = "https://github.com/valargroup/zcash_voting.git"
-rev = "f02ffe030376126b3606e667d957bb6b0053c247"
+path = "../../../projects-copy/zcash_voting/zcash_voting"
 default-features = false
 features = ["zakura"]
 
@@ -164,9 +166,24 @@ rusqlite = "0.37"
 zcash_note_encryption = "0.4"
 
 [dev-dependencies.vote-commitment-tree]
+path = "../../../projects-copy/zcash_voting/vote-commitment-tree"
 version = "=0.5.2"
 default-features = false
 features = ["zakura"]
+
+# Local wallet-layer + voting workspace crates for the replaces above.
+# Crypto (zakura-orchard/keys/primitives/…) stays on crates.io; only the
+# forked wallet crates and in-workspace VCT live here. voting-circuits and
+# vote-nullifier-pir stay on crates.io — versions already match (=0.10.3 /
+# pir-client=0.6.0 / imt-tree=0.4.0). Add path patches below if a local WIP
+# in those repos is required.
+[patch.crates-io]
+zakura-client-backend = { path = "../../wallet-libraries/librustzcash/zcash_client_backend" }
+zakura-client-sqlite = { path = "../../wallet-libraries/librustzcash/zcash_client_sqlite" }
+zakura-pczt = { path = "../../wallet-libraries/librustzcash/pczt" }
+zakura-wallet-lib = { path = "../../wallet-libraries/wallet-lib" }
+vote-commitment-tree = { path = "../../../projects-copy/zcash_voting/vote-commitment-tree" }
+vote-commitment-tree-client = { path = "../../../projects-copy/zcash_voting/vote-commitment-tree-client" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)', 'cfg(ironwood_masquerade)'] }

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -9,6 +9,8 @@ use super::voting_helpers::{
 use crate::frb_generated::StreamSink;
 use crate::wallet::{
     keys,
+    network::WalletNetwork,
+    sync::open_wallet_db_for_read,
     voting::{db, delegation, delegation::DelegationProgress, hotkey, network::voting_network},
 };
 use rand::{rngs::OsRng, RngCore};
@@ -782,6 +784,26 @@ pub async fn check_voting_eligibility(
         distinct_note_count,
         eligible_weight_zatoshi: eligibility.eligible_weight,
         privacy_trim_dropped_value_zatoshi: report.privacy_trim_dropped_value_zatoshi,
+    })
+}
+
+/// Return whether the wallet has scanned every required Ironwood block through
+/// the voting snapshot.
+///
+/// Unlike the wallet's contiguous fully-scanned height, this becomes true
+/// after the prioritized Ironwood window completes even while older history is
+/// still being backfilled.
+pub fn is_wallet_scanned_to_voting_snapshot(
+    db_path: String,
+    network: String,
+    snapshot_height: u64,
+) -> Result<bool, String> {
+    catch(|| {
+        let network = WalletNetwork::from_str(&network)
+            .ok_or_else(|| format!("Unsupported network: {network}"))?;
+        let wallet_db = open_wallet_db_for_read(&db_path, network)?;
+        zcash_voting::is_wallet_scanned_to_voting_snapshot(&wallet_db, snapshot_height)
+            .map_err(|e| e.to_string())
     })
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -339890453;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1242470621;
 
 // Section: executor
 
@@ -4190,6 +4190,45 @@ fn wire__crate__api__network_privacy__is_tor_enabled_impl(
                 let output_ok = Result::<_, ()>::Ok(crate::api::network_privacy::is_tor_enabled())?;
                 Ok(output_ok)
             })())
+        },
+    )
+}
+fn wire__crate__api__voting__is_wallet_scanned_to_voting_snapshot_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "is_wallet_scanned_to_voting_snapshot",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_snapshot_height = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::is_wallet_scanned_to_voting_snapshot(
+                        api_db_path,
+                        api_network,
+                        api_snapshot_height,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }
@@ -10831,70 +10870,71 @@ fn pde_ffi_dispatcher_primary_impl(
 99 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
 100 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
 103 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
-107 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
-116 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-119 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__voting__precompute_snapshot_bundles_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-135 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-145 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-172 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-174 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-175 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-177 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
-179 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-180 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__voting__is_wallet_scanned_to_voting_snapshot_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
+116 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
+117 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__voting__precompute_snapshot_bundles_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+136 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+146 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+175 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+176 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+178 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
+180 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+181 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10929,22 +10969,22 @@ fn pde_ffi_dispatcher_sync_impl(
         104 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
         105 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
         106 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
-        108 => {
+        109 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        117 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        137 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        147 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
-        149 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        118 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        138 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        148 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
+        150 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        150 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        160 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        173 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        176 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
-        178 => {
+        151 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        161 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        174 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        177 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        179 => {
             wire__crate__api__voting__warm_voting_proving_caches_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -273,10 +273,12 @@ pub(crate) fn suggest_scan_ranges(
             start: u32::from(r.block_range().start) as u64,
             end: u32::from(r.block_range().end) as u64,
             priority: match r.priority() {
-                ScanPriority::Verify => 6,
-                ScanPriority::ChainTip => 5,
-                ScanPriority::FoundNote => 4,
-                ScanPriority::OpenAdjacent => 3,
+                // Keep ordinal order aligned with librustzcash ScanPriority.
+                ScanPriority::Verify => 7,
+                ScanPriority::ChainTip => 6,
+                ScanPriority::FoundNote => 5,
+                ScanPriority::OpenAdjacent => 4,
+                ScanPriority::LatestPoolActivation => 3,
                 ScanPriority::Historic => 2,
                 ScanPriority::Scanned => 1,
                 ScanPriority::Ignored => 0,

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1508,6 +1508,18 @@ void main() {
     },
   );
 
+  test('Ironwood snapshot coverage satisfies wallet readiness', () {
+    const readiness = VotingWalletSyncReadiness(
+      scannedHeight: 122,
+      snapshotHeight: 123,
+      chainTipHeight: 130,
+      hasIronwoodSnapshotCoverage: true,
+    );
+
+    expect(readiness.isReady, isTrue);
+    expect(readiness.blocksRemaining, 0);
+  });
+
   test('wallet sync wait aborts stale account before queued action', () async {
     final rust = FakeVotingRustApi();
     final readiness = FakeVotingWalletSyncReadinessChecker(


### PR DESCRIPTION
## Summary
- consume the new Ironwood-first scan priority from [zakura-core/wallet-libraries#4](https://github.com/zakura-core/wallet-libraries/pull/4)
- treat complete Ironwood snapshot coverage as sufficient for voting readiness while older history continues backfilling
- expose snapshot coverage through Flutter Rust Bridge and add a voting-readiness regression test

## Motivation / Why
Wallets recovering from before NU6.3 currently wait for the full historic backfill before voting can proceed. Prioritizing the Ironwood era lets recent voting snapshot coverage become usable earlier without treating the wallet as fully synced.

## Tests
- `fvm flutter test test/providers/voting/voting_providers_test.dart` — passed
- `fvm dart format --output=none --set-exit-if-changed ...` — reported one changed test file, but produced no remaining working-tree diff
- `cargo fmt --check` — fails on pre-existing formatting in `rust/src/api/voting.rs`
- `cargo check --tests` — fails because the preserved local dependency checkout does not yet define `zcash_voting::is_wallet_scanned_to_voting_snapshot`; it also contains an unrelated uncommitted `plan_share_submissions` signature change

## Draft limitations
- Cargo currently uses machine-local path overrides for the in-development wallet and voting libraries. These must be replaced with publishable dependency references before this PR is ready for review.