### PR TITLE
Allow users to set a custom block explorer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,23 +178,6 @@ correct differences from the design.
   explicitly requests a Figma change. When they do, read `FIGMA-AI-FIX.md` in
   full and follow its target-approval, copy-only, and visual-parity workflow.
 
-## PR screenshots for design changes
-
-Any feature change that involves design or user-visible UI must attach
-review screenshots to the pull request before it is marked ready.
-
-- Capture with the widget-test path (`scripts/figma-compare.sh widget`).
-  Register a deterministic scenario in
-  `lib/figma_compare/figma_compare_scenarios.dart` when one does not exist.
-  Do not use Widgetbook chrome as the review evidence.
-- Include every form factor the change ships on (desktop, mobile, or both).
-- Show the states a reviewer needs to judge the design: the entry point (for
-  example the settings row) plus the new or changed screen, and the important
-  variants (default vs custom, empty vs populated). Dark is required; add
-  light when the change is theme-sensitive or both themes are in scope.
-- Embed the PNGs in the PR description. A design PR is not ready if the UI
-  is only described in prose.
-
 ## Figma Layer Interpretation
 
 When reading or implementing Figma designs, distinguish app UI from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,23 @@ correct differences from the design.
   explicitly requests a Figma change. When they do, read `FIGMA-AI-FIX.md` in
   full and follow its target-approval, copy-only, and visual-parity workflow.
 
+## PR screenshots for design changes
+
+Any feature change that involves design or user-visible UI must attach
+review screenshots to the pull request before it is marked ready.
+
+- Capture with the widget-test path (`scripts/figma-compare.sh widget`).
+  Register a deterministic scenario in
+  `lib/figma_compare/figma_compare_scenarios.dart` when one does not exist.
+  Do not use Widgetbook chrome as the review evidence.
+- Include every form factor the change ships on (desktop, mobile, or both).
+- Show the states a reviewer needs to judge the design: the entry point (for
+  example the settings row) plus the new or changed screen, and the important
+  variants (default vs custom, empty vs populated). Dark is required; add
+  light when the change is theme-sensitive or both themes are in scope.
+- Embed the PNGs in the PR description. A design PR is not ready if the UI
+  is only described in prose.
+
 ## Figma Layer Interpretation
 
 When reading or implementing Figma designs, distinguish app UI from

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,11 +262,7 @@ A pull request should:
   cross-platform implications.
 - Link the relevant issue or design when one exists.
 - Include tests for new behavior and exact local validation commands.
-- Include review screenshots for any design or user-visible UI change.
-  Attach widget-test captures (`scripts/figma-compare.sh widget`) for every
-  form factor the change ships on, covering the entry point and the important
-  new or changed states. Embed the images in the PR description; do not leave
-  the UI described only in prose.
+- Include before/after captures for visual changes.
 - Include generated Flutter Rust Bridge files when an exposed Rust API changes.
 - Avoid unrelated dependency, lockfile, formatting, asset, and generated-file
   churn.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,7 +262,11 @@ A pull request should:
   cross-platform implications.
 - Link the relevant issue or design when one exists.
 - Include tests for new behavior and exact local validation commands.
-- Include before/after captures for visual changes.
+- Include review screenshots for any design or user-visible UI change.
+  Attach widget-test captures (`scripts/figma-compare.sh widget`) for every
+  form factor the change ships on, covering the entry point and the important
+  new or changed states. Embed the images in the PR description; do not leave
+  the UI described only in prose.
 - Include generated Flutter Rust Bridge files when an exposed Rust API changes.
 - Avoid unrelated dependency, lockfile, formatting, asset, and generated-file
   churn.

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -72,6 +72,7 @@ import 'src/features/send/services/send_flow.dart'
 import 'src/features/settings/screens/settings_screen.dart';
 import 'src/features/settings/screens/settings_change_password_screen.dart';
 import 'src/features/settings/screens/settings_endpoint_screen.dart';
+import 'src/features/settings/screens/settings_explorer_screen.dart';
 import 'src/features/settings/screens/settings_seed_phrase_screen.dart';
 import 'src/features/settings/screens/settings_uninstall_screen.dart';
 import 'src/features/settings/screens/settings_viewing_key_screen.dart';
