### PR TITLE
fix(voting): preserve mobile voting information and notice placement

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -274,6 +274,20 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     mobile: true,
   ),
   FigmaCompareScenario(
+    id: 'mobile-voting-privacy-trim',
+    description: 'Mobile voting detail with the excluded voting power notice',
+    builder: buildMobileVotingPrivacyTrimUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-voting-eligibility-error',
+    description: 'Mobile voting detail with an eligibility lookup error',
+    builder: buildMobileVotingEligibilityErrorUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
     id: 'mobile-voting-ineligible',
     description: 'Mobile ineligible voting detail matching Figma 8048:35024',
     builder: buildMobileVotingIneligibleUseCase,

--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -266,6 +266,14 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     mobile: true,
   ),
   FigmaCompareScenario(
+    id: 'mobile-voting-eligible',
+    description:
+        'Mobile eligible voting detail with round timing and voting power',
+    builder: buildMobileVotingEligibleUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
     id: 'mobile-voting-ineligible',
     description: 'Mobile ineligible voting detail matching Figma 8048:35024',
     builder: buildMobileVotingIneligibleUseCase,

--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -573,47 +573,41 @@ class _MobilePollStatus extends StatelessWidget {
         : state == _PollCardState.closed
         ? context.colors.text.primary
         : context.colors.text.accent;
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        // Give the status its intrinsic width before allocating the date.
-        // Equal flex shares clip dates even when the full footer would fit.
-        final showDate =
-            displayedDate != null &&
-            constraints.maxWidth >= MediaQuery.textScalerOf(context).scale(160);
-        final status = Text(
-          _statusLabel(state),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: AppTypography.labelLarge.copyWith(
-            color: statusColor,
-            letterSpacing: -0.04,
-          ),
-        );
-        return Row(
-          children: [
-            if (voted) ...[
+    final status = Text(
+      _statusLabel(state),
+      style: AppTypography.labelLarge.copyWith(
+        color: statusColor,
+        letterSpacing: -0.04,
+      ),
+    );
+    // The parent gives this footer all space left beside the action button.
+    // Use intrinsic text widths on one line, then wrap instead of hiding dates.
+    return Wrap(
+      spacing: 7,
+      runSpacing: AppSpacing.xxs,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        if (voted)
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
               AppIcon(AppIcons.checkCircle, size: 20, color: statusColor),
               const SizedBox(width: 7),
+              Flexible(child: status),
             ],
-            if (showDate) status else Flexible(child: status),
-            if (showDate) ...[
-              const SizedBox(width: 7),
-              Expanded(
-                child: Text(
-                  displayedDate,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTypography.labelLarge.copyWith(
-                    color: context.colors.text.primary,
-                    fontWeight: FontWeight.w400,
-                    letterSpacing: -0.04,
-                  ),
-                ),
-              ),
-            ],
-          ],
-        );
-      },
+          )
+        else
+          status,
+        if (displayedDate != null)
+          Text(
+            displayedDate,
+            style: AppTypography.labelLarge.copyWith(
+              color: context.colors.text.primary,
+              fontWeight: FontWeight.w400,
+              letterSpacing: -0.04,
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -1097,6 +1097,15 @@ class _MobilePollSummary extends StatelessWidget {
             ],
           ],
         ),
+        if (!isIneligible && votingEligibilityMessage != null) ...[
+          const SizedBox(height: AppSpacing.xxs),
+          Text(
+            votingEligibilityMessage!,
+            style: AppTypography.bodySmall.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+        ],
         if (description.trim().isNotEmpty) ...[
           const SizedBox(height: AppSpacing.sm),
           VotingExpandableText(
@@ -1142,15 +1151,6 @@ class _MobilePollSummary extends StatelessWidget {
         ] else if (forum != null) ...[
           const SizedBox(height: AppSpacing.sm),
           Align(alignment: Alignment.centerRight, child: forum),
-        ],
-        if (!isIneligible && votingEligibilityMessage != null) ...[
-          const SizedBox(height: AppSpacing.xxs),
-          Text(
-            votingEligibilityMessage!,
-            style: AppTypography.bodySmall.copyWith(
-              color: colors.text.secondary,
-            ),
-          ),
         ],
       ],
     );

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -1077,6 +1077,26 @@ class _MobilePollSummary extends StatelessWidget {
             color: colors.text.accent,
           ),
         ),
+        // Round timing is useful even when this account cannot vote.
+        const SizedBox(height: AppSpacing.sm),
+        Wrap(
+          spacing: AppSpacing.xs,
+          runSpacing: AppSpacing.xxs,
+          children: [
+            _MetaText(
+              endDate == null
+                  ? 'Voting active'
+                  : 'Ends ${formatMonthDayYear(endDate!)}',
+            ),
+            if (!isIneligible) ...[
+              const _MetaText('·'),
+              _VotingPowerMeta(
+                zatoshi: votingPowerZatoshi,
+                preparing: votingPowerPreparing,
+              ),
+            ],
+          ],
+        ),
         if (description.trim().isNotEmpty) ...[
           const SizedBox(height: AppSpacing.sm),
           VotingExpandableText(
@@ -1123,30 +1143,6 @@ class _MobilePollSummary extends StatelessWidget {
           const SizedBox(height: AppSpacing.sm),
           Align(alignment: Alignment.centerRight, child: forum),
         ],
-        // Round timing is useful even when this account cannot vote.
-        const SizedBox(height: AppSpacing.sm),
-        Wrap(
-          spacing: AppSpacing.xs,
-          runSpacing: AppSpacing.xxs,
-          children: [
-            _MetaText(
-              endDate == null
-                  ? 'Voting active'
-                  : 'Ends ${formatMonthDayYear(endDate!)}',
-            ),
-            if (!isIneligible) ...[
-              const _MetaText('·'),
-              _VotingPowerMeta(
-                zatoshi: votingPowerZatoshi,
-                preparing: votingPowerPreparing,
-              ),
-            ],
-            if (endDate != null) ...[
-              const _MetaText('·'),
-              _MetaText(_daysLeftLabel(endDate!)),
-            ],
-          ],
-        ),
         if (!isIneligible && votingEligibilityMessage != null) ...[
           const SizedBox(height: AppSpacing.xxs),
           Text(

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -1123,39 +1123,38 @@ class _MobilePollSummary extends StatelessWidget {
           const SizedBox(height: AppSpacing.sm),
           Align(alignment: Alignment.centerRight, child: forum),
         ],
-        // Keep power, timing, loading, and retry context for eligible or unknown
-        // accounts. The confirmed-ineligible design replaces it with the badge.
-        if (!isIneligible) ...[
-          const SizedBox(height: AppSpacing.sm),
-          Wrap(
-            spacing: AppSpacing.xs,
-            runSpacing: AppSpacing.xxs,
-            children: [
-              _MetaText(
-                endDate == null
-                    ? 'Voting active'
-                    : 'Ends ${formatMonthDayYear(endDate!)}',
-              ),
+        // Round timing is useful even when this account cannot vote.
+        const SizedBox(height: AppSpacing.sm),
+        Wrap(
+          spacing: AppSpacing.xs,
+          runSpacing: AppSpacing.xxs,
+          children: [
+            _MetaText(
+              endDate == null
+                  ? 'Voting active'
+                  : 'Ends ${formatMonthDayYear(endDate!)}',
+            ),
+            if (!isIneligible) ...[
               const _MetaText('·'),
               _VotingPowerMeta(
                 zatoshi: votingPowerZatoshi,
                 preparing: votingPowerPreparing,
               ),
-              if (endDate != null) ...[
-                const _MetaText('·'),
-                _MetaText(_daysLeftLabel(endDate!)),
-              ],
             ],
-          ),
-          if (votingEligibilityMessage != null) ...[
-            const SizedBox(height: AppSpacing.xxs),
-            Text(
-              votingEligibilityMessage!,
-              style: AppTypography.bodySmall.copyWith(
-                color: colors.text.secondary,
-              ),
-            ),
+            if (endDate != null) ...[
+              const _MetaText('·'),
+              _MetaText(_daysLeftLabel(endDate!)),
+            ],
           ],
+        ),
+        if (!isIneligible && votingEligibilityMessage != null) ...[
+          const SizedBox(height: AppSpacing.xxs),
+          Text(
+            votingEligibilityMessage!,
+            style: AppTypography.bodySmall.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
         ],
       ],
     );

--- a/lib/widgetbook/voting_use_cases.dart
+++ b/lib/widgetbook/voting_use_cases.dart
@@ -153,9 +153,28 @@ Widget buildMobileVotingEligibleUseCase(BuildContext context) =>
 Widget buildMobileVotingIneligibleUseCase(BuildContext context) =>
     _buildMobileVotingActiveUseCase(context, eligible: false);
 
+Widget buildMobileVotingPrivacyTrimUseCase(BuildContext context) =>
+    _buildMobileVotingActiveUseCase(
+      context,
+      eligible: true,
+      votingEligibilityMessage:
+          '0.125 ZEC is left out of this vote '
+          'to keep your submission less identifiable.',
+    );
+
+Widget buildMobileVotingEligibilityErrorUseCase(BuildContext context) =>
+    _buildMobileVotingActiveUseCase(
+      context,
+      eligible: false,
+      eligibilityUnknown: true,
+      votingEligibilityMessage: 'Unable to check voting eligibility.',
+    );
+
 Widget _buildMobileVotingActiveUseCase(
   BuildContext context, {
   required bool eligible,
+  bool eligibilityUnknown = false,
+  String? votingEligibilityMessage,
 }) {
   return _mobileVotingFullPagePreview(
     context,
@@ -171,12 +190,16 @@ Widget _buildMobileVotingActiveUseCase(
             'without using real governance content.',
         forumUri: Uri.parse('https://forum.zcashcommunity.com/t/nsm'),
         endDate: DateTime(2026, 8, 24),
-        votingPowerZatoshi: eligible ? BigInt.from(37500000) : BigInt.zero,
+        votingPowerZatoshi: eligibilityUnknown
+            ? null
+            : eligible
+            ? BigInt.from(37500000)
+            : BigInt.zero,
         votingPowerPreparing: false,
         votingEligibilityConfirmed: eligible,
         answersEditable: eligible,
-        votingEligibilityMessage: null,
-        votingEligibilityErrorMessage: eligible
+        votingEligibilityMessage: votingEligibilityMessage,
+        votingEligibilityErrorMessage: eligible || eligibilityUnknown
             ? null
             : 'This account did not have enough eligible '
                   'shielded funds at snapshot block 3,543,600. Switch to an eligible account to vote.',

--- a/lib/widgetbook/voting_use_cases.dart
+++ b/lib/widgetbook/voting_use_cases.dart
@@ -147,7 +147,16 @@ Widget buildMobileVotingProposalDefaultUseCase(BuildContext context) {
   );
 }
 
-Widget buildMobileVotingIneligibleUseCase(BuildContext context) {
+Widget buildMobileVotingEligibleUseCase(BuildContext context) =>
+    _buildMobileVotingActiveUseCase(context, eligible: true);
+
+Widget buildMobileVotingIneligibleUseCase(BuildContext context) =>
+    _buildMobileVotingActiveUseCase(context, eligible: false);
+
+Widget _buildMobileVotingActiveUseCase(
+  BuildContext context, {
+  required bool eligible,
+}) {
   return _mobileVotingFullPagePreview(
     context,
     MobileVotingScaffold(
@@ -162,14 +171,15 @@ Widget buildMobileVotingIneligibleUseCase(BuildContext context) {
             'without using real governance content.',
         forumUri: Uri.parse('https://forum.zcashcommunity.com/t/nsm'),
         endDate: DateTime(2026, 8, 24),
-        votingPowerZatoshi: BigInt.zero,
+        votingPowerZatoshi: eligible ? BigInt.from(37500000) : BigInt.zero,
         votingPowerPreparing: false,
-        votingEligibilityConfirmed: false,
-        answersEditable: false,
+        votingEligibilityConfirmed: eligible,
+        answersEditable: eligible,
         votingEligibilityMessage: null,
-        votingEligibilityErrorMessage:
-            'This account did not have enough eligible '
-            'shielded funds at snapshot block 3,543,600. Switch to an eligible account to vote.',
+        votingEligibilityErrorMessage: eligible
+            ? null
+            : 'This account did not have enough eligible '
+                  'shielded funds at snapshot block 3,543,600. Switch to an eligible account to vote.',
         onVotingEligibilityRetry: _previewNoop,
         proposals: const [_previewNsmProposal],
         draft: const VotingDraftState(),

--- a/test/features/voting/mobile_voting_design_test.dart
+++ b/test/features/voting/mobile_voting_design_test.dart
@@ -166,6 +166,59 @@ void main() {
     }
   }
 
+  for (final (builder, message, power) in [
+    (
+      buildMobileVotingPrivacyTrimUseCase,
+      '0.125 ZEC is left out of this vote '
+          'to keep your submission less identifiable.',
+      'Voting power 0.375 ZEC',
+    ),
+    (
+      buildMobileVotingEligibilityErrorUseCase,
+      'Unable to check voting eligibility.',
+      'Voting power unavailable',
+    ),
+  ]) {
+    for (final brightness in Brightness.values) {
+      testWidgets(
+        'notice stays below power and above description: $power, $brightness',
+        (tester) async {
+          await _pumpMobileFixture(
+            tester,
+            builder,
+            size: const Size(320, 852),
+            brightness: brightness,
+          );
+          final notice = find.text(message);
+          final description = find.byType(VotingExpandableText).first;
+          expect(notice, findsOneWidget);
+          expect(
+            tester.getTopLeft(notice).dy,
+            greaterThan(tester.getBottomLeft(find.text(power)).dy),
+          );
+          expect(
+            tester.getBottomLeft(notice).dy,
+            lessThan(tester.getTopLeft(description).dy),
+          );
+          expect(
+            tester.renderObject<RenderParagraph>(notice).didExceedMaxLines,
+            isFalse,
+          );
+          final noticeRect = tester.getRect(notice);
+          final collapsedDescriptionHeight = tester.getSize(description).height;
+          await tester.tap(find.text('Show description'));
+          await tester.pumpAndSettle();
+          expect(
+            tester.getSize(description).height,
+            greaterThan(collapsedDescriptionHeight),
+          );
+          expect(tester.getRect(notice), noticeRect);
+          expect(tester.takeException(), isNull);
+        },
+      );
+    }
+  }
+
   testWidgets('ineligible detail keeps round timing but hides voting power', (
     tester,
   ) async {

--- a/test/features/voting/mobile_voting_design_test.dart
+++ b/test/features/voting/mobile_voting_design_test.dart
@@ -121,6 +121,51 @@ void main() {
     });
   }
 
+  for (final eligible in [true, false]) {
+    for (final brightness in Brightness.values) {
+      for (final width in [320.0, 393.0]) {
+        testWidgets(
+          'round metadata precedes description: eligible=$eligible, $brightness, width=$width',
+          (tester) async {
+            await _pumpMobileFixture(
+              tester,
+              eligible
+                  ? buildMobileVotingEligibleUseCase
+                  : buildMobileVotingIneligibleUseCase,
+              size: Size(width, 852),
+              brightness: brightness,
+            );
+            final title = find.text('[TEST] Very Serious Snack Governance 3');
+            final description = find.byType(VotingExpandableText).first;
+            final date = find.text('Ends Aug 24, 2026');
+            final remaining = find.textContaining(
+              RegExp(r'^(Ends today|1 day left|\d+ days left)$'),
+            );
+            final power = find.text('Voting power 0.375 ZEC');
+            expect(power, eligible ? findsOneWidget : findsNothing);
+            expect(remaining, findsNothing);
+            for (final label in [date, if (eligible) power]) {
+              expect(label, findsOneWidget);
+              expect(
+                tester.getTopLeft(label).dy,
+                greaterThan(tester.getBottomLeft(title).dy),
+              );
+              expect(
+                tester.getBottomLeft(label).dy,
+                lessThan(tester.getTopLeft(description).dy),
+              );
+              expect(
+                tester.renderObject<RenderParagraph>(label).didExceedMaxLines,
+                isFalse,
+              );
+            }
+            expect(tester.takeException(), isNull);
+          },
+        );
+      }
+    }
+  }
+
   testWidgets('ineligible detail keeps round timing but hides voting power', (
     tester,
   ) async {
@@ -140,9 +185,9 @@ void main() {
     expect(find.text('Ends Aug 24, 2026'), findsOneWidget);
     expect(
       find.textContaining(RegExp(r'^(Ends today|1 day left|\d+ days left)$')),
-      findsOneWidget,
+      findsNothing,
     );
-    expect(find.text('·'), findsOneWidget);
+    expect(find.text('·'), findsNothing);
     expect(tester.getTopLeft(find.text('Show description')).dx, 36);
     final option = find.byKey(const ValueKey('voting_proposal_1_option_1'));
     expect(tester.getTopLeft(option), const Offset(32, 713));
@@ -920,6 +965,7 @@ Future<void> _pumpMobileFixture(
   WidgetBuilder builder, {
   Size size = const Size(393, 852),
   TextScaler textScaler = TextScaler.noScaling,
+  Brightness brightness = Brightness.dark,
 }) async {
   tester.view.devicePixelRatio = 1;
   tester.view.physicalSize = size;
@@ -927,9 +973,11 @@ Future<void> _pumpMobileFixture(
 
   await tester.pumpWidget(
     MaterialApp(
-      theme: ThemeData.dark(),
+      theme: ThemeData(brightness: brightness),
       builder: (context, child) => AppTheme(
-        data: AppThemeData.dark,
+        data: brightness == Brightness.dark
+            ? AppThemeData.dark
+            : AppThemeData.light,
         child: MediaQuery(
           data: MediaQuery.of(context).copyWith(textScaler: textScaler),
           child: child!,

--- a/test/features/voting/mobile_voting_design_test.dart
+++ b/test/features/voting/mobile_voting_design_test.dart
@@ -101,7 +101,7 @@ void main() {
     });
   }
 
-  testWidgets('ineligible detail matches Figma and keeps the existing header', (
+  testWidgets('ineligible detail keeps round timing but hides voting power', (
     tester,
   ) async {
     await _pumpMobileFixture(tester, buildMobileVotingIneligibleUseCase);
@@ -114,13 +114,18 @@ void main() {
     expect(tester.getTopLeft(badge).dy, 140.5);
     expect(
       tester.getTopLeft(find.byType(VotingProposalCard)),
-      const Offset(16, 371),
+      const Offset(16, 406),
     );
     expect(find.textContaining('Voting power'), findsNothing);
-    expect(find.textContaining('Ends Aug'), findsNothing);
+    expect(find.text('Ends Aug 24, 2026'), findsOneWidget);
+    expect(
+      find.textContaining(RegExp(r'^(Ends today|1 day left|\d+ days left)$')),
+      findsOneWidget,
+    );
+    expect(find.text('·'), findsOneWidget);
     expect(tester.getTopLeft(find.text('Show description')).dx, 36);
     final option = find.byKey(const ValueKey('voting_proposal_1_option_1'));
-    expect(tester.getTopLeft(option), const Offset(32, 678));
+    expect(tester.getTopLeft(option), const Offset(32, 713));
     expect(tester.getSize(option), const Size(329, 115));
     expect(
       tester
@@ -139,7 +144,7 @@ void main() {
     expect(find.text('Hide description'), findsOneWidget);
     expect(
       tester.getTopLeft(find.byType(VotingProposalCard)),
-      const Offset(16, 371),
+      const Offset(16, 406),
     );
     await tester.tap(find.text('Hide description'));
     await tester.pumpAndSettle();

--- a/test/features/voting/mobile_voting_design_test.dart
+++ b/test/features/voting/mobile_voting_design_test.dart
@@ -79,24 +79,44 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  for (final scale in [1.0, 1.3]) {
-    testWidgets('compact poll list remains usable at text scale $scale', (
+  for (final (width, scale) in [
+    (320.0, 1.0),
+    (320.0, 1.3),
+    (360.0, 1.0),
+    (393.0, 1.0),
+  ]) {
+    testWidgets('poll dates remain visible at width $width and scale $scale', (
       tester,
     ) async {
       await _pumpMobileFixture(
         tester,
         buildMobileVotingPollsEligibilityUseCase,
-        size: const Size(320, 667),
+        size: Size(width, 667),
         textScaler: TextScaler.linear(scale),
       );
+      void expectFullDate(String roundId, String date) {
+        final card = find.byKey(ValueKey('voting_poll_card_$roundId'));
+        final label = find.descendant(of: card, matching: find.text(date));
+        expect(label, findsOneWidget);
+        final paragraph = tester.renderObject<RenderParagraph>(label);
+        expect(paragraph.didExceedMaxLines, isFalse);
+        expect(
+          tester.getRect(card).contains(tester.getRect(label).bottomRight),
+          isTrue,
+        );
+      }
+
       expect(find.text('Not eligible for this round'), findsOneWidget);
       expect(find.text('View'), findsOneWidget);
+      expectFullDate('nu7-ineligible', 'Closes Aug 24');
       await tester.drag(
         find.byType(VotingPaneListView),
         const Offset(0, -1200),
       );
       await tester.pumpAndSettle();
       expect(find.text('View results'), findsOneWidget);
+      expectFullDate('snack-governance-voted', 'Closes Aug 24');
+      expectFullDate('snack-governance-closed', 'Aug 24');
       expect(tester.takeException(), isNull);
     });
   }

--- a/test/features/voting/mobile_voting_screen_test.dart
+++ b/test/features/voting/mobile_voting_screen_test.dart
@@ -117,7 +117,6 @@ void main() {
       tester.renderObject<RenderParagraph>(descriptionFinder).didExceedMaxLines,
       isTrue,
     );
-    expect(tester.getSize(card).height, tester.getSize(secondCard).height);
     final cardDecoration = tester.widget<Ink>(card).decoration as BoxDecoration;
     expect(cardDecoration.boxShadow, isNotEmpty);
     final cardTap = tester.widget<InkWell>(


### PR DESCRIPTION
## Summary

Follow-up to #571, based on current `main`. Cherry-picks only the four subsequent mobile voting information fixes; the original Figma implementation is already merged.

- Keep poll-list dates visible by wrapping them on narrow screens instead of hiding or truncating them.
- Show the end date below the round title for eligible and ineligible accounts; show voting power only when applicable.
- Remove the relative days-left label, while keeping the explicit end date.
- Keep privacy-trim and eligibility-error notices directly below voting power and above the description.
- Add reusable visual scenarios and regression coverage for both themes and compact viewports.

## Verification

- Mobile voting and account-sheet tests: **67 passed**.
- Desktop voting tests: **113 passed, 9 skipped**.
- `fvm flutter analyze --no-pub`: no issues.
- Re-captured eligible, ineligible, privacy-trim, and eligibility-error states in light and dark mode: **all 8 PNGs byte-identical** to the reviewed source-branch captures.
- `git range-diff`: all four cherry-picked patches unchanged.
- Final diff review and `git diff --check`: no findings.

## Scope

Only mobile voting UI, its fixtures, and tests change (6 files). No voting protocol, wallet storage, Rust, desktop layout, or migration behavior changes. No additional rollout steps are required.
