### PR TITLE
Autocomplete contacts in send recipient fields

### DIFF
--- a/lib/src/features/address_book/models/address_book_contact.dart
+++ b/lib/src/features/address_book/models/address_book_contact.dart
@@ -160,6 +160,22 @@ class AddressBookContact {
   }
 }
 
+List<AddressBookContact> filterAddressBookContacts(
+  Iterable<AddressBookContact> contacts, {
+  required String query,
+  Set<AddressBookNetwork>? networks,
+}) {
+  final normalizedQuery = query.trim().toLowerCase();
+  return [
+    for (final contact in contacts)
+      if ((networks == null || networks.contains(contact.network)) &&
+          (normalizedQuery.isEmpty ||
+              contact.label.toLowerCase().contains(normalizedQuery) ||
+              contact.address.toLowerCase().contains(normalizedQuery)))
+        contact,
+  ];
+}
+
 String previewAddress(String address) {
   final trimmed = address.trim();
   if (trimmed.length <= 15) return trimmed;

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -1665,12 +1665,12 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     required bool hasFocusedRecipient,
   }) {
     final colors = context.colors;
-    final contacts = [
-      for (final contact
-          in ref.watch(addressBookProvider).value?.contacts ??
-              const <AddressBookContact>[])
-        if (contact.network == AddressBookNetwork.zcash) contact,
-    ];
+    final contacts = filterAddressBookContacts(
+      ref.watch(addressBookProvider).value?.contacts ??
+          const <AddressBookContact>[],
+      query: _addressController.text,
+      networks: const {AddressBookNetwork.zcash},
+    );
 
     return Column(
       children: [

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -1756,7 +1756,7 @@ class _SendContactAutocompleteRowState
                     ),
                     const SizedBox(height: AppSpacing.xxs),
                     Text(
-                      widget.contact.addressPreview,
+                      _sendContactAddressPreview(widget.contact.address),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: AppTypography.labelMedium.copyWith(
@@ -1773,6 +1773,18 @@ class _SendContactAutocompleteRowState
       ),
     );
   }
+}
+
+String _sendContactAddressPreview(String address) {
+  const leadingLength = 13;
+  const trailingLength = 11;
+  const separator = ' ... ';
+  final trimmed = address.trim();
+  if (trimmed.length <= leadingLength + trailingLength + separator.length) {
+    return trimmed;
+  }
+  return '${trimmed.substring(0, leadingLength)}$separator'
+      '${trimmed.substring(trimmed.length - trailingLength)}';
 }
 
 class _SendContactsLabelButton extends StatefulWidget {

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -19,6 +19,7 @@ import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
+import '../../../core/widgets/app_profile_picture.dart';
 import '../../../core/widgets/app_text_field.dart';
 import '../../../core/widgets/app_tooltip.dart';
 import '../../../providers/account_provider.dart';
@@ -941,6 +942,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       privacyModeEnabled: ref.watch(privacyModeProvider),
     );
     final colors = context.colors;
+    final addressBookContacts =
+        ref.watch(addressBookProvider).value?.contacts ??
+        const <AddressBookContact>[];
     final sendFieldLabelStyle = AppTypography.labelLarge.copyWith(
       color: colors.text.secondary,
     );
