### PR TITLE
Require immediate share confirmation

### DIFF
--- a/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
+++ b/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
@@ -164,7 +164,9 @@ class _VotingSubmissionConfirmationViewState
     final pollTitle = state.round?.title.isNotEmpty == true
         ? state.round!.title
         : 'Token holder voting';
-    final hasCompletedSubmission = hasCompletedVoteForDisplay(state.roundPlan);
+    final hasCompletedSubmission =
+        hasCompletedVoteForDisplay(state.roundPlan) &&
+        hasConfirmedImmediateShare(state.roundPlan, state.resumePlan);
     if (hasCompletedSubmission) {
       _lastSubmissionState = state;
     }

--- a/lib/src/features/voting/voting_resume_plan.dart
+++ b/lib/src/features/voting/voting_resume_plan.dart
@@ -23,6 +23,27 @@ bool hasCompletedVoteForDisplay(rust_wire.RoundPlanView? roundPlan) {
   return roundPlan?.completedForDisplay ?? false;
 }
 
+/// Whether the round's designated immediate share has durable confirmation.
+///
+/// Delayed shares intentionally remain background work, but the submission
+/// confirmation screen must not advance until this one round-level share has
+/// been observed by at least one helper that accepted it.
+bool hasConfirmedImmediateShare(
+  rust_wire.RoundPlanView? roundPlan,
+  VotingResumePlan? resumePlan,
+) {
+  final key = roundPlan?.immediateShareKey;
+  if (key == null) return true;
+  if (resumePlan == null) return false;
+  return resumePlan.shareDelegations.any(
+    (record) =>
+        record.bundleIndex == key.bundleIndex &&
+        record.proposalId == key.proposalId &&
+        record.shareIndex == key.shareIndex &&
+        record.confirmed,
+  );
+}
+
 bool roundPlanNeedsDraftSetup(rust_wire.RoundPlanView? roundPlan) {
   return roundPlan?.needsDraftSetup ?? false;
 }

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -537,6 +537,7 @@ abstract interface class VotingRustApi {
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
     required bool singleShare,
+    int? immediateShareIndex,
   });
 
   Future<List<String>> shareResubmissionServerOrder({
@@ -959,6 +960,7 @@ class FrbVotingRustApi implements VotingRustApi {
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
     required bool singleShare,
+    int? immediateShareIndex,
   }) {
     return rust_api.planShareSubmissions(
       shareCount: shareCount,
@@ -967,6 +969,7 @@ class FrbVotingRustApi implements VotingRustApi {
       voteEndTimeSeconds: voteEndTimeSeconds,
       lastMomentBufferSeconds: lastMomentBufferSeconds,
       singleShare: singleShare,
+      immediateShareIndex: immediateShareIndex,
     );
   }
 

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -14,6 +14,8 @@ import '../../features/voting/voting_resume_plan.dart';
 import '../../rust/api/voting.dart' as rust_api;
 import '../../rust/third_party/zcash_voting/config.dart' as rust_config;
 import '../../rust/third_party/zcash_voting/delegate.dart' as rust_delegate;
+import '../../rust/third_party/zcash_voting/share_policy.dart'
+    as rust_share_policy;
 import '../../rust/third_party/zcash_voting/wire.dart' as rust_wire;
 import '../../services/voting/pir_snapshot_resolver.dart';
 import '../../services/voting/resolved_voting_config_extensions.dart';
@@ -1157,6 +1159,12 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       if (!await writeBallotIntents()) {
         return;
       }
+      if (effectiveDraftVotes.isNotEmpty) {
+        // The immediate-share key is derived from durable ballot intents.
+        // Reload after writing them so a fresh cast uses the same stable key
+        // that recovery will derive after a restart.
+        roundPlan = await _loadRoundPlan(context);
+      }
       final totalQuestions = recoveredVoteWork.length + voteWork.length;
       final totalBundleTasks =
           recoveredVoteWork.length +
@@ -1252,6 +1260,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           helperAvailability: helperAvailability,
           vcTreePositions: vcTreePositions,
           singleShare: _commitmentsUseSingleShare(commitments),
+          immediateShareKey: roundPlan?.immediateShareKey,
           shareIndexFilter: shareIndexFilter,
           completedQuestions: completedQuestions,
           totalQuestions: totalQuestions,
@@ -1303,6 +1312,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             completedQuestions: completedQuestions,
             totalQuestions: totalQuestions,
             helperAvailability: helperAvailability,
+            immediateShareKey: roundPlan?.immediateShareKey,
           );
         } catch (_) {
           plan = await _loadResumePlan(context);
@@ -1469,6 +1479,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     Set<int>? shareIndexFilter,
     void Function(VotingSessionProgress progress)? publishProgress,
     required bool singleShare,
+    rust_share_policy.ImmediateShareKey? immediateShareKey,
     required int completedQuestions,
     required int totalQuestions,
     required double? voteSubmissionProgress,
@@ -1499,6 +1510,12 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
                 .toList(growable: false);
       if (shares.isEmpty) continue;
       final vcTreePosition = vcTreePositions[commitment.proposalId];
+      final immediateShareIndex = _immediateShareBatchPosition(
+        immediateShareKey: immediateShareKey,
+        bundleIndex: commitments.bundleIndex,
+        proposalId: commitment.proposalId,
+        shares: shares,
+      );
       final plans = await rust.planShareSubmissions(
         shareCount: shares.length,
         serverUrls: serverUrls,
@@ -1506,6 +1523,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         voteEndTimeSeconds: BigInt.from(timing.voteEndSeconds),
         lastMomentBufferSeconds: timing.lastMomentBufferSeconds,
         singleShare: singleShare,
+        immediateShareIndex: immediateShareIndex,
       );
       if (plans.length != shares.length) {
         throw StateError(
@@ -1513,6 +1531,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           '${shares.length} payload(s).',
         );
       }
+      _validateImmediateSharePlan(
+        plans: plans,
+        immediateShareIndex: immediateShareIndex,
+      );
       // Validate every body before starting helper requests. Otherwise a later
       // serialization failure could abandon already accepted submissions.
       final preparedSubmissions = <_PreparedInitialShareSubmission>[];
@@ -1612,6 +1634,49 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           'for proposal ${failedResult.share.proposalId}.',
         );
       }
+    }
+  }
+
+  int? _immediateShareBatchPosition({
+    required rust_share_policy.ImmediateShareKey? immediateShareKey,
+    required int bundleIndex,
+    required int proposalId,
+    required List<rust_wire.VoteShareWire> shares,
+  }) {
+    if (immediateShareKey == null ||
+        immediateShareKey.bundleIndex != bundleIndex ||
+        immediateShareKey.proposalId != proposalId) {
+      return null;
+    }
+    final batchPosition = shares.indexWhere(
+      (share) => share.shareIndex == immediateShareKey.shareIndex,
+    );
+    return batchPosition < 0 ? null : batchPosition;
+  }
+
+  void _validateImmediateSharePlan({
+    required List<rust_share_policy.ShareSubmissionPlan> plans,
+    required int? immediateShareIndex,
+  }) {
+    final designatedIndexes = [
+      for (var index = 0; index < plans.length; index++)
+        if (plans[index].immediate) index,
+    ];
+    if (immediateShareIndex == null) {
+      if (designatedIndexes.isNotEmpty) {
+        throw StateError(
+          'Share submission policy designated an unexpected immediate share.',
+        );
+      }
+      return;
+    }
+    if (designatedIndexes.length != 1 ||
+        designatedIndexes.single != immediateShareIndex ||
+        plans[immediateShareIndex].submitAt != BigInt.zero) {
+      throw StateError(
+        'Share submission policy did not preserve the immediate-share '
+        'designation.',
+      );
     }
   }
 
@@ -1836,6 +1901,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required int completedQuestions,
     required int totalQuestions,
     required Future<Map<String, bool>> helperAvailability,
