### PR TITLE
Warm Orchard proving keys on send entry

### DIFF
--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -34,8 +34,9 @@ import '../../../address_book/models/address_book_contact.dart';
 import '../../../address_book/providers/address_book_provider.dart';
 import '../../../address_book/widgets/contact_name_inline.dart';
 import '../../../migration/providers/ironwood_migration_announcement_provider.dart';
-import '../../services/send_flow.dart';
 import '../../services/send_amount_conversion.dart';
+import '../../services/send_flow.dart';
+import '../../services/send_proving_key_warmup.dart';
 import '../../widgets/send_recipient_resolver.dart';
 import '../../widgets/send_review_layout.dart' show SendReviewContactRecipient;
 import 'mobile_send_scan_screen.dart';
@@ -401,6 +402,11 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   @override
   void initState() {
     super.initState();
+    try {
+      ref.read(sendProvingKeyWarmupProvider).call();
+    } catch (error) {
+      log('Send: Orchard proving-key warmup failed to start: $error');
+    }
     _addressFocus.addListener(_handleAddressFocusChanged);
     _amountFocus.addListener(_handleAmountFocusChanged);
     final initial = widget.initialRecipient;
@@ -1982,9 +1988,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         enabledBorderColor: useBackdropColors
             ? colors.border.subtleOpacity
             : null,
-        onPressed: _hasValidAddress
-            ? _continueToAmount
-            : null,
+        onPressed: _hasValidAddress ? _continueToAmount : null,
         child: Text(
           _addressController.text.trim().isEmpty
               ? 'Enter address to continue'

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -36,6 +36,7 @@ import '../../migration/providers/ironwood_migration_announcement_provider.dart'
 import '../models/send_prefill_args.dart';
 import '../services/send_amount_conversion.dart';
 import '../services/send_flow.dart';
+import '../services/send_proving_key_warmup.dart';
 import '../widgets/send_recipient_resolver.dart';
 import '../widgets/send_review_layout.dart' show SendReviewContactRecipient;
 
@@ -53,6 +54,16 @@ class SendScreen extends ConsumerStatefulWidget {
 }
 
 class _SendScreenState extends ConsumerState<SendScreen> {
+  @override
+  void initState() {
+    super.initState();
+    try {
+      ref.read(sendProvingKeyWarmupProvider).call();
+    } catch (error) {
+      log('Send: Orchard proving-key warmup failed to start: $error');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final walletAsync = ref.watch(walletProvider);

--- a/lib/src/features/send/services/send_proving_key_warmup.dart
+++ b/lib/src/features/send/services/send_proving_key_warmup.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../rust/api/sync.dart' as rust_sync;
+
+/// Starts the process-lifetime Orchard proving-key warm-up used by sends.
+///
+/// Overridable so tests and design fixtures do not require an initialized
+/// Rust bridge.
+final sendProvingKeyWarmupProvider = Provider<void Function()>((ref) {
+  return rust_sync.warmOrchardProvingKeyCache;
+});

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -941,6 +941,14 @@ Future<void> retainProposalLockUntilExpiry({
   sendFlowId: sendFlowId,
 );
 
+/// Kick off process-lifetime Orchard proving-key warm-up for sends.
+///
+/// Safe to call repeatedly. The first call starts a background worker and
+/// returns immediately; proving blocks on the same shared cache if it catches
+/// up before warm-up completes.
+void warmOrchardProvingKeyCache() =>
+    RustLib.instance.api.crateApiSyncWarmOrchardProvingKeyCache();
+
 /// Add Orchard (and Sapling if needed) proofs to a PCZT locally. The output
 /// is the "PCZT with proofs" half that is later combined with the signed PCZT
 /// returned by the hardware wallet.

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -80,7 +80,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -578304843;
+  int get rustContentHash => -1021116587;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -1239,6 +1239,8 @@ abstract class RustLibApi extends BaseApi {
   });
 
   bool crateApiWalletWalletExists({required String dbPath});
+
+  void crateApiSyncWarmOrchardProvingKeyCache();
 
   Future<ApiPirCacheWarmupResult> crateApiVotingWarmPirProofCache({
     required String dbPath,
@@ -8882,6 +8884,35 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "wallet_exists", argNames: ["dbPath"]);
 
   @override
+  void crateApiSyncWarmOrchardProvingKeyCache() {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 180,
+          )!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiSyncWarmOrchardProvingKeyCacheConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncWarmOrchardProvingKeyCacheConstMeta =>
+      const TaskConstMeta(
+        debugName: "warm_orchard_proving_key_cache",
+        argNames: [],
+      );
+
+  @override
   Future<ApiPirCacheWarmupResult> crateApiVotingWarmPirProofCache({
     required String dbPath,
     required String accountUuid,
@@ -8907,7 +8938,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 180,
+            funcId: 181,
             port: port_,
           );
         },
@@ -8955,7 +8986,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 181,
+            funcId: 182,
           )!;
         },
         codec: SseCodec(
@@ -8989,7 +9020,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 182,
+            funcId: 183,
             port: port_,
           );
         },
@@ -9026,7 +9057,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 183,
+            funcId: 184,
             port: port_,
           );
         },

--- a/lib/widgetbook/send_use_cases.dart
+++ b/lib/widgetbook/send_use_cases.dart
@@ -18,6 +18,7 @@ import '../src/features/address_book/providers/address_book_provider.dart';
 import '../src/features/address_scan/widgets/address_qr_scan_modal.dart';
 import '../src/features/address_scan/widgets/mobile_address_scan_card.dart';
 import '../src/features/send/screens/mobile/mobile_send_screen.dart';
+import '../src/features/send/services/send_proving_key_warmup.dart';
 import '../src/features/send/widgets/send_compose_view.dart';
 import '../src/providers/account_provider.dart';
 import '../src/providers/sync_provider.dart';
@@ -357,6 +358,7 @@ class _MobileSendHarness extends StatelessWidget {
     return ProviderScope(
       overrides: [
         appBootstrapProvider.overrideWithValue(_mobileSendBootstrap),
+        sendProvingKeyWarmupProvider.overrideWithValue(() {}),
         syncProvider.overrideWith(() => _WidgetbookSendSyncNotifier()),
         zecLiveUsdUnitPriceProvider.overrideWithValue(70),
         addressBookRepositoryProvider.overrideWithValue(

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -2573,6 +2573,16 @@ pub fn retain_proposal_lock_until_expiry(
     wallet_sync::retain_proposal_lock_until_expiry(proposal_id, &send_flow_id)
 }
 
+/// Kick off process-lifetime Orchard proving-key warm-up for sends.
+///
+/// Safe to call repeatedly. The first call starts a background worker and
+/// returns immediately; proving blocks on the same shared cache if it catches
+/// up before warm-up completes.
+#[flutter_rust_bridge::frb(sync)]
+pub fn warm_orchard_proving_key_cache() {
+    wallet_sync::start_orchard_proving_key_warmup();
+}
+
 /// Add Orchard (and Sapling if needed) proofs to a PCZT locally. The output
 /// is the "PCZT with proofs" half that is later combined with the signed PCZT
 /// returned by the hardware wallet.

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -578304843;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1021116587;
 
 // Section: executor
 
@@ -7167,6 +7167,37 @@ fn wire__crate__api__wallet__wallet_exists_impl(
         },
     )
 }
+fn wire__crate__api__sync__warm_orchard_proving_key_cache_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "warm_orchard_proving_key_cache",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::sync::warm_orchard_proving_key_cache();
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__voting__warm_pir_proof_cache_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -11078,9 +11109,9 @@ fn pde_ffi_dispatcher_primary_impl(
 175 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
 177 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
 178 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-180 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
-182 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-183 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+181 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
+183 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+184 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -11145,7 +11176,10 @@ fn pde_ffi_dispatcher_sync_impl(
         ),
         176 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
         179 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
-        181 => {
+        180 => {
+            wire__crate__api__sync__warm_orchard_proving_key_cache_impl(ptr, rust_vec_len, data_len)
+        }
+        182 => {
             wire__crate__api__voting__warm_voting_proving_caches_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -51,8 +51,9 @@ pub(crate) use pczt::extract_compact_sigs_from_pczt;
 pub use pczt::{
     add_proofs_to_pczt, create_pczt_from_proposal, create_tex_pczts_from_proposal,
     discard_proposal, extract_and_broadcast_pczt, redact_pczt_for_signer,
-    retain_proposal_lock_until_expiry, store_and_broadcast_signed_pczts_for_proposal,
-    ExtractAndBroadcastPcztResult, StoreAndBroadcastPcztsResult, TexPcztPair,
+    retain_proposal_lock_until_expiry, start_orchard_proving_key_warmup,
+    store_and_broadcast_signed_pczts_for_proposal, ExtractAndBroadcastPcztResult,
+    StoreAndBroadcastPcztsResult, TexPcztPair,
 };
 pub(crate) use proposal_locks::recover_previous_process as recover_orphaned_send_locks;
 pub(crate) use send::estimate_send_max;

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -62,6 +62,7 @@
 
 use std::convert::Infallible;
 use std::sync::OnceLock;
+use std::thread;
 
 use transparent::address::TransparentAddress;
 use transparent::bundle::{OutPoint, TxOut};
@@ -70,7 +71,10 @@ use zcash_address::{ToAddress, ZcashAddress};
 use zcash_client_backend::data_api::{Account, OutputLockStore, WalletRead};
 use zcash_client_backend::proposal::{Proposal, Step, StepOutputIndex};
 use zcash_client_backend::wallet::WalletTransparentOutput;
-use zcash_primitives::transaction::{builder::BundlePadding, Transaction, TxId};
+use zcash_primitives::transaction::{
+    builder::{cached_orchard_proving_key, BundlePadding},
+    Transaction, TxId,
+};
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::consensus::{NetworkConstants, Parameters};
 
@@ -308,16 +312,36 @@ pub(crate) fn txid_from_io_finalized_pczt(pczt_bytes: &[u8]) -> Result<TxId, Str
 }
 
 fn legacy_orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
-    static LEGACY_ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
-    LEGACY_ORCHARD_PROVING_KEY.get_or_init(|| {
-        orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2)
-    })
+    cached_orchard_proving_key(orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2)
 }
 
 fn ironwood_orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
-    static IRONWOOD_ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
-    IRONWOOD_ORCHARD_PROVING_KEY
-        .get_or_init(|| orchard::circuit::ProvingKey::build(ironwood_orchard_circuit_version()))
+    cached_orchard_proving_key(ironwood_orchard_circuit_version())
+}
+
+static ORCHARD_PROVING_KEY_WARMUP_STARTED: OnceLock<()> = OnceLock::new();
+
+/// Starts process-lifetime Orchard proving-key warm-up if it has not started.
+///
+/// Returns immediately. A proof requested before warm-up completes blocks on
+/// the same shared cache, so this is a latency optimization rather than a
+/// correctness requirement.
+pub fn start_orchard_proving_key_warmup() {
+    if ORCHARD_PROVING_KEY_WARMUP_STARTED.set(()).is_err() {
+        return;
+    }
+
+    let spawn_result = thread::Builder::new()
+        .name("orchard-proving-key-warmup".to_string())
+        .spawn(|| {
+            let _ = ironwood_orchard_proving_key();
+        });
+    if let Err(error) = spawn_result {
+        log::warn!(
+            "Orchard proving-key warmup spawn failed: {error}; \
+             proving will build the key inline if needed"
+        );
+    }
 }
 
 /// The Orchard circuit version implied by a PCZT's `consensus_branch_id`.
@@ -2330,6 +2354,22 @@ mod tests {
             orchard_circuit_version_for_consensus_branch(u32::from(BranchId::Nu6_3)),
             orchard::bundle::BundleVersion::orchard_v3().circuit_version(),
         );
+    }
+
+    #[test]
+    fn pczt_and_warmup_share_the_transaction_builder_proving_key() {
+        start_orchard_proving_key_warmup();
+        start_orchard_proving_key_warmup();
+
+        let builder_key = cached_orchard_proving_key(ironwood_orchard_circuit_version());
+        assert!(std::ptr::eq(ironwood_orchard_proving_key(), builder_key));
+
+        let legacy_builder_key =
+            cached_orchard_proving_key(orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2);
+        assert!(std::ptr::eq(
+            legacy_orchard_proving_key(),
+            legacy_builder_key
+        ));
     }
 
     #[test]

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:zcash_wallet/src/features/address_book/models/address_book_conta
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
 import 'package:zcash_wallet/src/features/send/screens/mobile/mobile_send_screen.dart';
+import 'package:zcash_wallet/src/features/send/services/send_proving_key_warmup.dart';
 import 'package:zcash_wallet/src/features/send/widgets/send_recipient_resolver.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
@@ -282,6 +283,7 @@ Widget _app({
   NotifierProvider<_TestZecUsdPriceNotifier, double?>? zecUsdPriceProvider,
   IronwoodHomeMigrationCtaState migrationCta =
       const IronwoodHomeMigrationCtaState.hidden(),
+  void Function()? warmProvingKey,
 }) {
   final router = GoRouter(
     initialLocation: '/send',
@@ -303,6 +305,7 @@ Widget _app({
       appBootstrapProvider.overrideWithValue(
         _bootstrap(accountState: accountState),
       ),
+      sendProvingKeyWarmupProvider.overrideWithValue(warmProvingKey ?? () {}),
       syncProvider.overrideWith(syncNotifier ?? _FakeSyncNotifier.new),
       ironwoodHomeMigrationPresentationProvider.overrideWithValue(migrationCta),
       zecMarketDataSourceProvider.overrideWithValue(
@@ -337,6 +340,7 @@ Widget _amountStepWithPriceLoadingApp() {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
+      sendProvingKeyWarmupProvider.overrideWithValue(() {}),
       syncProvider.overrideWith(_FakeSyncNotifier.new),
       zecLiveUsdUnitPriceProvider.overrideWithValue(null),
       addressBookRepositoryProvider.overrideWithValue(
@@ -369,6 +373,7 @@ Widget _reviewApp({
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
+      sendProvingKeyWarmupProvider.overrideWithValue(() {}),
       syncProvider.overrideWith(() => syncNotifier),
       zecMarketDataSourceProvider.overrideWithValue(
         const _FakeMarketDataSource(),
@@ -477,6 +482,7 @@ Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
+      sendProvingKeyWarmupProvider.overrideWithValue(() {}),
       syncProvider.overrideWith(_FakeSyncNotifier.new),
       zecMarketDataSourceProvider.overrideWithValue(
         const _FakeMarketDataSource(),
@@ -587,6 +593,18 @@ void main() {
     binding.platformDispatcher.views.first
       ..physicalSize = const Size(520, 1100)
       ..devicePixelRatio = 1.0;
+  });
+
+  testWidgets('starts Orchard proving-key warmup when mobile send loads', (
+    tester,
+  ) async {
+    var calls = 0;
+
+    await tester.pumpWidget(_app(warmProvingKey: () => calls++));
+    await tester.pumpAndSettle();
+
+    expect(calls, 1);
+    expect(find.byType(MobileSendScreen), findsOneWidget);
   });
 
   testWidgets('recipient step lets a hardware account continue with TEX', (

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:zcash_wallet/src/features/address_book/providers/address_book_pr
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
 import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
 import 'package:zcash_wallet/src/features/send/screens/send_screen.dart';
+import 'package:zcash_wallet/src/features/send/services/send_proving_key_warmup.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
@@ -38,6 +39,33 @@ void main() {
   });
 
   tearDownAll(RustLib.dispose);
+
+  testWidgets('starts Orchard proving-key warmup when send loads', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    var calls = 0;
+
+    await tester.pumpWidget(_sendHarness(warmProvingKey: () => calls++));
+    await tester.pumpAndSettle();
+
+    expect(calls, 1);
+    expect(find.byType(SendScreen), findsOneWidget);
+  });
+
+  testWidgets('keeps rendering if Orchard warmup cannot start', (tester) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _sendHarness(
+        warmProvingKey: () => throw StateError('warmup unavailable'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SendScreen), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets('uses shell window backing behind the send sidebar and pane', (
     tester,
@@ -1150,6 +1178,7 @@ Widget _sendHarness({
   IronwoodHomeMigrationCtaState migrationCta =
       const IronwoodHomeMigrationCtaState.hidden(),
   _FakeSyncNotifier? syncNotifier,
+  void Function()? warmProvingKey,
 }) {
   final router = GoRouter(
     initialLocation: '/send',
@@ -1166,6 +1195,7 @@ Widget _sendHarness({
     overrides: [
       appBootstrapProvider.overrideWithValue(bootstrap ?? _bootstrap),
       sendWalletDbPathProvider.overrideWithValue(() async => '/tmp/test.db'),
+      sendProvingKeyWarmupProvider.overrideWithValue(warmProvingKey ?? () {}),
       ironwoodHomeMigrationCtaProvider.overrideWithValue(
         AsyncValue.data(migrationCta),
       ),


### PR DESCRIPTION
## Summary

- warm the post-NU6.3 Orchard proving key in a background worker when desktop or mobile send UI loads
- share the `zakura-primitives` transaction-builder cache with the Keystone PCZT path
- keep warm-up idempotent and non-fatal, with normal inline key construction as the fallback
- expose the warm-up through generated Flutter Rust Bridge bindings and cover both send form factors

## Motivation / Why

The first Orchard proof currently pays proving-key construction latency after the user confirms a send. Starting that process when the send screen opens overlaps the expensive work with address and amount entry without changing transaction correctness, wallet state, network behavior, or key handling.

## Tests

Passed:
- `cd rust && cargo fmt --all -- --check && cargo test`
- `fvm dart format --output=none --set-exit-if-changed <changed Dart files>`
- `fvm flutter analyze`
- `fvm flutter test`
- `fvm flutter test test/features/send/mobile_send_screen_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`

Full mobile lane attempted:
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- Existing baseline failures remain in unrelated Widgetbook and mobile feature tests (18 failures); the focused mobile send suite passes.