### PR TITLE
Payment request card: requester/transaction hierarchy and one spacing rule

### DIFF
--- a/lib/src/core/widgets/pool_badge.dart
+++ b/lib/src/core/widgets/pool_badge.dart
@@ -30,12 +30,14 @@ class PoolBadge extends StatelessWidget {
           color: isShielded ? colors.text.brandCrimson : colors.text.secondary,
         ),
         const SizedBox(width: AppSpacing.xxs),
-        Text(
-          isShielded ? 'Shielded' : 'Transparent',
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: AppTypography.labelSmall.copyWith(
-            color: colors.text.secondary,
+        Flexible(
+          child: Text(
+            isShielded ? 'Shielded' : 'Transparent',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.labelSmall.copyWith(
+              color: colors.text.secondary,
+            ),
           ),
         ),
       ],

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -19,14 +19,6 @@ import '../../../core/widgets/review_wrap_card.dart';
 /// the home confirmation cards).
 const double kPaymentRequestCardWidth = 396;
 
-/// Vertical padding added around the card's 24px-high compact ghost button
-/// ("Show full address") in the mobile layout.
-///
-/// The pill keeps its Figma height; the transparent ring around it brings the
-/// tap target to 44px, which is what a thumb needs. Desktop keeps the bare
-/// 24px control — it is above the WCAG 2.5.8 floor and pointer-driven.
-const double kPaymentRequestTouchRingInset = 10;
-
 /// Horizontal room the mobile header leaves for the sheet's pinned close.
 ///
 /// The card renders no close of its own on mobile — `MobileModalScaffold`
@@ -43,11 +35,28 @@ const double kPaymentRequestMobileCloseClearance = 40;
 /// far in from that card's edge. One gutter, two left edges.
 const double kPaymentRequestGutter = AppSpacing.sm;
 
+/// Horizontal breathing room inside the two-line disclosure controls.
+/// They stay visually quiet on hover like the existing review rows, while
+/// keeping their labels away from the full-row hit target's edges.
+const _paymentRequestDisclosurePadding = EdgeInsets.symmetric(
+  horizontal: AppSpacing.xs,
+);
+
 /// The scroll region's overlay scrollbar, for tests.
 const kPaymentRequestScrollbarKey = ValueKey('payment_request_scrollbar');
 
 /// The scroll region's scroll view, for tests.
 const kPaymentRequestScrollViewKey = ValueKey('payment_request_scroll_view');
+
+/// The requester note's nested scroll view, for tests.
+const kPaymentRequestRequesterNoteScrollViewKey = ValueKey(
+  'payment_request_requester_note_scroll_view',
+);
+
+/// The requester note's nested scrollbar, for tests.
+const kPaymentRequestRequesterNoteScrollbarKey = ValueKey(
+  'payment_request_requester_note_scrollbar',
+);
 
 /// Which of the two presentations [PaymentRequestCard] lays itself out for.
 ///
@@ -603,19 +612,16 @@ class _PaymentRequestCardState extends State<PaymentRequestCard> {
                 rows: rows,
                 bounded: false,
               ),
-            // One status slot for every condition, directly under the
-            // details card and directly above the buttons it explains.
+            // A request error belongs to the details card, so keep it close
+            // to that surface and leave the full section gap before actions.
             if (statusMessage != null) ...[
-              SizedBox(height: sectionGap),
+              SizedBox(height: isMobile ? AppSpacing.xxs : AppSpacing.xs),
               _StatusMessage(
                 key: const ValueKey('payment_request_status'),
                 status: status,
                 message: statusMessage,
               ),
-              // The status line explains the buttons underneath, so it sits
-              // close to them and far from the content above — the gap below
-              // stays well under half the gap above in both lanes.
-              SizedBox(height: isMobile ? AppSpacing.xxs : AppSpacing.xs),
+              SizedBox(height: sectionGap),
             ] else
               SizedBox(height: sectionGap),
             _Actions(
@@ -684,6 +690,7 @@ class _RequesterDetailsCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final transparent = colors.background.ground.withValues(alpha: 0);
     final summary = requester ?? 'Note from requester';
     final scaler = MediaQuery.textScalerOf(context);
     // Label over value, both at body size: the requester is text the link
@@ -737,9 +744,11 @@ class _RequesterDetailsCard extends StatelessWidget {
         : Semantics(
             button: true,
             expanded: expanded,
+            excludeSemantics: true,
             label: expanded
                 ? 'Hide requester details'
                 : 'Show requester details',
+            value: 'Requester, $summary',
             onTap: toggle,
             child: AppButton(
               key: const ValueKey('payment_request_requester_toggle'),
@@ -747,9 +756,11 @@ class _RequesterDetailsCard extends StatelessWidget {
               variant: AppButtonVariant.ghost,
               size: AppButtonSize.small,
               height: summaryHeight,
+              enabledBackgroundColor: transparent,
+              pressedBackgroundColor: transparent,
               expand: true,
               constrainContent: true,
-              contentPadding: EdgeInsets.zero,
+              contentPadding: _paymentRequestDisclosurePadding,
               child: summaryRow,
             ),
           );
@@ -773,11 +784,19 @@ class _RequesterDetailsCard extends StatelessWidget {
                 style: labelStyle.copyWith(color: colors.text.secondary),
               ),
               const SizedBox(height: AppSpacing.xxs),
-              Text(
-                note!,
-                key: const ValueKey('payment_request_requester_note'),
-                style: AppTypography.bodyMediumStrong.copyWith(
-                  color: colors.text.accent,
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: AppSpacing.xl3),
+                child: _FadingScrollRegion(
+                  scrollViewKey: kPaymentRequestRequesterNoteScrollViewKey,
+                  scrollbarKey: kPaymentRequestRequesterNoteScrollbarKey,
+                  contentPadding: EdgeInsets.zero,
+                  child: Text(
+                    note!,
+                    key: const ValueKey('payment_request_requester_note'),
+                    style: AppTypography.bodyMediumStrong.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
                 ),
               ),
             ],
@@ -980,6 +999,7 @@ class _AddressRow extends StatelessWidget {
         if (isMobileLayout)
           GestureDetector(
             behavior: HitTestBehavior.translucent,
+            excludeFromSemantics: true,
             onTap: onToggle,
             child: recipient,
           )
@@ -1153,38 +1173,6 @@ class _AddressChunks extends StatelessWidget {
   }
 }
 
-/// Adds a transparent ring around a compact control so the tap target
-/// reaches 44px on touch without changing the pill.
-///
-/// The inner control keeps its own opaque gesture detector; this one only
-/// catches the ring, and both call the same callback.
-class _TouchTargetRing extends StatelessWidget {
-  const _TouchTargetRing({
-    required this.apply,
-    required this.onTap,
-    required this.child,
-  });
-
-  final bool apply;
-  final VoidCallback onTap;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    if (!apply) return child;
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: kPaymentRequestTouchRingInset,
-        ),
-        child: child,
-      ),
-    );
-  }
-}
-
 /// The card's name in the serif headline scale the send screens use for
 /// their titles, with the desktop close affordance beside it.
 ///
@@ -1328,6 +1316,7 @@ class _ProseRows extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final transparent = colors.background.ground.withValues(alpha: 0);
     final valueStyle = AppTypography.bodyMediumStrong;
     final scaler = MediaQuery.textScalerOf(context);
     // The control is the whole label-over-value block: 54px on mobile,