+    rust_share_policy.ImmediateShareKey? immediateShareKey,
   }) async {
     // Transpose proposal -> bundles into bundle -> proposals. Proposal order
     // within a bundle follows the draft order so a restart resumes the same
@@ -2176,6 +2242,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
                 vcTreePositions: vcTreePositions,
                 publishProgress: publish,
                 singleShare: singleShare,
+                immediateShareKey: immediateShareKey,
                 completedQuestions: completedQuestions,
                 totalQuestions: totalQuestions,
                 voteSubmissionProgress: aggregateProgress(),

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -974,6 +974,10 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       done = completedEligibilitySession;
     }
     if (!_canCompleteSubmission(done)) {
+      if (_hasExpiredUnconfirmedImmediateShare(done)) {
+        _failForExpiredImmediateShare(key: key, generation: generation);
+        return;
+      }
       _scheduleCompletionPoll(key: key, generation: generation);
       return;
     }
@@ -1166,6 +1170,10 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       }
       if (_canCompleteSubmission(session)) {
         _completeJob(key: key, generation: generation);
+        return;
+      }
+      if (_hasExpiredUnconfirmedImmediateShare(session)) {
+        _failForExpiredImmediateShare(key: key, generation: generation);
       }
     });
   }
@@ -1180,6 +1188,31 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     return session.hasConfirmedVotingEligibility &&
         _hasCompletedSubmissionArtifacts(session) &&
         hasConfirmedImmediateShare(session.roundPlan, session.resumePlan);
