### PR TITLE
Use progressive helper delivery policy

### DIFF
--- a/lib/src/core/network/network_http_client.dart
+++ b/lib/src/core/network/network_http_client.dart
@@ -40,16 +40,42 @@ class DirectNetworkRequestsBlockedException implements Exception {
       'Direct network requests are blocked while the app switches to Tor.';
 }
 
+class NetworkHttpRequestCancelledException implements Exception {
+  const NetworkHttpRequestCancelledException();
+
+  @override
+  String toString() => 'Network HTTP request cancelled';
+}
+
+class _DirectRequestOperation<T> {
+  _DirectRequestOperation({required this.result, required Future<T> source})
+    : drained = source.then<void>((_) {}, onError: (_, _) {});
+
+  factory _DirectRequestOperation.fromFuture(Future<T> source) =>
+      _DirectRequestOperation(result: source, source: source);
+
+  final Future<T> result;
+  final Future<void> drained;
+}
+
+/// Tor transport boundary used after the process-wide route selects Tor.
+///
+/// Implementations must apply each timeout to the underlying transport
+/// operation, not only to the Future returned to Dart.
 abstract interface class TorHttpBridge {
   Future<NetworkHttpResponse> get(
     Uri uri, {
     required Map<String, String> headers,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   });
 
   Future<NetworkHttpResponse> post(
     Uri uri, {
     required Map<String, String> headers,
     required List<int> bodyBytes,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   });
 
   Future<NetworkHttpResponse> download(
@@ -62,16 +88,25 @@ abstract interface class TorHttpBridge {
 class RustTorHttpBridge implements TorHttpBridge {
   const RustTorHttpBridge();
 
+  static const _requestTimeoutError = 'Tor HTTP request timed out';
+
   @override
   Future<NetworkHttpResponse> get(
     Uri uri, {
     required Map<String, String> headers,
-  }) async {
-    final response = await rust_network_privacy.torHttpGet(
-      url: uri.toString(),
-      headers: _rustHeaders(headers),
+    required Duration? timeout,
+    Future<void>? cancelSignal,
+  }) {
+    return _request(
+      timeout,
+      cancelSignal,
+      (requestId) => rust_network_privacy.torHttpGet(
+        url: uri.toString(),
+        headers: _rustHeaders(headers),
+        timeoutMilliseconds: _timeoutMilliseconds(timeout),
+        requestId: requestId,
+      ),
     );
-    return networkHttpResponseFromRust(response);
   }
 
   @override
@@ -79,13 +114,20 @@ class RustTorHttpBridge implements TorHttpBridge {
     Uri uri, {
     required Map<String, String> headers,
     required List<int> bodyBytes,
-  }) async {
-    final response = await rust_network_privacy.torHttpPost(
-      url: uri.toString(),
-      headers: _rustHeaders(headers),
-      body: bodyBytes,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
+  }) {
+    return _request(
+      timeout,
+      cancelSignal,
+      (requestId) => rust_network_privacy.torHttpPost(
+        url: uri.toString(),
+        headers: _rustHeaders(headers),
+        body: bodyBytes,
+        timeoutMilliseconds: _timeoutMilliseconds(timeout),
+        requestId: requestId,
+      ),
     );
-    return networkHttpResponseFromRust(response);
   }
 
   @override
@@ -100,6 +142,49 @@ class RustTorHttpBridge implements TorHttpBridge {
       destinationPath: destinationPath,
     );
     return networkHttpResponseFromRust(response);
+  }
+
+  static BigInt? _timeoutMilliseconds(Duration? timeout) {
+    if (timeout == null) return null;
+    if (timeout <= Duration.zero) {
+      throw ArgumentError.value(timeout, 'timeout', 'must be positive');
+    }
+    return BigInt.from(timeout.inMilliseconds < 1 ? 1 : timeout.inMilliseconds);
+  }
+
+  Future<NetworkHttpResponse> _request(
+    Duration? timeout,
+    Future<void>? cancelSignal,
+    Future<rust_network_privacy.NetworkHttpResponse> Function(BigInt? requestId)
+    send,
+  ) async {
+    final signal = cancelSignal;
+    final requestId = signal == null
+        ? null
+        : rust_network_privacy.torHttpBeginRequest();
+    var completed = false;
+    if (requestId != null) {
+      unawaited(
+        signal!.then((_) {
+          if (!completed) {
+            rust_network_privacy.torHttpCancelRequest(requestId: requestId);
+          }
+        }, onError: (_, _) {}),
+      );
+    }
+    try {
+      return networkHttpResponseFromRust(await send(requestId));
+    } catch (error, stackTrace) {
+      if (timeout != null && error.toString().contains(_requestTimeoutError)) {
+        throw TimeoutException(_requestTimeoutError, timeout);
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    } finally {
+      completed = true;
+      if (requestId != null) {
+        rust_network_privacy.torHttpCancelRequest(requestId: requestId);
+      }
+    }
   }
 
   static List<rust_network_privacy.NetworkHttpHeader> _rustHeaders(
@@ -184,13 +269,17 @@ class NetworkHttpClient {
     Map<String, String> headers = const {},
     List<int> bodyBytes = const [],
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) {
-    final future = _torDesired()
+    _requirePositiveTimeout(timeout);
+    return _torDesired()
         ? _requestViaTorWithRedirects(
             method.toUpperCase(),
             uri,
             headers: headers,
             bodyBytes: bodyBytes,
+            timeout: timeout,
+            cancelSignal: cancelSignal,
           )
         : _runDirectRequest(
             () => _requestDirect(
@@ -198,9 +287,10 @@ class NetworkHttpClient {
               uri,
               headers: headers,
               bodyBytes: bodyBytes,
+              timeout: timeout,
+              cancelSignal: cancelSignal,
             ),
           );
-    return timeout == null ? future : future.timeout(timeout);
   }
 
   /// Streams a GET response to [destination] without retaining the response
@@ -219,9 +309,13 @@ class NetworkHttpClient {
             headers: headers,
             bodyBytes: const [],
             destinationPath: destination.path,
+            timeout: null,
+            cancelSignal: null,
           )
         : _runDirectRequest(
-            () => _downloadDirect(uri, destination, headers: headers),
+            () => _DirectRequestOperation.fromFuture(
+              _downloadDirect(uri, destination, headers: headers),
+            ),
           );
     return timeout == null ? future : future.timeout(timeout);
   }
@@ -233,20 +327,30 @@ class NetworkHttpClient {
     if (_activeDirectRequests == 0) _instances.remove(this);
   }
 
-  Future<T> _runDirectRequest<T>(Future<T> Function() request) async {
+  Future<T> _runDirectRequest<T>(
+    _DirectRequestOperation<T> Function() request,
+  ) {
     if (_directRequestsBlocked || _closed) {
-      throw const DirectNetworkRequestsBlockedException();
+      return Future.error(const DirectNetworkRequestsBlockedException());
     }
     _activeDirectRequests++;
+    final _DirectRequestOperation<T> operation;
     try {
-      return await request();
-    } finally {
-      _activeDirectRequests--;
-      if (_activeDirectRequests == 0) {
-        _directRequestsDrained?.complete();
-        _directRequestsDrained = null;
-        if (_closed) _instances.remove(this);
-      }
+      operation = request();
+    } catch (error, stackTrace) {
+      _finishDirectRequest();
+      return Future.error(error, stackTrace);
+    }
+    unawaited(operation.drained.whenComplete(_finishDirectRequest));
+    return operation.result;
+  }
+
+  void _finishDirectRequest() {
+    _activeDirectRequests--;
+    if (_activeDirectRequests == 0) {
+      _directRequestsDrained?.complete();
+      _directRequestsDrained = null;
+      if (_closed) _instances.remove(this);
     }
   }
 
@@ -269,6 +373,8 @@ class NetworkHttpClient {
     required Map<String, String> headers,
     required List<int> bodyBytes,
     String? destinationPath,
+    required Duration? timeout,
+    required Future<void>? cancelSignal,
   }) async {
     if (method != 'GET' && method != 'POST') {
       throw TorUnsupportedHttpMethodException(method);
@@ -278,7 +384,9 @@ class NetworkHttpClient {
     var currentUri = initialUri;
     var currentHeaders = Map<String, String>.of(headers);
     var currentBody = bodyBytes;
+    final stopwatch = Stopwatch()..start();
     for (var redirectCount = 0; redirectCount <= 5; redirectCount++) {
+      final remainingTimeout = _remainingTimeout(timeout, stopwatch);
       final response = destinationPath != null
           ? await _torBridge.download(
               currentUri,
@@ -286,11 +394,18 @@ class NetworkHttpClient {
               destinationPath: destinationPath,
             )
           : currentMethod == 'GET'
-          ? await _torBridge.get(currentUri, headers: currentHeaders)
+          ? await _torBridge.get(
+              currentUri,
+              headers: currentHeaders,
+              timeout: remainingTimeout,
+              cancelSignal: cancelSignal,
+            )
           : await _torBridge.post(
               currentUri,
               headers: currentHeaders,
               bodyBytes: currentBody,
+              timeout: remainingTimeout,
+              cancelSignal: cancelSignal,
             );
       final location = response.header(HttpHeaders.locationHeader);
       if (!_isRedirect(response.statusCode) || location == null) {
@@ -319,29 +434,103 @@ class NetworkHttpClient {
     throw const HttpException('Too many HTTP redirects');
   }
 
-  Future<NetworkHttpResponse> _requestDirect(
+  _DirectRequestOperation<NetworkHttpResponse> _requestDirect(
     String method,
     Uri uri, {
     required Map<String, String> headers,
     required List<int> bodyBytes,
-  }) async {
-    final request = await _directClient.openUrl(method, uri);
-    headers.forEach(request.headers.set);
-    if (bodyBytes.isNotEmpty) request.add(bodyBytes);
-    final response = await request.close();
-    final bytes = await response.fold<List<int>>(
-      <int>[],
-      (buffer, chunk) => buffer..addAll(chunk),
-    );
-    final responseHeaders = <String, List<String>>{};
-    response.headers.forEach((name, values) {
-      responseHeaders[name.toLowerCase()] = List.unmodifiable(values);
-    });
-    return NetworkHttpResponse(
-      statusCode: response.statusCode,
-      bodyBytes: Uint8List.fromList(bytes),
-      headers: Map.unmodifiable(responseHeaders),
-    );
+    required Duration? timeout,
+    required Future<void>? cancelSignal,
+  }) {
+    HttpClientRequest? activeRequest;
+    StreamSubscription<List<int>>? responseSubscription;
+    Completer<Uint8List>? responseBody;
+    Object? terminationError;
+    var sourceCompleted = false;
+    Future<void> abort(Object error) async {
+      try {
+        activeRequest?.abort(error);
+      } catch (_) {
+        // Continue cleanup and preserve the original public failure.
+      }
+      try {
+        await responseSubscription?.cancel();
+      } catch (_) {
+        // Continue cleanup and preserve the original public failure.
+      }
+      final body = responseBody;
+      if (body != null && !body.isCompleted) body.completeError(error);
+    }
+
+    final request = () async {
+      try {
+        final request = await _directClient.openUrl(method, uri);
+        activeRequest = request;
+        final pendingError = terminationError;
+        if (pendingError != null) {
+          final error = pendingError;
+          request.abort(error);
+          throw error;
+        }
+        headers.forEach(request.headers.set);
+        if (bodyBytes.isNotEmpty) request.add(bodyBytes);
+        final response = await request.close();
+        final body = responseBody = Completer<Uint8List>();
+        final bytes = BytesBuilder();
+        responseSubscription = response.listen(
+          bytes.add,
+          onError: (Object error, StackTrace stackTrace) {
+            if (!body.isCompleted) body.completeError(error, stackTrace);
+          },
+          onDone: () {
+            if (!body.isCompleted) body.complete(bytes.takeBytes());
+          },
+          cancelOnError: true,
+        );
+        final responseHeaders = <String, List<String>>{};
+        response.headers.forEach((name, values) {
+          responseHeaders[name.toLowerCase()] = List.unmodifiable(values);
+        });
+        return NetworkHttpResponse(
+          statusCode: response.statusCode,
+          bodyBytes: await body.future,
+          headers: Map.unmodifiable(responseHeaders),
+        );
+      } finally {
+        sourceCompleted = true;
+      }
+    }();
+    final signal = cancelSignal;
+    final cancellation = signal == null
+        ? null
+        : Completer<NetworkHttpResponse>();
+    if (cancellation != null) {
+      unawaited(
+        signal!.then((_) async {
+          if (sourceCompleted) return;
+          final error = terminationError ??=
+              const NetworkHttpRequestCancelledException();
+          await abort(error);
+          if (!cancellation.isCompleted) {
+            cancellation.completeError(error);
+          }
+        }, onError: (_, _) {}),
+      );
+    }
+    final cancellableRequest = cancellation == null
+        ? request
+        : Future.any([request, cancellation.future]);
+    final result = timeout == null
+        ? cancellableRequest
+        : cancellableRequest.timeout(
+            timeout,
+            onTimeout: () async {
+              final error = terminationError ??= _timeoutException(timeout);
+              await abort(error);
+              throw error;
+            },
+          );
+    return _DirectRequestOperation(result: result, source: request);
   }
 
   Future<NetworkHttpResponse> _downloadDirect(
@@ -363,6 +552,22 @@ class NetworkHttpClient {
       headers: Map.unmodifiable(responseHeaders),
     );
   }
+
+  static Duration? _remainingTimeout(Duration? timeout, Stopwatch stopwatch) {
+    if (timeout == null) return null;
+    final remaining = timeout - stopwatch.elapsed;
+    if (remaining <= Duration.zero) throw _timeoutException(timeout);
+    return remaining;
+  }
+
+  static void _requirePositiveTimeout(Duration? timeout) {
+    if (timeout != null && timeout <= Duration.zero) {
+      throw ArgumentError.value(timeout, 'timeout', 'must be positive');
+    }
+  }
+
+  static TimeoutException _timeoutException(Duration timeout) =>
+      TimeoutException('Network HTTP request timed out', timeout);
 
   static Map<String, String> _headersForRedirect(
     Uri from,

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -62,14 +62,9 @@ final votingApiRequestTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 10);
 });
 
-/// Timeout for one helper share request.
+/// Timeout for one helper share-status request.
 final votingHelperRequestTimeoutProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 5);
-});
-
-/// Timeout for one helper readiness probe.
-final votingHelperPreflightTimeoutProvider = Provider<Duration>((ref) {
-  return const Duration(seconds: 2);
 });
 
 /// Delay before retrying a failed automatic helper-share tracking pass.
@@ -138,7 +133,6 @@ final votingApiClientProvider =
         httpClient: ref.watch(votingHttpClientProvider),
         timeout: ref.watch(votingApiRequestTimeoutProvider),
         helperTimeout: ref.watch(votingHelperRequestTimeoutProvider),
-        helperPreflightTimeout: ref.watch(votingHelperPreflightTimeoutProvider),
         readRetryPolicy: ref.watch(votingApiReadRetryPolicyProvider),
         helperRetryPolicy: ref.watch(votingHelperRetryPolicyProvider),
         broadcastRetryPolicy: ref.watch(votingBroadcastRetryPolicyProvider),
@@ -533,11 +527,16 @@ abstract interface class VotingRustApi {
   Future<List<rust_share_policy.ShareSubmissionPlan>> planShareSubmissions({
     required int shareCount,
     required List<String> serverUrls,
+    required int preferredServerCount,
     required BigInt nowSeconds,
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
     required bool singleShare,
     int? immediateShareIndex,
+  });
+
+  rust_share_policy.ShareServerSelectionPolicy shareServerSelectionPolicy({
+    required int serverCount,
   });
 
   Future<List<String>> shareResubmissionServerOrder({
@@ -956,6 +955,7 @@ class FrbVotingRustApi implements VotingRustApi {
   Future<List<rust_share_policy.ShareSubmissionPlan>> planShareSubmissions({
     required int shareCount,
     required List<String> serverUrls,
+    required int preferredServerCount,
     required BigInt nowSeconds,
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
@@ -965,12 +965,20 @@ class FrbVotingRustApi implements VotingRustApi {
     return rust_api.planShareSubmissions(
       shareCount: shareCount,
       serverUrls: serverUrls,
+      preferredServerCount: preferredServerCount,
       nowSeconds: nowSeconds,
       voteEndTimeSeconds: voteEndTimeSeconds,
       lastMomentBufferSeconds: lastMomentBufferSeconds,
       singleShare: singleShare,
       immediateShareIndex: immediateShareIndex,
     );
+  }
+
+  @override
+  rust_share_policy.ShareServerSelectionPolicy shareServerSelectionPolicy({
+    required int serverCount,
+  }) {
+    return rust_api.shareServerSelectionPolicy(serverCount: serverCount);
   }
 
   @override

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1167,9 +1167,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         // that recovery will derive after a restart.
         roundPlan = await _loadRoundPlan(context);
       }
-      final immediateShareKey = roundPlan?.allDecided == true
-          ? roundPlan?.immediateShareKey
-          : null;
       final totalQuestions = recoveredVoteWork.length + voteWork.length;
       final totalBundleTasks =
           recoveredVoteWork.length +
@@ -1288,7 +1285,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           helperPostPool: helperPostPool,
           vcTreePositions: vcTreePositions,
           singleShare: _commitmentsUseSingleShare(commitments),
-          immediateShareKey: immediateShareKey,
+          immediateShareKey: roundPlan?.immediateShareKey,
           shareIndexFilter: shareIndexFilter,
           completedQuestions: completedQuestions,
           totalQuestions: totalQuestions,
@@ -1342,7 +1339,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             helperPreflight: helperPreflight,
             helperSelectionPolicy: helperSelectionPolicy,
             helperPostPool: helperPostPool,
-            immediateShareKey: immediateShareKey,
+            immediateShareKey: roundPlan?.immediateShareKey,
           );
         } catch (_) {
           plan = await _loadResumePlan(context);

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1167,6 +1167,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         // that recovery will derive after a restart.
         roundPlan = await _loadRoundPlan(context);
       }
+      final immediateShareKey = roundPlan?.allDecided == true
+          ? roundPlan?.immediateShareKey
+          : null;
       final totalQuestions = recoveredVoteWork.length + voteWork.length;
       final totalBundleTasks =
           recoveredVoteWork.length +
@@ -1285,7 +1288,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           helperPostPool: helperPostPool,
           vcTreePositions: vcTreePositions,
           singleShare: _commitmentsUseSingleShare(commitments),
-          immediateShareKey: roundPlan?.immediateShareKey,
+          immediateShareKey: immediateShareKey,
           shareIndexFilter: shareIndexFilter,
           completedQuestions: completedQuestions,
           totalQuestions: totalQuestions,
@@ -1339,7 +1342,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             helperPreflight: helperPreflight,
             helperSelectionPolicy: helperSelectionPolicy,
             helperPostPool: helperPostPool,
-            immediateShareKey: roundPlan?.immediateShareKey,
+            immediateShareKey: immediateShareKey,
           );
         } catch (_) {
           plan = await _loadResumePlan(context);
@@ -1515,7 +1518,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     Set<int>? shareIndexFilter,
     void Function(VotingSessionProgress progress)? publishProgress,
     required bool singleShare,
-    rust_share_policy.ImmediateShareKey? immediateShareKey,
+    required rust_share_policy.ImmediateShareKey? immediateShareKey,
     required int completedQuestions,
     required int totalQuestions,
     required double? voteSubmissionProgress,
@@ -2003,7 +2006,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required Future<List<String>> helperPreflight,
     required rust_share_policy.ShareServerSelectionPolicy helperSelectionPolicy,
     required _AsyncPermitPool helperPostPool,
-    rust_share_policy.ImmediateShareKey? immediateShareKey,
+    required rust_share_policy.ImmediateShareKey? immediateShareKey,
   }) async {
     // Transpose proposal -> bundles into bundle -> proposals. Proposal order
     // within a bundle follows the draft order so a restart resumes the same

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -937,7 +937,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     List<int>? allProposalIds,
     Map<int, int>? proposalOptionCounts,
   }) {
-    return _enqueue(() async {
+    final helperPreflightCancellation = Completer<void>();
+    Future<List<String>>? activeHelperPreflight;
+    final operation = _enqueue(() async {
       final current = await future;
       final context = await _loadContext(_roundId);
       await _waitUntilWalletReadyForVoting(context);
@@ -1172,11 +1174,32 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             0,
             (total, work) => total + work.bundleIndexes.length,
           );
-      final helperAvailability = totalBundleTasks == 0
-          ? Future.value(const <String, bool>{})
+      final helperSelectionPolicy = rust.shareServerSelectionPolicy(
+        serverCount: context.config.apiServers.all.length,
+      );
+      final helperPostPool = _AsyncPermitPool(
+        helperSelectionPolicy.maxConcurrentPosts,
+      );
+      final helperPreflight = totalBundleTasks == 0
+          ? Future.value(const <String>[])
           : ref
                 .read(votingApiClientProvider(context.config.apiServers))
-                .preflightHelpers(context.config.apiServers.all);
+                .preflightHelpers(
+                  context.config.apiServers.all,
+                  readyTargetCount: helperSelectionPolicy.targetCount,
+                  softTimeout: Duration(
+                    milliseconds: helperSelectionPolicy
+                        .preflightSoftTimeoutMilliseconds
+                        .toInt(),
+                  ),
+                  hardTimeout: Duration(
+                    milliseconds: helperSelectionPolicy
+                        .preflightHardTimeoutMilliseconds
+                        .toInt(),
+                  ),
+                  cancelSignal: helperPreflightCancellation.future,
+                );
+      activeHelperPreflight = helperPreflight;
       var completedBundleTasks = 0;
       var completedQuestions = 0;
       final startTiming = _roundShareTiming(context, _nowSeconds());
@@ -1257,7 +1280,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         await _submitCommitmentShares(
           context,
           commitments,
-          helperAvailability: helperAvailability,
+          helperPreflight: helperPreflight,
+          helperSelectionPolicy: helperSelectionPolicy,
+          helperPostPool: helperPostPool,
           vcTreePositions: vcTreePositions,
           singleShare: _commitmentsUseSingleShare(commitments),
           immediateShareKey: roundPlan?.immediateShareKey,
@@ -1311,7 +1336,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             totalBundleTasks: totalBundleTasks,
             completedQuestions: completedQuestions,
             totalQuestions: totalQuestions,
-            helperAvailability: helperAvailability,
+            helperPreflight: helperPreflight,
+            helperSelectionPolicy: helperSelectionPolicy,
+            helperPostPool: helperPostPool,
             immediateShareKey: roundPlan?.immediateShareKey,
           );
         } catch (_) {
@@ -1387,6 +1414,13 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       );
       await _scheduleShareTracking(context, refreshedPlan);
     }, cleanupProcessStateOnError: false);
+    return operation.whenComplete(() async {
+      if (!helperPreflightCancellation.isCompleted) {
+        helperPreflightCancellation.complete();
+      }
+      final preflight = activeHelperPreflight;
+      if (preflight != null) await preflight;
+    });
   }
 
   Future<List<int>?> _hotkeyForVoteCasting(
@@ -1474,7 +1508,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   Future<void> _submitCommitmentShares(
     _VotingSessionContext context,
     rust_wire.SignedVoteCommitmentsView commitments, {
-    required Future<Map<String, bool>> helperAvailability,
+    required Future<List<String>> helperPreflight,
+    required rust_share_policy.ShareServerSelectionPolicy helperSelectionPolicy,
+    required _AsyncPermitPool helperPostPool,
     Map<int, BigInt> vcTreePositions = const {},
     Set<int>? shareIndexFilter,
     void Function(VotingSessionProgress progress)? publishProgress,
@@ -1493,8 +1529,32 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     if (serverUrls.isEmpty) {
       throw StateError('No vote servers configured for share submission.');
     }
-    final availableHelpers = await helperAvailability;
+    final readyServerUrls = await helperPreflight;
     _throwIfContextStale(context, 'helper-preflight-finished');
+    final readyServerSet = readyServerUrls.toSet();
+    final rankedServerUrls = <String>[
+      ...readyServerUrls,
+      for (final serverUrl in serverUrls)
+        if (!readyServerSet.contains(serverUrl)) serverUrl,
+    ];
+    final preferredPlanningCount = readyServerUrls.length;
+    final targetCount = helperSelectionPolicy.targetCount.clamp(
+      0,
+      rankedServerUrls.length,
+    );
+    final planningPoolCount = preferredPlanningCount < targetCount
+        ? targetCount
+        : preferredPlanningCount;
+    if (planningPoolCount < helperSelectionPolicy.minServerCount) {
+      debugPrint(
+        '[zcash] Voting: initial helper distribution is degraded '
+        'ready=${readyServerUrls.length} configured=${serverUrls.length} '
+        'planningPool=$planningPoolCount '
+        'minimum=${helperSelectionPolicy.minServerCount} '
+        'target=${helperSelectionPolicy.targetCount} '
+        'maxSharesPerServer=${helperSelectionPolicy.maxSharesPerServer}',
+      );
+    }
 
     final timing = _roundShareTiming(context, _nowSeconds());
     final bundleProgressMessage = _bundleProgressMessage(
@@ -1518,7 +1578,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       );
       final plans = await rust.planShareSubmissions(
         shareCount: shares.length,
-        serverUrls: serverUrls,
+        serverUrls: rankedServerUrls,
+        preferredServerCount: preferredPlanningCount,
         nowSeconds: BigInt.from(timing.nowSeconds),
         voteEndTimeSeconds: BigInt.from(timing.voteEndSeconds),
         lastMomentBufferSeconds: timing.lastMomentBufferSeconds,
@@ -1544,11 +1605,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         final targetCount = plan.targetCount
             .clamp(1, serverUrls.length)
             .toInt();
-        final candidateServers = _plannedShareServers(
-          plannedServers: plan.targetServers,
-          fallbackServers: helperHealth.candidateServers(serverUrls),
-          helperAvailability: availableHelpers,
-        );
+        final candidateServers = <String>{
+          ...plan.targetServers,
+          ...rankedServerUrls,
+        }.toList(growable: false);
         final body = await _wireJsonMap(
           rust.voteShareWireJson(
             share: share,
@@ -1587,6 +1647,18 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
       }
 
+      final deliveryBudget = _InitialShareDeliveryBudget(
+        Duration(
+          milliseconds: helperSelectionPolicy.initialDeliveryTimeoutMilliseconds
+              .toInt(),
+        ),
+        preferredFallbackServers: readyServerUrls.take(
+          helperSelectionPolicy.targetCount,
+        ),
+      );
+      final helperPostTimeout = Duration(
+        milliseconds: helperSelectionPolicy.postTimeoutMilliseconds.toInt(),
+      );
       final submissions = [
         for (final prepared in preparedSubmissions)
           _submitInitialShareToHelpers(
@@ -1597,6 +1669,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             candidateServers: prepared.candidateServers,
             targetCount: prepared.targetCount,
             submitAt: prepared.submitAt,
+            helperPostPool: helperPostPool,
+            helperPostTimeout: helperPostTimeout,
+            deliveryBudget: deliveryBudget,
           ),
       ];
       _InitialShareSubmissionResult? failedResult;
@@ -1688,42 +1763,86 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required List<String> candidateServers,
     required int targetCount,
     required BigInt submitAt,
+    required _AsyncPermitPool helperPostPool,
+    required Duration helperPostTimeout,
+    required _InitialShareDeliveryBudget deliveryBudget,
   }) async {
     final acceptedServers = <String>[];
     final remainingServers = LinkedHashSet<String>.of(candidateServers);
-    while (remainingServers.isNotEmpty &&
-        acceptedServers.length < targetCount) {
-      // Re-evaluate health before every attempt so failures observed by
-      // concurrent submissions can move a degraded helper behind healthy
-      // alternatives. The tracker still returns every helper when all are
-      // degraded, preserving the liveness fallback.
-      final serverUrl = helperHealth.candidateServers(remainingServers).first;
-      remainingServers.remove(serverUrl);
-      try {
-        debugPrint(
-          '[zcash] Voting: submitting share '
-          'proposal=${share.proposalId} share=${share.shareIndex} '
-          'server=$serverUrl treePosition=${body['tree_position']} '
-          'submitAt=$submitAt target=$targetCount',
-        );
-        await api.submitShare(serverUrl: Uri.parse(serverUrl), share: body);
-        helperHealth.recordSuccess(serverUrl);
-        acceptedServers.add(serverUrl);
-        debugPrint(
-          '[zcash] Voting: share accepted '
-          'proposal=${share.proposalId} share=${share.shareIndex} '
-          'server=$serverUrl accepted=${acceptedServers.length}/$targetCount',
-        );
-      } catch (e) {
-        debugPrint(
-          '[zcash] Voting: share rejected '
-          'proposal=${share.proposalId} share=${share.shareIndex} '
-          'server=$serverUrl error=$e',
-        );
-        helperHealth.recordFailure(serverUrl);
-        // Recovery retries helpers that did not accept this share.
+
+    Future<({bool attempted, String? acceptedServer})> submitNext() {
+      return helperPostPool.run(() async {
+        final budgetRemaining = deliveryBudget.remaining;
+        if (budgetRemaining == Duration.zero || remainingServers.isEmpty) {
+          return (attempted: false, acceptedServer: null);
+        }
+        // Choose only after receiving a permit. A queued request must see
+        // failures reported by earlier attempts instead of remaining bound to
+        // a helper that became degraded while it waited.
+        final serverUrl = helperHealth
+            .candidateServers(deliveryBudget.rankCandidates(remainingServers))
+            .first;
+        remainingServers.remove(serverUrl);
+        final requestTimeout = budgetRemaining < helperPostTimeout
+            ? budgetRemaining
+            : helperPostTimeout;
+        try {
+          debugPrint(
+            '[zcash] Voting: submitting share '
+            'proposal=${share.proposalId} share=${share.shareIndex} '
+            'server=$serverUrl treePosition=${body['tree_position']} '
+            'submitAt=$submitAt target=$targetCount '
+            'timeoutMs=${requestTimeout.inMilliseconds} '
+            'budgetRemainingMs=${budgetRemaining.inMilliseconds}',
+          );
+          await api.submitShare(
+            serverUrl: Uri.parse(serverUrl),
+            share: body,
+            timeout: requestTimeout,
+            overallTimeout: budgetRemaining,
+          );
+          helperHealth.recordSuccess(serverUrl);
+          deliveryBudget.recordSuccess(serverUrl);
+          debugPrint(
+            '[zcash] Voting: share accepted '
+            'proposal=${share.proposalId} share=${share.shareIndex} '
+            'server=$serverUrl',
+          );
+          return (attempted: true, acceptedServer: serverUrl);
+        } catch (e) {
+          debugPrint(
+            '[zcash] Voting: share rejected '
+            'proposal=${share.proposalId} share=${share.shareIndex} '
+            'server=$serverUrl error=$e',
+          );
+          helperHealth.recordFailure(serverUrl);
+          if (e is TimeoutException) {
+            deliveryBudget.recordTimeout(serverUrl);
+          }
+          // Recovery retries helpers that did not accept this share.
+          return (attempted: true, acceptedServer: null);
+        }
+      });
+    }
+
+    Future<void> submitUntilAccepted() async {
+      while (!deliveryBudget.expired && remainingServers.isNotEmpty) {
+        final result = await submitNext();
+        if (!result.attempted) return;
+        final serverUrl = result.acceptedServer;
+        if (serverUrl != null) {
+          acceptedServers.add(serverUrl);
+          debugPrint(
+            '[zcash] Voting: share acceptance progress '
+            'proposal=${share.proposalId} share=${share.shareIndex} '
+            'accepted=${acceptedServers.length}/$targetCount',
+          );
+          return;
+        }
       }
     }
+
+    await Future.wait(List.generate(targetCount, (_) => submitUntilAccepted()));
     if (acceptedServers.length < targetCount && acceptedServers.isNotEmpty) {
       debugPrint(
         '[zcash] Voting: share accepted by fewer helpers than planned '
@@ -1809,25 +1928,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     debugPrint('[zcash] Voting: $message');
   }
 
-  List<String> _plannedShareServers({
-    required List<String> plannedServers,
-    required Iterable<String> fallbackServers,
-    Map<String, bool> helperAvailability = const {},
-  }) {
-    final ordered = <String>{};
-    for (final server in plannedServers) {
-      if (server.trim().isNotEmpty) ordered.add(server);
-    }
-    for (final server in fallbackServers) {
-      if (server.trim().isNotEmpty) ordered.add(server);
-    }
-    return [
-      for (final readiness in const <bool?>[true, null, false])
-        for (final server in ordered)
-          if (helperAvailability[server] == readiness) server,
-    ];
-  }
-
   void _setShareSubmissionProgress({
     required _VotingSessionContext context,
     required int bundleIndex,
@@ -1900,7 +2000,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required int totalBundleTasks,
     required int completedQuestions,
     required int totalQuestions,
-    required Future<Map<String, bool>> helperAvailability,
+    required Future<List<String>> helperPreflight,
+    required rust_share_policy.ShareServerSelectionPolicy helperSelectionPolicy,
+    required _AsyncPermitPool helperPostPool,
     rust_share_policy.ImmediateShareKey? immediateShareKey,
   }) async {
     // Transpose proposal -> bundles into bundle -> proposals. Proposal order
@@ -2238,7 +2340,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
               await _submitCommitmentShares(
                 context,
                 commitments,
-                helperAvailability: helperAvailability,
+                helperPreflight: helperPreflight,
+                helperSelectionPolicy: helperSelectionPolicy,
+                helperPostPool: helperPostPool,
                 vcTreePositions: vcTreePositions,
                 publishProgress: publish,
                 singleShare: singleShare,
@@ -2990,6 +3094,12 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       final configuredServerUrls = context.config.apiServers.all
           .map((endpoint) => endpoint.toString())
           .toList(growable: false);
+      final helperSelectionPolicy = rust.shareServerSelectionPolicy(
+        serverCount: configuredServerUrls.length,
+      );
+      final helperPostTimeout = Duration(
+        milliseconds: helperSelectionPolicy.postTimeoutMilliseconds.toInt(),
+      );
       final configuredServerUrlSet = configuredServerUrls.toSet();
       final nowSeconds = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
       final voteEnd = context.round.voteEndTime;
@@ -3047,6 +3157,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             share: share,
             configuredServerUrls: configuredServerUrls,
             sentToUrls: acceptedUrls,
+            helperPostTimeout: helperPostTimeout,
           );
           if (retryServer != null && acceptedUrls.add(retryServer)) {
             await ref
@@ -3110,6 +3221,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required rust_wire.ShareDelegationRecordView share,
     required List<String> configuredServerUrls,
     required Set<String> sentToUrls,
+    required Duration helperPostTimeout,
   }) async {
     if (!ref.mounted || !_isCurrentContext(context)) return null;
     final rust = ref.read(votingRustApiProvider);
@@ -3164,6 +3276,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           serverUrl: Uri.parse(serverUrl),
           shareId: shareId,
           share: body,
+          timeout: helperPostTimeout,
         );
         // Preserve a known acceptance even if a stop arrived during the POST;
         // forgetting it could resend the same share after unlock.
@@ -5029,6 +5142,54 @@ class _InitialShareSubmissionResult {
   final rust_wire.VoteShareWire share;
   final BigInt submitAt;
   final List<String> acceptedServers;
+}
+
+class _InitialShareDeliveryBudget {
+  _InitialShareDeliveryBudget(
+    this.timeout, {
+    required Iterable<String> preferredFallbackServers,
+  }) : assert(timeout > Duration.zero),
+       _preferredFallbackServers = preferredFallbackServers.toSet();
+
+  final Duration timeout;
+  final Set<String> _preferredFallbackServers;
+  final Set<String> _timedOutServers = {};
+  final Stopwatch _stopwatch = Stopwatch()..start();
+
+  Duration get remaining {
+    final remaining = timeout - _stopwatch.elapsed;
+    return remaining.isNegative ? Duration.zero : remaining;
+  }
+
+  bool get expired => remaining == Duration.zero;
+
+  Iterable<String> rankCandidates(Iterable<String> candidates) {
+    if (_timedOutServers.isEmpty) return candidates;
+    // A full POST timeout has consumed half of the normal delivery budget.
+    // Use helpers from the readiness-winning prefix before spending the
+    // remainder on unproven or already timed-out candidates.
+    final candidateList = candidates.toList(growable: false);
+    return [
+      for (final candidate in candidateList)
+        if (_preferredFallbackServers.contains(candidate) &&
+            !_timedOutServers.contains(candidate))
+          candidate,
+      for (final candidate in candidateList)
+        if (!_preferredFallbackServers.contains(candidate) &&
+            !_timedOutServers.contains(candidate))
+          candidate,
+      for (final candidate in candidateList)
+        if (_timedOutServers.contains(candidate)) candidate,
+    ];
+  }
+
+  void recordTimeout(String serverUrl) {
+    _timedOutServers.add(serverUrl);
+  }
+
+  void recordSuccess(String serverUrl) {
+    _timedOutServers.remove(serverUrl);
+  }
 }
 
 final votingSessionProvider =

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1677,12 +1677,12 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       _InitialShareSubmissionResult? failedResult;
       Object? persistenceError;
       StackTrace? persistenceStackTrace;
-      // Persist in completion order so accepted shares become durable promptly
-      // while Rust DB writes remain sequential.
+      // Persist in completion order so every share becomes durable promptly
+      // while Rust DB writes remain sequential. An empty server list records
+      // recovery work for a share that exhausted the initial delivery budget.
       await for (final result in Stream.fromFutures(submissions)) {
         if (result.acceptedServers.isEmpty) {
           failedResult ??= result;
-          continue;
         }
         try {
           await rust.recordShareDelegation(

--- a/lib/src/rust/api/network_privacy.dart
+++ b/lib/src/rust/api/network_privacy.dart
@@ -7,7 +7,7 @@ import '../frb_generated.dart';
 import '../network_privacy.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `apply_headers`, `binary_search_birthday_height`, `block_at_height`, `collect_body`, `correct_estimated_height`, `divide_round_nearest`, `estimate_mainnet_birthday_height`, `interpolate_height`, `is_mainnet`, `mainnet_anchor_segment`, `network_http_response`, `timed_birthday_request`, `with_api_response_body_timeout`, `write_body_to_file`
+// These functions are ignored because they are not marked as `pub`: `apply_headers`, `binary_search_birthday_height`, `block_at_height`, `collect_body`, `correct_estimated_height`, `divide_round_nearest`, `estimate_mainnet_birthday_height`, `interpolate_height`, `is_mainnet`, `mainnet_anchor_segment`, `network_http_response`, `timed_birthday_request`, `with_api_response_body_timeout`, `with_tor_http_request_cancellation`, `with_tor_http_request_timeout`, `write_body_to_file`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `BirthdayAnchor`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `eq`, `fmt`
 
@@ -64,9 +64,13 @@ Future<void> stopTorUpdateRelay() =>
 Future<NetworkHttpResponse> torHttpGet({
   required String url,
   required List<NetworkHttpHeader> headers,
+  BigInt? timeoutMilliseconds,
+  BigInt? requestId,
 }) => RustLib.instance.api.crateApiNetworkPrivacyTorHttpGet(
   url: url,
   headers: headers,
+  timeoutMilliseconds: timeoutMilliseconds,
+  requestId: requestId,
 );
 
 /// Makes a POST request on a fresh Tor circuit. Every app-owned HTTP call is
@@ -75,11 +79,23 @@ Future<NetworkHttpResponse> torHttpPost({
   required String url,
   required List<NetworkHttpHeader> headers,
   required List<int> body,
+  BigInt? timeoutMilliseconds,
+  BigInt? requestId,
 }) => RustLib.instance.api.crateApiNetworkPrivacyTorHttpPost(
   url: url,
   headers: headers,
   body: body,
+  timeoutMilliseconds: timeoutMilliseconds,
+  requestId: requestId,
 );
+
+/// Reserves a process-unique cancellation token for one Tor HTTP request.
+BigInt torHttpBeginRequest() =>
+    RustLib.instance.api.crateApiNetworkPrivacyTorHttpBeginRequest();
+
+/// Cancels one in-flight Tor HTTP request without affecting other circuits.
+void torHttpCancelRequest({required BigInt requestId}) => RustLib.instance.api
+    .crateApiNetworkPrivacyTorHttpCancelRequest(requestId: requestId);
 
 /// Streams an HTTP GET response over an isolated Tor route directly to disk.
 /// This avoids moving large proving-parameter files through Rust and Dart

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -68,6 +68,8 @@ Future<String> voteShareWireJson({
 /// This mirrors the zcash-swift-wallet-sdk wrapper around
 /// `zcash_voting::share_policy::plan_share_submissions`, with Rust drawing the
 /// policy-sized entropy from the OS CSPRNG before returning FRB-safe plans.
+/// `immediate_share_index` is the position of the round's designated immediate
+/// share in this batch, after any caller-side filtering or reordering.
 ///
 /// # Errors
 ///
@@ -76,6 +78,7 @@ Future<String> voteShareWireJson({
 Future<List<ShareSubmissionPlan>> planShareSubmissions({
   required int shareCount,
   required List<String> serverUrls,
+  required int preferredServerCount,
   required BigInt nowSeconds,
   required BigInt voteEndTimeSeconds,
   BigInt? lastMomentBufferSeconds,
@@ -84,11 +87,19 @@ Future<List<ShareSubmissionPlan>> planShareSubmissions({
 }) => RustLib.instance.api.crateApiVotingPlanShareSubmissions(
   shareCount: shareCount,
   serverUrls: serverUrls,
+  preferredServerCount: preferredServerCount,
   nowSeconds: nowSeconds,
   voteEndTimeSeconds: voteEndTimeSeconds,
   lastMomentBufferSeconds: lastMomentBufferSeconds,
   singleShare: singleShare,
   immediateShareIndex: immediateShareIndex,
+);
+
+/// Return the crate-owned progressive helper probe and privacy policy.
+ShareServerSelectionPolicy shareServerSelectionPolicy({
+  required int serverCount,
+}) => RustLib.instance.api.crateApiVotingShareServerSelectionPolicy(
+  serverCount: serverCount,
 );
 
 /// Return the crate-owned randomized helper order for one share retry.

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -80,7 +80,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -339890453;
+  int get rustContentHash => -578304843;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -853,6 +853,7 @@ abstract class RustLibApi extends BaseApi {
   Future<List<ShareSubmissionPlan>> crateApiVotingPlanShareSubmissions({
     required int shareCount,
     required List<String> serverUrls,
+    required int preferredServerCount,
     required BigInt nowSeconds,
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
@@ -1093,6 +1094,10 @@ abstract class RustLibApi extends BaseApi {
     required List<String> sentToUrls,
   });
 
+  ShareServerSelectionPolicy crateApiVotingShareServerSelectionPolicy({
+    required int serverCount,
+  });
+
   Future<int> crateApiVotingShareTrackingFlags({
     required ShareDelegationRecordView share,
     required BigInt nowSeconds,
@@ -1178,6 +1183,10 @@ abstract class RustLibApi extends BaseApi {
     required String nodeUrl,
   });
 
+  BigInt crateApiNetworkPrivacyTorHttpBeginRequest();
+
+  void crateApiNetworkPrivacyTorHttpCancelRequest({required BigInt requestId});
+
   Future<NetworkHttpResponse> crateApiNetworkPrivacyTorHttpDownload({
     required String url,
     required List<NetworkHttpHeader> headers,
@@ -1187,12 +1196,16 @@ abstract class RustLibApi extends BaseApi {
   Future<NetworkHttpResponse> crateApiNetworkPrivacyTorHttpGet({
     required String url,
     required List<NetworkHttpHeader> headers,
+    BigInt? timeoutMilliseconds,
+    BigInt? requestId,
   });
 
   Future<NetworkHttpResponse> crateApiNetworkPrivacyTorHttpPost({
     required String url,
     required List<NetworkHttpHeader> headers,
     required List<int> body,
+    BigInt? timeoutMilliseconds,
+    BigInt? requestId,
   });
 
   Future<VotingRoundParams> crateApiVotingTrustedVotingRoundParamsFromConfig({
@@ -6277,6 +6290,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<List<ShareSubmissionPlan>> crateApiVotingPlanShareSubmissions({
     required int shareCount,
     required List<String> serverUrls,
+    required int preferredServerCount,
     required BigInt nowSeconds,
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
@@ -6289,6 +6303,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_32(shareCount, serializer);
           sse_encode_list_String(serverUrls, serializer);
+          sse_encode_u_32(preferredServerCount, serializer);
           sse_encode_u_64(nowSeconds, serializer);
           sse_encode_u_64(voteEndTimeSeconds, serializer);
           sse_encode_opt_box_autoadd_u_64(lastMomentBufferSeconds, serializer);
@@ -6309,6 +6324,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argValues: [
           shareCount,
           serverUrls,
+          preferredServerCount,
           nowSeconds,
           voteEndTimeSeconds,
           lastMomentBufferSeconds,
@@ -6326,6 +6342,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [
           "shareCount",
           "serverUrls",
+          "preferredServerCount",
           "nowSeconds",
           "voteEndTimeSeconds",
           "lastMomentBufferSeconds",
@@ -7850,6 +7867,38 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  ShareServerSelectionPolicy crateApiVotingShareServerSelectionPolicy({
+    required int serverCount,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_u_32(serverCount, serializer);
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 154,
+          )!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_share_server_selection_policy,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiVotingShareServerSelectionPolicyConstMeta,
+        argValues: [serverCount],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVotingShareServerSelectionPolicyConstMeta =>
+      const TaskConstMeta(
+        debugName: "share_server_selection_policy",
+        argNames: ["serverCount"],
+      );
+
+  @override
   Future<int> crateApiVotingShareTrackingFlags({
     required ShareDelegationRecordView share,
     required BigInt nowSeconds,
@@ -7868,7 +7917,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
             port: port_,
           );
         },
@@ -7909,7 +7958,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7963,7 +8012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 157,
             port: port_,
           );
         },
@@ -8013,7 +8062,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 157,
+              funcId: 158,
               port: port_,
             );
           },
@@ -8054,7 +8103,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 158,
+              funcId: 159,
               port: port_,
             );
           },
@@ -8086,7 +8135,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8113,7 +8162,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
           )!;
         },
         codec: SseCodec(
@@ -8139,7 +8188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8186,7 +8235,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8253,7 +8302,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8309,7 +8358,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8344,7 +8393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
             port: port_,
           );
         },
@@ -8383,7 +8432,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8404,6 +8453,62 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  BigInt crateApiNetworkPrivacyTorHttpBeginRequest() {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 168,
+          )!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_u_64,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiNetworkPrivacyTorHttpBeginRequestConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiNetworkPrivacyTorHttpBeginRequestConstMeta =>
+      const TaskConstMeta(debugName: "tor_http_begin_request", argNames: []);
+
+  @override
+  void crateApiNetworkPrivacyTorHttpCancelRequest({required BigInt requestId}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_u_64(requestId, serializer);
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 169,
+          )!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiNetworkPrivacyTorHttpCancelRequestConstMeta,
+        argValues: [requestId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiNetworkPrivacyTorHttpCancelRequestConstMeta =>
+      const TaskConstMeta(
+        debugName: "tor_http_cancel_request",
+        argNames: ["requestId"],
+      );
+
+  @override
   Future<NetworkHttpResponse> crateApiNetworkPrivacyTorHttpDownload({
     required String url,
     required List<NetworkHttpHeader> headers,
@@ -8419,7 +8524,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8444,6 +8549,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<NetworkHttpResponse> crateApiNetworkPrivacyTorHttpGet({
     required String url,
     required List<NetworkHttpHeader> headers,
+    BigInt? timeoutMilliseconds,
+    BigInt? requestId,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -8451,10 +8558,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(url, serializer);
           sse_encode_list_network_http_header(headers, serializer);
+          sse_encode_opt_box_autoadd_u_64(timeoutMilliseconds, serializer);
+          sse_encode_opt_box_autoadd_u_64(requestId, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 171,
             port: port_,
           );
         },
@@ -8463,7 +8572,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiNetworkPrivacyTorHttpGetConstMeta,
-        argValues: [url, headers],
+        argValues: [url, headers, timeoutMilliseconds, requestId],
         apiImpl: this,
       ),
     );
@@ -8472,7 +8581,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiNetworkPrivacyTorHttpGetConstMeta =>
       const TaskConstMeta(
         debugName: "tor_http_get",
-        argNames: ["url", "headers"],
+        argNames: ["url", "headers", "timeoutMilliseconds", "requestId"],
       );
 
   @override
@@ -8480,6 +8589,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String url,
     required List<NetworkHttpHeader> headers,
     required List<int> body,
+    BigInt? timeoutMilliseconds,
+    BigInt? requestId,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -8488,10 +8599,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(url, serializer);
           sse_encode_list_network_http_header(headers, serializer);
           sse_encode_list_prim_u_8_loose(body, serializer);
+          sse_encode_opt_box_autoadd_u_64(timeoutMilliseconds, serializer);
+          sse_encode_opt_box_autoadd_u_64(requestId, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8500,7 +8613,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiNetworkPrivacyTorHttpPostConstMeta,
-        argValues: [url, headers, body],
+        argValues: [url, headers, body, timeoutMilliseconds, requestId],
         apiImpl: this,
       ),
     );
@@ -8509,7 +8622,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiNetworkPrivacyTorHttpPostConstMeta =>
       const TaskConstMeta(
         debugName: "tor_http_post",
-        argNames: ["url", "headers", "body"],
+        argNames: [
+          "url",
+          "headers",
+          "body",
+          "timeoutMilliseconds",
+          "requestId",
+        ],
       );
 
   @override
@@ -8535,7 +8654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 173,
             port: port_,
           );
         },
@@ -8585,7 +8704,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 174,
             port: port_,
           );
         },
@@ -8617,7 +8736,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 175,
             port: port_,
           );
         },
@@ -8645,7 +8764,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 176,
           )!;
         },
         codec: SseCodec(
@@ -8677,7 +8796,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 177,
             port: port_,
           );
         },
@@ -8714,7 +8833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 178,
             port: port_,
           );
         },
@@ -8745,7 +8864,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 179,
           )!;
         },
         codec: SseCodec(
@@ -8788,7 +8907,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 180,
             port: port_,
           );
         },
@@ -8836,7 +8955,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 178,
+            funcId: 181,
           )!;
         },
         codec: SseCodec(
@@ -8870,7 +8989,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 179,
+            funcId: 182,
             port: port_,
           );
         },
@@ -8907,7 +9026,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 180,
+            funcId: 183,
             port: port_,
           );
         },
@@ -10909,6 +11028,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       confirmed: dco_decode_bool(arr[7]),
       submitAt: dco_decode_u_64(arr[8]),
       createdAt: dco_decode_u_64(arr[9]),
+    );
+  }
+
+  @protected
+  ShareServerSelectionPolicy dco_decode_share_server_selection_policy(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 8)
+      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    return ShareServerSelectionPolicy(
+      targetCount: dco_decode_u_32(arr[0]),
+      maxSharesPerServer: dco_decode_u_32(arr[1]),
+      minServerCount: dco_decode_u_32(arr[2]),
+      preflightSoftTimeoutMilliseconds: dco_decode_u_64(arr[3]),
+      preflightHardTimeoutMilliseconds: dco_decode_u_64(arr[4]),
+      postTimeoutMilliseconds: dco_decode_u_64(arr[5]),
+      initialDeliveryTimeoutMilliseconds: dco_decode_u_64(arr[6]),
+      maxConcurrentPosts: dco_decode_u_32(arr[7]),
     );
   }
 
@@ -14213,6 +14352,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ShareServerSelectionPolicy sse_decode_share_server_selection_policy(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_targetCount = sse_decode_u_32(deserializer);
+    var var_maxSharesPerServer = sse_decode_u_32(deserializer);
+    var var_minServerCount = sse_decode_u_32(deserializer);
+    var var_preflightSoftTimeoutMilliseconds = sse_decode_u_64(deserializer);
+    var var_preflightHardTimeoutMilliseconds = sse_decode_u_64(deserializer);
+    var var_postTimeoutMilliseconds = sse_decode_u_64(deserializer);
+    var var_initialDeliveryTimeoutMilliseconds = sse_decode_u_64(deserializer);
+    var var_maxConcurrentPosts = sse_decode_u_32(deserializer);
+    return ShareServerSelectionPolicy(
+      targetCount: var_targetCount,
+      maxSharesPerServer: var_maxSharesPerServer,
+      minServerCount: var_minServerCount,
+      preflightSoftTimeoutMilliseconds: var_preflightSoftTimeoutMilliseconds,
+      preflightHardTimeoutMilliseconds: var_preflightHardTimeoutMilliseconds,
+      postTimeoutMilliseconds: var_postTimeoutMilliseconds,
+      initialDeliveryTimeoutMilliseconds:
+          var_initialDeliveryTimeoutMilliseconds,
+      maxConcurrentPosts: var_maxConcurrentPosts,
+    );
+  }
+
+  @protected
   ShareSubmissionPlan sse_decode_share_submission_plan(
     SseDeserializer deserializer,
   ) {
@@ -17141,6 +17306,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self.confirmed, serializer);
     sse_encode_u_64(self.submitAt, serializer);
     sse_encode_u_64(self.createdAt, serializer);
+  }
+
+  @protected
+  void sse_encode_share_server_selection_policy(
+    ShareServerSelectionPolicy self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_32(self.targetCount, serializer);
+    sse_encode_u_32(self.maxSharesPerServer, serializer);
+    sse_encode_u_32(self.minServerCount, serializer);
+    sse_encode_u_64(self.preflightSoftTimeoutMilliseconds, serializer);
+    sse_encode_u_64(self.preflightHardTimeoutMilliseconds, serializer);
+    sse_encode_u_64(self.postTimeoutMilliseconds, serializer);
+    sse_encode_u_64(self.initialDeliveryTimeoutMilliseconds, serializer);
+    sse_encode_u_32(self.maxConcurrentPosts, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -697,6 +697,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ShareServerSelectionPolicy dco_decode_share_server_selection_policy(
+    dynamic raw,
+  );
+
+  @protected
   ShareSubmissionPlan dco_decode_share_submission_plan(dynamic raw);
 
   @protected
@@ -1682,6 +1687,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ShareDelegationRecordView sse_decode_share_delegation_record_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ShareServerSelectionPolicy sse_decode_share_server_selection_policy(
     SseDeserializer deserializer,
   );
 
@@ -2891,6 +2901,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_share_delegation_record_view(
     ShareDelegationRecordView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_share_server_selection_policy(
+    ShareServerSelectionPolicy self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -699,6 +699,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ShareServerSelectionPolicy dco_decode_share_server_selection_policy(
+    dynamic raw,
+  );
+
+  @protected
   ShareSubmissionPlan dco_decode_share_submission_plan(dynamic raw);
 
   @protected
@@ -1684,6 +1689,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ShareDelegationRecordView sse_decode_share_delegation_record_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ShareServerSelectionPolicy sse_decode_share_server_selection_policy(
     SseDeserializer deserializer,
   );
 
@@ -2893,6 +2903,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_share_delegation_record_view(
     ShareDelegationRecordView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_share_server_selection_policy(
+    ShareServerSelectionPolicy self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/third_party/zcash_voting/share_policy.dart
+++ b/lib/src/rust/third_party/zcash_voting/share_policy.dart
@@ -34,6 +34,66 @@ class ImmediateShareKey {
           shareIndex == other.shareIndex;
 }
 
+/// Shared helper probing and initial-delivery values.
+///
+/// Clients own transport and recovery. They should start all readiness probes
+/// together, inspect responses after the soft timeout, and continue until at
+/// least `target_count` helpers are ready or the hard timeout expires. For a
+/// complete commitment, `max_shares_per_server` is the balanced maximum when
+/// at least `min_server_count` helpers are in the preferred planning pool.
+/// These limits are derived from the configured fleet size. Retries may exceed
+/// them when needed for liveness. The limit is per helper and does not make a
+/// claim about the combined view of colluding helpers.
+class ShareServerSelectionPolicy {
+  final int targetCount;
+  final int maxSharesPerServer;
+  final int minServerCount;
+  final BigInt preflightSoftTimeoutMilliseconds;
+  final BigInt preflightHardTimeoutMilliseconds;
+  final BigInt postTimeoutMilliseconds;
+  final BigInt initialDeliveryTimeoutMilliseconds;
+  final int maxConcurrentPosts;
+
+  const ShareServerSelectionPolicy({
+    required this.targetCount,
+    required this.maxSharesPerServer,
+    required this.minServerCount,
+    required this.preflightSoftTimeoutMilliseconds,
+    required this.preflightHardTimeoutMilliseconds,
+    required this.postTimeoutMilliseconds,
+    required this.initialDeliveryTimeoutMilliseconds,
+    required this.maxConcurrentPosts,
+  });
+
+  @override
+  int get hashCode =>
+      targetCount.hashCode ^
+      maxSharesPerServer.hashCode ^
+      minServerCount.hashCode ^
+      preflightSoftTimeoutMilliseconds.hashCode ^
+      preflightHardTimeoutMilliseconds.hashCode ^
+      postTimeoutMilliseconds.hashCode ^
+      initialDeliveryTimeoutMilliseconds.hashCode ^
+      maxConcurrentPosts.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ShareServerSelectionPolicy &&
+          runtimeType == other.runtimeType &&
+          targetCount == other.targetCount &&
+          maxSharesPerServer == other.maxSharesPerServer &&
+          minServerCount == other.minServerCount &&
+          preflightSoftTimeoutMilliseconds ==
+              other.preflightSoftTimeoutMilliseconds &&
+          preflightHardTimeoutMilliseconds ==
+              other.preflightHardTimeoutMilliseconds &&
+          postTimeoutMilliseconds == other.postTimeoutMilliseconds &&
+          initialDeliveryTimeoutMilliseconds ==
+              other.initialDeliveryTimeoutMilliseconds &&
+          maxConcurrentPosts == other.maxConcurrentPosts;
+}
+
 /// Planned helper-share submission values that SDKs can apply to payloads.
 class ShareSubmissionPlan {
   /// True only for the round's designated immediate share.

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -18,7 +18,6 @@ class VotingApiClient {
     List<Uri> fallbackBaseUrls = const [],
     Duration timeout = const Duration(seconds: 10),
     Duration helperTimeout = const Duration(seconds: 5),
-    Duration helperPreflightTimeout = const Duration(seconds: 2),
     VotingRetryPolicy? readRetryPolicy,
     VotingRetryPolicy? helperRetryPolicy,
     VotingRetryPolicy? broadcastRetryPolicy,
@@ -28,7 +27,6 @@ class VotingApiClient {
        _fallbackBaseUrls = _dedupeBaseUrls(fallbackBaseUrls, baseUrl: baseUrl),
        _timeout = timeout,
        _helperTimeout = helperTimeout,
-       _helperPreflightTimeout = helperPreflightTimeout,
        _readRetryPolicy =
            readRetryPolicy ??
            VotingRetryPolicy.transientHttp(
@@ -57,7 +55,6 @@ class VotingApiClient {
   final VotingHttpClient _httpClient;
   final Duration _timeout;
   final Duration _helperTimeout;
-  final Duration _helperPreflightTimeout;
   final VotingRetryPolicy _readRetryPolicy;
   final VotingRetryPolicy _helperRetryPolicy;
   final VotingRetryPolicy _broadcastRetryPolicy;
@@ -255,18 +252,87 @@ class VotingApiClient {
     );
   }
 
-  /// Checks helper readiness concurrently without failing the voting flow.
+  /// Returns ready helpers in response order using progressive timeouts.
   ///
-  /// A helper is ready only when its public status endpoint returns a
-  /// successful `{"status":"ok"}` response.
-  Future<Map<String, bool>> preflightHelpers(Iterable<Uri> serverUrls) async {
-    final entries = await Future.wait([
+  /// All probes start together. The first decision happens after [softTimeout];
+  /// if fewer than [readyTargetCount] helpers are ready, slower responses keep
+  /// racing until enough arrive or [hardTimeout] expires. A helper is ready only
+  /// when its public status endpoint returns `{"status":"ok"}` successfully.
+  /// Completing [cancelSignal] stops the wait and returns the responses already
+  /// collected. Outstanding probe transports are cancelled before returning.
+  Future<List<String>> preflightHelpers(
+    Iterable<Uri> serverUrls, {
+    required int readyTargetCount,
+    required Duration softTimeout,
+    required Duration hardTimeout,
+    Future<void>? cancelSignal,
+  }) async {
+    if (softTimeout.isNegative || hardTimeout <= softTimeout) {
+      throw ArgumentError(
+        'helper preflight requires 0 <= softTimeout < hardTimeout',
+      );
+    }
+
+    final seen = <String>{};
+    final servers = [
       for (final serverUrl in serverUrls)
+        if (seen.add(serverUrl.toString())) serverUrl,
+    ];
+    if (servers.isEmpty) {
+      return const [];
+    }
+
+    final targetCount = readyTargetCount.clamp(1, servers.length).toInt();
+    final readyServers = <String>[];
+    var completedServerCount = 0;
+    var acceptingResults = true;
+    final cancelProbes = Completer<void>();
+    final targetOrAllCompleted = Completer<void>();
+    for (final serverUrl in servers) {
+      unawaited(
         _probeHelper(
           serverUrl,
-        ).then((isReady) => MapEntry(serverUrl.toString(), isReady)),
-    ]);
-    return Map<String, bool>.unmodifiable(Map.fromEntries(entries));
+          timeout: hardTimeout,
+          cancelSignal: cancelProbes.future,
+        ).then((isReady) {
+          if (!acceptingResults) return;
+          completedServerCount++;
+          if (isReady) readyServers.add(serverUrl.toString());
+          if (!targetOrAllCompleted.isCompleted &&
+              (readyServers.length >= targetCount ||
+                  completedServerCount == servers.length)) {
+            targetOrAllCompleted.complete();
+          }
+        }),
+      );
+    }
+
+    final softDeadline = Completer<void>();
+    final hardDeadline = Completer<void>();
+    final softTimer = Timer(softTimeout, softDeadline.complete);
+    final hardTimer = Timer(hardTimeout, hardDeadline.complete);
+    try {
+      final cancelled = await Future.any([
+        softDeadline.future.then((_) => false),
+        if (cancelSignal != null) cancelSignal.then((_) => true),
+      ]);
+      if (!cancelled &&
+          readyServers.length < targetCount &&
+          completedServerCount < servers.length) {
+        await Future.any([
+          targetOrAllCompleted.future,
+          hardDeadline.future,
+          ?cancelSignal,
+        ]);
+      }
+    } finally {
+      softTimer.cancel();
+      hardTimer.cancel();
+      acceptingResults = false;
+      cancelProbes.complete();
+    }
+
+    return List<String>.unmodifiable(readyServers);
   }
 
   /// Posts one encrypted share directly to a helper server.
@@ -274,14 +340,19 @@ class VotingApiClient {
   /// The share map is expected to be the complete service JSON body produced
   /// by the voting pipeline. Fast transient failures retain the helper retry
   /// policy. An ambiguous timeout is never retried against the same helper so
-  /// the caller can promptly move to another candidate.
+  /// the caller can promptly move to another candidate. [timeout] bounds each
+  /// transport attempt; [overallTimeout] also bounds retries and their delays.
   Future<VotingShareSubmissionResult> submitShare({
     required Uri serverUrl,
     required Map<String, dynamic> share,
+    required Duration timeout,
+    Duration? overallTimeout,
   }) async {
     final decoded = await _postInitialShareJson(
       _endpoint(['shares'], baseUrl: serverUrl),
       share,
+      timeout: timeout,
+      overallTimeout: overallTimeout,
     );
     return VotingShareSubmissionResult.fromJson(_objectFromValue(decoded));
   }
@@ -315,15 +386,17 @@ class VotingApiClient {
   /// key nearby, but the current helper endpoint accepts the same body as the
   /// initial submission. This makes one transport attempt because a timeout is
   /// ambiguous; the caller decides whether to try another helper or wait.
+  /// [timeout] bounds the transport attempt.
   Future<VotingShareSubmissionResult> resubmitShare({
     required Uri serverUrl,
     required String shareId,
     required Map<String, dynamic> share,
+    required Duration timeout,
   }) async {
     final decoded = await _postJson(
       _endpoint(['shares'], baseUrl: serverUrl),
       share,
-      timeout: _helperTimeout,
+      timeout: timeout,
     );
     return VotingShareSubmissionResult.fromJson(_objectFromValue(decoded));
   }
@@ -379,13 +452,18 @@ class VotingApiClient {
     return jsonDecode(response.bodyText);
   }
 
-  Future<bool> _probeHelper(Uri serverUrl) async {
+  Future<bool> _probeHelper(
+    Uri serverUrl, {
+    required Duration timeout,
+    required Future<void> cancelSignal,
+  }) async {
     final uri = _endpoint(['status'], baseUrl: serverUrl);
     try {
       final response = await _get(
         uri,
-        timeout: _helperPreflightTimeout,
-      ).timeout(_helperPreflightTimeout);
+        timeout: timeout,
+        cancelSignal: cancelSignal,
+      );
       if (response.statusCode < 200 || response.statusCode >= 300) return false;
       final status = _objectFromValue(jsonDecode(response.bodyText))['status'];
       return status?.toString().trim().toLowerCase() == 'ok';
@@ -396,31 +474,74 @@ class VotingApiClient {
 
   Future<Object?> _postInitialShareJson(
     Uri uri,
-    Map<String, dynamic> body,
-  ) async {
+    Map<String, dynamic> body, {
+    required Duration timeout,
+    Duration? overallTimeout,
+  }) async {
+    final requestTimeout = timeout;
+    if (requestTimeout <= Duration.zero) {
+      throw ArgumentError.value(requestTimeout, 'timeout', 'must be positive');
+    }
+    if (overallTimeout != null && overallTimeout <= Duration.zero) {
+      throw ArgumentError.value(
+        overallTimeout,
+        'overallTimeout',
+        'must be positive',
+      );
+    }
+    final stopwatch = Stopwatch()..start();
+    var budgetExpired = false;
     final retryPolicy = VotingRetryPolicy(
       name: '${_helperRetryPolicy.name}-initial',
       delays: _helperRetryPolicy.delays,
       shouldRetry: (error) =>
           error is! TimeoutException && _helperRetryPolicy.shouldRetry(error),
     );
-    final response = await _runRequestWithRetry(
+    final request = _runRequestWithRetry(
       retryPolicy: retryPolicy,
+      isCancelled: () => budgetExpired,
       operation: () async {
+        var attemptTimeout = requestTimeout;
+        if (overallTimeout != null) {
+          final remaining = overallTimeout - stopwatch.elapsed;
+          if (remaining <= Duration.zero) {
+            throw TimeoutException(
+              'Initial helper delivery attempt exceeded its overall timeout',
+              overallTimeout,
+            );
+          }
+          if (remaining < attemptTimeout) attemptTimeout = remaining;
+        }
         final response = await _post(
           uri,
           body,
-          timeout: _helperTimeout,
-        ).timeout(_helperTimeout);
+          timeout: attemptTimeout,
+        ).timeout(attemptTimeout);
         _throwIfNotSuccess(uri, response);
         return response;
       },
     );
+    final response = overallTimeout == null
+        ? await request
+        : await request.timeout(
+            overallTimeout,
+            onTimeout: () {
+              budgetExpired = true;
+              throw TimeoutException(
+                'Initial helper delivery attempt exceeded its overall timeout',
+                overallTimeout,
+              );
+            },
+          );
     return jsonDecode(response.bodyText);
   }
 
-  Future<VotingHttpResponse> _get(Uri uri, {required Duration timeout}) {
-    return _httpClient.get(uri, timeout: timeout);
+  Future<VotingHttpResponse> _get(
+    Uri uri, {
+    required Duration timeout,
+    Future<void>? cancelSignal,
+  }) {
+    return _httpClient.get(uri, timeout: timeout, cancelSignal: cancelSignal);
   }
 
   Future<VotingHttpResponse> _post(

--- a/lib/src/services/voting/voting_endpoint_mapper.dart
+++ b/lib/src/services/voting/voting_endpoint_mapper.dart
@@ -90,8 +90,14 @@ class MappedVotingHttpClient implements VotingHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) {
-    return _inner.get(_mapper.map(uri), headers: headers, timeout: timeout);
+    return _inner.get(
+      _mapper.map(uri),
+      headers: headers,
+      timeout: timeout,
+      cancelSignal: cancelSignal,
+    );
   }
 
   @override

--- a/lib/src/services/voting/voting_http.dart
+++ b/lib/src/services/voting/voting_http.dart
@@ -13,6 +13,7 @@ abstract interface class VotingHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   });
 
   Future<VotingHttpResponse> postJson(
@@ -63,8 +64,15 @@ class DartIoVotingHttpClient implements VotingHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) {
-    return _send('GET', uri, headers: headers, timeout: timeout);
+    return _send(
+      'GET',
+      uri,
+      headers: headers,
+      timeout: timeout,
+      cancelSignal: cancelSignal,
+    );
   }
 
   @override
@@ -93,6 +101,7 @@ class DartIoVotingHttpClient implements VotingHttpClient {
     ContentType? contentType,
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     final requestHeaders = <String, String>{
       if (contentType != null)
@@ -105,6 +114,7 @@ class DartIoVotingHttpClient implements VotingHttpClient {
       headers: requestHeaders,
       bodyBytes: bodyBytes ?? const [],
       timeout: timeout,
+      cancelSignal: cancelSignal,
     );
     return VotingHttpResponse(
       statusCode: response.statusCode,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7105,8 +7105,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f5f6190045301a6f713015b698bc43881786ab3f30973429630ea71aa04d17"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=994cc7f56095e2441225d3986859f23d8cbfb169#994cc7f56095e2441225d3986859f23d8cbfb169"
 dependencies = [
  "anyhow",
  "imt-tree",
@@ -7120,8 +7119,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613504fa62ac7832b9d8b17a3da936b35fdf7403a5286576a377f0728918958e"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=994cc7f56095e2441225d3986859f23d8cbfb169#994cc7f56095e2441225d3986859f23d8cbfb169"
 dependencies = [
  "base64",
  "hex",
@@ -8497,8 +8495,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "3.1.0-rc.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa6cd28e32560f128d8492b782efddb1addd4db3c09103d454625d696ea02a5"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=994cc7f56095e2441225d3986859f23d8cbfb169#994cc7f56095e2441225d3986859f23d8cbfb169"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7105,7 +7105,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=994cc7f56095e2441225d3986859f23d8cbfb169#994cc7f56095e2441225d3986859f23d8cbfb169"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=7f304b640f31a33d108ef83f8b38dcb2cbb3f780#7f304b640f31a33d108ef83f8b38dcb2cbb3f780"
 dependencies = [
  "anyhow",
  "imt-tree",
@@ -7119,7 +7119,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.7.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=994cc7f56095e2441225d3986859f23d8cbfb169#994cc7f56095e2441225d3986859f23d8cbfb169"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=7f304b640f31a33d108ef83f8b38dcb2cbb3f780#7f304b640f31a33d108ef83f8b38dcb2cbb3f780"
 dependencies = [
  "base64",
  "hex",
@@ -8494,8 +8494,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "3.1.0-rc.10"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=994cc7f56095e2441225d3986859f23d8cbfb169#994cc7f56095e2441225d3986859f23d8cbfb169"
+version = "3.1.0-rc.11"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=7f304b640f31a33d108ef83f8b38dcb2cbb3f780#7f304b640f31a33d108ef83f8b38dcb2cbb3f780"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7105,7 +7105,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=7f304b640f31a33d108ef83f8b38dcb2cbb3f780#7f304b640f31a33d108ef83f8b38dcb2cbb3f780"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=fb12d5329f84285f96526bfda08c1206cb06841e#fb12d5329f84285f96526bfda08c1206cb06841e"
 dependencies = [
  "anyhow",
  "imt-tree",
@@ -7119,7 +7119,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.7.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=7f304b640f31a33d108ef83f8b38dcb2cbb3f780#7f304b640f31a33d108ef83f8b38dcb2cbb3f780"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=fb12d5329f84285f96526bfda08c1206cb06841e#fb12d5329f84285f96526bfda08c1206cb06841e"
 dependencies = [
  "base64",
  "hex",
@@ -8495,7 +8495,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "3.1.0-rc.11"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=7f304b640f31a33d108ef83f8b38dcb2cbb3f780#7f304b640f31a33d108ef83f8b38dcb2cbb3f780"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=fb12d5329f84285f96526bfda08c1206cb06841e#fb12d5329f84285f96526bfda08c1206cb06841e"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7105,7 +7105,8 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=fb12d5329f84285f96526bfda08c1206cb06841e#fb12d5329f84285f96526bfda08c1206cb06841e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f5f6190045301a6f713015b698bc43881786ab3f30973429630ea71aa04d17"
 dependencies = [
  "anyhow",
  "imt-tree",
@@ -7119,7 +7120,8 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.7.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=fb12d5329f84285f96526bfda08c1206cb06841e#fb12d5329f84285f96526bfda08c1206cb06841e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613504fa62ac7832b9d8b17a3da936b35fdf7403a5286576a377f0728918958e"
 dependencies = [
  "base64",
  "hex",
@@ -8494,8 +8496,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "3.1.0-rc.11"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=fb12d5329f84285f96526bfda08c1206cb06841e#fb12d5329f84285f96526bfda08c1206cb06841e"
+version = "3.1.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf51901f953c8a86059e71979a65dc8da8bf91e615bbb34b80fe60fc76434a49"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -116,7 +116,7 @@ version = "0.1.0-rc2"
 features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 [dependencies.zcash_voting]
-version = "=3.1.0-rc.11"
+version = "=3.1.0-rc.12"
 default-features = false
 features = ["zakura"]
 
@@ -193,8 +193,3 @@ opt-level = 3
 
 [profile.dev.package."*"]
 opt-level = 3
-
-[patch.crates-io]
-vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "fb12d5329f84285f96526bfda08c1206cb06841e" }
-vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "fb12d5329f84285f96526bfda08c1206cb06841e" }
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "fb12d5329f84285f96526bfda08c1206cb06841e" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -116,7 +116,7 @@ version = "0.1.0-rc2"
 features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 [dependencies.zcash_voting]
-version = "3.1.0-rc.10"
+version = "=3.1.0-rc.10"
 default-features = false
 features = ["zakura"]
 
@@ -193,3 +193,8 @@ opt-level = 3
 
 [profile.dev.package."*"]
 opt-level = 3
+
+[patch.crates-io]
+vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "994cc7f56095e2441225d3986859f23d8cbfb169" }
+vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "994cc7f56095e2441225d3986859f23d8cbfb169" }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "994cc7f56095e2441225d3986859f23d8cbfb169" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -116,7 +116,7 @@ version = "0.1.0-rc2"
 features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 [dependencies.zcash_voting]
-version = "=3.1.0-rc.10"
+version = "=3.1.0-rc.11"
 default-features = false
 features = ["zakura"]
 
@@ -195,6 +195,6 @@ opt-level = 3
 opt-level = 3
 
 [patch.crates-io]
-vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "994cc7f56095e2441225d3986859f23d8cbfb169" }
-vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "994cc7f56095e2441225d3986859f23d8cbfb169" }
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "994cc7f56095e2441225d3986859f23d8cbfb169" }
+vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7f304b640f31a33d108ef83f8b38dcb2cbb3f780" }
+vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7f304b640f31a33d108ef83f8b38dcb2cbb3f780" }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7f304b640f31a33d108ef83f8b38dcb2cbb3f780" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -195,6 +195,6 @@ opt-level = 3
 opt-level = 3
 
 [patch.crates-io]
-vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7f304b640f31a33d108ef83f8b38dcb2cbb3f780" }
-vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7f304b640f31a33d108ef83f8b38dcb2cbb3f780" }
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7f304b640f31a33d108ef83f8b38dcb2cbb3f780" }
+vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "fb12d5329f84285f96526bfda08c1206cb06841e" }
+vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "fb12d5329f84285f96526bfda08c1206cb06841e" }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "fb12d5329f84285f96526bfda08c1206cb06841e" }

--- a/rust/src/api/network_privacy.rs
+++ b/rust/src/api/network_privacy.rs
@@ -1,5 +1,10 @@
 use std::{
+    collections::{hash_map::Entry, HashMap},
     path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        LazyLock, Mutex,
+    },
     time::Duration,
 };
 
@@ -16,10 +21,15 @@ use zcash_client_backend::tor::http::{HttpError, TimeoutPhase};
 pub use crate::network_privacy::NetworkPrivacyStatus;
 
 const TOR_API_RESPONSE_BODY_TIMEOUT: Duration = Duration::from_secs(30);
+const TOR_HTTP_REQUEST_TIMEOUT_ERROR: &str = "Tor HTTP request timed out";
+const TOR_HTTP_REQUEST_CANCELLED_ERROR: &str = "Tor HTTP request cancelled";
 const MAINNET_SAPLING_ACTIVATION_HEIGHT: u64 = 419_200;
 const MAINNET_SAPLING_ACTIVATION_TIME: u32 = 1_540_779_337;
 const BIRTHDAY_ESTIMATE_TOLERANCE_SECONDS: i64 = 6 * 60 * 60;
 const MAX_BIRTHDAY_CORRECTION_PROBES: usize = 2;
+static TOR_HTTP_CANCELLATIONS: LazyLock<Mutex<HashMap<u64, tokio::sync::watch::Sender<bool>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static NEXT_TOR_HTTP_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct BirthdayAnchor {
@@ -148,22 +158,28 @@ pub struct NetworkHttpResponse {
 pub async fn tor_http_get(
     url: String,
     headers: Vec<NetworkHttpHeader>,
+    timeout_milliseconds: Option<u64>,
+    request_id: Option<u64>,
 ) -> Result<NetworkHttpResponse, String> {
-    let client = crate::network_privacy::tor_client_for_route(true)?
-        .ok_or_else(|| "Tor is not enabled".to_string())?;
-    let uri = url
-        .parse()
-        .map_err(|error| format!("Invalid HTTP URL: {error}"))?;
-    let response = client
-        .http_get(
-            uri,
-            |builder| apply_headers(builder, &headers),
-            collect_body,
-            0,
-            |_| None,
+    let response = with_tor_http_request_cancellation(request_id, async {
+        let client = crate::network_privacy::tor_client_for_route(true)?
+            .ok_or_else(|| "Tor is not enabled".to_string())?;
+        let uri = url
+            .parse()
+            .map_err(|error| format!("Invalid HTTP URL: {error}"))?;
+        with_tor_http_request_timeout(
+            timeout_milliseconds,
+            client.http_get(
+                uri,
+                |builder| apply_headers(builder, &headers),
+                collect_body,
+                0,
+                |_| None,
+            ),
         )
         .await
-        .map_err(|error| error.to_string())?;
+    })
+    .await?;
     network_http_response(response)
 }
 
@@ -173,24 +189,92 @@ pub async fn tor_http_post(
     url: String,
     headers: Vec<NetworkHttpHeader>,
     body: Vec<u8>,
+    timeout_milliseconds: Option<u64>,
+    request_id: Option<u64>,
 ) -> Result<NetworkHttpResponse, String> {
-    let client = crate::network_privacy::tor_client_for_route(true)?
-        .ok_or_else(|| "Tor is not enabled".to_string())?;
-    let uri = url
-        .parse()
-        .map_err(|error| format!("Invalid HTTP URL: {error}"))?;
-    let response = client
-        .http_post(
-            uri,
-            |builder| apply_headers(builder, &headers),
-            Full::new(Bytes::from(body)),
-            collect_body,
-            0,
-            |_| None,
+    let response = with_tor_http_request_cancellation(request_id, async {
+        let client = crate::network_privacy::tor_client_for_route(true)?
+            .ok_or_else(|| "Tor is not enabled".to_string())?;
+        let uri = url
+            .parse()
+            .map_err(|error| format!("Invalid HTTP URL: {error}"))?;
+        with_tor_http_request_timeout(
+            timeout_milliseconds,
+            client.http_post(
+                uri,
+                |builder| apply_headers(builder, &headers),
+                Full::new(Bytes::from(body)),
+                collect_body,
+                0,
+                |_| None,
+            ),
         )
         .await
-        .map_err(|error| error.to_string())?;
+    })
+    .await?;
     network_http_response(response)
+}
+
+/// Reserves a process-unique cancellation token for one Tor HTTP request.
+#[flutter_rust_bridge::frb(sync)]
+pub fn tor_http_begin_request() -> u64 {
+    loop {
+        let request_id = NEXT_TOR_HTTP_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+        if request_id == 0 {
+            continue;
+        }
+        let mut cancellations = TOR_HTTP_CANCELLATIONS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Entry::Vacant(entry) = cancellations.entry(request_id) {
+            let (sender, _) = tokio::sync::watch::channel(false);
+            entry.insert(sender);
+            return request_id;
+        }
+    }
+}
+
+/// Cancels one in-flight Tor HTTP request without affecting other circuits.
+#[flutter_rust_bridge::frb(sync)]
+pub fn tor_http_cancel_request(request_id: u64) {
+    let sender = TOR_HTTP_CANCELLATIONS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&request_id);
+    if let Some(sender) = sender {
+        sender.send_replace(true);
+    }
+}
+
+async fn with_tor_http_request_cancellation<T>(
+    request_id: Option<u64>,
+    request: impl std::future::Future<Output = Result<T, String>>,
+) -> Result<T, String> {
+    let Some(request_id) = request_id else {
+        return request.await;
+    };
+    let mut cancellation = {
+        let cancellations = TOR_HTTP_CANCELLATIONS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        cancellations
+            .get(&request_id)
+            .ok_or_else(|| "Tor HTTP request cancellation token is not registered".to_string())?
+            .subscribe()
+    };
+    let result = if *cancellation.borrow() {
+        Err(TOR_HTTP_REQUEST_CANCELLED_ERROR.to_string())
+    } else {
+        tokio::select! {
+            result = request => result,
+            _ = cancellation.changed() => Err(TOR_HTTP_REQUEST_CANCELLED_ERROR.to_string()),
+        }
+    };
+    TOR_HTTP_CANCELLATIONS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&request_id);
+    result
 }
 
 /// Streams an HTTP GET response over an isolated Tor route directly to disk.
@@ -218,6 +302,27 @@ pub async fn tor_http_download(
         .await
         .map_err(|error| error.to_string())?;
     network_http_response(response.map(|_| Vec::new()))
+}
+
+async fn with_tor_http_request_timeout<T, E>(
+    timeout_milliseconds: Option<u64>,
+    future: impl std::future::Future<Output = Result<T, E>>,
+) -> Result<T, String>
+where
+    E: std::fmt::Display,
+{
+    let result = match timeout_milliseconds {
+        Some(0) => return Err("Tor HTTP request timeout must be positive".to_string()),
+        Some(timeout_milliseconds) => {
+            tokio::time::timeout(Duration::from_millis(timeout_milliseconds), future)
+                .await
+                .map_err(|_| {
+                    format!("{TOR_HTTP_REQUEST_TIMEOUT_ERROR} after {timeout_milliseconds} ms")
+                })?
+        }
+        None => future.await,
+    };
+    result.map_err(|error| error.to_string())
 }
 
 fn apply_headers(
@@ -571,7 +676,13 @@ fn timed_birthday_request<T>(message: T) -> Request<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
 
     use zcash_client_backend::tor::{
         http::{HttpError, TimeoutPhase},
@@ -580,7 +691,9 @@ mod tests {
 
     use super::{
         correct_estimated_height, interpolate_height, mainnet_anchor_segment,
-        with_api_response_body_timeout, BirthdayAnchor, MAINNET_BIRTHDAY_ANCHORS,
+        tor_http_begin_request, tor_http_cancel_request, with_api_response_body_timeout,
+        with_tor_http_request_cancellation, with_tor_http_request_timeout, BirthdayAnchor,
+        MAINNET_BIRTHDAY_ANCHORS,
     };
 
     #[test]
@@ -655,5 +768,58 @@ mod tests {
             result,
             Err(Error::Http(HttpError::Timeout(TimeoutPhase::ResponseBody)))
         ));
+    }
+
+    #[tokio::test]
+    async fn whole_http_deadline_drops_the_in_flight_tor_request() {
+        struct DropSignal(Arc<AtomicBool>);
+
+        impl Drop for DropSignal {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let request_drop = Arc::clone(&dropped);
+        let result = with_tor_http_request_timeout(Some(1), async move {
+            let _drop_signal = DropSignal(request_drop);
+            std::future::pending::<Result<(), &'static str>>().await
+        })
+        .await;
+
+        assert_eq!(
+            result,
+            Err("Tor HTTP request timed out after 1 ms".to_string())
+        );
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn explicit_cancellation_drops_only_the_selected_tor_request() {
+        let cancelled_id = tor_http_begin_request();
+        let retained_id = tor_http_begin_request();
+        let cancelled = tokio::spawn(with_tor_http_request_cancellation(
+            Some(cancelled_id),
+            std::future::pending::<Result<(), String>>(),
+        ));
+        let retained = tokio::spawn(with_tor_http_request_cancellation(
+            Some(retained_id),
+            std::future::pending::<Result<(), String>>(),
+        ));
+        tokio::task::yield_now().await;
+
+        tor_http_cancel_request(cancelled_id);
+
+        assert_eq!(
+            cancelled.await.unwrap(),
+            Err("Tor HTTP request cancelled".to_string())
+        );
+        assert!(!retained.is_finished());
+        tor_http_cancel_request(retained_id);
+        assert_eq!(
+            retained.await.unwrap(),
+            Err("Tor HTTP request cancelled".to_string())
+        );
     }
 }

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -2657,24 +2657,24 @@ mod tests {
 
     #[test]
     fn helper_selection_wrappers_expose_crate_policy() {
-        let policy = share_server_selection_policy(10);
-        assert_eq!(policy.target_count, 5);
+        let policy = share_server_selection_policy(6);
+        assert_eq!(policy.target_count, 3);
         assert_eq!(policy.max_shares_per_server, 8);
-        assert_eq!(policy.min_server_count, 10);
+        assert_eq!(policy.min_server_count, 6);
         assert_eq!(policy.preflight_soft_timeout_milliseconds, 2_000);
         assert_eq!(policy.preflight_hard_timeout_milliseconds, 30_000);
         assert_eq!(policy.post_timeout_milliseconds, 30_000);
         assert_eq!(policy.initial_delivery_timeout_milliseconds, 60_000);
         assert_eq!(policy.max_concurrent_posts, 16);
 
-        let servers: Vec<String> = (0..10)
+        let servers: Vec<String> = (0..6)
             .map(|index| format!("https://helper-{index}.example"))
             .collect();
         let plans =
-            plan_share_submissions(16, servers, 10, 100, 600, Some(120), false, None).unwrap();
+            plan_share_submissions(16, servers, 6, 100, 600, Some(120), false, None).unwrap();
         let mut usage = std::collections::HashMap::<String, usize>::new();
         for plan in plans {
-            assert_eq!(plan.target_servers.len(), 5);
+            assert_eq!(plan.target_servers.len(), 3);
             for server in plan.target_servers {
                 *usage.entry(server).or_default() += 1;
             }

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -272,6 +272,8 @@ pub fn vote_share_wire_json(
 /// This mirrors the zcash-swift-wallet-sdk wrapper around
 /// `zcash_voting::share_policy::plan_share_submissions`, with Rust drawing the
 /// policy-sized entropy from the OS CSPRNG before returning FRB-safe plans.
+/// `immediate_share_index` is the position of the round's designated immediate
+/// share in this batch, after any caller-side filtering or reordering.
 ///
 /// # Errors
 ///
@@ -2627,6 +2629,33 @@ mod tests {
     }
 
     #[test]
+    fn plan_share_submissions_marks_designated_batch_position_immediate() {
+        let server_urls = vec![
+            "https://helper-a.example".to_string(),
+            "https://helper-b.example".to_string(),
+        ];
+        let plans = plan_share_submissions(
+            3,
+            server_urls.clone(),
+            server_urls.len() as u32,
+            100,
+            600,
+            Some(120),
+            false,
+            Some(1),
+        )
+        .unwrap();
+
+        assert_eq!(plans.len(), 3);
+        assert!(!plans[0].immediate);
+        assert!(plans[0].submit_at >= 100);
+        assert!(plans[1].immediate);
+        assert_eq!(plans[1].submit_at, 0);
+        assert!(!plans[2].immediate);
+        assert!(plans[2].submit_at >= 100);
+    }
+
+    #[test]
     fn helper_selection_wrappers_expose_crate_policy() {
         let policy = share_server_selection_policy(10);
         assert_eq!(policy.target_count, 5);
@@ -2641,7 +2670,8 @@ mod tests {
         let servers: Vec<String> = (0..10)
             .map(|index| format!("https://helper-{index}.example"))
             .collect();
-        let plans = plan_share_submissions(16, servers, 10, 100, 600, Some(120), false).unwrap();
+        let plans =
+            plan_share_submissions(16, servers, 10, 100, 600, Some(120), false, None).unwrap();
         let mut usage = std::collections::HashMap::<String, usize>::new();
         for plan in plans {
             assert_eq!(plan.target_servers.len(), 5);

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -280,6 +280,7 @@ pub fn vote_share_wire_json(
 pub fn plan_share_submissions(
     share_count: u32,
     server_urls: Vec<String>,
+    preferred_server_count: u32,
     now_seconds: u64,
     vote_end_time_seconds: u64,
     last_moment_buffer_seconds: Option<u64>,
@@ -312,9 +313,12 @@ pub fn plan_share_submissions(
             .map_err(|e| format!("failed to draw share-server entropy: {e}"))?;
 
         // Build FRB-safe plans with fully materialized random inputs.
-        let plans = zcash_voting::share_policy::plan_share_submissions(
+        let preferred_server_count = usize::try_from(preferred_server_count)
+            .map_err(|_| "preferred_server_count does not fit in usize".to_string())?;
+        let plans = zcash_voting::share_policy::plan_share_submissions_with_preferred_servers(
             share_count,
             &server_urls,
+            preferred_server_count,
             now_seconds,
             vote_end_time_seconds,
             last_moment_buffer_seconds,
@@ -327,6 +331,14 @@ pub fn plan_share_submissions(
 
         Ok(plans)
     })
+}
+
+/// Return the crate-owned progressive helper probe and privacy policy.
+#[flutter_rust_bridge::frb(sync)]
+pub fn share_server_selection_policy(
+    server_count: u32,
+) -> zcash_voting::share_policy::ShareServerSelectionPolicy {
+    zcash_voting::share_policy::share_server_selection_policy(server_count as usize)
 }
 
 /// Return the crate-owned randomized helper order for one share retry.
@@ -2585,9 +2597,17 @@ mod tests {
             "https://helper-a.example".to_string(),
             "https://helper-b.example".to_string(),
         ];
-        let plans =
-            plan_share_submissions(3, server_urls.clone(), 100, 600, Some(120), false, Some(1))
-                .unwrap();
+        let plans = plan_share_submissions(
+            3,
+            server_urls.clone(),
+            server_urls.len() as u32,
+            100,
+            600,
+            Some(120),
+            false,
+            Some(1),
+        )
+        .unwrap();
 
         assert_eq!(plans.len(), 3);
         for (index, plan) in plans.into_iter().enumerate() {
@@ -2604,6 +2624,32 @@ mod tests {
                 .iter()
                 .all(|url| server_urls.contains(url)));
         }
+    }
+
+    #[test]
+    fn helper_selection_wrappers_expose_crate_policy() {
+        let policy = share_server_selection_policy(10);
+        assert_eq!(policy.target_count, 5);
+        assert_eq!(policy.max_shares_per_server, 8);
+        assert_eq!(policy.min_server_count, 10);
+        assert_eq!(policy.preflight_soft_timeout_milliseconds, 2_000);
+        assert_eq!(policy.preflight_hard_timeout_milliseconds, 30_000);
+        assert_eq!(policy.post_timeout_milliseconds, 30_000);
+        assert_eq!(policy.initial_delivery_timeout_milliseconds, 60_000);
+        assert_eq!(policy.max_concurrent_posts, 16);
+
+        let servers: Vec<String> = (0..10)
+            .map(|index| format!("https://helper-{index}.example"))
+            .collect();
+        let plans = plan_share_submissions(16, servers, 10, 100, 600, Some(120), false).unwrap();
+        let mut usage = std::collections::HashMap::<String, usize>::new();
+        for plan in plans {
+            assert_eq!(plan.target_servers.len(), 5);
+            for server in plan.target_servers {
+                *usage.entry(server).or_default() += 1;
+            }
+        }
+        assert!(usage.values().all(|count| *count <= 8));
     }
 
     #[test]

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -339890453;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -578304843;
 
 // Section: executor
 
@@ -4744,6 +4744,7 @@ fn wire__crate__api__voting__plan_share_submissions_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_share_count = <u32>::sse_decode(&mut deserializer);
             let api_server_urls = <Vec<String>>::sse_decode(&mut deserializer);
+            let api_preferred_server_count = <u32>::sse_decode(&mut deserializer);
             let api_now_seconds = <u64>::sse_decode(&mut deserializer);
             let api_vote_end_time_seconds = <u64>::sse_decode(&mut deserializer);
             let api_last_moment_buffer_seconds = <Option<u64>>::sse_decode(&mut deserializer);
@@ -4755,6 +4756,7 @@ fn wire__crate__api__voting__plan_share_submissions_impl(
                     let output_ok = crate::api::voting::plan_share_submissions(
                         api_share_count,
                         api_server_urls,
+                        api_preferred_server_count,
                         api_now_seconds,
                         api_vote_end_time_seconds,
                         api_last_moment_buffer_seconds,
@@ -6140,6 +6142,38 @@ fn wire__crate__api__voting__share_resubmission_server_order_impl(
         },
     )
 }
+fn wire__crate__api__voting__share_server_selection_policy_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "share_server_selection_policy",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_server_count = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(
+                    crate::api::voting::share_server_selection_policy(api_server_count),
+                )?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__voting__share_tracking_flags_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -6682,6 +6716,68 @@ fn wire__crate__api__voting__sync_vote_tree_impl(
         },
     )
 }
+fn wire__crate__api__network_privacy__tor_http_begin_request_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "tor_http_begin_request",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok =
+                    Result::<_, ()>::Ok(crate::api::network_privacy::tor_http_begin_request())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__network_privacy__tor_http_cancel_request_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "tor_http_cancel_request",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_request_id = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::network_privacy::tor_http_cancel_request(api_request_id);
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__network_privacy__tor_http_download_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -6753,12 +6849,19 @@ fn wire__crate__api__network_privacy__tor_http_get_impl(
             let api_headers = <Vec<crate::api::network_privacy::NetworkHttpHeader>>::sse_decode(
                 &mut deserializer,
             );
+            let api_timeout_milliseconds = <Option<u64>>::sse_decode(&mut deserializer);
+            let api_request_id = <Option<u64>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, String>(
                     (move || async move {
-                        let output_ok =
-                            crate::api::network_privacy::tor_http_get(api_url, api_headers).await?;
+                        let output_ok = crate::api::network_privacy::tor_http_get(
+                            api_url,
+                            api_headers,
+                            api_timeout_milliseconds,
+                            api_request_id,
+                        )
+                        .await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -6794,6 +6897,8 @@ fn wire__crate__api__network_privacy__tor_http_post_impl(
                 &mut deserializer,
             );
             let api_body = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_timeout_milliseconds = <Option<u64>>::sse_decode(&mut deserializer);
+            let api_request_id = <Option<u64>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, String>(
@@ -6802,6 +6907,8 @@ fn wire__crate__api__network_privacy__tor_http_post_impl(
                             api_url,
                             api_headers,
                             api_body,
+                            api_timeout_milliseconds,
+                            api_request_id,
                         )
                         .await?;
                         Ok(output_ok)
@@ -7421,6 +7528,18 @@ const _: fn() = || {
         let _: bool = ShareDelegationRecordView.confirmed;
         let _: u64 = ShareDelegationRecordView.submit_at;
         let _: u64 = ShareDelegationRecordView.created_at;
+    }
+    {
+        let ShareServerSelectionPolicy =
+            None::<zcash_voting::share_policy::ShareServerSelectionPolicy>.unwrap();
+        let _: u32 = ShareServerSelectionPolicy.target_count;
+        let _: u32 = ShareServerSelectionPolicy.max_shares_per_server;
+        let _: u32 = ShareServerSelectionPolicy.min_server_count;
+        let _: u64 = ShareServerSelectionPolicy.preflight_soft_timeout_milliseconds;
+        let _: u64 = ShareServerSelectionPolicy.preflight_hard_timeout_milliseconds;
+        let _: u64 = ShareServerSelectionPolicy.post_timeout_milliseconds;
+        let _: u64 = ShareServerSelectionPolicy.initial_delivery_timeout_milliseconds;
+        let _: u32 = ShareServerSelectionPolicy.max_concurrent_posts;
     }
     {
         let ShareSubmissionPlan = None::<zcash_voting::share_policy::ShareSubmissionPlan>.unwrap();
@@ -10043,6 +10162,30 @@ impl SseDecode for zcash_voting::wire::ShareDelegationRecordView {
     }
 }
 
+impl SseDecode for zcash_voting::share_policy::ShareServerSelectionPolicy {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_targetCount = <u32>::sse_decode(deserializer);
+        let mut var_maxSharesPerServer = <u32>::sse_decode(deserializer);
+        let mut var_minServerCount = <u32>::sse_decode(deserializer);
+        let mut var_preflightSoftTimeoutMilliseconds = <u64>::sse_decode(deserializer);
+        let mut var_preflightHardTimeoutMilliseconds = <u64>::sse_decode(deserializer);
+        let mut var_postTimeoutMilliseconds = <u64>::sse_decode(deserializer);
+        let mut var_initialDeliveryTimeoutMilliseconds = <u64>::sse_decode(deserializer);
+        let mut var_maxConcurrentPosts = <u32>::sse_decode(deserializer);
+        return zcash_voting::share_policy::ShareServerSelectionPolicy {
+            target_count: var_targetCount,
+            max_shares_per_server: var_maxSharesPerServer,
+            min_server_count: var_minServerCount,
+            preflight_soft_timeout_milliseconds: var_preflightSoftTimeoutMilliseconds,
+            preflight_hard_timeout_milliseconds: var_preflightHardTimeoutMilliseconds,
+            post_timeout_milliseconds: var_postTimeoutMilliseconds,
+            initial_delivery_timeout_milliseconds: var_initialDeliveryTimeoutMilliseconds,
+            max_concurrent_posts: var_maxConcurrentPosts,
+        };
+    }
+}
+
 impl SseDecode for zcash_voting::share_policy::ShareSubmissionPlan {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -10915,29 +11058,29 @@ fn pde_ffi_dispatcher_primary_impl(
 151 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
 152 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
 153 => wire__crate__api__voting__share_resubmission_server_order_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-172 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-174 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-175 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-177 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
-179 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-180 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+174 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+175 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+177 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+178 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+180 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
+182 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+183 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10984,10 +11127,25 @@ fn pde_ffi_dispatcher_sync_impl(
             data_len,
         ),
         150 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        160 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        173 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        176 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
-        178 => {
+        154 => wire__crate__api__voting__share_server_selection_policy_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        161 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        168 => wire__crate__api__network_privacy__tor_http_begin_request_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        169 => wire__crate__api__network_privacy__tor_http_cancel_request_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        176 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        179 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        181 => {
             wire__crate__api__voting__warm_voting_proving_caches_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -12981,6 +13139,49 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::ShareDeleg
     for zcash_voting::wire::ShareDelegationRecordView
 {
     fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::ShareDelegationRecordView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart
+    for FrbWrapper<zcash_voting::share_policy::ShareServerSelectionPolicy>
+{
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.target_count.into_into_dart().into_dart(),
+            self.0.max_shares_per_server.into_into_dart().into_dart(),
+            self.0.min_server_count.into_into_dart().into_dart(),
+            self.0
+                .preflight_soft_timeout_milliseconds
+                .into_into_dart()
+                .into_dart(),
+            self.0
+                .preflight_hard_timeout_milliseconds
+                .into_into_dart()
+                .into_dart(),
+            self.0
+                .post_timeout_milliseconds
+                .into_into_dart()
+                .into_dart(),
+            self.0
+                .initial_delivery_timeout_milliseconds
+                .into_into_dart()
+                .into_dart(),
+            self.0.max_concurrent_posts.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::share_policy::ShareServerSelectionPolicy>
+{
+}
+impl
+    flutter_rust_bridge::IntoIntoDart<
+        FrbWrapper<zcash_voting::share_policy::ShareServerSelectionPolicy>,
+    > for zcash_voting::share_policy::ShareServerSelectionPolicy
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::share_policy::ShareServerSelectionPolicy> {
         self.into()
     }
 }
@@ -15698,6 +15899,20 @@ impl SseEncode for zcash_voting::wire::ShareDelegationRecordView {
         <bool>::sse_encode(self.confirmed, serializer);
         <u64>::sse_encode(self.submit_at, serializer);
         <u64>::sse_encode(self.created_at, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::share_policy::ShareServerSelectionPolicy {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.target_count, serializer);
+        <u32>::sse_encode(self.max_shares_per_server, serializer);
+        <u32>::sse_encode(self.min_server_count, serializer);
+        <u64>::sse_encode(self.preflight_soft_timeout_milliseconds, serializer);
+        <u64>::sse_encode(self.preflight_hard_timeout_milliseconds, serializer);
+        <u64>::sse_encode(self.post_timeout_milliseconds, serializer);
+        <u64>::sse_encode(self.initial_delivery_timeout_milliseconds, serializer);
+        <u32>::sse_encode(self.max_concurrent_posts, serializer);
     }
 }
 

--- a/test/core/network/network_http_client_test.dart
+++ b/test/core/network/network_http_client_test.dart
@@ -31,6 +31,25 @@ void main() {
     ]);
   });
 
+  test('Tor mode passes the caller deadline into the Rust request', () async {
+    final bridge = _RecordingTorBridge([
+      NetworkHttpResponse(statusCode: 200, bodyBytes: Uint8List(0)),
+    ]);
+    final client = NetworkHttpClient(torDesired: () => true, torBridge: bridge);
+    addTearDown(() => client.close());
+
+    await client.request(
+      'POST',
+      Uri.parse('https://example.com/data'),
+      timeout: const Duration(seconds: 30),
+    );
+
+    expect(
+      bridge.timeouts.single!.inMilliseconds,
+      inInclusiveRange(29_000, 30_000),
+    );
+  });
+
   test('Rust Tor responses preserve typed repeated headers', () {
     final response = networkHttpResponseFromRust(
       rust_network_privacy.NetworkHttpResponse(
@@ -210,6 +229,110 @@ void main() {
     expect(await destination.readAsBytes(), [0, 1, 2, 3]);
   });
 
+  test('direct timeout aborts transport and drains its request slot', () async {
+    final requestReceived = Completer<void>();
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((request) async {
+      request.response.write('partial response');
+      await request.response.flush();
+      if (!requestReceived.isCompleted) requestReceived.complete();
+    });
+    final client = NetworkHttpClient(torDesired: () => false);
+    addTearDown(() async {
+      NetworkHttpClient.allowDirectRequests();
+      client.close(force: true);
+      await server.close(force: true);
+    });
+
+    final request = client.request(
+      'GET',
+      Uri(
+        scheme: 'http',
+        host: InternetAddress.loopbackIPv4.address,
+        port: server.port,
+        path: '/stalled',
+      ),
+      timeout: const Duration(milliseconds: 250),
+    );
+    await requestReceived.future;
+
+    await expectLater(request, throwsA(isA<TimeoutException>()));
+    await NetworkHttpClient.quiesceDirectRequests().timeout(
+      const Duration(seconds: 1),
+    );
+  });
+
+  test('direct cancellation aborts the active transport', () async {
+    final requestReceived = Completer<void>();
+    final cancellation = Completer<void>();
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((request) {
+      if (!requestReceived.isCompleted) requestReceived.complete();
+    });
+    final client = NetworkHttpClient(torDesired: () => false);
+    addTearDown(() async {
+      NetworkHttpClient.allowDirectRequests();
+      client.close(force: true);
+      await server.close(force: true);
+    });
+
+    final pending = client.request(
+      'GET',
+      Uri(
+        scheme: 'http',
+        host: InternetAddress.loopbackIPv4.address,
+        port: server.port,
+        path: '/stalled',
+      ),
+      timeout: const Duration(seconds: 30),
+      cancelSignal: cancellation.future,
+    );
+    await requestReceived.future;
+
+    cancellation.complete();
+
+    await expectLater(
+      pending,
+      throwsA(isA<NetworkHttpRequestCancelledException>()),
+    );
+    await NetworkHttpClient.quiesceDirectRequests().timeout(
+      const Duration(seconds: 1),
+    );
+  });
+
+  test('direct timeout keeps its slot until openUrl unwinds', () async {
+    final directClient = _StallingHttpClient();
+    final client = NetworkHttpClient(
+      directClient: directClient,
+      torDesired: () => false,
+    );
+    addTearDown(() {
+      NetworkHttpClient.allowDirectRequests();
+      client.close(force: true);
+    });
+
+    await expectLater(
+      client.request(
+        'GET',
+        Uri.parse('https://example.com/stalled'),
+        timeout: const Duration(milliseconds: 10),
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+
+    var drained = false;
+    final quiesce = NetworkHttpClient.quiesceDirectRequests().then(
+      (_) => drained = true,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(directClient.forceClosed, isTrue);
+    expect(drained, isFalse);
+
+    directClient.failPendingOpen();
+    await quiesce.timeout(const Duration(seconds: 1));
+    expect(drained, isTrue);
+  });
+
   test(
     'Tor activation drains in-flight direct requests after client disposal',
     () async {
@@ -253,11 +376,33 @@ void main() {
   );
 }
 
+class _StallingHttpClient implements HttpClient {
+  final _pendingOpen = Completer<HttpClientRequest>();
+  bool forceClosed = false;
+
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) =>
+      _pendingOpen.future;
+
+  @override
+  void close({bool force = false}) {
+    forceClosed = force;
+  }
+
+  void failPendingOpen() {
+    _pendingOpen.completeError(StateError('direct client closed'));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 class _RecordingTorBridge implements TorHttpBridge {
   _RecordingTorBridge(this.responses);
 
   final List<NetworkHttpResponse> responses;
   final requests = <_RecordedRequest>[];
+  final timeouts = <Duration?>[];
 
   @override
   Future<NetworkHttpResponse> download(
@@ -285,7 +430,10 @@ class _RecordingTorBridge implements TorHttpBridge {
   Future<NetworkHttpResponse> get(
     Uri uri, {
     required Map<String, String> headers,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
+    timeouts.add(timeout);
     requests.add(
       _RecordedRequest(
         method: 'GET',
@@ -301,7 +449,10 @@ class _RecordingTorBridge implements TorHttpBridge {
     Uri uri, {
     required Map<String, String> headers,
     required List<int> bodyBytes,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
+    timeouts.add(timeout);
     requests.add(
       _RecordedRequest(
         method: 'POST',
@@ -328,6 +479,8 @@ class _FailingTorBridge implements TorHttpBridge {
   Future<NetworkHttpResponse> get(
     Uri uri, {
     required Map<String, String> headers,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   }) => throw StateError('Tor is not ready');
 
   @override
@@ -335,6 +488,8 @@ class _FailingTorBridge implements TorHttpBridge {
     Uri uri, {
     required Map<String, String> headers,
     required List<int> bodyBytes,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   }) => throw StateError('Tor is not ready');
 }
 

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -5196,6 +5196,8 @@ class _FakeVotingHotkeyStore implements VotingHotkeyStore {
   }) async {}
 }
 
+int _fakeShareTargetCount(int serverCount) => (serverCount + 1) ~/ 2;
+
 class _VotingStatusRustApi extends _NoopVotingRustApi {
   _VotingStatusRustApi(
     this.recoveryApi, {
@@ -5632,7 +5634,7 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
     required bool singleShare,
     int? immediateShareIndex,
   }) async {
-    final targetCount = serverUrls.length > 5 ? 5 : serverUrls.length;
+    final targetCount = _fakeShareTargetCount(serverUrls.length);
     return [
       for (var i = 0; i < shareCount; i++)
         rust_share_policy.ShareSubmissionPlan(
@@ -5648,10 +5650,18 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
   rust_share_policy.ShareServerSelectionPolicy shareServerSelectionPolicy({
     required int serverCount,
   }) {
+    final targetCount = _fakeShareTargetCount(serverCount);
+    final assignmentCount = 16 * targetCount;
+    final maxSharesPerServer = serverCount == 0
+        ? 0
+        : (assignmentCount + serverCount - 1) ~/ serverCount;
+    final minServerCount = maxSharesPerServer == 0
+        ? 0
+        : (assignmentCount + maxSharesPerServer - 1) ~/ maxSharesPerServer;
     return rust_share_policy.ShareServerSelectionPolicy(
-      targetCount: serverCount > 5 ? 5 : serverCount,
-      maxSharesPerServer: 8,
-      minServerCount: 10,
+      targetCount: targetCount,
+      maxSharesPerServer: maxSharesPerServer,
+      minServerCount: minServerCount,
       preflightSoftTimeoutMilliseconds: BigInt.zero,
       preflightHardTimeoutMilliseconds: BigInt.one,
       postTimeoutMilliseconds: BigInt.from(30000),

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -5625,13 +5625,14 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
   Future<List<rust_share_policy.ShareSubmissionPlan>> planShareSubmissions({
     required int shareCount,
     required List<String> serverUrls,
+    required int preferredServerCount,
     required BigInt nowSeconds,
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
     required bool singleShare,
     int? immediateShareIndex,
   }) async {
-    final targetCount = serverUrls.isEmpty ? 0 : (serverUrls.length / 2).ceil();
+    final targetCount = serverUrls.length > 5 ? 5 : serverUrls.length;
     return [
       for (var i = 0; i < shareCount; i++)
         rust_share_policy.ShareSubmissionPlan(
@@ -5641,6 +5642,22 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
           targetServers: serverUrls.take(targetCount).toList(growable: false),
         ),
     ];
+  }
+
+  @override
+  rust_share_policy.ShareServerSelectionPolicy shareServerSelectionPolicy({
+    required int serverCount,
+  }) {
+    return rust_share_policy.ShareServerSelectionPolicy(
+      targetCount: serverCount > 5 ? 5 : serverCount,
+      maxSharesPerServer: 8,
+      minServerCount: 10,
+      preflightSoftTimeoutMilliseconds: BigInt.zero,
+      preflightHardTimeoutMilliseconds: BigInt.one,
+      postTimeoutMilliseconds: BigInt.from(30000),
+      initialDeliveryTimeoutMilliseconds: BigInt.from(60000),
+      maxConcurrentPosts: 16,
+    );
   }
 
   @override

--- a/test/features/wallet_link/wallet_link_api_client_test.dart
+++ b/test/features/wallet_link/wallet_link_api_client_test.dart
@@ -102,6 +102,8 @@ class _RecordingTorBridge implements TorHttpBridge {
   Future<NetworkHttpResponse> get(
     Uri uri, {
     required Map<String, String> headers,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   }) => throw UnsupportedError('Unexpected GET');
 
   @override
@@ -109,6 +111,8 @@ class _RecordingTorBridge implements TorHttpBridge {
     Uri uri, {
     required Map<String, String> headers,
     required List<int> bodyBytes,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     posts.add(_RecordedPost(uri: uri, bodyBytes: List.of(bodyBytes)));
     return responses[posts.length - 1];

--- a/test/providers/linux_update_provider_test.dart
+++ b/test/providers/linux_update_provider_test.dart
@@ -270,10 +270,17 @@ class _LinuxUpdateTorBridge implements TorHttpBridge {
   Future<NetworkHttpResponse> get(
     Uri uri, {
     required Map<String, String> headers,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   }) {
     requests.add(uri);
     this.headers.add(Map<String, String>.of(headers));
-    if (waitForever) return Completer<NetworkHttpResponse>().future;
+    if (waitForever) {
+      return Future<NetworkHttpResponse>.delayed(
+        timeout!,
+        () => throw TimeoutException('Tor request timed out', timeout),
+      );
+    }
     return Future.value(response!);
   }
 
@@ -282,6 +289,8 @@ class _LinuxUpdateTorBridge implements TorHttpBridge {
     Uri uri, {
     required Map<String, String> headers,
     required List<int> bodyBytes,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   }) => throw UnimplementedError();
 
   @override

--- a/test/providers/voting/voting_config_provider_test.dart
+++ b/test/providers/voting/voting_config_provider_test.dart
@@ -323,6 +323,7 @@ class _NoopVotingHttpClient implements VotingHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     throw UnimplementedError('HTTP should not be used in this test.');
   }

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6874,7 +6874,9 @@ void main() {
     expect(session.error?.message, contains('No vote server accepted share'));
     expect(rust.storedVoteTxHashes, ['0:7:vote-tx']);
     expect(rust.storedCommitmentBundles, ['0:7:2']);
-    expect(rust.recordedShares, isEmpty);
+    expect(rust.recordedShares, hasLength(1));
+    expect(rust.recordedShares.single.shareIndex, 0);
+    expect(rust.recordedShares.single.sentToUrls, isEmpty);
     final postTimeouts = http.requests
         .where(
           (request) =>

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6609,6 +6609,140 @@ void main() {
   });
 
   test(
+    'final ballot plan sends only its designated share immediately',
+    () async {
+      final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final rust = FakeVotingRustApi(
+        emitCommitments: true,
+        commitmentShareCount: 3,
+      );
+      final initialPlan = apiRoundPlan(
+        roundId: kRoundId,
+        pendingRecovery: false,
+        nextSteps: const [],
+        openProposals: Uint32List.fromList(const [7]),
+        allDecided: false,
+      );
+      final finalPlan = apiRoundPlan(
+        roundId: kRoundId,
+        pendingRecovery: false,
+        nextSteps: const [],
+        openProposals: Uint32List(0),
+        immediateShareKey: const rust_share_policy.ImmediateShareKey(
+          bundleIndex: 0,
+          proposalId: 7,
+          shareIndex: 0,
+        ),
+        allDecided: true,
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        roundPlanSequence: [initialPlan, finalPlan],
+        state: recoveryState(
+          bundleCount: 1,
+          delegationTxHashes: [
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: 0,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-0',
+              vanLeafPosition: null,
+            ),
+          ],
+          votes: [vote(bundleIndex: 0, proposalId: 7)],
+        ),
+      );
+      final container = _sessionContainer(
+        http: FakeVotingHttpClient(
+          responses: votingHttpResponses(
+            roundStatus: roundStatusJson(
+              roundId: kRoundId,
+              ceremonyStart: nowSeconds - 100,
+              voteEnd: nowSeconds + 903,
+            ),
+          ),
+        ),
+        rust: rust,
+        recoveryApi: recoveryApi,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: _singleProposalDrafts(),
+            allProposalIds: const [7],
+          );
+
+      expect(rust.planImmediateShareIndexes, [0]);
+      final sharesByIndex = {
+        for (final share in rust.recordedShares) share.shareIndex: share,
+      };
+      expect(sharesByIndex[0]!.submitAt, BigInt.zero);
+      expect(sharesByIndex[1]!.submitAt, greaterThan(BigInt.zero));
+      expect(sharesByIndex[2]!.submitAt, greaterThan(BigInt.zero));
+    },
+  );
+
+  test('recovery subset does not move an absent immediate share', () async {
+    final rust = FakeVotingRustApi(
+      emitCommitments: true,
+      commitmentShareCount: 2,
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      roundPlan: apiRoundPlan(
+        roundId: kRoundId,
+        pendingRecovery: true,
+        nextSteps: const [
+          rust_wire.NextStepView(
+            kind: 'submit_shares',
+            bundleIndex: 0,
+            proposalId: 7,
+            shareIndex: 1,
+            choice: 1,
+          ),
+        ],
+        openProposals: Uint32List(0),
+        immediateShareKey: const rust_share_policy.ImmediateShareKey(
+          bundleIndex: 0,
+          proposalId: 7,
+          shareIndex: 0,
+        ),
+        allDecided: true,
+      ),
+      state: recoveryState(
+        bundleCount: 1,
+        delegationTxHashes: [
+          rust_frb_types.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.submittedDelegation,
+            txHash: 'delegation-0',
+            vanLeafPosition: null,
+          ),
+        ],
+        votes: [vote(bundleIndex: 0, proposalId: 7)],
+        commitmentBundles: [
+          rust_frb_types.RecoverableCommitmentBundle(
+            bundleIndex: 0,
+            proposalId: 7,
+            commitmentBundleJson: commitmentBundleRecoveryJson(proposalId: 7),
+            vcTreePosition: BigInt.from(2),
+          ),
+        ],
+      ),
+    );
+    final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(draftVotes: const []);
+
+    expect(rust.planImmediateShareIndexes, [null]);
+    expect(rust.recordedShares.single.shareIndex, 1);
+  });
+
+  test(
     'vote commitment submits shares concurrently and persists completions',
     () async {
       final http = _GatedSharePostVotingHttpClient(

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6852,8 +6852,8 @@ void main() {
         )
         .map((request) => request.uri.host)
         .toList(growable: false);
-    expect(sharePostHosts, ['helper-b.example', 'helper-a.example']);
-    expect(rust.recordedShares.single.sentToUrls, [helperB, helperA]);
+    expect(sharePostHosts, ['helper-b.example']);
+    expect(rust.recordedShares.single.sentToUrls, [helperB]);
   });
 
   test(
@@ -6902,7 +6902,7 @@ void main() {
       http.releaseSharePosts.complete();
       await cast;
 
-      expect(http.startedSharePostCount, 6);
+      expect(http.startedSharePostCount, 4);
       expect(http.maxConcurrentSharePostCount, 2);
       expect(
         rust.recordedShares.single.sentToUrls,
@@ -6910,8 +6910,6 @@ void main() {
           'https://helper-2.example',
           'https://helper-3.example',
           'https://helper-4.example',
-          'https://helper-5.example',
-          'https://helper-6.example',
         ]),
       );
     },
@@ -7021,10 +7019,13 @@ void main() {
         .toList(growable: false);
     expect(postTimeouts, hasLength(6));
     expect(
-      postTimeouts.take(5),
+      postTimeouts.take(3),
       everyElement(const Duration(milliseconds: 30)),
     );
-    expect(postTimeouts.last, lessThan(const Duration(milliseconds: 30)));
+    expect(
+      postTimeouts.skip(3),
+      everyElement(lessThan(const Duration(milliseconds: 30))),
+    );
   });
 
   test('vote commitment validates all shares before submission', () async {
@@ -7279,8 +7280,6 @@ void main() {
       'helper-2.example',
       'helper-3.example',
       'helper-4.example',
-      'helper-5.example',
-      'helper-6.example',
     ]);
     expect(sharePosts.map((request) => request.timeout).toSet(), {
       const Duration(seconds: 30),
@@ -7289,8 +7288,6 @@ void main() {
       'https://helper-2.example',
       'https://helper-3.example',
       'https://helper-4.example',
-      'https://helper-5.example',
-      'https://helper-6.example',
     ]);
   });
 
@@ -10814,6 +10811,8 @@ class _WitnessHandoffVotingRustApi extends FakeVotingRustApi {
   }
 }
 
+int _fakeShareTargetCount(int serverCount) => (serverCount + 1) ~/ 2;
+
 class FakeVotingRustApi implements VotingRustApi {
   FakeVotingRustApi({
     this.setupDelay = Duration.zero,
@@ -11682,7 +11681,7 @@ class FakeVotingRustApi implements VotingRustApi {
     planLastMomentBufferSeconds.add(lastMomentBufferSeconds);
     planSingleShareValues.add(singleShare);
     planImmediateShareIndexes.add(immediateShareIndex);
-    final targetCount = serverUrls.length > 5 ? 5 : serverUrls.length;
+    final targetCount = _fakeShareTargetCount(serverUrls.length);
     final planningServerCount =
         (preferredServerCount < targetCount
                 ? targetCount
@@ -11713,10 +11712,18 @@ class FakeVotingRustApi implements VotingRustApi {
   rust_share_policy.ShareServerSelectionPolicy shareServerSelectionPolicy({
     required int serverCount,
   }) {
+    final targetCount = _fakeShareTargetCount(serverCount);
+    final assignmentCount = 16 * targetCount;
+    final maxSharesPerServer = serverCount == 0
+        ? 0
+        : (assignmentCount + serverCount - 1) ~/ serverCount;
+    final minServerCount = maxSharesPerServer == 0
+        ? 0
+        : (assignmentCount + maxSharesPerServer - 1) ~/ maxSharesPerServer;
     return rust_share_policy.ShareServerSelectionPolicy(
-      targetCount: serverCount > 5 ? 5 : serverCount,
-      maxSharesPerServer: 8,
-      minServerCount: 10,
+      targetCount: targetCount,
+      maxSharesPerServer: maxSharesPerServer,
+      minServerCount: minServerCount,
       preflightSoftTimeoutMilliseconds: BigInt.zero,
       preflightHardTimeoutMilliseconds: BigInt.one,
       postTimeoutMilliseconds: BigInt.from(helperPostTimeoutMilliseconds),

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6695,20 +6695,7 @@ void main() {
       failureThreshold: 1,
       cooldown: const Duration(hours: 1),
     );
-    final recoveryApi = FakeVotingRecoveryApi(
-      state: recoveryState(
-        bundleCount: 1,
-        delegationTxHashes: [
-          rust_frb_types.DelegationRecoveryView(
-            bundleIndex: 0,
-            phase: VotingWorkflowPhase.submittedDelegation,
-            txHash: 'delegation-0',
-            vanLeafPosition: null,
-          ),
-        ],
-        votes: [vote(bundleIndex: 0, proposalId: 7)],
-      ),
-    );
+    final recoveryApi = _singleVoteRecoveryApi();
     final container = _sessionContainer(
       http: http,
       rust: rust,
@@ -6721,17 +6708,7 @@ void main() {
     helperHealth.recordFailure(helperA);
     await container
         .read(votingSessionProvider(kRoundId).notifier)
-        .castVotes(
-          draftVotes: [
-            rust_wire.DraftVote(
-              proposalId: 7,
-              choice: 1,
-              numOptions: 2,
-              vcTreePosition: BigInt.zero,
-              singleShare: false,
-            ),
-          ],
-        );
+        .castVotes(draftVotes: _singleProposalDrafts());
 
     final sharePostHosts = http.requests
         .where(
@@ -6741,90 +6718,178 @@ void main() {
         )
         .map((request) => request.uri.host)
         .toList(growable: false);
-    expect(sharePostHosts, ['helper-b.example']);
-    expect(rust.recordedShares.single.sentToUrls, [helperB]);
+    expect(sharePostHosts, ['helper-b.example', 'helper-a.example']);
+    expect(rust.recordedShares.single.sentToUrls, [helperB, helperA]);
   });
 
   test(
-    'share submission reorders remaining helpers after a concurrent failure',
+    'share submission bounds concurrency and replaces a rejection',
     () async {
-      const helperA = 'https://helper-a.example';
-      const helperB = 'https://helper-b.example';
-      const helperC = 'https://helper-c.example';
+      final helperUrls = [
+        for (var i = 1; i <= 6; i++)
+          {'url': 'https://helper-$i.example', 'label': 'helper-$i'},
+      ];
       final http = _GatedSharePostVotingHttpClient(
         expectedShareCount: 1,
+        expectedSharePostCount: 2,
         gatedShareIndexes: const {0},
-        responses: votingHttpResponses(
-          dynamicConfig: dynamicConfigJson(
-            voteServers: const [
-              {'url': helperA, 'label': 'helper-a'},
-              {'url': helperB, 'label': 'helper-b'},
-              {'url': helperC, 'label': 'helper-c'},
-            ],
+        responses: {
+          ...votingHttpResponses(
+            dynamicConfig: dynamicConfigJson(voteServers: helperUrls),
           ),
-        ),
+          'https://helper-1.example/shielded-vote/v1/shares': jsonResponse({
+            'error': 'rejected',
+          }, statusCode: 400),
+        },
       );
-      final rust = FakeVotingRustApi(emitCommitments: true);
-      final helperHealth = VotingHelperHealthTracker(
-        failureThreshold: 1,
-        cooldown: const Duration(hours: 1),
+      final rust = FakeVotingRustApi(
+        emitCommitments: true,
+        maxConcurrentHelperPosts: 2,
       );
-      final recoveryApi = FakeVotingRecoveryApi(
-        state: recoveryState(
-          bundleCount: 1,
-          delegationTxHashes: [
-            rust_frb_types.DelegationRecoveryView(
-              bundleIndex: 0,
-              phase: VotingWorkflowPhase.submittedDelegation,
-              txHash: 'delegation-0',
-              vanLeafPosition: null,
-            ),
-          ],
-          votes: [vote(bundleIndex: 0, proposalId: 7)],
-        ),
-      );
+      final recoveryApi = _singleVoteRecoveryApi();
       final container = _sessionContainer(
         http: http,
         rust: rust,
         recoveryApi: recoveryApi,
-        helperHealthTracker: helperHealth,
       );
       addTearDown(container.dispose);
 
       await container.read(votingSessionProvider(kRoundId).future);
       final cast = container
           .read(votingSessionProvider(kRoundId).notifier)
-          .castVotes(
-            draftVotes: [
-              rust_wire.DraftVote(
-                proposalId: 7,
-                choice: 1,
-                numOptions: 2,
-                vcTreePosition: BigInt.zero,
-                singleShare: false,
-              ),
-            ],
-          );
+          .castVotes(draftVotes: _singleProposalDrafts());
 
       await http.allSharePostsStarted.future.timeout(
         const Duration(seconds: 1),
       );
-      helperHealth.recordFailure(helperB);
+      expect(http.startedSharePostCount, 2);
+      expect(http.maxConcurrentSharePostCount, 2);
+
       http.releaseSharePosts.complete();
       await cast;
 
-      final sharePostHosts = http.requests
-          .where(
-            (request) =>
-                request.method == 'POST' &&
-                request.uri.path == '/shielded-vote/v1/shares',
-          )
-          .map((request) => request.uri.host)
-          .toList(growable: false);
-      expect(sharePostHosts, ['helper-a.example', 'helper-c.example']);
-      expect(rust.recordedShares.single.sentToUrls, [helperA, helperC]);
+      expect(http.startedSharePostCount, 6);
+      expect(http.maxConcurrentSharePostCount, 2);
+      expect(
+        rust.recordedShares.single.sentToUrls,
+        unorderedEquals([
+          'https://helper-2.example',
+          'https://helper-3.example',
+          'https://helper-4.example',
+          'https://helper-5.example',
+          'https://helper-6.example',
+        ]),
+      );
     },
   );
+
+  test('queued share posts move to healthy helpers after timeouts', () async {
+    final serverUrls = [
+      for (var i = 1; i <= 10; i++) 'https://helper-$i.example',
+    ];
+    final slowServers = serverUrls.skip(5);
+    final blackholedSharePost = Completer<VotingHttpResponse>();
+    final http = FakeVotingHttpClient(
+      responses: {
+        ...votingHttpResponses(
+          dynamicConfig: dynamicConfigJson(
+            voteServers: [
+              for (var i = 0; i < serverUrls.length; i++)
+                {'url': serverUrls[i], 'label': 'helper-${i + 1}'},
+            ],
+          ),
+        ),
+        for (final serverUrl in slowServers)
+          '$serverUrl/shielded-vote/v1/shares': blackholedSharePost.future,
+      },
+    );
+    final rust = FakeVotingRustApi(
+      emitCommitments: true,
+      commitmentShareCount: 16,
+      helperPostTimeoutMilliseconds: 100,
+      initialDeliveryTimeoutMilliseconds: 200,
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: _singleVoteRecoveryApi(),
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(draftVotes: _singleProposalDrafts());
+
+    expect(rust.recordedShares, hasLength(16));
+    expect(
+      rust.recordedShares,
+      everyElement(
+        isA<_RecordedShare>().having(
+          (share) => share.sentToUrls.length,
+          'accepted helper count',
+          5,
+        ),
+      ),
+    );
+  });
+
+  test('initial share delivery stops at the shared overall budget', () async {
+    final helperUrls = [
+      for (var i = 1; i <= 6; i++)
+        {'url': 'https://helper-$i.example', 'label': 'helper-$i'},
+    ];
+    final blackholedSharePost = Completer<VotingHttpResponse>();
+    final http = FakeVotingHttpClient(
+      responses: {
+        ...votingHttpResponses(
+          dynamicConfig: dynamicConfigJson(voteServers: helperUrls),
+        ),
+        '/shielded-vote/v1/shares': blackholedSharePost.future,
+      },
+    );
+    final rust = FakeVotingRustApi(
+      emitCommitments: true,
+      helperPostTimeoutMilliseconds: 30,
+      initialDeliveryTimeoutMilliseconds: 40,
+      maxConcurrentHelperPosts: 5,
+    );
+    final recoveryApi = _singleVoteRecoveryApi();
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+    );
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final timer = Stopwatch()..start();
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(draftVotes: _singleProposalDrafts());
+
+    final session = container.read(votingSessionProvider(kRoundId)).value!;
+    expect(timer.elapsed, lessThan(const Duration(seconds: 1)));
+    expect(session.phase, VotingSessionPhase.error);
+    expect(session.error?.message, contains('No vote server accepted share'));
+    expect(rust.storedVoteTxHashes, ['0:7:vote-tx']);
+    expect(rust.storedCommitmentBundles, ['0:7:2']);
+    expect(rust.recordedShares, isEmpty);
+    final postTimeouts = http.requests
+        .where(
+          (request) =>
+              request.method == 'POST' &&
+              request.uri.path == '/shielded-vote/v1/shares',
+        )
+        .map((request) => request.timeout!)
+        .toList(growable: false);
+    expect(postTimeouts, hasLength(6));
+    expect(
+      postTimeouts.take(5),
+      everyElement(const Duration(milliseconds: 30)),
+    );
+    expect(postTimeouts.last, lessThan(const Duration(milliseconds: 30)));
+  });
 
   test('vote commitment validates all shares before submission', () async {
     final http = FakeVotingHttpClient(responses: votingHttpResponses());
@@ -7078,11 +7143,18 @@ void main() {
       'helper-2.example',
       'helper-3.example',
       'helper-4.example',
+      'helper-5.example',
+      'helper-6.example',
     ]);
+    expect(sharePosts.map((request) => request.timeout).toSet(), {
+      const Duration(seconds: 30),
+    });
     expect(rust.recordedShares.single.sentToUrls, [
       'https://helper-2.example',
       'https://helper-3.example',
       'https://helper-4.example',
+      'https://helper-5.example',
+      'https://helper-6.example',
     ]);
   });
 
@@ -8102,6 +8174,7 @@ void main() {
     expect(helperBPost.body?['vote_round_id'], kRoundId);
     expect(helperBPost.body?['tree_position'], 42);
     expect(helperBPost.body?['submit_at'], 0);
+    expect(helperBPost.timeout, const Duration(seconds: 30));
     expect(helperBPost.body?['enc_share'], {
       'c1': base64Encode([8]),
       'c2': base64Encode([9]),
@@ -8848,22 +8921,33 @@ class _YieldingFakeVotingHttpClient extends FakeVotingHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     await Future<void>.delayed(Duration.zero);
-    return super.get(uri, headers: headers, timeout: timeout);
+    return super.get(
+      uri,
+      headers: headers,
+      timeout: timeout,
+      cancelSignal: cancelSignal,
+    );
   }
 }
 
 class _GatedSharePostVotingHttpClient extends FakeVotingHttpClient {
   _GatedSharePostVotingHttpClient({
     required this.expectedShareCount,
+    this.expectedSharePostCount,
     required this.gatedShareIndexes,
     super.responses,
   });
 
   final int expectedShareCount;
+  final int? expectedSharePostCount;
   final Set<int> gatedShareIndexes;
   final Set<int> startedShareIndexes = {};
+  int startedSharePostCount = 0;
+  int _activeSharePostCount = 0;
+  int maxConcurrentSharePostCount = 0;
   final Completer<void> allSharePostsStarted = Completer<void>();
   final Completer<void> releaseSharePosts = Completer<void>();
 
@@ -8876,12 +8960,23 @@ class _GatedSharePostVotingHttpClient extends FakeVotingHttpClient {
     if (uri.path == '/shielded-vote/v1/shares') {
       final shareIndex = body['share_index'] as int;
       startedShareIndexes.add(shareIndex);
-      if (startedShareIndexes.length == expectedShareCount &&
-          !allSharePostsStarted.isCompleted) {
+      startedSharePostCount++;
+      _activeSharePostCount++;
+      if (_activeSharePostCount > maxConcurrentSharePostCount) {
+        maxConcurrentSharePostCount = _activeSharePostCount;
+      }
+      final expectedPostsStarted = expectedSharePostCount == null
+          ? startedShareIndexes.length == expectedShareCount
+          : startedSharePostCount == expectedSharePostCount;
+      if (expectedPostsStarted && !allSharePostsStarted.isCompleted) {
         allSharePostsStarted.complete();
       }
-      if (gatedShareIndexes.contains(shareIndex)) {
-        await releaseSharePosts.future;
+      try {
+        if (gatedShareIndexes.contains(shareIndex)) {
+          await releaseSharePosts.future;
+        }
+      } finally {
+        _activeSharePostCount--;
       }
     }
     return super.postJson(uri, body, timeout: timeout);
@@ -9404,13 +9499,19 @@ class _GatedVotingHttpClient extends FakeVotingHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     _recordGet(uri.path);
     final gates = _getGates[uri.path];
     if (gates != null && gates.isNotEmpty) {
       await gates.removeAt(0).future;
     }
-    return super.get(uri, headers: headers, timeout: timeout);
+    return super.get(
+      uri,
+      headers: headers,
+      timeout: timeout,
+      cancelSignal: cancelSignal,
+    );
   }
 
   void _recordGet(String path) {
@@ -10329,9 +10430,15 @@ class _DelegationConcurrencyHttpClient extends FakeVotingHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     if (!uri.path.contains('/tx/')) {
-      return super.get(uri, headers: headers, timeout: timeout);
+      return super.get(
+        uri,
+        headers: headers,
+        timeout: timeout,
+        cancelSignal: cancelSignal,
+      );
     }
     _activeConfirmationGets++;
     if (_activeConfirmationGets > maxConcurrentConfirmationGets) {
@@ -10342,7 +10449,12 @@ class _DelegationConcurrencyHttpClient extends FakeVotingHttpClient {
       // a confirmation wait spans blocks. This is what makes "confirmations
       // overlap the next bundle's broadcast" observable.
       await Future<void>.delayed(const Duration(milliseconds: 50));
-      return await super.get(uri, headers: headers, timeout: timeout);
+      return await super.get(
+        uri,
+        headers: headers,
+        timeout: timeout,
+        cancelSignal: cancelSignal,
+      );
     } finally {
       _activeConfirmationGets--;
     }
@@ -10385,6 +10497,7 @@ class _GatedVoteConfirmationHttpClient extends _UniqueVoteTxHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     if (uri.path.endsWith('/tx/vote-tx-0')) {
       if (!slowConfirmationStarted.isCompleted) {
@@ -10392,7 +10505,12 @@ class _GatedVoteConfirmationHttpClient extends _UniqueVoteTxHttpClient {
       }
       await releaseSlowConfirmation.future;
     }
-    return super.get(uri, headers: headers, timeout: timeout);
+    return super.get(
+      uri,
+      headers: headers,
+      timeout: timeout,
+      cancelSignal: cancelSignal,
+    );
   }
 }
 
@@ -10407,6 +10525,7 @@ class _GatedSubmittedVoteConfirmationHttpClient extends FakeVotingHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     if (uri.path.endsWith('/tx/submitted-vote-tx')) {
       if (!confirmationStarted.isCompleted) {
@@ -10414,7 +10533,12 @@ class _GatedSubmittedVoteConfirmationHttpClient extends FakeVotingHttpClient {
       }
       await releaseConfirmation.future;
     }
-    return super.get(uri, headers: headers, timeout: timeout);
+    return super.get(
+      uri,
+      headers: headers,
+      timeout: timeout,
+      cancelSignal: cancelSignal,
+    );
   }
 }
 
@@ -10462,12 +10586,18 @@ class _SeparatedVoteStagePoolsHttpClient extends _UniqueVoteTxHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     if (uri.path.endsWith('/tx/vote-tx-3') &&
         !fourthConfirmationStarted.isCompleted) {
       fourthConfirmationStarted.complete();
     }
-    return super.get(uri, headers: headers, timeout: timeout);
+    return super.get(
+      uri,
+      headers: headers,
+      timeout: timeout,
+      cancelSignal: cancelSignal,
+    );
   }
 }
 
@@ -10585,6 +10715,9 @@ class FakeVotingRustApi implements VotingRustApi {
     this.failingRecordShareIndexes = const {},
     this.onShareConfirmed,
     this.recoveredShareOrder,
+    this.helperPostTimeoutMilliseconds = 30000,
+    this.initialDeliveryTimeoutMilliseconds = 60000,
+    this.maxConcurrentHelperPosts = 16,
   });
 
   final Duration setupDelay;
@@ -10622,6 +10755,9 @@ class FakeVotingRustApi implements VotingRustApi {
   final void Function(int bundleIndex, int proposalId, int shareIndex)?
   onShareConfirmed;
   final List<int>? recoveredShareOrder;
+  final int helperPostTimeoutMilliseconds;
+  final int initialDeliveryTimeoutMilliseconds;
+  final int maxConcurrentHelperPosts;
   int setupCalls = 0;
   int _activeSetups = 0;
   int maxConcurrentSetups = 0;
@@ -11400,6 +11536,7 @@ class FakeVotingRustApi implements VotingRustApi {
   Future<List<rust_share_policy.ShareSubmissionPlan>> planShareSubmissions({
     required int shareCount,
     required List<String> serverUrls,
+    required int preferredServerCount,
     required BigInt nowSeconds,
     required BigInt voteEndTimeSeconds,
     BigInt? lastMomentBufferSeconds,
@@ -11409,7 +11546,12 @@ class FakeVotingRustApi implements VotingRustApi {
     planLastMomentBufferSeconds.add(lastMomentBufferSeconds);
     planSingleShareValues.add(singleShare);
     planImmediateShareIndexes.add(immediateShareIndex);
-    final targetCount = serverUrls.isEmpty ? 0 : (serverUrls.length / 2).ceil();
+    final targetCount = serverUrls.length > 5 ? 5 : serverUrls.length;
+    final planningServerCount =
+        (preferredServerCount < targetCount
+                ? targetCount
+                : preferredServerCount)
+            .clamp(0, serverUrls.length);
     final now = nowSeconds.toInt();
     final voteEnd = voteEndTimeSeconds.toInt();
     final buffer = lastMomentBufferSeconds?.toInt();
@@ -11423,9 +11565,30 @@ class FakeVotingRustApi implements VotingRustApi {
           immediate: immediateShareIndex == i,
           submitAt: immediateShareIndex == i ? BigInt.zero : submitAt,
           targetCount: targetCount,
-          targetServers: serverUrls.take(targetCount).toList(growable: false),
+          targetServers: [
+            for (var offset = 0; offset < targetCount; offset++)
+              serverUrls[(i * targetCount + offset) % planningServerCount],
+          ],
         ),
     ];
+  }
+
+  @override
+  rust_share_policy.ShareServerSelectionPolicy shareServerSelectionPolicy({
+    required int serverCount,
+  }) {
+    return rust_share_policy.ShareServerSelectionPolicy(
+      targetCount: serverCount > 5 ? 5 : serverCount,
+      maxSharesPerServer: 8,
+      minServerCount: 10,
+      preflightSoftTimeoutMilliseconds: BigInt.zero,
+      preflightHardTimeoutMilliseconds: BigInt.one,
+      postTimeoutMilliseconds: BigInt.from(helperPostTimeoutMilliseconds),
+      initialDeliveryTimeoutMilliseconds: BigInt.from(
+        initialDeliveryTimeoutMilliseconds,
+      ),
+      maxConcurrentPosts: maxConcurrentHelperPosts,
+    );
   }
 
   @override

--- a/test/services/desktop_tor_update_proxy_test.dart
+++ b/test/services/desktop_tor_update_proxy_test.dart
@@ -181,6 +181,8 @@ class _UpdateTorBridge implements TorHttpBridge {
   Future<NetworkHttpResponse> get(
     Uri uri, {
     required Map<String, String> headers,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     final body = bodies[uri.toString()];
     if (body == null) throw StateError('Unexpected GET: $uri');
@@ -195,5 +197,7 @@ class _UpdateTorBridge implements TorHttpBridge {
     Uri uri, {
     required Map<String, String> headers,
     required List<int> bodyBytes,
+    required Duration? timeout,
+    Future<void>? cancelSignal,
   }) => throw UnimplementedError();
 }

--- a/test/services/voting/fake_voting_http.dart
+++ b/test/services/voting/fake_voting_http.dart
@@ -7,6 +7,7 @@ import 'package:zcash_wallet/src/services/voting/voting_http.dart';
 class FakeVotingHttpClient implements VotingHttpClient {
   final Map<String, Object> responses;
   final requests = <FakeVotingHttpRequest>[];
+  final cancelledRequests = <Uri>[];
 
   FakeVotingHttpClient({this.responses = const {}});
 
@@ -15,11 +16,27 @@ class FakeVotingHttpClient implements VotingHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     requests.add(
       FakeVotingHttpRequest('GET', uri, headers: headers, timeout: timeout),
     );
-    return _responseFor(uri);
+    var completed = false;
+    final response = _responseFor(uri);
+    unawaited(
+      response.then<void>(
+        (_) => completed = true,
+        onError: (_, _) => completed = true,
+      ),
+    );
+    if (cancelSignal != null) {
+      unawaited(
+        cancelSignal.then((_) {
+          if (!completed) cancelledRequests.add(uri);
+        }, onError: (_, _) {}),
+      );
+    }
+    return response;
   }
 
   @override

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -13,6 +13,7 @@ void main() {
       '125e5475f653b074d5f4c36730852695f356416c2b6c3042516a912e5bffdd11';
   const otherHexRoundId =
       'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+  const helperPostTimeout = Duration(seconds: 30);
 
   test('composes vote-sdk URLs under shielded-vote v1', () async {
     final http = FakeVotingHttpClient(
@@ -54,6 +55,7 @@ void main() {
     await client.submitShare(
       serverUrl: Uri.parse('https://helper.example'),
       share: {'share_index': 0, 'vote_round_id': hexRoundId},
+      timeout: helperPostTimeout,
     );
     await client.getShareStatus(
       roundId: encodedRoundId,
@@ -64,6 +66,7 @@ void main() {
       serverUrl: Uri.parse('https://helper.example'),
       shareId: 'share-1',
       share: {'share_index': 0, 'vote_round_id': hexRoundId},
+      timeout: helperPostTimeout,
     );
 
     expect(http.requests.map((request) => request.uri.path), [
@@ -77,6 +80,9 @@ void main() {
     ]);
     expect(http.requests[4].uri.host, 'helper.example');
     expect(http.requests[5].uri.host, 'helper.example');
+    expect(http.requests[4].timeout, const Duration(seconds: 30));
+    expect(http.requests[5].timeout, const Duration(seconds: 5));
+    expect(http.requests[6].timeout, const Duration(seconds: 30));
     expect(rounds.single.roundId, hexRoundId);
     expect(status.roundId, hexRoundId);
     expect(tally.roundId, hexRoundId);
@@ -767,7 +773,7 @@ void main() {
     },
   );
 
-  test('share request payloads forward crate wire JSON unchanged', () async {
+  test('share requests preserve payloads and apply their timeout', () async {
     final http = FakeVotingHttpClient(
       responses: {
         'https://helper.example/shielded-vote/v1/shares': {'status': 'queued'},
@@ -781,6 +787,7 @@ void main() {
     final result = await client.submitShare(
       serverUrl: Uri.parse('https://helper.example'),
       share: {'share_index': 7, 'vote_round_id': hexRoundId},
+      timeout: helperPostTimeout,
     );
 
     expect(result.status, 'queued');
@@ -788,11 +795,92 @@ void main() {
       'share_index': 7,
       'vote_round_id': hexRoundId,
     });
-    expect(http.requests.single.timeout, const Duration(seconds: 5));
+    expect(http.requests.single.timeout, const Duration(seconds: 30));
+  });
+
+  test('share retries stop when the overall delivery budget expires', () async {
+    final retryDelayStarted = Completer<void>();
+    final releaseRetryDelay = Completer<void>();
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://helper.example/shielded-vote/v1/shares':
+            SequentialVotingHttpResponses([
+              jsonResponse({'error': 'unavailable'}, statusCode: 503),
+              {'status': 'queued'},
+            ]),
+      },
+    );
+    final client = VotingApiClient(
+      baseUrl: Uri.parse('https://voting.valargroup.org'),
+      httpClient: http,
+      helperRetryPolicy: VotingRetryPolicy.transientHttp(
+        name: 'test-helper-retry',
+        delays: const [Duration(seconds: 1)],
+      ),
+      delay: (_) {
+        retryDelayStarted.complete();
+        return releaseRetryDelay.future;
+      },
+    );
+
+    final pending = client.submitShare(
+      serverUrl: Uri.parse('https://helper.example'),
+      share: {'share_index': 7, 'vote_round_id': hexRoundId},
+      timeout: const Duration(milliseconds: 30),
+      overallTimeout: const Duration(milliseconds: 20),
+    );
+    await retryDelayStarted.future;
+
+    await expectLater(pending, throwsA(isA<TimeoutException>()));
+    expect(http.requests, hasLength(1));
+
+    releaseRetryDelay.complete();
+    await Future<void>.delayed(Duration.zero);
+    expect(http.requests, hasLength(1));
   });
 
   test(
-    'preflights helpers concurrently and treats failures as unavailable',
+    'preflight waits for the soft deadline when enough helpers are fast',
+    () async {
+      final primaryResponse = Completer<VotingHttpResponse>();
+      final secondaryResponse = Completer<VotingHttpResponse>();
+      final http = FakeVotingHttpClient(
+        responses: {
+          'https://helper-1.example/shielded-vote/v1/status':
+              primaryResponse.future,
+          'https://helper-2.example/shielded-vote/v1/status':
+              secondaryResponse.future,
+        },
+      );
+      final client = VotingApiClient(
+        baseUrl: Uri.parse('https://voting.valargroup.org'),
+        httpClient: http,
+      );
+      var completed = false;
+      final pending = client.preflightHelpers(
+        [
+          Uri.parse('https://helper-1.example'),
+          Uri.parse('https://helper-2.example'),
+        ],
+        readyTargetCount: 2,
+        softTimeout: const Duration(milliseconds: 50),
+        hardTimeout: const Duration(milliseconds: 500),
+      );
+      unawaited(pending.then((_) => completed = true));
+      await Future<void>.delayed(Duration.zero);
+
+      primaryResponse.complete(jsonResponse({'status': 'ok'}));
+      secondaryResponse.complete(jsonResponse({'status': 'ok'}));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(completed, isFalse);
+      final result = await pending;
+      expect(result, ['https://helper-1.example', 'https://helper-2.example']);
+    },
+  );
+
+  test(
+    'preflight keeps racing after soft timeout until enough helpers reply',
     () async {
       final primaryResponse = Completer<VotingHttpResponse>();
       final secondaryResponse = Completer<VotingHttpResponse>();
@@ -810,34 +898,109 @@ void main() {
       final client = VotingApiClient(
         baseUrl: Uri.parse('https://voting.valargroup.org'),
         httpClient: http,
-        helperPreflightTimeout: const Duration(milliseconds: 30),
       );
-
-      final pending = client.preflightHelpers([
-        Uri.parse('https://helper-1.example'),
-        Uri.parse('https://helper-2.example'),
-        Uri.parse('https://helper-3.example'),
-      ]);
+      var completed = false;
+      final pending = client.preflightHelpers(
+        [
+          Uri.parse('https://helper-1.example'),
+          Uri.parse('https://helper-2.example'),
+          Uri.parse('https://helper-3.example'),
+        ],
+        readyTargetCount: 2,
+        softTimeout: const Duration(milliseconds: 20),
+        hardTimeout: const Duration(milliseconds: 500),
+      );
+      unawaited(pending.then((_) => completed = true));
       await Future<void>.delayed(Duration.zero);
 
-      expect(http.requests.map((request) => request.uri.host), [
-        'helper-1.example',
-        'helper-2.example',
-        'helper-3.example',
-      ]);
       primaryResponse.complete(jsonResponse({'status': 'ok'}));
-      secondaryResponse.complete(jsonResponse({'status': 'starting'}));
-      expect(await pending, {
-        'https://helper-1.example': true,
-        'https://helper-2.example': false,
-        'https://helper-3.example': false,
-      });
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      expect(completed, isFalse);
 
-      expect(http.requests, hasLength(3));
+      secondaryResponse.complete(jsonResponse({'status': 'ok'}));
+      final result = await pending;
+      expect(result, ['https://helper-1.example', 'https://helper-2.example']);
       expect(
         http.requests.map((request) => request.timeout),
-        everyElement(const Duration(milliseconds: 30)),
+        everyElement(const Duration(milliseconds: 500)),
       );
+      await Future<void>.delayed(Duration.zero);
+      expect(http.cancelledRequests, [
+        Uri.parse('https://helper-3.example/shielded-vote/v1/status'),
+      ]);
+    },
+  );
+
+  test(
+    'preflight returns the available helpers at the hard deadline',
+    () async {
+      final blackholedResponse = Completer<VotingHttpResponse>();
+      final readyResponse = Completer<VotingHttpResponse>();
+      final http = FakeVotingHttpClient(
+        responses: {
+          'https://helper-1.example/shielded-vote/v1/status':
+              blackholedResponse.future,
+          'https://helper-2.example/shielded-vote/v1/status':
+              readyResponse.future,
+        },
+      );
+      final client = VotingApiClient(
+        baseUrl: Uri.parse('https://voting.valargroup.org'),
+        httpClient: http,
+      );
+      final timer = Stopwatch()..start();
+      final pending = client.preflightHelpers(
+        [
+          Uri.parse('https://helper-1.example'),
+          Uri.parse('https://helper-2.example'),
+        ],
+        readyTargetCount: 2,
+        softTimeout: const Duration(milliseconds: 10),
+        hardTimeout: const Duration(milliseconds: 60),
+      );
+      await Future<void>.delayed(Duration.zero);
+      readyResponse.complete(jsonResponse({'status': 'ok'}));
+
+      final result = await pending;
+
+      expect(
+        timer.elapsed,
+        greaterThanOrEqualTo(const Duration(milliseconds: 40)),
+      );
+      expect(timer.elapsed, lessThan(const Duration(seconds: 1)));
+      expect(result, ['https://helper-2.example']);
+    },
+  );
+
+  test(
+    'preflight cancellation returns without waiting for either deadline',
+    () async {
+      final blackholedResponse = Completer<VotingHttpResponse>();
+      final cancellation = Completer<void>();
+      final http = FakeVotingHttpClient(
+        responses: {
+          'https://helper.example/shielded-vote/v1/status':
+              blackholedResponse.future,
+        },
+      );
+      final client = VotingApiClient(
+        baseUrl: Uri.parse('https://voting.valargroup.org'),
+        httpClient: http,
+      );
+      final pending = client.preflightHelpers(
+        [Uri.parse('https://helper.example')],
+        readyTargetCount: 1,
+        softTimeout: const Duration(seconds: 5),
+        hardTimeout: const Duration(seconds: 30),
+        cancelSignal: cancellation.future,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      cancellation.complete();
+      final result = await pending.timeout(const Duration(seconds: 1));
+
+      expect(result, isEmpty);
+      expect(http.requests.single.timeout, const Duration(seconds: 30));
     },
   );
 
@@ -857,7 +1020,6 @@ void main() {
     final client = VotingApiClient(
       baseUrl: Uri.parse('https://voting.valargroup.org'),
       httpClient: http,
-      helperTimeout: const Duration(milliseconds: 30),
       helperRetryPolicy: VotingRetryPolicy.transientHttp(
         name: 'test-helper-retry',
         delays: const [Duration(milliseconds: 2), Duration(milliseconds: 4)],
@@ -870,6 +1032,7 @@ void main() {
       client.submitShare(
         serverUrl: Uri.parse('https://helper.example'),
         share: {'share_index': 0, 'vote_round_id': hexRoundId},
+        timeout: const Duration(milliseconds: 30),
       ),
       throwsA(isA<TimeoutException>()),
     );
@@ -905,6 +1068,7 @@ void main() {
         serverUrl: Uri.parse('https://helper.example'),
         shareId: 'share-1',
         share: {'share_index': 0, 'vote_round_id': hexRoundId},
+        timeout: helperPostTimeout,
       ),
       throwsA(isA<TimeoutException>()),
     );
@@ -930,6 +1094,7 @@ void main() {
     final submitted = await acceptedClient.submitShare(
       serverUrl: Uri.parse('https://helper.example'),
       share: {'share_index': 0, 'vote_round_id': hexRoundId},
+      timeout: helperPostTimeout,
     );
     final status = await acceptedClient.getShareStatus(
       roundId: hexRoundId,
@@ -954,6 +1119,7 @@ void main() {
       rejectedSubmitClient.submitShare(
         serverUrl: Uri.parse('https://helper.example'),
         share: {'share_index': 0, 'vote_round_id': hexRoundId},
+        timeout: helperPostTimeout,
       ),
       throwsA(isA<FormatException>()),
     );

--- a/test/services/voting/voting_endpoint_mapper_test.dart
+++ b/test/services/voting/voting_endpoint_mapper_test.dart
@@ -96,6 +96,7 @@ class _RecordingVotingHttpClient implements VotingHttpClient {
     Uri uri, {
     Map<String, String>? headers,
     Duration? timeout,
+    Future<void>? cancelSignal,
   }) async {
     getUris.add(uri);
     return VotingHttpResponse(statusCode: 200, bodyBytes: Uint8List(0));


### PR DESCRIPTION
Before, helper probes stopped after a fixed short timeout and share POSTs used five-second attempts. After, probes start together, readiness returns no sooner than two seconds once half the configured fleet is available and waits up to a thirty-second hard cap otherwise. Each initial encrypted share targets half the configured helpers rounded up, using the shared balanced assignment and bounded thirty-second POST attempts.

A sixty-second overall budget hands incomplete delivery to the existing liveness-first recovery path, which may use additional configured helpers.