### PR TITLE
Drain voting precompute before wallet reset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,6 +276,9 @@ the Accounts UI treats it as a full wallet reset, clearing the wallet DB, secure
 storage, active account state, and routing back to onboarding. Dart
 `AccountNotifier.removeAccount` and Rust `delete_account` still validate the
 target account exists before removing account-scoped wallet rows.
+Voting background work that can write account state or secure storage must
+register with the destructive-operation drain before its first asynchronous
+step, and account deletion/reset must await that work before clearing data.
 
 **Account identification**: `AccountUuid` (UUID string like `"550e8400-e29b-41d4-a716-446655440000"`). Passed as `String` between Dart and Rust via `Uuid::parse_str()` / `Uuid::to_string()`.
 

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -195,15 +195,20 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       );
     }
 
-    await runWithSyncPausedForAccountMutation(ref, () async {
-      logPauseComplete();
-      final mutationWatch = Stopwatch()..start();
-      await accountNotifier.removeAccount(uuid);
-      log(
-        'removeAccountFlow: account mutation complete in '
-        '${mutationWatch.elapsedMilliseconds}ms uuid=$uuid',
-      );
-    }, onSyncPaused: logPauseComplete);
+    await runWithSyncPausedForAccountMutation(
+      ref,
+      () async {
+        logPauseComplete();
+        final mutationWatch = Stopwatch()..start();
+        await accountNotifier.removeAccount(uuid);
+        log(
+          'removeAccountFlow: account mutation complete in '
+          '${mutationWatch.elapsedMilliseconds}ms uuid=$uuid',
+        );
+      },
+      onSyncPaused: logPauseComplete,
+      quiesceVotingWork: true,
+    );
     if (!mounted) return;
     _closeModal();
     final refreshWatch = Stopwatch()..start();

--- a/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
+++ b/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
@@ -478,6 +478,7 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
         await runWithSyncPausedForAccountMutation(
           ref,
           () => accountNotifier.removeAccount(account.uuid),
+          quiesceVotingWork: true,
         );
         final activeAccountAfterRemoval = ref
             .read(accountProvider)

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -532,11 +532,11 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   /// Remove an account from the wallet.
   ///
   /// Destructive account changes are blocked while any vote submission is in
-  /// progress. Once removal is allowed, in-flight helper-share tracking is
+  /// progress. Once removal is allowed, in-flight voting background work is
   /// quiesced and drained so it cannot keep reading or writing this account's