@@ -999,6 +1000,10 @@ List<RouteBase> _desktopRoutes(Ref ref) => [
   GoRoute(
     path: '/settings/endpoint',
     builder: (_, _) => const SettingsEndpointScreen(),
+  ),
+  GoRoute(
+    path: '/settings/explorer',
+    builder: (_, _) => const SettingsExplorerScreen(),
   ),
   GoRoute(
     path: '/settings/link-mobile',

--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -151,6 +151,37 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     builder: buildSettingsMainUseCase,
   ),
   FigmaCompareScenario(
+    id: 'settings-explorer',
+    description: 'Desktop explorer settings with CipherScan selected',
+    builder: buildSettingsExplorerUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'settings-explorer-custom',
+    description: 'Desktop explorer settings with a custom URL template',
+    builder: buildSettingsExplorerCustomUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-settings-explorer',
+    description: 'Mobile settings scrolled to the Explorer row',
+    builder: buildMobileSettingsExplorerUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-explorer',
+    description: 'Mobile explorer settings with CipherScan selected',
+    builder: buildMobileExplorerUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-explorer-custom',
+    description: 'Mobile explorer settings with a custom URL template',
+    builder: buildMobileExplorerCustomUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
     id: 'mobile-settings-footer',
     description: 'Mobile settings scrolled to the branded version footer',
     builder: buildMobileSettingsFooterUseCase,

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -10,6 +10,7 @@ import 'core/profile_pictures.dart';
 import 'core/config/app_version_config.dart';
 import 'core/config/rpc_endpoint_config.dart';
 import 'core/config/swap_remote_enable_config.dart';
+import 'core/config/zcash_explorer.dart';
 import 'core/storage/app_secure_store.dart';
 import 'core/storage/wallet_paths.dart';
 import 'providers/account_models.dart';
@@ -49,6 +50,7 @@ class AppBootstrapState {
     required this.initialSyncSnapshot,
     required this.network,
     required this.rpcEndpointConfig,
+    this.explorerUrlTemplate = '',
     required this.themeMode,
     required this.privacyModeEnabled,
     required this.isPasswordConfigured,
@@ -67,6 +69,7 @@ class AppBootstrapState {
   final AppSyncSnapshot initialSyncSnapshot;
   final String network;
   final RpcEndpointConfig rpcEndpointConfig;
+  final String explorerUrlTemplate;
   final ThemeMode themeMode;
   final bool privacyModeEnabled;
   final bool swapEnabledOverrideCachedForRelease;
@@ -235,6 +238,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       await storage.readString(_networkKey),
     );
     final rpcEndpointConfig = await _readRpcEndpointConfig(storage, network);
+    final explorerUrlTemplate = await _readExplorerUrlTemplate(storage);
     final themeMode = await _readThemeMode(storage);
     final privacyModeEnabled = await _readPrivacyModeEnabled(storage);
     final swapEnabledOverrideCachedForRelease =
@@ -344,6 +348,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       initialSyncSnapshot: initialSyncSnapshot,
       network: network,
       rpcEndpointConfig: rpcEndpointConfig,
+      explorerUrlTemplate: explorerUrlTemplate,
       themeMode: themeMode,
       privacyModeEnabled: privacyModeEnabled,
       swapEnabledOverrideCachedForRelease: swapEnabledOverrideCachedForRelease,
@@ -446,6 +451,22 @@ Future<RpcEndpointConfig> _readRpcEndpointConfig(
   } catch (e) {
     log('bootstrap: failed to read RPC endpoint: $e');
     return defaultRpcEndpointConfig(network);
+  }
+}
+
+Future<String> _readExplorerUrlTemplate(AppSecureStore storage) async {
+  try {
+    final stored = await storage.readString(kZcashExplorerUrlKey);
+    if (stored == null || stored.trim().isEmpty) return '';
+    return normalizeExplorerUrlTemplate(stored);
+  } on SecureStorageUnavailableException {
+    rethrow;
+  } on FormatException catch (e) {
+    log('bootstrap: ignoring invalid explorer URL: $e');
+    return '';
+  } catch (e) {
+    log('bootstrap: failed to read explorer URL: $e');
+    return '';
   }
 }
 

--- a/lib/src/core/config/zcash_explorer.dart
+++ b/lib/src/core/config/zcash_explorer.dart
@@ -9,8 +9,9 @@ typedef ZcashExplorerLauncher = Future<bool> Function(Uri uri);
 const kDefaultZcashExplorerLabel = 'CipherScan';
 
 const kZcashExplorerPrivacyCopy =
-    'Opening a public explorer after you send can link your IP address to '
-    'that transaction. Use your own instance to keep that off the public site.';
+    'Transaction links open in this explorer. Use CipherScan or another site '
+    'you prefer. Opening a public explorer after you send can link your IP '
+    'address to that transaction.';
 
 const kZcashExplorerTemplateHint =
     'Use {txid} or {txHash} in the path, or enter just the origin.';

--- a/lib/src/core/config/zcash_explorer.dart
+++ b/lib/src/core/config/zcash_explorer.dart
@@ -1,26 +1,107 @@
 import 'package:url_launcher/url_launcher.dart';
 
 import 'network_config.dart';
-import 'rpc_endpoint_config.dart';
 
 enum ZcashExplorerTxidOrder { protocol, display }
 
 typedef ZcashExplorerLauncher = Future<bool> Function(Uri uri);
 
+const kDefaultZcashExplorerLabel = 'CipherScan';
+
+const kZcashExplorerPrivacyCopy =
+    'Opening a public explorer after you send can link your IP address to '
+    'that transaction. Use your own instance to keep that off the public site.';
+
+const kZcashExplorerTemplateHint =
+    'Use {txid} or {txHash} in the path, or enter just the origin.';
+
 final _txidHexPattern = RegExp(r'^[0-9a-f]{64}$');
+final _txidHexPathTailPattern = RegExp(r'/[0-9a-fA-F]{64}/?$');
+final _txidPlaceholderPattern = RegExp(
+  r'\{txid\}|\{txHash\}|\{tx_hash\}|\{hash\}',
+  caseSensitive: false,
+);
+
+String defaultZcashExplorerHost(String networkName) {
+  final network = zcashNetworkFromName(networkName);
+  return switch (network) {
+    ZcashNetwork.mainnet => 'cipherscan.app',
+    ZcashNetwork.testnet => 'testnet.cipherscan.app',
+    ZcashNetwork.regtest => 'testnet.cipherscan.app',
+  };
+}
+
+/// Settings-row label: CipherScan when unset, otherwise the custom host.
+String explorerSettingsLabel(
+  String? customTemplate, {
+  required String networkName,
+}) {
+  final template = customTemplate?.trim() ?? '';
+  if (template.isEmpty) return kDefaultZcashExplorerLabel;
+  try {
+    return Uri.parse(normalizeExplorerUrlTemplate(template)).host;
+  } on FormatException {
+    return 'Custom';
+  }
+}
+
+/// Normalize user input into a stored explorer URL template.
+///
+/// Accepts an origin (`https://explorer.example`), a path that already
+/// includes `{txid}` / `{txHash}`, or a concrete `/tx/<64-hex>` URL.
+String normalizeExplorerUrlTemplate(String input) {
+  var raw = input.trim();
+  if (raw.isEmpty) {
+    throw const FormatException('Enter an explorer URL.');
+  }
+
+  final lower = raw.toLowerCase();
+  if (lower.startsWith('javascript:') ||
+      lower.startsWith('data:') ||
+      lower.startsWith('file:') ||
+      lower.startsWith('vbscript:')) {
+    throw const FormatException('Enter an http or https URL.');
+  }
+
+  if (!raw.contains('://')) {
+    raw = 'https://$raw';
+  }
+
+  final parsed = Uri.tryParse(raw);
+  if (parsed == null || !parsed.hasScheme || parsed.host.isEmpty) {
+    throw const FormatException('Enter a host, like explorer.example.');
+  }
+  if (parsed.scheme != 'http' && parsed.scheme != 'https') {
+    throw const FormatException('Enter an http or https URL.');
+  }
+
+  return _decodeTxidPlaceholders(_ensureTxidPlaceholder(parsed).toString());
+}
+
+Uri applyExplorerUrlTemplate(String template, String txidHex) {
+  final normalized = normalizeExplorerUrlTemplate(template);
+  final filled = _decodeTxidPlaceholders(
+    normalized,
+  ).replaceAllMapped(_txidPlaceholderPattern, (_) => txidHex);
+  final uri = Uri.parse(filled);
+  if (uri.scheme != 'http' && uri.scheme != 'https') {
+    throw const FormatException('Enter an http or https URL.');
+  }
+  return uri;
+}
 
 Uri zcashExplorerTransactionUri({
   required String networkName,
   required String txidHex,
   required ZcashExplorerTxidOrder txidOrder,
+  String? customTemplate,
 }) {
-  final network = zcashNetworkFromName(networkName);
-  final host = switch (network) {
-    ZcashNetwork.mainnet => 'cipherscan.app',
-    ZcashNetwork.testnet => 'testnet.cipherscan.app',
-    ZcashNetwork.regtest => 'testnet.cipherscan.app',
-  };
-  return Uri.https(host, '/tx/${_explorerTxidHex(txidHex, txidOrder)}');
+  final displayTxid = _explorerTxidHex(txidHex, txidOrder);
+  final template = customTemplate?.trim() ?? '';
+  if (template.isNotEmpty) {
+    return applyExplorerUrlTemplate(template, displayTxid);
+  }
+  return Uri.https(defaultZcashExplorerHost(networkName), '/tx/$displayTxid');
 }
 
 String _explorerTxidHex(String txidHex, ZcashExplorerTxidOrder txidOrder) {
@@ -46,18 +127,50 @@ String _protocolOrderToDisplayTxidHex(String normalizedTxidHex) {
   return bytes.reversed.join();
 }
 
+String _decodeTxidPlaceholders(String value) {
+  return value.replaceAllMapped(
+    RegExp(r'%7B(txid|txHash|tx_hash|hash)%7D', caseSensitive: false),
+    (match) => '{${match[1]}}',
+  );
+}
+
+Uri _ensureTxidPlaceholder(Uri uri) {
+  final haystack =
+      '${uri.path}${uri.hasQuery ? '?${uri.query}' : ''}'
+      '${uri.hasFragment ? '#${uri.fragment}' : ''}';
+  if (_txidPlaceholderPattern.hasMatch(haystack)) {
+    return uri;
+  }
+
+  final path = uri.path;
+  if (_txidHexPathTailPattern.hasMatch(path)) {
+    return uri.replace(
+      path: path.replaceFirst(_txidHexPathTailPattern, '/{txid}'),
+    );
+  }
+  if (path.isEmpty || path == '/') {
+    return uri.replace(path: '/tx/{txid}');
+  }
+  if (path.endsWith('/')) {
+    return uri.replace(path: '$path{txid}');
+  }
+  return uri.replace(path: '$path/{txid}');
+}
+
 Future<bool> launchZcashExplorerTransaction({
   required String networkName,
   required String txidHex,
   required ZcashExplorerTxidOrder txidOrder,
+  String? customTemplate,
   ZcashExplorerLauncher? launcher,
 }) async {
-  final uri = zcashExplorerTransactionUri(
-    networkName: networkName,
-    txidHex: txidHex,
-    txidOrder: txidOrder,
-  );
   try {
+    final uri = zcashExplorerTransactionUri(
+      networkName: networkName,
+      txidHex: txidHex,
+      txidOrder: txidOrder,
+      customTemplate: customTemplate,
+    );
     return await (launcher ?? _launchExternalUrl)(uri);
   } on Exception {
     return false;

--- a/lib/src/core/config/zcash_explorer.dart
+++ b/lib/src/core/config/zcash_explorer.dart
@@ -135,9 +135,10 @@ String _decodeTxidPlaceholders(String value) {
 }
 
 Uri _ensureTxidPlaceholder(Uri uri) {
-  final haystack =
-      '${uri.path}${uri.hasQuery ? '?${uri.query}' : ''}'
-      '${uri.hasFragment ? '#${uri.fragment}' : ''}';
+  final haystack = _decodeTxidPlaceholders(
+    '${uri.path}${uri.hasQuery ? '?${uri.query}' : ''}'
+    '${uri.hasFragment ? '#${uri.fragment}' : ''}',
+  );
   if (_txidPlaceholderPattern.hasMatch(haystack)) {
     return uri;
   }

--- a/lib/src/core/navigation/app_back_resolver.dart
+++ b/lib/src/core/navigation/app_back_resolver.dart
@@ -54,6 +54,7 @@ abstract final class AppBackResolver {
     '/settings/viewing-key': 'Viewing key',
     '/settings/change-password': 'Change password',
     '/settings/endpoint': 'Endpoint',
+    '/settings/explorer': 'Explorer',
     '/settings/uninstall': 'Uninstall Vizor',
     '/onboarding/keystone': 'Connect Keystone',
     '/voting': 'Vote',

--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -36,6 +36,7 @@ import '../../rust/api/sync.dart' as rust_sync;
 import '../../features/about/screens/mobile/mobile_about_screens.dart';
 import '../../features/settings/screens/mobile/mobile_change_passcode_screen.dart';
 import '../../features/settings/screens/mobile/mobile_endpoint_screen.dart';
+import '../../features/settings/screens/mobile/mobile_explorer_screen.dart';
 import '../../features/settings/screens/mobile/mobile_seed_phrase_screen.dart';
 import '../../features/settings/screens/mobile/mobile_settings_screen.dart';
 import '../../features/settings/screens/mobile/mobile_viewing_key_screen.dart';
@@ -127,6 +128,13 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
       pageBuilder: (context, state) => CupertinoPage(
         key: state.pageKey,
         child: const MobileEndpointScreen(),
+      ),
+    ),
+    GoRoute(
+      path: '/settings/explorer',
+      pageBuilder: (context, state) => CupertinoPage(
+        key: state.pageKey,
+        child: const MobileExplorerScreen(),
       ),
     ),
     // The Set New Passcode frames also drop the tab bar — same

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -26,6 +26,7 @@ const kSyncKeepAwakeEnabledKey = 'zcash_sync_keep_awake_enabled';
 const kSyncKeepAwakePromptSeenKey = 'zcash_sync_keep_awake_prompt_seen';
 const kRpcEndpointUrlKey = 'zcash_rpc_endpoint_url';
 const kRpcEndpointPresetKey = 'zcash_rpc_endpoint_preset';
+const kZcashExplorerUrlKey = 'zcash_explorer_url';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';
 const _passwordVerifierKey = 'zcash_password_verifier';
 const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -23,6 +23,7 @@ import '../../../core/widgets/review_wrap_card.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/privacy_mode_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
+import '../../../providers/zcash_explorer_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../address_book/models/address_book_contact.dart';
@@ -233,6 +234,7 @@ class _ActivityTransactionStatusScreenState
       networkName: endpoint.networkName,
       txidHex: widget.args.txidHex,
       txidOrder: ZcashExplorerTxidOrder.protocol,
+      customTemplate: ref.read(zcashExplorerProvider),
     );
     if (launched || !mounted) return;
     copyTextWithToast(

--- a/lib/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart
@@ -22,6 +22,7 @@ import '../../../../core/widgets/mobile/mobile_tx_fee_info_sheet.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/privacy_mode_provider.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
+import '../../../../providers/zcash_explorer_provider.dart';
 import '../../../../providers/sync_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../address_book/models/address_book_contact.dart';
@@ -260,6 +261,7 @@ class _MobileTransactionStatusScreenState
       networkName: endpoint.networkName,
       txidHex: widget.args.txidHex,
       txidOrder: ZcashExplorerTxidOrder.protocol,
+      customTemplate: ref.read(zcashExplorerProvider),
     );
     if (launched || !mounted) return;
     await Clipboard.setData(ClipboardData(text: widget.args.txidHex));

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -18,6 +18,7 @@ import '../../../core/widgets/app_back_link.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/zec_price_change_provider.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../providers/zcash_explorer_provider.dart';
 import '../../address_book/models/address_book_contact.dart';
 import '../../address_book/providers/address_book_provider.dart';
 import '../../keystone/widgets/keystone_transaction_progress_panel.dart';
@@ -148,6 +149,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
       networkName: endpoint.networkName,
       txidHex: txid,
       txidOrder: ZcashExplorerTxidOrder.display,
+      customTemplate: ref.read(zcashExplorerProvider),
     );
     if (launched || !mounted) return;
     _copyTransactionHash();

--- a/lib/src/features/settings/screens/mobile/mobile_explorer_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_explorer_screen.dart
@@ -16,9 +16,8 @@ import '../../../../providers/zcash_explorer_provider.dart';
 
 enum _ExplorerChoice { cipherscan, custom }
 
-/// Mobile explorer settings — CipherScan by default, or a user-owned
-/// instance so opening a transaction does not reveal the signer's IP
-/// to a public explorer.
+/// Mobile explorer settings — CipherScan by default, or any other
+/// explorer URL the user prefers for transaction links.
 class MobileExplorerScreen extends ConsumerStatefulWidget {
   const MobileExplorerScreen({super.key});
 
@@ -174,7 +173,7 @@ class _MobileExplorerScreenState extends ConsumerState<MobileExplorerScreen> {
                     key: const ValueKey('mobile_explorer_option_custom'),
                     iconName: AppIcons.edit,
                     label: 'Custom',
-                    subtitle: 'Your own instance',
+                    subtitle: 'Any explorer you prefer',
                     selected: _choice == _ExplorerChoice.custom,
                     onTap: _isSubmitting
                         ? null

--- a/lib/src/features/settings/screens/mobile/mobile_explorer_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_explorer_screen.dart
@@ -1,0 +1,358 @@
+import 'package:flutter/material.dart' show Scaffold, TextInputType;
+import 'package:flutter/services.dart' show TextInputAction;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../../main.dart' show log;
+import '../../../../core/config/zcash_explorer.dart';
+import '../../../../core/layout/mobile/mobile_top_nav.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_button.dart';
+import '../../../../core/widgets/app_icon.dart';
+import '../../../../core/widgets/mobile_text_field.dart';
+import '../../../../providers/rpc_endpoint_provider.dart';
+import '../../../../providers/zcash_explorer_provider.dart';
+
+enum _ExplorerChoice { cipherscan, custom }
+
+/// Mobile explorer settings — CipherScan by default, or a user-owned
+/// instance so opening a transaction does not reveal the signer's IP
+/// to a public explorer.
+class MobileExplorerScreen extends ConsumerStatefulWidget {
+  const MobileExplorerScreen({super.key});
+
+  @override
+  ConsumerState<MobileExplorerScreen> createState() =>
+      _MobileExplorerScreenState();
+}
+
+class _MobileExplorerScreenState extends ConsumerState<MobileExplorerScreen> {
+  final _customController = TextEditingController();
+  final _customFocusNode = FocusNode();
+  late _ExplorerChoice _choice;
+  bool _isSubmitting = false;
+  String? _submitError;
+
+  @override
+  void initState() {
+    super.initState();
+    final current = ref.read(zcashExplorerProvider);
+    _choice = current.trim().isEmpty
+        ? _ExplorerChoice.cipherscan
+        : _ExplorerChoice.custom;
+    if (_choice == _ExplorerChoice.custom) {
+      _customController.text = current;
+    }
+  }
+
+  @override
+  void dispose() {
+    _customController.dispose();
+    _customFocusNode.dispose();
+    super.dispose();
+  }
+
+  bool _canUpdate(String current) {
+    if (_isSubmitting) return false;
+    return switch (_choice) {
+      _ExplorerChoice.cipherscan => current.trim().isNotEmpty,
+      _ExplorerChoice.custom => _customTemplateChanged(current),
+    };
+  }
+
+  bool _customTemplateChanged(String current) {
+    try {
+      final normalized = normalizeExplorerUrlTemplate(_customController.text);
+      return normalized != current.trim();
+    } on FormatException {
+      return _customController.text.trim().isNotEmpty;
+    }
+  }
+
+  String? _customMessageText() {
+    if (_choice != _ExplorerChoice.custom) return null;
+    if (_customController.text.trim().isEmpty) return null;
+    try {
+      normalizeExplorerUrlTemplate(_customController.text);
+      return null;
+    } on FormatException catch (e) {
+      return e.message;
+    }
+  }
+
+  Future<void> _submit() async {
+    final current = ref.read(zcashExplorerProvider);
+    if (!_canUpdate(current)) return;
+
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+
+    try {
+      final notifier = ref.read(zcashExplorerProvider.notifier);
+      if (_choice == _ExplorerChoice.cipherscan) {
+        await notifier.resetToDefault();
+      } else {
+        await notifier.setCustom(_customController.text);
+      }
+      if (!mounted) return;
+      final next = ref.read(zcashExplorerProvider);
+      setState(() {
+        _customController.text = next;
+        _isSubmitting = false;
+      });
+    } on FormatException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _submitError = e.message;
+        _isSubmitting = false;
+      });
+    } catch (e, st) {
+      log('MobileExplorerScreen._submit: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _submitError = "Couldn't save that explorer URL.";
+        _isSubmitting = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final current = ref.watch(zcashExplorerProvider);
+    final networkName = ref.watch(rpcEndpointProvider).networkName;
+    final colors = context.colors;
+    final customMessage = _customMessageText();
+
+    return Scaffold(
+      backgroundColor: colors.background.window,
+      body: SafeArea(
+        child: Column(
+          children: [
+            MobileTopNav.back(
+              title: 'Explorer',
+              onBack: _isSubmitting ? null : () => context.pop(),
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.sm,
+                  AppSpacing.xs,
+                  AppSpacing.sm,
+                  AppSpacing.lg,
+                ),
+                children: [
+                  Text(
+                    current.trim().isEmpty
+                        ? 'Current: ${defaultZcashExplorerHost(networkName)} (default)'
+                        : 'Current: ${explorerSettingsLabel(current, networkName: networkName)}',
+                    textAlign: TextAlign.center,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  _ExplorerOptionCard(
+                    key: const ValueKey('mobile_explorer_option_cipherscan'),
+                    iconName: AppIcons.globe,
+                    label: kDefaultZcashExplorerLabel,
+                    subtitle: defaultZcashExplorerHost(networkName),
+                    selected: _choice == _ExplorerChoice.cipherscan,
+                    onTap: _isSubmitting
+                        ? null
+                        : () => setState(() {
+                            _choice = _ExplorerChoice.cipherscan;
+                            _submitError = null;
+                          }),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  _ExplorerOptionCard(
+                    key: const ValueKey('mobile_explorer_option_custom'),
+                    iconName: AppIcons.edit,
+                    label: 'Custom',
+                    subtitle: 'Your own instance',
+                    selected: _choice == _ExplorerChoice.custom,
+                    onTap: _isSubmitting
+                        ? null
+                        : () => setState(() {
+                            _choice = _ExplorerChoice.custom;
+                            _submitError = null;
+                            if (_customController.text.trim().isEmpty &&
+                                current.trim().isNotEmpty) {
+                              _customController.text = current;
+                            }
+                          }),
+                  ),
+                  if (_choice == _ExplorerChoice.custom) ...[
+                    const SizedBox(height: AppSpacing.md),
+                    MobileTextField(
+                      key: const ValueKey('mobile_explorer_custom_field_shell'),
+                      fieldKey: const ValueKey('mobile_explorer_custom_field'),
+                      hintText: 'https://explorer.example/tx/{txid}',
+                      controller: _customController,
+                      focusNode: _customFocusNode,
+                      keyboardType: TextInputType.url,
+                      textInputAction: TextInputAction.done,
+                      onChanged: (_) => setState(() => _submitError = null),
+                      onSubmitted: (_) => _submit(),
+                    ),
+                    if (customMessage != null) ...[
+                      const SizedBox(height: AppSpacing.xs),
+                      Text(
+                        customMessage,
+                        style: AppTypography.bodySmall.copyWith(
+                          color: colors.text.destructive,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: AppSpacing.xs),
+                    Text(
+                      kZcashExplorerTemplateHint,
+                      style: AppTypography.bodySmall.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: AppSpacing.md),
+                  AppIcon(AppIcons.book, size: 20, color: colors.icon.accent),
+                  const SizedBox(height: AppSpacing.sm),
+                  Text(
+                    kZcashExplorerPrivacyCopy,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.secondary,
+                    ),
+                  ),
+                  if (_submitError != null) ...[
+                    const SizedBox(height: AppSpacing.sm),
+                    Text(
+                      _submitError!,
+                      textAlign: TextAlign.center,
+                      style: AppTypography.bodySmall.copyWith(
+                        color: colors.text.destructive,
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: AppSpacing.md),
+                  Center(
+                    child: AppButton(
+                      key: const ValueKey('mobile_explorer_update'),
+                      minWidth: 226,
+                      onPressed: _canUpdate(current) ? _submit : null,
+                      child: Text(
+                        _isSubmitting ? 'Updating...' : 'Update explorer',
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ExplorerOptionCard extends StatelessWidget {
+  const _ExplorerOptionCard({
+    required this.iconName,
+    required this.label,
+    required this.subtitle,
+    required this.selected,
+    required this.onTap,
+    super.key,
+  });
+
+  final String iconName;
+  final String label;
+  final String subtitle;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: label,
+      excludeSemantics: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          height: 64,
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+          decoration: BoxDecoration(
+            color: colors.background.ground,
+            borderRadius: BorderRadius.circular(AppRadii.medium),
+            border: Border.all(
+              color: selected ? colors.border.strong : colors.border.subtle,
+              width: selected ? 1.5 : 1,
+            ),
+          ),
+          child: Row(
+            children: [
+              Opacity(
+                opacity: selected ? 1 : 0.5,
+                child: AppIcon(iconName, size: 20, color: colors.icon.accent),
+              ),
+              const SizedBox(width: AppSpacing.s),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      label,
+                      style: AppTypography.bodyMediumStrong.copyWith(
+                        color: colors.text.accent,
+                      ),
+                    ),
+                    Text(
+                      subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.labelSmall.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (selected)
+                Container(
+                  width: 24,
+                  height: 24,
+                  decoration: BoxDecoration(
+                    color: colors.background.inverse,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: AppIcon(
+                      AppIcons.check,
+                      size: 14,
+                      color: colors.text.inverse,
+                    ),
+                  ),
+                )
+              else
+                Container(
+                  width: 24,
+                  height: 24,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: colors.background.raised,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
@@ -22,7 +22,9 @@ import '../../../../core/widgets/mobile/mobile_surface_card.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/app_security_provider.dart';
 import '../../../../providers/biometric_unlock_provider.dart';
+import '../../../../core/config/zcash_explorer.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
+import '../../../../providers/zcash_explorer_provider.dart';
 import '../../../../providers/sync_keep_awake_provider.dart';
 import '../../../../providers/theme_mode_provider.dart';
 import '../../../../services/biometric_unlock.dart';
@@ -41,7 +43,12 @@ class MobileSettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final account = ref.watch(accountProvider).value?.activeAccount;
-    final endpoint = ref.watch(rpcEndpointProvider).hostPort;
+    final endpointConfig = ref.watch(rpcEndpointProvider);
+    final endpoint = endpointConfig.hostPort;
+    final explorer = explorerSettingsLabel(
+      ref.watch(zcashExplorerProvider),
+      networkName: endpointConfig.networkName,
+    );
     final themeMode = ref.watch(themeModeProvider);
     final profilePictureId =
         account?.profilePictureId ?? kDefaultProfilePictureId;
@@ -219,6 +226,19 @@ class MobileSettingsScreen extends ConsumerWidget {
                       chevronColor: settingsChevronColor,
                       showChevron: true,
                       onTap: () => context.push('/settings/endpoint'),
+                    ),
+                    MobileListRow(
+                      key: const ValueKey('mobile_settings_explorer_row'),
+                      leading: _RowIcon(AppIcons.globe),
+                      label: 'Explorer',
+                      value: explorer,
+                      minRowHeight: _settingsRowHeight,
+                      textStyle: settingsRowStyle,
+                      valueTextStyle: settingsRowStyle,
+                      valueColor: settingsValueColor,
+                      chevronColor: settingsChevronColor,
+                      showChevron: true,
+                      onTap: () => context.push('/settings/explorer'),
                     ),
                     MobileListRow(
                       key: const ValueKey('mobile_settings_theme_row'),

--- a/lib/src/features/settings/screens/settings_explorer_screen.dart
+++ b/lib/src/features/settings/screens/settings_explorer_screen.dart
@@ -1,0 +1,352 @@
+import 'package:flutter/services.dart' show TextInputAction, TextInputType;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/config/zcash_explorer.dart';
+import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/layout/app_pane_scroll_scaffold.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_text_field.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
+import '../../../providers/zcash_explorer_provider.dart';
+
+enum _ExplorerChoice { cipherscan, custom }
+
+class SettingsExplorerScreen extends ConsumerStatefulWidget {
+  const SettingsExplorerScreen({super.key});
+
+  @override
+  ConsumerState<SettingsExplorerScreen> createState() =>
+      _SettingsExplorerScreenState();
+}
+
+class _SettingsExplorerScreenState
+    extends ConsumerState<SettingsExplorerScreen> {
+  final _customController = TextEditingController();
+  late _ExplorerChoice _choice;
+  bool _isSubmitting = false;
+  String? _submitError;
+
+  @override
+  void initState() {
+    super.initState();
+    final current = ref.read(zcashExplorerProvider);
+    _choice = current.trim().isEmpty
+        ? _ExplorerChoice.cipherscan
+        : _ExplorerChoice.custom;
+    if (_choice == _ExplorerChoice.custom) {
+      _customController.text = current;
+    }
+  }
+
+  @override
+  void dispose() {
+    _customController.dispose();
+    super.dispose();
+  }
+
+  bool _canUpdate(String current) {
+    if (_isSubmitting) return false;
+    return switch (_choice) {
+      _ExplorerChoice.cipherscan => current.trim().isNotEmpty,
+      _ExplorerChoice.custom => _customTemplateChanged(current),
+    };
+  }
+
+  bool _customTemplateChanged(String current) {
+    try {
+      final normalized = normalizeExplorerUrlTemplate(_customController.text);
+      return normalized != current.trim();
+    } on FormatException {
+      return _customController.text.trim().isNotEmpty;
+    }
+  }
+
+  String? _customMessageText() {
+    if (_choice != _ExplorerChoice.custom) return null;
+    if (_customController.text.trim().isEmpty) return null;
+    try {
+      normalizeExplorerUrlTemplate(_customController.text);
+      return null;
+    } on FormatException catch (e) {
+      return e.message;
+    }
+  }
+
+  Future<void> _submit() async {
+    final current = ref.read(zcashExplorerProvider);
+    if (!_canUpdate(current)) return;
+
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+
+    try {
+      final notifier = ref.read(zcashExplorerProvider.notifier);
+      if (_choice == _ExplorerChoice.cipherscan) {
+        await notifier.resetToDefault();
+      } else {
+        await notifier.setCustom(_customController.text);
+      }
+      if (!mounted) return;
+      final next = ref.read(zcashExplorerProvider);
+      setState(() {
+        _customController.text = next;
+        _isSubmitting = false;
+      });
+    } on FormatException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _submitError = e.message;
+        _isSubmitting = false;
+      });
+    } catch (e, st) {
+      log('SettingsExplorerScreen._submit: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _submitError = "Couldn't save that explorer URL.";
+        _isSubmitting = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final current = ref.watch(zcashExplorerProvider);
+    final networkName = ref.watch(rpcEndpointProvider).networkName;
+    final colors = context.colors;
+    final customMessage = _customMessageText();
+
+    return AppDesktopShell(
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: EdgeInsets.zero,
+        child: AppPaneScrollScaffold(
+          toolbar: const AppPaneToolbar(backLinkMinWidth: 60),
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              width: 420,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.s,
+                  vertical: AppSpacing.sm,
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      'Explorer',
+                      textAlign: TextAlign.center,
+                      style: AppTypography.headlineLarge.copyWith(
+                        color: colors.text.accent,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    Text(
+                      current.trim().isEmpty
+                          ? 'Current: ${defaultZcashExplorerHost(networkName)} (default)'
+                          : 'Current: ${explorerSettingsLabel(current, networkName: networkName)}',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.accent,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.base),
+                    _ExplorerOptionCard(
+                      key: const ValueKey('explorer_option_cipherscan'),
+                      iconName: AppIcons.globe,
+                      label: kDefaultZcashExplorerLabel,
+                      subtitle: defaultZcashExplorerHost(networkName),
+                      selected: _choice == _ExplorerChoice.cipherscan,
+                      onTap: _isSubmitting
+                          ? null
+                          : () => setState(() {
+                              _choice = _ExplorerChoice.cipherscan;
+                              _submitError = null;
+                            }),
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                    _ExplorerOptionCard(
+                      key: const ValueKey('explorer_option_custom'),
+                      iconName: AppIcons.edit,
+                      label: 'Custom',
+                      subtitle: 'Your own instance',
+                      selected: _choice == _ExplorerChoice.custom,
+                      onTap: _isSubmitting
+                          ? null
+                          : () => setState(() {
+                              _choice = _ExplorerChoice.custom;
+                              _submitError = null;
+                              if (_customController.text.trim().isEmpty &&
+                                  current.trim().isNotEmpty) {
+                                _customController.text = current;
+                              }
+                            }),
+                    ),
+                    if (_choice == _ExplorerChoice.custom) ...[
+                      const SizedBox(height: AppSpacing.md),
+                      AppTextField(
+                        key: const ValueKey('explorer_custom_field'),
+                        label: 'Explorer URL',
+                        hintText: 'https://explorer.example/tx/{txid}',
+                        controller: _customController,
+                        keyboardType: TextInputType.url,
+                        textInputAction: TextInputAction.done,
+                        messageText: customMessage,
+                        tone: customMessage == null
+                            ? AppTextFieldTone.neutral
+                            : AppTextFieldTone.destructive,
+                        onChanged: (_) => setState(() => _submitError = null),
+                        onSubmitted: (_) => _submit(),
+                      ),
+                      const SizedBox(height: AppSpacing.xs),
+                      Text(
+                        kZcashExplorerTemplateHint,
+                        style: AppTypography.bodySmall.copyWith(
+                          color: colors.text.secondary,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: AppSpacing.md),
+                    AppIcon(AppIcons.book, size: 20, color: colors.icon.accent),
+                    const SizedBox(height: AppSpacing.xs),
+                    Text(
+                      kZcashExplorerPrivacyCopy,
+                      style: AppTypography.bodyMedium.copyWith(
+                        color: colors.text.primary,
+                      ),
+                    ),
+                    if (_submitError != null) ...[
+                      const SizedBox(height: AppSpacing.sm),
+                      Text(
+                        _submitError!,
+                        textAlign: TextAlign.center,
+                        style: AppTypography.bodyMedium.copyWith(
+                          color: colors.text.destructive,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: AppSpacing.md),
+                    Center(
+                      child: AppButton(
+                        key: const ValueKey('explorer_update'),
+                        onPressed: _canUpdate(current) ? _submit : null,
+                        minWidth: 196,
+                        child: Text(
+                          _isSubmitting ? 'Updating...' : 'Update explorer',
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ExplorerOptionCard extends StatelessWidget {
+  const _ExplorerOptionCard({
+    required this.iconName,
+    required this.label,
+    required this.subtitle,
+    required this.selected,
+    required this.onTap,
+    super.key,
+  });
+
+  final String iconName;
+  final String label;
+  final String subtitle;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: label,
+      excludeSemantics: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          height: 64,
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+          decoration: BoxDecoration(
+            color: colors.background.ground,
+            borderRadius: BorderRadius.circular(AppRadii.medium),
+            border: Border.all(
+              color: selected ? colors.border.strong : colors.border.subtle,
+              width: selected ? 1.5 : 1,
+            ),
+          ),
+          child: Row(
+            children: [
+              Opacity(
+                opacity: selected ? 1 : 0.5,
+                child: AppIcon(iconName, size: 20, color: colors.icon.accent),
+              ),
+              const SizedBox(width: AppSpacing.s),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      label,
+                      style: AppTypography.bodyMediumStrong.copyWith(
+                        color: colors.text.accent,
+                      ),
+                    ),
+                    Text(
+                      subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.labelSmall.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                width: 16,
+                height: 16,
+                decoration: BoxDecoration(
+                  color: selected
+                      ? colors.background.inverse
+                      : colors.background.neutralSubtleOpacity,
+                  shape: BoxShape.circle,
+                ),
+                child: selected
+                    ? Center(
+                        child: AppIcon(
+                          AppIcons.check,
+                          size: 12,
+                          color: colors.background.ground,
+                        ),
+                      )
+                    : null,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/settings/screens/settings_explorer_screen.dart
+++ b/lib/src/features/settings/screens/settings_explorer_screen.dart
@@ -179,7 +179,7 @@ class _SettingsExplorerScreenState
                       key: const ValueKey('explorer_option_custom'),
                       iconName: AppIcons.edit,
                       label: 'Custom',
-                      subtitle: 'Your own instance',
+                      subtitle: 'Any explorer you prefer',
                       selected: _choice == _ExplorerChoice.custom,
                       onTap: _isSubmitting
                           ? null

--- a/lib/src/features/settings/screens/settings_screen.dart
+++ b/lib/src/features/settings/screens/settings_screen.dart
@@ -17,8 +17,10 @@ import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../../core/widgets/app_profile_picture.dart';
 import '../../../providers/account_provider.dart';
+import '../../../core/config/zcash_explorer.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/theme_mode_provider.dart';
+import '../../../providers/zcash_explorer_provider.dart';
 import '../../../providers/windows_update_provider.dart';
 import '../../accounts/widgets/account_modal_card.dart';
 import '../../accounts/widgets/account_edit_modal.dart';
@@ -143,7 +145,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final activeAccountIsHardware =
         accountState?.activeAccount?.isHardware ?? false;
     final themeMode = ref.watch(themeModeProvider);
-    final endpointLabel = ref.watch(rpcEndpointProvider).hostPort;
+    final endpoint = ref.watch(rpcEndpointProvider);
+    final endpointLabel = endpoint.hostPort;
+    final explorerLabel = explorerSettingsLabel(
+      ref.watch(zcashExplorerProvider),
+      networkName: endpoint.networkName,
+    );
     final updateState = defaultTargetPlatform == TargetPlatform.windows
         ? ref.watch(windowsUpdateProvider)
         : null;
@@ -170,6 +177,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ),
                 activeAccountIsHardware: activeAccountIsHardware,
                 endpointLabel: endpointLabel,
+                explorerLabel: explorerLabel,
                 themeLabel: _themeLabel(themeMode),
                 updateLabel: updateState == null
                     ? null
@@ -179,6 +187,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 onChangePassword: () =>
                     context.push('/settings/change-password'),
                 onEndpoint: () => context.push('/settings/endpoint'),
+                onExplorer: () => context.push('/settings/explorer'),
                 onAccountName: hasActiveAccount
                     ? () => _showModal(_SettingsModalType.accountName)
                     : null,
@@ -285,12 +294,14 @@ class _SettingsPane extends StatelessWidget {
     required this.profilePictureLabel,
     required this.activeAccountIsHardware,
     required this.endpointLabel,
+    required this.explorerLabel,
     required this.themeLabel,
     required this.updateLabel,
     required this.onSeedPhrase,
     required this.onViewingKey,
     required this.onChangePassword,
     required this.onEndpoint,
+    required this.onExplorer,
     required this.onAccountName,
     required this.onProfilePicture,
     required this.onAddressBook,
@@ -306,12 +317,14 @@ class _SettingsPane extends StatelessWidget {
   final String profilePictureLabel;
   final bool activeAccountIsHardware;
   final String endpointLabel;
+  final String explorerLabel;
   final String themeLabel;
   final String? updateLabel;
   final VoidCallback onSeedPhrase;
   final VoidCallback onViewingKey;
   final VoidCallback onChangePassword;
   final VoidCallback onEndpoint;
+  final VoidCallback onExplorer;
   final VoidCallback? onAccountName;
   final VoidCallback? onProfilePicture;
   final VoidCallback onAddressBook;
@@ -350,12 +363,14 @@ class _SettingsPane extends StatelessWidget {
                 profilePictureLabel: profilePictureLabel,
                 activeAccountIsHardware: activeAccountIsHardware,
                 endpointLabel: endpointLabel,
+                explorerLabel: explorerLabel,
                 themeLabel: themeLabel,
                 updateLabel: updateLabel,
                 onSeedPhrase: onSeedPhrase,
                 onViewingKey: onViewingKey,
                 onChangePassword: onChangePassword,
                 onEndpoint: onEndpoint,
+                onExplorer: onExplorer,
                 onAccountName: onAccountName,
                 onProfilePicture: onProfilePicture,
                 onAddressBook: onAddressBook,
@@ -381,12 +396,14 @@ class _SettingsList extends StatelessWidget {
     required this.profilePictureLabel,
     required this.activeAccountIsHardware,
     required this.endpointLabel,
+    required this.explorerLabel,
     required this.themeLabel,
     required this.updateLabel,
     required this.onSeedPhrase,
     required this.onViewingKey,
     required this.onChangePassword,
     required this.onEndpoint,
+    required this.onExplorer,
     required this.onAccountName,
     required this.onProfilePicture,
     required this.onAddressBook,
@@ -402,12 +419,14 @@ class _SettingsList extends StatelessWidget {
   final String profilePictureLabel;
   final bool activeAccountIsHardware;
   final String endpointLabel;
+  final String explorerLabel;
   final String themeLabel;
   final String? updateLabel;
   final VoidCallback onSeedPhrase;
   final VoidCallback onViewingKey;
   final VoidCallback onChangePassword;
   final VoidCallback onEndpoint;
+  final VoidCallback onExplorer;
   final VoidCallback? onAccountName;
   final VoidCallback? onProfilePicture;
   final VoidCallback onAddressBook;
@@ -487,6 +506,12 @@ class _SettingsList extends StatelessWidget {
               label: 'Endpoint',
               value: endpointLabel,
               onTap: onEndpoint,
+            ),
+            _SettingsRow(
+              iconName: AppIcons.globe,
+              label: 'Explorer',
+              value: explorerLabel,
+              onTap: onExplorer,
             ),
             _SettingsRow(
               iconName: AppIcons.theme,

--- a/lib/src/providers/zcash_explorer_provider.dart
+++ b/lib/src/providers/zcash_explorer_provider.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../app_bootstrap.dart';
+import '../core/config/zcash_explorer.dart';
+import '../core/storage/app_secure_store.dart';
+
+class ZcashExplorerNotifier extends Notifier<String> {
+  static final _store = AppSecureStore.instance;
+
+  @override
+  String build() => ref.watch(appBootstrapProvider).explorerUrlTemplate;
+
+  bool get isCustom => state.trim().isNotEmpty;
+
+  String labelForNetwork(String networkName) {
+    return explorerSettingsLabel(state, networkName: networkName);
+  }
+
+  Future<void> setCustom(String input) async {
+    final normalized = normalizeExplorerUrlTemplate(input);
+    await _store.writePlain(kZcashExplorerUrlKey, normalized);
+    state = normalized;
+  }
+
+  Future<void> resetToDefault() async {
+    await _store.delete(kZcashExplorerUrlKey);
+    state = '';
+  }
+}
+
+final zcashExplorerProvider = NotifierProvider<ZcashExplorerNotifier, String>(
+  ZcashExplorerNotifier.new,
+);

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -55,6 +55,7 @@ import '../src/features/onboarding/create/onboarding_split_view.dart';
 import '../src/features/onboarding/shared/onboarding_flow_args.dart';
 import '../src/features/settings/screens/settings_change_password_screen.dart';
 import '../src/features/settings/screens/settings_endpoint_screen.dart';
+import '../src/features/settings/screens/settings_explorer_screen.dart';
 import '../src/features/settings/screens/settings_screen.dart';
 import '../src/features/settings/screens/settings_seed_phrase_screen.dart';
 import '../src/features/settings/screens/settings_uninstall_screen.dart';
@@ -805,6 +806,13 @@ Widget buildSettingsEndpointUseCase(BuildContext context) {
   return _buildSettingsSubScreenUseCase(
     '/settings/endpoint',
     const SettingsEndpointScreen(),
+  );
+}
+
+Widget buildSettingsExplorerUseCase(BuildContext context) {
+  return _buildSettingsSubScreenUseCase(
+    '/settings/explorer',
+    const SettingsExplorerScreen(),
   );
 }
 
@@ -2426,6 +2434,7 @@ class _SettingsHarnessState extends State<_SettingsHarness> {
           '/settings/secret-passphrase',
           '/settings/change-password',
           '/settings/endpoint',
+          '/settings/explorer',
           '/settings/uninstall',
           '/address-book',
           '/about',
@@ -2754,6 +2763,11 @@ class _DesktopHomeHarnessState extends State<_DesktopHomeHarness> {
           path: '/settings/endpoint',
           builder: (_, _) =>
               const _PreviewRoutePlaceholder(label: '/settings/endpoint'),
+        ),
+        GoRoute(
+          path: '/settings/explorer',
+          builder: (_, _) =>
+              const _PreviewRoutePlaceholder(label: '/settings/explorer'),
         ),
         GoRoute(
           path: '/migration',

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -64,6 +64,7 @@ import '../src/features/wallet_link/models/wallet_link_models.dart';
 import '../src/features/wallet_link/screens/wallet_link_desktop_screen.dart';
 import '../src/features/onboarding/unlock_screen.dart';
 import '../src/features/onboarding/welcome.dart';
+import '../src/features/settings/screens/mobile/mobile_explorer_screen.dart';
 import '../src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart';
 import '../src/features/settings/screens/mobile/mobile_settings_screen.dart';
 import '../src/features/settings/screens/mobile/mobile_viewing_key_screen.dart';
@@ -734,6 +735,67 @@ class _MobileSettingsFooterPreviewState
   }
 }
 
+class _MobileSettingsExplorerPreview extends StatefulWidget {
+  const _MobileSettingsExplorerPreview();
+
+  @override
+  State<_MobileSettingsExplorerPreview> createState() =>
+      _MobileSettingsExplorerPreviewState();
+}
+
+class _MobileSettingsExplorerPreviewState
+    extends State<_MobileSettingsExplorerPreview> {
+  final _controller = ScrollController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _scrollExplorerRowIntoView() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      Element? found;
+      void visitor(Element element) {
+        if (found != null) return;
+        if (element.widget.key ==
+            const ValueKey('mobile_settings_explorer_row')) {
+          found = element;
+          return;
+        }
+        element.visitChildren(visitor);
+      }
+
+      context.visitChildElements(visitor);
+      final rowContext = found;
+      if (rowContext == null) return;
+      Scrollable.ensureVisible(rowContext, alignment: 0.4);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppMobileShell(
+      body: NotificationListener<ScrollMetricsNotification>(
+        onNotification: (_) {
+          _scrollExplorerRowIntoView();
+          return false;
+        },
+        child: PrimaryScrollController(
+          controller: _controller,
+          child: const MobileSettingsScreen(),
+        ),
+      ),
+      tabBar: AppMobileTabBar(
+        items: _mobileHomeTabItems,
+        currentIndex: 3,
+        onSelect: (_) {},
+      ),
+    );
+  }
+}
+
 Widget buildSettingsTorConnectingUseCase(BuildContext context) {
   return _buildSettingsMainUseCase(
     const NetworkPrivacyState(
@@ -813,6 +875,70 @@ Widget buildSettingsExplorerUseCase(BuildContext context) {
   return _buildSettingsSubScreenUseCase(
     '/settings/explorer',
     const SettingsExplorerScreen(),
+  );
+}
+
+Widget buildSettingsExplorerCustomUseCase(BuildContext context) {
+  return _buildSettingsSubScreenUseCase(
+    '/settings/explorer',
+    const SettingsExplorerScreen(),
+    explorerUrlTemplate: 'https://zcashblockexplorer.com/tx/{txid}',
+  );
+}
+
+Widget buildMobileExplorerUseCase(BuildContext context) {
+  return _buildMobileExplorerUseCase();
+}
+
+Widget buildMobileExplorerCustomUseCase(BuildContext context) {
+  return _buildMobileExplorerUseCase(
+    explorerUrlTemplate: 'https://zcashblockexplorer.com/tx/{txid}',
+  );
+}
+
+Widget buildMobileSettingsExplorerUseCase(BuildContext context) {
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(
+        _accountsBootstrap(_accountsDesignState, initialLocation: '/settings'),
+      ),
+      accountProvider.overrideWith(
+        () => _PreviewAccountNotifier(_accountsDesignState),
+      ),
+      networkPrivacyProvider.overrideWith(
+        () => _PreviewNetworkPrivacyNotifier(const NetworkPrivacyState.off()),
+      ),
+      biometricUnlockProvider.overrideWith(
+        () => _PreviewBiometricUnlockNotifier(BiometricUnlockState.initial),
+      ),
+    ],
+    child: const _MobilePreviewFrame(
+      constrainToDesignSize: false,
+      child: IgnorePointer(child: _MobileSettingsExplorerPreview()),
+    ),
+  );
+}
+
+Widget _buildMobileExplorerUseCase({String explorerUrlTemplate = ''}) {
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(
+        _accountsBootstrap(
+          _accountsDesignState,
+          initialLocation: '/settings/explorer',
+          explorerUrlTemplate: explorerUrlTemplate,
+        ),
+      ),
+      accountProvider.overrideWith(
+        () => _PreviewAccountNotifier(_accountsDesignState),
+      ),
+      syncProvider.overrideWith(
+        () => _PreviewSyncNotifier(_accountsDesignState.activeAccountUuid),
+      ),
+    ],
+    child: const _MobilePreviewFrame(
+      child: IgnorePointer(child: MobileExplorerScreen()),
+    ),
   );
 }
 
@@ -933,11 +1059,19 @@ Widget _buildSettingsWalletLinkUseCase(WalletLinkState state) {
   );
 }
 
-Widget _buildSettingsSubScreenUseCase(String path, Widget screen) {
+Widget _buildSettingsSubScreenUseCase(
+  String path,
+  Widget screen, {
+  String explorerUrlTemplate = '',
+}) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(
-        _accountsBootstrap(_accountsDesignState, initialLocation: path),
+        _accountsBootstrap(
+          _accountsDesignState,
+          initialLocation: path,
+          explorerUrlTemplate: explorerUrlTemplate,
+        ),
       ),
       accountProvider.overrideWith(
         () => _PreviewAccountNotifier(_accountsDesignState),
@@ -3585,6 +3719,7 @@ const _mobileHomeTabItems = [
 AppBootstrapState _accountsBootstrap(
   AccountState accountState, {
   String initialLocation = '/accounts',
+  String explorerUrlTemplate = '',
 }) {
   return AppBootstrapState(
     initialLocation: initialLocation,
@@ -3592,6 +3727,7 @@ AppBootstrapState _accountsBootstrap(
     initialSyncSnapshot: AppSyncSnapshot.empty,
     network: 'main',
     rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+    explorerUrlTemplate: explorerUrlTemplate,
     themeMode: ThemeMode.system,
     privacyModeEnabled: false,
     isPasswordConfigured: true,

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -649,6 +649,10 @@ class WidgetbookApp extends StatelessWidget {
                       builder: buildSettingsEndpointUseCase,
                     ),
                     WidgetbookUseCase(
+                      name: 'Explorer',
+                      builder: buildSettingsExplorerUseCase,
+                    ),
+                    WidgetbookUseCase(
                       name: 'Secret passphrase gate',
                       builder: buildSettingsSecretPassphraseGateUseCase,
                     ),

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -653,6 +653,22 @@ class WidgetbookApp extends StatelessWidget {
                       builder: buildSettingsExplorerUseCase,
                     ),
                     WidgetbookUseCase(
+                      name: 'Explorer custom',
+                      builder: buildSettingsExplorerCustomUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Mobile explorer',
+                      builder: buildMobileExplorerUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Mobile explorer custom',
+                      builder: buildMobileExplorerCustomUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Mobile settings explorer row',
+                      builder: buildMobileSettingsExplorerUseCase,
+                    ),
+                    WidgetbookUseCase(
                       name: 'Secret passphrase gate',
                       builder: buildSettingsSecretPassphraseGateUseCase,
                     ),

--- a/test/features/settings/mobile_explorer_screen_test.dart
+++ b/test/features/settings/mobile_explorer_screen_test.dart
@@ -88,6 +88,7 @@ void main() {
 
     expect(find.text('Explorer'), findsOneWidget);
     expect(find.text('CipherScan'), findsOneWidget);
+    expect(find.text('Any explorer you prefer'), findsOneWidget);
 
     await tester.tap(
       find.byKey(const ValueKey('mobile_explorer_option_custom')),

--- a/test/features/settings/mobile_explorer_screen_test.dart
+++ b/test/features/settings/mobile_explorer_screen_test.dart
@@ -1,0 +1,108 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/config/zcash_explorer.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/settings/screens/mobile/mobile_explorer_screen.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zcash_explorer_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+
+const _accountState = AccountState(
+  accounts: [AccountInfo(uuid: 'account-1', name: 'John', order: 0)],
+  activeAccountUuid: 'account-1',
+  activeAddress: 'u1exploreraddress',
+);
+
+AppBootstrapState _bootstrap({String explorerUrlTemplate = ''}) =>
+    AppBootstrapState(
+      initialLocation: '/settings/explorer',
+      initialAccountState: _accountState,
+      initialSyncSnapshot: AppSyncSnapshot.empty,
+      network: 'main',
+      rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+      explorerUrlTemplate: explorerUrlTemplate,
+      themeMode: ThemeMode.dark,
+      privacyModeEnabled: false,
+      isPasswordConfigured: true,
+      isUnlocked: true,
+      passwordRotationRecoveryFailed: false,
+    );
+
+class _FakeExplorerNotifier extends ZcashExplorerNotifier {
+  _FakeExplorerNotifier(this.initial);
+
+  final String initial;
+
+  @override
+  String build() => initial;
+
+  @override
+  Future<void> setCustom(String input) async {
+    state = normalizeExplorerUrlTemplate(input);
+  }
+
+  @override
+  Future<void> resetToDefault() async {
+    state = '';
+  }
+}
+
+Widget _app({String explorerUrlTemplate = ''}) {
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(
+        _bootstrap(explorerUrlTemplate: explorerUrlTemplate),
+      ),
+      syncProvider.overrideWith(() => FakeSyncNotifier(SyncState())),
+      zcashExplorerProvider.overrideWith(
+        () => _FakeExplorerNotifier(explorerUrlTemplate),
+      ),
+    ],
+    child: MaterialApp(
+      builder: (_, child) => AppTheme(data: AppThemeData.dark, child: child!),
+      home: const MobileExplorerScreen(),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('saves a custom explorer URL from the mobile settings screen', (
+    tester,
+  ) async {
+    tester.view
+      ..physicalSize = const Size(393, 852)
+      ..devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(_app());
+    await tester.pump();
+
+    expect(find.text('Explorer'), findsOneWidget);
+    expect(find.text('CipherScan'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_explorer_option_custom')),
+    );
+    await tester.pump();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('mobile_explorer_custom_field')),
+      'https://privacy.example/tx/{txid}',
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_explorer_update')));
+    await tester.pump();
+
+    expect(find.textContaining('privacy.example'), findsWidgets);
+  });
+}

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -786,6 +786,8 @@ void main() {
       find.text(defaultRpcEndpointConfig('main').hostPort),
       findsOneWidget,
     );
+    expect(find.text('Explorer'), findsOneWidget);
+    expect(find.text('CipherScan'), findsOneWidget);
   });
 
   testWidgets('theme row opens the sheet and applies the selection', (

--- a/test/features/settings/settings_explorer_screen_test.dart
+++ b/test/features/settings/settings_explorer_screen_test.dart
@@ -99,6 +99,7 @@ void main() {
     expect(find.text('CipherScan'), findsOneWidget);
     expect(find.textContaining('cipherscan.app'), findsWidgets);
     expect(find.text(kZcashExplorerPrivacyCopy), findsOneWidget);
+    expect(find.text('Any explorer you prefer'), findsOneWidget);
 
     await tester.tap(find.byKey(const ValueKey('explorer_option_custom')));
     await tester.pump();

--- a/test/features/settings/settings_explorer_screen_test.dart
+++ b/test/features/settings/settings_explorer_screen_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/config/zcash_explorer.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/settings/screens/settings_explorer_screen.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zcash_explorer_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+
+const _accountState = AccountState(
+  accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+  activeAccountUuid: 'account-1',
+  activeAddress: 'u1exploreraddress',
+);
+
+AppBootstrapState _bootstrap({String explorerUrlTemplate = ''}) =>
+    AppBootstrapState(
+      initialLocation: '/settings/explorer',
+      initialAccountState: _accountState,
+      initialSyncSnapshot: AppSyncSnapshot.empty,
+      network: 'main',
+      rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+      explorerUrlTemplate: explorerUrlTemplate,
+      themeMode: ThemeMode.light,
+      privacyModeEnabled: false,
+      isPasswordConfigured: true,
+      isUnlocked: true,
+      passwordRotationRecoveryFailed: false,
+    );
+
+class _FakeExplorerNotifier extends ZcashExplorerNotifier {
+  _FakeExplorerNotifier(this.initial);
+
+  final String initial;
+
+  @override
+  String build() => initial;
+
+  @override
+  Future<void> setCustom(String input) async {
+    state = normalizeExplorerUrlTemplate(input);
+  }
+
+  @override
+  Future<void> resetToDefault() async {
+    state = '';
+  }
+}
+
+Widget _harness({String explorerUrlTemplate = ''}) {
+  final router = GoRouter(
+    initialLocation: '/settings/explorer',
+    routes: [
+      GoRoute(
+        path: '/settings/explorer',
+        builder: (_, _) => const SettingsExplorerScreen(),
+      ),
+      GoRoute(path: '/settings', builder: (_, _) => const SizedBox()),
+      GoRoute(path: '/home', builder: (_, _) => const SizedBox()),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(
+        _bootstrap(explorerUrlTemplate: explorerUrlTemplate),
+      ),
+      syncProvider.overrideWith(FakeSyncNotifier.new),
+      zcashExplorerProvider.overrideWith(
+        () => _FakeExplorerNotifier(explorerUrlTemplate),
+      ),
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('defaults to CipherScan and saves a custom origin', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(_harness());
+    await tester.pump();
+
+    expect(find.text('Explorer'), findsOneWidget);
+    expect(find.text('CipherScan'), findsOneWidget);
+    expect(find.textContaining('cipherscan.app'), findsWidgets);
+    expect(find.text(kZcashExplorerPrivacyCopy), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('explorer_option_custom')));
+    await tester.pump();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('explorer_custom_field')),
+      'https://privacy.example',
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('explorer_update')));
+    await tester.pump();
+
+    expect(find.textContaining('privacy.example'), findsWidgets);
+  });
+
+  testWidgets('resetting to CipherScan clears a custom explorer', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(
+      _harness(explorerUrlTemplate: 'https://privacy.example/tx/{txid}'),
+    );
+    await tester.pump();
+
+    expect(find.textContaining('privacy.example'), findsWidgets);
+
+    await tester.tap(find.byKey(const ValueKey('explorer_option_cipherscan')));
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('explorer_update')));
+    await tester.pump();
+
+    expect(find.textContaining('(default)'), findsOneWidget);
+  });
+}

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -47,6 +47,8 @@ void main() {
     await tester.pump();
 
     expect(_rowBackgroundColor(tester, 'Password'), isNull);
+    expect(find.text('Explorer'), findsOneWidget);
+    expect(find.text('CipherScan'), findsOneWidget);
 
     final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
     addTearDown(mouse.removePointer);

--- a/test/widgetbook/settings_use_cases_test.dart
+++ b/test/widgetbook/settings_use_cases_test.dart
@@ -74,6 +74,23 @@ void main() {
     expect(find.text('CipherScan'), findsOneWidget);
   });
 
+  testWidgets('settings explorer custom use case shows the URL field', (
+    tester,
+  ) async {
+    final errors = await _pumpSettingsUseCase(
+      tester,
+      buildSettingsExplorerCustomUseCase,
+    );
+
+    _expectNoCrash(errors);
+    expect(find.text('Explorer'), findsOneWidget);
+    expect(find.text('Custom'), findsOneWidget);
+    expect(
+      find.text('https://zcashblockexplorer.com/tx/{txid}'),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('settings secret passphrase gate use case renders the gate', (
     tester,
   ) async {

--- a/test/widgetbook/settings_use_cases_test.dart
+++ b/test/widgetbook/settings_use_cases_test.dart
@@ -61,6 +61,19 @@ void main() {
     expect(find.text('Endpoint'), findsOneWidget);
   });
 
+  testWidgets('settings explorer use case renders the explorer header', (
+    tester,
+  ) async {
+    final errors = await _pumpSettingsUseCase(
+      tester,
+      buildSettingsExplorerUseCase,
+    );
+
+    _expectNoCrash(errors);
+    expect(find.text('Explorer'), findsOneWidget);
+    expect(find.text('CipherScan'), findsOneWidget);
+  });
+
   testWidgets('settings secret passphrase gate use case renders the gate', (
     tester,
   ) async {

--- a/test/zcash_explorer_test.dart
+++ b/test/zcash_explorer_test.dart
@@ -118,9 +118,9 @@ void main() {
         networkName: 'main',
         txidHex: txid,
         txidOrder: ZcashExplorerTxidOrder.display,
-        customTemplate: 'https://self-hosted.example/zcash/{txHash}',
+        customTemplate: 'https://alternate.example/zcash/{txHash}',
       ).toString(),
-      'https://self-hosted.example/zcash/$txid',
+      'https://alternate.example/zcash/$txid',
     );
   });
 

--- a/test/zcash_explorer_test.dart
+++ b/test/zcash_explorer_test.dart
@@ -91,4 +91,102 @@ void main() {
 
     expect(launched, isFalse);
   });
+
+  test('origin-only custom template appends /tx/{txid}', () {
+    expect(
+      normalizeExplorerUrlTemplate('https://explorer.example'),
+      'https://explorer.example/tx/{txid}',
+    );
+    expect(
+      zcashExplorerTransactionUri(
+        networkName: 'main',
+        txidHex:
+            '477ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f',
+        txidOrder: ZcashExplorerTxidOrder.display,
+        customTemplate: 'https://explorer.example',
+      ).toString(),
+      'https://explorer.example/tx/'
+      '477ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f',
+    );
+  });
+
+  test('substitutes {txid} and {txHash} placeholders', () {
+    const txid =
+        '477ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f';
+    expect(
+      zcashExplorerTransactionUri(
+        networkName: 'main',
+        txidHex: txid,
+        txidOrder: ZcashExplorerTxidOrder.display,
+        customTemplate: 'https://self-hosted.example/zcash/{txHash}',
+      ).toString(),
+      'https://self-hosted.example/zcash/$txid',
+    );
+  });
+
+  test('replaces a concrete 64-hex path tail with {txid}', () {
+    expect(
+      normalizeExplorerUrlTemplate(
+        'https://cipherscan.app/tx/'
+        '477ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f',
+      ),
+      'https://cipherscan.app/tx/{txid}',
+    );
+  });
+
+  test('adds https when the scheme is omitted', () {
+    expect(
+      normalizeExplorerUrlTemplate('my-explorer.local/tx/{txid}'),
+      'https://my-explorer.local/tx/{txid}',
+    );
+  });
+
+  test('rejects non-http schemes', () {
+    expect(
+      () => normalizeExplorerUrlTemplate('javascript:alert(1)'),
+      throwsA(
+        isA<FormatException>().having(
+          (e) => e.message,
+          'message',
+          'Enter an http or https URL.',
+        ),
+      ),
+    );
+  });
+
+  test('settings label is CipherScan until a custom host is set', () {
+    expect(
+      explorerSettingsLabel('', networkName: 'main'),
+      kDefaultZcashExplorerLabel,
+    );
+    expect(
+      explorerSettingsLabel(
+        'https://privacy.example/tx/{txid}',
+        networkName: 'main',
+      ),
+      'privacy.example',
+    );
+  });
+
+  test('launch uses the custom template when provided', () async {
+    final launched = <Uri>[];
+    final opened = await launchZcashExplorerTransaction(
+      networkName: 'main',
+      txidHex:
+          '477ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f',
+      txidOrder: ZcashExplorerTxidOrder.display,
+      customTemplate: 'http://127.0.0.1:8080/tx/{txid}',
+      launcher: (uri) async {
+        launched.add(uri);
+        return true;
+      },
+    );
+
+    expect(opened, isTrue);
+    expect(
+      launched.single.toString(),
+      'http://127.0.0.1:8080/tx/'
+      '477ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f',
+    );
+  });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves **VZR-143**.

Settings → System → **Explorer** lets users keep CipherScan or point transaction links at any other explorer they prefer — a self-hosted instance, or just an alternate public site.

Opening a public explorer right after sending can still link the viewer’s IP to that transaction; choosing another explorer is optional, not required to be self-hosted.

## What changed
- Persist an optional explorer URL template (`{txid}` / `{txHash}`, or just an origin).
- History, send status, and related explorer links use that choice.
- Reset / CipherScan restores the default host for the current network.
- Desktop and mobile settings screens, plus widgetbook coverage.

## Screenshots

Widget-test captures of the shipped desktop and mobile UI.

### Desktop

Settings → System with the new Explorer row (CipherScan):

[Desktop settings with Explorer row set to CipherScan](https://cursor.com/agents/bc-8c456c47-e2ee-4c54-855c-61fd4dc2bfe9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_settings_explorer_row_dark.png)

Explorer screen, CipherScan selected (dark):

[Desktop Explorer screen, CipherScan selected, dark theme](https://cursor.com/agents/bc-8c456c47-e2ee-4c54-855c-61fd4dc2bfe9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_explorer_cipherscan_dark.png)

Explorer screen, custom URL template:

[Desktop Explorer screen with custom URL template](https://cursor.com/agents/bc-8c456c47-e2ee-4c54-855c-61fd4dc2bfe9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_explorer_custom_dark.png)

Explorer screen, CipherScan selected (light):

[Desktop Explorer screen, CipherScan selected, light theme](https://cursor.com/agents/bc-8c456c47-e2ee-4c54-855c-61fd4dc2bfe9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_explorer_cipherscan_light.png)

### Mobile

Settings scrolled to the System Explorer row:

[Mobile settings scrolled to Explorer row](https://cursor.com/agents/bc-8c456c47-e2ee-4c54-855c-61fd4dc2bfe9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_settings_explorer_row_dark.png)

Explorer screen, CipherScan selected (dark):

[Mobile Explorer screen, CipherScan selected, dark theme](https://cursor.com/agents/bc-8c456c47-e2ee-4c54-855c-61fd4dc2bfe9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_explorer_cipherscan_dark.png)

Explorer screen, custom URL template:

[Mobile Explorer screen with custom URL template](https://cursor.com/agents/bc-8c456c47-e2ee-4c54-855c-61fd4dc2bfe9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_explorer_custom_dark.png)

Explorer screen, CipherScan selected (light):

[Mobile Explorer screen, CipherScan selected, light theme](https://cursor.com/agents/bc-8c456c47-e2ee-4c54-855c-61fd4dc2bfe9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_explorer_cipherscan_light.png)

## Testing
- Unit tests for URL templates and settings labels (including encoded `{txid}` / `{txHash}` paths).
- Widget tests for the desktop and mobile Explorer screens, including the “any explorer you prefer” copy.
- Existing settings / send-status explorer tests still pass.
- `flutter analyze` on the changed files is clean.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [VZR-143](https://linear.app/keplrwallet/issue/VZR-143/allow-users-to-set-custom-explorers)

<div><a href="https://cursor.com/agents/bc-8c456c47-e2ee-4c54-855c-61fd4dc2bfe9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c456c47-e2ee-4c54-855c-61fd4dc2bfe9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