@@ -1345,9 +1334,11 @@ class _ProseRows extends StatelessWidget {
         Semantics(
           button: true,
           expanded: expanded,
+          excludeSemantics: true,
           label: expanded
               ? 'Collapse transaction memo'
               : 'Expand transaction memo',
+          value: '$label, $text',
           onTap: onToggle,
           child: AppButton(
             key: const ValueKey('payment_request_memo_toggle'),
@@ -1355,9 +1346,11 @@ class _ProseRows extends StatelessWidget {
             variant: AppButtonVariant.ghost,
             size: AppButtonSize.small,
             height: controlHeight,
+            enabledBackgroundColor: transparent,
+            pressedBackgroundColor: transparent,
             expand: true,
             constrainContent: true,
-            contentPadding: EdgeInsets.zero,
+            contentPadding: _paymentRequestDisclosurePadding,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
@@ -1479,8 +1472,9 @@ class _QuietNotice extends StatelessWidget {
   }
 }
 
-/// The card's action area: one full-width primary with a compact text-only
-/// edit action underneath.
+/// The card's action area: one full-width primary over one full-width ghost
+/// action, the pair `ReviewButtonsStack` already uses on the send review
+/// screens.
 ///
 /// "Review" names where the primary lands — the send review step — rather
 /// than the generic "Continue" it replaced; nothing is signed from here.
@@ -1541,7 +1535,7 @@ class _Actions extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _primaryFill(),
-        if (hasAmount) ...[const SizedBox(height: AppSpacing.xs), _editText()],
+        if (hasAmount) ...[const SizedBox(height: AppSpacing.xs), _editFill()],
       ],
     );
 
@@ -1623,22 +1617,11 @@ class _Actions extends StatelessWidget {
     leading: _primaryLeading(),
   );
 
-  Widget _editText() => Align(
-    child: _TouchTargetRing(
-      apply: isMobileLayout,
-      onTap: onEdit,
-      child: _semantics(
-        enabled: true,
-        label: 'Edit',
-        child: AppButton(
-          key: const ValueKey('payment_request_edit'),
-          onPressed: onEdit,
-          variant: AppButtonVariant.ghost,
-          size: AppButtonSize.small,
-          child: const Text('Edit'),
-        ),
-      ),
-    ),
+  Widget _editFill() => _fillButton(
+    key: const ValueKey('payment_request_edit'),
+    label: 'Edit',
+    onPressed: onEdit,
+    variant: AppButtonVariant.ghost,
   );
 }
 
@@ -1707,9 +1690,17 @@ class _DetailsFrame extends StatelessWidget {
 /// result — the reason an expanded memo collapsed the moment the user
 /// scrolled.
 class _FadingScrollRegion extends StatefulWidget {
-  const _FadingScrollRegion({required this.child});
+  const _FadingScrollRegion({
+    required this.child,
+    this.scrollViewKey = kPaymentRequestScrollViewKey,
+    this.scrollbarKey = kPaymentRequestScrollbarKey,
+    this.contentPadding = defaultContentPadding,
+  });
 
   final Widget child;
+  final Key scrollViewKey;
+  final Key scrollbarKey;
+  final EdgeInsetsGeometry contentPadding;
 
   static const _fadeHeight = AppSpacing.md;
 
@@ -1717,7 +1708,7 @@ class _FadingScrollRegion extends StatefulWidget {
   /// the full height of the card. The card gutter on every side, not the
   /// review screen's 24/16 pair: this card sits inside a frame that uses
   /// 16, and two vertical rhythms one level apart read as a mistake.
-  static const contentPadding = EdgeInsets.all(kPaymentRequestGutter);
+  static const defaultContentPadding = EdgeInsets.all(kPaymentRequestGutter);
 
   /// Overlay scrollbar geometry: the pane scrollbar's 6px capsule, centered
   /// in the card's 16px inner gutter so it never rides over text.
@@ -1800,9 +1791,9 @@ class _FadingScrollRegionState extends State<_FadingScrollRegion> {
       child: ScrollConfiguration(
         behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
         child: SingleChildScrollView(
-          key: kPaymentRequestScrollViewKey,
+          key: widget.scrollViewKey,
           controller: _controller,
-          padding: _FadingScrollRegion.contentPadding,
+          padding: widget.contentPadding,
           child: widget.child,
         ),
       ),
@@ -1812,7 +1803,7 @@ class _FadingScrollRegionState extends State<_FadingScrollRegion> {
     // content, and a cue that dissolves the control it belongs to reads as
     // a rendering fault.
     return RawScrollbar(
-      key: kPaymentRequestScrollbarKey,
+      key: widget.scrollbarKey,
       controller: _controller,
       thumbVisibility: _canScroll,
       thickness: _FadingScrollRegion.scrollbarThickness,

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -1339,7 +1339,7 @@ class _ProseRows extends StatelessWidget {
           label: expanded
               ? 'Collapse transaction memo'
               : 'Expand transaction memo',
-          value: '$label, $text',
+          value: expanded ? null : '$label, $text',
           onTap: onToggle,
           child: AppButton(
             key: const ValueKey('payment_request_memo_toggle'),

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -789,7 +789,9 @@ class _RequesterDetailsCard extends StatelessWidget {
                 child: _FadingScrollRegion(
                   scrollViewKey: kPaymentRequestRequesterNoteScrollViewKey,
                   scrollbarKey: kPaymentRequestRequesterNoteScrollbarKey,
-                  contentPadding: EdgeInsets.zero,
+                  contentPadding: const EdgeInsetsDirectional.only(
+                    end: kPaymentRequestGutter,
+                  ),
                   child: Text(
                     note!,
                     key: const ValueKey('payment_request_requester_note'),

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -35,6 +35,14 @@ const double kPaymentRequestTouchRingInset = 10;
 /// ellipsizes instead of sliding under that button.
 const double kPaymentRequestMobileCloseClearance = 40;
 
+/// The one horizontal content inset every group on this card uses.
+///
+/// Sheet/modal chrome (title, actions, status line) sits on the outer
+/// edge; everything inside a card — the requester summary, the
+/// transaction label and amount, the To and memo rows — sits exactly this
+/// far in from that card's edge. One gutter, two left edges.
+const double kPaymentRequestGutter = AppSpacing.sm;
+
 /// The scroll region's overlay scrollbar, for tests.
 const kPaymentRequestScrollbarKey = ValueKey('payment_request_scrollbar');
 
@@ -630,16 +638,17 @@ class _PaymentRequestCardState extends State<PaymentRequestCard> {
   List<Widget> _detailRows() {
     final request = _request;
     final memo = request.displayMemo;
+    final addressRow = _AddressRow(
+      key: const ValueKey('payment_request_to_row'),
+      address: request.address,
+      identity: request.displayRecipientIdentity,
+      isMobileLayout: _isMobile,
+      expanded: _addressExpanded,
+      onToggle: _toggleAddress,
+    );
 
     return [
-      _AddressRow(
-        key: const ValueKey('payment_request_to_row'),
-        address: request.address,
-        identity: request.displayRecipientIdentity,
-        isMobileLayout: _isMobile,
-        expanded: _addressExpanded,
-        onToggle: _toggleAddress,
-      ),
+      addressRow,
       if (memo != null) ...[
         const ReviewWrapDivider(),
         _ProseRows(
@@ -677,15 +686,17 @@ class _RequesterDetailsCard extends StatelessWidget {
     final colors = context.colors;
     final summary = requester ?? 'Note from requester';
     final scaler = MediaQuery.textScalerOf(context);
-    final labelStyle = AppTypography.bodyMedium;
-    final valueStyle = AppTypography.headlineSmall;
-    final naturalSummaryHeight =
-        scaler.scale(labelStyle.fontSize! * labelStyle.height!) +
-        AppSpacing.xxs +
-        scaler.scale(valueStyle.fontSize! * valueStyle.height!);
-    final summaryHeight = naturalSummaryHeight < 56
-        ? 56.0
-        : naturalSummaryHeight.ceilToDouble() + 1;
+    // Label over value, both at body size: the requester is text the link
+    // supplied, not an identity the wallet verified, so it does not take
+    // the headline the address-book name gets in the To row.
+    final labelStyle = AppTypography.bodyMediumStrong;
+    final valueStyle = AppTypography.bodyMediumStrong;
+    final summaryHeight =
+        (scaler.scale(labelStyle.fontSize! * labelStyle.height!) +
+                AppSpacing.xxs +
+                scaler.scale(valueStyle.fontSize! * valueStyle.height!))
+            .ceilToDouble() +
+        1;
     final summaryRow = Row(
       children: [
         Expanded(
@@ -695,9 +706,9 @@ class _RequesterDetailsCard extends StatelessWidget {
             children: [
               Text(
                 'Requester',
-                style: AppTypography.bodyMedium.copyWith(
-                  color: colors.text.secondary,
-                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: labelStyle.copyWith(color: colors.text.secondary),
               ),
               const SizedBox(height: AppSpacing.xxs),
               Text(
@@ -705,9 +716,7 @@ class _RequesterDetailsCard extends StatelessWidget {
                 key: const ValueKey('payment_request_requester'),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                style: AppTypography.headlineSmall.copyWith(
-                  color: colors.text.accent,
-                ),
+                style: valueStyle.copyWith(color: colors.text.accent),
               ),
             ],
           ),
@@ -724,10 +733,7 @@ class _RequesterDetailsCard extends StatelessWidget {
 
     final toggle = onToggle;
     final summaryControl = toggle == null
-        ? Padding(
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
-            child: summaryRow,
-          )
+        ? summaryRow
         : Semantics(
             button: true,
             expanded: expanded,
@@ -751,32 +757,30 @@ class _RequesterDetailsCard extends StatelessWidget {
     return ReviewWrapCard(
       key: const ValueKey('payment_request_requester_group'),
       mainAxisSize: MainAxisSize.min,
-      padding: const EdgeInsets.all(AppSpacing.xs),
+      // The card's content gutter: the same 16 every group on this card
+      // uses, so the label here, the transaction label, and the rows in
+      // the details card all share one left edge.
+      padding: const EdgeInsets.all(kPaymentRequestGutter),
       children: [
         summaryControl,
         if (expanded && note != null) ...[
           const ReviewWrapDivider(),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Note from requester',
-                  style: AppTypography.bodyMedium.copyWith(
-                    color: colors.text.secondary,
-                  ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Note from requester',
+                style: labelStyle.copyWith(color: colors.text.secondary),
+              ),
+              const SizedBox(height: AppSpacing.xxs),
+              Text(
+                note!,
+                key: const ValueKey('payment_request_requester_note'),
+                style: AppTypography.bodyMediumStrong.copyWith(
+                  color: colors.text.accent,
                 ),
-                const SizedBox(height: AppSpacing.xxs),
-                Text(
-                  note!,
-                  key: const ValueKey('payment_request_requester_note'),
-                  style: AppTypography.bodyMediumStrong.copyWith(
-                    color: colors.text.accent,
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ],
       ],
@@ -806,34 +810,52 @@ class _TransactionContentFrame extends StatelessWidget {
     final colors = context.colors;
     final details = bounded
         ? Flexible(child: _DetailsFrame(rows: rows))
-        : ReviewWrapCard(children: rows);
+        : ReviewWrapCard(
+            padding: const EdgeInsets.all(kPaymentRequestGutter),
+            children: rows,
+          );
 
+    final radius = BorderRadius.circular(AppRadii.large);
     return Container(
       key: const ValueKey('payment_request_transaction_content'),
       width: double.infinity,
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.xs,
-        vertical: AppSpacing.sm,
-      ),
-      decoration: BoxDecoration(
+      padding: const EdgeInsets.only(top: kPaymentRequestGutter),
+      decoration: BoxDecoration(borderRadius: radius),
+      // Painted over the content rather than as part of the box so the 1px
+      // stroke does not shift the gutter: content sits exactly 16 in from
+      // the frame edge, the same as inside every other card here.
+      foregroundDecoration: BoxDecoration(
         border: Border.all(color: colors.border.regular),
-        borderRadius: BorderRadius.circular(AppRadii.large),
+        borderRadius: radius,
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Text(
-            'Transaction content',
-            style: AppTypography.bodyMediumStrong.copyWith(
-              color: colors.text.secondary,
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: kPaymentRequestGutter,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Transaction content',
+                  style: AppTypography.bodyMediumStrong.copyWith(
+                    color: colors.text.secondary,
+                  ),
+                ),
+                if (amountText != null) ...[
+                  const SizedBox(height: AppSpacing.xs),
+                  _AmountHero(amountText: amountText!, fiatText: fiatText),
+                ],
+              ],
             ),
           ),
-          if (amountText != null) ...[
-            const SizedBox(height: AppSpacing.xs),
-            _AmountHero(amountText: amountText!, fiatText: fiatText),
-          ],
           const SizedBox(height: AppSpacing.sm),
+          // Flush with the frame: same radius at zero inset keeps the two
+          // corners concentric, and the card's own 16 inset lands its rows
+          // on the frame label's left edge.
           details,
         ],
       ),
@@ -889,29 +911,9 @@ class _AddressRow extends StatelessWidget {
       address: address,
     );
 
-    return Column(
+    final recipient = Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Wrap(
-          crossAxisAlignment: WrapCrossAlignment.center,
-          spacing: AppSpacing.xs,
-          runSpacing: AppSpacing.xxs,
-          children: [
-            Text(
-              'To',
-              maxLines: 1,
-              style: AppTypography.bodyMediumStrong.copyWith(
-                color: colors.text.secondary,
-              ),
-            ),
-            // Paying a transparent address is the one detail on this card
-            // with a privacy consequence the review step cannot undo.
-            PoolBadge(
-              key: const ValueKey('payment_request_pool_badge'),
-              isShielded: isShielded,
-            ),
-          ],
-        ),
         if (identity != null) ...[
           const SizedBox(height: AppSpacing.xs),
           _RecipientIdentityBlock(identity: identity),
@@ -935,7 +937,7 @@ class _AddressRow extends StatelessWidget {
                     ? null
                     : const ValueKey('payment_request_recipient_address'),
                 maxLines: 1,
-                style: AppTypography.codeSmall.copyWith(
+                style: AppTypography.codeMedium.copyWith(
                   color: identity == null
                       ? colors.text.accent
                       : colors.text.secondary,
@@ -946,41 +948,76 @@ class _AddressRow extends StatelessWidget {
           ),
       ],
     );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: AppSpacing.xs,
+          runSpacing: AppSpacing.xxs,
+          children: [
+            Text(
+              'To',
+              maxLines: 1,
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+            // Paying a transparent address is the one detail on this card
+            // with a privacy consequence the review step cannot undo.
+            PoolBadge(
+              key: const ValueKey('payment_request_pool_badge'),
+              isShielded: isShielded,
+            ),
+          ],
+        ),
+        // On touch the whole recipient block toggles the full address —
+        // address line plus pill is 45px, above the 44px floor — so the
+        // pill keeps its 24px Figma height and no transparent ring has
+        // to be padded into the row rhythm. Translucent: the pill's own
+        // detector still wins inside its bounds.
+        if (isMobileLayout)
+          GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: onToggle,
+            child: recipient,
+          )
+        else
+          recipient,
+      ],
+    );
   }
 
   Widget _addressAction(BuildContext context, String label) {
     final colors = context.colors;
     final usesLargeText = MediaQuery.textScalerOf(context).scale(1) >= 1.5;
     final visibleLabel = usesLargeText ? (expanded ? 'Hide' : 'Show') : label;
-    return _TouchTargetRing(
-      apply: isMobileLayout,
+    return Semantics(
+      button: true,
+      label: label,
       onTap: onToggle,
-      child: Semantics(
-        button: true,
-        label: label,
-        onTap: onToggle,
-        excludeSemantics: true,
-        child: MediaQuery.withClampedTextScaling(
-          maxScaleFactor: 1.5,
-          child: AppButton(
-            key: const ValueKey('payment_request_show_full_address'),
-            onPressed: onToggle,
-            variant: AppButtonVariant.ghost,
-            size: AppButtonSize.small,
-            iconGap: 0,
-            leading: usesLargeText
-                ? null
-                : AppIcon(
-                    expanded ? AppIcons.eyeClosed : AppIcons.eye,
-                    color: colors.button.ghost.label,
-                  ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
-              child: Text(
-                visibleLabel,
-                maxLines: 1,
-                style: AppTypography.labelSmall,
-              ),
+      excludeSemantics: true,
+      child: MediaQuery.withClampedTextScaling(
+        maxScaleFactor: 1.5,
+        child: AppButton(
+          key: const ValueKey('payment_request_show_full_address'),
+          onPressed: onToggle,
+          variant: AppButtonVariant.ghost,
+          size: AppButtonSize.small,
+          iconGap: 0,
+          leading: usesLargeText
+              ? null
+              : AppIcon(
+                  expanded ? AppIcons.eyeClosed : AppIcons.eye,
+                  color: colors.button.ghost.label,
+                ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+            child: Text(
+              visibleLabel,
+              maxLines: 1,
+              style: AppTypography.labelSmall,
             ),
           ),
         ),
@@ -1292,21 +1329,19 @@ class _ProseRows extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final valueStyle = AppTypography.bodyMediumStrong;
-    final scaledLineHeight = MediaQuery.textScalerOf(
-      context,
-    ).scale(valueStyle.fontSize! * valueStyle.height!);
-    final controlHeight = scaledLineHeight < 32 ? 32.0 : scaledLineHeight;
+    final scaler = MediaQuery.textScalerOf(context);
+    // The control is the whole label-over-value block: 54px on mobile,
+    // 46 on desktop, so it clears the 44px touch floor by itself instead
+    // of padding an oversized box around the value line.
+    final controlHeight =
+        (scaler.scale(valueStyle.fontSize! * valueStyle.height!) * 2 +
+                AppSpacing.xxs)
+            .ceilToDouble() +
+        1;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(
-          label,
-          style: AppTypography.bodyMediumStrong.copyWith(
-            color: colors.text.secondary,
-          ),
-        ),
-        const SizedBox(height: AppSpacing.xxs),
         Semantics(
           button: true,
           expanded: expanded,
@@ -1323,20 +1358,33 @@ class _ProseRows extends StatelessWidget {
             expand: true,
             constrainContent: true,
             contentPadding: EdgeInsets.zero,
-            child: Row(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Expanded(
-                  child: Text(
-                    expanded ? 'Collapse' : text,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: valueStyle.copyWith(color: colors.text.accent),
-                  ),
+                Text(
+                  label,
+                  // Inside a fixed-height control a label must not wrap.
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: valueStyle.copyWith(color: colors.text.secondary),
                 ),
-                const SizedBox(width: AppSpacing.xxs),
-                AppIcon(
-                  expanded ? AppIcons.collapsed : AppIcons.expand,
-                  color: colors.icon.regular,
+                const SizedBox(height: AppSpacing.xxs),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        expanded ? 'Collapse' : text,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: valueStyle.copyWith(color: colors.text.accent),
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.xxs),
+                    AppIcon(
+                      expanded ? AppIcons.collapsed : AppIcons.expand,
+                      color: colors.icon.regular,
+                    ),
+                  ],
                 ),
               ],
             ),
@@ -1493,7 +1541,7 @@ class _Actions extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _primaryFill(),
-        if (hasAmount) ...[const SizedBox(height: AppSpacing.xxs), _editText()],
+        if (hasAmount) ...[const SizedBox(height: AppSpacing.xs), _editText()],
       ],
     );
 
@@ -1665,9 +1713,11 @@ class _FadingScrollRegion extends StatefulWidget {
 
   static const _fadeHeight = AppSpacing.md;
 
-  /// The wrap card's own inset, moved inside the viewport so the content
-  /// scrolls the full height of the card.
-  static const contentPadding = kReviewWrapCardPadding;
+  /// The card's inset, moved inside the viewport so the content scrolls
+  /// the full height of the card. The card gutter on every side, not the
+  /// review screen's 24/16 pair: this card sits inside a frame that uses
+  /// 16, and two vertical rhythms one level apart read as a mistake.
+  static const contentPadding = EdgeInsets.all(kPaymentRequestGutter);
 
   /// Overlay scrollbar geometry: the pane scrollbar's 6px capsule, centered
   /// in the card's 16px inner gutter so it never rides over text.

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -699,9 +699,9 @@ class _RequesterDetailsCard extends StatelessWidget {
     final labelStyle = AppTypography.bodyMediumStrong;
     final valueStyle = AppTypography.bodyMediumStrong;
     final summaryHeight =
-        (scaler.scale(labelStyle.fontSize! * labelStyle.height!) +
+        (scaler.scale(labelStyle.fontSize!) * labelStyle.height! +
                 AppSpacing.xxs +
-                scaler.scale(valueStyle.fontSize! * valueStyle.height!))
+                scaler.scale(valueStyle.fontSize!) * valueStyle.height!)
             .ceilToDouble() +
         1;
     final summaryRow = Row(
@@ -1324,7 +1324,7 @@ class _ProseRows extends StatelessWidget {
     // 46 on desktop, so it clears the 44px touch floor by itself instead
     // of padding an oversized box around the value line.
     final controlHeight =
-        (scaler.scale(valueStyle.fontSize! * valueStyle.height!) * 2 +
+        (scaler.scale(valueStyle.fontSize!) * valueStyle.height! * 2 +
                 AppSpacing.xxs)
             .ceilToDouble() +
         1;

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -956,6 +956,7 @@ class _AddressRow extends StatelessWidget {
                     ? null
                     : const ValueKey('payment_request_recipient_address'),
                 maxLines: 1,
+                overflow: TextOverflow.ellipsis,
                 style: AppTypography.codeMedium.copyWith(
                   color: identity == null
                       ? colors.text.accent

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -1,5 +1,3 @@
-import 'dart:math' as math;
-
 import 'package:flutter/widgets.dart';
 
 import '../../../core/formatting/address_display.dart';
@@ -11,7 +9,6 @@ import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_icon_hover_button.dart';
 import '../../../core/widgets/app_profile_picture.dart';
 import '../../../core/widgets/pool_badge.dart';
-import '../../../core/widgets/review_list_row.dart';
 import '../../../core/widgets/review_wrap_card.dart';
 
 /// Desktop width of the payment-request modal card.
@@ -282,18 +279,19 @@ class PaymentRequestView {
   /// at all — an empty or invented identity would be worse than none.
   ///
   /// This string is attacker-controlled: it is whatever the link's `label`
-  /// parameter said, which is why it is stated as a muted "Requested by …"
-  /// line rather than dressed up as a title of its own.
+  /// parameter said. The card keeps it inside the collapsed requester group
+  /// instead of presenting it as verified contact information.
   final String? requesterLabel;
 
   /// Preformatted fiat equivalent, e.g. `$35.00`. Null hides the line.
   final String? fiatText;
 
-  /// Encrypted memo that travels with the payment. Labelled "Message" —
-  /// the name the send composer and the send review both give it.
+  /// Encrypted memo that travels with the payment. The request card calls it
+  /// "Transaction memo" to distinguish it from the requester's link message.
   final String? memo;
 
-  /// Message that stays local to this device.
+  /// Off-chain message embedded by the requester in the link or QR code.
+  /// It is shown as "Note from requester" and is not copied into the payment.
   final String? note;
 
   /// Preformatted spendable balance used by the insufficient-funds message.
@@ -436,12 +434,8 @@ class PaymentRequestView {
   /// it, because a link-supplied name is not this card's identity.
   String get headerTitle => 'Payment request';
 
-  /// The one muted line under the title, or null when the request carried
-  /// no label at all — an invented identity would be worse than none.
-  String? get requesterLine {
-    final requester = displayRequesterLabel;
-    return requester == null ? null : 'Requested by $requester';
-  }
+  bool get hasRequesterDetails =>
+      displayRequesterLabel != null || displayNote != null;
 }
 
 /// A payment request someone else sent you, rendered as received content
@@ -454,9 +448,8 @@ class PaymentRequestView {
 /// provides the card/sheet chrome, so the same widget renders in the
 /// desktop modal and the mobile sheet.
 ///
-/// The details block is built from the send review's own row components
-/// ([ReviewWrapCard], [ReviewListRow], [ReviewWrapDivider]), so the card
-/// reads as a preview of the screen its primary action lands on.
+/// The details block uses the send review's card and divider components, so
+/// the request reads as a preview of the screen its primary action lands on.
 class PaymentRequestCard extends StatefulWidget {
   const PaymentRequestCard({
     required this.request,
@@ -530,11 +523,12 @@ class PaymentRequestCard extends StatefulWidget {
 class _PaymentRequestCardState extends State<PaymentRequestCard> {
   late bool _addressExpanded = widget.initialAddressExpanded;
   late bool _messageExpanded = widget.initialMessageExpanded;
-  bool _noteExpanded = false;
+  bool _requesterExpanded = false;
 
   void _toggleAddress() => setState(() => _addressExpanded = !_addressExpanded);
   void _toggleMessage() => setState(() => _messageExpanded = !_messageExpanded);
-  void _toggleNote() => setState(() => _noteExpanded = !_noteExpanded);
+  void _toggleRequester() =>
+      setState(() => _requesterExpanded = !_requesterExpanded);
 
   PaymentRequestView get _request => widget.request;
 
@@ -553,11 +547,8 @@ class _PaymentRequestCardState extends State<PaymentRequestCard> {
     final statusMessage = request.resolvedStatusMessage;
     final amount = request.displayAmount;
 
-    // Header, amount, status and actions stay pinned. The details card is a
-    // fixed frame whose *content* scrolls inside it, so neither a 512-byte
-    // memo nor the scroll offset can push the amount being consented to off
-    // the card, and long content ends on the card's own rounded edge rather
-    // than at a straight cut under the header.
+    // Header, requester, amount, status and actions stay pinned. The
+    // transaction details scroll only when expanded or unusually long.
     final rows = _detailRows();
 
     return LayoutBuilder(
@@ -568,7 +559,6 @@ class _PaymentRequestCardState extends State<PaymentRequestCard> {
           children: [
             _Header(
               title: request.headerTitle,
-              requesterLine: request.requesterLine,
               isMobileLayout: isMobile,
               onClose: widget.onCancel,
             ),
@@ -579,20 +569,32 @@ class _PaymentRequestCardState extends State<PaymentRequestCard> {
                 message: 'Replaced an earlier link',
               ),
             ],
-            // An amount-less request has no hero at all: the title and the
-            // requester line flow straight into the details card.
-            if (amount != null) ...[
-              const SizedBox(height: AppSpacing.sm),
-              _AmountHero(amountText: amount, fiatText: request.fiatText),
+            if (request.hasRequesterDetails) ...[
+              SizedBox(height: sectionGap),
+              _RequesterDetailsCard(
+                requester: request.displayRequesterLabel,
+                note: request.displayNote,
+                expanded: _requesterExpanded,
+                onToggle: request.displayNote == null ? null : _toggleRequester,
+              ),
             ],
             SizedBox(height: sectionGap),
-            // A scroll viewport needs a bounded height. When the host gives
-            // the card unbounded space there is nothing to overflow, so the
-            // details lay out at their natural height in a plain card.
             if (constraints.maxHeight.isFinite)
-              Flexible(child: _DetailsFrame(rows: rows))
+              Flexible(
+                child: _TransactionContentFrame(
+                  amountText: amount,
+                  fiatText: request.fiatText,
+                  rows: rows,
+                  bounded: true,
+                ),
+              )
             else
-              ReviewWrapCard(children: rows),
+              _TransactionContentFrame(
+                amountText: amount,
+                fiatText: request.fiatText,
+                rows: rows,
+                bounded: false,
+              ),
             // One status slot for every condition, directly under the
             // details card and directly above the buttons it explains.
             if (statusMessage != null) ...[
@@ -623,14 +625,11 @@ class _PaymentRequestCardState extends State<PaymentRequestCard> {
     );
   }
 
-  /// The three received values, laid out with the send review's own rows:
-  /// "To" label-above-value (the review's `Review Info` shape), "Message"
-  /// and "Note" label-beside-value in a [ReviewListRow], separated by the
-  /// review's hairline divider.
+  /// Transaction content only. Requester metadata lives in its own disclosure
+  /// above this group so off-chain request text is not confused with the memo.
   List<Widget> _detailRows() {
     final request = _request;
     final memo = request.displayMemo;
-    final note = request.displayNote;
 
     return [
       _AddressRow(
@@ -645,30 +644,206 @@ class _PaymentRequestCardState extends State<PaymentRequestCard> {
         const ReviewWrapDivider(),
         _ProseRows(
           key: const ValueKey('payment_request_memo'),
-          label: 'Message',
+          label: 'Transaction memo',
           text: memo,
           expanded: _messageExpanded,
           onToggle: _toggleMessage,
-        ),
-      ],
-      if (note != null) ...[
-        const ReviewWrapDivider(),
-        _ProseRows(
-          key: const ValueKey('payment_request_note'),
-          label: 'Note',
-          text: note,
-          expanded: _noteExpanded,
-          onToggle: _toggleNote,
         ),
       ],
     ];
   }
 }
 
-/// The "To" block: the label above the address, with the pool badge and the
-/// expand control on the line below — the composition the send review's
-/// "To" row uses (`ReviewInfoRow`), minus the 32px leading circle, which in
-/// Vizor lives *outside* the wrap card.
+/// Off-chain metadata supplied by the payment link's requester.
+///
+/// The name remains visible as the collapsed summary. A requester note is
+/// progressive disclosure because it is context for the request, not content
+/// that will be included in the Zcash transaction.
+class _RequesterDetailsCard extends StatelessWidget {
+  const _RequesterDetailsCard({
+    required this.requester,
+    required this.note,
+    required this.expanded,
+    required this.onToggle,
+  });
+
+  final String? requester;
+  final String? note;
+  final bool expanded;
+  final VoidCallback? onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final summary = requester ?? 'Note from requester';
+    final scaler = MediaQuery.textScalerOf(context);
+    final labelStyle = AppTypography.bodyMedium;
+    final valueStyle = AppTypography.headlineSmall;
+    final naturalSummaryHeight =
+        scaler.scale(labelStyle.fontSize! * labelStyle.height!) +
+        AppSpacing.xxs +
+        scaler.scale(valueStyle.fontSize! * valueStyle.height!);
+    final summaryHeight = naturalSummaryHeight < 56
+        ? 56.0
+        : naturalSummaryHeight.ceilToDouble() + 1;
+    final summaryRow = Row(
+      children: [
+        Expanded(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Requester',
+                style: AppTypography.bodyMedium.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.xxs),
+              Text(
+                summary,
+                key: const ValueKey('payment_request_requester'),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.headlineSmall.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (onToggle != null) ...[
+          const SizedBox(width: AppSpacing.xs),
+          AppIcon(
+            expanded ? AppIcons.collapsed : AppIcons.expand,
+            color: colors.icon.regular,
+          ),
+        ],
+      ],
+    );
+
+    final toggle = onToggle;
+    final summaryControl = toggle == null
+        ? Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+            child: summaryRow,
+          )
+        : Semantics(
+            button: true,
+            expanded: expanded,
+            label: expanded
+                ? 'Hide requester details'
+                : 'Show requester details',
+            onTap: toggle,
+            child: AppButton(
+              key: const ValueKey('payment_request_requester_toggle'),
+              onPressed: toggle,
+              variant: AppButtonVariant.ghost,
+              size: AppButtonSize.small,
+              height: summaryHeight,
+              expand: true,
+              constrainContent: true,
+              contentPadding: EdgeInsets.zero,
+              child: summaryRow,
+            ),
+          );
+
+    return ReviewWrapCard(
+      key: const ValueKey('payment_request_requester_group'),
+      mainAxisSize: MainAxisSize.min,
+      padding: const EdgeInsets.all(AppSpacing.xs),
+      children: [
+        summaryControl,
+        if (expanded && note != null) ...[
+          const ReviewWrapDivider(),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Note from requester',
+                  style: AppTypography.bodyMedium.copyWith(
+                    color: colors.text.secondary,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xxs),
+                Text(
+                  note!,
+                  key: const ValueKey('payment_request_requester_note'),
+                  style: AppTypography.bodyMediumStrong.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// The amount and the on-chain destination/memo as one visual group.
+///
+/// Only the inner details region flexes and scrolls. The group label and the
+/// amount being approved remain pinned in every state.
+class _TransactionContentFrame extends StatelessWidget {
+  const _TransactionContentFrame({
+    required this.amountText,
+    required this.fiatText,
+    required this.rows,
+    required this.bounded,
+  });
+
+  final String? amountText;
+  final String? fiatText;
+  final List<Widget> rows;
+  final bool bounded;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final details = bounded
+        ? Flexible(child: _DetailsFrame(rows: rows))
+        : ReviewWrapCard(children: rows);
+
+    return Container(
+      key: const ValueKey('payment_request_transaction_content'),
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: AppSpacing.sm,
+      ),
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.border.regular),
+        borderRadius: BorderRadius.circular(AppRadii.large),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Transaction content',
+            style: AppTypography.bodyMediumStrong.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+          if (amountText != null) ...[
+            const SizedBox(height: AppSpacing.xs),
+            _AmountHero(amountText: amountText!, fiatText: fiatText),
+          ],
+          const SizedBox(height: AppSpacing.sm),
+          details,
+        ],
+      ),
+    );
+  }
+}
+
+/// The "To" block: pool beside the label, then the address beside its
+/// verification action. Keeping each related pair together saves a row and
+/// makes the privacy status and address action easier to scan.
 ///
 /// The full address never leaves this card. "Show full address" swaps the
 /// one-line truncation for the canonical verify grouping — 5-character
@@ -702,18 +877,6 @@ class _AddressRow extends StatelessWidget {
   final bool expanded;
   final VoidCallback onToggle;
 
-  /// Small ghost button chrome around its label: outer padding 4 per side,
-  /// the button's own glyph, and the label's own 4 per side.
-  ///
-  /// The glyph is the *button's* icon token, not [AppIconSize.medium]: a
-  /// small `AppButton` resolves 16px on desktop and 20px on mobile, so
-  /// hardcoding 16 under-reserved the chrome by 4px in the mobile lane and
-  /// overflowed the row.
-  static const _ghostChrome =
-      AppSpacing.xxs * 2 +
-      AppButtonSizing.mediumSmallIconSize +
-      AppSpacing.xxs * 2;
-
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
@@ -729,103 +892,104 @@ class _AddressRow extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(
-          'To',
-          maxLines: 1,
-          // The review's row label: the same size and weight as the value
-          // it labels, one colour step down — never a tiny muted caption.
-          style: AppTypography.bodyMediumStrong.copyWith(
-            color: colors.text.secondary,
-          ),
-        ),
-        const SizedBox(height: AppSpacing.xxs),
-        if (identity != null) ...[
-          // The name takes the row's value slot; the address stays visible
-          // underneath it, because that is the fact being consented to.
-          _RecipientIdentityBlock(
-            identity: identity,
-            address: address,
-            showAddress: !expanded,
-          ),
-          // Expanded, the grid takes the row's full width rather than the
-          // column beside the avatar, which would squeeze it to a fraction
-          // of the size a user needs to compare characters.
-          if (expanded) ...[const SizedBox(height: AppSpacing.xs), chunks],
-        ] else if (expanded)
-          chunks
-        else
-          Text(
-            truncatedAddress(address),
-            // Monospace so the head and tail characters a user compares
-            // are fixed-width; the amount above keeps the serif style.
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: AppTypography.codeMedium.copyWith(color: colors.text.accent),
-          ),
-        const SizedBox(height: AppSpacing.xxs),
-        LayoutBuilder(
-          builder: (context, constraints) => Wrap(
-            alignment: WrapAlignment.spaceBetween,
-            crossAxisAlignment: WrapCrossAlignment.center,
-            spacing: AppSpacing.xs,
-            runSpacing: AppSpacing.xxs,
-            children: [
-              // Paying a transparent address is the one detail on this card
-              // with a privacy consequence the review step cannot undo.
-              PoolBadge(
-                key: const ValueKey('payment_request_pool_badge'),
-                isShielded: isShielded,
+        Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: AppSpacing.xs,
+          runSpacing: AppSpacing.xxs,
+          children: [
+            Text(
+              'To',
+              maxLines: 1,
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: colors.text.secondary,
               ),
-              _TouchTargetRing(
-                apply: isMobileLayout,
-                onTap: onToggle,
-                child: Semantics(
-                  button: true,
-                  label: actionLabel,
-                  onTap: onToggle,
-                  excludeSemantics: true,
-                  child: AppButton(
-                    key: const ValueKey('payment_request_show_full_address'),
-                    onPressed: onToggle,
-                    variant: AppButtonVariant.ghost,
-                    size: AppButtonSize.small,
-                    iconGap: 0,
-                    leading: AppIcon(
-                      expanded ? AppIcons.eyeClosed : AppIcons.eye,
-                      color: colors.button.ghost.label,
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.xxs,
-                      ),
-                      child: ConstrainedBox(
-                        constraints: BoxConstraints(
-                          maxWidth: math.max(
-                            0,
-                            constraints.maxWidth - _AddressRow._ghostChrome,
-                          ),
-                        ),
-                        child: Text(
-                          actionLabel,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: AppTypography.labelLarge,
-                        ),
-                      ),
-                    ),
-                  ),
+            ),
+            // Paying a transparent address is the one detail on this card
+            // with a privacy consequence the review step cannot undo.
+            PoolBadge(
+              key: const ValueKey('payment_request_pool_badge'),
+              isShielded: isShielded,
+            ),
+          ],
+        ),
+        if (identity != null) ...[
+          const SizedBox(height: AppSpacing.xs),
+          _RecipientIdentityBlock(identity: identity),
+        ],
+        const SizedBox(height: AppSpacing.xxs),
+        if (expanded) ...[
+          chunks,
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: _addressAction(context, actionLabel),
+          ),
+        ] else
+          Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: AppSpacing.xxs,
+            runSpacing: 0,
+            children: [
+              Text(
+                truncatedAddress(address),
+                key: identity == null
+                    ? null
+                    : const ValueKey('payment_request_recipient_address'),
+                maxLines: 1,
+                style: AppTypography.codeSmall.copyWith(
+                  color: identity == null
+                      ? colors.text.accent
+                      : colors.text.secondary,
                 ),
               ),
+              _addressAction(context, actionLabel),
             ],
           ),
-        ),
       ],
+    );
+  }
+
+  Widget _addressAction(BuildContext context, String label) {
+    final colors = context.colors;
+    final usesLargeText = MediaQuery.textScalerOf(context).scale(1) >= 1.5;
+    final visibleLabel = usesLargeText ? (expanded ? 'Hide' : 'Show') : label;
+    return _TouchTargetRing(
+      apply: isMobileLayout,
+      onTap: onToggle,
+      child: Semantics(
+        button: true,
+        label: label,
+        onTap: onToggle,
+        excludeSemantics: true,
+        child: MediaQuery.withClampedTextScaling(
+          maxScaleFactor: 1.5,
+          child: AppButton(
+            key: const ValueKey('payment_request_show_full_address'),
+            onPressed: onToggle,
+            variant: AppButtonVariant.ghost,
+            size: AppButtonSize.small,
+            iconGap: 0,
+            leading: usesLargeText
+                ? null
+                : AppIcon(
+                    expanded ? AppIcons.eyeClosed : AppIcons.eye,
+                    color: colors.button.ghost.label,
+                  ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+              child: Text(
+                visibleLabel,
+                maxLines: 1,
+                style: AppTypography.labelSmall,
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }
 
-/// Avatar + name for a recipient the wallet recognizes, with the truncated
-/// address underneath.
+/// Avatar + name for a recipient the wallet recognizes.
 ///
 /// The composition is the pay/send review's contact recipient
 /// (`AppProfilePicture` leading, name headline, address sub-line) fitted to
@@ -838,18 +1002,9 @@ class _AddressRow extends StatelessWidget {
 /// swapped-address attack looks like from the other direction, so the card
 /// states the relationship instead of leaving the user to recognize a name.
 class _RecipientIdentityBlock extends StatelessWidget {
-  const _RecipientIdentityBlock({
-    required this.identity,
-    required this.address,
-    required this.showAddress,
-  });
+  const _RecipientIdentityBlock({required this.identity});
 
   final PaymentRequestRecipientIdentity identity;
-  final String address;
-
-  /// False while the full address is expanded below, which would otherwise
-  /// state the same address twice.
-  final bool showAddress;
 
   @override
   Widget build(BuildContext context) {
@@ -893,20 +1048,6 @@ class _RecipientIdentityBlock extends StatelessWidget {
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: AppTypography.labelSmall.copyWith(
-                    color: colors.text.secondary,
-                  ),
-                ),
-              ],
-              if (showAddress) ...[
-                const SizedBox(height: AppSpacing.xxs),
-                Text(
-                  truncatedAddress(address),
-                  key: const ValueKey('payment_request_recipient_address'),
-                  // Same monospace token the unmapped row uses; one colour
-                  // step down, because the name is the headline now.
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTypography.codeMedium.copyWith(
                     color: colors.text.secondary,
                   ),
                 ),
@@ -1008,8 +1149,7 @@ class _TouchTargetRing extends StatelessWidget {
 }
 
 /// The card's name in the serif headline scale the send screens use for
-/// their titles, the desktop close affordance beside it, and — only when
-/// the request carried a label — the muted "Requested by …" line under it.
+/// their titles, with the desktop close affordance beside it.
 ///
 /// The title takes the step below the amount hero: the amount is the value
 /// being consented to and has to stay the largest thing on the card, so a
@@ -1017,13 +1157,11 @@ class _TouchTargetRing extends StatelessWidget {
 class _Header extends StatelessWidget {
   const _Header({
     required this.title,
-    required this.requesterLine,
     required this.isMobileLayout,
     required this.onClose,
   });
 
   final String title;
-  final String? requesterLine;
   final bool isMobileLayout;
   final VoidCallback onClose;
 
@@ -1031,60 +1169,42 @@ class _Header extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Padding(
-          // Mobile has no close of its own; it reserves the room the sheet's
-          // pinned ⨯ occupies instead.
-          padding: EdgeInsetsDirectional.only(
-            end: isMobileLayout ? kPaymentRequestMobileCloseClearance : 0,
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: Semantics(
-                  header: true,
-                  child: Text(
-                    title,
-                    key: const ValueKey('payment_request_title'),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: AppTypography.headlineMedium.copyWith(
-                      color: colors.text.accent,
-                    ),
-                  ),
+    return Padding(
+      // Mobile has no close of its own; it reserves the room the sheet's
+      // pinned ⨯ occupies instead.
+      padding: EdgeInsetsDirectional.only(
+        end: isMobileLayout ? kPaymentRequestMobileCloseClearance : 0,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Semantics(
+              header: true,
+              child: Text(
+                title,
+                key: const ValueKey('payment_request_title'),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.headlineMedium.copyWith(
+                  color: colors.text.accent,
                 ),
               ),
-              if (!isMobileLayout) ...[
-                const SizedBox(width: AppSpacing.xs),
-                AppIconHoverButton(
-                  key: const ValueKey('payment_request_close'),
-                  icon: AppIcons.cross,
-                  semanticLabel: 'Close payment request',
-                  onTap: onClose,
-                  size: 32,
-                  iconColor: colors.icon.regular,
-                ),
-              ],
-            ],
-          ),
-        ),
-        if (requesterLine != null) ...[
-          const SizedBox(height: AppSpacing.xxs),
-          Text(
-            requesterLine!,
-            key: const ValueKey('payment_request_requester'),
-            // One line: an 80-character label is cut, never wrapped.
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: AppTypography.bodyMedium.copyWith(
-              color: colors.text.secondary,
             ),
           ),
+          if (!isMobileLayout) ...[
+            const SizedBox(width: AppSpacing.xs),
+            AppIconHoverButton(
+              key: const ValueKey('payment_request_close'),
+              icon: AppIcons.cross,
+              semanticLabel: 'Close payment request',
+              onTap: onClose,
+              size: 32,
+              iconColor: colors.icon.regular,
+            ),
+          ],
         ],
-      ],
+      ),
     );
   }
 }
@@ -1144,13 +1264,11 @@ class _AmountHero extends StatelessWidget {
   }
 }
 
-/// The Message / Note block, in the send review's own Message shape.
+/// The transaction memo block, in the send review's own message shape.
 ///
-/// Collapsed it is a single [ReviewListRow]: the label on the leading edge,
-/// the text truncated to one line inside the trailing pill, and the expand
-/// glyph. Expanded, the pill swaps to a "Collapse" affordance and the full
-/// text renders underneath the row — exactly what `ReviewMemoRows` does on
-/// the review screen, so the two surfaces read as one component.
+/// The label sits above the value so it remains readable at mobile widths and
+/// large text sizes. The value toggles between a one-line preview and the full
+/// memo.
 ///
 /// The expanded flag is owned by [_PaymentRequestCardState]; this widget is
 /// stateless on purpose, so no rebuild of the scrolling content can reset it.
@@ -1163,8 +1281,7 @@ class _ProseRows extends StatelessWidget {
     super.key,
   });
 
-  /// Visible label — "Message" (the memo, which travels with the payment)
-  /// or "Note" (local to this device).
+  /// Visible label for the encrypted memo that travels with the payment.
   final String label;
 
   final String text;
@@ -1173,33 +1290,62 @@ class _ProseRows extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (!expanded) {
-      return ReviewListRow(
-        label: label,
-        value: text,
-        trailingIconName: AppIcons.expand,
-        onPressed: onToggle,
-      );
-    }
+    final colors = context.colors;
+    final valueStyle = AppTypography.bodyMediumStrong;
+    final scaledLineHeight = MediaQuery.textScalerOf(
+      context,
+    ).scale(valueStyle.fontSize! * valueStyle.height!);
+    final controlHeight = scaledLineHeight < 32 ? 32.0 : scaledLineHeight;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        ReviewListRow(
-          label: label,
-          value: 'Collapse',
-          trailingIconName: AppIcons.collapsed,
-          onPressed: onToggle,
+        Text(
+          label,
+          style: AppTypography.bodyMediumStrong.copyWith(
+            color: colors.text.secondary,
+          ),
         ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
-          child: Text(
-            text,
-            style: AppTypography.bodyMediumStrong.copyWith(
-              color: context.colors.text.accent,
+        const SizedBox(height: AppSpacing.xxs),
+        Semantics(
+          button: true,
+          expanded: expanded,
+          label: expanded
+              ? 'Collapse transaction memo'
+              : 'Expand transaction memo',
+          onTap: onToggle,
+          child: AppButton(
+            key: const ValueKey('payment_request_memo_toggle'),
+            onPressed: onToggle,
+            variant: AppButtonVariant.ghost,
+            size: AppButtonSize.small,
+            height: controlHeight,
+            expand: true,
+            constrainContent: true,
+            contentPadding: EdgeInsets.zero,
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    expanded ? 'Collapse' : text,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: valueStyle.copyWith(color: colors.text.accent),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.xxs),
+                AppIcon(
+                  expanded ? AppIcons.collapsed : AppIcons.expand,
+                  color: colors.icon.regular,
+                ),
+              ],
             ),
           ),
         ),
+        if (expanded) ...[
+          const SizedBox(height: AppSpacing.xxs),
+          Text(text, style: valueStyle.copyWith(color: colors.text.accent)),
+        ],
       ],
     );
   }
@@ -1285,9 +1431,8 @@ class _QuietNotice extends StatelessWidget {
   }
 }
 
-/// The card's action area: one full-width primary over one full-width
-/// secondary, the pair `ReviewButtonsStack` already uses on the send review
-/// screens.
+/// The card's action area: one full-width primary with a compact text-only
+/// edit action underneath.
 ///
 /// "Review" names where the primary lands — the send review step — rather
 /// than the generic "Continue" it replaced; nothing is signed from here.
@@ -1348,7 +1493,7 @@ class _Actions extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _primaryFill(),
-        if (hasAmount) ...[const SizedBox(height: AppSpacing.xs), _editFill()],
+        if (hasAmount) ...[const SizedBox(height: AppSpacing.xxs), _editText()],
       ],
     );
 
@@ -1430,11 +1575,22 @@ class _Actions extends StatelessWidget {
     leading: _primaryLeading(),
   );
 
-  Widget _editFill() => _fillButton(
-    key: const ValueKey('payment_request_edit'),
-    label: 'Edit',
-    onPressed: onEdit,
-    variant: AppButtonVariant.secondary,
+  Widget _editText() => Align(
+    child: _TouchTargetRing(
+      apply: isMobileLayout,
+      onTap: onEdit,
+      child: _semantics(
+        enabled: true,
+        label: 'Edit',
+        child: AppButton(
+          key: const ValueKey('payment_request_edit'),
+          onPressed: onEdit,
+          variant: AppButtonVariant.ghost,
+          size: AppButtonSize.small,
+          child: const Text('Edit'),
+        ),
+      ),
+    ),
   );
 }
 

--- a/lib/src/features/send/widgets/payment_request_host.dart
+++ b/lib/src/features/send/widgets/payment_request_host.dart
@@ -128,6 +128,7 @@ class PaymentRequestHost extends ConsumerWidget {
     // owned by `PaymentRequestSurface`.
     return PaymentRequestSurface(
       key: const ValueKey('payment_request_host_surface'),
+      cardKey: ValueKey(flow.prefill.id),
       request: request,
       onContinue: review,
       onEdit: edit,

--- a/lib/src/features/send/widgets/payment_request_surface.dart
+++ b/lib/src/features/send/widgets/payment_request_surface.dart
@@ -26,6 +26,7 @@ class PaymentRequestSurface extends StatelessWidget {
     this.layout = PaymentRequestLayout.auto,
     this.initialAddressExpanded = false,
     this.initialMessageExpanded = false,
+    this.cardKey,
     this.background,
     super.key,
   });
@@ -43,6 +44,9 @@ class PaymentRequestSurface extends StatelessWidget {
 
   /// Tooling-only: renders the Message row already expanded to its full text.
   final bool initialMessageExpanded;
+
+  /// Identity of the request whose disclosure state the card owns.
+  final Key? cardKey;
 
   /// What the modal sits on top of. Defaults to the flat window color so a
   /// preview does not have to supply a whole screen.
@@ -63,6 +67,7 @@ class PaymentRequestSurface extends StatelessWidget {
     final card = Material(
       type: MaterialType.transparency,
       child: PaymentRequestCard(
+        key: cardKey,
         request: request,
         onContinue: onContinue,
         onEdit: onEdit,

--- a/lib/src/features/send/widgets/payment_request_surface.dart
+++ b/lib/src/features/send/widgets/payment_request_surface.dart
@@ -138,7 +138,7 @@ class PaymentRequestSurface extends StatelessWidget {
 /// off — the shared reservation for the pinned close lives in the card's
 /// header instead ([kPaymentRequestMobileCloseClearance]).
 ///
-/// [bottomPadding] is 16, the inset the card's action stack sits on; the
+/// [bottomPadding] is the Figma modal base's 32 under the action stack; the
 /// bottom safe area itself stays with `MobileModalCard`, so it is never
 /// applied twice.
 Widget paymentRequestSheetBody(Widget card, {required VoidCallback onClose}) {
@@ -146,7 +146,9 @@ Widget paymentRequestSheetBody(Widget card, {required VoidCallback onClose}) {
     title: '',
     showTitle: false,
     onClose: onClose,
-    bottomPadding: AppSpacing.sm,
+    // Figma `_Modal Type` (4638:74505): 32 between the button stack and
+    // the sheet's bottom edge.
+    bottomPadding: AppSpacing.base,
     // The scaffold lays its body out in a min-size Column, which hands a
     // plain child unbounded height. The card needs a bounded one — that is
     // what makes its details region scroll instead of overflowing the sheet.

--- a/lib/widgetbook/payment_request_use_cases.dart
+++ b/lib/widgetbook/payment_request_use_cases.dart
@@ -158,10 +158,9 @@ const _ownAccountRequest = PaymentRequestView(
   ),
 );
 
-/// Note without a message — the pair is otherwise only ever seen together.
+/// Requester note without a requester name or transaction memo.
 const _noteOnlyRequest = PaymentRequestView(
   source: PaymentRequestSource.link,
-  requesterLabel: 'Blue Door Coffee',
   amountZecText: '0.5 ZEC',
   fiatText: r'$35.00',
   address: _sampleAddress,

--- a/test/features/send/payment_request_host_test.dart
+++ b/test/features/send/payment_request_host_test.dart
@@ -212,7 +212,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Payment request'), findsOneWidget);
-    expect(find.text('Requested by Coffee shop'), findsOneWidget);
+    expect(find.text('Requester'), findsOneWidget);
+    expect(find.text('Coffee shop'), findsOneWidget);
+    expect(find.text('Requested by Coffee shop'), findsNothing);
     expect(
       find.text('screen /home'),
       findsOneWidget,

--- a/test/features/send/payment_request_host_test.dart
+++ b/test/features/send/payment_request_host_test.dart
@@ -33,6 +33,15 @@ const _request = SendPrefillArgs(
   label: 'Coffee shop',
 );
 
+const _replacementRequest = SendPrefillArgs(
+  id: 'payment-uri-2',
+  source: kPaymentUriPrefillSource,
+  address: _address,
+  amountText: '0.75',
+  label: 'Bakery',
+  message: 'Second request note',
+);
+
 AddressBookContact _contact(String label, String address) => AddressBookContact(
   id: 'contact-$label',
   label: label,
@@ -220,6 +229,48 @@ void main() {
       findsOneWidget,
       reason: 'the screen underneath stays mounted',
     );
+    expect(_location(container), '/home');
+  });
+
+  testWidgets('a replacement request starts with disclosures collapsed', (
+    tester,
+  ) async {
+    final container = await _pumpHost(tester);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(
+          const SendPrefillArgs(
+            id: 'payment-uri-1-with-note',
+            source: kPaymentUriPrefillSource,
+            address: _address,
+            amountText: '0.5',
+            label: 'Coffee shop',
+            message: 'First request note',
+          ),
+          source: PaymentRequestSource.link,
+        );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey('payment_request_requester_toggle')),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('payment_request_requester_note')),
+      findsOneWidget,
+    );
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_replacementRequest, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Bakery'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('payment_request_requester_note')),
+      findsNothing,
+    );
+    expect(find.text('screen /home'), findsOneWidget);
     expect(_location(container), '/home');
   });
 

--- a/test/features/send/payment_request_pane_layout_test.dart
+++ b/test/features/send/payment_request_pane_layout_test.dart
@@ -16,7 +16,6 @@ import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_modal_card.dart';
-import 'package:zcash_wallet/src/core/widgets/review_list_row.dart';
 import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
 import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
 import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
@@ -133,10 +132,7 @@ void main() {
       _expectFits(tester, size);
 
       await tester.tap(
-        find.descendant(
-          of: find.byKey(const ValueKey('payment_request_memo')),
-          matching: find.byType(ReviewListRow),
-        ),
+        find.byKey(const ValueKey('payment_request_memo_toggle')),
       );
       await tester.pumpAndSettle();
       _expectFits(tester, size);

--- a/test/widgetbook/mobile_payment_request_use_cases_test.dart
+++ b/test/widgetbook/mobile_payment_request_use_cases_test.dart
@@ -8,6 +8,7 @@ import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/send/widgets/payment_request_card.dart';
 import 'package:zcash_wallet/src/features/send/widgets/payment_request_surface.dart';
+import 'package:zcash_wallet/widgetbook/payment_request_use_cases.dart';
 
 void main() {
   testWidgets('collapsed address and pool badge fit at 2x text scale', (
@@ -54,12 +55,39 @@ void main() {
     }
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('default mobile requests fit without scrolling', (tester) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildMobilePaymentRequestFullUseCase, const Size(393, 852)),
+      (buildMobilePaymentRequestFullUseCase, const Size(375, 812)),
+      (buildMobilePaymentRequestContactUseCase, const Size(393, 852)),
+      (buildMobilePaymentRequestContactUseCase, const Size(375, 812)),
+    ]) {
+      await _pumpPaymentRequest(
+        tester,
+        size: size,
+        child: Builder(builder: builder),
+      );
+
+      expect(tester.takeException(), isNull, reason: '$builder at $size');
+      expect(_maxScrollExtent(tester), 0, reason: '$builder at $size');
+      expect(find.text('Review'), findsOneWidget);
+      expect(find.text('Edit'), findsOneWidget);
+    }
+  });
 }
+
+double _maxScrollExtent(WidgetTester tester) => tester
+    .widget<SingleChildScrollView>(find.byKey(kPaymentRequestScrollViewKey))
+    .controller!
+    .position
+    .maxScrollExtent;
 
 Future<void> _pumpPaymentRequest(
   WidgetTester tester, {
   required Size size,
-  required TextScaler textScaler,
+  TextScaler textScaler = TextScaler.noScaling,
+  Widget? child,
 }) async {
   tester.view.physicalSize = size;
   tester.view.devicePixelRatio = 1;
@@ -78,22 +106,24 @@ Future<void> _pumpPaymentRequest(
           child: SizedBox(
             width: size.width,
             height: size.height,
-            child: PaymentRequestSurface(
-              layout: PaymentRequestLayout.mobile,
-              request: const PaymentRequestView(
-                source: PaymentRequestSource.link,
-                requesterLabel: 'Blue Door Coffee',
-                note: 'Meet at the side entrance.',
-                amountZecText: '0.5 ZEC',
-                address:
-                    'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
-                    '73d57f73c6dc05121591a83861cd190591',
-                memo: 'Table 4',
-              ),
-              onContinue: () {},
-              onEdit: () {},
-              onCancel: () {},
-            ),
+            child:
+                child ??
+                PaymentRequestSurface(
+                  layout: PaymentRequestLayout.mobile,
+                  request: const PaymentRequestView(
+                    source: PaymentRequestSource.link,
+                    requesterLabel: 'Blue Door Coffee',
+                    note: 'Meet at the side entrance.',
+                    amountZecText: '0.5 ZEC',
+                    address:
+                        'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+                        '73d57f73c6dc05121591a83861cd190591',
+                    memo: 'Table 4',
+                  ),
+                  onContinue: () {},
+                  onEdit: () {},
+                  onCancel: () {},
+                ),
           ),
         ),
       ),

--- a/test/widgetbook/mobile_payment_request_use_cases_test.dart
+++ b/test/widgetbook/mobile_payment_request_use_cases_test.dart
@@ -1,0 +1,64 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_card.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_surface.dart';
+
+void main() {
+  testWidgets('collapsed address and pool badge fit at 2x text scale', (
+    tester,
+  ) async {
+    // Keep the narrow width that exercises the horizontal overflow without
+    // changing the card's pinned-amount contract for unusually short screens.
+    const size = Size(320, 852);
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(textScaler: const TextScaler.linear(2)),
+          child: child!,
+        ),
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: Center(
+            child: SizedBox(
+              width: size.width,
+              height: size.height,
+              child: PaymentRequestSurface(
+                layout: PaymentRequestLayout.mobile,
+                request: const PaymentRequestView(
+                  source: PaymentRequestSource.link,
+                  requesterLabel: 'Blue Door Coffee',
+                  amountZecText: '0.5 ZEC',
+                  address:
+                      'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+                      '73d57f73c6dc05121591a83861cd190591',
+                ),
+                onContinue: () {},
+                onEdit: () {},
+                onCancel: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(
+      tester.widget<Text>(find.text('u195091 ... 190591')).overflow,
+      TextOverflow.ellipsis,
+    );
+  });
+}

--- a/test/widgetbook/mobile_payment_request_use_cases_test.dart
+++ b/test/widgetbook/mobile_payment_request_use_cases_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart' show MaterialApp;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/send/widgets/payment_request_card.dart';
 import 'package:zcash_wallet/src/features/send/widgets/payment_request_surface.dart';
 
@@ -15,45 +16,11 @@ void main() {
     // Keep the narrow width that exercises the horizontal overflow without
     // changing the card's pinned-amount contract for unusually short screens.
     const size = Size(320, 852);
-    tester.view.physicalSize = size;
-    tester.view.devicePixelRatio = 1;
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
-
-    await tester.pumpWidget(
-      MaterialApp(
-        builder: (context, child) => MediaQuery(
-          data: MediaQuery.of(
-            context,
-          ).copyWith(textScaler: const TextScaler.linear(2)),
-          child: child!,
-        ),
-        home: AppTheme(
-          data: AppThemeData.light,
-          child: Center(
-            child: SizedBox(
-              width: size.width,
-              height: size.height,
-              child: PaymentRequestSurface(
-                layout: PaymentRequestLayout.mobile,
-                request: const PaymentRequestView(
-                  source: PaymentRequestSource.link,
-                  requesterLabel: 'Blue Door Coffee',
-                  amountZecText: '0.5 ZEC',
-                  address:
-                      'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
-                      '73d57f73c6dc05121591a83861cd190591',
-                ),
-                onContinue: () {},
-                onEdit: () {},
-                onCancel: () {},
-              ),
-            ),
-          ),
-        ),
-      ),
+    await _pumpPaymentRequest(
+      tester,
+      size: size,
+      textScaler: const TextScaler.linear(2),
     );
-    await tester.pump();
 
     expect(tester.takeException(), isNull);
     expect(
@@ -61,4 +28,87 @@ void main() {
       TextOverflow.ellipsis,
     );
   });
+
+  testWidgets('disclosure heights follow nonlinear text scaling', (
+    tester,
+  ) async {
+    const scaler = _NonlinearTestScaler();
+    await _pumpPaymentRequest(
+      tester,
+      size: const Size(393, 852),
+      textScaler: scaler,
+    );
+
+    final style = AppTypography.bodyMediumStrong;
+    final lineHeight = scaler.scale(style.fontSize!) * style.height!;
+    final expectedHeight = (lineHeight * 2 + AppSpacing.xxs).ceilToDouble() + 1;
+
+    for (final key in <String>[
+      'payment_request_requester_toggle',
+      'payment_request_memo_toggle',
+    ]) {
+      expect(
+        tester.widget<AppButton>(find.byKey(ValueKey(key))).height,
+        expectedHeight,
+      );
+    }
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpPaymentRequest(
+  WidgetTester tester, {
+  required Size size,
+  required TextScaler textScaler,
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(textScaler: textScaler),
+        child: child!,
+      ),
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: Center(
+          child: SizedBox(
+            width: size.width,
+            height: size.height,
+            child: PaymentRequestSurface(
+              layout: PaymentRequestLayout.mobile,
+              request: const PaymentRequestView(
+                source: PaymentRequestSource.link,
+                requesterLabel: 'Blue Door Coffee',
+                note: 'Meet at the side entrance.',
+                amountZecText: '0.5 ZEC',
+                address:
+                    'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+                    '73d57f73c6dc05121591a83861cd190591',
+                memo: 'Table 4',
+              ),
+              onContinue: () {},
+              onEdit: () {},
+              onCancel: () {},
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+final class _NonlinearTestScaler extends TextScaler {
+  const _NonlinearTestScaler();
+
+  @override
+  double scale(double fontSize) =>
+      fontSize <= 16 ? fontSize * 2 : fontSize * 1.5;
+
+  @override
+  double get textScaleFactor => 2;
 }

--- a/test/widgetbook/payment_request_use_cases_test.dart
+++ b/test/widgetbook/payment_request_use_cases_test.dart
@@ -169,6 +169,23 @@ void main() {
     expect(find.text('Review'), findsOneWidget);
     expect(find.text('Edit'), findsOneWidget);
     expect(_requesterNoteMaxScrollExtent(tester), greaterThan(0));
+    expect(
+      tester
+          .widget<SingleChildScrollView>(
+            find.byKey(kPaymentRequestRequesterNoteScrollViewKey),
+          )
+          .padding,
+      const EdgeInsetsDirectional.only(end: kPaymentRequestGutter),
+      reason: 'the overlay scrollbar needs its own trailing gutter',
+    );
+    final noteViewport = tester.getRect(
+      find.byKey(kPaymentRequestRequesterNoteScrollViewKey),
+    );
+    final noteText = tester.getRect(_key('payment_request_requester_note'));
+    expect(
+      noteViewport.right - noteText.right,
+      greaterThanOrEqualTo(kPaymentRequestGutter),
+    );
 
     await tester.drag(
       find.byKey(kPaymentRequestRequesterNoteScrollViewKey),

--- a/test/widgetbook/payment_request_use_cases_test.dart
+++ b/test/widgetbook/payment_request_use_cases_test.dart
@@ -8,7 +8,6 @@ import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_profile_picture.dart';
 import 'package:zcash_wallet/src/core/widgets/app_tooltip.dart';
-import 'package:zcash_wallet/src/core/widgets/review_list_row.dart';
 import 'package:zcash_wallet/src/core/widgets/review_wrap_card.dart';
 import 'package:zcash_wallet/src/features/send/widgets/payment_request_card.dart';
 import 'package:zcash_wallet/src/features/send/widgets/payment_request_surface.dart';
@@ -20,17 +19,20 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(find.text('Payment request'), findsOneWidget);
-    // One muted line under the title names the requester, nothing else.
-    expect(find.text('Requested by Blue Door Coffee'), findsOneWidget);
+    expect(find.text('Requester'), findsOneWidget);
+    expect(find.text('Blue Door Coffee'), findsOneWidget);
+    expect(find.text('Requested by Blue Door Coffee'), findsNothing);
     expect(find.textContaining('From a link'), findsNothing);
     expect(find.text('0.5 ZEC'), findsOneWidget);
     expect(find.text('u195091 ... 190591'), findsOneWidget);
     expect(find.text('Show full address'), findsOneWidget);
     expect(find.text('Shielded'), findsOneWidget);
-    // The memo row is labelled the way the composer and the review label it.
-    expect(find.text('Message'), findsOneWidget);
-    expect(find.text('Memo'), findsNothing);
-    expect(find.text('Note'), findsOneWidget);
+    expect(find.text('Transaction memo'), findsOneWidget);
+    expect(find.text('Message'), findsNothing);
+    expect(find.text('Note'), findsNothing);
+    // Requester notes are progressive disclosure and start hidden.
+    expect(find.text('Note from requester'), findsNothing);
+    expect(_key('payment_request_requester_note'), findsNothing);
     expect(find.text('Review'), findsOneWidget);
     expect(find.text('Edit'), findsOneWidget);
     // Desktop refuses through the header's close, not a third pill in the
@@ -47,16 +49,14 @@ void main() {
       await _pumpUseCase(tester, builder, size: size);
 
       expect(tester.takeException(), isNull);
-      // No ⓘ beside the requester, the message or the note: the labels
-      // carry the meaning on their own.
+      // No ⓘ beside requester or transaction content: the labels carry the
+      // meaning on their own.
       expect(find.byType(AppTooltip), findsNothing);
       expect(find.bySemanticsLabel('About this name'), findsNothing);
     }
   });
 
-  testWidgets('the header keeps one title and one requester line', (
-    tester,
-  ) async {
+  testWidgets('the title and requester group stay separate', (tester) async {
     for (final (builder, size) in <(WidgetBuilder, Size)>[
       (buildPaymentRequestFullUseCase, _desktopSize),
       (buildMobilePaymentRequestFullUseCase, _mobileSize),
@@ -66,14 +66,43 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(_titleText(tester), 'Payment request');
       expect(
-        find.byKey(const ValueKey('payment_request_requester')),
+        find.byKey(const ValueKey('payment_request_requester_group')),
         findsOneWidget,
       );
+      expect(find.text('Requested by Blue Door Coffee'), findsNothing);
       expect(
         find.byKey(const ValueKey('payment_request_eyebrow')),
         findsNothing,
       );
     }
+  });
+
+  testWidgets('requester note expands from the collapsed requester group', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    expect(_key('payment_request_requester_note'), findsNothing);
+    expect(find.bySemanticsLabel('Show requester details'), findsOneWidget);
+
+    await tester.tap(_key('payment_request_requester_toggle'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Note from requester'), findsOneWidget);
+    expect(_key('payment_request_requester_note'), findsOneWidget);
+    expect(find.bySemanticsLabel('Hide requester details'), findsOneWidget);
+    semantics.dispose();
+  });
+
+  testWidgets('a requester name without a note is not an empty accordion', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestContactUseCase);
+
+    expect(_key('payment_request_requester_group'), findsOneWidget);
+    expect(_key('payment_request_requester_toggle'), findsNothing);
+    expect(find.text('Note from requester'), findsNothing);
   });
 
   testWidgets('the request rows use the send review row treatment', (
@@ -82,16 +111,14 @@ void main() {
     await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
 
     expect(tester.takeException(), isNull);
-    // The details block is the review's wrap card, with the review's
-    // hairline between the To / Message / Note groups.
-    expect(find.byType(ReviewWrapCard), findsOneWidget);
-    expect(find.byType(ReviewWrapDivider), findsNWidgets(2));
-    // Message and Note are the review's label-beside-value list rows; "To"
-    // stays label-above-value, as the review's own To row is.
-    expect(find.byType(ReviewListRow), findsNWidgets(2));
+    // Requester metadata and transaction content are separate visual groups.
+    expect(_key('payment_request_requester_group'), findsOneWidget);
+    expect(_key('payment_request_transaction_content'), findsOneWidget);
+    expect(find.byType(ReviewWrapCard), findsNWidgets(2));
+    expect(find.byType(ReviewWrapDivider), findsOneWidget);
 
     final labelStyle = AppTypography.bodyMediumStrong;
-    for (final label in const ['To', 'Message', 'Note']) {
+    for (final label in const ['To', 'Transaction memo']) {
       final text = tester.widget<Text>(find.text(label));
       expect(text.style!.fontSize, labelStyle.fontSize, reason: label);
       expect(text.style!.fontWeight, labelStyle.fontWeight, reason: label);
@@ -152,18 +179,19 @@ void main() {
     }
   });
 
-  testWidgets('minimal use case omits the requester, message and note rows', (
+  testWidgets('minimal use case renders transaction content only', (
     tester,
   ) async {
     await _pumpUseCase(tester, buildPaymentRequestMinimalUseCase);
 
     expect(tester.takeException(), isNull);
     expect(find.text('Blue Door Coffee'), findsNothing);
-    // No label, no line at all.
     expect(
-      find.byKey(const ValueKey('payment_request_requester')),
+      find.byKey(const ValueKey('payment_request_requester_group')),
       findsNothing,
     );
+    expect(find.text('Transaction content'), findsOneWidget);
+    expect(_key('payment_request_transaction_content'), findsOneWidget);
     expect(find.text('Message'), findsNothing);
     expect(find.text('Note'), findsNothing);
     expect(find.byType(ReviewWrapDivider), findsNothing);
@@ -289,7 +317,7 @@ void main() {
     // It rides inside the details card, not outside it.
     final region = tester.getRect(find.byKey(kPaymentRequestScrollbarKey));
     final view = tester.getRect(find.byKey(kPaymentRequestScrollViewKey));
-    final card = tester.getRect(find.byType(ReviewWrapCard));
+    final card = tester.getRect(_transactionDetailsCard());
     expect(region.right, lessThanOrEqualTo(view.right + 0.5));
     expect(region.left, greaterThanOrEqualTo(card.left - 0.5));
     expect(region.right, lessThanOrEqualTo(card.right + 0.5));
@@ -306,7 +334,7 @@ void main() {
       size: _mobileSize,
     );
 
-    final card = find.byType(ReviewWrapCard);
+    final card = _transactionDetailsCard();
     final before = tester.getRect(card);
     expect(_maxScrollExtent(tester), greaterThan(0));
 
@@ -335,9 +363,25 @@ void main() {
     // Nothing to scroll, and the card takes only the height it needs rather
     // than stretching to the space the sheet could give it.
     expect(_maxScrollExtent(tester), 0);
-    final card = tester.getRect(find.byType(ReviewWrapCard));
+    final card = tester.getRect(_transactionDetailsCard());
     final status = tester.getRect(_key('payment_request_continue'));
     expect(card.height, lessThan(status.top - card.top));
+  });
+
+  testWidgets('default mobile requests fit without scrolling', (tester) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildMobilePaymentRequestFullUseCase, const Size(393, 852)),
+      (buildMobilePaymentRequestFullUseCase, const Size(375, 812)),
+      (buildMobilePaymentRequestContactUseCase, const Size(393, 852)),
+      (buildMobilePaymentRequestContactUseCase, const Size(375, 812)),
+    ]) {
+      await _pumpUseCase(tester, builder, size: size);
+
+      expect(tester.takeException(), isNull, reason: '$builder at $size');
+      expect(_maxScrollExtent(tester), 0, reason: '$builder at $size');
+      expect(find.text('Review'), findsOneWidget);
+      expect(find.text('Edit'), findsOneWidget);
+    }
   });
 
   // ─── Status ────────────────────────────────────────────────────────
@@ -389,7 +433,7 @@ void main() {
     final status = tester.getRect(
       find.byKey(const ValueKey('payment_request_status')),
     );
-    final card = tester.getRect(find.byType(ReviewWrapCard));
+    final card = tester.getRect(_transactionDetailsCard());
     final review = tester.getRect(_key('payment_request_continue'));
 
     expect(tester.takeException(), isNull);
@@ -530,15 +574,25 @@ void main() {
     expect(find.text('Shielded'), findsNothing);
   });
 
-  testWidgets('a note without a message renders only the note row', (
+  testWidgets('a requester note without a name stays collapsed', (
     tester,
   ) async {
     await _pumpUseCase(tester, buildPaymentRequestNoteOnlyUseCase);
 
     expect(tester.takeException(), isNull);
-    expect(find.text('Note'), findsOneWidget);
-    expect(find.text('Message'), findsNothing);
-    expect(find.byType(ReviewWrapDivider), findsOneWidget);
+    expect(find.text('Requester'), findsOneWidget);
+    expect(find.text('Note from requester'), findsOneWidget);
+    expect(_key('payment_request_requester_note'), findsNothing);
+    expect(find.text('Transaction memo'), findsNothing);
+
+    await tester.tap(_key('payment_request_requester_toggle'));
+    await tester.pumpAndSettle();
+
+    expect(_key('payment_request_requester_note'), findsOneWidget);
+    expect(
+      tester.widget<Text>(_key('payment_request_requester_note')).data,
+      'Saved from the invoice link you opened.',
+    );
   });
 
   testWidgets('a blocked primary action still announces why', (tester) async {
@@ -668,7 +722,7 @@ void main() {
     expect(actions.bottom, lessThanOrEqualTo(sheet.bottom - 8));
   });
 
-  testWidgets('the details card spans the full mobile content width', (
+  testWidgets('the transaction group spans the mobile action width', (
     tester,
   ) async {
     await _pumpUseCase(
@@ -678,15 +732,15 @@ void main() {
     );
 
     expect(tester.takeException(), isNull);
-    // The scroll region reserves no trailing gutter, so the wrap card sits
-    // the same distance from both edges of the sheet content.
-    final wrap = tester.getRect(find.byType(ReviewWrapCard));
+    final transaction = tester.getRect(
+      _key('payment_request_transaction_content'),
+    );
     final actions = tester.getRect(_key('payment_request_continue'));
     expect(
-      wrap.left - actions.left,
-      moreOrLessEquals(actions.right - wrap.right, epsilon: 0.5),
+      transaction.left - actions.left,
+      moreOrLessEquals(actions.right - transaction.right, epsilon: 0.5),
     );
-    expect(wrap.width, moreOrLessEquals(actions.width, epsilon: 0.5));
+    expect(transaction.width, moreOrLessEquals(actions.width, epsilon: 0.5));
   });
 
   // ─── A recipient the wallet can name ───────────────────────────────
@@ -842,9 +896,9 @@ void main() {
       expect(find.text('Edit'), findsNothing);
       expect(_key('payment_request_edit'), findsNothing);
       expect(_button(tester, 'payment_request_continue').onPressed, isNotNull);
-      // The title flows straight into the details card.
+      // The amount slot is omitted inside the transaction group.
       expect(_titleText(tester), 'Payment request');
-      expect(find.byType(ReviewWrapCard), findsOneWidget);
+      expect(_key('payment_request_transaction_content'), findsOneWidget);
     }
   });
 
@@ -878,7 +932,7 @@ void main() {
 
   // ─── Actions ───────────────────────────────────────────────────────
 
-  testWidgets('the actions are one full-width primary over a full-width Edit', (
+  testWidgets('the actions are a full-width primary over text-only Edit', (
     tester,
   ) async {
     for (final (builder, size) in <(WidgetBuilder, Size)>[
@@ -895,22 +949,18 @@ void main() {
       final review = _button(tester, 'payment_request_continue');
       final edit = _button(tester, 'payment_request_edit');
       expect(review.variant, AppButtonVariant.primary);
-      expect(edit.variant, AppButtonVariant.secondary);
+      expect(edit.variant, AppButtonVariant.ghost);
+      expect(edit.size, AppButtonSize.small);
       expect(review.expand, isTrue);
-      expect(edit.expand, isTrue);
+      expect(edit.expand, isFalse);
 
-      // Same size and shape, Edit under Review, 8px apart.
+      // Edit remains a real button but no longer paints a second full-width
+      // pill under the primary action.
       final reviewRect = tester.getRect(_key('payment_request_continue'));
       final editRect = tester.getRect(_key('payment_request_edit'));
-      expect(editRect.width, moreOrLessEquals(reviewRect.width, epsilon: 0.5));
-      expect(
-        editRect.height,
-        moreOrLessEquals(reviewRect.height, epsilon: 0.5),
-      );
-      expect(
-        editRect.top - reviewRect.bottom,
-        moreOrLessEquals(8, epsilon: 0.5),
-      );
+      expect(editRect.width, lessThan(reviewRect.width));
+      expect(editRect.height, lessThan(reviewRect.height));
+      expect(editRect.top, greaterThan(reviewRect.bottom));
 
       // Nothing edits in place any more.
       expect(
@@ -963,6 +1013,11 @@ const _desktopSize = Size(1080, 720);
 const _mobileSize = Size(393, 852);
 
 Finder _key(String value) => find.byKey(ValueKey(value));
+
+Finder _transactionDetailsCard() => find.descendant(
+  of: _key('payment_request_transaction_content'),
+  matching: find.byType(ReviewWrapCard),
+);
 
 /// Taps the value pill of a `ReviewListRow`-shaped row. The label itself is
 /// not the tap target — the review's rows put the gesture on the pill.

--- a/test/widgetbook/payment_request_use_cases_test.dart
+++ b/test/widgetbook/payment_request_use_cases_test.dart
@@ -490,22 +490,6 @@ void main() {
     expect(card.height, lessThan(status.top - card.top));
   });
 
-  testWidgets('default mobile requests fit without scrolling', (tester) async {
-    for (final (builder, size) in <(WidgetBuilder, Size)>[
-      (buildMobilePaymentRequestFullUseCase, const Size(393, 852)),
-      (buildMobilePaymentRequestFullUseCase, const Size(375, 812)),
-      (buildMobilePaymentRequestContactUseCase, const Size(393, 852)),
-      (buildMobilePaymentRequestContactUseCase, const Size(375, 812)),
-    ]) {
-      await _pumpUseCase(tester, builder, size: size);
-
-      expect(tester.takeException(), isNull, reason: '$builder at $size');
-      expect(_maxScrollExtent(tester), 0, reason: '$builder at $size');
-      expect(find.text('Review'), findsOneWidget);
-      expect(find.text('Edit'), findsOneWidget);
-    }
-  });
-
   // ─── Status ────────────────────────────────────────────────────────
 
   testWidgets('blocking statuses disable the primary action and say why', (

--- a/test/widgetbook/payment_request_use_cases_test.dart
+++ b/test/widgetbook/payment_request_use_cases_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart' show MaterialApp;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -95,6 +96,65 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('requester and memo disclosures expose one semantics action', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    final requester = tester.getSemantics(
+      find.bySemanticsLabel('Show requester details'),
+    );
+    final memo = tester.getSemantics(
+      find.bySemanticsLabel('Expand transaction memo'),
+    );
+
+    expect(requester.childrenCountInTraversalOrder, 0);
+    expect(memo.childrenCountInTraversalOrder, 0);
+    semantics.dispose();
+  });
+
+  testWidgets('a very long requester note scrolls inside its existing card', (
+    tester,
+  ) async {
+    final note = List.filled(12000, 'a').join();
+    await _pumpUseCase(
+      tester,
+      (_) => PaymentRequestSurface(
+        layout: PaymentRequestLayout.mobile,
+        request: PaymentRequestView(
+          source: PaymentRequestSource.link,
+          requesterLabel: 'Blue Door Coffee',
+          amountZecText: '0.5 ZEC',
+          address:
+              'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+              '73d57f73c6dc05121591a83861cd190591',
+          note: note,
+        ),
+        onContinue: () {},
+        onEdit: () {},
+        onCancel: () {},
+      ),
+      size: _mobileSize,
+    );
+
+    await tester.tap(_key('payment_request_requester_toggle'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Review'), findsOneWidget);
+    expect(find.text('Edit'), findsOneWidget);
+    expect(_requesterNoteMaxScrollExtent(tester), greaterThan(0));
+
+    await tester.drag(
+      find.byKey(kPaymentRequestRequesterNoteScrollViewKey),
+      const Offset(0, -80),
+    );
+    await tester.pumpAndSettle();
+
+    expect(_requesterNoteScrollOffset(tester), greaterThan(0));
+  });
+
   testWidgets('a requester name without a note is not an empty accordion', (
     tester,
   ) async {
@@ -127,6 +187,44 @@ void main() {
         text.style!.color,
         AppThemeData.light.colors.text.secondary,
         reason: label,
+      );
+    }
+  });
+
+  testWidgets('disclosures do not add a hover fill', (tester) async {
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer();
+
+    for (final key in const [
+      'payment_request_requester_toggle',
+      'payment_request_memo_toggle',
+    ]) {
+      final button = _key(key);
+      await mouse.moveTo(tester.getCenter(button));
+      await tester.pump();
+
+      final decoration =
+          tester
+                  .widget<AnimatedContainer>(
+                    find.descendant(
+                      of: button,
+                      matching: find.byType(AnimatedContainer),
+                    ),
+                  )
+                  .decoration!
+              as ShapeDecoration;
+      final container = tester.widget<AnimatedContainer>(
+        find.descendant(of: button, matching: find.byType(AnimatedContainer)),
+      );
+      expect(
+        decoration.color,
+        AppThemeData.light.colors.background.ground.withValues(alpha: 0),
+      );
+      expect(
+        container.padding,
+        const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
       );
     }
   });
@@ -410,7 +508,7 @@ void main() {
       await _pumpUseCase(tester, builder);
 
       expect(tester.takeException(), isNull, reason: message);
-      // Exactly one status line, in the one slot above the actions.
+      // Exactly one status line, attached to the details card.
       expect(find.text(message), findsOneWidget, reason: message);
       expect(
         find.byKey(const ValueKey('payment_request_status')),
@@ -425,7 +523,7 @@ void main() {
     }
   });
 
-  testWidgets('the status line sits between the details and the actions', (
+  testWidgets('the status line sits below the card, away from the actions', (
     tester,
   ) async {
     await _pumpUseCase(tester, buildPaymentRequestInvalidAddressUseCase);
@@ -439,6 +537,7 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(status.top, greaterThanOrEqualTo(card.bottom - 0.5));
     expect(status.bottom, lessThanOrEqualTo(review.top + 0.5));
+    expect(status.top - card.bottom, lessThan(review.top - status.bottom));
   });
 
   testWidgets('checking is a button state, not a status line', (tester) async {
@@ -932,7 +1031,7 @@ void main() {
 
   // ─── Actions ───────────────────────────────────────────────────────
 
-  testWidgets('the actions are a full-width primary over text-only Edit', (
+  testWidgets('the actions are full-width primary and ghost buttons', (
     tester,
   ) async {
     for (final (builder, size) in <(WidgetBuilder, Size)>[
@@ -950,16 +1049,13 @@ void main() {
       final edit = _button(tester, 'payment_request_edit');
       expect(review.variant, AppButtonVariant.primary);
       expect(edit.variant, AppButtonVariant.ghost);
-      expect(edit.size, AppButtonSize.small);
       expect(review.expand, isTrue);
-      expect(edit.expand, isFalse);
+      expect(edit.expand, isTrue);
 
-      // Edit remains a real button but no longer paints a second full-width
-      // pill under the primary action.
       final reviewRect = tester.getRect(_key('payment_request_continue'));
       final editRect = tester.getRect(_key('payment_request_edit'));
-      expect(editRect.width, lessThan(reviewRect.width));
-      expect(editRect.height, lessThan(reviewRect.height));
+      expect(editRect.width, moreOrLessEquals(reviewRect.width));
+      expect(editRect.height, moreOrLessEquals(reviewRect.height));
       expect(editRect.top, greaterThan(reviewRect.bottom));
 
       // Nothing edits in place any more.
@@ -1056,6 +1152,21 @@ double _scrollOffset(WidgetTester tester) => tester
 
 double _maxScrollExtent(WidgetTester tester) => tester
     .widget<SingleChildScrollView>(find.byKey(kPaymentRequestScrollViewKey))
+    .controller!
+    .position
+    .maxScrollExtent;
+
+double _requesterNoteScrollOffset(WidgetTester tester) => tester
+    .widget<SingleChildScrollView>(
+      find.byKey(kPaymentRequestRequesterNoteScrollViewKey),
+    )
+    .controller!
+    .offset;
+
+double _requesterNoteMaxScrollExtent(WidgetTester tester) => tester
+    .widget<SingleChildScrollView>(
+      find.byKey(kPaymentRequestRequesterNoteScrollViewKey),
+    )
     .controller!
     .position
     .maxScrollExtent;

--- a/test/widgetbook/payment_request_use_cases_test.dart
+++ b/test/widgetbook/payment_request_use_cases_test.dart
@@ -721,40 +721,6 @@ void main() {
     }
   });
 
-  testWidgets('collapsed mobile address and pool badge fit at 2x text scale', (
-    tester,
-  ) async {
-    await _pumpUseCase(
-      tester,
-      (context) => MediaQuery(
-        data: MediaQuery.of(
-          context,
-        ).copyWith(textScaler: const TextScaler.linear(2)),
-        child: PaymentRequestSurface(
-          layout: PaymentRequestLayout.mobile,
-          request: const PaymentRequestView(
-            source: PaymentRequestSource.link,
-            requesterLabel: 'Blue Door Coffee',
-            amountZecText: '0.5 ZEC',
-            address:
-                'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
-                '73d57f73c6dc05121591a83861cd190591',
-          ),
-          onContinue: () {},
-          onEdit: () {},
-          onCancel: () {},
-        ),
-      ),
-      size: const Size(320, 700),
-    );
-
-    expect(tester.takeException(), isNull);
-    expect(
-      tester.widget<Text>(find.text('u195091 ... 190591')).overflow,
-      TextOverflow.ellipsis,
-    );
-  });
-
   testWidgets('every registered use case renders in its own lane', (
     tester,
   ) async {

--- a/test/widgetbook/payment_request_use_cases_test.dart
+++ b/test/widgetbook/payment_request_use_cases_test.dart
@@ -721,6 +721,40 @@ void main() {
     }
   });
 
+  testWidgets('collapsed mobile address and pool badge fit at 2x text scale', (
+    tester,
+  ) async {
+    await _pumpUseCase(
+      tester,
+      (context) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(textScaler: const TextScaler.linear(2)),
+        child: PaymentRequestSurface(
+          layout: PaymentRequestLayout.mobile,
+          request: const PaymentRequestView(
+            source: PaymentRequestSource.link,
+            requesterLabel: 'Blue Door Coffee',
+            amountZecText: '0.5 ZEC',
+            address:
+                'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+                '73d57f73c6dc05121591a83861cd190591',
+          ),
+          onContinue: () {},
+          onEdit: () {},
+          onCancel: () {},
+        ),
+      ),
+      size: const Size(320, 700),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(
+      tester.widget<Text>(find.text('u195091 ... 190591')).overflow,
+      TextOverflow.ellipsis,
+    );
+  });
+
   testWidgets('every registered use case renders in its own lane', (
     tester,
   ) async {

--- a/test/widgetbook/payment_request_use_cases_test.dart
+++ b/test/widgetbook/payment_request_use_cases_test.dart
@@ -114,6 +114,30 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('expanded memo is not announced by its disclosure twice', (
+    tester,
+  ) async {
+    const memoText =
+        'Table 4 — two flat whites and a pastry. Thanks for stopping by, '
+        'see you next week.';
+    final semantics = tester.ensureSemantics();
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    final collapsed = tester.getSemantics(
+      find.bySemanticsLabel('Expand transaction memo'),
+    );
+    expect(collapsed.value, 'Transaction memo, $memoText');
+
+    await tester.tap(_key('payment_request_memo_toggle'));
+    await tester.pumpAndSettle();
+
+    final expanded = tester.getSemantics(
+      find.bySemanticsLabel('Collapse transaction memo'),
+    );
+    expect(expanded.value, isEmpty);
+    semantics.dispose();
+  });
+
   testWidgets('a very long requester note scrolls inside its existing card', (
     tester,
   ) async {


### PR DESCRIPTION
Stacked on #595 (targets `rowan/vzr-91`). Presentation-only: two commits touching the payment request card, its sheet wrapper, the Widgetbook fixtures and their tests. No change to the request flow, pre-check, resolver, routing, or the Request ZEC creator.

## Summary

The card now separates what the requester supplied from what the transaction will carry. Requester name and the off-chain `message=` sit in a collapsed "Requester" group above; the amount, recipient and the on-chain `memo=` (relabelled "Transaction memo") sit in a "Transaction content" group below, so the two kinds of text are no longer siblings with only a label telling them apart. The explanatory helper copy is gone, "Shielded" moves beside "To", "Show full address" sits beside the address, Edit becomes a compact text action under a full-width Review, and address-book contacts keep the avatar/name treatment while the requester name drops to body text so link-supplied text no longer outranks a wallet-verified name. Spacing follows one rule: 16 px inside every card on all sides and between groups, 4 px label-to-value, 32 px at the sheet top and bottom (the Figma modal base), with the frame border painted as a foreground so it never shifts the gutter and the details card flush with the frame so the radii stay concentric. Touch targets no longer borrow layout: the memo control is the whole label-over-value block and on mobile the whole recipient block toggles the full address. Verified with `fvm flutter analyze`, the 70 focused card/host/layout/resolver tests, and deterministic `figma-compare.sh` captures at 393×852, 375×812 and desktop; default mobile states fit without scrolling.

## Before / after

Before = PR #595 head (bc608a7b0). After = this branch (14592d387). Deterministic `scripts/figma-compare.sh widget` captures, dark theme.

**Mobile, 393×852 — unknown address and address-book contact**

<img width="1732" height="1026" alt="payment-request-mobile-before-after" src="https://github.com/user-attachments/assets/19209c09-769e-427a-b7e0-7d2b241c550c" />

**Desktop — unknown address and address-book contact**

<img width="2080" height="894" alt="payment-request-desktop-before-after" src="https://github.com/user-attachments/assets/7f1e618f-73fa-4bc0-af26-ff3f0df614be" />

<details><summary>Measured spacing on the new mobile card (393×852)</summary>

<img width="1179" height="2556" alt="payment-request-mobile-gap-map" src="https://github.com/user-attachments/assets/f1f09b13-5fe2-4df1-b8c6-db8fcf170075" />

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and copy only on the payment-request consent surface; routing, pre-check, and transaction data are unchanged, though clearer labeling of attacker-controlled requester fields slightly reduces phishing confusion risk.
> 
> **Overview**
> **Presentation-only** rework of the payment request modal/sheet so link-supplied text is visually separated from what the payment will carry.
> 
> The header no longer shows a muted **"Requested by …"** line. Requester name and the off-chain link **note** move into a **Requester** card above the fold; the note expands via **"Note from requester"** when present (no toggle when there is only a name). Amount, **To**, and on-chain **memo** sit in a bordered **Transaction content** group, with the memo relabeled **Transaction memo** and the requester note removed from that block.
> 
> Layout and actions tighten to one **16px** gutter (`kPaymentRequestGutter`), **Shielded/Transparent** beside **To**, **Show full address** beside the address (on mobile the whole recipient block toggles expand), memo/requester controls use label-over-value ghost buttons instead of `ReviewListRow`, and **Edit** becomes a compact ghost control under full-width **Review**. Mobile sheet **bottom padding** increases to **32px** (`AppSpacing.base`). Widgetbook fixtures and tests follow the new keys, copy, and expectations (including default mobile fitting without scroll).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14592d387ac0587bf63d6a627ab57ec08e23683c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

