### PR TITLE
build(android): canonicalize reproducible APK builds

### DIFF
--- a/fdroid/README.md
+++ b/fdroid/README.md
@@ -63,6 +63,14 @@ fails if the stable version and ABI-specific version code do not agree. After
 building, it also verifies the package ID, version name, version code, single
 ABI contents, and absence of an APK signature using Android Build Tools 36.0.0.
 
+Both Direct Release and F-Droid call
+`scripts/build-android-reproducible.sh`. The shared entry point exports the
+source commit into `/tmp/vizor-android-reproducible/source`, uses fixed Pub,
+Cargo, and Gradle cache paths, pins the source timestamp, and remaps Rust source
+paths. Builds on one host are serialized because the canonical directory is
+shared. The directory is private to its owner and symlinks are rejected before
+it is cleaned or used.
+
 The Direct Release workflow must use the same public endpoint values embedded
 by this script:
 

--- a/scripts/build-android-fdroid.sh
+++ b/scripts/build-android-fdroid.sh
@@ -97,50 +97,26 @@ if ((calculated_version_code > 2100000000)); then
   exit 2
 fi
 
-flutter_command=(fvm flutter)
-if [[ -n "${FLUTTER_BIN:-}" ]]; then
-  if [[ "${FLUTTER_BIN}" != /* ]]; then
-    echo "FLUTTER_BIN must be an absolute path: ${FLUTTER_BIN}" >&2
-    exit 2
-  fi
-  flutter_command=("${FLUTTER_BIN}")
-fi
-
-build_args=(
-  build apk
-  --release
-  --split-per-abi
-  --target-platform android-arm64,android-arm,android-x64
-  --build-name "${version}"
-  --build-number "${version_code_base}"
-  --dart-define=VIZOR_FORM_FACTOR=mobile
-  --dart-define="VIZOR_RELEASE_VERSION=${version}"
-  --dart-define=VIZOR_COINGECKO_PRICE_BASE_URL=https://functions.vizor.cash/api/v3
-  --dart-define=VIZOR_WALLET_LINK_BACKEND_URL=https://functions.vizor.cash
-)
-
 printf 'F-Droid build: version=%s baseVersionCode=%s selectedAbi=%s selectedVersionCode=%s rust=%s\n' \
   "${version}" "${version_code_base}" "${expected_abi}" "${calculated_version_code}" \
   "${release_rust_toolchain}"
-printf 'Command:'
-printf ' %q' "${flutter_command[@]}" "${build_args[@]}"
-printf '\n'
 
 if [[ "${dry_run}" == "true" ]]; then
-  exit 0
+  exec "${script_dir}/build-android-reproducible.sh" \
+    --build-name "${version}" \
+    --build-number "${version_code_base}" \
+    --release-version "${version}" \
+    --signing unsigned \
+    --offline \
+    --dry-run
 fi
 
-# An F-Droid build must never inherit an upstream or debug signing identity.
-unset ANDROID_KEYSTORE_PATH
-unset ANDROID_KEYSTORE_PASSWORD
-unset ANDROID_KEY_ALIAS
-unset ANDROID_KEY_PASSWORD
-unset ANDROID_REQUIRE_RELEASE_SIGNING
-export ANDROID_ALLOW_UNSIGNED_RELEASE=true
-export CI=true
-
-"${script_dir}/run-with-android-reproducible-rust.sh" \
-  "${flutter_command[@]}" "${build_args[@]}"
+"${script_dir}/build-android-reproducible.sh" \
+  --build-name "${version}" \
+  --build-number "${version_code_base}" \
+  --release-version "${version}" \
+  --signing unsigned \
+  --offline
 
 abis=(arm64-v8a armeabi-v7a x86_64)
 version_code_offsets=(2000 1000 4000)

--- a/scripts/build-android-reproducible.sh
+++ b/scripts/build-android-reproducible.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-android-reproducible.sh \
+  --build-name X.Y.Z \
+  --build-number CODE \
+  --release-version VERSION \
+  --signing required|unsigned [--offline] [--dry-run]
+
+Builds all three Android APK ABIs from a clean copy of HEAD under Vizor's
+canonical Linux build path. Direct Release and F-Droid must both use this
+entry point so Flutter and Rust embed the same source/cache paths.
+
+Set FLUTTER_BIN to an absolute Flutter executable in F-Droid. It defaults to
+the repository's required `fvm flutter` command for Direct/local builds.
+EOF
+}
+
+build_name=""
+build_number=""
+release_version=""
+signing=""
+offline="false"
+dry_run="false"
+
+while (($# > 0)); do
+  case "$1" in
+    --build-name)
+      build_name="${2:-}"
+      shift 2
+      ;;
+    --build-number)
+      build_number="${2:-}"
+      shift 2
+      ;;
+    --release-version)
+      release_version="${2:-}"
+      shift 2
+      ;;
+    --signing)
+      signing="${2:-}"
+      shift 2
+      ;;
+    --offline)
+      offline="true"
+      shift
+      ;;
+    --dry-run)
+      dry_run="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! "${build_name}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "--build-name must be an X.Y.Z version: ${build_name:-<missing>}" >&2
+  exit 2
+fi
+if [[ ! "${build_number}" =~ ^[0-9]+$ ]] || ((10#${build_number} <= 0)); then
+  echo "--build-number must be a positive integer: ${build_number:-<missing>}" >&2
+  exit 2
+fi
+if [[ ! "${release_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "--release-version must start with an X.Y.Z version: ${release_version:-<missing>}" >&2
+  exit 2
+fi
+if [[ "${signing}" != "required" && "${signing}" != "unsigned" ]]; then
+  echo "--signing must be required or unsigned: ${signing:-<missing>}" >&2
+  exit 2
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd -- "${script_dir}/.." && pwd)"
+canonical_root="/tmp/vizor-android-reproducible"
+canonical_source="${canonical_root}/source"
+canonical_pub_cache="${canonical_root}/pub-cache"
+canonical_cargo_home="${canonical_root}/cargo-home"
+canonical_gradle_home="${canonical_root}/gradle-home"
+
+flutter_command=(fvm flutter)
+if [[ -n "${FLUTTER_BIN:-}" ]]; then
+  if [[ "${FLUTTER_BIN}" != /* ]]; then
+    echo "FLUTTER_BIN must be an absolute path: ${FLUTTER_BIN}" >&2
+    exit 2
+  fi
+  flutter_command=("${FLUTTER_BIN}")
+fi
+
+build_args=(
+  build apk
+  --release
+  --split-per-abi
+  --target-platform android-arm64,android-arm,android-x64
+  --build-name "${build_name}"
+  --build-number "${build_number}"
+  --dart-define=VIZOR_FORM_FACTOR=mobile
+  --dart-define="VIZOR_RELEASE_VERSION=${release_version}"
+  --dart-define=VIZOR_COINGECKO_PRICE_BASE_URL=https://functions.vizor.cash/api/v3
+  --dart-define=VIZOR_WALLET_LINK_BACKEND_URL=https://functions.vizor.cash
+)
+
+printf 'Reproducible Android build: name=%s number=%s release=%s signing=%s offline=%s\n' \
+  "${build_name}" "${build_number}" "${release_version}" "${signing}" "${offline}"
+printf 'Canonical source: %s\n' "${canonical_source}"
+printf 'Command:'
+printf ' %q' "${flutter_command[@]}" "${build_args[@]}"
+printf '\n'
+
+if [[ "${dry_run}" == "true" ]]; then
+  exit 0
+fi
+
+cd "${repository_root}"
+if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+  echo "The reproducible build requires a Git checkout with a valid HEAD." >&2
+  exit 1
+fi
+
+umask 077
+if [[ -L "${canonical_root}" ]]; then
+  echo "Canonical build root must not be a symlink: ${canonical_root}" >&2
+  exit 1
+fi
+if [[ -e "${canonical_root}" && ! -d "${canonical_root}" ]]; then
+  echo "Canonical build root is not a directory: ${canonical_root}" >&2
+  exit 1
+fi
+mkdir -p -m 700 "${canonical_root}"
+if [[ ! -O "${canonical_root}" ]]; then
+  echo "Canonical build root is not owned by the current user: ${canonical_root}" >&2
+  exit 1
+fi
+chmod 700 "${canonical_root}"
+
+fallback_lock=""
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"${canonical_root}/build.lock"
+  flock 9
+else
+  fallback_lock="${canonical_root}/build.lock.d"
+  if ! mkdir "${fallback_lock}" 2>/dev/null; then
+    echo "Another reproducible Android build holds ${fallback_lock}." >&2
+    exit 1
+  fi
+  trap 'rmdir "${fallback_lock}" 2>/dev/null || true' EXIT
+fi
+
+for cache_dir in "${canonical_pub_cache}" "${canonical_cargo_home}" "${canonical_gradle_home}"; do
+  if [[ -L "${cache_dir}" ]]; then
+    echo "Canonical cache must not be a symlink: ${cache_dir}" >&2
+    exit 1
+  fi
+  mkdir -p -m 700 "${cache_dir}"
+  if [[ ! -O "${cache_dir}" ]]; then
+    echo "Canonical cache is not owned by the current user: ${cache_dir}" >&2
+    exit 1
+  fi
+  chmod 700 "${cache_dir}"
+done
+
+if [[ -L "${canonical_source}" ]]; then
+  echo "Canonical source must not be a symlink: ${canonical_source}" >&2
+  exit 1
+fi
+if [[ -e "${canonical_source}" && ! -O "${canonical_source}" ]]; then
+  echo "Canonical source is not owned by the current user: ${canonical_source}" >&2
+  exit 1
+fi
+rm -rf -- "${canonical_source}"
+mkdir -m 700 "${canonical_source}"
+git archive --format=tar HEAD | tar -xf - -C "${canonical_source}"
+
+source_date_epoch="$(git show -s --format=%ct HEAD)"
+export SOURCE_DATE_EPOCH="${source_date_epoch}"
+export PUB_CACHE="${canonical_pub_cache}"
+export CARGO_HOME="${canonical_cargo_home}"
+export GRADLE_USER_HOME="${canonical_gradle_home}"
+export CI=true
+
+# rustc stores dependency and workspace paths in native debug/provenance data.
+# Use stable virtual paths as a second line of defense beyond the canonical
+# checkout/cache locations. Cargokit preserves and extends this flag list.
+export CARGO_ENCODED_RUSTFLAGS="--remap-path-prefix=${canonical_source}=/vizor/source"$'\x1f'"--remap-path-prefix=${canonical_cargo_home}=/vizor/cargo"
+
+if [[ "${signing}" == "unsigned" ]]; then
+  unset ANDROID_KEYSTORE_PATH
+  unset ANDROID_KEYSTORE_PASSWORD
+  unset ANDROID_KEY_ALIAS
+  unset ANDROID_KEY_PASSWORD
+  unset ANDROID_REQUIRE_RELEASE_SIGNING
+  export ANDROID_ALLOW_UNSIGNED_RELEASE=true
+else
+  unset ANDROID_ALLOW_UNSIGNED_RELEASE
+  export ANDROID_REQUIRE_RELEASE_SIGNING=true
+fi
+
+pub_get_args=(pub get --enforce-lockfile)
+cargo_fetch_args=(fetch --locked --manifest-path rust/Cargo.toml)
+if [[ "${offline}" == "true" ]]; then
+  pub_get_args+=(--offline)
+  cargo_fetch_args+=(--offline)
+fi
+
+cd "${canonical_source}"
+"${flutter_command[@]}" "${pub_get_args[@]}"
+cargo "${cargo_fetch_args[@]}"
+"${canonical_source}/scripts/run-with-android-reproducible-rust.sh" \
+  "${flutter_command[@]}" "${build_args[@]}"
+
+output_dir="${repository_root}/build/app/outputs/flutter-apk"
+mkdir -p "${output_dir}"
+for abi in arm64-v8a armeabi-v7a x86_64; do
+  apk="app-${abi}-release.apk"
+  source_apk="${canonical_source}/build/app/outputs/flutter-apk/${apk}"
+  if [[ ! -s "${source_apk}" ]]; then
+    echo "Expected APK is missing or empty: ${source_apk}" >&2
+    exit 1
+  fi
+  cp -f -- "${source_apk}" "${output_dir}/${apk}"
+done
+
+printf 'Copied reproducible APKs to %s\n' "${output_dir}"

--- a/scripts/generate-fdroid-metadata.py
+++ b/scripts/generate-fdroid-metadata.py
@@ -25,6 +25,11 @@ ABI_CONFIG = (
     ("x86_64", 4000, "app-x86_64-release.apk", "Vizor-android-x86_64.apk"),
 )
 REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parent.parent
+FLUTTER_VERSION = json.loads(
+    (REPOSITORY_ROOT / ".fvmrc").read_text(encoding="utf-8")
+)["flutter"]
+if re.fullmatch(r"\d+\.\d+\.\d+", FLUTTER_VERSION) is None:
+    raise RuntimeError(".fvmrc must pin Flutter to an exact X.Y.Z version.")
 RELEASE_RUST_TOOLCHAIN = (
     REPOSITORY_ROOT
     / "scripts"
@@ -142,7 +147,7 @@ def render(metadata: dict[str, Any]) -> str:
             f"    output: build/app/outputs/flutter-apk/{output_name}",
             f"    binary: {BINARY_BASE}/{release_name}",
             "    srclibs:",
-            "      - flutter@stable",
+            f"      - flutter@{FLUTTER_VERSION}",
             "      - rustup@1.28.2",
             "    rm:",
             "      - ios",
@@ -151,19 +156,22 @@ def render(metadata: dict[str, Any]) -> str:
             "      - windows",
             "    prebuild:",
             "      - git -C $$flutter$$ checkout -f db50e20168db8fee486b9abf32fc912de3bc5b6a",
-            "      - export PUB_CACHE=$(pwd)/.pub-cache",
+            "      - export PUB_CACHE=/tmp/vizor-android-reproducible/pub-cache",
+            "      - export CARGO_HOME=/tmp/vizor-android-reproducible/cargo-home",
+            "      - export GRADLE_USER_HOME=/tmp/vizor-android-reproducible/gradle-home",
+            "      - install -d -m 700 /tmp/vizor-android-reproducible $PUB_CACHE $CARGO_HOME $GRADLE_USER_HOME",
             "      - $$flutter$$/bin/flutter config --no-analytics",
             "      - $$flutter$$/bin/flutter pub get --enforce-lockfile",
             f"      - $$rustup$$/rustup-init.sh -y --profile minimal --default-toolchain {RELEASE_RUST_TOOLCHAIN}",
             "        --target armv7-linux-androideabi --target aarch64-linux-android",
             "        --target x86_64-linux-android",
-            "      - source $HOME/.cargo/env",
+            "      - source $CARGO_HOME/env",
             "      - cargo fetch --locked --manifest-path rust/Cargo.toml",
-            "    scandelete:",
-            "      - .pub-cache",
             "    build:",
-            "      - export PUB_CACHE=$(pwd)/.pub-cache",
-            "      - source $HOME/.cargo/env",
+            "      - export PUB_CACHE=/tmp/vizor-android-reproducible/pub-cache",
+            "      - export CARGO_HOME=/tmp/vizor-android-reproducible/cargo-home",
+            "      - export GRADLE_USER_HOME=/tmp/vizor-android-reproducible/gradle-home",
+            "      - source $CARGO_HOME/env",
             f"      - FLUTTER_BIN=$$flutter$$/bin/flutter ./scripts/build-android-fdroid.sh --version $$VERSION$$ --expected-abi {abi}",
             "        --expected-version-code $$VERCODE$$",
             "    ndk: 28.2.13676358",

--- a/scripts/test_fdroid_tools.py
+++ b/scripts/test_fdroid_tools.py
@@ -15,6 +15,7 @@ import unittest
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 GENERATOR_PATH = ROOT / "scripts" / "generate-fdroid-metadata.py"
 RUST_WRAPPER_PATH = ROOT / "scripts" / "run-with-android-reproducible-rust.sh"
+REPRODUCIBLE_BUILD_PATH = ROOT / "scripts" / "build-android-reproducible.sh"
 SPEC = importlib.util.spec_from_file_location("generate_fdroid_metadata", GENERATOR_PATH)
 assert SPEC is not None and SPEC.loader is not None
 GENERATOR = importlib.util.module_from_spec(SPEC)
@@ -93,6 +94,20 @@ class FdroidMetadataTest(unittest.TestCase):
             ),
             3,
         )
+        self.assertEqual(rendered.count(f"flutter@{GENERATOR.FLUTTER_VERSION}"), 3)
+        self.assertNotIn("flutter@stable", rendered)
+        self.assertEqual(
+            rendered.count(
+                "export PUB_CACHE=/tmp/vizor-android-reproducible/pub-cache"
+            ),
+            6,
+        )
+        self.assertEqual(
+            rendered.count(
+                "export CARGO_HOME=/tmp/vizor-android-reproducible/cargo-home"
+            ),
+            6,
+        )
 
     def test_rejects_unexpected_signing_key(self) -> None:
         metadata = release_metadata()
@@ -166,6 +181,12 @@ class FdroidBuildScriptTest(unittest.TestCase):
             "--dart-define=VIZOR_WALLET_LINK_BACKEND_URL=https://functions.vizor.cash",
             command_output,
         )
+        self.assertIn(
+            "Canonical source: /tmp/vizor-android-reproducible/source",
+            command_output,
+        )
+        self.assertIn("signing=unsigned", command_output)
+        self.assertIn("offline=true", command_output)
 
     def test_dry_run_rejects_wrong_abi_version_code(self) -> None:
         result = subprocess.run(
@@ -186,6 +207,66 @@ class FdroidBuildScriptTest(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 2)
         self.assertIn("Version code mismatch", result.stderr)
+
+
+class AndroidReproducibleBuildScriptTest(unittest.TestCase):
+    def test_dry_run_centralizes_release_inputs(self) -> None:
+        result = subprocess.run(
+            [
+                str(REPRODUCIBLE_BUILD_PATH),
+                "--build-name",
+                "0.0.35",
+                "--build-number",
+                "350999",
+                "--release-version",
+                "0.0.35-internal.2",
+                "--signing",
+                "required",
+                "--dry-run",
+            ],
+            check=True,
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        command_output = result.stdout.replace("\\", "")
+        self.assertIn("signing=required", command_output)
+        self.assertIn("offline=false", command_output)
+        self.assertIn("--build-name 0.0.35", command_output)
+        self.assertIn("--build-number 350999", command_output)
+        self.assertIn(
+            "--dart-define=VIZOR_RELEASE_VERSION=0.0.35-internal.2",
+            command_output,
+        )
+        self.assertIn(
+            "--dart-define=VIZOR_COINGECKO_PRICE_BASE_URL=https://functions.vizor.cash/api/v3",
+            command_output,
+        )
+
+    def test_rejects_relative_flutter_binary(self) -> None:
+        environment = os.environ.copy()
+        environment["FLUTTER_BIN"] = "flutter"
+        result = subprocess.run(
+            [
+                str(REPRODUCIBLE_BUILD_PATH),
+                "--build-name",
+                "0.0.35",
+                "--build-number",
+                "350999",
+                "--release-version",
+                "0.0.35",
+                "--signing",
+                "unsigned",
+                "--dry-run",
+            ],
+            check=False,
+            cwd=ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("FLUTTER_BIN must be an absolute path", result.stderr)
 
 
 class AndroidReproducibleRustWrapperTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add a shared canonical-path Android APK builder for Direct Release and F-Droid
- pin and share Flutter, Rust, Pub, Cargo, Gradle, release defines, and source timestamps
- generate three exact F-Droid ABI recipes using the shared unsigned build path
- document the reproducible-build contract and extend script tests

## Verification

- `python3 scripts/test_fdroid_tools.py`
- shell syntax and diff checks
- two complete three-ABI release builds, including an offline F-Droid invocation
- all three APKs were byte-identical across the two builds
- generated F-Droid YAML parsed with all three build entries