@@ -990,9 +994,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     String? matchedRecipientName;
     if (_hasValidAddress) {
       final recipient = sendReviewRecipientFor(
-        contacts:
-            ref.watch(addressBookProvider).value?.contacts ??
-            const <AddressBookContact>[],
+        contacts: addressBookContacts,
         address: _addressController.text.trim(),
         ownAccounts: ref.watch(ownAccountAddressesProvider).value ?? const {},
       );
@@ -1095,50 +1097,80 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          AppTextField(
-                            key: const ValueKey('send_address_field'),
-                            label: 'Send to',
-                            labelStyle: sendFieldLabelStyle,
-                            rightSlot: _SendContactsLabelButton(
-                              label: 'Contacts',
-                              onTap: _openContactPicker,
-                            ),
-                            tone: addressTone,
-                            borderColor:
-                                addressTone == AppTextFieldTone.destructive
-                                ? colors.border.utilityDestructive
-                                : null,
+                          RawAutocomplete<AddressBookContact>(
+                            textEditingController: _addressController,
                             focusNode: _addressFocusNode,
-                            controller: _addressController,
-                            hintText: 'Zcash address',
-                            leading: AppIcon(
-                              addressLeadingIcon,
-                              size: 20,
-                              color: addressLeadingColor,
-                            ),
-                            messageText: addressMessage,
-                            messageIcon: addressMessageIcon,
-                            onChanged: (_) => _handleAddressChanged(),
-                            keyboardType: TextInputType.text,
-                            showClearButton: true,
-                            onClear: () {
-                              _addressSeq++;
-                              _maxDebounceTimer?.cancel();
-                              setState(() {
-                                _addressType = '';
-                                _error = null;
-                                if (_isMaxMode) {
-                                  _validateSeq++;
-                                  _maxSeq++;
-                                  _maxQuote = null;
-                                  _isResolvingMax = false;
-                                  _amountError = '';
-                                }
-                              });
-                              if (!_isMaxMode) {
-                                _validateAmount();
+                            displayStringForOption: (contact) => contact.label,
+                            optionsBuilder: (value) {
+                              if (value.text.trim().isEmpty) {
+                                return const <AddressBookContact>[];
                               }
+                              return filterAddressBookContacts(
+                                addressBookContacts,
+                                query: value.text,
+                                networks: const {AddressBookNetwork.zcash},
+                              );
                             },
+                            onSelected: _selectContact,
+                            optionsViewBuilder:
+                                (context, onSelected, options) =>
+                                    _SendContactAutocompleteOptions(
+                                      contacts: options.toList(growable: false),
+                                      onSelected: onSelected,
+                                    ),
+                            fieldViewBuilder:
+                                (
+                                  context,
+                                  controller,
+                                  focusNode,
+                                  onFieldSubmitted,
+                                ) => AppTextField(
+                                  key: const ValueKey('send_address_field'),
+                                  label: 'Send to',
+                                  labelStyle: sendFieldLabelStyle,
+                                  rightSlot: _SendContactsLabelButton(
+                                    label: 'Contacts',
+                                    onTap: _openContactPicker,
+                                  ),
+                                  tone: addressTone,
+                                  borderColor:
+                                      addressTone ==
+                                          AppTextFieldTone.destructive
+                                      ? colors.border.utilityDestructive
+                                      : null,
+                                  focusNode: focusNode,
+                                  controller: controller,
+                                  hintText: 'Zcash address',
+                                  leading: AppIcon(
+                                    addressLeadingIcon,
+                                    size: 20,
+                                    color: addressLeadingColor,
+                                  ),
+                                  messageText: addressMessage,
+                                  messageIcon: addressMessageIcon,
+                                  onChanged: (_) => _handleAddressChanged(),
+                                  onSubmitted: (_) => onFieldSubmitted(),
+                                  keyboardType: TextInputType.text,
+                                  showClearButton: true,
+                                  onClear: () {
+                                    _addressSeq++;
+                                    _maxDebounceTimer?.cancel();
+                                    setState(() {
+                                      _addressType = '';
+                                      _error = null;
+                                      if (_isMaxMode) {
+                                        _validateSeq++;
+                                        _maxSeq++;
+                                        _maxQuote = null;
+                                        _isResolvingMax = false;
+                                        _amountError = '';
+                                      }
+                                    });
+                                    if (!_isMaxMode) {
+                                      _validateAmount();
+                                    }
+                                  },
+                                ),
                           ),
                           const SizedBox(
                             height: _singleLineFieldOverlayReserve,
@@ -1399,6 +1431,104 @@ class _SendTitle extends StatelessWidget {
         color: context.colors.text.accent,
       ),
       textAlign: TextAlign.center,
+    );
+  }
+}
+
+class _SendContactAutocompleteOptions extends StatelessWidget {
+  const _SendContactAutocompleteOptions({
+    required this.contacts,
+    required this.onSelected,
+  });
+
+  final List<AddressBookContact> contacts;
+  final ValueChanged<AddressBookContact> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Align(
+      alignment: Alignment.topLeft,
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          key: const ValueKey('send_contact_autocomplete_options'),
+          width: _SendComposeLayout.fieldsWidth,
+          constraints: const BoxConstraints(maxHeight: 240),
+          padding: const EdgeInsets.all(AppSpacing.xs),
+          decoration: BoxDecoration(
+            color: colors.background.base,
+            borderRadius: BorderRadius.circular(AppRadii.medium),
+            boxShadow: [
+              BoxShadow(
+                color: colors.shadows.subtle,
+                offset: const Offset(0, 4),
+                blurRadius: 12,
+              ),
+            ],
+          ),
+          child: ListView.builder(
+            padding: EdgeInsets.zero,
+            shrinkWrap: true,
+            itemCount: contacts.length,
+            itemBuilder: (context, index) {
+              final contact = contacts[index];
+              final highlighted =
+                  AutocompleteHighlightedOption.of(context) == index;
+              return InkWell(
+                key: ValueKey('send_contact_autocomplete_${contact.id}'),
+                borderRadius: BorderRadius.circular(AppRadii.small),
+                onTap: () => onSelected(contact),
+                child: Container(
+                  height: 52,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.xs,
+                  ),
+                  decoration: BoxDecoration(
+                    color: highlighted ? colors.background.ground : null,
+                    borderRadius: BorderRadius.circular(AppRadii.small),
+                  ),
+                  child: Row(
+                    children: [
+                      AppProfilePicture(
+                        profilePictureId: contact.profilePictureId,
+                        size: AppProfilePictureSize.large,
+                      ),
+                      const SizedBox(width: AppSpacing.xs),
+                      Expanded(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              contact.label,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: AppTypography.labelMedium.copyWith(
+                                color: colors.text.accent,
+                              ),
+                            ),
+                            const SizedBox(height: AppSpacing.xxs),
+                            Text(
+                              contact.addressPreview,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: AppTypography.labelMedium.copyWith(
+                                color: colors.text.secondary,
+                                fontWeight: FontWeight.w400,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -277,6 +277,22 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     if (mounted) setState(() {});
   }
 
+  void _refreshAddressAutocompleteOptions() {
+    final value = _addressController.value;
+    final text = value.text;
+    if (text.trim().isEmpty) return;
+
+    // RawAutocomplete only recomputes options when the text value changes.
+    // Preserve the user's selection and composing range while refreshing the
+    // options after the asynchronously loaded contact list changes.
+    _addressController.value = value.copyWith(
+      text: '$text ',
+      selection: TextSelection.collapsed(offset: text.length + 1),
+      composing: TextRange.empty,
+    );
+    _addressController.value = value;
+  }
+
   void _openContactPicker() {
     setState(() => _contactPickerOpen = true);
   }
@@ -932,6 +948,16 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       if (previous == next || !mounted) return;
       _handleZecUsdPriceChanged(next);
     });
+    ref.listen<List<AddressBookContact>?>(
+      addressBookProvider.select((value) => value.value?.contacts),
+      (previous, next) {
+        if (identical(previous, next)) return;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          _refreshAddressAutocompleteOptions();
+        });
+      },
+    );
 
     final available = _availableBalanceForCurrentAddress;
     final visibleSpendableText = ZecAmount.fromZatoshi(

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -1101,6 +1101,8 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                             textEditingController: _addressController,
                             focusNode: _addressFocusNode,
                             displayStringForOption: (contact) => contact.label,
+                            optionsViewOpenDirection:
+                                OptionsViewOpenDirection.down,
                             optionsBuilder: (value) {
                               if (value.text.trim().isEmpty) {
                                 return const <AddressBookContact>[];
@@ -1113,63 +1115,87 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                             },
                             onSelected: _selectContact,
                             optionsViewBuilder:
-                                (context, onSelected, options) =>
-                                    _SendContactAutocompleteOptions(
-                                      contacts: options.toList(growable: false),
-                                      onSelected: onSelected,
-                                    ),
+                                (context, onSelected, options) => Padding(
+                                  padding: const EdgeInsets.only(
+                                    top: AppSpacing.xs,
+                                  ),
+                                  child: _SendContactAutocompleteOptions(
+                                    contacts: options.toList(growable: false),
+                                    highlightedIndex:
+                                        AutocompleteHighlightedOption.of(
+                                          context,
+                                        ),
+                                    onSelected: onSelected,
+                                  ),
+                                ),
                             fieldViewBuilder:
                                 (
                                   context,
                                   controller,
                                   focusNode,
                                   onFieldSubmitted,
-                                ) => AppTextField(
-                                  key: const ValueKey('send_address_field'),
-                                  label: 'Send to',
-                                  labelStyle: sendFieldLabelStyle,
-                                  rightSlot: _SendContactsLabelButton(
-                                    label: 'Contacts',
-                                    onTap: _openContactPicker,
-                                  ),
-                                  tone: addressTone,
-                                  borderColor:
-                                      addressTone ==
-                                          AppTextFieldTone.destructive
-                                      ? colors.border.utilityDestructive
-                                      : null,
-                                  focusNode: focusNode,
-                                  controller: controller,
-                                  hintText: 'Zcash address',
-                                  leading: AppIcon(
-                                    addressLeadingIcon,
-                                    size: 20,
-                                    color: addressLeadingColor,
-                                  ),
-                                  messageText: addressMessage,
-                                  messageIcon: addressMessageIcon,
-                                  onChanged: (_) => _handleAddressChanged(),
-                                  onSubmitted: (_) => onFieldSubmitted(),
-                                  keyboardType: TextInputType.text,
-                                  showClearButton: true,
-                                  onClear: () {
-                                    _addressSeq++;
-                                    _maxDebounceTimer?.cancel();
-                                    setState(() {
-                                      _addressType = '';
-                                      _error = null;
-                                      if (_isMaxMode) {
-                                        _validateSeq++;
-                                        _maxSeq++;
-                                        _maxQuote = null;
-                                        _isResolvingMax = false;
-                                        _amountError = '';
-                                      }
-                                    });
-                                    if (!_isMaxMode) {
-                                      _validateAmount();
+                                ) => Focus(
+                                  canRequestFocus: false,
+                                  skipTraversal: true,
+                                  onKeyEvent: (node, event) {
+                                    if (event is KeyDownEvent &&
+                                        (event.logicalKey ==
+                                                LogicalKeyboardKey.enter ||
+                                            event.logicalKey ==
+                                                LogicalKeyboardKey
+                                                    .numpadEnter)) {
+                                      onFieldSubmitted();
+                                      return KeyEventResult.handled;
                                     }
+                                    return KeyEventResult.ignored;
                                   },
+                                  child: AppTextField(
+                                    key: const ValueKey('send_address_field'),
+                                    label: 'Send to',
+                                    labelStyle: sendFieldLabelStyle,
+                                    rightSlot: _SendContactsLabelButton(
+                                      label: 'Contacts',
+                                      onTap: _openContactPicker,
+                                    ),
+                                    tone: addressTone,
+                                    borderColor:
+                                        addressTone ==
+                                            AppTextFieldTone.destructive
+                                        ? colors.border.utilityDestructive
+                                        : null,
+                                    focusNode: focusNode,
+                                    controller: controller,
+                                    hintText: 'Zcash address',
+                                    leading: AppIcon(
+                                      addressLeadingIcon,
+                                      size: 20,
+                                      color: addressLeadingColor,
+                                    ),
+                                    messageText: addressMessage,
+                                    messageIcon: addressMessageIcon,
+                                    onChanged: (_) => _handleAddressChanged(),
+                                    onSubmitted: (_) => onFieldSubmitted(),
+                                    keyboardType: TextInputType.text,
+                                    showClearButton: true,
+                                    onClear: () {
+                                      _addressSeq++;
+                                      _maxDebounceTimer?.cancel();
+                                      setState(() {
+                                        _addressType = '';
+                                        _error = null;
+                                        if (_isMaxMode) {
+                                          _validateSeq++;
+                                          _maxSeq++;
+                                          _maxQuote = null;
+                                          _isResolvingMax = false;
+                                          _amountError = '';
+                                        }
+                                      });
+                                      if (!_isMaxMode) {
+                                        _validateAmount();
+                                      }
+                                    },
+                                  ),
                                 ),
                           ),
                           const SizedBox(
@@ -1435,97 +1461,287 @@ class _SendTitle extends StatelessWidget {
   }
 }
 
-class _SendContactAutocompleteOptions extends StatelessWidget {
+class _SendContactAutocompleteOptions extends StatefulWidget {
   const _SendContactAutocompleteOptions({
     required this.contacts,
+    required this.highlightedIndex,
     required this.onSelected,
   });
 
   final List<AddressBookContact> contacts;
+  final int highlightedIndex;
   final ValueChanged<AddressBookContact> onSelected;
+
+  @override
+  State<_SendContactAutocompleteOptions> createState() =>
+      _SendContactAutocompleteOptionsState();
+}
+
+class _SendContactAutocompleteOptionsState
+    extends State<_SendContactAutocompleteOptions> {
+  static const _rowHeight = 44.0;
+  static const _rowGap = AppSpacing.xxs;
+  static const _visibleRows = 4;
+  static const _listPadding = AppSpacing.xxs;
+  static const _scrollbarTrackWidth = 12.0;
+  static const _outerVerticalPadding = AppSpacing.xs;
+
+  final ScrollController _scrollController = ScrollController();
+  bool _canScroll = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleCanScrollUpdate();
+  }
+
+  @override
+  void didUpdateWidget(covariant _SendContactAutocompleteOptions oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final contactsChanged = !_sameContactSequence(
+      oldWidget.contacts,
+      widget.contacts,
+    );
+    if (oldWidget.highlightedIndex != widget.highlightedIndex ||
+        contactsChanged) {
+      _scheduleCanScrollUpdate();
+      _scheduleHighlightedOptionScroll();
+    }
+  }
+
+  bool _sameContactSequence(
+    List<AddressBookContact> previous,
+    List<AddressBookContact> next,
+  ) {
+    if (previous.length != next.length) return false;
+    for (var index = 0; index < previous.length; index++) {
+      if (previous[index].id != next[index].id) return false;
+    }
+    return true;
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scheduleCanScrollUpdate() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scrollController.hasClients) return;
+      final nextCanScroll = _scrollController.position.maxScrollExtent > 0;
+      if (_canScroll == nextCanScroll) return;
+      setState(() => _canScroll = nextCanScroll);
+    });
+  }
+
+  void _scheduleHighlightedOptionScroll() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted ||
+          !_scrollController.hasClients ||
+          widget.contacts.isEmpty) {
+        return;
+      }
+      final index = widget.highlightedIndex
+          .clamp(0, widget.contacts.length - 1)
+          .toInt();
+      final rowTop = _listPadding + index * (_rowHeight + _rowGap);
+      final rowBottom = rowTop + _rowHeight;
+      final viewportTop = _scrollController.offset;
+      final viewportBottom =
+          viewportTop + _scrollController.position.viewportDimension;
+
+      double? nextOffset;
+      if (rowTop < viewportTop) {
+        nextOffset = rowTop;
+      } else if (rowBottom > viewportBottom) {
+        nextOffset = rowBottom - _scrollController.position.viewportDimension;
+      }
+      if (nextOffset == null) return;
+      _scrollController.jumpTo(
+        nextOffset.clamp(0.0, _scrollController.position.maxScrollExtent),
+      );
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return Align(
-      alignment: Alignment.topLeft,
-      child: Material(
-        color: Colors.transparent,
+    final optionCount = widget.contacts.length;
+    if (optionCount == 0) return const SizedBox.shrink();
+    final visibleCount = optionCount < _visibleRows
+        ? optionCount
+        : _visibleRows;
+    final gapCount = visibleCount - 1;
+    final listHeight =
+        _listPadding * 2 + visibleCount * _rowHeight + gapCount * _rowGap;
+    final popoverHeight = listHeight + _outerVerticalPadding * 2;
+
+    return SizedBox(
+      key: const ValueKey('send_contact_autocomplete_options'),
+      width: _SendComposeLayout.fieldsWidth,
+      height: popoverHeight,
+      child: DecoratedBox(
+        key: const ValueKey('send_contact_autocomplete_surface'),
+        decoration: BoxDecoration(
+          color: colors.background.ground,
+          borderRadius: BorderRadius.circular(AppRadii.medium),
+          border: Border.all(
+            color: colors.border.subtle,
+            strokeAlign: BorderSide.strokeAlignInside,
+          ),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x0F000000),
+              blurRadius: 8,
+              offset: Offset(0, 2),
+            ),
+            BoxShadow(
+              color: Color(0x08000000),
+              blurRadius: 12,
+              offset: Offset(0, -6),
+            ),
+            BoxShadow(
+              color: Color(0x14000000),
+              blurRadius: 28,
+              offset: Offset(0, 14),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.xxs,
+            vertical: _outerVerticalPadding,
+          ),
+          child: ScrollbarTheme(
+            data: ScrollbarThemeData(
+              thumbColor: WidgetStatePropertyAll(
+                colors.text.muted.withValues(alpha: 0.55),
+              ),
+              radius: const Radius.circular(AppRadii.full),
+              thickness: const WidgetStatePropertyAll(6),
+              mainAxisMargin: 3,
+              crossAxisMargin: 3,
+            ),
+            child: Scrollbar(
+              key: const ValueKey('send_contact_autocomplete_scrollbar'),
+              controller: _scrollController,
+              thumbVisibility: _canScroll,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: ScrollConfiguration(
+                      behavior: ScrollConfiguration.of(
+                        context,
+                      ).copyWith(scrollbars: false),
+                      child: ListView.builder(
+                        key: const ValueKey('send_contact_autocomplete_list'),
+                        controller: _scrollController,
+                        padding: const EdgeInsets.all(_listPadding),
+                        itemCount: optionCount,
+                        itemBuilder: (context, index) {
+                          final contact = widget.contacts[index];
+                          return Padding(
+                            padding: EdgeInsets.only(
+                              bottom: index == optionCount - 1 ? 0 : _rowGap,
+                            ),
+                            child: _SendContactAutocompleteRow(
+                              key: ValueKey(
+                                'send_contact_autocomplete_${contact.id}',
+                              ),
+                              contact: contact,
+                              highlighted: index == widget.highlightedIndex,
+                              onTap: () => widget.onSelected(contact),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                  if (_canScroll) const SizedBox(width: _scrollbarTrackWidth),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SendContactAutocompleteRow extends StatefulWidget {
+  const _SendContactAutocompleteRow({
+    required this.contact,
+    required this.highlighted,
+    required this.onTap,
+    super.key,
+  });
+
+  final AddressBookContact contact;
+  final bool highlighted;
+  final VoidCallback onTap;
+
+  @override
+  State<_SendContactAutocompleteRow> createState() =>
+      _SendContactAutocompleteRowState();
+}
+
+class _SendContactAutocompleteRowState
+    extends State<_SendContactAutocompleteRow> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final selected = widget.highlighted || _hovered;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: widget.onTap,
         child: Container(
-          key: const ValueKey('send_contact_autocomplete_options'),
-          width: _SendComposeLayout.fieldsWidth,
-          constraints: const BoxConstraints(maxHeight: 240),
-          padding: const EdgeInsets.all(AppSpacing.xs),
+          height: _SendContactAutocompleteOptionsState._rowHeight,
           decoration: BoxDecoration(
-            color: colors.background.base,
-            borderRadius: BorderRadius.circular(AppRadii.medium),
-            boxShadow: [
-              BoxShadow(
-                color: colors.shadows.subtle,
-                offset: const Offset(0, 4),
-                blurRadius: 12,
+            color: selected ? colors.background.base : null,
+            borderRadius: BorderRadius.circular(AppRadii.xSmall),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+          child: Row(
+            children: [
+              AppProfilePicture(
+                profilePictureId: widget.contact.profilePictureId,
+                size: AppProfilePictureSize.large,
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      widget.contact.label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.labelMedium.copyWith(
+                        color: colors.text.accent,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.xxs),
+                    Text(
+                      widget.contact.addressPreview,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.labelMedium.copyWith(
+                        color: colors.text.secondary,
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ],
-          ),
-          child: ListView.builder(
-            padding: EdgeInsets.zero,
-            shrinkWrap: true,
-            itemCount: contacts.length,
-            itemBuilder: (context, index) {
-              final contact = contacts[index];
-              final highlighted =
-                  AutocompleteHighlightedOption.of(context) == index;
-              return InkWell(
-                key: ValueKey('send_contact_autocomplete_${contact.id}'),
-                borderRadius: BorderRadius.circular(AppRadii.small),
-                onTap: () => onSelected(contact),
-                child: Container(
-                  height: 52,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.xs,
-                  ),
-                  decoration: BoxDecoration(
-                    color: highlighted ? colors.background.ground : null,
-                    borderRadius: BorderRadius.circular(AppRadii.small),
-                  ),
-                  child: Row(
-                    children: [
-                      AppProfilePicture(
-                        profilePictureId: contact.profilePictureId,
-                        size: AppProfilePictureSize.large,
-                      ),
-                      const SizedBox(width: AppSpacing.xs),
-                      Expanded(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              contact.label,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: AppTypography.labelMedium.copyWith(
-                                color: colors.text.accent,
-                              ),
-                            ),
-                            const SizedBox(height: AppSpacing.xxs),
-                            Text(
-                              contact.addressPreview,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: AppTypography.labelMedium.copyWith(
-                                color: colors.text.secondary,
-                                fontWeight: FontWeight.w400,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            },
           ),
         ),
       ),

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -1325,6 +1325,44 @@ void main() {
     expect(find.text('Alice'), findsOneWidget);
   });
 
+  testWidgets('recipient text filters the contacts section', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        contacts: const [
+          AddressBookContact(
+            id: 'alice',
+            label: 'Alice',
+            network: AddressBookNetwork.zcash,
+            address: _shieldedAddress,
+            profilePictureId: 'pfp-01',
+            createdAtMs: 1,
+            updatedAtMs: 1,
+          ),
+          AddressBookContact(
+            id: 'bob',
+            label: 'Bob',
+            network: AddressBookNetwork.zcash,
+            address: _transparentAddress,
+            profilePictureId: 'pfp-02',
+            createdAtMs: 1,
+            updatedAtMs: 1,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('2 contacts'), findsOneWidget);
+    expect(find.text('Alice'), findsOneWidget);
+    expect(find.text('Bob'), findsOneWidget);
+
+    await _enterAddress(tester, 'ali');
+
+    expect(find.text('1 contact'), findsOneWidget);
+    expect(find.text('Alice'), findsOneWidget);
+    expect(find.text('Bob'), findsNothing);
+  });
+
   testWidgets('review marks a TEX contact distinctly from transparent', (
     tester,
   ) async {

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -181,6 +181,54 @@ void main() {
     expect(find.text('Contacts'), findsOneWidget);
   });
 
+  testWidgets('typing a contact name autocompletes the send address', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _sendHarness(
+        addressBookRepository: _FakeAddressBookRepository([
+          _contact(
+            id: 'alice',
+            label: 'Alice',
+            network: AddressBookNetwork.zcash,
+            address: _shieldedAddress,
+          ),
+          _contact(
+            id: 'alina',
+            label: 'Alina',
+            network: AddressBookNetwork.solana,
+            address: 'solana-address',
+          ),
+        ]),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(_editableIn('send_address_field'));
+    await tester.enterText(_editableIn('send_address_field'), 'ALI');
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('send_contact_autocomplete_options')),
+      findsOneWidget,
+    );
+    expect(find.text('Alice'), findsOneWidget);
+    expect(find.text('Alina'), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey('send_contact_autocomplete_alice')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(_fieldText(tester, 'send_address_field'), _shieldedAddress);
+    expect(
+      find.byKey(const ValueKey('send_contact_autocomplete_options')),
+      findsNothing,
+    );
+  });
+
   testWidgets('keeps contacts label for prefilled and cleared addresses', (
     tester,
   ) async {

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -217,6 +217,7 @@ void main() {
     );
     expect(find.text('Alice'), findsOneWidget);
     expect(find.text('Alina'), findsNothing);
+    expect(find.text('u1testshielde ... 00000000000'), findsOneWidget);
 
     await tester.tap(
       find.byKey(const ValueKey('send_contact_autocomplete_alice')),

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
     as frb;
@@ -227,6 +228,137 @@ void main() {
       find.byKey(const ValueKey('send_contact_autocomplete_options')),
       findsNothing,
     );
+  });
+
+  testWidgets('contact autocomplete follows the mnemonic popover styling', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _sendHarness(
+        addressBookRepository: _FakeAddressBookRepository([
+          for (var index = 0; index < 5; index++)
+            _contact(
+              id: 'alice-$index',
+              label: 'Alice $index',
+              network: AddressBookNetwork.zcash,
+              address: '$_shieldedAddress$index',
+            ),
+        ]),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(_editableIn('send_address_field'));
+    await tester.enterText(_editableIn('send_address_field'), 'ali');
+    await tester.pumpAndSettle();
+
+    final field = find.byKey(const ValueKey('send_address_field'));
+    final options = find.byKey(
+      const ValueKey('send_contact_autocomplete_options'),
+    );
+    expect(tester.getTopLeft(options).dy - tester.getBottomLeft(field).dy, 8);
+    expect(tester.getSize(options), const Size(396, 212));
+
+    final surface = tester.widget<DecoratedBox>(
+      find.byKey(const ValueKey('send_contact_autocomplete_surface')),
+    );
+    final decoration = surface.decoration as BoxDecoration;
+    expect(decoration.color, AppThemeData.light.colors.background.ground);
+    expect(decoration.borderRadius, BorderRadius.circular(AppRadii.medium));
+    expect(
+      decoration.border,
+      Border.all(
+        color: AppThemeData.light.colors.border.subtle,
+        strokeAlign: BorderSide.strokeAlignInside,
+      ),
+    );
+    expect(decoration.boxShadow, _mnemonicPopoverShadows);
+
+    final scrollbar = tester.widget<Scrollbar>(
+      find.byKey(const ValueKey('send_contact_autocomplete_scrollbar')),
+    );
+    expect(scrollbar.thumbVisibility, isTrue);
+  });
+
+  testWidgets('keyboard highlight keeps autocomplete options visible', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _sendHarness(
+        addressBookRepository: _FakeAddressBookRepository([
+          for (var index = 0; index < 6; index++)
+            _contact(
+              id: 'alice-$index',
+              label: 'Alice $index',
+              network: AddressBookNetwork.zcash,
+              address: '$_shieldedAddress$index',
+            ),
+        ]),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(_editableIn('send_address_field'));
+    await tester.enterText(_editableIn('send_address_field'), 'ali');
+    await tester.pumpAndSettle();
+
+    for (var index = 0; index < 4; index++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+    }
+
+    final scrollbar = tester.widget<Scrollbar>(
+      find.byKey(const ValueKey('send_contact_autocomplete_scrollbar')),
+    );
+    expect(scrollbar.controller!.offset, greaterThan(0));
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(_fieldText(tester, 'send_address_field'), '${_shieldedAddress}4');
+  });
+
+  testWidgets('equal-sized result changes reset stale autocomplete scroll', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _sendHarness(
+        addressBookRepository: _FakeAddressBookRepository([
+          for (final prefix in ['Alpha', 'Beta'])
+            for (var index = 0; index < 6; index++)
+              _contact(
+                id: '${prefix.toLowerCase()}-$index',
+                label: '$prefix $index',
+                network: AddressBookNetwork.zcash,
+                address: '$_shieldedAddress$prefix$index',
+              ),
+        ]),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(_editableIn('send_address_field'));
+    await tester.enterText(_editableIn('send_address_field'), 'alpha');
+    await tester.pumpAndSettle();
+
+    final scrollbarFinder = find.byKey(
+      const ValueKey('send_contact_autocomplete_scrollbar'),
+    );
+    var scrollbar = tester.widget<Scrollbar>(scrollbarFinder);
+    scrollbar.controller!.jumpTo(
+      scrollbar.controller!.position.maxScrollExtent,
+    );
+    await tester.pump();
+    expect(scrollbar.controller!.offset, greaterThan(0));
+
+    await tester.enterText(_editableIn('send_address_field'), 'beta');
+    await tester.pumpAndSettle();
+
+    scrollbar = tester.widget<Scrollbar>(scrollbarFinder);
+    expect(scrollbar.controller!.offset, lessThanOrEqualTo(AppSpacing.xxs));
+    expect(find.text('Beta 0'), findsOneWidget);
   });
 
   testWidgets('keeps contacts label for prefilled and cleared addresses', (
@@ -855,9 +987,7 @@ void main() {
     expect(rustApi.lastProposeAmountZatoshi, BigInt.from(125000000));
   });
 
-  testWidgets('hardware TEX sends can proceed to proposal', (
-    tester,
-  ) async {
+  testWidgets('hardware TEX sends can proceed to proposal', (tester) async {
     await _setDesktopViewport(tester);
 
     await tester.pumpWidget(
@@ -1029,6 +1159,12 @@ Widget _sendHarness({
     ),
   );
 }
+
+const _mnemonicPopoverShadows = [
+  BoxShadow(color: Color(0x0F000000), blurRadius: 8, offset: Offset(0, 2)),
+  BoxShadow(color: Color(0x08000000), blurRadius: 12, offset: Offset(0, -6)),
+  BoxShadow(color: Color(0x14000000), blurRadius: 28, offset: Offset(0, 14)),
+];
 
 AddressBookContact _contact({
   required String id,

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -230,6 +230,41 @@ void main() {
     );
   });
 
+  testWidgets('refreshes autocomplete when contacts finish loading', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final repository = _DelayedAddressBookRepository();
+
+    await tester.pumpWidget(_sendHarness(addressBookRepository: repository));
+    await tester.pump();
+
+    await tester.tap(_editableIn('send_address_field'));
+    await tester.enterText(_editableIn('send_address_field'), 'ali');
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey('send_contact_autocomplete_options')),
+      findsNothing,
+    );
+
+    repository.complete([
+      _contact(
+        id: 'alice',
+        label: 'Alice',
+        network: AddressBookNetwork.zcash,
+        address: _shieldedAddress,
+      ),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(_fieldText(tester, 'send_address_field'), 'ali');
+    expect(
+      find.byKey(const ValueKey('send_contact_autocomplete_options')),
+      findsOneWidget,
+    );
+    expect(find.text('Alice'), findsOneWidget);
+  });
+
   testWidgets('contact autocomplete follows the mnemonic popover styling', (
     tester,
   ) async {
@@ -1198,6 +1233,20 @@ class _FakeAddressBookRepository implements AddressBookRepository {
       ..clear()
       ..addAll(contacts);
   }
+}
+
+class _DelayedAddressBookRepository implements AddressBookRepository {
+  final _contacts = Completer<List<AddressBookContact>>();
+
+  void complete(List<AddressBookContact> contacts) {
+    _contacts.complete([...contacts]);
+  }
+
+  @override
+  Future<List<AddressBookContact>> loadContacts() => _contacts.future;
+
+  @override
+  Future<void> saveContacts(List<AddressBookContact> contacts) async {}
 }
 
 Future<void> _setDesktopViewport(WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- add contact autocomplete to the desktop send recipient field
- filter the existing mobile contacts section from recipient input
- align the desktop suggestion popover with the mnemonic autocomplete design
- keep keyboard-highlighted suggestions visible while scrolling

## Testing
- fvm flutter test test/features/send/send_screen_test.dart
- fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/send/mobile_send_screen_test.dart
- fvm flutter analyze

Closes #550