-  /// voting records. Process-local voting state is then cleared before the
-  /// wallet delete. Durable voting rows, hotkeys, and other account-scoped
-  /// sidecars are cleared after the wallet account is deleted.
+  /// records or secure storage. Process-local voting state is then cleared
+  /// before the wallet delete. Durable voting rows, hotkeys, and other
+  /// account-scoped sidecars are cleared after the wallet account is deleted.
   Future<void> removeAccount(String uuid) async {
     ref.read(votingSubmissionGuardProvider.notifier).throwIfActive();
     final prev = state.value ?? const AccountState();
@@ -683,10 +683,10 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
 
   /// Delete all wallet data (DB + keychain). Caller must stop sync first.
   ///
-  /// In-flight helper-share tracking is quiesced and drained first so it
-  /// cannot keep reading or writing voting records during the wipe. This also
-  /// clears voting state held in this process for every account before the
-  /// wallet DB and voting sidecar DB are deleted.
+  /// In-flight voting background work is quiesced and drained first so it
+  /// cannot keep reading or writing voting records or secure storage during
+  /// the wipe. This also clears voting state held in this process for every
+  /// account before the wallet DB and voting sidecar DB are deleted.
   ///
   /// Migration work must first stop without deleting its credential. After
   /// that fail-closed preflight, the wipe is best-effort: deletion steps remain

--- a/lib/src/providers/voting/voting_pir_warmup_provider.dart
+++ b/lib/src/providers/voting/voting_pir_warmup_provider.dart
@@ -9,6 +9,7 @@ import '../../services/voting/resolved_voting_config_extensions.dart';
 import 'voting_config_provider.dart';
 import 'voting_round_visibility_provider.dart';
 import 'voting_service_providers.dart';
+import 'voting_share_tracking_registry_provider.dart';
 import 'voting_state.dart';
 
 /// Upper bound for waiting on wallet scan readiness before giving up on one
@@ -91,12 +92,23 @@ class VotingPirWarmupCoordinator {
     final inFlight = _passInFlight;
     if (inFlight != null) return inFlight;
 
-    final pass = _startPass();
+    final releaseBackgroundWork = _ref
+        .read(votingShareTrackingRegistryProvider)
+        .beginBackgroundWork();
+    if (releaseBackgroundWork == null) {
+      debugPrint(
+        '[zcash] Voting: PIR cache warmup skipped '
+        'reason=wallet-mutation-in-progress',
+      );
+      return Future.value();
+    }
+
+    final pass = _startPass(releaseBackgroundWork);
     _passInFlight = pass;
     return pass;
   }
 
-  Future<void> _startPass() async {
+  Future<void> _startPass(VoidCallback releaseBackgroundWork) async {
     try {
       final accountUuid = await _ref
           .read(votingActiveAccountUuidProvider)
@@ -122,6 +134,7 @@ class VotingPirWarmupCoordinator {
       debugPrint('[zcash] Voting: PIR cache warmup pass failed: $error');
     } finally {
       _passInFlight = null;
+      releaseBackgroundWork();
     }
   }
 

--- a/lib/src/providers/voting/voting_pir_warmup_provider.dart
+++ b/lib/src/providers/voting/voting_pir_warmup_provider.dart
@@ -236,14 +236,18 @@ class VotingPirWarmupCoordinator {
 
       final ready = await _waitForWalletScannedToSnapshot(
         dbPath: dbPath,
+        accountUuid: accountUuid,
         network: endpoint.networkName,
         snapshotHeight: round.snapshotHeight,
       );
       if (!ready) {
+        final reason = _isWalletMutationInProgress(accountUuid)
+            ? 'wallet-mutation-in-progress'
+            : 'wallet-sync-timeout';
         debugPrint(
           '[zcash] Voting: PIR cache warmup skipped '
           'round=${round.roundId} snapshot=${round.snapshotHeight} '
-          'reason=wallet-sync-timeout',
+          'reason=$reason',
         );
         return false;
       }
@@ -251,6 +255,13 @@ class VotingPirWarmupCoordinator {
       // The account may have switched while waiting; warming the old
       // account's sidecar would be wasted (though harmless) work.
       final activeNow = await _ref.read(votingActiveAccountUuidProvider).call();
+      if (_isWalletMutationInProgress(accountUuid)) {
+        debugPrint(
+          '[zcash] Voting: PIR cache warmup skipped '
+          'round=${round.roundId} reason=wallet-mutation-in-progress',
+        );
+        return false;
+      }
       if (activeNow != accountUuid) {
         debugPrint(
           '[zcash] Voting: PIR cache warmup skipped '
@@ -314,6 +325,7 @@ class VotingPirWarmupCoordinator {
 
   Future<bool> _waitForWalletScannedToSnapshot({
     required String dbPath,
+    required String accountUuid,
     required String network,
     required int snapshotHeight,
   }) async {
@@ -322,14 +334,22 @@ class VotingPirWarmupCoordinator {
     final maxWait = _ref.read(votingPirWarmupSyncMaxWaitProvider);
     final deadline = Stopwatch()..start();
     while (true) {
+      if (_isWalletMutationInProgress(accountUuid)) return false;
       final readiness = await checker.check(
         dbPath: dbPath,
         network: network,
         snapshotHeight: snapshotHeight,
       );
+      if (_isWalletMutationInProgress(accountUuid)) return false;
       if (readiness.isReady) return true;
       if (deadline.elapsed >= maxWait) return false;
       await Future<void>.delayed(pollInterval);
     }
+  }
+
+  bool _isWalletMutationInProgress(String accountUuid) {
+    return _ref
+        .read(votingShareTrackingRegistryProvider)
+        .isQuiesced(accountUuid);
   }
 }

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -423,6 +423,30 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     String accountUuid, {
     required String precomputeKey,
   }) async {
+    final releaseBackgroundWork = ref
+        .read(votingShareTrackingRegistryProvider)
+        .beginBackgroundWork(accountUuid: accountUuid);
+    if (releaseBackgroundWork == null) {
+      debugPrint(
+        '[zcash] Voting: snapshot bundle precompute skipped '
+        'round=$_roundId reason=wallet-mutation-in-progress',
+      );
+      return;
+    }
+    try {
+      await _runRegisteredSnapshotBundlePrecomputeForAccount(
+        accountUuid,
+        precomputeKey: precomputeKey,
+      );
+    } finally {
+      releaseBackgroundWork();
+    }
+  }
+
+  Future<void> _runRegisteredSnapshotBundlePrecomputeForAccount(
+    String accountUuid, {
+    required String precomputeKey,
+  }) async {
     final context = await _loadContext(_roundId);
     if (!_isCurrentPrecomputeContext(context, accountUuid)) return;
     final current = state.value;

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -458,8 +458,17 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       return;
     }
     try {
-      await _waitUntilWalletReadyForVoting(context);
+      await _waitUntilWalletReadyForVoting(
+        context,
+        stopIfVotingBackgroundWorkQuiesced: true,
+      );
     } on _StaleVotingSessionAction {
+      return;
+    } on _VotingBackgroundWorkQuiesced {
+      debugPrint(
+        '[zcash] Voting: snapshot bundle precompute skipped '
+        'round=${context.round.roundId} reason=wallet-mutation-in-progress',
+      );
       return;
     } on _VotingWalletSyncTimeout catch (e) {
       _setWalletSyncReadinessState(
@@ -4063,13 +4072,24 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   }
 
   Future<void> _waitUntilWalletReadyForVoting(
-    _VotingSessionContext context,
-  ) async {
+    _VotingSessionContext context, {
+    bool stopIfVotingBackgroundWorkQuiesced = false,
+  }) async {
+    void throwIfBackgroundWorkQuiesced() {
+      if (stopIfVotingBackgroundWorkQuiesced &&
+          ref
+              .read(votingShareTrackingRegistryProvider)
+              .isQuiesced(context.accountUuid)) {
+        throw const _VotingBackgroundWorkQuiesced();
+      }
+    }
+
     var loggedWait = false;
     final maxWait = ref.read(votingWalletSyncMaxWaitProvider);
     final waitTimer = Stopwatch()..start();
     final sessionInvalidated = _sessionInvalidated.future;
     while (true) {
+      throwIfBackgroundWorkQuiesced();
       _throwIfContextStale(context, 'wallet-sync-wait');
       final readiness = await ref
           .read(votingWalletSyncReadinessCheckerProvider)
@@ -4078,6 +4098,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             network: context.network,
             snapshotHeight: context.round.snapshotHeight,
           );
+      throwIfBackgroundWorkQuiesced();
       _throwIfContextStale(context, 'wallet-sync-readiness');
       if (readiness.isReady) {
         _setWalletSyncReadinessState(
@@ -4916,6 +4937,10 @@ class _VotingSessionContext {
 
 class _StaleVotingSessionAction implements Exception {
   const _StaleVotingSessionAction();
+}
+
+class _VotingBackgroundWorkQuiesced implements Exception {
+  const _VotingBackgroundWorkQuiesced();
 }
 
 class _VotingWalletSyncTimeout implements Exception {

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -464,7 +464,15 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       );
     } on _StaleVotingSessionAction {
       return;
-    } on _VotingBackgroundWorkQuiesced {
+    } on _VotingBackgroundWorkQuiesced catch (e) {
+      final readiness = e.readiness;
+      if (readiness != null) {
+        _setWalletSyncReadinessState(
+          context: context,
+          readiness: readiness,
+          waiting: false,
+        );
+      }
       debugPrint(
         '[zcash] Voting: snapshot bundle precompute skipped '
         'round=${context.round.roundId} reason=wallet-mutation-in-progress',
@@ -4075,12 +4083,13 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     _VotingSessionContext context, {
     bool stopIfVotingBackgroundWorkQuiesced = false,
   }) async {
+    VotingWalletSyncReadiness? lastReadiness;
     void throwIfBackgroundWorkQuiesced() {
       if (stopIfVotingBackgroundWorkQuiesced &&
           ref
               .read(votingShareTrackingRegistryProvider)
               .isQuiesced(context.accountUuid)) {
-        throw const _VotingBackgroundWorkQuiesced();
+        throw _VotingBackgroundWorkQuiesced(readiness: lastReadiness);
       }
     }
 
@@ -4098,6 +4107,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             network: context.network,
             snapshotHeight: context.round.snapshotHeight,
           );
+      lastReadiness = readiness;
       throwIfBackgroundWorkQuiesced();
       _throwIfContextStale(context, 'wallet-sync-readiness');
       if (readiness.isReady) {
@@ -4940,7 +4950,9 @@ class _StaleVotingSessionAction implements Exception {
 }
 
 class _VotingBackgroundWorkQuiesced implements Exception {
-  const _VotingBackgroundWorkQuiesced();
+  const _VotingBackgroundWorkQuiesced({this.readiness});
+
+  final VotingWalletSyncReadiness? readiness;
 }
 
 class _VotingWalletSyncTimeout implements Exception {

--- a/lib/src/providers/voting/voting_share_tracking_registry_provider.dart
+++ b/lib/src/providers/voting/voting_share_tracking_registry_provider.dart
@@ -10,25 +10,35 @@ typedef VotingShareTrackingDrain = Future<void> Function();
 class VotingShareTrackingRegistry {
   final Map<VotingSessionKey, _VotingShareTrackingRegistration> _registrations =
       {};
-  final Set<Completer<void>> _discoveries = {};
+  final Map<Completer<void>, String?> _backgroundWork = {};
   final Set<VoidCallback> _restoreRequestListeners = {};
   final Map<String, int> _accountQuiescenceDepths = {};
   int _globalQuiescenceDepth = 0;
+
+  /// Starts drainable voting work before its first asynchronous operation.
+  ///
+  /// A null account scope may inspect every account. Account delete/reset block
+  /// matching work and await the returned lease before mutating wallet state.
+  VoidCallback? beginBackgroundWork({String? accountUuid}) {
+    final accountIsQuiesced = accountUuid == null
+        ? _accountQuiescenceDepths.isNotEmpty
+        : (_accountQuiescenceDepths[accountUuid] ?? 0) > 0;
+    if (_globalQuiescenceDepth > 0 || accountIsQuiesced) return null;
+
+    final completion = Completer<void>();
+    _backgroundWork[completion] = accountUuid;
+    return () {
+      if (!_backgroundWork.containsKey(completion)) return;
+      _backgroundWork.remove(completion);
+      completion.complete();
+    };
+  }
 
   /// Starts discovery before its first asynchronous operation.
   ///
   /// Destructive wallet operations block new discovery and await the returned
   /// lease, so sidecar reads cannot outlive the state they are inspecting.
-  VoidCallback? beginDiscovery() {
-    if (_globalQuiescenceDepth > 0 || _accountQuiescenceDepths.isNotEmpty) {
-      return null;
-    }
-    final completion = Completer<void>();
-    _discoveries.add(completion);
-    return () {
-      if (_discoveries.remove(completion)) completion.complete();
-    };
-  }
+  VoidCallback? beginDiscovery() => beginBackgroundWork();
 
   void addRestoreRequestListener(VoidCallback listener) {
     _restoreRequestListeners.add(listener);
@@ -68,7 +78,7 @@ class VotingShareTrackingRegistry {
         (_accountQuiescenceDepths[accountUuid] ?? 0) > 0;
   }
 
-  /// Blocks matching discovery until paired with [resume].
+  /// Blocks matching background work until paired with [resume].
   ///
   /// Global calls are reference counted so overlapping owners cannot release
   /// each other's destructive boundary.
@@ -86,12 +96,16 @@ class VotingShareTrackingRegistry {
       for (final entry in _registrations.entries)
         if (accountUuid == null || entry.key.accountUuid == accountUuid) entry,
     ];
-    final discoveries = [
-      for (final completion in _discoveries) completion.future,
+    final backgroundWork = [
+      for (final entry in _backgroundWork.entries)
+        if (accountUuid == null ||
+            entry.value == null ||
+            entry.value == accountUuid)
+          entry.key.future,
     ];
     try {
       await Future.wait([
-        ...discoveries,
+        ...backgroundWork,
         ...sessions.map((entry) => entry.value.stopAndDrain()),
       ]);
     } finally {

--- a/lib/src/providers/voting/voting_share_tracking_restorer_provider.dart
+++ b/lib/src/providers/voting/voting_share_tracking_restorer_provider.dart
@@ -49,9 +49,22 @@ class VotingShareTrackingRestorer {
   Future<void> restore() {
     final inFlight = _restoreInFlight;
     if (inFlight != null) return inFlight;
+
+    _cancelRetry();
+    if (_ref.read(appSecurityProvider).requiresUnlock) return Future.value();
+    final registry = _ref.read(votingShareTrackingRegistryProvider);
+    final releaseDiscovery = registry.beginDiscovery();
+    // A request rejected by quiescence is not active work. Recording its
+    // already-completed future would swallow a request made just after resume.
+    if (releaseDiscovery == null) return Future.value();
+
     late final Future<void> restore;
-    restore = _restoreOnce().whenComplete(() {
-      if (identical(_restoreInFlight, restore)) _restoreInFlight = null;
+    restore = _restoreTracked(registry).whenComplete(() {
+      try {
+        releaseDiscovery();
+      } finally {
+        if (identical(_restoreInFlight, restore)) _restoreInFlight = null;
+      }
     });
     _restoreInFlight = restore;
     return restore;
@@ -85,19 +98,6 @@ class VotingShareTrackingRestorer {
     }
     await _restoreInFlight;
     await restore();
-  }
-
-  Future<void> _restoreOnce() async {
-    _cancelRetry();
-    if (_ref.read(appSecurityProvider).requiresUnlock) return;
-    final registry = _ref.read(votingShareTrackingRegistryProvider);
-    final releaseDiscovery = registry.beginDiscovery();
-    if (releaseDiscovery == null) return;
-    try {
-      await _restoreTracked(registry);
-    } finally {
-      releaseDiscovery();
-    }
   }
 
   Future<void> _restoreTracked(VotingShareTrackingRegistry registry) async {

--- a/lib/src/providers/wallet_mutation_guard.dart
+++ b/lib/src/providers/wallet_mutation_guard.dart
@@ -6,7 +6,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../features/migration/services/ironwood_migration_background_credential_store.dart';
 import 'account_provider.dart';
 import 'sync_provider.dart';
+import 'voting/voting_share_tracking_registry_provider.dart';
 
+/// Pauses foreground sync around a wallet mutation.
+///
+/// Destructive callers set [quiesceVotingWork] so voting work is drained before
+/// the sync pause. This prevents a waiting precompute from queuing a newer sync
+/// between the pause and the database mutation.
 Future<T> runWithSyncPausedForAccountMutation<T>(
   WidgetRef ref,
   Future<T> Function() action, {
@@ -16,6 +22,7 @@ Future<T> runWithSyncPausedForAccountMutation<T>(
   bool resumeAfterFailure = true,
   bool Function(Object error, StackTrace stackTrace)? shouldResumeAfterFailure,
   bool quiesceMigrationWork = true,
+  bool quiesceVotingWork = false,
   IronwoodMigrationBackgroundLifecycle? migrationLifecycle,
 }) async {
   final hasExistingAccounts =
@@ -28,6 +35,11 @@ Future<T> runWithSyncPausedForAccountMutation<T>(
       migrationLifecycle ?? IronwoodMigrationBackgroundLifecycle.instance;
   var migrationWorkQuiesced = false;
   var migrationQuiesceAttempted = false;
+  final votingRegistry = quiesceVotingWork
+      ? ref.read(votingShareTrackingRegistryProvider)
+      : null;
+  var votingQuiesceAttempted = false;
+  var shouldRequestVotingRestore = resumeAfterMutation;
 
   try {
     // Migration preparation has its own native sync/advance loop. Stop that
@@ -39,6 +51,11 @@ Future<T> runWithSyncPausedForAccountMutation<T>(
       migrationQuiesceAttempted = true;
       await lifecycle.quiesce();
       migrationWorkQuiesced = true;
+    }
+
+    if (votingRegistry != null) {
+      votingQuiesceAttempted = true;
+      await votingRegistry.quiesceAndDrain();
     }
 
     if (!hasExistingAccounts && !syncNotifier.needsPauseForWalletMutation()) {
@@ -80,7 +97,24 @@ Future<T> runWithSyncPausedForAccountMutation<T>(
         syncNotifier.resumeAfterWalletMutation(pause);
       }
     }
+  } catch (error, stackTrace) {
+    shouldRequestVotingRestore =
+        shouldResumeAfterFailure?.call(error, stackTrace) ?? resumeAfterFailure;
+    rethrow;
   } finally {
+    if (votingQuiesceAttempted) {
+      votingRegistry!.resume();
+      if (shouldRequestVotingRestore) {
+        try {
+          votingRegistry.requestRestore();
+        } catch (error, stackTrace) {
+          log(
+            'Failed to restore voting background work after account mutation: '
+            '$error\n$stackTrace',
+          );
+        }
+      }
+    }
     if (migrationQuiesceAttempted) {
       try {
         await lifecycle.resumeAfterMutation();
@@ -121,6 +155,7 @@ Future<void> runWithSyncPausedForWalletReset(
     resumeAfterMutation: false,
     shouldResumeAfterFailure: (error, stackTrace) =>
         error is! WalletResetException || !error.dbDeleted,
+    quiesceVotingWork: true,
     migrationLifecycle: migrationLifecycle,
   );
 }

--- a/test/features/settings/settings_uninstall_screen_test.dart
+++ b/test/features/settings/settings_uninstall_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:zcash_wallet/src/features/swap/providers/swap_activity_store.dar
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_share_tracking_restorer_provider.dart';
 
 const _validPassword = 'Correct123!';
 
@@ -58,6 +59,10 @@ Future<void> _runUninstallFlow(
           accountProvider.overrideWith(() => accountNotifier),
           appSecurityProvider.overrideWith(_TestAppSecurityNotifier.new),
           syncProvider.overrideWith(_TestSyncNotifier.new),
+          // The mutation guard tests cover draining pending voting work.
+          votingShareTrackingRestorerProvider.overrideWith(
+            (ref) => VotingShareTrackingRestorer(ref),
+          ),
           swapPendingIntentCountProvider.overrideWith(
             (ref, accountUuid) async => 0,
           ),

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -9634,6 +9634,48 @@ void main() {
     },
   );
 
+  test('background PIR cache warmup drains and stays blocked during account '
+      'mutation', () async {
+    final rust = FakeVotingRustApi()
+      ..warmPirProofCacheGate = Completer()
+      ..warmPirProofCacheError = StateError('expected warmup failure');
+    final container = _sessionContainer(
+      rust: rust,
+      http: FakeVotingHttpClient(responses: warmupHttpResponses()),
+    );
+    addTearDown(container.dispose);
+
+    final coordinator = container.read(votingPirWarmupProvider);
+    final warmup = coordinator.maybeWarmActiveRounds();
+    await rust.warmPirProofCacheStarted.future;
+
+    final registry = container.read(votingShareTrackingRegistryProvider);
+    addTearDown(() => registry.resume(accountUuid: 'account-1'));
+    var drained = false;
+    final drain = registry
+        .quiesceAndDrain(accountUuid: 'account-1')
+        .then<void>((_) {
+          drained = true;
+        });
+    await Future<void>.delayed(Duration.zero);
+    expect(drained, isFalse);
+
+    rust.warmPirProofCacheGate!.complete();
+    await Future.wait([warmup, drain]);
+    expect(drained, isTrue);
+    expect(rust.warmPirProofCacheSnapshotHeights, [123]);
+
+    // The failed pass is retryable, but no retry may start while the
+    // destructive account boundary still owns quiescence.
+    await coordinator.maybeWarmActiveRounds();
+    expect(rust.warmPirProofCacheSnapshotHeights, [123]);
+
+    registry.resume(accountUuid: 'account-1');
+    rust.warmPirProofCacheError = null;
+    await coordinator.maybeWarmActiveRounds();
+    expect(rust.warmPirProofCacheSnapshotHeights, [123, 123]);
+  });
+
   test(
     'background PIR cache warmup skips a second pass within the min interval',
     () async {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -8384,6 +8384,21 @@ void main() {
     releaseDiscovery!();
   });
 
+  test('account quiescence blocks matching background work only', () async {
+    final registry = VotingShareTrackingRegistry();
+
+    await registry.quiesceAndDrain(accountUuid: 'account-1');
+
+    expect(registry.beginBackgroundWork(accountUuid: 'account-1'), isNull);
+    final otherAccountWork = registry.beginBackgroundWork(
+      accountUuid: 'account-2',
+    );
+    expect(otherAccountWork, isNotNull);
+
+    otherAccountWork!();
+    registry.resume(accountUuid: 'account-1');
+  });
+
   test('repeated lifecycle pause acquires one quiescence owner', () async {
     final container = _sessionContainer(
       pendingShareRoundLoader:
@@ -9091,6 +9106,49 @@ void main() {
     backgroundProofGate.complete();
     await precomputeFuture;
   });
+
+  test(
+    'destructive drain waits for precompute before secure hotkey wipe',
+    () async {
+      final hotkeyGenerationGate = Completer<void>();
+      final rust = FakeVotingRustApi(
+        hotkeyGenerationGate: hotkeyGenerationGate,
+      );
+      final hotkeyStore = FakeVotingHotkeyStore(null);
+      final container = _sessionContainer(rust: rust, hotkeyStore: hotkeyStore);
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final notifier = container.read(votingSessionProvider(kRoundId).notifier);
+      await notifier.refreshEligibleWeight();
+      final precompute = notifier.precomputeSnapshotBundles(
+        accountUuid: 'account-1',
+      );
+      await rust.hotkeyGenerationStarted.future;
+
+      final registry = container.read(votingShareTrackingRegistryProvider);
+      var secureStorageWiped = false;
+      final drainAndWipe = registry.quiesceAndDrain().then((_) {
+        hotkeyStore.hotkey = null;
+        secureStorageWiped = true;
+      });
+
+      try {
+        await Future<void>.delayed(Duration.zero);
+        expect(secureStorageWiped, isFalse);
+      } finally {
+        if (!hotkeyGenerationGate.isCompleted) {
+          hotkeyGenerationGate.complete();
+        }
+        await Future.wait([precompute, drainAndWipe]);
+        registry.resume();
+      }
+
+      expect(rust.backgroundDelegationProofCalls, [0]);
+      expect(secureStorageWiped, isTrue);
+      expect(hotkeyStore.hotkey, isNull);
+    },
+  );
 
   test('prepareDelegation warms proving caches before bundle setup', () async {
     final rust = FakeVotingRustApi();

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -9150,6 +9150,58 @@ void main() {
     },
   );
 
+  test(
+    'destructive drain stops waiting precompute before it restarts sync',
+    () async {
+      final readiness = _MutableVotingWalletSyncReadinessChecker(ready: true);
+      final firstSyncStart = Completer<void>();
+      final syncStartDuringDrain = Completer<void>();
+      var drainStarted = false;
+      final rust = FakeVotingRustApi();
+      final container = _sessionContainer(
+        rust: rust,
+        walletSyncReadinessChecker: readiness,
+        walletSyncPollInterval: const Duration(milliseconds: 20),
+        walletSyncStarter: () {
+          if (!firstSyncStart.isCompleted) {
+            firstSyncStart.complete();
+          } else if (drainStarted && !syncStartDuringDrain.isCompleted) {
+            syncStartDuringDrain.complete();
+          }
+        },
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final notifier = container.read(votingSessionProvider(kRoundId).notifier);
+      await notifier.refreshEligibleWeight();
+      readiness.ready = false;
+      final precompute = notifier.precomputeSnapshotBundles(
+        accountUuid: 'account-1',
+      );
+      await firstSyncStart.future;
+
+      final registry = container.read(votingShareTrackingRegistryProvider);
+      drainStarted = true;
+      final drain = registry.quiesceAndDrain(accountUuid: 'account-1');
+
+      try {
+        final firstResult = await Future.any<String>([
+          drain.then((_) => 'drained'),
+          syncStartDuringDrain.future.then((_) => 'sync-restarted'),
+        ]);
+        expect(firstResult, 'drained');
+      } finally {
+        readiness.ready = true;
+        await Future.wait([precompute, drain]);
+        registry.resume(accountUuid: 'account-1');
+      }
+
+      expect(syncStartDuringDrain.isCompleted, isFalse);
+      expect(rust.snapshotBundlePrecomputeAccounts, isEmpty);
+    },
+  );
+
   test('prepareDelegation warms proving caches before bundle setup', () async {
     final rust = FakeVotingRustApi();
     final container = _sessionContainer(rust: rust);

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -9676,6 +9676,39 @@ void main() {
     expect(rust.warmPirProofCacheSnapshotHeights, [123, 123]);
   });
 
+  test('destructive drain stops PIR warmup waiting for wallet scan', () async {
+    final rust = FakeVotingRustApi();
+    final readiness = _QuiescenceGatedVotingWalletSyncReadinessChecker();
+    final container = _sessionContainer(
+      rust: rust,
+      http: FakeVotingHttpClient(responses: warmupHttpResponses()),
+      walletSyncReadinessChecker: readiness,
+    );
+    addTearDown(container.dispose);
+
+    final warmup = container
+        .read(votingPirWarmupProvider)
+        .maybeWarmActiveRounds();
+    await readiness.checkStarted.future;
+
+    final registry = container.read(votingShareTrackingRegistryProvider);
+    addTearDown(() => registry.resume(accountUuid: 'account-1'));
+    var drained = false;
+    final drain = registry.quiesceAndDrain(accountUuid: 'account-1').then<void>(
+      (_) {
+        drained = true;
+      },
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(drained, isFalse);
+
+    readiness.releaseCheck();
+    await Future.wait([warmup, drain]).timeout(const Duration(seconds: 1));
+
+    expect(drained, isTrue);
+    expect(rust.warmPirProofCacheSnapshotHeights, isEmpty);
+  });
+
   test(
     'background PIR cache warmup skips a second pass within the min interval',
     () async {
@@ -11460,6 +11493,31 @@ class _GatedVotingWalletSyncReadinessChecker
     if (!firstCheck.isCompleted) firstCheck.complete();
     return VotingWalletSyncReadiness(
       scannedHeight: _ready ? snapshotHeight : snapshotHeight - 1,
+      snapshotHeight: snapshotHeight,
+      chainTipHeight: snapshotHeight,
+    );
+  }
+}
+
+class _QuiescenceGatedVotingWalletSyncReadinessChecker
+    implements VotingWalletSyncReadinessChecker {
+  final checkStarted = Completer<void>();
+  final _releaseCheck = Completer<void>();
+
+  void releaseCheck() {
+    if (!_releaseCheck.isCompleted) _releaseCheck.complete();
+  }
+
+  @override
+  Future<VotingWalletSyncReadiness> check({
+    required String dbPath,
+    required String network,
+    required int snapshotHeight,
+  }) async {
+    if (!checkStarted.isCompleted) checkStarted.complete();
+    await _releaseCheck.future;
+    return VotingWalletSyncReadiness(
+      scannedHeight: snapshotHeight - 1,
       snapshotHeight: snapshotHeight,
       chainTipHeight: snapshotHeight,
     );

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -9153,7 +9153,7 @@ void main() {
   test(
     'destructive drain stops waiting precompute before it restarts sync',
     () async {
-      final readiness = _MutableVotingWalletSyncReadinessChecker(ready: true);
+      final readiness = _VotingWalletSyncDrainRaceReadinessChecker();
       final firstSyncStart = Completer<void>();
       final syncStartDuringDrain = Completer<void>();
       var drainStarted = false;
@@ -9175,15 +9175,16 @@ void main() {
       await container.read(votingSessionProvider(kRoundId).future);
       final notifier = container.read(votingSessionProvider(kRoundId).notifier);
       await notifier.refreshEligibleWeight();
-      readiness.ready = false;
       final precompute = notifier.precomputeSnapshotBundles(
         accountUuid: 'account-1',
       );
       await firstSyncStart.future;
+      await readiness.racedCheckStarted.future;
 
       final registry = container.read(votingShareTrackingRegistryProvider);
       drainStarted = true;
       final drain = registry.quiesceAndDrain(accountUuid: 'account-1');
+      readiness.releaseRacedCheck();
 
       try {
         final firstResult = await Future.any<String>([
@@ -9192,13 +9193,17 @@ void main() {
         ]);
         expect(firstResult, 'drained');
       } finally {
-        readiness.ready = true;
+        readiness.releaseRacedCheck();
         await Future.wait([precompute, drain]);
         registry.resume(accountUuid: 'account-1');
       }
 
       expect(syncStartDuringDrain.isCompleted, isFalse);
       expect(rust.snapshotBundlePrecomputeAccounts, isEmpty);
+      expect(
+        container.read(votingSessionProvider(kRoundId)).value!.phase,
+        VotingSessionPhase.idle,
+      );
     },
   );
 
@@ -11431,6 +11436,36 @@ class _MutableVotingWalletSyncReadinessChecker
     required String network,
     required int snapshotHeight,
   }) async {
+    return VotingWalletSyncReadiness(
+      scannedHeight: ready ? snapshotHeight : snapshotHeight - 1,
+      snapshotHeight: snapshotHeight,
+      chainTipHeight: snapshotHeight,
+    );
+  }
+}
+
+class _VotingWalletSyncDrainRaceReadinessChecker
+    implements VotingWalletSyncReadinessChecker {
+  final racedCheckStarted = Completer<void>();
+  final _releaseRacedCheck = Completer<void>();
+  var _calls = 0;
+
+  void releaseRacedCheck() {
+    if (!_releaseRacedCheck.isCompleted) _releaseRacedCheck.complete();
+  }
+
+  @override
+  Future<VotingWalletSyncReadiness> check({
+    required String dbPath,
+    required String network,
+    required int snapshotHeight,
+  }) async {
+    _calls++;
+    if (_calls == 3) {
+      racedCheckStarted.complete();
+      await _releaseRacedCheck.future;
+    }
+    final ready = _calls == 1 || _calls >= 4;
     return VotingWalletSyncReadiness(
       scannedHeight: ready ? snapshotHeight : snapshotHeight - 1,
       snapshotHeight: snapshotHeight,

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -8484,6 +8484,34 @@ void main() {
     expect(loadCount, 2);
   });
 
+  test(
+    'blocked restore request does not swallow post-resume discovery',
+    () async {
+      var loadCount = 0;
+      final container = _sessionContainer(
+        pendingShareRoundLoader:
+            ({required dbPath, required accountUuids}) async {
+              loadCount++;
+              return const [];
+            },
+      );
+      addTearDown(container.dispose);
+
+      final restorer = container.read(votingShareTrackingRestorerProvider);
+      await restorer.restore();
+      expect(loadCount, 1);
+
+      final registry = container.read(votingShareTrackingRegistryProvider);
+      await registry.quiesceAndDrain(accountUuid: 'account-1');
+      registry.requestRestore();
+      registry.resume(accountUuid: 'account-1');
+      registry.requestRestore();
+      await restorer.restore();
+
+      expect(loadCount, 2);
+    },
+  );
+
   test('unlock resumes discovery after a tracking drain fails', () async {
     final container = _sessionContainer(
       pendingShareRoundLoader:

--- a/test/providers/wallet_mutation_guard_test.dart
+++ b/test/providers/wallet_mutation_guard_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/features/migration/services/ironwood_migration_background_credential_store.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_share_tracking_registry_provider.dart';
 import 'package:zcash_wallet/src/providers/wallet_mutation_guard.dart';
 
 void main() {
@@ -65,6 +66,57 @@ void main() {
     }, resumeAfterMutation: false);
 
     expect(events, ['pause', 'action']);
+  });
+
+  testWidgets('destructive voting drain precedes the sync pause', (
+    tester,
+  ) async {
+    final events = <String>[];
+    final votingRegistry = VotingShareTrackingRegistry();
+    var restoreRequests = 0;
+    votingRegistry.addRestoreRequestListener(() {
+      expect(votingRegistry.isQuiesced('account-1'), isFalse);
+      restoreRequests++;
+    });
+    final releaseVotingWork = votingRegistry.beginBackgroundWork(
+      accountUuid: 'account-1',
+    );
+    expect(releaseVotingWork, isNotNull);
+    late WidgetRef capturedRef;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountProvider.overrideWith(_ExistingAccountNotifier.new),
+          syncProvider.overrideWith(() => _QueuedPreflightSyncNotifier(events)),
+          votingShareTrackingRegistryProvider.overrideWithValue(votingRegistry),
+        ],
+        child: Consumer(
+          builder: (context, ref, child) {
+            capturedRef = ref;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final mutation = runWithSyncPausedForAccountMutation(
+      capturedRef,
+      () async => events.add('action'),
+      quiesceMigrationWork: false,
+      quiesceVotingWork: true,
+    );
+
+    expect(votingRegistry.isQuiesced('account-1'), isTrue);
+    expect(events, isEmpty);
+    capturedRef.read(syncProvider.notifier).startSync();
+    releaseVotingWork!();
+    await mutation;
+
+    expect(events, ['queued-sync-start', 'pause', 'action', 'resume']);
+    expect(votingRegistry.isQuiesced('account-1'), isFalse);
+    expect(restoreRequests, 1);
   });
 
   testWidgets('resumes after failed non-destructive mutation by default', (
@@ -358,6 +410,9 @@ void main() {
     tester,
   ) async {
     final events = <String>[];
+    final votingRegistry = VotingShareTrackingRegistry();
+    var restoreRequests = 0;
+    votingRegistry.addRestoreRequestListener(() => restoreRequests++);
     late WidgetRef capturedRef;
 
     await tester.pumpWidget(
@@ -365,6 +420,7 @@ void main() {
         overrides: [
           accountProvider.overrideWith(_ExistingAccountNotifier.new),
           syncProvider.overrideWith(() => _StaleSyncNotifier(events)),
+          votingShareTrackingRegistryProvider.overrideWithValue(votingRegistry),
         ],
         child: Consumer(
           builder: (context, ref, child) {
@@ -389,10 +445,15 @@ void main() {
       'clearCachedWalletDbPath',
       'migration-resume',
     ]);
+    expect(votingRegistry.isQuiesced('account-1'), isFalse);
+    expect(restoreRequests, 0);
   });
 
   testWidgets('wallet reset resumes after pre-delete failure', (tester) async {
     final events = <String>[];
+    final votingRegistry = VotingShareTrackingRegistry();
+    var restoreRequests = 0;
+    votingRegistry.addRestoreRequestListener(() => restoreRequests++);
     late WidgetRef capturedRef;
 
     await tester.pumpWidget(
@@ -400,6 +461,7 @@ void main() {
         overrides: [
           accountProvider.overrideWith(_EmptyAccountNotifier.new),
           syncProvider.overrideWith(() => _StaleSyncNotifier(events)),
+          votingShareTrackingRegistryProvider.overrideWithValue(votingRegistry),
         ],
         child: Consumer(
           builder: (context, ref, child) {
@@ -425,12 +487,17 @@ void main() {
       'clearCachedWalletDbPath',
       'resume',
     ]);
+    expect(votingRegistry.isQuiesced('account-1'), isFalse);
+    expect(restoreRequests, 1);
   });
 
   testWidgets('wallet reset stays paused after post-delete failure', (
     tester,
   ) async {
     final events = <String>[];
+    final votingRegistry = VotingShareTrackingRegistry();
+    var restoreRequests = 0;
+    votingRegistry.addRestoreRequestListener(() => restoreRequests++);
     late WidgetRef capturedRef;
 
     await tester.pumpWidget(
@@ -438,6 +505,7 @@ void main() {
         overrides: [
           accountProvider.overrideWith(_EmptyAccountNotifier.new),
           syncProvider.overrideWith(() => _StaleSyncNotifier(events)),
+          votingShareTrackingRegistryProvider.overrideWithValue(votingRegistry),
         ],
         child: Consumer(
           builder: (context, ref, child) {
@@ -461,6 +529,8 @@ void main() {
     );
 
     expect(events, ['pause', 'resetWallet', 'clearCachedWalletDbPath']);
+    expect(votingRegistry.isQuiesced('account-1'), isFalse);
+    expect(restoreRequests, 0);
   });
 }
 
@@ -542,5 +612,14 @@ class _StaleSyncNotifier extends SyncNotifier {
   @override
   void clearCachedWalletDbPath() {
     events.add('clearCachedWalletDbPath');
+  }
+}
+
+class _QueuedPreflightSyncNotifier extends _StaleSyncNotifier {
+  _QueuedPreflightSyncNotifier(super.events);
+
+  @override
+  void startSync({int? latestTipHeight}) {
+    events.add('queued-sync-start');
   }
 }


### PR DESCRIPTION
Follow-up to the [PR 582 review finding](https://github.com/chainapsis/vizor-wallet/pull/582#discussion_r3904226452).

Before, automatic PIR cache warmup and ZKP1 precompute were not registered with the wallet destructive-operation drain. A reset could wipe secure storage while hotkey generation was still running, allowing the late completion to write the hotkey back. A precompute waiting for the wallet scan could also restart sync after the mutation flow had paused it.

After, both background paths acquire a drain lease before their first asynchronous step. Destructive flows drain voting work before pausing foreground sync, so a queued sync preflight cannot escape the pause and overlap the database mutation. Reset and account deletion wait for active work, waiting precompute exits cleanly, and voting restoration follows the existing pre-delete versus post-delete failure policy.