### PR TITLE
Preserve singleton voting before batch activation

### DIFF
--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -12,7 +12,7 @@ import '../third_party/zcash_voting/vote.dart';
 import '../third_party/zcash_voting/wire.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `build_vote_commitments_result`, `catch`, `emit_signed_delegation_result`, `emit_signed_vote_result`, `log_sink_closed`, `parse_tx_events_json`, `require_len`, `share_record`
+// These functions are ignored because they are not marked as `pub`: `build_vote_commitments_result`, `catch`, `emit_signed_delegation_result`, `emit_signed_vote_result`, `log_sink_closed`, `parse_tx_events_json`, `require_len`, `share_record`, `singleton_vote_draft`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
 
 /// Return the shared last-moment helper-share buffer, in Unix seconds.
@@ -630,7 +630,8 @@ Future<SignedVoteCommitmentsView> recoverVoteCommitment({
 /// Streaming variant of `build_vote_commitments`.
 ///
 /// Emits per-proposal progress events, then a terminal `"result"` event carrying
-/// `SignedVoteCommitmentsView`.
+/// `SignedVoteCommitmentsView`. The current singleton transport requires exactly
+/// one draft; atomic batch preparation is enabled together with batch broadcast.
 Stream<ApiVoteCommitEvent> buildVoteCommitmentsWithProgress({
   required String dbPath,
   required String accountUuid,

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1627,6 +1627,18 @@ pub fn recover_vote_commitment(
     })
 }
 
+fn singleton_vote_draft(
+    draft_votes: &[zcash_voting::wire::DraftVote],
+) -> Result<&zcash_voting::wire::DraftVote, String> {
+    if draft_votes.len() != 1 {
+        return Err(format!(
+            "singleton cast-vote requires exactly one draft, got {}",
+            draft_votes.len()
+        ));
+    }
+    Ok(&draft_votes[0])
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn build_vote_commitments_result<F>(
     db_path: String,
@@ -1642,6 +1654,8 @@ async fn build_vote_commitments_result<F>(
 where
     F: Fn(zcash_voting::vote::VoteCommitStage) + Send + Sync + 'static,
 {
+    singleton_vote_draft(&draft_votes)?;
+
     // Parse network once and keep hotkey bytes in a secrecy wrapper.
     let network = keys::parse_network(&network)?;
     let stored_hotkey_secret = secrecy::SecretVec::new(stored_hotkey_secret);
@@ -1662,31 +1676,37 @@ where
             voting_network(network),
         )
         .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
+        let draft = singleton_vote_draft(&draft_votes)?;
 
         let prepare_started = Instant::now();
-        let prepared = zcash_voting::vote::prepare_commit_batch(
+        let prepared = zcash_voting::vote::prepare_commit(
             &voting_db,
+            &round_id,
+            bundle_index,
+            draft,
+            &van_witness,
             zcash_voting::vote::VoteSigner::hotkey(&voting_hotkey),
-            zcash_voting::vote::VoteCommitBatch {
-                round_id: &round_id,
-                bundle_index,
-                drafts: &draft_votes,
-                witness: &van_witness,
-                stages: &reporter,
-            },
+            &reporter,
         )
-        .map_err(|e| format!("vote commit batch preparation failed: {e}"))?;
+        .map_err(|e| format!("singleton vote commitment preparation failed: {e}"))?;
         log::info!(
-            "{VOTING_VOTE_LOG} bundle={bundle_index} prepare-batch elapsed={:.3}s",
+            "{VOTING_VOTE_LOG} bundle={bundle_index} prepare-singleton elapsed={:.3}s",
             prepare_started.elapsed().as_secs_f64()
         );
         let persist_started = Instant::now();
         let persisted = db::with_voting_sidecar_write_lock(&db_path, || {
-            zcash_voting::vote::persist_prepared_commit_batch(&voting_db, prepared)
-                .map_err(|e| format!("vote commit batch persistence failed: {e}"))
+            let committed = zcash_voting::vote::persist_prepared_commit(&voting_db, prepared)
+                .map_err(|e| format!("singleton vote commitment persistence failed: {e}"))?;
+            zcash_voting::vote::recover_signed_commitments(
+                &voting_db,
+                &round_id,
+                bundle_index,
+                committed.proposal_id(),
+            )
+            .map_err(|e| format!("singleton vote commitment recovery failed: {e}"))
         })?;
         log::info!(
-            "{VOTING_VOTE_LOG} bundle={bundle_index} persist-batch elapsed={:.3}s worker_total={:.3}s",
+            "{VOTING_VOTE_LOG} bundle={bundle_index} persist-singleton elapsed={:.3}s worker_total={:.3}s",
             persist_started.elapsed().as_secs_f64(),
             total_started.elapsed().as_secs_f64()
         );
@@ -1705,7 +1725,8 @@ where
 /// Streaming variant of `build_vote_commitments`.
 ///
 /// Emits per-proposal progress events, then a terminal `"result"` event carrying
-/// `SignedVoteCommitmentsView`.
+/// `SignedVoteCommitmentsView`. The current singleton transport requires exactly
+/// one draft; atomic batch preparation is enabled together with batch broadcast.
 pub async fn build_vote_commitments_with_progress(
     db_path: String,
     account_uuid: String,
@@ -2799,6 +2820,29 @@ mod tests {
         };
         assert_eq!(result.phase, "result");
         assert_eq!(result.commitments.as_ref().unwrap().bundle_index, 2);
+    }
+
+    #[test]
+    fn singleton_vote_bridge_requires_exactly_one_draft() {
+        let draft = zcash_voting::wire::DraftVote {
+            proposal_id: 1,
+            choice: 0,
+            num_options: 2,
+            vc_tree_position: 0,
+            single_share: false,
+        };
+
+        assert_eq!(
+            singleton_vote_draft(std::slice::from_ref(&draft))
+                .unwrap()
+                .proposal_id,
+            1
+        );
+        for drafts in [Vec::new(), vec![draft.clone(), draft]] {
+            assert!(singleton_vote_draft(&drafts)
+                .unwrap_err()
+                .contains("requires exactly one draft"));
+        }
     }
 
     #[test]

--- a/rust/src/wallet/voting/README.md
+++ b/rust/src/wallet/voting/README.md
@@ -111,10 +111,14 @@ directly. The mapping from FRB functions to crate APIs:
 | Bundle setup | `setup_delegation_bundles` | `delegate::ensure_round_context`, `VotingDb::ensure_bundles_with_skipped_suffix_with_policy` |
 | Delegation prove/sign | `build_prove_and_sign_delegation_payload_with_progress`, Keystone variant | `delegate::{prepare_delegation_bundle, setup, prove, signing_request, signed_bundle, keystone_request}` |
 | Delegation submit/confirm | `mark_delegation_submitted`, `confirm_delegation_submission` | `VotingDb::mark_delegation_submitted`, `confirmation::confirm_delegation_submission` |
-| Vote commit | `build_vote_commitments_with_progress`, `recover_vote_commitment` | `vote::prepare_commit_batch`, `vote::persist_prepared_commit_batch`, `vote::recover_signed_commitments` |
+| Vote commit | `build_vote_commitments_with_progress`, `recover_vote_commitment` | `vote::prepare_commit`, `vote::persist_prepared_commit`, `vote::recover_signed_commitments` |
 | Vote submit/confirm | `mark_vote_submitted`, `confirm_vote_submission` | `VotingDb::mark_vote_submitted`, `confirmation::confirm_vote_submission` |
 | Share submit/confirm | `record_share_delegation`, `mark_share_confirmed`, `add_sent_servers` | `vote::CommittedVote::{record_share, confirm_share}`, `share::add_sent_servers` |
 | Ballot intent / restart | `set_ballot_intent`, `get_round_plan`, `get_round_recovery_state` | `VotingDb::set_ballot_intent`, `session::resume_plan`, `recovery::round_snapshot` |
+
+The vote-commit bridge accepts exactly one draft while Vizor broadcasts through
+the singleton `cast-vote` endpoint. Atomic batch preparation must be enabled in
+the same change as batch broadcast, submission recording, and confirmation.
 
 The `confirmation::*` APIs parse chain `tx` events and atomically record tx
 hashes, VAN positions, and VC positions. Restart recovery is driven by


### PR DESCRIPTION
Vizor currently submits one cast-vote transaction at a time, but its Rust bridge used the batch preparation helper. Batch preparation now has atomic transaction semantics, so this switches the existing path to the explicit singleton prepare and persist lifecycle while preserving the current bridge result shape and cast-vote transport.

The bridge rejects zero or multiple drafts until batch broadcast, recovery, and confirmation are enabled together. The dependency pin remains unchanged; this is the compatibility prerequisite for a later zcash_voting update.