### PR TITLE
Use ZXing-C++ mobile scanner fork

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -595,8 +595,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: b56cca07e09f377a33cd99ff1ea837b7a96a44f9
-      resolved-ref: b56cca07e09f377a33cd99ff1ea837b7a96a44f9
+      ref: "7224aa38c18459159acde0ae2f22685fbe46ceb4"
+      resolved-ref: "7224aa38c18459159acde0ae2f22685fbe46ceb4"
       url: "https://github.com/chainapsis/mobile_scanner.git"
     source: git
     version: "7.2.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   mobile_scanner:
     git:
       url: https://github.com/chainapsis/mobile_scanner.git
-      ref: b56cca07e09f377a33cd99ff1ea837b7a96a44f9
+      ref: 7224aa38c18459159acde0ae2f22685fbe46ceb4
   desktop_window_bootstrap:
     git:
       url: https://github.com/chainapsis/desktop_window_bootstrap.git


### PR DESCRIPTION
## Summary

- pin the Chainapsis mobile_scanner fork to commit 7224aa38c18459159acde0ae2f22685fbe46ceb4
- use the fork revision that replaces the Android ML Kit implementation with ZXing-C++
- keep the dependency reproducible through the exact commit in pubspec.yaml and pubspec.lock

Related to #543.

## Verification

- fvm flutter analyze
- fvm flutter test (2553 passed, 88 mobile-tagged tests skipped as designed)
- mobile lane compared against origin/main: both currently produce the same 911 passed / 20 failed baseline
- fvm flutter build apk --debug --target-platform android-arm64 --dart-define=VIZOR_FORM_FACTOR=mobile
- confirmed libzxingcpp_android.so is packaged in the generated APK