### PR TITLE
Skip repeated voting precompute passes

### DIFF
--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -94,6 +94,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   Future<void> _operation = Future.value();
   final String _roundId;
   final Map<String, Future<void>> _snapshotBundlePrecomputes = {};
+  final Set<String> _completedSnapshotBundlePrecomputes = {};
   final Map<String, Future<List<int>>> _hotkeyEnsures = {};
   Timer? _shareTrackingTimer;
   Future<void>? _shareTrackingPass;
@@ -178,6 +179,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       _isDisposed = true;
       _advanceSessionGeneration();
       _snapshotBundlePrecomputes.clear();
+      _completedSnapshotBundlePrecomputes.clear();
       _hotkeyEnsures.clear();
       _shareTrackingTimer?.cancel();
       _releaseAutomaticShareTracking();
@@ -263,6 +265,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     _sessionIsHardwareAccount = null;
     _currentContext = null;
     _snapshotBundlePrecomputes.clear();
+    _completedSnapshotBundlePrecomputes.clear();
     _hotkeyEnsures.clear();
     _shareTrackingTimer?.cancel();
     if (!hadSessionAccount || _isDisposed) return;
@@ -341,8 +344,18 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     final key = _snapshotBundlePrecomputeKey(accountUuid);
     final existing = _snapshotBundlePrecomputes[key];
     if (existing != null) return existing;
+    if (_completedSnapshotBundlePrecomputes.contains(key)) {
+      debugPrint(
+        '[zcash] Voting: snapshot bundle precompute skipped '
+        'round=$_roundId reason=already-completed',
+      );
+      return Future<void>.value();
+    }
 
-    final precompute = _runSnapshotBundlePrecomputeForAccount(accountUuid);
+    final precompute = _runSnapshotBundlePrecomputeForAccount(
+      accountUuid,
+      precomputeKey: key,
+    );
     _snapshotBundlePrecomputes[key] = precompute;
     void removeIfCurrent() {
       if (identical(_snapshotBundlePrecomputes[key], precompute)) {
@@ -360,8 +373,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   }
 
   Future<void> _runSnapshotBundlePrecomputeForAccount(
-    String accountUuid,
-  ) async {
+    String accountUuid, {
+    required String precomputeKey,
+  }) async {
     final context = await _loadContext(_roundId);
     if (!_isCurrentPrecomputeContext(context, accountUuid)) return;
     final current = state.value;
@@ -392,10 +406,13 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     final pirEndpoint = await _resolvePirEndpoint(context);
     if (!_isCurrentPrecomputeContext(context, accountUuid)) return;
     if (pirEndpoint == null) return;
-    await _runSnapshotBundlePrecompute(
+    final completed = await _runSnapshotBundlePrecompute(
       context: context,
       pirEndpoint: pirEndpoint,
     );
+    if (completed && _isCurrentPrecomputeContext(context, accountUuid)) {
+      _completedSnapshotBundlePrecomputes.add(precomputeKey);
+    }
   }
 
   Future<void> delegatePendingBundles({String? mnemonic}) {
@@ -3590,7 +3607,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     }
   }
 
-  Future<void> _runSnapshotBundlePrecompute({
+  Future<bool> _runSnapshotBundlePrecompute({
     required _VotingSessionContext context,
     required Uri pirEndpoint,
   }) async {
@@ -3620,7 +3637,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         'cached=$cached fetched=$fetched '
         'elapsed=${formatElapsedSeconds(timer.elapsed)}',
       );
-      await _runBackgroundDelegationProofPrecompute(
+      return await _runBackgroundDelegationProofPrecompute(
         context: context,
         pirEndpoint: pirEndpoint,
         bundleCount: result.bundleCount,
@@ -3632,10 +3649,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         'elapsed=${formatElapsedSeconds(timer.elapsed)} error=$e '
         'reason=cache-miss',
       );
+      return false;
     }
   }
 
-  Future<void> _runBackgroundDelegationProofPrecompute({
+  Future<bool> _runBackgroundDelegationProofPrecompute({
     required _VotingSessionContext context,
     required Uri pirEndpoint,
     required int bundleCount,
@@ -3643,8 +3661,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     // Keystone must retain the original PCZT bytes for its QR signing request.
     // The software path can persist ZKP1 now and reconstruct its signed payload
     // from the stored setup fields later without retaining those bytes in Dart.
-    if (context.isHardwareAccount || bundleCount == 0) return;
-    if (!_isCurrentPrecomputeContext(context, context.accountUuid)) return;
+    if (context.isHardwareAccount || bundleCount == 0) return true;
+    if (!_isCurrentPrecomputeContext(context, context.accountUuid)) {
+      return false;
+    }
 
     final rust = ref.read(votingRustApiProvider);
     late final List<int> storedHotkeySecret;
@@ -3655,12 +3675,14 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         '[zcash] Voting: background delegation proof skipped '
         'round=${context.round.roundId} reason=hotkey-unavailable error=$e',
       );
-      return;
+      return false;
     }
-    if (!_isCurrentPrecomputeContext(context, context.accountUuid)) return;
+    if (!_isCurrentPrecomputeContext(context, context.accountUuid)) {
+      return false;
+    }
 
     final current = state.value;
-    if (current == null) return;
+    if (current == null) return false;
     final pirServerUrls = List<String>.from(
       _delegationPirTransportUrls(current),
     );
@@ -3668,8 +3690,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       pirServerUrls.add(_transportUrl(pirEndpoint));
     }
 
+    var allProofsReady = true;
     for (var bundleIndex = 0; bundleIndex < bundleCount; bundleIndex++) {
-      if (!_isCurrentPrecomputeContext(context, context.accountUuid)) return;
+      if (!_isCurrentPrecomputeContext(context, context.accountUuid)) {
+        return false;
+      }
       final timer = Stopwatch()..start();
       debugPrint(
         '[zcash] Voting: background delegation proof start '
@@ -3695,8 +3720,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           'elapsed=${formatElapsedSeconds(timer.elapsed)} error=$e '
           'reason=foreground-fallback',
         );
+        allProofsReady = false;
       }
     }
+    return allProofsReady;
   }
 
   Future<void> _awaitSnapshotBundlePrecomputeIfRunning(
@@ -3734,7 +3761,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   }
 
   String _snapshotBundlePrecomputeKey(String accountUuid) {
-    return '$_roundId|$accountUuid';
+    return '$_roundId|$accountUuid|$_sessionGeneration';
   }
 
   static void _logPirSnapshotMismatch({

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -8615,6 +8615,59 @@ void main() {
     ]);
   });
 
