### PR TITLE
Keep mobile awake throughout sync startup

### DIFF
--- a/lib/src/core/widgets/mobile/sync_keep_awake_native_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_native_host.dart
@@ -7,15 +7,23 @@ import '../../layout/app_form_factor.dart';
 import '../../../providers/sync_keep_awake_provider.dart';
 import '../../../services/native_screen_awake.dart';
 
+const kNativeScreenAwakeRetryDelays = <Duration>[
+  Duration(seconds: 1),
+  Duration(seconds: 4),
+  Duration(seconds: 16),
+];
+
 class SyncKeepAwakeNativeHost extends ConsumerStatefulWidget {
   const SyncKeepAwakeNativeHost({
     required this.child,
     this.bridge = const NativeScreenAwakeBridge(),
+    this.retryDelays = kNativeScreenAwakeRetryDelays,
     super.key,
   });
 
   final Widget child;
   final NativeScreenAwakeBridge bridge;
+  final List<Duration> retryDelays;
 
   @override
   ConsumerState<SyncKeepAwakeNativeHost> createState() =>
@@ -25,9 +33,13 @@ class SyncKeepAwakeNativeHost extends ConsumerStatefulWidget {
 class _SyncKeepAwakeNativeHostState
     extends ConsumerState<SyncKeepAwakeNativeHost> {
   AppLifecycleListener? _lifecycleListener;
+  Timer? _retryTimer;
   bool _isInForeground = true;
-  bool _lastRequestedEnabled = false;
+  bool _desiredEnabled = false;
   bool _lastAppliedEnabled = false;
+  bool _nativeStateUncertain = false;
+  bool _isDisposed = false;
+  int _requestGeneration = 0;
   Future<void> _nativeQueue = Future<void>.value();
 
   @override
@@ -59,8 +71,10 @@ class _SyncKeepAwakeNativeHostState
   @override
   void dispose() {
     _lifecycleListener?.dispose();
-    if (_lastRequestedEnabled || _lastAppliedEnabled) {
-      _requestNativeState(false, force: true);
+    _retryTimer?.cancel();
+    _isDisposed = true;
+    if (_desiredEnabled || _lastAppliedEnabled || _nativeStateUncertain) {
+      _requestNativeState(false, force: true, allowDisposed: true);
     }
     super.dispose();
   }
@@ -77,28 +91,99 @@ class _SyncKeepAwakeNativeHostState
     _requestNativeState(ref.read(syncKeepAwakeActiveProvider));
   }
 
-  void _requestNativeState(bool enabled, {bool force = false}) {
-    if (!force && _lastRequestedEnabled == enabled) return;
-    _lastRequestedEnabled = enabled;
-    final bridge = widget.bridge;
-    _nativeQueue = _nativeQueue.then(
-      (_) => _applyNativeState(bridge, enabled, force: force),
+  void _requestNativeState(
+    bool enabled, {
+    bool force = false,
+    bool allowDisposed = false,
+  }) {
+    if (_isDisposed && !allowDisposed) return;
+    if (!force && _desiredEnabled == enabled) return;
+
+    _desiredEnabled = enabled;
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    final generation = ++_requestGeneration;
+    _enqueueNativeAttempt(
+      enabled,
+      generation: generation,
+      failedAttempts: 0,
+      force: force,
     );
   }
 
-  Future<void> _applyNativeState(
+  void _enqueueNativeAttempt(
+    bool enabled, {
+    required int generation,
+    required int failedAttempts,
+    bool force = false,
+  }) {
+    final bridge = widget.bridge;
+    _nativeQueue = _nativeQueue.then((_) async {
+      if (!_isCurrentRequest(enabled, generation)) return;
+      final applied = await _applyNativeState(
+        bridge,
+        enabled,
+        force: force,
+        attempt: failedAttempts + 1,
+      );
+      if (!applied) {
+        _scheduleRetry(
+          enabled,
+          generation: generation,
+          failedAttempts: failedAttempts + 1,
+        );
+      }
+    });
+  }
+
+  bool _isCurrentRequest(bool enabled, int generation) {
+    return generation == _requestGeneration && _desiredEnabled == enabled;
+  }
+
+  Future<bool> _applyNativeState(
     NativeScreenAwakeBridge bridge,
     bool enabled, {
     required bool force,
+    required int attempt,
   }) async {
-    if (!force && _lastAppliedEnabled == enabled) return;
+    if (!force && !_nativeStateUncertain && _lastAppliedEnabled == enabled) {
+      return true;
+    }
     try {
       await bridge.setEnabled(enabled);
       _lastAppliedEnabled = enabled;
+      _nativeStateUncertain = false;
+      return true;
     } catch (error) {
+      _nativeStateUncertain = true;
       debugPrint(
-        'SyncKeepAwakeNativeHost: setEnabled($enabled) failed: $error',
+        'SyncKeepAwakeNativeHost: setEnabled($enabled) failed '
+        '(attempt $attempt/${widget.retryDelays.length + 1}): $error',
       );
+      return false;
     }
+  }
+
+  void _scheduleRetry(
+    bool enabled, {
+    required int generation,
+    required int failedAttempts,
+  }) {
+    if (_isDisposed ||
+        !_isCurrentRequest(enabled, generation) ||
+        failedAttempts > widget.retryDelays.length) {
+      return;
+    }
+
+    _retryTimer?.cancel();
+    _retryTimer = Timer(widget.retryDelays[failedAttempts - 1], () {
+      _retryTimer = null;
+      if (_isDisposed || !_isCurrentRequest(enabled, generation)) return;
+      _enqueueNativeAttempt(
+        enabled,
+        generation: generation,
+        failedAttempts: failedAttempts,
+      );
+    });
   }
 }

--- a/lib/src/core/widgets/mobile/sync_keep_awake_native_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_native_host.dart
@@ -118,6 +118,7 @@ class _SyncKeepAwakeNativeHostState
     bool force = false,
   }) {
     final bridge = widget.bridge;
+    final totalAttempts = widget.retryDelays.length + 1;
     _nativeQueue = _nativeQueue.then((_) async {
       if (!_isCurrentRequest(enabled, generation)) return;
       final applied = await _applyNativeState(
@@ -125,6 +126,7 @@ class _SyncKeepAwakeNativeHostState
         enabled,
         force: force,
         attempt: failedAttempts + 1,
+        totalAttempts: totalAttempts,
       );
       if (!applied) {
         _scheduleRetry(
@@ -145,6 +147,7 @@ class _SyncKeepAwakeNativeHostState
     bool enabled, {
     required bool force,
     required int attempt,
+    required int totalAttempts,
   }) async {
     if (!force && !_nativeStateUncertain && _lastAppliedEnabled == enabled) {
       return true;
@@ -158,7 +161,7 @@ class _SyncKeepAwakeNativeHostState
       _nativeStateUncertain = true;
       debugPrint(
         'SyncKeepAwakeNativeHost: setEnabled($enabled) failed '
-        '(attempt $attempt/${widget.retryDelays.length + 1}): $error',
+        '(attempt $attempt/$totalAttempts): $error',
       );
       return false;
     }

--- a/lib/src/providers/sync_keep_awake_provider.dart
+++ b/lib/src/providers/sync_keep_awake_provider.dart
@@ -245,6 +245,14 @@ bool isSyncKeepAwakeActiveSync(SyncState sync) {
     return false;
   }
 
+  // The foreground sync has started, but Rust has not necessarily emitted
+  // enough progress metadata to describe the remaining work yet. Keep the
+  // screen awake during this discovery window so a slow endpoint/Tor preflight
+  // cannot let the device sleep before the first progress event arrives.
+  if (sync.phase == kSyncPhasePreflight || sync.phase == kSyncPhaseSetup) {
+    return true;
+  }
+
   final hasKnownHeights = sync.chainTipHeight > 0 && sync.scannedHeight > 0;
   if (hasKnownHeights) {
     return !isNearTipCatchUp(sync);

--- a/lib/src/providers/sync_keep_awake_provider.dart
+++ b/lib/src/providers/sync_keep_awake_provider.dart
@@ -245,15 +245,17 @@ bool isSyncKeepAwakeActiveSync(SyncState sync) {
     return false;
   }
 
-  // The foreground sync has started, but Rust has not necessarily emitted
+  final hasKnownHeights = sync.chainTipHeight > 0 && sync.scannedHeight > 0;
+
+  // A fresh foreground sync has started, but Rust has not necessarily emitted
   // enough progress metadata to describe the remaining work yet. Keep the
   // screen awake during this discovery window so a slow endpoint/Tor preflight
-  // cannot let the device sleep before the first progress event arrives.
-  if (isSyncPreparationPhase(sync.phase)) {
+  // cannot let the device sleep before the first progress event arrives. When
+  // heights are already known, preserve the near-tip catch-up exclusion.
+  if (isSyncPreparationPhase(sync.phase) && !hasKnownHeights) {
     return true;
   }
 
-  final hasKnownHeights = sync.chainTipHeight > 0 && sync.scannedHeight > 0;
   if (hasKnownHeights) {
     return !isNearTipCatchUp(sync);
   }

--- a/lib/src/providers/sync_keep_awake_provider.dart
+++ b/lib/src/providers/sync_keep_awake_provider.dart
@@ -249,7 +249,7 @@ bool isSyncKeepAwakeActiveSync(SyncState sync) {
   // enough progress metadata to describe the remaining work yet. Keep the
   // screen awake during this discovery window so a slow endpoint/Tor preflight
   // cannot let the device sleep before the first progress event arrives.
-  if (sync.phase == kSyncPhasePreflight || sync.phase == kSyncPhaseSetup) {
+  if (isSyncPreparationPhase(sync.phase)) {
     return true;
   }
 

--- a/test/core/widgets/sync_keep_awake_native_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_native_host_test.dart
@@ -84,37 +84,60 @@ void main() {
     expect(_enabledArgs(calls), [true]);
   });
 
-  testWidgets('enables during preflight then disables when sync is near tip', (
-    tester,
-  ) async {
-    final calls = _recordScreenAwakeCalls();
-    final startedAt = DateTime(2026, 7, 9, 12);
-    final syncNotifier = FakeSyncNotifier(
-      _sync(
-        percentage: 0,
-        scannedHeight: 0,
-        chainTipHeight: 0,
-        lastSyncStartedAt: startedAt,
-        phase: kSyncPhasePreflight,
-      ),
-    );
+  testWidgets(
+    'stays enabled through preparation then disables when sync is near tip',
+    (tester) async {
+      final calls = _recordScreenAwakeCalls();
+      final startedAt = DateTime(2026, 7, 9, 12);
+      final syncNotifier = FakeSyncNotifier(
+        _sync(
+          percentage: 0,
+          scannedHeight: 0,
+          chainTipHeight: 0,
+          lastSyncStartedAt: startedAt,
+          phase: kSyncPhasePreflight,
+        ),
+      );
 
-    await tester.pumpWidget(_app(syncNotifier: syncNotifier));
-    await _drainNativeQueue(tester);
-    expect(_enabledArgs(calls), [true]);
+      await tester.pumpWidget(_app(syncNotifier: syncNotifier));
+      await _drainNativeQueue(tester);
+      expect(_enabledArgs(calls), [true]);
 
-    syncNotifier.emit(
-      _sync(
-        percentage: 0,
-        scannedHeight: 100,
-        chainTipHeight: 102,
-        lastSyncStartedAt: startedAt,
-      ),
-    );
-    await _drainNativeQueue(tester);
+      for (final phase in [
+        kSyncPhaseSetup,
+        kSyncPhaseActiveUtxo,
+        kSyncPhaseChainPrepare,
+      ]) {
+        syncNotifier.emit(
+          _sync(
+            percentage: 0,
+            scannedHeight: 0,
+            chainTipHeight: 200,
+            lastSyncStartedAt: startedAt,
+            phase: phase,
+          ),
+        );
+        await _drainNativeQueue(tester);
+        expect(
+          _enabledArgs(calls),
+          [true],
+          reason: '$phase must not disable keep-awake during preparation',
+        );
+      }
 
-    expect(_enabledArgs(calls), [true, false]);
-  });
+      syncNotifier.emit(
+        _sync(
+          percentage: 0,
+          scannedHeight: 100,
+          chainTipHeight: 102,
+          lastSyncStartedAt: startedAt,
+        ),
+      );
+      await _drainNativeQueue(tester);
+
+      expect(_enabledArgs(calls), [true, false]);
+    },
+  );
 
   testWidgets('disables native keep-awake while the app is not foreground', (
     tester,

--- a/test/core/widgets/sync_keep_awake_native_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_native_host_test.dart
@@ -39,6 +39,26 @@ void main() {
     expect(calls, isEmpty);
   });
 
+  testWidgets('does not enable native keep-awake for known near-tip setup', (
+    tester,
+  ) async {
+    final calls = _recordScreenAwakeCalls();
+    final syncNotifier = FakeSyncNotifier(
+      _sync(
+        percentage: 0,
+        scannedHeight: 100,
+        chainTipHeight: 102,
+        lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+        phase: kSyncPhasePreflight,
+      ),
+    );
+
+    await tester.pumpWidget(_app(syncNotifier: syncNotifier));
+    await _drainNativeQueue(tester);
+
+    expect(calls, isEmpty);
+  });
+
   testWidgets('enables native keep-awake only while sync is eligible', (
     tester,
   ) async {

--- a/test/core/widgets/sync_keep_awake_native_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_native_host_test.dart
@@ -76,6 +76,38 @@ void main() {
     expect(_enabledArgs(calls), [true]);
   });
 
+  testWidgets('enables during preflight then disables when sync is near tip', (
+    tester,
+  ) async {
+    final calls = _recordScreenAwakeCalls();
+    final startedAt = DateTime(2026, 7, 9, 12);
+    final syncNotifier = FakeSyncNotifier(
+      _sync(
+        percentage: 0,
+        scannedHeight: 0,
+        chainTipHeight: 0,
+        lastSyncStartedAt: startedAt,
+        phase: kSyncPhasePreflight,
+      ),
+    );
+
+    await tester.pumpWidget(_app(syncNotifier: syncNotifier));
+    await _drainNativeQueue(tester);
+    expect(_enabledArgs(calls), [true]);
+
+    syncNotifier.emit(
+      _sync(
+        percentage: 0,
+        scannedHeight: 100,
+        chainTipHeight: 102,
+        lastSyncStartedAt: startedAt,
+      ),
+    );
+    await _drainNativeQueue(tester);
+
+    expect(_enabledArgs(calls), [true, false]);
+  });
+
   testWidgets('disables native keep-awake while the app is not foreground', (
     tester,
   ) async {
@@ -202,6 +234,7 @@ SyncState _sync({
   int scannedHeight = 100,
   int chainTipHeight = 200,
   DateTime? lastSyncStartedAt,
+  String phase = '',
 }) {
   return SyncState(
     isSyncing: isSyncing,
@@ -211,5 +244,6 @@ SyncState _sync({
     scannedHeight: scannedHeight,
     chainTipHeight: chainTipHeight,
     lastSyncStartedAt: lastSyncStartedAt,
+    phase: phase,
   );
 }

--- a/test/core/widgets/sync_keep_awake_native_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_native_host_test.dart
@@ -1,6 +1,8 @@
 @Tags(['mobile'])
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -363,6 +365,40 @@ void main() {
     await tester.pump(const Duration(milliseconds: 20));
     await _drainNativeQueue(tester);
 
+    expect(_enabledArgs(calls), [true, false]);
+  });
+
+  testWidgets('handles an in-flight native failure after dispose', (
+    tester,
+  ) async {
+    final calls = <MethodCall>[];
+    final enableResult = Completer<void>();
+    const channel = MethodChannel(kNativeScreenAwakeChannelName);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          final enabled =
+              (call.arguments as Map<Object?, Object?>?)?['enabled'] as bool;
+          if (enabled) await enableResult.future;
+          return null;
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+    final syncNotifier = FakeSyncNotifier(
+      _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+    );
+
+    await tester.pumpWidget(_app(syncNotifier: syncNotifier));
+    await tester.pump();
+    expect(_enabledArgs(calls), [true]);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    enableResult.completeError(PlatformException(code: 'delayed_failure'));
+    await _drainNativeQueue(tester);
+
+    expect(tester.takeException(), isNull);
     expect(_enabledArgs(calls), [true, false]);
   });
 }

--- a/test/core/widgets/sync_keep_awake_native_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_native_host_test.dart
@@ -15,6 +15,14 @@ import 'package:zcash_wallet/src/services/native_screen_awake.dart';
 import '../../fakes/fake_sync_notifier.dart';
 
 void main() {
+  test('uses the production native retry backoff', () {
+    expect(kNativeScreenAwakeRetryDelays, const [
+      Duration(seconds: 1),
+      Duration(seconds: 4),
+      Duration(seconds: 16),
+    ]);
+  });
+
   testWidgets('does not call native API for near-tip catch-up', (tester) async {
     final calls = _recordScreenAwakeCalls();
     final syncNotifier = FakeSyncNotifier(
@@ -162,14 +170,173 @@ void main() {
 
     expect(_enabledArgs(calls), [true, false]);
   });
+
+  testWidgets('retries a failed native request while the state is unchanged', (
+    tester,
+  ) async {
+    final calls = _recordScreenAwakeCalls(
+      shouldFail: (_, callIndex) => callIndex == 0,
+    );
+    final syncNotifier = FakeSyncNotifier(
+      _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+    );
+
+    await tester.pumpWidget(
+      _app(
+        syncNotifier: syncNotifier,
+        retryDelays: const [Duration(milliseconds: 10)],
+      ),
+    );
+    await _drainNativeQueue(tester);
+    expect(_enabledArgs(calls), [true]);
+
+    await tester.pump(const Duration(milliseconds: 10));
+    await _drainNativeQueue(tester);
+
+    expect(_enabledArgs(calls), [true, true]);
+  });
+
+  testWidgets('stops retrying after the configured attempts are exhausted', (
+    tester,
+  ) async {
+    final calls = _recordScreenAwakeCalls(shouldFail: (_, _) => true);
+    final syncNotifier = FakeSyncNotifier(
+      _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+    );
+
+    await tester.pumpWidget(
+      _app(
+        syncNotifier: syncNotifier,
+        retryDelays: const [
+          Duration(milliseconds: 10),
+          Duration(milliseconds: 20),
+          Duration(milliseconds: 30),
+        ],
+      ),
+    );
+    await _drainNativeQueue(tester);
+
+    for (final delay in const [
+      Duration(milliseconds: 10),
+      Duration(milliseconds: 20),
+      Duration(milliseconds: 30),
+    ]) {
+      await tester.pump(delay);
+      await _drainNativeQueue(tester);
+    }
+    await tester.pump(const Duration(seconds: 1));
+    await _drainNativeQueue(tester);
+
+    expect(_enabledArgs(calls), [true, true, true, true]);
+  });
+
+  testWidgets('cancels a stale enable retry when the desired state changes', (
+    tester,
+  ) async {
+    final calls = _recordScreenAwakeCalls(
+      shouldFail: (enabled, callIndex) => enabled && callIndex == 0,
+    );
+    final startedAt = DateTime(2026, 7, 9, 12);
+    final syncNotifier = FakeSyncNotifier(_sync(lastSyncStartedAt: startedAt));
+
+    await tester.pumpWidget(
+      _app(
+        syncNotifier: syncNotifier,
+        retryDelays: const [Duration(milliseconds: 10)],
+      ),
+    );
+    await _drainNativeQueue(tester);
+    expect(_enabledArgs(calls), [true]);
+
+    syncNotifier.emit(
+      _sync(
+        scannedHeight: 100,
+        chainTipHeight: 102,
+        lastSyncStartedAt: startedAt,
+      ),
+    );
+    await _drainNativeQueue(tester);
+    await tester.pump(const Duration(milliseconds: 20));
+    await _drainNativeQueue(tester);
+
+    expect(_enabledArgs(calls), [true, false]);
+  });
+
+  testWidgets('retries a failed native disable request', (tester) async {
+    var failedDisable = false;
+    final calls = _recordScreenAwakeCalls(
+      shouldFail: (enabled, _) {
+        if (enabled || failedDisable) return false;
+        failedDisable = true;
+        return true;
+      },
+    );
+    final startedAt = DateTime(2026, 7, 9, 12);
+    final syncNotifier = FakeSyncNotifier(_sync(lastSyncStartedAt: startedAt));
+
+    await tester.pumpWidget(
+      _app(
+        syncNotifier: syncNotifier,
+        retryDelays: const [Duration(milliseconds: 10)],
+      ),
+    );
+    await _drainNativeQueue(tester);
+
+    syncNotifier.emit(
+      _sync(
+        scannedHeight: 100,
+        chainTipHeight: 102,
+        lastSyncStartedAt: startedAt,
+      ),
+    );
+    await _drainNativeQueue(tester);
+    await tester.pump(const Duration(milliseconds: 10));
+    await _drainNativeQueue(tester);
+
+    expect(_enabledArgs(calls), [true, false, false]);
+  });
+
+  testWidgets('dispose cancels a pending enable retry and forces disable', (
+    tester,
+  ) async {
+    final calls = _recordScreenAwakeCalls(
+      shouldFail: (enabled, callIndex) => enabled && callIndex == 0,
+    );
+    final syncNotifier = FakeSyncNotifier(
+      _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+    );
+
+    await tester.pumpWidget(
+      _app(
+        syncNotifier: syncNotifier,
+        retryDelays: const [Duration(milliseconds: 10)],
+      ),
+    );
+    await _drainNativeQueue(tester);
+    expect(_enabledArgs(calls), [true]);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await _drainNativeQueue(tester);
+    await tester.pump(const Duration(milliseconds: 20));
+    await _drainNativeQueue(tester);
+
+    expect(_enabledArgs(calls), [true, false]);
+  });
 }
 
-List<MethodCall> _recordScreenAwakeCalls() {
+List<MethodCall> _recordScreenAwakeCalls({
+  bool Function(bool enabled, int callIndex)? shouldFail,
+}) {
   final calls = <MethodCall>[];
   const channel = MethodChannel(kNativeScreenAwakeChannelName);
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(channel, (call) async {
+        final enabled =
+            (call.arguments as Map<Object?, Object?>?)?['enabled'] as bool;
         calls.add(call);
+        if (shouldFail?.call(enabled, calls.length - 1) ?? false) {
+          throw PlatformException(code: 'transient_failure');
+        }
         return null;
       });
   addTearDown(() {
@@ -195,6 +362,7 @@ Future<void> _drainNativeQueue(WidgetTester tester) async {
 Widget _app({
   required FakeSyncNotifier syncNotifier,
   bool syncKeepAwakeEnabled = true,
+  List<Duration> retryDelays = kNativeScreenAwakeRetryDelays,
 }) {
   return ProviderScope(
     overrides: [
@@ -203,8 +371,11 @@ Widget _app({
       ),
       syncProvider.overrideWith(() => syncNotifier),
     ],
-    child: const MaterialApp(
-      home: SyncKeepAwakeNativeHost(child: SizedBox.shrink()),
+    child: MaterialApp(
+      home: SyncKeepAwakeNativeHost(
+        retryDelays: retryDelays,
+        child: const SizedBox.shrink(),
+      ),
     ),
   );
 }

--- a/test/providers/sync_keep_awake_provider_test.dart
+++ b/test/providers/sync_keep_awake_provider_test.dart
@@ -118,7 +118,12 @@ void main() {
     final startedAt = DateTime(2026, 7, 9, 12);
     const settings = SyncKeepAwakeSettings(enabled: true, promptSeen: true);
 
-    for (final phase in [kSyncPhasePreflight, kSyncPhaseSetup]) {
+    for (final phase in [
+      kSyncPhasePreflight,
+      kSyncPhaseSetup,
+      kSyncPhaseActiveUtxo,
+      kSyncPhaseChainPrepare,
+    ]) {
       expect(
         shouldKeepScreenAwakeForSync(
           settings: settings,

--- a/test/providers/sync_keep_awake_provider_test.dart
+++ b/test/providers/sync_keep_awake_provider_test.dart
@@ -155,6 +155,47 @@ void main() {
     );
   });
 
+  test('preparation phases preserve the known near-tip exclusion', () {
+    final startedAt = DateTime(2026, 7, 9, 12);
+    const settings = SyncKeepAwakeSettings(enabled: true, promptSeen: true);
+
+    for (final phase in [
+      kSyncPhasePreflight,
+      kSyncPhaseSetup,
+      kSyncPhaseActiveUtxo,
+      kSyncPhaseChainPrepare,
+    ]) {
+      expect(
+        shouldKeepScreenAwakeForSync(
+          settings: settings,
+          sync: _sync(
+            percentage: 0,
+            scannedHeight: 100,
+            chainTipHeight: 102,
+            lastSyncStartedAt: startedAt,
+            phase: phase,
+          ),
+        ),
+        isFalse,
+        reason: 'known near-tip $phase should not keep the screen awake',
+      );
+      expect(
+        shouldKeepScreenAwakeForSync(
+          settings: settings,
+          sync: _sync(
+            percentage: 0,
+            scannedHeight: 100,
+            chainTipHeight: 103,
+            lastSyncStartedAt: startedAt,
+            phase: phase,
+          ),
+        ),
+        isTrue,
+        reason: '$phase with more than two blocks should stay awake',
+      );
+    }
+  });
+
   test(
     'screen keep-awake active provider combines settings and sync state',
     () async {

--- a/test/providers/sync_keep_awake_provider_test.dart
+++ b/test/providers/sync_keep_awake_provider_test.dart
@@ -114,6 +114,42 @@ void main() {
     );
   });
 
+  test('screen keep-awake covers progress discovery during sync startup', () {
+    final startedAt = DateTime(2026, 7, 9, 12);
+    const settings = SyncKeepAwakeSettings(enabled: true, promptSeen: true);
+
+    for (final phase in [kSyncPhasePreflight, kSyncPhaseSetup]) {
+      expect(
+        shouldKeepScreenAwakeForSync(
+          settings: settings,
+          sync: _sync(
+            percentage: 0,
+            displayTargetBlocks: 0,
+            scannedHeight: 0,
+            chainTipHeight: 0,
+            lastSyncStartedAt: startedAt,
+            phase: phase,
+          ),
+        ),
+        isTrue,
+        reason: 'foreground $phase should stay awake before progress arrives',
+      );
+    }
+
+    expect(
+      shouldKeepScreenAwakeForSync(
+        settings: settings,
+        sync: _sync(
+          isBackgroundMode: true,
+          percentage: 0,
+          lastSyncStartedAt: startedAt,
+          phase: kSyncPhasePreflight,
+        ),
+      ),
+      isFalse,
+    );
+  });
+
   test(
     'screen keep-awake active provider combines settings and sync state',
     () async {
@@ -535,6 +571,7 @@ SyncState _sync({
   int scannedHeight = 100,
   int chainTipHeight = 200,
   DateTime? lastSyncStartedAt,
+  String phase = '',
 }) {
   return SyncState(
     isSyncing: isSyncing,
@@ -545,5 +582,6 @@ SyncState _sync({
     scannedHeight: scannedHeight,
     chainTipHeight: chainTipHeight,
     lastSyncStartedAt: lastSyncStartedAt,
+    phase: phase,
   );
 }


### PR DESCRIPTION
## Summary

- enable mobile screen keep-awake during sync preflight and setup before the first progress event
- retry failed native screen-awake updates with a bounded 1s/4s/16s backoff
- cancel stale retries when sync, lifecycle, or disposal changes the desired state

## Validation

- `fvm flutter test test/providers/sync_keep_awake_provider_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/core/widgets/sync_keep_awake_native_host_test.dart test/core/widgets/sync_keep_awake_interaction_listener_test.dart test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart`
- `fvm flutter analyze`
- `git diff --check`