+  }
+
+  bool _hasExpiredUnconfirmedImmediateShare(
+    VotingSessionState? session, {
+    DateTime? now,
+  }) {
+    if (session == null ||
+        hasConfirmedImmediateShare(session.roundPlan, session.resumePlan)) {
+      return false;
+    }
+    final voteEnd = session.round?.voteEndTime;
+    return voteEnd != null && !(now ?? DateTime.now()).isBefore(voteEnd);
+  }
+
+  void _failForExpiredImmediateShare({
+    required VotingSessionKey key,
+    required int generation,
+  }) {
+    _failJob(
+      key: key,
+      generation: generation,
+      message:
+          'The voting round ended before a helper confirmed the immediate '
+          'share. Check the voting status before retrying.',
+    );
   }
 
   Future<VotingSessionState?> _ensureEligibilityForCompletedSession({

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -1178,7 +1178,8 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
   bool _canCompleteSubmission(VotingSessionState? session) {
     if (session == null) return false;
     return session.hasConfirmedVotingEligibility &&
-        _hasCompletedSubmissionArtifacts(session);
+        _hasCompletedSubmissionArtifacts(session) &&
+        hasConfirmedImmediateShare(session.roundPlan, session.resumePlan);
   }
 
   Future<VotingSessionState?> _ensureEligibilityForCompletedSession({

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -80,6 +80,7 @@ Future<List<ShareSubmissionPlan>> planShareSubmissions({
   required BigInt voteEndTimeSeconds,
   BigInt? lastMomentBufferSeconds,
   required bool singleShare,
+  int? immediateShareIndex,
 }) => RustLib.instance.api.crateApiVotingPlanShareSubmissions(
   shareCount: shareCount,
   serverUrls: serverUrls,
@@ -87,6 +88,7 @@ Future<List<ShareSubmissionPlan>> planShareSubmissions({
   voteEndTimeSeconds: voteEndTimeSeconds,
   lastMomentBufferSeconds: lastMomentBufferSeconds,
   singleShare: singleShare,
+  immediateShareIndex: immediateShareIndex,
 );
 
 /// Return the crate-owned randomized helper order for one share retry.
@@ -570,8 +572,10 @@ Future<void> resetVotingSessionState({
 ///
 /// This removes every persisted round scoped to `account_uuid`, relying on the
 /// `zcash_voting` round deletion cascade for bundles, recovery rows, share
-/// history, ballot intent, and cached tree state. Use this only at account
-/// deletion boundaries, not for ordinary voting-session retries.
+/// history, ballot intent, and cached tree state. It also deletes
+/// round-independent `pir_proof_cache` rows for the same wallet id — browse-
+/// only warm-up can persist those without ever creating a round. Use this only
+/// at account deletion boundaries, not for ordinary voting-session retries.
 Future<int> deleteVotingAccountState({
   required String dbPath,
   required String accountUuid,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -857,6 +857,7 @@ abstract class RustLibApi extends BaseApi {
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
     required bool singleShare,
+    int? immediateShareIndex,
   });
 
   Future<DelegationPirPrecomputeResultView>
@@ -6280,6 +6281,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
     required bool singleShare,
+    int? immediateShareIndex,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -6291,6 +6293,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_64(voteEndTimeSeconds, serializer);
           sse_encode_opt_box_autoadd_u_64(lastMomentBufferSeconds, serializer);
           sse_encode_bool(singleShare, serializer);
+          sse_encode_opt_box_autoadd_u_32(immediateShareIndex, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -6310,6 +6313,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           voteEndTimeSeconds,
           lastMomentBufferSeconds,
           singleShare,
+          immediateShareIndex,
         ],
         apiImpl: this,
       ),
@@ -6326,6 +6330,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "voteEndTimeSeconds",
           "lastMomentBufferSeconds",
           "singleShare",
+          "immediateShareIndex",
         ],
       );
 
@@ -9308,6 +9313,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ImmediateShareKey dco_decode_box_autoadd_immediate_share_key(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_immediate_share_key(raw);
+  }
+
+  @protected
   MigrationOutboxBatch dco_decode_box_autoadd_migration_outbox_batch(
     dynamic raw,
   ) {
@@ -9638,6 +9649,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PlatformInt64 dco_decode_i_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dcoDecodeI64(raw);
+  }
+
+  @protected
+  ImmediateShareKey dco_decode_immediate_share_key(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return ImmediateShareKey(
+      bundleIndex: dco_decode_u_32(arr[0]),
+      proposalId: dco_decode_u_32(arr[1]),
+      shareIndex: dco_decode_u_32(arr[2]),
+    );
   }
 
   @protected
@@ -10558,6 +10582,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ImmediateShareKey? dco_decode_opt_box_autoadd_immediate_share_key(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_immediate_share_key(raw);
+  }
+
+  @protected
   MigrationOutboxBatch? dco_decode_opt_box_autoadd_migration_outbox_batch(
     dynamic raw,
   ) {
@@ -10763,8 +10795,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RoundPlanView dco_decode_round_plan_view(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 16)
-      throw Exception('unexpected arr length: expect 16 but see ${arr.length}');
+    if (arr.length != 17)
+      throw Exception('unexpected arr length: expect 17 but see ${arr.length}');
     return RoundPlanView(
       roundId: dco_decode_String(arr[0]),
       pendingRecovery: dco_decode_bool(arr[1]),
@@ -10784,7 +10816,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       ),
       recoveredVoteWork: dco_decode_list_vote_recovery_work_view(arr[13]),
       openProposals: dco_decode_list_prim_u_32_strict(arr[14]),
-      allDecided: dco_decode_bool(arr[15]),
+      immediateShareKey: dco_decode_opt_box_autoadd_immediate_share_key(
+        arr[15],
+      ),
+      allDecided: dco_decode_bool(arr[16]),
     );
   }
 
@@ -10881,12 +10916,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ShareSubmissionPlan dco_decode_share_submission_plan(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ShareSubmissionPlan(
-      submitAt: dco_decode_u_64(arr[0]),
-      targetCount: dco_decode_u_32(arr[1]),
-      targetServers: dco_decode_list_String(arr[2]),
+      immediate: dco_decode_bool(arr[0]),
+      submitAt: dco_decode_u_64(arr[1]),
+      targetCount: dco_decode_u_32(arr[2]),
+      targetServers: dco_decode_list_String(arr[3]),
     );
   }
 
@@ -11939,6 +11975,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ImmediateShareKey sse_decode_box_autoadd_immediate_share_key(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_immediate_share_key(deserializer));
+  }
+
+  @protected
   MigrationOutboxBatch sse_decode_box_autoadd_migration_outbox_batch(
     SseDeserializer deserializer,
   ) {
@@ -12323,6 +12367,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PlatformInt64 sse_decode_i_64(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getPlatformInt64();
+  }
+
+  @protected
+  ImmediateShareKey sse_decode_immediate_share_key(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_bundleIndex = sse_decode_u_32(deserializer);
+    var var_proposalId = sse_decode_u_32(deserializer);
+    var var_shareIndex = sse_decode_u_32(deserializer);
+    return ImmediateShareKey(
+      bundleIndex: var_bundleIndex,
+      proposalId: var_proposalId,
+      shareIndex: var_shareIndex,
+    );
   }
 
   @protected
@@ -13683,6 +13742,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ImmediateShareKey? sse_decode_opt_box_autoadd_immediate_share_key(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_immediate_share_key(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   MigrationOutboxBatch? sse_decode_opt_box_autoadd_migration_outbox_batch(
     SseDeserializer deserializer,
   ) {
@@ -14013,6 +14085,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       deserializer,
     );
     var var_openProposals = sse_decode_list_prim_u_32_strict(deserializer);
+    var var_immediateShareKey = sse_decode_opt_box_autoadd_immediate_share_key(
+      deserializer,
+    );
     var var_allDecided = sse_decode_bool(deserializer);
     return RoundPlanView(
       roundId: var_roundId,
@@ -14030,6 +14105,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       recoveredDelegationWork: var_recoveredDelegationWork,
       recoveredVoteWork: var_recoveredVoteWork,
       openProposals: var_openProposals,
+      immediateShareKey: var_immediateShareKey,
       allDecided: var_allDecided,
     );
   }
@@ -14141,10 +14217,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     SseDeserializer deserializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_immediate = sse_decode_bool(deserializer);
     var var_submitAt = sse_decode_u_64(deserializer);
     var var_targetCount = sse_decode_u_32(deserializer);
     var var_targetServers = sse_decode_list_String(deserializer);
     return ShareSubmissionPlan(
+      immediate: var_immediate,
       submitAt: var_submitAt,
       targetCount: var_targetCount,
       targetServers: var_targetServers,
@@ -15246,6 +15324,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_immediate_share_key(
+    ImmediateShareKey self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_immediate_share_key(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_migration_outbox_batch(
     MigrationOutboxBatch self,
     SseSerializer serializer,
@@ -15569,6 +15656,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putPlatformInt64(self);
+  }
+
+  @protected
+  void sse_encode_immediate_share_key(
+    ImmediateShareKey self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_32(self.bundleIndex, serializer);
+    sse_encode_u_32(self.proposalId, serializer);
+    sse_encode_u_32(self.shareIndex, serializer);
   }
 
   @protected
@@ -16676,6 +16774,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_opt_box_autoadd_immediate_share_key(
+    ImmediateShareKey? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_immediate_share_key(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_opt_box_autoadd_migration_outbox_batch(
     MigrationOutboxBatch? self,
     SseSerializer serializer,
@@ -16944,6 +17055,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     );
     sse_encode_list_vote_recovery_work_view(self.recoveredVoteWork, serializer);
     sse_encode_list_prim_u_32_strict(self.openProposals, serializer);
+    sse_encode_opt_box_autoadd_immediate_share_key(
+      self.immediateShareKey,
+      serializer,
+    );
     sse_encode_bool(self.allDecided, serializer);
   }
 
@@ -17034,6 +17149,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_bool(self.immediate, serializer);
     sse_encode_u_64(self.submitAt, serializer);
     sse_encode_u_32(self.targetCount, serializer);
     sse_encode_list_String(self.targetServers, serializer);

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -145,6 +145,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double dco_decode_box_autoadd_f_64(dynamic raw);
 
   @protected
+  ImmediateShareKey dco_decode_box_autoadd_immediate_share_key(dynamic raw);
+
+  @protected
   MigrationOutboxBatch dco_decode_box_autoadd_migration_outbox_batch(
     dynamic raw,
   );
@@ -260,6 +263,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 dco_decode_i_64(dynamic raw);
+
+  @protected
+  ImmediateShareKey dco_decode_immediate_share_key(dynamic raw);
 
   @protected
   ImportBirthdayMetadata dco_decode_import_birthday_metadata(dynamic raw);
@@ -592,6 +598,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double? dco_decode_opt_box_autoadd_f_64(dynamic raw);
+
+  @protected
+  ImmediateShareKey? dco_decode_opt_box_autoadd_immediate_share_key(
+    dynamic raw,
+  );
 
   @protected
   MigrationOutboxBatch? dco_decode_opt_box_autoadd_migration_outbox_batch(
@@ -981,6 +992,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double sse_decode_box_autoadd_f_64(SseDeserializer deserializer);
 
   @protected
+  ImmediateShareKey sse_decode_box_autoadd_immediate_share_key(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   MigrationOutboxBatch sse_decode_box_autoadd_migration_outbox_batch(
     SseDeserializer deserializer,
   );
@@ -1128,6 +1144,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 sse_decode_i_64(SseDeserializer deserializer);
+
+  @protected
+  ImmediateShareKey sse_decode_immediate_share_key(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ImportBirthdayMetadata sse_decode_import_birthday_metadata(
@@ -1546,6 +1567,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double? sse_decode_opt_box_autoadd_f_64(SseDeserializer deserializer);
+
+  @protected
+  ImmediateShareKey? sse_decode_opt_box_autoadd_immediate_share_key(
+    SseDeserializer deserializer,
+  );
 
   @protected
   MigrationOutboxBatch? sse_decode_opt_box_autoadd_migration_outbox_batch(
@@ -2023,6 +2049,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_box_autoadd_f_64(double self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_immediate_share_key(
+    ImmediateShareKey self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_migration_outbox_batch(
     MigrationOutboxBatch self,
     SseSerializer serializer,
@@ -2201,6 +2233,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_immediate_share_key(
+    ImmediateShareKey self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_import_birthday_metadata(
@@ -2717,6 +2755,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_f_64(double? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_immediate_share_key(
+    ImmediateShareKey? self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_opt_box_autoadd_migration_outbox_batch(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -147,6 +147,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double dco_decode_box_autoadd_f_64(dynamic raw);
 
   @protected
+  ImmediateShareKey dco_decode_box_autoadd_immediate_share_key(dynamic raw);
+
+  @protected
   MigrationOutboxBatch dco_decode_box_autoadd_migration_outbox_batch(
     dynamic raw,
   );
@@ -262,6 +265,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 dco_decode_i_64(dynamic raw);
+
+  @protected
+  ImmediateShareKey dco_decode_immediate_share_key(dynamic raw);
 
   @protected
   ImportBirthdayMetadata dco_decode_import_birthday_metadata(dynamic raw);
@@ -594,6 +600,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double? dco_decode_opt_box_autoadd_f_64(dynamic raw);
+
+  @protected
+  ImmediateShareKey? dco_decode_opt_box_autoadd_immediate_share_key(
+    dynamic raw,
+  );
 
   @protected
   MigrationOutboxBatch? dco_decode_opt_box_autoadd_migration_outbox_batch(
@@ -983,6 +994,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double sse_decode_box_autoadd_f_64(SseDeserializer deserializer);
 
   @protected
+  ImmediateShareKey sse_decode_box_autoadd_immediate_share_key(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   MigrationOutboxBatch sse_decode_box_autoadd_migration_outbox_batch(
     SseDeserializer deserializer,
   );
@@ -1130,6 +1146,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 sse_decode_i_64(SseDeserializer deserializer);
+
+  @protected
+  ImmediateShareKey sse_decode_immediate_share_key(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ImportBirthdayMetadata sse_decode_import_birthday_metadata(
@@ -1548,6 +1569,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double? sse_decode_opt_box_autoadd_f_64(SseDeserializer deserializer);
+
+  @protected
+  ImmediateShareKey? sse_decode_opt_box_autoadd_immediate_share_key(
+    SseDeserializer deserializer,
+  );
 
   @protected
   MigrationOutboxBatch? sse_decode_opt_box_autoadd_migration_outbox_batch(
@@ -2025,6 +2051,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_box_autoadd_f_64(double self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_immediate_share_key(
+    ImmediateShareKey self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_migration_outbox_batch(
     MigrationOutboxBatch self,
     SseSerializer serializer,
@@ -2203,6 +2235,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_immediate_share_key(
+    ImmediateShareKey self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_import_birthday_metadata(
@@ -2719,6 +2757,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_f_64(double? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_immediate_share_key(
+    ImmediateShareKey? self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_opt_box_autoadd_migration_outbox_batch(

--- a/lib/src/rust/third_party/zcash_voting/share_policy.dart
+++ b/lib/src/rust/third_party/zcash_voting/share_policy.dart
@@ -6,8 +6,42 @@
 import '../../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
+/// Identifies the round's single designated immediate helper share.
+class ImmediateShareKey {
+  final int bundleIndex;
+  final int proposalId;
+
+  /// Domain share index, always [`IMMEDIATE_SHARE_INDEX`].
+  final int shareIndex;
+
+  const ImmediateShareKey({
+    required this.bundleIndex,
+    required this.proposalId,
+    required this.shareIndex,
+  });
+
+  @override
+  int get hashCode =>
+      bundleIndex.hashCode ^ proposalId.hashCode ^ shareIndex.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImmediateShareKey &&
+          runtimeType == other.runtimeType &&
+          bundleIndex == other.bundleIndex &&
+          proposalId == other.proposalId &&
+          shareIndex == other.shareIndex;
+}
+
 /// Planned helper-share submission values that SDKs can apply to payloads.
 class ShareSubmissionPlan {
+  /// True only for the round's designated immediate share.
+  ///
+  /// This is distinct from `submit_at == 0`: last-moment and single-share
+  /// planning can schedule other, undesignated shares immediately.
+  final bool immediate;
+
   /// Unix seconds when helpers should submit the share, or 0 for immediate.
   final BigInt submitAt;
 
@@ -18,6 +52,7 @@ class ShareSubmissionPlan {
   final List<String> targetServers;
 
   const ShareSubmissionPlan({
+    required this.immediate,
     required this.submitAt,
     required this.targetCount,
     required this.targetServers,
@@ -25,13 +60,17 @@ class ShareSubmissionPlan {
 
   @override
   int get hashCode =>
-      submitAt.hashCode ^ targetCount.hashCode ^ targetServers.hashCode;
+      immediate.hashCode ^
+      submitAt.hashCode ^
+      targetCount.hashCode ^
+      targetServers.hashCode;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is ShareSubmissionPlan &&
           runtimeType == other.runtimeType &&
+          immediate == other.immediate &&
           submitAt == other.submitAt &&
           targetCount == other.targetCount &&
           targetServers == other.targetServers;

--- a/lib/src/rust/third_party/zcash_voting/wire.dart
+++ b/lib/src/rust/third_party/zcash_voting/wire.dart
@@ -5,6 +5,7 @@
 
 import '../../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+import 'share_policy.dart';
 import 'types.dart';
 
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `BoundedU32`, `VoteRecord`, `VotingHotkeyTargetV1`, `VotingNoteRefView`, `VotingNoteSelectionResultView`
@@ -383,6 +384,9 @@ class RoundPlanView {
   final List<DelegationRecoveryWorkView> recoveredDelegationWork;
   final List<VoteRecoveryWorkView> recoveredVoteWork;
   final Uint32List openProposals;
+
+  /// The round's single immediate helper-share submission, if designated.
+  final ImmediateShareKey? immediateShareKey;
   final bool allDecided;
 
   const RoundPlanView({
@@ -401,6 +405,7 @@ class RoundPlanView {
     required this.recoveredDelegationWork,
     required this.recoveredVoteWork,
     required this.openProposals,
+    this.immediateShareKey,
     required this.allDecided,
   });
 
@@ -421,6 +426,7 @@ class RoundPlanView {
       recoveredDelegationWork.hashCode ^
       recoveredVoteWork.hashCode ^
       openProposals.hashCode ^
+      immediateShareKey.hashCode ^
       allDecided.hashCode;
 
   @override
@@ -443,6 +449,7 @@ class RoundPlanView {
           recoveredDelegationWork == other.recoveredDelegationWork &&
           recoveredVoteWork == other.recoveredVoteWork &&
           openProposals == other.openProposals &&
+          immediateShareKey == other.immediateShareKey &&
           allDecided == other.allDecided;
 }
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1377,7 +1377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d308ebe4b10924331bd079044b418da7b227d724d3e2408567a47ad7c3da2a0"
 dependencies = [
  "derive-deftly-macros",
- "heck 0.4.1",
+ "heck 0.5.0",
 ]
 
 [[package]]
@@ -1386,9 +1386,9 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "indexmap 2.14.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1513,7 +1513,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1721,7 +1721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2962,7 +2962,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3318,7 +3318,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4125,8 +4125,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -4158,7 +4158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4621,7 +4621,7 @@ dependencies = [
  "ur-registry",
  "url",
  "uuid",
- "vote-commitment-tree 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vote-commitment-tree",
  "voting-crypto-deps",
  "zakura-bls12-381",
  "zakura-client-backend",
@@ -4691,7 +4691,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5410,7 +5410,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7118,30 +7118,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "vote-commitment-tree"
-version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=ddce017b2d4959465b2c52d36263d9aa5da1c7fc#ddce017b2d4959465b2c52d36263d9aa5da1c7fc"
-dependencies = [
- "anyhow",
- "imt-tree",
- "incrementalmerkletree",
- "lazy_static",
- "libc",
- "shardtree",
- "voting-crypto-deps",
-]
-
-[[package]]
 name = "vote-commitment-tree-client"
 version = "0.7.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=ddce017b2d4959465b2c52d36263d9aa5da1c7fc#ddce017b2d4959465b2c52d36263d9aa5da1c7fc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613504fa62ac7832b9d8b17a3da936b35fdf7403a5286576a377f0728918958e"
 dependencies = [
  "base64",
  "hex",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "vote-commitment-tree 0.5.2 (git+https://github.com/valargroup/zcash_voting.git?rev=ddce017b2d4959465b2c52d36263d9aa5da1c7fc)",
+ "vote-commitment-tree",
  "voting-crypto-deps",
 ]
 
@@ -7340,7 +7327,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8509,8 +8496,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "3.1.0-rc.9"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=ddce017b2d4959465b2c52d36263d9aa5da1c7fc#ddce017b2d4959465b2c52d36263d9aa5da1c7fc"
+version = "3.1.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fa6cd28e32560f128d8492b782efddb1addd4db3c09103d454625d696ea02a5"
 dependencies = [
  "anyhow",
  "base64",
@@ -8542,7 +8530,7 @@ dependencies = [
  "uuid",
  "valar-spiral-rs",
  "valar-ypir",
- "vote-commitment-tree 0.5.2 (git+https://github.com/valargroup/zcash_voting.git?rev=ddce017b2d4959465b2c52d36263d9aa5da1c7fc)",
+ "vote-commitment-tree",
  "vote-commitment-tree-client",
  "voting-circuits",
  "voting-crypto-deps",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree"
 version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=f02ffe030376126b3606e667d957bb6b0053c247#f02ffe030376126b3606e667d957bb6b0053c247"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=ddce017b2d4959465b2c52d36263d9aa5da1c7fc#ddce017b2d4959465b2c52d36263d9aa5da1c7fc"
 dependencies = [
  "anyhow",
  "imt-tree",
@@ -7134,14 +7134,14 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.7.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=f02ffe030376126b3606e667d957bb6b0053c247#f02ffe030376126b3606e667d957bb6b0053c247"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=ddce017b2d4959465b2c52d36263d9aa5da1c7fc#ddce017b2d4959465b2c52d36263d9aa5da1c7fc"
 dependencies = [
  "base64",
  "hex",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "vote-commitment-tree 0.5.2 (git+https://github.com/valargroup/zcash_voting.git?rev=f02ffe030376126b3606e667d957bb6b0053c247)",
+ "vote-commitment-tree 0.5.2 (git+https://github.com/valargroup/zcash_voting.git?rev=ddce017b2d4959465b2c52d36263d9aa5da1c7fc)",
  "voting-crypto-deps",
 ]
 
@@ -8510,7 +8510,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "3.1.0-rc.9"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=f02ffe030376126b3606e667d957bb6b0053c247#f02ffe030376126b3606e667d957bb6b0053c247"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=ddce017b2d4959465b2c52d36263d9aa5da1c7fc#ddce017b2d4959465b2c52d36263d9aa5da1c7fc"
 dependencies = [
  "anyhow",
  "base64",
@@ -8542,7 +8542,7 @@ dependencies = [
  "uuid",
  "valar-spiral-rs",
  "valar-ypir",
- "vote-commitment-tree 0.5.2 (git+https://github.com/valargroup/zcash_voting.git?rev=f02ffe030376126b3606e667d957bb6b0053c247)",
+ "vote-commitment-tree 0.5.2 (git+https://github.com/valargroup/zcash_voting.git?rev=ddce017b2d4959465b2c52d36263d9aa5da1c7fc)",
  "vote-commitment-tree-client",
  "voting-circuits",
  "voting-crypto-deps",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -116,8 +116,7 @@ version = "0.1.0-rc2"
 features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 [dependencies.zcash_voting]
-git = "https://github.com/valargroup/zcash_voting.git"
-rev = "ddce017b2d4959465b2c52d36263d9aa5da1c7fc"
+version = "3.1.0-rc.10"
 default-features = false
 features = ["zakura"]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -117,7 +117,7 @@ features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 [dependencies.zcash_voting]
 git = "https://github.com/valargroup/zcash_voting.git"
-rev = "f02ffe030376126b3606e667d957bb6b0053c247"
+rev = "ddce017b2d4959465b2c52d36263d9aa5da1c7fc"
 default-features = false
 features = ["zakura"]
 

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -284,6 +284,7 @@ pub fn plan_share_submissions(
     vote_end_time_seconds: u64,
     last_moment_buffer_seconds: Option<u64>,
     single_share: bool,
+    immediate_share_index: Option<u32>,
 ) -> Result<Vec<zcash_voting::wire::ShareSubmissionPlan>, String> {
     catch(|| {
         // Convert to usize once for policy sizing and planner inputs.
@@ -318,6 +319,7 @@ pub fn plan_share_submissions(
             vote_end_time_seconds,
             last_moment_buffer_seconds,
             single_share,
+            immediate_share_index,
             &submit_at_random_bytes,
             &server_random_bytes,
         )
@@ -2584,11 +2586,17 @@ mod tests {
             "https://helper-b.example".to_string(),
         ];
         let plans =
-            plan_share_submissions(3, server_urls.clone(), 100, 600, Some(120), false).unwrap();
+            plan_share_submissions(3, server_urls.clone(), 100, 600, Some(120), false, Some(1))
+                .unwrap();
 
         assert_eq!(plans.len(), 3);
-        for plan in plans {
-            assert!(plan.submit_at >= 100);
+        for (index, plan) in plans.into_iter().enumerate() {
+            assert_eq!(plan.immediate, index == 1);
+            if plan.immediate {
+                assert_eq!(plan.submit_at, 0);
+            } else {
+                assert!(plan.submit_at >= 100);
+            }
             assert!(!plan.target_servers.is_empty());
             assert!(plan.target_servers.len() <= plan.target_count as usize);
             assert!(plan
@@ -3878,11 +3886,7 @@ mod tests {
             .unwrap();
     }
 
-    fn seed_pir_cache_row(
-        db: &zcash_voting::storage::VotingDb,
-        wallet_id: &str,
-        marker: u8,
-    ) {
+    fn seed_pir_cache_row(db: &zcash_voting::storage::VotingDb, wallet_id: &str, marker: u8) {
         db.conn()
             .execute(
                 "INSERT INTO pir_proof_cache

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -4748,6 +4748,7 @@ fn wire__crate__api__voting__plan_share_submissions_impl(
             let api_vote_end_time_seconds = <u64>::sse_decode(&mut deserializer);
             let api_last_moment_buffer_seconds = <Option<u64>>::sse_decode(&mut deserializer);
             let api_single_share = <bool>::sse_decode(&mut deserializer);
+            let api_immediate_share_index = <Option<u32>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -4758,6 +4759,7 @@ fn wire__crate__api__voting__plan_share_submissions_impl(
                         api_vote_end_time_seconds,
                         api_last_moment_buffer_seconds,
                         api_single_share,
+                        api_immediate_share_index,
                     )?;
                     Ok(output_ok)
                 })())
@@ -7301,6 +7303,12 @@ const _: fn() = || {
         let _: bool = DraftVote.single_share;
     }
     {
+        let ImmediateShareKey = None::<zcash_voting::share_policy::ImmediateShareKey>.unwrap();
+        let _: u32 = ImmediateShareKey.bundle_index;
+        let _: u32 = ImmediateShareKey.proposal_id;
+        let _: u32 = ImmediateShareKey.share_index;
+    }
+    {
         let KeystoneSignatureRecord = None::<zcash_voting::wire::KeystoneSignatureRecord>.unwrap();
         let _: u32 = KeystoneSignatureRecord.bundle_index;
         let _: Vec<u8> = KeystoneSignatureRecord.sig;
@@ -7377,6 +7385,8 @@ const _: fn() = || {
             RoundPlanView.recovered_delegation_work;
         let _: Vec<zcash_voting::wire::VoteRecoveryWorkView> = RoundPlanView.recovered_vote_work;
         let _: Vec<u32> = RoundPlanView.open_proposals;
+        let _: Option<zcash_voting::share_policy::ImmediateShareKey> =
+            RoundPlanView.immediate_share_key;
         let _: bool = RoundPlanView.all_decided;
     }
     {
@@ -7414,6 +7424,7 @@ const _: fn() = || {
     }
     {
         let ShareSubmissionPlan = None::<zcash_voting::share_policy::ShareSubmissionPlan>.unwrap();
+        let _: bool = ShareSubmissionPlan.immediate;
         let _: u64 = ShareSubmissionPlan.submit_at;
         let _: u32 = ShareSubmissionPlan.target_count;
         let _: Vec<String> = ShareSubmissionPlan.target_servers;
@@ -8240,6 +8251,20 @@ impl SseDecode for i64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         deserializer.cursor.read_i64::<NativeEndian>().unwrap()
+    }
+}
+
+impl SseDecode for zcash_voting::share_policy::ImmediateShareKey {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_shareIndex = <u32>::sse_decode(deserializer);
+        return zcash_voting::share_policy::ImmediateShareKey {
+            bundle_index: var_bundleIndex,
+            proposal_id: var_proposalId,
+            share_index: var_shareIndex,
+        };
     }
 }
 
@@ -9565,6 +9590,19 @@ impl SseDecode for Option<f64> {
     }
 }
 
+impl SseDecode for Option<zcash_voting::share_policy::ImmediateShareKey> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<zcash_voting::share_policy::ImmediateShareKey>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<crate::api::sync::MigrationOutboxBatch> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -9873,6 +9911,8 @@ impl SseDecode for zcash_voting::wire::RoundPlanView {
         let mut var_recoveredVoteWork =
             <Vec<zcash_voting::wire::VoteRecoveryWorkView>>::sse_decode(deserializer);
         let mut var_openProposals = <Vec<u32>>::sse_decode(deserializer);
+        let mut var_immediateShareKey =
+            <Option<zcash_voting::share_policy::ImmediateShareKey>>::sse_decode(deserializer);
         let mut var_allDecided = <bool>::sse_decode(deserializer);
         return zcash_voting::wire::RoundPlanView {
             round_id: var_roundId,
@@ -9890,6 +9930,7 @@ impl SseDecode for zcash_voting::wire::RoundPlanView {
             recovered_delegation_work: var_recoveredDelegationWork,
             recovered_vote_work: var_recoveredVoteWork,
             open_proposals: var_openProposals,
+            immediate_share_key: var_immediateShareKey,
             all_decided: var_allDecided,
         };
     }
@@ -10005,10 +10046,12 @@ impl SseDecode for zcash_voting::wire::ShareDelegationRecordView {
 impl SseDecode for zcash_voting::share_policy::ShareSubmissionPlan {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_immediate = <bool>::sse_decode(deserializer);
         let mut var_submitAt = <u64>::sse_decode(deserializer);
         let mut var_targetCount = <u32>::sse_decode(deserializer);
         let mut var_targetServers = <Vec<String>>::sse_decode(deserializer);
         return zcash_voting::share_policy::ShareSubmissionPlan {
+            immediate: var_immediate,
             submit_at: var_submitAt,
             target_count: var_targetCount,
             target_servers: var_targetServers,
@@ -11839,6 +11882,28 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ExtractAndBroadcastPczt
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::share_policy::ImmediateShareKey> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.share_index.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::share_policy::ImmediateShareKey>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::share_policy::ImmediateShareKey>>
+    for zcash_voting::share_policy::ImmediateShareKey
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::share_policy::ImmediateShareKey> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::network_privacy::ImportBirthdayMetadata {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -12764,6 +12829,7 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundPlanV
                 .into_dart(),
             self.0.recovered_vote_work.into_into_dart().into_dart(),
             self.0.open_proposals.into_into_dart().into_dart(),
+            self.0.immediate_share_key.into_into_dart().into_dart(),
             self.0.all_decided.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -12922,6 +12988,7 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::ShareDeleg
 impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::share_policy::ShareSubmissionPlan> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
+            self.0.immediate.into_into_dart().into_dart(),
             self.0.submit_at.into_into_dart().into_dart(),
             self.0.target_count.into_into_dart().into_dart(),
             self.0.target_servers.into_into_dart().into_dart(),
@@ -14338,6 +14405,15 @@ impl SseEncode for i64 {
     }
 }
 
+impl SseEncode for zcash_voting::share_policy::ImmediateShareKey {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <u32>::sse_encode(self.share_index, serializer);
+    }
+}
+
 impl SseEncode for crate::api::network_privacy::ImportBirthdayMetadata {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -15300,6 +15376,16 @@ impl SseEncode for Option<f64> {
     }
 }
 
+impl SseEncode for Option<zcash_voting::share_policy::ImmediateShareKey> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <zcash_voting::share_policy::ImmediateShareKey>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for Option<crate::api::sync::MigrationOutboxBatch> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -15535,6 +15621,10 @@ impl SseEncode for zcash_voting::wire::RoundPlanView {
             serializer,
         );
         <Vec<u32>>::sse_encode(self.open_proposals, serializer);
+        <Option<zcash_voting::share_policy::ImmediateShareKey>>::sse_encode(
+            self.immediate_share_key,
+            serializer,
+        );
         <bool>::sse_encode(self.all_decided, serializer);
     }
 }
@@ -15614,6 +15704,7 @@ impl SseEncode for zcash_voting::wire::ShareDelegationRecordView {
 impl SseEncode for zcash_voting::share_policy::ShareSubmissionPlan {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.immediate, serializer);
         <u64>::sse_encode(self.submit_at, serializer);
         <u32>::sse_encode(self.target_count, serializer);
         <Vec<String>>::sse_encode(self.target_servers, serializer);

--- a/test/features/voting/round_plan_test_utils.dart
+++ b/test/features/voting/round_plan_test_utils.dart
@@ -1,5 +1,7 @@
 import 'dart:typed_data';
 
+import 'package:zcash_wallet/src/rust/third_party/zcash_voting/share_policy.dart'
+    as rust_share_policy;
 import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
     as rust_wire;
 
@@ -20,6 +22,7 @@ rust_wire.RoundPlanView apiRoundPlan({
   List<rust_wire.DelegationStatusView> delegationStatuses = const [],
   List<rust_wire.DelegationRecoveryWorkView>? recoveredDelegationWork,
   List<rust_wire.VoteRecoveryWorkView>? recoveredVoteWork,
+  rust_share_policy.ImmediateShareKey? immediateShareKey,
 }) {
   final resolvedDelegationWork =
       recoveredDelegationWork ?? _delegationRecoveryWork(nextSteps);
@@ -62,6 +65,7 @@ rust_wire.RoundPlanView apiRoundPlan({
     recoveredDelegationWork: resolvedDelegationWork,
     recoveredVoteWork: resolvedVoteWork,
     openProposals: openProposals,
+    immediateShareKey: immediateShareKey,
     allDecided: allDecided,
   );
 }

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -422,6 +422,96 @@ void main() {
     );
   });
 
+  testWidgets('submitted route waits for the designated immediate share', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+    final pendingShare = rust_wire.ShareDelegationRecordView(
+      roundId: _roundId,
+      bundleIndex: 0,
+      proposalId: 1,
+      shareIndex: 0,
+      sentToUrls: const ['https://helper.example'],
+      nullifier: Uint8List.fromList(List.filled(32, 1)),
+      phase: VotingWorkflowPhase.submittedShare,
+      confirmed: false,
+      submitAt: BigInt.zero,
+      createdAt: BigInt.one,
+    );
+    final recoveryApi = _MutableVotingRecoveryApi()
+      ..state = _recoveryState(
+        shareDelegations: [pendingShare],
+        unconfirmedShareDelegations: [pendingShare],
+      );
+    final resumePlan = await VotingRecoveryService(api: recoveryApi)
+        .loadResumePlan(
+          dbPath: 'wallet.db',
+          accountUuid: 'account-1',
+          roundId: _roundId,
+        );
+    final completedRoundPlan = apiRoundPlan(
+      roundId: _roundId,
+      pendingRecovery: true,
+      blockingRecovery: false,
+      nextSteps: const [
+        rust_wire.NextStepView(
+          kind: 'confirm_share',
+          bundleIndex: 0,
+          proposalId: 1,
+          choice: 0,
+          shareIndex: 0,
+        ),
+      ],
+      openProposals: Uint32List(0),
+      immediateShareKey: const rust_share_policy.ImmediateShareKey(
+        bundleIndex: 0,
+        proposalId: 1,
+        shareIndex: 0,
+      ),
+      allDecided: true,
+      completedVoteArtifact: true,
+      completedForDisplay: true,
+    );
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      overrides: [
+        votingSessionProvider(_roundId).overrideWith(
+          () => _StaticVotingSessionNotifier(
+            VotingSessionState(
+              roundId: _roundId,
+              accountUuid: 'account-1',
+              phase: VotingSessionPhase.done,
+              roundPlan: completedRoundPlan,
+              resumePlan: resumePlan,
+              eligibleWeightZatoshi: BigInt.from(100),
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _submissionHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _pumpUntilFound(tester, find.text('Submission not complete'));
+
+    expect(find.text('Submission confirmed!'), findsNothing);
+    expect(
+      find.text(
+        'This account has not completed submission for this voting round.',
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('submitted route does not confirm without eligibility', (
     tester,
   ) async {
@@ -5539,11 +5629,13 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
     required bool singleShare,
+    int? immediateShareIndex,
   }) async {
     final targetCount = serverUrls.isEmpty ? 0 : (serverUrls.length / 2).ceil();
     return [
       for (var i = 0; i < shareCount; i++)
         rust_share_policy.ShareSubmissionPlan(
+          immediate: immediateShareIndex == i,
           submitAt: BigInt.zero,
           targetCount: targetCount,
           targetServers: serverUrls.take(targetCount).toList(growable: false),

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3709,6 +3709,95 @@ void main() {
   );
 
   test(
+    'immediate share keeps submission running until an accepted helper confirms',
+    () async {
+      final shareNullifier = Uint8List.fromList(List.filled(32, 9));
+      final shareId = _hexFromBytes(shareNullifier);
+      final acceptedShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const [
+          'https://helper-a.example',
+          'https://helper-b.example',
+        ],
+        nullifier: shareNullifier,
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.zero,
+        createdAt: BigInt.one,
+      );
+      final confirmedShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: acceptedShare.roundId,
+        bundleIndex: acceptedShare.bundleIndex,
+        proposalId: acceptedShare.proposalId,
+        shareIndex: acceptedShare.shareIndex,
+        sentToUrls: acceptedShare.sentToUrls,
+        nullifier: acceptedShare.nullifier,
+        phase: VotingWorkflowPhase.confirmed,
+        confirmed: true,
+        submitAt: acceptedShare.submitAt,
+        createdAt: acceptedShare.createdAt,
+      );
+      late final FakeVotingRecoveryApi recoveryApi;
+      final rust = FakeVotingRustApi(
+        onShareConfirmed: (_, _, _) {
+          recoveryApi.state = recoveryState(
+            bundleCount: 1,
+            shareDelegations: [confirmedShare],
+          );
+        },
+      );
+      recoveryApi = _submittedDelegationWithShareRecoveryApi(
+        acceptedShare,
+        designateImmediateShare: true,
+      );
+      final http = FakeVotingHttpClient(
+        responses:
+            votingHttpResponses(
+              dynamicConfig: dynamicConfigJson(
+                voteServers: const [
+                  {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                  {'url': 'https://helper-b.example', 'label': 'helper-b'},
+                ],
+              ),
+            )..addAll({
+              'https://helper-a.example/shielded-vote/v1/share-status/$kRoundId/$shareId':
+                  StateError('helper unavailable'),
+              'https://helper-b.example/shielded-vote/v1/share-status/$kRoundId/$shareId':
+                  {'status': 'confirmed'},
+            }),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+        txConfirmationPolling: _fastTxConfirmationPolling,
+      );
+      addTearDown(container.dispose);
+
+      final key = await container
+          .read(votingSubmissionJobsProvider.notifier)
+          .start(kRoundId);
+      final completed = await _waitForJobStatus(
+        container,
+        key!,
+        VotingSubmissionJobStatus.complete,
+      );
+
+      expect(completed.errorMessage, isNull);
+      expect(rust.confirmedShares, ['0:7:0']);
+      expect(
+        http.requests
+            .where((request) => request.uri.path.contains('/share-status/'))
+            .map((request) => request.uri.host),
+        ['helper-a.example', 'helper-b.example'],
+      );
+    },
+  );
+
+  test(
     'share tracking releases its registration when the round expires',
     () async {
       final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -5453,6 +5542,11 @@ void main() {
           ),
         ],
         openProposals: Uint32List.fromList(const [9]),
+        immediateShareKey: const rust_share_policy.ImmediateShareKey(
+          bundleIndex: 1,
+          proposalId: 7,
+          shareIndex: 0,
+        ),
         allDecided: false,
       ),
       state: recoveryState(
@@ -5522,12 +5616,110 @@ void main() {
     );
     expect(rust.storedVoteTxHashes, isNot(contains('1:7:vote-tx')));
     expect(rust.voteCommitmentKeys, ['0:8', '1:8']);
+    expect(rust.planImmediateShareIndexes, everyElement(isNull));
     expect(rust.operationLog.take(3).toList(), [
       'recover_vote:1:7',
       'record_share:1:7:1',
       'build_vote:0:8',
     ]);
   });
+
+  test(
+    'recovery maps immediate share zero to a reordered subset position',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final rust = FakeVotingRustApi(
+        commitmentShareCount: 3,
+        recoveredShareOrder: const [2, 0, 1],
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        roundPlan: apiRoundPlan(
+          roundId: kRoundId,
+          pendingRecovery: true,
+          nextSteps: const [
+            rust_wire.NextStepView(
+              kind: 'submit_shares',
+              bundleIndex: 0,
+              proposalId: 7,
+              shareIndex: 2,
+              choice: 0,
+            ),
+            rust_wire.NextStepView(
+              kind: 'submit_shares',
+              bundleIndex: 0,
+              proposalId: 7,
+              shareIndex: 0,
+              choice: 0,
+            ),
+          ],
+          openProposals: Uint32List(0),
+          immediateShareKey: const rust_share_policy.ImmediateShareKey(
+            bundleIndex: 0,
+            proposalId: 7,
+            shareIndex: 0,
+          ),
+          allDecided: true,
+        ),
+        state: recoveryState(
+          bundleCount: 1,
+          delegationTxHashes: [
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: 0,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-0',
+              vanLeafPosition: null,
+            ),
+          ],
+          votes: [vote(bundleIndex: 0, proposalId: 7)],
+          commitmentBundles: [
+            rust_frb_types.RecoverableCommitmentBundle(
+              bundleIndex: 0,
+              proposalId: 7,
+              commitmentBundleJson: commitmentBundleRecoveryJson(proposalId: 7),
+              vcTreePosition: BigInt.from(55),
+            ),
+          ],
+        ),
+      );
+      final http = FakeVotingHttpClient(
+        responses: votingHttpResponses(
+          roundStatus: roundStatusJson(
+            roundId: kRoundId,
+            ceremonyStart: nowSeconds - 100,
+            voteEnd: nowSeconds + 1000,
+          ),
+        ),
+      );
+      final container = _sessionContainer(
+        rust: rust,
+        recoveryApi: recoveryApi,
+        http: http,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(draftVotes: const []);
+
+      expect(rust.planImmediateShareIndexes, [1]);
+      final recoveredShares = rust.recordedShares.where(
+        (share) => share.bundleIndex == 0 && share.proposalId == 7,
+      );
+      expect(
+        recoveredShares.map((share) => share.shareIndex),
+        unorderedEquals([0, 2]),
+      );
+      expect(
+        recoveredShares.singleWhere((share) => share.shareIndex == 0).submitAt,
+        BigInt.zero,
+      );
+      expect(
+        recoveredShares.singleWhere((share) => share.shareIndex == 2).submitAt,
+        greaterThan(BigInt.zero),
+      );
+    },
+  );
 
   test(
     'resume refreshes planner after vote confirmation before later proposal casts',
@@ -6656,19 +6848,41 @@ void main() {
   );
 
   test(
-    'last-moment vote uses single-share mode and immediate submit_at',
+    'share planning maps the round immediate key to its batch position',
     () async {
       final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       final http = FakeVotingHttpClient(
         responses: votingHttpResponses(
           roundStatus: roundStatusJson(
             roundId: kRoundId,
-            ceremonyStart: nowSeconds - 1000,
-            voteEnd: nowSeconds + 100,
+            ceremonyStart: nowSeconds - 100,
+            voteEnd: nowSeconds + 1000,
           ),
         ),
       );
-      final rust = FakeVotingRustApi(emitCommitments: true);
+      final rust = FakeVotingRustApi(
+        emitCommitments: true,
+        commitmentShareCount: 3,
+      );
+      final beforeIntent = apiRoundPlan(
+        roundId: kRoundId,
+        pendingRecovery: false,
+        nextSteps: const [],
+        openProposals: Uint32List.fromList(const [7]),
+        allDecided: false,
+      );
+      final afterIntent = apiRoundPlan(
+        roundId: kRoundId,
+        pendingRecovery: false,
+        nextSteps: const [],
+        openProposals: Uint32List.fromList(const [7]),
+        immediateShareKey: const rust_share_policy.ImmediateShareKey(
+          bundleIndex: 0,
+          proposalId: 7,
+          shareIndex: 0,
+        ),
+        allDecided: false,
+      );
       final recoveryApi = FakeVotingRecoveryApi(
         state: recoveryState(
           bundleCount: 1,
@@ -6681,6 +6895,83 @@ void main() {
             ),
           ],
           votes: [vote(bundleIndex: 0, proposalId: 7)],
+        ),
+        roundPlanSequence: [beforeIntent, beforeIntent, afterIntent],
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+
+      expect(rust.planImmediateShareIndexes, [0]);
+      final submitAtByShare = {
+        for (final share in rust.recordedShares)
+          share.shareIndex: share.submitAt,
+      };
+      expect(submitAtByShare[0], BigInt.zero);
+      expect(submitAtByShare[1], greaterThan(BigInt.zero));
+      expect(submitAtByShare[2], greaterThan(BigInt.zero));
+    },
+  );
+
+  test(
+    'last-moment vote uses single-share mode and immediate submit_at',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final http = FakeVotingHttpClient(
+        responses: votingHttpResponses(
+          roundStatus: roundStatusJson(
+            roundId: kRoundId,
+            ceremonyStart: nowSeconds - 1000,
+            voteEnd: nowSeconds + 100,
+          ),
+        ),
+      );
+      final rust = FakeVotingRustApi(
+        emitCommitments: true,
+        commitmentShareCount: 2,
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 1,
+          delegationTxHashes: [
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: 0,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-0',
+              vanLeafPosition: null,
+            ),
+          ],
+          votes: [vote(bundleIndex: 0, proposalId: 7)],
+        ),
+        roundPlan: apiRoundPlan(
+          roundId: kRoundId,
+          pendingRecovery: false,
+          nextSteps: const [],
+          openProposals: Uint32List.fromList(const [7]),
+          immediateShareKey: const rust_share_policy.ImmediateShareKey(
+            bundleIndex: 0,
+            proposalId: 7,
+            shareIndex: 0,
+          ),
+          allDecided: false,
         ),
       );
       final container = _sessionContainer(
@@ -6707,8 +6998,21 @@ void main() {
 
       expect(rust.draftSingleShareValues, [true]);
       expect(rust.planSingleShareValues, [true]);
-      expect(_postBody(http, '/shielded-vote/v1/shares')['submit_at'], 0);
-      expect(rust.recordedShares.single.submitAt, BigInt.zero);
+      expect(rust.planImmediateShareIndexes, [0]);
+      expect(
+        http.requests
+            .where(
+              (request) =>
+                  request.method == 'POST' &&
+                  request.uri.path == '/shielded-vote/v1/shares',
+            )
+            .map((request) => request.body!['submit_at']),
+        everyElement(0),
+      );
+      expect(
+        rust.recordedShares.map((share) => share.submitAt),
+        everyElement(BigInt.zero),
+      );
     },
   );
 
@@ -8512,6 +8816,7 @@ FakeVotingRecoveryApi _submittedDelegationOnlyRecoveryApi() {
 FakeVotingRecoveryApi _submittedDelegationWithShareRecoveryApi(
   rust_frb_types.ShareDelegationRecordView share, {
   bool includeCommitmentBundle = false,
+  bool designateImmediateShare = false,
 }) {
   final beforeConfirmation = apiRoundPlan(
     roundId: kRoundId,
@@ -8541,6 +8846,13 @@ FakeVotingRecoveryApi _submittedDelegationWithShareRecoveryApi(
       ),
     ],
     openProposals: Uint32List(0),
+    immediateShareKey: designateImmediateShare
+        ? rust_share_policy.ImmediateShareKey(
+            bundleIndex: share.bundleIndex,
+            proposalId: share.proposalId,
+            shareIndex: share.shareIndex,
+          )
+        : null,
     allDecided: true,
     recoveredDelegationWork: const [],
   );
@@ -9921,6 +10233,8 @@ class FakeVotingRustApi implements VotingRustApi {
     this.shareTrackingFlagsGate,
     this.failingVoteShareWireIndexes = const {},
     this.failingRecordShareIndexes = const {},
+    this.onShareConfirmed,
+    this.recoveredShareOrder,
   });
 
   final Duration setupDelay;
@@ -9955,6 +10269,9 @@ class FakeVotingRustApi implements VotingRustApi {
   final Completer<void>? shareTrackingFlagsGate;
   final Set<int> failingVoteShareWireIndexes;
   final Set<int> failingRecordShareIndexes;
+  final void Function(int bundleIndex, int proposalId, int shareIndex)?
+  onShareConfirmed;
+  final List<int>? recoveredShareOrder;
   int setupCalls = 0;
   int _activeSetups = 0;
   int maxConcurrentSetups = 0;
@@ -10004,6 +10321,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final draftSingleShareValues = <bool>[];
   final planLastMomentBufferSeconds = <BigInt?>[];
   final planSingleShareValues = <bool>[];
+  final planImmediateShareIndexes = <int?>[];
   final accountUuids = <String>[];
   final confirmedShares = <String>[];
   final shareResubmissionConfiguredServerUrls = <List<String>>[];
@@ -10680,6 +10998,7 @@ class FakeVotingRustApi implements VotingRustApi {
       proposalId: proposalId,
       choice: 1,
       shareCount: commitmentShareCount,
+      shareOrder: recoveredShareOrder,
     );
   }
 
@@ -10735,9 +11054,11 @@ class FakeVotingRustApi implements VotingRustApi {
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
     required bool singleShare,
+    int? immediateShareIndex,
   }) async {
     planLastMomentBufferSeconds.add(lastMomentBufferSeconds);
     planSingleShareValues.add(singleShare);
+    planImmediateShareIndexes.add(immediateShareIndex);
     final targetCount = serverUrls.isEmpty ? 0 : (serverUrls.length / 2).ceil();
     final now = nowSeconds.toInt();
     final voteEnd = voteEndTimeSeconds.toInt();
@@ -10749,7 +11070,8 @@ class FakeVotingRustApi implements VotingRustApi {
     return [
       for (var i = 0; i < shareCount; i++)
         rust_share_policy.ShareSubmissionPlan(
-          submitAt: submitAt,
+          immediate: immediateShareIndex == i,
+          submitAt: immediateShareIndex == i ? BigInt.zero : submitAt,
           targetCount: targetCount,
           targetServers: serverUrls.take(targetCount).toList(growable: false),
         ),
@@ -11024,6 +11346,7 @@ class FakeVotingRustApi implements VotingRustApi {
     required int shareIndex,
   }) async {
     confirmedShares.add('$bundleIndex:$proposalId:$shareIndex');
+    onShareConfirmed?.call(bundleIndex, proposalId, shareIndex);
   }
 }
 
@@ -11115,9 +11438,12 @@ rust_wire.SignedVoteCommitmentsView _commitments({
   required int proposalId,
   required int choice,
   int shareCount = 1,
+  List<int>? shareOrder,
 }) {
+  final orderedShareIndexes =
+      shareOrder ?? List<int>.generate(shareCount, (index) => index);
   final wireShares = [
-    for (var shareIndex = 0; shareIndex < shareCount; shareIndex++)
+    for (final shareIndex in orderedShareIndexes)
       rust_types.WireEncryptedShare(
         c1: Uint8List.fromList(shareCount == 1 ? [8] : [8, shareIndex]),
         c2: Uint8List.fromList(shareCount == 1 ? [9] : [9, shareIndex]),

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3798,6 +3798,91 @@ void main() {
   );
 
   test(
+    'unconfirmed immediate share fails the submission job when voting ends',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final voteEndSeconds = nowSeconds + 2;
+      final shareNullifier = Uint8List.fromList(List.filled(32, 9));
+      final shareId = _hexFromBytes(shareNullifier);
+      final acceptedShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        nullifier: shareNullifier,
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.zero,
+        createdAt: BigInt.one,
+      );
+      final rust = FakeVotingRustApi();
+      final http = FakeVotingHttpClient(
+        responses:
+            votingHttpResponses(
+              roundStatus: roundStatusJson(
+                roundId: kRoundId,
+                voteEnd: voteEndSeconds,
+              ),
+              dynamicConfig: dynamicConfigJson(
+                voteServers: const [
+                  {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                ],
+              ),
+            )..addAll({
+              'https://helper-a.example/shielded-vote/v1/share-status/$kRoundId/$shareId':
+                  StateError('helper unavailable'),
+            }),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: _submittedDelegationWithShareRecoveryApi(
+          acceptedShare,
+          designateImmediateShare: true,
+        ),
+        txConfirmationPolling: _fastTxConfirmationPolling,
+      );
+      addTearDown(container.dispose);
+
+      final key = await container
+          .read(votingSubmissionJobsProvider.notifier)
+          .start(kRoundId);
+      await _waitForStoredVanPosition(rust, '0:0');
+      expect(
+        container.read(votingSubmissionJobProvider(key!)).status,
+        VotingSubmissionJobStatus.running,
+      );
+
+      final waitUntilExpiry = DateTime.fromMillisecondsSinceEpoch(
+        voteEndSeconds * 1000,
+      ).difference(DateTime.now());
+      if (waitUntilExpiry > Duration.zero) {
+        await Future<void>.delayed(
+          waitUntilExpiry + const Duration(milliseconds: 50),
+        );
+      }
+      final failed = await _waitForJobStatus(
+        container,
+        key,
+        VotingSubmissionJobStatus.error,
+      );
+
+      expect(
+        failed.errorMessage,
+        'The voting round ended before a helper confirmed the immediate share. '
+        'Check the voting status before retrying.',
+      );
+      expect(
+        container
+            .read(votingSubmissionGuardProvider.notifier)
+            .guardForAccount('account-1'),
+        isNull,
+      );
+    },
+  );
+
+  test(
     'share tracking releases its registration when the round expires',
     () async {
       final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;


### PR DESCRIPTION
## Summary
- integrate the deterministic round-level immediate share from [zcash_voting#211](https://github.com/valargroup/zcash_voting/pull/211)
- map the designated domain share into fresh and recovery submission batches without changing sibling schedules or helper targets
- keep voting submission finalizing until any helper that accepted the immediate share reports it confirmed

## Motivation / Why
The confirmation screen could previously appear after helper acceptance while every share reveal was still pending. One deliberately immediate share now provides an explicit confirmation gate, while ordinary delayed shares continue through existing background tracking.

## Tests
- `fvm flutter test test/providers/voting/voting_providers_test.dart test/features/voting/voting_status_screen_test.dart`
- `fvm flutter test`
- `fvm flutter test test/features/voting/mobile_voting_submission_progress_screen_test.dart --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter analyze`
- `cd rust && cargo test`

The full mobile-tagged lane was also attempted and has unrelated existing widgetbook and Ironwood migration failures; the targeted mobile voting suite passes.