+  test('completed snapshot bundle precompute is not repeated', () async {
+    final rust = FakeVotingRustApi();
+    final hotkeyStore = FakeVotingHotkeyStore(null);
+    final container = _sessionContainer(rust: rust, hotkeyStore: hotkeyStore);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final notifier = container.read(votingSessionProvider(kRoundId).notifier);
+    await notifier.refreshEligibleWeight();
+
+    await notifier.precomputeSnapshotBundles(accountUuid: 'account-1');
+    await notifier.precomputeSnapshotBundles(accountUuid: 'account-1');
+
+    expect(rust.snapshotBundlePrecomputeAccounts, ['account-1']);
+    expect(rust.backgroundDelegationProofCalls, [0]);
+  });
+
+  test('failed snapshot bundle precompute remains retryable', () async {
+    final rust = FakeVotingRustApi(failPrecompute: true);
+    final container = _sessionContainer(rust: rust);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final notifier = container.read(votingSessionProvider(kRoundId).notifier);
+    await notifier.refreshEligibleWeight();
+
+    await notifier.precomputeSnapshotBundles(accountUuid: 'account-1');
+    await notifier.precomputeSnapshotBundles(accountUuid: 'account-1');
+
+    expect(rust.snapshotBundlePrecomputeAccounts, ['account-1', 'account-1']);
+    expect(rust.backgroundDelegationProofCalls, isEmpty);
+  });
+
+  test('failed background ZKP1 remains retryable', () async {
+    final rust = FakeVotingRustApi(
+      backgroundDelegationProofErrorsByBundle: {
+        0: StateError('background proof failed'),
+      },
+    );
+    final container = _sessionContainer(rust: rust);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    final notifier = container.read(votingSessionProvider(kRoundId).notifier);
+    await notifier.refreshEligibleWeight();
+
+    await notifier.precomputeSnapshotBundles(accountUuid: 'account-1');
+    await notifier.precomputeSnapshotBundles(accountUuid: 'account-1');
+
+    expect(rust.snapshotBundlePrecomputeAccounts, ['account-1', 'account-1']);
+    expect(rust.backgroundDelegationProofCalls, [0, 0]);
+  });
+
   test('snapshot bundle precompute skips after account switch', () async {
     final rust = FakeVotingRustApi();
     final activeAccountProvider =


### PR DESCRIPTION
Before, moving from proposal details to review could invoke snapshot and ZKP1 precompute again after the first pass completed. The second pass was safe but redundant.

After, the voting session remembers a fully completed precompute and skips later triggers for that round, account, and session. Failed PIR or ZKP1 passes remain retryable. Provider regression tests cover both paths, and the real regtest voting E2E showed one generated ZKP1 followed by an already-completed skip on review.