### PR TITLE
[2/10] ZIP-321 payment requests: parser, parking, drain policy, and flow provider

### DIFF
--- a/integration_test/regtest_ironwood_pre_migration_send_test.dart
+++ b/integration_test/regtest_ironwood_pre_migration_send_test.dart
@@ -103,6 +103,7 @@ void main() {
 
       final validation = await rust_sync.validateAddress(
         address: _recipientAddress,
+        network: _network,
       );
       expect(validation.isValid, isTrue);
       expect(_recipientAddress, startsWith('uregtest1'));

--- a/integration_test/regtest_mobile_ironwood_pre_migration_send_test.dart
+++ b/integration_test/regtest_mobile_ironwood_pre_migration_send_test.dart
@@ -111,6 +111,7 @@ void main() {
 
       final validation = await rust_sync.validateAddress(
         address: _recipientAddress,
+        network: mobileE2eNetwork,
       );
       expect(validation.isValid, isTrue);
       expect(_recipientAddress, startsWith('uregtest1'));

--- a/integration_test/regtest_tex_send_test.dart
+++ b/integration_test/regtest_tex_send_test.dart
@@ -77,7 +77,7 @@ void main() {
       final senderAccountUuid = await _accountUuidAtOrder(0);
       final receiverAccountUuid = await _accountUuidAtOrder(1);
 
-      final validation = await rust_sync.validateAddress(address: _texAddress);
+      final validation = await rust_sync.validateAddress(address: _texAddress, network: _network);
       expect(validation.isValid, isTrue);
       expect(validation.addressType, 'tex');
       expect(_texAddress, startsWith('texregtest1'));

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -17,7 +17,8 @@ import 'src/core/navigation/mobile_exit_back_guard.dart';
 import 'src/core/navigation/mobile_onboarding_routes.dart';
 import 'src/core/navigation/mobile_routes.dart';
 import 'src/core/navigation/incoming_link_dispatch.dart';
-import 'src/core/navigation/payload_page_key.dart';
+import 'src/core/navigation/payment_uri_busy_surface_provider.dart';
+import 'src/core/navigation/payment_uri_drain_policy.dart';
 import 'src/core/motion/onboarding_motion.dart';
 import 'src/core/theme/app_theme.dart';
 import 'src/core/theme/app_theme_host.dart';
@@ -29,6 +30,7 @@ import 'src/core/widgets/mobile/sync_keep_awake_interaction_listener.dart';
 import 'src/core/widgets/mobile/sync_keep_awake_native_host.dart';
 import 'src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart';
 import 'src/core/widgets/network_fallback_toast.dart';
+import 'src/core/zcash/zip321_payment_request.dart';
 import 'src/features/activity/screens/activity_screen.dart';
 import 'src/features/activity/screens/activity_transaction_status_screen.dart';
 import 'src/features/activity/screens/swap_activity_detail_screen.dart';
@@ -73,8 +75,10 @@ import 'src/features/send/screens/send_status_screen.dart';
 import 'src/features/send/services/send_flow.dart'
     show
         resolveSendStatusRoutePayload,
+        SendReviewArgs,
         SendStatusRoutePayloadObserver,
-        sendStatusRoutePayloadProvider;
+        sendStatusRoutePayloadProvider,
+        sendStatusTerminalProvider;
 import 'src/features/settings/screens/settings_screen.dart';
 import 'src/features/settings/screens/settings_change_password_screen.dart';
 import 'src/features/settings/screens/settings_endpoint_screen.dart';
@@ -110,6 +114,9 @@ import 'src/rust/api/sync.dart' as rust_sync;
 import 'src/rust/frb_generated.dart';
 import 'src/rust/api/simple.dart' as rust_simple;
 import 'src/services/incoming_uri_service.dart';
+import 'src/providers/migration_send_gate_provider.dart';
+import 'src/providers/payment_request_flow_provider.dart';
+import 'src/providers/payment_uri_prefill_provider.dart';
 
 void log(String message) => debugPrint('[zcash] $message');
 
@@ -248,6 +255,15 @@ final _routerProvider = Provider<_AppRouter>((ref) {
     canPop: () => router.canPop(),
     currentLocation: () =>
         router.routerDelegate.currentConfiguration.uri.toString(),
+    // `PaymentRequestHost` is mounted above the `Router`, where a `PopScope`
+    // finds no `ModalRoute` to register with and is therefore inert. Back has
+    // to reach the card here or it would navigate — and on the second press
+    // exit the app — underneath a modal the user is still looking at.
+    handleBackAboveRouter: () {
+      if (ref.read(paymentRequestFlowProvider) == null) return false;
+      ref.read(paymentRequestFlowProvider.notifier).dismiss();
+      return true;
+    },
   );
   ref.onDispose(mobileExitBackDispatcher.dispose);
   final useMobileExitBackGuard = mobileExitBackGuard.enabled;
@@ -345,23 +361,17 @@ String? appRedirect({
   final hasWallet = wallet?.hasWallet ?? bootstrap.hasWallet;
   final isUnlocked = security.isUnlocked || bootstrap.isUnlocked;
   final requiresUnlock = hasWallet && !isUnlocked;
-  final isOnboarding =
-      state.matchedLocation == '/welcome' ||
-      state.matchedLocation == '/add-account' ||
-      state.matchedLocation.startsWith('/onboarding/') ||
-      state.matchedLocation.startsWith('/import');
+  final isOnboarding = isOnboardingLocation(state.matchedLocation);
   final isPublicLegal =
       state.matchedLocation == '/terms' || state.matchedLocation == '/privacy';
   // The uninstall flow ends with hasWallet == false on purpose; keep the
   // route alive so its "done" stage can show instead of onboarding.
   final isUninstall = state.matchedLocation == '/settings/uninstall';
-  final isUnlock = state.matchedLocation == '/unlock';
-  final isLostPassword = state.matchedLocation == '/lost-password';
-  final isUnlockFlow = isUnlock || isLostPassword;
+  final isUnlockFlow = isUnlockFlowLocation(state.matchedLocation);
   final isSwap =
-      state.matchedLocation.startsWith('/swap') ||
-      state.matchedLocation.startsWith('/pay') ||
-      state.matchedLocation.startsWith('/activity/swap');
+      _isRouteOrChild(state.matchedLocation, '/swap') ||
+      _isRouteOrChild(state.matchedLocation, '/pay') ||
+      _isRouteOrChild(state.matchedLocation, '/activity/swap');
   final swapFeatureEnabled = ref.read(swapFeatureEnabledProvider);
 
   log(
@@ -391,6 +401,11 @@ String? appRedirect({
   }
   if (!swapFeatureEnabled && isSwap) return '/home';
   return null;
+}
+
+bool _isRouteOrChild(String matchedLocation, String routePath) {
+  return matchedLocation == routePath ||
+      matchedLocation.startsWith('$routePath/');
 }
 
 /// Entry, onboarding, and auth routes shared by the desktop and mobile
@@ -778,24 +793,6 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
   ),
 ];
 
-// ignore: unused_element
-MaterialPage<void> _payloadKeyedDesktopPage(
-  GoRouterState state, {
-  required String? payloadId,
-  required Widget child,
-}) {
-  final key = payloadScopedPageKey(state, payloadId);
-  return MaterialPage<void>(
-    key: key,
-    name: state.name ?? state.path,
-    arguments: <String, String>{
-      ...state.pathParameters,
-      ...state.uri.queryParameters,
-    },
-    restorationId: key.value,
-    child: child,
-  );
-}
 
 /// Main application routes for the desktop (large-form-factor) tree.
 List<RouteBase> _desktopRoutes(Ref ref) => [
@@ -1291,12 +1288,38 @@ class _IncomingLinkHost extends ConsumerStatefulWidget {
   ConsumerState<_IncomingLinkHost> createState() => _IncomingLinkHostState();
 }
 
+/// How long an incoming-link notice stays up. Longer than the default toast:
+/// every one of these sentences tells the user something they have to act on
+/// (open the link again, finish setup) rather than confirming something they
+/// just did.
+const _kIncomingLinkNoticeDuration = Duration(seconds: 4);
+
 class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   StreamSubscription<String>? _subscription;
+
+  // --- payment request lane ---
+  var _paymentSequence = 0;
+
+  /// Last wallet-existence value seen from [walletProvider]. Used to spot the
+  /// true -> false transition of a wallet reset, which must drop a parked link
+  /// instead of draining it onto the freshly wiped wallet.
+  bool? _lastKnownHasWallet;
 
   @override
   void initState() {
     super.initState();
+    // Seed the wallet-existence baseline before anything can park a link.
+    // `ref.listen` below only fires on a *change*, and `AccountNotifier.build`
+    // returns the bootstrap snapshot synchronously, so a session that starts
+    // locked emits nothing until the user resets the wallet from
+    // `/lost-password` (desktop) or the forgot-passcode sheet (mobile, always
+    // this case). Without this seed that reset emission looks like the first
+    // value ever seen instead of the true -> false reset edge, and the parked
+    // link drains onto the freshly wiped wallet.
+    _lastKnownHasWallet =
+        ref.read(walletProvider).value?.hasWallet ??
+        ref.read(appBootstrapProvider).hasWallet;
+    widget.router.routerDelegate.addListener(_handleRouteChanged);
     final service = ref.read(incomingUriServiceProvider);
     _subscription = service.uriStream.listen(_handleIncomingUri);
     unawaited(service.initialize());
@@ -1305,16 +1328,55 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   @override
   void didUpdateWidget(covariant _IncomingLinkHost oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.router == widget.router) return;
+    oldWidget.router.routerDelegate.removeListener(_handleRouteChanged);
+    widget.router.routerDelegate.addListener(_handleRouteChanged);
   }
 
   @override
   void dispose() {
+    widget.router.routerDelegate.removeListener(_handleRouteChanged);
     unawaited(_subscription?.cancel());
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<AsyncValue<WalletState>>(walletProvider, (_, next) {
+      final wallet = next.value;
+      if (wallet != null) {
+        final hadWallet = _lastKnownHasWallet;
+        _lastKnownHasWallet = wallet.hasWallet;
+        if (paymentUriShouldDropOnWalletTransition(
+          previousHasWallet: hadWallet,
+          hasWallet: wallet.hasWallet,
+        )) {
+          // Wallet reset (uninstall, lost-password reset). Drop the parked
+          // ZIP-321 link quietly: draining it here would follow the wipe with
+          // a "Set up or import a wallet" notice and a jump to /welcome.
+          //
+          // Only the ZIP-321 park and its card.
+          ref.read(paymentUriPrefillProvider.notifier).clear();
+          ref.read(paymentRequestFlowProvider.notifier).clear();
+          return;
+        }
+      }
+      _schedulePendingDrain();
+    });
+    // A hardware signing session keeps the link parked rather than dropping
+    // it, so the drain has to be re-run when the hold is given back.
+    ref.listen<int>(paymentUriBusySurfaceProvider, (previous, next) {
+      if (next == 0 && (previous ?? 0) > 0) _schedulePendingDrain();
+    });
+    // Same shape for a send mid-broadcast: the link stays parked until the
+    // receipt is on screen, so the drain has to be re-run when it gets there.
+    ref.listen<bool>(sendStatusTerminalProvider, (previous, next) {
+      if (next && !(previous ?? false)) _schedulePendingDrain();
+    });
+    // No appSecurityProvider listener: the unlock screens own the post-unlock
+    // navigation for a parked prefill (claim + present the card). Draining
+    // here on unlock too would race and clobber that navigation. The wallet
+    // listener still covers the loading -> loaded transition.
     return AppToastHost(child: widget.child);
   }
 
@@ -1323,12 +1385,10 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
 
   void _handleIncomingUri(String rawUri) {
     switch (classifyIncomingLink(rawUri)) {
-      case IncomingPaymentRequestLink():
-        // ZIP-321 park/drain wired in PR 2 (zip321-02-core).
-        return;
+      case IncomingPaymentRequestLink(:final raw):
+        _handlePaymentRequestLink(raw);
       case IncomingGiftCardLink():
-        // Gift Card intake wired in PR 5 (giftcard-05-core).
-        return;
+        _handleGiftCardLink(rawUri);
       case IncomingVizorHomeLink():
         if (ref.read(appSecurityProvider).requiresUnlock) return;
         // Onboarding, import, and add-account keep their state only in the
@@ -1341,9 +1401,167 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
         if (isOnboardingLocation(_currentLocation)) return;
         widget.router.go('/home');
       case IncomingLinkUnknown():
-        // Silent by contract — see classifyIncomingLink.
+        // Silent by contract — see `classifyIncomingLink`.
         return;
     }
+  }
+
+  // Gift card lane placeholder (PR 5+).
+  void _handleGiftCardLink(String rawUri) {}
+
+  void _handleRouteChanged() {}
+
+  // ---------------------------------------------------------------------
+  // Payment request lane
+  // ---------------------------------------------------------------------
+
+  void _handlePaymentRequestLink(String rawUri) {
+    try {
+      final replacedParkedPrefill = ref
+          .read(paymentUriPrefillProvider.notifier)
+          .set(_prefillFromUri(rawUri));
+      _schedulePendingDrain();
+      if (replacedParkedPrefill) {
+        // A batch of links from native on cold start, or a second link while
+        // the first is still parked (locked wallet, wallet still loading).
+        // Only the newest survives, so say so instead of silently dropping
+        // the earlier one.
+        _showPaymentUriMessage(kPaymentUriReplacedMessage);
+      }
+    } on Zip321UnsupportedRequestException catch (e) {
+      // Do not clear here: a refused link must not wipe a prefill already
+      // parked from an earlier valid one.
+      log('Payment URI: unsupported: ${e.reason}');
+      _showPaymentUriMessage(paymentUriRejectionMessage(e));
+    } on Zip321ParseException catch (e) {
+      // The parser's message is spec wording written for us, and it echoes
+      // fragments of the link's own text; keep it in the log and show the
+      // payer one sentence they can act on.
+      log('Payment URI: rejected: ${e.message}');
+      _showPaymentUriMessage(paymentUriRejectionMessage(e));
+    } catch (e) {
+      // Defensive: no current parse path reaches this. It shares the drain
+      // policy's constant rather than a literal of its own so the two cannot
+      // drift into two different sentences for the same "the link is gone".
+      // Only `zcash:` links reach this lane, so `$e` cannot carry a Gift
+      // Card's mnemonic fragment.
+      log('Payment URI: failed to parse: $e');
+      _showPaymentUriMessage(kPaymentUriUnavailableMessage);
+    }
+  }
+
+  SendPrefillArgs _prefillFromUri(String rawUri) {
+    final request = Zip321PaymentRequest.parse(rawUri);
+    if (!request.isSupported) {
+      // Its own type, not a parse exception: the link is well-formed and the
+      // payer needs a different sentence than a broken one gets.
+      throw Zip321UnsupportedRequestException(request.unsupportedReason!);
+    }
+    final payment = request.primaryPayment;
+    return sendPrefillArgsFromZip321Payment(
+      id: 'payment-uri-${++_paymentSequence}',
+      payment: payment,
+    );
+  }
+
+  void _schedulePendingDrain() {
+    // After the next frame's post-frame callbacks, not as one of them. A busy
+    // surface takes its hold from a post-frame callback registered in its own
+    // initState, so a signing screen whose navigation was requested in this
+    // same turn registers that callback *during* the coming frame — after a
+    // callback registered here, which would then run first, read a hold count
+    // of zero, and present the card over the signing surface. `endOfFrame`
+    // completes once every post-frame callback of the frame has run.
+    unawaited(
+      WidgetsBinding.instance.endOfFrame.then((_) {
+        if (!mounted) return;
+        _drainPendingPrefill();
+      }),
+    );
+    // endOfFrame requests a frame only while the scheduler is idle. A hold
+    // given back from dispose lands here in a post-frame phase, and an idle
+    // app (locked, nothing animating) would otherwise sit on the parked link
+    // until some unrelated frame happens to be scheduled.
+    WidgetsBinding.instance.scheduleFrame();
+  }
+
+  void _drainPendingPrefill() {
+    final prefillNotifier = ref.read(paymentUriPrefillProvider.notifier);
+    final prefill = ref.read(paymentUriPrefillProvider);
+    final bootstrap = ref.read(appBootstrapProvider);
+    final walletAsync = ref.read(walletProvider);
+    final security = ref.read(appSecurityProvider);
+
+    final decision = decidePaymentUriDrain(
+      hasParkedPrefill: prefill != null,
+      parkedFor: prefillNotifier.parkedFor,
+      hasBlockingFailure: bootstrap.hasBlockingFailure,
+      walletIsLoading: walletAsync.isLoading && walletAsync.value == null,
+      walletHasError: walletAsync.hasError,
+      hasWallet: walletAsync.value?.hasWallet ?? bootstrap.hasWallet,
+      isUnlocked: security.isUnlocked,
+      matchedLocation: widget.router.state.matchedLocation,
+      // In-progress surfaces that own no route of their own — the desktop
+      // Keystone shield signing overlay on `/home`, and the Gift Card funding
+      // overlay on `/payment-links`.
+      hasBusySurface: ref.read(paymentUriBusySurfaceProvider) > 0,
+      // Desktop review owns a live Rust proposal whose selected inputs stay
+      // locked until the screen is disposed. The review also takes a busy hold
+      // so leaving it schedules another drain; this route-payload check closes
+      // the short mount window before that post-frame hold is acquired.
+      hasActiveSendProposal:
+          widget.router.state.matchedLocation == '/send/review' &&
+          widget.router.state.extra is SendReviewArgs,
+      // The receipt screen publishes only the "safe to leave" bit; the policy
+      // pairs it with the location, because the flag also reads false when no
+      // send has ever run.
+      sendIsInFlight: !ref.read(sendStatusTerminalProvider),
+      sendGatedByMigration: ref.read(migrationSendGateProvider),
+    );
+
+    switch (decision.action) {
+      case PaymentUriDrainAction.wait:
+        return;
+      case PaymentUriDrainAction.dropWithMessage:
+        prefillNotifier.clear();
+        _showPaymentUriMessage(decision.message!);
+      case PaymentUriDrainAction.routeToUnlock:
+        // Leave the prefill parked in paymentUriPrefillProvider. The unlock
+        // flow claims it and presents the card, so the payment intent is not
+        // lost when the link is opened while the wallet is locked.
+        widget.router.go('/unlock');
+      case PaymentUriDrainAction.routeToWelcome:
+        prefillNotifier.clear();
+        widget.router.go('/welcome');
+        _showPaymentUriMessage(decision.message!);
+      case PaymentUriDrainAction.deliver:
+        prefillNotifier.clear();
+        // The request is presented over the current screen, not navigated to.
+        ref
+            .read(paymentRequestFlowProvider.notifier)
+            .present(prefill!, source: PaymentRequestSource.link);
+    }
+  }
+
+  /// Shows one payment-link notice on the app-level toast host.
+  ///
+  /// The host outlives the screen that asked for the notice, which matters on
+  /// the unlock path: the unlock screen navigates in the same turn, so a
+  /// notice tied to its own `BuildContext` would never arrive.
+  void _showPaymentUriMessage(String message) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      showAppToast(
+        context,
+        message,
+        duration: _kIncomingLinkNoticeDuration,
+        iconName: AppIcons.warning,
+      );
+    });
+    // addPostFrameCallback does not request a frame on its own. An idle app
+    // (locked, nothing animating) would otherwise sit on the notice until some
+    // unrelated frame happens to be scheduled.
+    WidgetsBinding.instance.scheduleFrame();
   }
 }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1534,11 +1534,13 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
         widget.router.go('/welcome');
         _showPaymentUriMessage(decision.message!);
       case PaymentUriDrainAction.deliver:
-        prefillNotifier.clear();
-        // The request is presented over the current screen, not navigated to.
-        ref
-            .read(paymentRequestFlowProvider.notifier)
-            .present(prefill!, source: PaymentRequestSource.link);
+        // Nothing to deliver onto yet. The presenting surface — the payment
+        // request card and its host — arrives in the next PR of this stack;
+        // presenting here would run the precheck and leave a live Rust
+        // proposal holding the wallet's inputs behind a card the user can
+        // neither see nor dismiss. So the link stays parked: a parked link is
+        // drained on the next pass, once a host exists.
+        return;
     }
   }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,7 +12,6 @@ import 'src/app_bootstrap.dart';
 import 'src/core/config/swap_feature_config.dart';
 import 'src/core/config/network_config.dart';
 import 'src/core/layout/app_layout.dart';
-import 'src/core/navigation/app_route_predicates.dart';
 import 'src/core/navigation/mobile_exit_back_guard.dart';
 import 'src/core/navigation/mobile_onboarding_routes.dart';
 import 'src/core/navigation/mobile_routes.dart';

--- a/lib/src/core/navigation/mobile_exit_back_guard.dart
+++ b/lib/src/core/navigation/mobile_exit_back_guard.dart
@@ -82,10 +82,12 @@ class MobileExitBackDispatcher extends RootBackButtonDispatcher {
     required GlobalKey<NavigatorState> navigatorKey,
     required bool Function() canPop,
     required String Function() currentLocation,
+    bool Function()? handleBackAboveRouter,
   }) : _exitBackGuard = exitBackGuard,
        _navigatorKey = navigatorKey,
        _canPop = canPop,
-       _currentLocation = currentLocation {
+       _currentLocation = currentLocation,
+       _handleBackAboveRouter = handleBackAboveRouter {
     if (_exitBackGuard.enabled) {
       _lifecycleListener = AppLifecycleListener(
         onInactive: _clearExitBackGuard,
@@ -101,6 +103,16 @@ class MobileExitBackDispatcher extends RootBackButtonDispatcher {
   final GlobalKey<NavigatorState> _navigatorKey;
   final bool Function() _canPop;
   final String Function() _currentLocation;
+
+  /// Modal layers mounted *above* the `Router`, given the back press first.
+  ///
+  /// A `PopScope` only works below a `ModalRoute`, so anything hosted from
+  /// `MaterialApp.router`'s `builder` — the payment-request card — is
+  /// invisible to the route layer and would otherwise let a back press
+  /// navigate, or exit the app, underneath itself. Returns true when the
+  /// layer consumed the press.
+  final bool Function()? _handleBackAboveRouter;
+
   AppLifecycleListener? _lifecycleListener;
 
   bool handleNavigationNotification(NavigationNotification notification) {
@@ -117,19 +129,26 @@ class MobileExitBackDispatcher extends RootBackButtonDispatcher {
 
   @override
   Future<bool> invokeCallback(Future<bool> defaultValue) async {
+    // Above-router modals answer first, on every platform this dispatcher
+    // runs on: they are drawn over the whole route stack, so a press that
+    // reached anything underneath them would act on a screen the user cannot
+    // even see.
+    if (_handleBackAboveRouter?.call() ?? false) {
+      _clearExitBackGuard();
+      return true;
+    }
     if (!_exitBackGuard.enabled) {
       return super.invokeCallback(defaultValue);
     }
 
-    // The migration flow is a set of flat, top-level routes that replace each
-    // other with `go`, so its screens routinely sit on a stack that cannot
-    // pop. Offering the route layer the back press first is what lets their
-    // `PopScope` handlers run at all; without it a mid-flow back press skips
-    // straight to the exit hint and a second press quits the app. The check is
-    // pinned to `/migration` on purpose: every other screen keeps the existing
-    // "root back means exit" behaviour, which has not been audited for
-    // `PopScope` dependencies.
-    if (_canPop() || _isMigrationLocation(_currentLocation())) {
+    // Some flows are flat, top-level routes that replace each other with `go`,
+    // so their screens routinely sit on a stack that cannot pop. Offering the
+    // route layer the back press first is what lets their `PopScope` handlers
+    // run at all; without it a mid-flow back press skips straight to the exit
+    // hint and a second press quits the app. The list is pinned on purpose:
+    // every other screen keeps the existing "root back means exit" behaviour,
+    // which has not been audited for `PopScope` dependencies.
+    if (_canPop() || _routeLayerHandlesRootBack(_currentLocation())) {
       final handledByRoute = await super.invokeCallback(
         Future<bool>.value(false),
       );
@@ -154,9 +173,21 @@ class MobileExitBackDispatcher extends RootBackButtonDispatcher {
     return true;
   }
 
-  static bool _isMigrationLocation(String location) {
+  /// Flows whose screens own the root back press through their own
+  /// `PopScope`.
+  ///
+  /// `/migration` replaces its steps with `go`. `/send` is normally pushed
+  /// from home (so `_canPop()` already covers it), but a `zcash:` payment URI
+  /// opens it with `go` as well, which makes `/send` the entire stack: the
+  /// send screen's `PopScope` is then the only thing that can send the press
+  /// to its own step fallback instead of exiting the app.
+  static const _rootBackFlowPrefixes = ['/migration', '/send'];
+
+  static bool _routeLayerHandlesRootBack(String location) {
     final path = Uri.tryParse(location)?.path ?? location;
-    return path == '/migration' || path.startsWith('/migration/');
+    return _rootBackFlowPrefixes.any(
+      (prefix) => path == prefix || path.startsWith('$prefix/'),
+    );
   }
 
   void dispose() {

--- a/lib/src/core/navigation/payment_uri_busy_surface_hold.dart
+++ b/lib/src/core/navigation/payment_uri_busy_surface_hold.dart
@@ -1,0 +1,93 @@
+/// The one way a surface takes a `paymentUriBusySurfaceProvider` hold.
+///
+/// Every holder owes the notifier the same contract — acquire once from a
+/// post-frame callback after mount, give exactly that hold back from
+/// `dispose` via `releaseAfterNavigation`, and guard both ends with a
+/// per-holder bit so a surface disposed before its callback ran cannot
+/// decrement a hold it never took.
+///
+/// The post-frame acquire is early enough only because the drain in
+/// `app.dart` runs *after* every post-frame callback of a frame
+/// (`WidgetsBinding.endOfFrame`), not as one of them: a link that arrives in
+/// the same turn as the navigation that mounts a holder schedules its drain
+/// before this `initState` runs, and a drain that was itself a post-frame
+/// callback would run first and read a count of zero. Writing that by hand in a dozen Keystone
+/// screens is how one of them ends up releasing twice, so the pattern lives
+/// here once.
+///
+/// Two shapes, because the surfaces come in two shapes:
+///
+/// * [PaymentUriBusySurfaceHoldMixin] for a screen whose whole lifetime is
+///   the protected session (`/send/keystone/scan`, the mobile signing screens).
+/// * [PaymentUriBusySurfaceHold] for a QR that is only part of a longer-lived
+///   screen — the desktop send review and the voting status screen show one
+///   mid-flow, and the hold must last exactly as long as that subtree, not as
+///   long as the review.
+library;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'payment_uri_busy_surface_provider.dart';
+
+/// Holds one `paymentUriBusySurfaceProvider` hold for the mounted lifetime of
+/// the state that mixes it in.
+///
+/// The state must call `super.initState()` first and `super.dispose()` last,
+/// which is the normal shape anyway.
+mixin PaymentUriBusySurfaceHoldMixin<T extends ConsumerStatefulWidget>
+    on ConsumerState<T> {
+  /// Captured in [initState] so [dispose] can give the hold back without
+  /// reading from `ref` after the element is gone.
+  late final PaymentUriBusySurfaceNotifier _paymentUriBusySurface;
+
+  /// Whether this holder actually took a hold. Guards the release so a holder
+  /// disposed before its post-frame callback ran cannot decrement a hold it
+  /// never took.
+  bool _holdsPaymentUriBusySurface = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _paymentUriBusySurface = ref.read(paymentUriBusySurfaceProvider.notifier);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _holdsPaymentUriBusySurface) return;
+      _paymentUriBusySurface.acquire();
+      _holdsPaymentUriBusySurface = true;
+    });
+  }
+
+  @override
+  void dispose() {
+    if (_holdsPaymentUriBusySurface) {
+      _holdsPaymentUriBusySurface = false;
+      _paymentUriBusySurface.releaseAfterNavigation();
+    }
+    super.dispose();
+  }
+}
+
+/// Wraps [child] in one `paymentUriBusySurfaceProvider` hold for as long as it
+/// is mounted.
+///
+/// Use it where the QR surface is a conditional subtree rather than a whole
+/// screen; use [PaymentUriBusySurfaceHoldMixin] where the screen *is* the
+/// session. Put it above any keyed subtree that remounts mid-session (a
+/// per-round signing flow), so the count never dips to zero between rounds and
+/// lets a parked link through in the gap.
+class PaymentUriBusySurfaceHold extends ConsumerStatefulWidget {
+  const PaymentUriBusySurfaceHold({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  ConsumerState<PaymentUriBusySurfaceHold> createState() =>
+      _PaymentUriBusySurfaceHoldState();
+}
+
+class _PaymentUriBusySurfaceHoldState
+    extends ConsumerState<PaymentUriBusySurfaceHold>
+    with PaymentUriBusySurfaceHoldMixin {
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/lib/src/core/navigation/payment_uri_busy_surface_provider.dart
+++ b/lib/src/core/navigation/payment_uri_busy_surface_provider.dart
@@ -1,0 +1,63 @@
+/// Hold count for in-progress surfaces a payment URI must not interrupt.
+///
+/// A delivered request is now presented as a card over the current screen, so
+/// `decidePaymentUriDrain` no longer refuses to deliver based on where the
+/// user is: nothing gets unmounted. What a hold here still buys is the one
+/// cases where even a modal card is destructive: a live animated QR an
+/// external device's camera is reading, or a send-review proposal whose inputs
+/// must be released before the incoming request can be pre-checked. A holder
+/// keeps the link parked (the drain answers `wait`), and `app.dart` re-runs the
+/// drain when the count falls back to zero.
+library;
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// A count rather than a flag so overlapping holders compose: the surface is
+/// busy while at least one holder is mounted, and an outgoing holder cannot
+/// clear an incoming one's hold.
+///
+/// Every holder must take at most one hold and give exactly that one back.
+/// [releaseAfterNavigation] exists because `dispose()` is one of the places
+/// Riverpod forbids a synchronous provider write; hold the "did I acquire"
+/// bit on the holder itself so a double release can never steal another
+/// surface's hold.
+class PaymentUriBusySurfaceNotifier extends Notifier<int> {
+  var _disposed = false;
+
+  @override
+  int build() {
+    ref.onDispose(() => _disposed = true);
+    return 0;
+  }
+
+  /// Takes one hold. Call once per holder, from a post-frame callback rather
+  /// than `initState`/`build`.
+  void acquire() {
+    if (_disposed) return;
+    state = state + 1;
+  }
+
+  /// Gives one hold back. Clamped at zero so a stray release cannot drive the
+  /// count negative and wedge the latch open.
+  void release() {
+    if (_disposed || state == 0) return;
+    state = state - 1;
+  }
+
+  /// Releases once the current lifecycle call has returned, for holders that
+  /// give their hold back from `dispose`. A microtask rather than a timer, so
+  /// it cannot outlive a widget test's tree.
+  void releaseAfterNavigation() {
+    scheduleMicrotask(() {
+      if (_disposed) return;
+      release();
+    });
+  }
+}
+
+final paymentUriBusySurfaceProvider =
+    NotifierProvider<PaymentUriBusySurfaceNotifier, int>(
+      PaymentUriBusySurfaceNotifier.new,
+    );

--- a/lib/src/core/navigation/payment_uri_drain_policy.dart
+++ b/lib/src/core/navigation/payment_uri_drain_policy.dart
@@ -1,0 +1,324 @@
+/// Pure routing policy for a parked ZIP-321 `zcash:` payment URI.
+///
+/// `_IncomingLinkHost` in `app.dart` parks an arriving payment URI in
+/// `paymentUriPrefillProvider` and then asks this policy what to do with it.
+/// Everything here is a plain function of the app's observable state so the
+/// whole decision table can be unit-tested without a router, a wallet, or a
+/// widget tree; `app.dart` only executes the returned action.
+///
+/// The policy no longer blocks on where the user happens to be. A delivered
+/// request is presented as a card over the current screen rather than a jump
+/// to `/send`, so there is nothing to interrupt: the swap review and the
+/// migration steps stay exactly where they were until the user answers the
+/// card. The rows that remain are the ones about whether the request can be
+/// shown at all — no wallet, mid-onboarding, locked, stale, or a wallet that
+/// failed to load — plus the two surfaces that would lose something if a card
+/// went over them: a hardware signing session, and a broadcast still running
+/// on `/send/status`.
+library;
+
+import '../zcash/zip321_payment_request.dart';
+import 'app_route_predicates.dart';
+
+// Re-exported so a caller that already reasons about the drain (`appRedirect`
+// in `app.dart`) does not need a second import for the two route questions
+// this table asks.
+export 'app_route_predicates.dart'
+    show isOnboardingLocation, isUnlockFlowLocation;
+
+/// A parked prefill older than this is stale and is dropped instead of
+/// delivered.
+///
+/// Without it, a link opened and then left parked (the user never unlocks, or
+/// the wallet sits on an error screen) would fire as a payment on a much later,
+/// unrelated wallet emission. `PaymentUriPrefillNotifier.takeIfFresh` enforces
+/// the same age on the unlock-screen claim path.
+const kPaymentUriParkTtl = Duration(minutes: 10);
+
+/// Shown when the link cannot be opened at all: blocking storage failure or a
+/// wallet load error.
+///
+/// It does not name a cause. A blocking failure is one of several things (a
+/// locked keyring, a failed DB migration), and `/storage-unavailable` already
+/// states the one that happened and offers Retry. What the payer needs here is
+/// the one thing that is always true: the link is gone, and re-opening it once
+/// the wallet is up recovers it.
+const kPaymentUriUnavailableMessage =
+    "Vizor couldn't open this payment link. "
+    'Open it again once your wallet has loaded.';
+
+/// Shown when a second `zcash:` link arrives before the first one has been
+/// delivered or claimed. The prefill holds one link at a time (latest wins,
+/// no queue), so the earlier one is gone and the user is told rather than
+/// left to wonder which link opened.
+const kPaymentUriReplacedMessage =
+    'Only the newest payment link was kept. Open the earlier one again to '
+    'pay it.';
+
+/// Shown when a parked link outlived [kPaymentUriParkTtl] before it could be
+/// delivered — most often a link tapped while locked and unlocked much later.
+///
+/// The user acted on that link deliberately, so the drop is stated rather than
+/// silent, and the link itself is still good: opening it again pays it.
+const kPaymentUriExpiredMessage =
+    'That payment link timed out. Open it again to pay.';
+
+/// Shown when there is no wallet yet and the user is not already inside a
+/// setup flow.
+const kPaymentUriNoWalletMessage =
+    'Set up or import a wallet before opening payment links.';
+
+/// Shown when the link arrives while the user is part-way through onboarding,
+/// import, or adding an account. Navigating away from those screens throws
+/// away a typed seed phrase or a generated mnemonic, so the link is dropped
+/// and the user is left exactly where they were.
+const kPaymentUriOnboardingMessage =
+    'Finish setting up your wallet before opening payment links.';
+
+/// Shown when a Private (Ironwood) migration has the account's whole
+/// spendable balance in flight, so the product disables sending entirely.
+/// Delivering the link would open a send form that cannot be submitted.
+const kPaymentUriMigrationSendGateMessage =
+    'Finish your Ironwood migration before opening payment links.';
+
+/// Shown when a `zcash:` link parses but asks for a ZIP-321 feature Vizor does
+/// not implement yet: more than one recipient, a binary memo, a custom asset.
+/// Nothing about the link is wrong, so it does not tell the sender off.
+const kPaymentUriUnsupportedMessage =
+    "This payment link uses a feature Vizor doesn't support yet.";
+
+/// Shown when a `zcash:` link cannot be parsed at all — bad encoding, a
+/// malformed amount, a missing address, a link too long to read.
+///
+/// The parser's own message is spec wording written for us, not for the payer,
+/// and it echoes back fragments of the link's own text; it belongs in the log.
+const kPaymentUriMalformedMessage =
+    "This payment link isn't valid. Ask the sender for a new one.";
+
+/// The one sentence the payer sees when a `zcash:` link is refused.
+///
+/// Two buckets, because only two answers differ for the user: wait for Vizor
+/// to support the feature, or ask the sender for a link that works.
+/// [Zip321UnsupportedRequestException] carries the first, every other rejection
+/// the second.
+String paymentUriRejectionMessage(Object error) =>
+    error is Zip321UnsupportedRequestException
+    ? kPaymentUriUnsupportedMessage
+    : kPaymentUriMalformedMessage;
+
+/// What `_drainPendingPrefill` should do with the parked prefill.
+enum PaymentUriDrainAction {
+  /// Leave the prefill parked and do nothing. Something else (the unlock
+  /// screen, a later wallet emission) still owns it.
+  wait,
+
+  /// Drop the prefill and show [PaymentUriDrainDecision.message].
+  dropWithMessage,
+
+  /// Leave the prefill parked and route to `/unlock`; the unlock flow claims
+  /// it after a successful unlock.
+  routeToUnlock,
+
+  /// Drop the prefill, route to `/welcome`, and show the message.
+  routeToWelcome,
+
+  /// Clear the prefill and present it as a payment-request card.
+  deliver,
+}
+
+/// The action plus everything needed to execute it.
+class PaymentUriDrainDecision {
+  const PaymentUriDrainDecision(this.action, {this.message});
+
+  final PaymentUriDrainAction action;
+
+  /// Snackbar text, when the action carries one.
+  final String? message;
+
+  @override
+  String toString() => 'PaymentUriDrainDecision($action, message: $message)';
+}
+
+const _waitDecision = PaymentUriDrainDecision(PaymentUriDrainAction.wait);
+
+/// The send receipt route, desktop and mobile — both register `/send/status`.
+///
+/// `sendStatusLocation()` appends a `flow` query parameter, which
+/// `matchedLocation` does not carry, so the comparison is on the path alone.
+bool isSendStatusLocation(String matchedLocation) =>
+    matchedLocation == '/send/status';
+
+/// Whether a wallet emission is the reset transition — the wallet existed a
+/// moment ago and does not any more (uninstall, lost-password reset).
+///
+/// A parked link must be dropped silently on that edge: draining it would
+/// follow the wipe with a "Set up or import a wallet" snackbar and a jump to
+/// `/welcome`, which reads as an error caused by the reset the user just
+/// asked for.
+///
+/// [previousHasWallet] is null only when no wallet value has been observed
+/// yet. That is not a reset, so it does not drop: the caller seeds the
+/// baseline from the bootstrap snapshot precisely so a session that starts
+/// locked (and therefore never emits before the reset) still sees `true` here.
+bool paymentUriShouldDropOnWalletTransition({
+  required bool? previousHasWallet,
+  required bool hasWallet,
+}) => previousHasWallet == true && !hasWallet;
+
+/// Decides what to do with the parked payment-URI prefill.
+///
+/// The rows, in order:
+///
+/// | condition                                   | action                    |
+/// |---------------------------------------------|---------------------------|
+/// | nothing parked                              | wait                      |
+/// | parked longer than [kPaymentUriParkTtl]      | drop + expired msg        |
+/// | blocking storage failure / wallet error      | drop + unavailable msg    |
+/// | wallet still loading                         | wait                      |
+/// | `/welcome`, no wallet                        | drop + no-wallet msg      |
+/// | onboarding / import / add-account location   | drop + onboarding msg     |
+/// | a busy overlay is up                         | wait (present when it goes)|
+/// | another send proposal owns inputs            | wait (present when freed)  |
+/// | a broadcast is running on `/send/status`      | wait (present on receipt) |
+/// | no wallet, anywhere else                     | `/welcome` + no-wallet msg|
+/// | locked, already on `/unlock`/`/lost-password`| wait (stay parked)        |
+/// | locked, anywhere else                        | `/unlock` (stay parked)   |
+/// | unlocked but still on `/unlock`              | wait (unlock screen owns) |
+/// | migration disables sending                   | drop + migration msg      |
+/// | otherwise                                    | present the card          |
+///
+/// [parkedFor] is how long the prefill has been parked (null when nothing is
+/// parked, or when the park time is unknown). [hasBusySurface] is true while a
+/// hardware signing session is mounted — see `paymentUriBusySurfaceProvider`.
+/// [hasActiveSendProposal] is true while the current desktop send-review route
+/// owns a proposal and its selected inputs. A second proposal must wait until
+/// that route releases the first one. [sendIsInFlight] is the negation of
+/// `sendStatusTerminalProvider`: the send
+/// on the receipt screen has not finished. It is read only on
+/// [isSendStatusLocation], because the flag is also false when no send has run
+/// at all. [sendGatedByMigration] is true when the product disables sending
+/// because a Private migration holds the whole spendable balance — see
+/// `migrationSendGateProvider`. It is deliberately the last row: the gate is
+/// only meaningful for an unlocked wallet (see the comment on that row).
+PaymentUriDrainDecision decidePaymentUriDrain({
+  required bool hasParkedPrefill,
+  required Duration? parkedFor,
+  required bool hasBlockingFailure,
+  required bool walletIsLoading,
+  required bool walletHasError,
+  required bool hasWallet,
+  required bool isUnlocked,
+  required String matchedLocation,
+  bool hasBusySurface = false,
+  bool hasActiveSendProposal = false,
+  bool sendIsInFlight = false,
+  bool sendGatedByMigration = false,
+}) {
+  if (!hasParkedPrefill) return _waitDecision;
+
+  // Age first, whatever screen the app happens to be on. The user opened this
+  // link on purpose, so the drop is said out loud: without it the link simply
+  // never arrives and nothing ever explains why.
+  if (parkedFor != null && parkedFor > kPaymentUriParkTtl) {
+    return const PaymentUriDrainDecision(
+      PaymentUriDrainAction.dropWithMessage,
+      message: kPaymentUriExpiredMessage,
+    );
+  }
+
+  // A bootstrap retry rebuilds the ProviderScope and takes the parked prefill
+  // with it, so staying silent here means the link disappears without the user
+  // ever being told.
+  if (hasBlockingFailure || walletHasError) {
+    return const PaymentUriDrainDecision(
+      PaymentUriDrainAction.dropWithMessage,
+      message: kPaymentUriUnavailableMessage,
+    );
+  }
+
+  // Wallet existence is not known yet; a later emission re-runs the drain.
+  if (walletIsLoading) return _waitDecision;
+
+  // Setup flows hold state that only lives in the widget tree (a typed seed
+  // phrase, a freshly generated mnemonic, an in-flight account creation).
+  // A card over a half-typed seed phrase is the one presentation that would
+  // still cost the user something, so onboarding keeps its drop.
+  if (isOnboardingLocation(matchedLocation)) {
+    // On the welcome screen with no wallet nothing has been started yet, so
+    // the plain no-wallet wording fits better than "finish setting up".
+    return PaymentUriDrainDecision(
+      PaymentUriDrainAction.dropWithMessage,
+      message: matchedLocation == '/welcome' && !hasWallet
+          ? kPaymentUriNoWalletMessage
+          : kPaymentUriOnboardingMessage,
+    );
+  }
+
+  // A hardware signing session waits rather than drops. The device is showing
+  // a QR the user is part-way through scanning, so a card over it would be
+  // both a distraction and, on the desktop shield overlay, a scrim over a
+  // live animated QR. The listener re-drains when the hold is given back, and
+  // the TTL still bounds the wait.
+  if (hasBusySurface) return _waitDecision;
+
+  // A proposal locks its selected inputs until its review owner is disposed.
+  // Pre-checking a new request before that release can report insufficient
+  // funds even when the requested payment becomes affordable immediately after
+  // leaving the existing review. Keep the link parked; the review's busy hold
+  // re-runs the drain once disposal has released the proposal.
+  if (hasActiveSendProposal) return _waitDecision;
+
+  // A broadcast still running on `/send/status` waits too, and for a harder
+  // reason than distraction: the card's Review and Edit both `go(...)`, which
+  // unmounts the status screen, and `runSendBroadcast`'s
+  // `shouldAbort: () async => !mounted` then discards the outcome at the
+  // post-`executeProposal` checkpoint. The transaction is already on the
+  // network but the user never sees a txid or a receipt. Holding until the
+  // send reaches a terminal phase costs nothing — the listener re-drains when
+  // the flag flips, and the TTL still bounds the wait.
+  if (sendIsInFlight && isSendStatusLocation(matchedLocation)) {
+    return _waitDecision;
+  }
+
+  if (!hasWallet) {
+    return const PaymentUriDrainDecision(
+      PaymentUriDrainAction.routeToWelcome,
+      message: kPaymentUriNoWalletMessage,
+    );
+  }
+
+  if (!isUnlocked) {
+    // Already at the unlock/reset flow: leave it alone and keep the prefill
+    // parked for the unlock screen to claim.
+    if (isUnlockFlowLocation(matchedLocation)) return _waitDecision;
+    return const PaymentUriDrainDecision(PaymentUriDrainAction.routeToUnlock);
+  }
+
+  // Unlocked but still on the unlock screen: the unlock flow's own claim owns
+  // the handoff. Presenting here too would race it.
+  if (matchedLocation == '/unlock') return _waitDecision;
+
+  // The send the card offers is one the product has already taken away, so
+  // the user needs the migration explanation rather than a card whose Review
+  // and Edit both lead nowhere.
+  //
+  // Read last, and only for an unlocked wallet that is past the unlock flow,
+  // because the gate cannot be trusted before that point:
+  // `migrationSendGateProvider` is `cta == resume && ironwoodBalance <= 0`,
+  // and locking resets `syncProvider` to a bare `SyncState()`, so the balance
+  // half is unconditionally true while locked and the Home CTA cache keeps
+  // answering `resume` across that gap
+  // (`test/core/navigation/payment_uri_migration_gate_test.dart` measures
+  // both). Dropping a parked link on that reading would refuse a payment on
+  // the strength of a balance the lock itself zeroed. Nothing is lost by
+  // waiting: `claimParkedPaymentUriAfterUnlock` runs this same table once the
+  // wallet is open, when the gate is answering about a real balance.
+  if (sendGatedByMigration) {
+    return const PaymentUriDrainDecision(
+      PaymentUriDrainAction.dropWithMessage,
+      message: kPaymentUriMigrationSendGateMessage,
+    );
+  }
+
+  return const PaymentUriDrainDecision(PaymentUriDrainAction.deliver);
+}

--- a/lib/src/core/navigation/payment_uri_unlock_claim.dart
+++ b/lib/src/core/navigation/payment_uri_unlock_claim.dart
@@ -1,0 +1,89 @@
+/// The post-unlock claim of a `zcash:` link parked while the wallet was locked.
+///
+/// `decidePaymentUriDrain` deliberately answers `wait` on `/unlock`, so the
+/// unlock screens — not `_IncomingLinkHost` — own the handoff. This is
+/// the provider-reading half of that: the two unlock screens (desktop and
+/// mobile) call it so they cannot drift into two different claims.
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app_bootstrap.dart';
+import '../../features/send/models/send_prefill_args.dart';
+import '../../providers/migration_send_gate_provider.dart'
+    show migrationSendGateProvider;
+import '../../providers/payment_uri_prefill_provider.dart';
+import '../../providers/wallet_provider.dart';
+import 'payment_uri_drain_policy.dart';
+
+/// What the unlock screen should do once it has navigated to `/home`.
+class PaymentUriUnlockClaim {
+  const PaymentUriUnlockClaim({this.prefill, this.notice});
+
+  /// Present this as a payment-request card. Null when nothing was parked, or
+  /// when the link cannot be shown.
+  final SendPrefillArgs? prefill;
+
+  /// Say this instead — the link was claimed but is not being delivered.
+  /// Null when there is nothing to say (nothing was parked).
+  final String? notice;
+}
+
+/// Claims the parked payment-URI prefill after a successful unlock.
+///
+/// Call it *after* the post-unlock work (`restoreAfterUnlock`,
+/// `refreshAfterUnlock`, `startSyncAnyway`) and before the `go('/home')`:
+/// claiming earlier would clear the prefill with no way to recover it if any
+/// of those threw, and the returned decision reads state those calls settle.
+///
+/// The claim is more than the TTL. `decidePaymentUriDrain` is the one place
+/// that says whether a link can be shown at all, and its answer can change
+/// across the unlock itself: `migrationSendGateProvider` reads an Ironwood
+/// presentation that is still unresolved while locked, so a link that parked
+/// under a false gate can land on a wallet whose Send the product has since
+/// taken away. Running the same table here keeps the unlock claim and the
+/// app-level drain on one decision rather than two.
+PaymentUriUnlockClaim claimParkedPaymentUriAfterUnlock(WidgetRef ref) {
+  final claimed = ref.read(paymentUriPrefillProvider.notifier).takeIfFresh();
+  final prefill = claimed.prefill;
+  if (prefill == null) {
+    // `takeIfFresh` already applied the park TTL; `expired` is the only
+    // no-prefill outcome the user needs told about.
+    return PaymentUriUnlockClaim(
+      notice: claimed.expired ? kPaymentUriExpiredMessage : null,
+    );
+  }
+
+  final bootstrap = ref.read(appBootstrapProvider);
+  final walletAsync = ref.read(walletProvider);
+  final decision = decidePaymentUriDrain(
+    hasParkedPrefill: true,
+    // The age row already ran, inside the `takeIfFresh` above. Passing null
+    // keeps one clock rather than two that can disagree.
+    parkedFor: null,
+    hasBlockingFailure: bootstrap.hasBlockingFailure,
+    walletIsLoading: walletAsync.isLoading && walletAsync.value == null,
+    walletHasError: walletAsync.hasError,
+    hasWallet: walletAsync.value?.hasWallet ?? bootstrap.hasWallet,
+    // Only reached from a successful unlock.
+    isUnlocked: true,
+    // The card is presented over `/home`, which is where the unlock is
+    // heading. Asking about `/unlock` — still the current location here —
+    // would answer "wait" for the handoff this very function is performing.
+    matchedLocation: '/home',
+    sendGatedByMigration: ref.read(migrationSendGateProvider),
+  );
+
+  return switch (decision.action) {
+    // Whatever the policy would drop, drop here too, with its own sentence.
+    PaymentUriDrainAction.dropWithMessage ||
+    PaymentUriDrainAction.routeToWelcome => PaymentUriUnlockClaim(
+      notice: decision.message,
+    ),
+    // `wait` and `routeToUnlock` cannot be reached from a successful unlock
+    // landing on `/home`. If the table ever grows a row that can, presenting
+    // is the answer that does not silently swallow a payment the user
+    // deliberately opened — the prefill is already claimed either way.
+    _ => PaymentUriUnlockClaim(prefill: prefill),
+  };
+}

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -26,6 +26,8 @@ const kSyncKeepAwakeEnabledKey = 'zcash_sync_keep_awake_enabled';
 const kSyncKeepAwakePromptSeenKey = 'zcash_sync_keep_awake_prompt_seen';
 const kRpcEndpointUrlKey = 'zcash_rpc_endpoint_url';
 const kRpcEndpointPresetKey = 'zcash_rpc_endpoint_preset';
+const kPaymentLinkRecoveryStorageKey = 'zcash_gift_card_recovery_v1';
+const kPaymentLinkReceivedStorageKey = 'zcash_gift_card_received_v1';
 const kZcashExplorerUrlKey = 'zcash_explorer_url';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';
 const _passwordVerifierKey = 'zcash_password_verifier';
@@ -378,7 +380,9 @@ class AppSecureStore {
       });
       return;
     }
-    if (key.startsWith(_votingHotkeyKeyPrefix)) {
+    if (key.startsWith(_votingHotkeyKeyPrefix) ||
+        key == kPaymentLinkRecoveryStorageKey ||
+        key == kPaymentLinkReceivedStorageKey) {
       await _secretMutationLock.run(() async {
         await _runStorageOperation(
           'delete "$key"',
@@ -471,8 +475,9 @@ class AppSecureStore {
 
   /// Rotates the wallet password and re-encrypts every app-managed secret.
   ///
-  /// Account mnemonics and voting hotkeys are both encrypted with the wallet
-  /// password, but they may live in different secure storage backends.
+  /// Account mnemonics, voting hotkeys, and payment-link recovery records are
+  /// encrypted with the wallet password, but they may live in different secure
+  /// storage backends.
   Future<bool> changePassword({
     required String currentPassword,
     required String newPassword,
@@ -551,12 +556,12 @@ class AppSecureStore {
           ),
         );
       }
-      final votingHotkeyValues = await _runStorageOperation(
-        'read all voting hotkeys',
+      final appManagedSecretValues = await _runStorageOperation(
+        'read all app-managed secrets',
         _storage.readAll,
       );
-      for (final entry in votingHotkeyValues.entries) {
-        if (!entry.key.startsWith(_votingHotkeyKeyPrefix)) continue;
+      for (final entry in appManagedSecretValues.entries) {
+        if (!_isAppManagedGeneralSecretKey(entry.key)) continue;
 
         if (!_isEncryptedPayload(entry.value)) {
           throw StateError(
@@ -1034,6 +1039,12 @@ class AppSecureStore {
     return key.startsWith(_accountMnemonicKeyPrefix)
         ? _mnemonicStorage
         : _storage;
+  }
+
+  bool _isAppManagedGeneralSecretKey(String key) {
+    return key.startsWith(_votingHotkeyKeyPrefix) ||
+        key == kPaymentLinkRecoveryStorageKey ||
+        key == kPaymentLinkReceivedStorageKey;
   }
 
   Future<void> _deleteRotationRecordBestEffort() async {

--- a/lib/src/core/widgets/pool_badge.dart
+++ b/lib/src/core/widgets/pool_badge.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/widgets.dart';
+
+import '../theme/app_theme.dart';
+import 'app_icon.dart';
+
+/// Shielded / Transparent pool badge — the icon-plus-label pair every surface
+/// in the product uses to state which pool an address belongs to.
+///
+/// Shielded takes the crimson glyph; transparent takes the muted one. The
+/// label stays in the secondary text colour in both cases, so the badge reads
+/// as an attribute of the value beside it rather than as a status of its own.
+///
+/// It was promoted out of the payment request card when the Receive request
+/// flow needed the same badge under its QR: two copies of a privacy label is
+/// exactly the kind of drift that ends with the two surfaces disagreeing.
+class PoolBadge extends StatelessWidget {
+  const PoolBadge({required this.isShielded, super.key});
+
+  final bool isShielded;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppIcon(
+          isShielded ? AppIcons.shieldKeyhole : AppIcons.transparentBalance,
+          size: AppIconSize.medium,
+          color: isShielded ? colors.text.brandCrimson : colors.text.secondary,
+        ),
+        const SizedBox(width: AppSpacing.xxs),
+        Flexible(
+          child: Text(
+            isShielded ? 'Shielded' : 'Transparent',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.labelSmall.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/core/widgets/review_list_row.dart
+++ b/lib/src/core/widgets/review_list_row.dart
@@ -10,6 +10,11 @@ import 'app_tooltip.dart';
 const kTxFeeHelpTooltip =
     'Fee paid to the Zcash network to process this transaction.';
 
+/// Tooltip for the requester name on a payment-request card. The name is
+/// supplied by the payment link, not verified by Vizor.
+const kPaymentRequestRequesterTooltip =
+    "Name supplied by the payment link. Vizor can't verify who sent it.";
+
 /// One 32px "List Item" row inside a `ReviewWrapCard`: left label, right
 /// value cluster with optional 16px leading/trailing icons.
 ///

--- a/lib/src/core/widgets/review_wrap_card.dart
+++ b/lib/src/core/widgets/review_wrap_card.dart
@@ -2,6 +2,12 @@ import 'package:flutter/widgets.dart';
 
 import '../theme/app_theme.dart';
 
+/// The [ReviewWrapCard] inner inset shared by every default instance.
+const kReviewWrapCardPadding = EdgeInsets.symmetric(
+  vertical: AppSpacing.md,
+  horizontal: AppSpacing.sm,
+);
+
 /// The "Review Wrap" card from the send review/status and received receipt
 /// screens: full-width, 24px-radius surface with the subtle four-layer
 /// surface shadow, hosting list rows and dividers with a 16px gap.
@@ -9,10 +15,26 @@ import '../theme/app_theme.dart';
 /// Figma `radii/m` is 24px → [AppRadii.large], NOT `AppRadii.medium` (16);
 /// the radii scale is mapped by value, not by token name.
 class ReviewWrapCard extends StatelessWidget {
-  const ReviewWrapCard({required this.children, this.surfaceColor, super.key});
+  const ReviewWrapCard({
+    required this.children,
+    this.surfaceColor,
+    this.padding = kReviewWrapCardPadding,
+    this.mainAxisSize = MainAxisSize.max,
+    super.key,
+  });
 
   /// List rows / dividers, separated by a 16px gap.
   final List<Widget> children;
+
+  /// Inner inset. Defaults to [kReviewWrapCardPadding]; a card whose content
+  /// scrolls inside it passes [EdgeInsets.zero] and applies the same inset
+  /// inside the scroll viewport, so the scrollbar can ride in the gutter.
+  final EdgeInsetsGeometry padding;
+
+  /// Whether the card hugs its content when its parent bounds the height.
+  /// The default fills; a card in a `Flexible` passes [MainAxisSize.min] to
+  /// shrink to short content instead.
+  final MainAxisSize mainAxisSize;
 
   /// Fixed surface override. The failed status screen keeps the dark
   /// `#1b1f1f` card (`Primitives.p50Dark`) in BOTH themes — that instance
@@ -31,11 +53,9 @@ class ReviewWrapCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(AppRadii.large),
         boxShadow: appSurfaceShadow(colors),
       ),
-      padding: const EdgeInsets.symmetric(
-        vertical: AppSpacing.md,
-        horizontal: AppSpacing.sm,
-      ),
+      padding: padding,
       child: Column(
+        mainAxisSize: mainAxisSize,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           for (var i = 0; i < children.length; i++) ...[

--- a/lib/src/core/zcash/zip321_payment_request.dart
+++ b/lib/src/core/zcash/zip321_payment_request.dart
@@ -306,6 +306,23 @@ void _validateBase64Url(String value, String label) {
   if (bytes.length > 512) {
     throw const Zip321ParseException('ZIP-321 memo exceeds 512 bytes.');
   }
+  // ZIP-302's canonical "no memo": 0xF6 followed by nothing but zeros, which
+  // `memo=9g` is the shortest spelling of. `librustzcash` — the locked
+  // `zip321`/`Memo` implementation this parser has to agree with — reads that
+  // field as `Memo::Empty`, so the request is a well-formed shielded request
+  // that simply says nothing, not an unreadable one.
+  //
+  // It has to be answered before the UTF-8 decode below, because 0xF6 is not
+  // valid UTF-8: left to the decode it comes back malformed, is classified
+  // binary, and the whole link is refused as an unsupported memo.
+  //
+  // Only this exact shape. 0xF5 is ZIP-302's reserved prefix for future memo
+  // formats, anything else above 0xF4 is arbitrary bytes, and a 0xF6 with a
+  // non-zero byte after it is none of the three — all of them stay binary,
+  // because a memo this wallet cannot read is not a memo it may drop.
+  if (_isEmptyZip302Memo(bytes)) {
+    return (text: null, isBinary: false);
+  }
   // ZIP-302 memos are a fixed 512-byte field that producers zero-pad on the
   // right, so a full-width encoding of "Invoice 42" arrives as the text plus
   // 502 trailing NULs. Drop that padding before decoding; interior NULs stay
@@ -322,6 +339,16 @@ void _validateBase64Url(String value, String label) {
   } on FormatException {
     return (text: null, isBinary: true);
   }
+}
+
+/// Whether [bytes] are ZIP-302's empty memo: a leading 0xF6 and zeros to the
+/// end of whatever width the producer transmitted.
+bool _isEmptyZip302Memo(List<int> bytes) {
+  if (bytes.isEmpty || bytes.first != 0xF6) return false;
+  for (var i = 1; i < bytes.length; i++) {
+    if (bytes[i] != 0x00) return false;
+  }
+  return true;
 }
 
 List<int> _stripTrailingMemoPadding(List<int> bytes) {

--- a/lib/src/core/zcash/zip321_payment_request.dart
+++ b/lib/src/core/zcash/zip321_payment_request.dart
@@ -1,5 +1,18 @@
 import 'dart:convert';
 
+/// Upper bound on a `zcash:` payment URI we are willing to parse, in UTF-8
+/// bytes. Matches `kMaxZcashUriBytes` in `windows/runner/utils.h`, which
+/// measures the bytes it receives, so the native handoff and the Dart parser
+/// refuse the same inputs — measuring UTF-16 code units here would let a URI
+/// the native side rejects through, since one CJK character is one code unit
+/// but three bytes.
+const kMaxPaymentUriLength = 16384;
+
+/// Longest attacker-controlled fragment we echo back into a user-facing parse
+/// error. Anything longer is truncated so a hostile link cannot fill a
+/// SnackBar with its own text.
+const _maxEchoedNameLength = 32;
+
 class Zip321PaymentRequest {
   const Zip321PaymentRequest({required this.payments, this.unsupportedReason});
 
@@ -11,6 +24,12 @@ class Zip321PaymentRequest {
   Zip321Payment get primaryPayment => payments.first;
 
   static Zip321PaymentRequest parse(String input) {
+    // Code units are never more than bytes, so the cheap check settles the
+    // common case before the string is encoded.
+    if (input.length > kMaxPaymentUriLength ||
+        utf8.encode(input).length > kMaxPaymentUriLength) {
+      throw const Zip321ParseException('Payment link is too long.');
+    }
     final trimmed = input.trim();
     if (trimmed.isEmpty) {
       throw const Zip321ParseException('Paste a zcash: payment URI.');
@@ -61,13 +80,13 @@ class Zip321PaymentRequest {
         if (!_recognizedParamNames.contains(name)) {
           if (name.startsWith('req-')) {
             throw Zip321ParseException(
-              'Required ZIP-321 parameter $name is not supported.',
+              'Required ZIP-321 parameter ${_echoSafe(name)} is not supported.',
             );
           }
           continue;
         }
         if (!seenKeys.add(seenKey)) {
-          throw Zip321ParseException('Duplicate $name parameter.');
+          throw Zip321ParseException('Duplicate ${_echoSafe(name)} parameter.');
         }
 
         final builder = builders.putIfAbsent(
@@ -165,6 +184,7 @@ const _recognizedParamNames = {
   'memo',
   'req-asset',
 };
+const _maxMemoBase64UrlLength = 684; // ceil(512 / 3) * 4
 
 class Zip321Payment {
   const Zip321Payment({
@@ -195,6 +215,23 @@ class Zip321ParseException implements Exception {
 
   @override
   String toString() => message;
+}
+
+/// A `zcash:` link that parsed cleanly but asks for something Vizor does not
+/// implement yet — see [Zip321PaymentRequest.unsupportedReason].
+///
+/// Separate from [Zip321ParseException] so a surface can tell "we cannot do
+/// this yet" apart from "this link is broken" without matching on the spec
+/// wording of a parse message. Both reasons are for the log; the user-facing
+/// sentence comes from `paymentUriRejectionMessage`.
+class Zip321UnsupportedRequestException implements Exception {
+  const Zip321UnsupportedRequestException(this.reason);
+
+  /// The parser's own wording, for the log. Never shown to the user.
+  final String reason;
+
+  @override
+  String toString() => reason;
 }
 
 class _Zip321PaymentBuilder {
@@ -262,16 +299,82 @@ void _validateBase64Url(String value, String label) {
 
 ({String? text, bool isBinary}) _parseMemo(String value) {
   _validateBase64Url(value, 'memo');
+  if (value.length > _maxMemoBase64UrlLength) {
+    throw const Zip321ParseException('ZIP-321 memo exceeds 512 bytes.');
+  }
   final bytes = _decodeBase64UrlBytes(value, 'memo');
   if (bytes.length > 512) {
     throw const Zip321ParseException('ZIP-321 memo exceeds 512 bytes.');
   }
+  // ZIP-302 memos are a fixed 512-byte field that producers zero-pad on the
+  // right, so a full-width encoding of "Invoice 42" arrives as the text plus
+  // 502 trailing NULs. Drop that padding before decoding; interior NULs stay
+  // in place and are still rejected as unsupported control characters.
+  final unpadded = _stripTrailingMemoPadding(bytes);
   try {
-    return (text: utf8.decode(bytes, allowMalformed: false), isBinary: false);
+    final text = utf8.decode(unpadded, allowMalformed: false);
+    if (_containsUnsupportedMemoText(text)) {
+      throw const Zip321ParseException(
+        'ZIP-321 memo contains unsupported control characters.',
+      );
+    }
+    return (text: text, isBinary: false);
   } on FormatException {
     return (text: null, isBinary: true);
   }
 }
+
+List<int> _stripTrailingMemoPadding(List<int> bytes) {
+  var end = bytes.length;
+  while (end > 0 && bytes[end - 1] == 0x00) {
+    end--;
+  }
+  return end == bytes.length ? bytes : bytes.sublist(0, end);
+}
+
+bool _containsUnsupportedMemoText(String value) =>
+    value.runes.any(_isUnsupportedMemoCodePoint);
+
+/// Whether [text] can travel as a ZIP-321 memo this parser will accept:
+/// no bidi controls, no C0/C1 control characters other than tab, LF and CR.
+///
+/// Producers (the request composer) call this so every artefact the wallet
+/// hands out round-trips through its own parser.
+bool zip321MemoTextIsSupported(String text) =>
+    !_containsUnsupportedMemoText(text);
+
+/// [text] with every code point the parser refuses removed. The characters
+/// dropped are invisible (bidi overrides, control characters), so the visible
+/// message is unchanged.
+String stripUnsupportedZip321MemoText(String text) {
+  if (!_containsUnsupportedMemoText(text)) return text;
+  return String.fromCharCodes(
+    text.runes.where((codePoint) => !_isUnsupportedMemoCodePoint(codePoint)),
+  );
+}
+
+bool _isUnsupportedMemoCodePoint(int codePoint) {
+  if (_bidiControlCodePoints.contains(codePoint)) return true;
+  if (codePoint < 0x20) {
+    return codePoint != 0x09 && codePoint != 0x0A && codePoint != 0x0D;
+  }
+  return codePoint >= 0x7F && codePoint <= 0x9F;
+}
+
+const _bidiControlCodePoints = <int>{
+  0x061C,
+  0x200E,
+  0x200F,
+  0x202A,
+  0x202B,
+  0x202C,
+  0x202D,
+  0x202E,
+  0x2066,
+  0x2067,
+  0x2068,
+  0x2069,
+};
 
 List<int> _decodeBase64UrlBytes(String value, String label) {
   final normalized = value.padRight(
@@ -285,11 +388,17 @@ List<int> _decodeBase64UrlBytes(String value, String label) {
   }
 }
 
+String _echoSafe(String value) => value.length <= _maxEchoedNameLength
+    ? value
+    : '${value.substring(0, _maxEchoedNameLength)}\u2026';
+
 String _decodeQChar(String value, String label) {
   try {
     return Uri.decodeComponent(value);
   } catch (_) {
-    throw Zip321ParseException('Invalid percent encoding in $label.');
+    throw Zip321ParseException(
+      'Invalid percent encoding in ${_echoSafe(label)}.',
+    );
   }
 }
 

--- a/lib/src/core/zcash/zip321_payment_request_builder.dart
+++ b/lib/src/core/zcash/zip321_payment_request_builder.dart
@@ -1,0 +1,197 @@
+/// Builds the `zcash:` payment URIs this wallet hands out when someone
+/// requests an amount from the Receive screen.
+///
+/// This is the write side of [Zip321PaymentRequest], which only parses. Every
+/// URI produced here has to survive `Zip321PaymentRequest.parse` unchanged —
+/// the round-trip is what makes a request link usable by the same wallet that
+/// created it, and it is pinned by the unit tests.
+///
+/// Scope is deliberately narrow: one recipient, an amount, and an optional
+/// text memo. `label` and `message` are never emitted. They would travel to
+/// everyone the link is forwarded to, and the only value the wallet could put
+/// in them is the local account name — a privacy leak with no payer benefit.
+library;
+
+import 'dart:convert';
+import 'zip321_payment_request.dart' show zip321MemoTextIsSupported;
+
+/// ZIP-302 memo field size. A memo is rejected above this, not truncated:
+/// silently cutting a message in half is worse than refusing it.
+const kZip321MaxMemoBytes = 512;
+
+/// Total ZEC supply, the ceiling ZIP-321 puts on an `amount` parameter.
+const kZip321MaxAmountZec = 21000000;
+
+/// Zatoshi per ZEC — the amount is normalized through integers so no
+/// binary-float rounding can reach the emitted string.
+const _zatoshiPerZec = 100000000;
+
+/// Decimal places an `amount` parameter may carry.
+const kZip321MaxAmountDecimals = 8;
+
+/// Why [buildZip321PaymentUri] refused to build a URI.
+///
+/// The caller maps these onto its own copy: the same rejection reads as an
+/// inline field error on the request form and as a thrown bug anywhere else.
+enum Zip321BuildErrorKind {
+  /// Address is empty or is not the base-alphanumeric shape ZIP-321 allows.
+  address,
+
+  /// Amount is empty, not a plain decimal number, or is zero.
+  amountFormat,
+
+  /// Amount carries more than [kZip321MaxAmountDecimals] decimal places.
+  amountDecimals,
+
+  /// Amount is above [kZip321MaxAmountZec].
+  amountSupply,
+
+  /// Memo is longer than [kZip321MaxMemoBytes] when UTF-8 encoded.
+  memoTooLong,
+
+  /// Memo carries a control or bidi character the ZIP-321 parser refuses.
+  memoCharacters,
+
+  /// A memo was supplied for a transparent address, which cannot carry one.
+  memoTransparent,
+}
+
+/// A refusal from [buildZip321PaymentUri], carrying the machine-readable
+/// [kind] beside a plain sentence for logs.
+class Zip321BuildException implements Exception {
+  const Zip321BuildException(this.kind, this.message);
+
+  final Zip321BuildErrorKind kind;
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// True when [address] belongs to the transparent pool.
+///
+/// Matches `Zip321PaymentRequest.parse`, which rejects a memo on any address
+/// starting with `t`, so the builder refuses exactly what the parser refuses.
+bool zip321AddressIsTransparent(String address) => address.startsWith('t');
+
+/// Builds `zcash:<address>?amount=<decimal>[&memo=<base64url>]`.
+///
+/// [amountZec] is a plain decimal string as typed (`'0.50'`, `'1'`,
+/// `'0.00010000'`); it is normalized to its shortest exact form, so `0.50`
+/// becomes `0.5` and `1.00000000` becomes `1`. Exponent notation is not
+/// accepted — it never appears in the amount field and would not round-trip.
+///
+/// [memoText] is omitted when null or blank. Otherwise it is UTF-8 encoded
+/// and written as unpadded base64url, which is the only memo form ZIP-321
+/// defines.
+///
+/// Throws [Zip321BuildException] rather than returning a partial URI: a
+/// half-valid payment link is the one output nobody can use.
+String buildZip321PaymentUri({
+  required String address,
+  required String amountZec,
+  String? memoText,
+}) {
+  final recipient = address.trim();
+  if (recipient.isEmpty || !RegExp(r'^[A-Za-z0-9]+$').hasMatch(recipient)) {
+    throw const Zip321BuildException(
+      Zip321BuildErrorKind.address,
+      'Payment address is not a valid Zcash address.',
+    );
+  }
+
+  final amount = normalizeZip321Amount(amountZec);
+
+  final buffer = StringBuffer('zcash:$recipient?amount=$amount');
+
+  final memo = memoText;
+  if (memo != null && memo.trim().isNotEmpty) {
+    if (zip321AddressIsTransparent(recipient)) {
+      throw const Zip321BuildException(
+        Zip321BuildErrorKind.memoTransparent,
+        'Transparent payments cannot carry a message.',
+      );
+    }
+    buffer.write('&memo=${encodeZip321Memo(memo)}');
+  }
+
+  return buffer.toString();
+}
+
+/// Normalizes a typed ZEC amount to the shortest exact decimal ZIP-321
+/// accepts, or throws [Zip321BuildException].
+///
+/// Exposed separately so a form can validate a keystroke without building a
+/// whole URI, and so the tests can pin the trimming rules on their own.
+String normalizeZip321Amount(String amountZec) {
+  final raw = amountZec.trim();
+  final match = RegExp(r'^([0-9]+)(?:\.([0-9]*))?$').firstMatch(raw);
+  if (match == null) {
+    throw const Zip321BuildException(
+      Zip321BuildErrorKind.amountFormat,
+      'Enter an amount as a plain decimal number.',
+    );
+  }
+
+  final rawFraction = match.group(2) ?? '';
+  if (rawFraction.length > kZip321MaxAmountDecimals) {
+    throw const Zip321BuildException(
+      Zip321BuildErrorKind.amountDecimals,
+      'Enter up to $kZip321MaxAmountDecimals decimals.',
+    );
+  }
+
+  // Integer arithmetic all the way: parsing to double first would let
+  // 0.1 + 0.2 style error into a value someone is asked to pay.
+  final zatoshi =
+      BigInt.parse(match.group(1)!) * BigInt.from(_zatoshiPerZec) +
+      BigInt.parse(rawFraction.padRight(kZip321MaxAmountDecimals, '0'));
+
+  if (zatoshi == BigInt.zero) {
+    throw const Zip321BuildException(
+      Zip321BuildErrorKind.amountFormat,
+      'Enter an amount greater than zero.',
+    );
+  }
+  if (zatoshi >
+      BigInt.from(kZip321MaxAmountZec) * BigInt.from(_zatoshiPerZec)) {
+    throw const Zip321BuildException(
+      Zip321BuildErrorKind.amountSupply,
+      'Amount exceeds the ZEC supply.',
+    );
+  }
+
+  final integerPart = (zatoshi ~/ BigInt.from(_zatoshiPerZec)).toString();
+  final fractionPart = (zatoshi % BigInt.from(_zatoshiPerZec))
+      .toString()
+      .padLeft(kZip321MaxAmountDecimals, '0')
+      .replaceFirst(RegExp(r'0+$'), '');
+
+  return fractionPart.isEmpty ? integerPart : '$integerPart.$fractionPart';
+}
+
+/// UTF-8 encodes [memoText] as the unpadded base64url ZIP-321 specifies.
+///
+/// The limit is measured in bytes, not characters: one emoji is four bytes,
+/// so a 512-character message can be four times over the protocol maximum.
+String encodeZip321Memo(String memoText) {
+  // The parser on the other end of this URI is our own: a memo it would
+  // refuse must not be handed out as a request in the first place.
+  if (!zip321MemoTextIsSupported(memoText)) {
+    throw const Zip321BuildException(
+      Zip321BuildErrorKind.memoCharacters,
+      'Message contains characters a memo cannot carry.',
+    );
+  }
+  final bytes = utf8.encode(memoText);
+  if (bytes.length > kZip321MaxMemoBytes) {
+    throw const Zip321BuildException(
+      Zip321BuildErrorKind.memoTooLong,
+      'Message is longer than $kZip321MaxMemoBytes bytes.',
+    );
+  }
+  return base64Url.encode(bytes).replaceAll('=', '');
+}
+
+/// UTF-8 byte length of [memoText] — what the 512-byte counter shows.
+int zip321MemoByteLength(String memoText) => utf8.encode(memoText).length;

--- a/lib/src/features/address_scan/domain/address_scan_payload.dart
+++ b/lib/src/features/address_scan/domain/address_scan_payload.dart
@@ -25,8 +25,175 @@ String? _zcashAddressFromUri(String raw, Uri uri) {
   try {
     return Zip321PaymentRequest.parse(raw).primaryPayment.address.trim();
   } on Zip321ParseException {
-    return _genericAddressFromUri(uri);
+    // A scan only needs the recipient, so a ZIP-321 request we refuse for an
+    // unrelated reason (an unsupported memo, say) must still surrender its
+    // address.
+    //
+    // But a request the parser refused *because it is ambiguous* has no single
+    // recipient to recover. `zcash:?address.1=u1REAL&address.1=u1ATTACKER` is
+    // the shape that matters: `Uri.queryParameters` keeps the last value, so
+    // recovering here would hand the scan the attacker's address. Refuse
+    // instead, and let the caller surface the failure.
+    if (_hasRepeatedAddressKey(raw, uri)) return null;
+    // `Uri.queryParameters` decodes every name and value, so a hostile escape
+    // (`%FF`) throws out of the read. Recovery fails closed instead: refusing
+    // hands the raw payload back, which downstream validation rejects.
+    final query = _tryQueryParameters(uri);
+    if (query == null) return null;
+    final queryAddress = query['address']?.trim();
+    if (queryAddress != null && queryAddress.isNotEmpty) return queryAddress;
+    final path = _tryDecodeComponent(uri.path).trim();
+    // `zcash://<address>/…` parses with a path of `/`, which is non-empty but
+    // names no recipient. A path made only of separators has to read as empty
+    // so the authority below still gets consulted.
+    if (path.replaceAll('/', '').trim().isNotEmpty) return path;
+    // `zcash://<address>` is not valid ZIP-321 (the parser rejects `//`), but
+    // it is a shape scanners produce. Recover the authority from the raw
+    // string: `uri.host` is lowercased, which corrupts the mixed case of a
+    // transparent or TEX address.
+    return _zcashAuthorityFromRaw(raw) ?? _indexedZcashAddressFromUri(uri);
   }
+}
+
+final _indexedAddressKeyPattern = RegExp(r'^address\.([1-9][0-9]{0,3})$');
+
+/// Every name that reads as an address slot, well formed or not.
+///
+/// Classification is by prefix on purpose: `address.0`, `address.01`,
+/// `address.10000` and `address.1x` all plainly *say* address, so they have to
+/// be counted even though [_indexedAddressKeyPattern] — and the parser — refuse
+/// them.
+final _addressKeyPattern = RegExp(r'^address(\..*)?$');
+
+/// Whether the payload names an `address` or `address.N` slot more than once.
+///
+/// The query is read off the raw string rather than `Uri.queryParameters`,
+/// which has already collapsed the repeats this looks for — but the names are
+/// compared *decoded*, the way `Uri.queryParameters` will read them: ZIP-321
+/// forbids percent-encoded names, so `%61ddress` is refused by the parser and
+/// lands here, where it must count as a second `address`, not a stranger. A
+/// name that cannot be decoded is compared as written; it cannot alias
+/// `address`.
+///
+/// Three shapes beyond the plain repeat count as ambiguous:
+///
+///  * The *positional* address (`zcash:<addr>…`, or the `zcash://<addr>`
+///    authority scanners produce) is the address of paramindex 0 — the same
+///    slot a bare `address=` names. `zcash:u1REAL?address=u1ATTACKER` is
+///    therefore a repeat, and recovering the query value would hand the scan
+///    the appended address instead of the one the payload plainly reads as.
+///  * A percent-encoded address key beside *any* other address key. The
+///    encoded name can never be a legitimate paramindex-0 payment, so
+///    `%61ddress` next to `address.1` has no single recipient either.
+///  * An address key whose paramindex the parser can never accept —
+///    `address.0`, `address.01`, `address.10000`, `address.1x`. Such a key owns
+///    no slot at all, so it can only add a competing recipient to whichever
+///    well-formed key recovery would otherwise read. Classifying address keys
+///    by validity instead of by prefix would let it slip past both the repeat
+///    check and the encoded-key flag.
+bool _hasRepeatedAddressKey(String raw, Uri uri) {
+  final seen = <String>{};
+  final positional = uri.path.trim().isNotEmpty
+      ? uri.path
+      : _zcashAuthorityFromRaw(raw);
+  if (positional != null && positional.trim().isNotEmpty) {
+    seen.add('address');
+  }
+
+  final queryStart = raw.indexOf('?');
+  if (queryStart == -1) return false;
+  var query = raw.substring(queryStart + 1);
+  final fragmentStart = query.indexOf('#');
+  if (fragmentStart != -1) query = query.substring(0, fragmentStart);
+
+  var sawEncodedAddressKey = false;
+  for (final param in query.split('&')) {
+    if (param.isEmpty) continue;
+    final separator = param.indexOf('=');
+    final rawName = separator == -1 ? param : param.substring(0, separator);
+    final name = _decodedQueryName(rawName);
+    if (!_addressKeyPattern.hasMatch(name)) continue;
+    if (rawName != name) sawEncodedAddressKey = true;
+    if (name != 'address' && !_indexedAddressKeyPattern.hasMatch(name)) {
+      return true;
+    }
+    if (!seen.add(name)) return true;
+  }
+  return sawEncodedAddressKey && seen.length > 1;
+}
+
+String _decodedQueryName(String rawName) {
+  try {
+    return Uri.decodeQueryComponent(rawName);
+  } on ArgumentError {
+    return rawName;
+  } on FormatException {
+    return rawName;
+  }
+}
+
+/// [uri]'s decoded query, or null when a percent-escape in a name or a value
+/// cannot be decoded. `Uri.queryParameters` throws in that case, and a scanned
+/// payload must never turn into an exception escaping the scan callback.
+Map<String, String>? _tryQueryParameters(Uri uri) {
+  try {
+    return uri.queryParameters;
+  } on ArgumentError {
+    return null;
+  } on FormatException {
+    return null;
+  }
+}
+
+/// The authority of a `zcash://<authority>...` string, exactly as written.
+String? _zcashAuthorityFromRaw(String raw) {
+  const prefix = 'zcash://';
+  if (raw.length <= prefix.length) return null;
+  if (raw.substring(0, prefix.length).toLowerCase() != prefix) return null;
+
+  final rest = raw.substring(prefix.length);
+  var end = rest.length;
+  for (final index in [
+    rest.indexOf('?'),
+    rest.indexOf('/'),
+    rest.indexOf('#'),
+  ]) {
+    if (index != -1 && index < end) end = index;
+  }
+  final authority = rest.substring(0, end);
+  if (authority.isEmpty) return null;
+  final decoded = _tryDecodeComponent(authority).trim();
+  return decoded.isEmpty ? null : decoded;
+}
+
+String _tryDecodeComponent(String value) {
+  try {
+    return Uri.decodeComponent(value);
+  } on ArgumentError {
+    return value;
+  } on FormatException {
+    return value;
+  }
+}
+
+String? _indexedZcashAddressFromUri(Uri uri) {
+  final query = _tryQueryParameters(uri);
+  if (query == null) return null;
+
+  int? lowestIndex;
+  String? lowestAddress;
+  for (final entry in query.entries) {
+    final match = _indexedAddressKeyPattern.firstMatch(entry.key);
+    if (match == null) continue;
+    final address = entry.value.trim();
+    if (address.isEmpty) continue;
+    final index = int.parse(match.group(1)!);
+    if (lowestIndex == null || index < lowestIndex) {
+      lowestIndex = index;
+      lowestAddress = address;
+    }
+  }
+  return lowestAddress;
 }
 
 String? _ethereumAddressFromUri(Uri uri) {

--- a/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
@@ -8,16 +8,13 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/layout/mobile/app_mobile_sheet.dart';
-import '../../../core/navigation/payment_uri_unlock_claim.dart';
 import '../../../core/feedback/app_haptics.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
-import '../../../core/widgets/app_toast.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
 import '../../../providers/biometric_unlock_provider.dart';
 import '../../../providers/device_owner_auth_provider.dart';
-import '../../../providers/payment_request_flow_provider.dart';
 import '../../../providers/router_refresh_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../services/biometric_unlock.dart';
@@ -216,36 +213,13 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
         await syncNotifier.refreshAfterUnlock();
         await syncNotifier.startSyncAnyway();
         if (!mounted) return;
-        // Claim the payment-URI prefill (parked while locked) only now, after
-        // the post-unlock work has succeeded. Claiming earlier would drop the
-        // payment if any of the awaits above threw or this screen unmounted —
-        // the prefill would already be cleared with no way to recover it —
-        // and the drain policy inside the claim reads state those awaits
-        // settle.
-        final claimed = claimParkedPaymentUriAfterUnlock(ref);
+        // No payment-URI claim here yet. The surface that presents a claimed
+        // link — the payment request card and its host — arrives in the next
+        // PR of this stack, and claiming without one would clear the park to
+        // present nothing. The link stays parked instead: `/home` re-runs the
+        // app-level drain, which still says whatever the policy has to say
+        // about a link this wallet cannot open.
         context.go('/home');
-        final pendingPrefill = claimed.prefill;
-        final notice = claimed.notice;
-        if (pendingPrefill != null) {
-          // The link becomes a card over the wallet the user just unlocked,
-          // not a jump into the composer.
-          ref
-              .read(paymentRequestFlowProvider.notifier)
-              .present(pendingPrefill, source: PaymentRequestSource.link);
-        } else if (notice != null) {
-          // The link outlived its park window while the user was finding their
-          // passcode, or the wallet it landed on cannot open it. Landing with
-          // no card and no word is the one silent loss of something the user
-          // deliberately asked for. The toast is asked for before this screen
-          // is torn down; `showAppToast` renders it on the app-level host,
-          // which outlives the navigation.
-          showAppToast(
-            context,
-            notice,
-            duration: const Duration(seconds: 4),
-            iconName: AppIcons.warning,
-          );
-        }
       });
     } catch (e, st) {
       log('MobileUnlockScreen._submit: ERROR: $e\n$st');

--- a/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
@@ -8,13 +8,16 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../core/navigation/payment_uri_unlock_claim.dart';
 import '../../../core/feedback/app_haptics.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_toast.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
 import '../../../providers/biometric_unlock_provider.dart';
 import '../../../providers/device_owner_auth_provider.dart';
+import '../../../providers/payment_request_flow_provider.dart';
 import '../../../providers/router_refresh_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../services/biometric_unlock.dart';
@@ -213,7 +216,36 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
         await syncNotifier.refreshAfterUnlock();
         await syncNotifier.startSyncAnyway();
         if (!mounted) return;
+        // Claim the payment-URI prefill (parked while locked) only now, after
+        // the post-unlock work has succeeded. Claiming earlier would drop the
+        // payment if any of the awaits above threw or this screen unmounted —
+        // the prefill would already be cleared with no way to recover it —
+        // and the drain policy inside the claim reads state those awaits
+        // settle.
+        final claimed = claimParkedPaymentUriAfterUnlock(ref);
         context.go('/home');
+        final pendingPrefill = claimed.prefill;
+        final notice = claimed.notice;
+        if (pendingPrefill != null) {
+          // The link becomes a card over the wallet the user just unlocked,
+          // not a jump into the composer.
+          ref
+              .read(paymentRequestFlowProvider.notifier)
+              .present(pendingPrefill, source: PaymentRequestSource.link);
+        } else if (notice != null) {
+          // The link outlived its park window while the user was finding their
+          // passcode, or the wallet it landed on cannot open it. Landing with
+          // no card and no word is the one silent loss of something the user
+          // deliberately asked for. The toast is asked for before this screen
+          // is torn down; `showAppToast` renders it on the app-level host,
+          // which outlives the navigation.
+          showAppToast(
+            context,
+            notice,
+            duration: const Duration(seconds: 4),
+            iconName: AppIcons.warning,
+          );
+        }
       });
     } catch (e, st) {
       log('MobileUnlockScreen._submit: ERROR: $e\n$st');

--- a/lib/src/features/onboarding/unlock_screen.dart
+++ b/lib/src/features/onboarding/unlock_screen.dart
@@ -4,17 +4,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../main.dart' show log;
-import '../../core/navigation/payment_uri_unlock_claim.dart';
 import '../../core/security/password_policy.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/widgets/app_button.dart';
-import '../../core/widgets/app_icon.dart';
 import '../../core/widgets/app_text_field.dart';
-import '../../core/widgets/app_toast.dart';
 import '../../core/widgets/password_text_field.dart';
 import '../../providers/account_provider.dart';
 import '../../providers/app_security_provider.dart';
-import '../../providers/payment_request_flow_provider.dart';
 import '../../providers/router_refresh_provider.dart';
 import '../../providers/sync_provider.dart';
 import 'shared/onboarding_auth_shell.dart';
@@ -75,39 +71,17 @@ class _UnlockScreenState extends ConsumerState<UnlockScreen> {
         await syncNotifier.refreshAfterUnlock();
         await syncNotifier.startSyncAnyway();
         if (!mounted) return;
-        // Claim the payment-URI prefill (parked while locked) only now, after
-        // the post-unlock work has succeeded. Claiming earlier would drop the
-        // payment if any of the awaits above threw or this screen unmounted —
-        // the prefill would already be cleared with no way to recover it —
-        // and the drain policy inside the claim reads state those awaits
-        // settle.
-        final claimed = claimParkedPaymentUriAfterUnlock(ref);
+        // No payment-URI claim here yet. The surface that presents a claimed
+        // link — the payment request card and its host — arrives in the next
+        // PR of this stack, and claiming without one would clear the park to
+        // present nothing. The link stays parked instead: `/home` re-runs the
+        // app-level drain, which still says whatever the policy has to say
+        // about a link this wallet cannot open.
+        //
         // Desktop has no Gift Card branch here: the desktop runners never
         // register the HTTPS deeplink, so `/payment-links` is only ever
         // reached from inside the app.
         context.go('/home');
-        final pendingPrefill = claimed.prefill;
-        final notice = claimed.notice;
-        if (pendingPrefill != null) {
-          // The link becomes a card over the wallet the user just unlocked,
-          // not a jump into the composer.
-          ref
-              .read(paymentRequestFlowProvider.notifier)
-              .present(pendingPrefill, source: PaymentRequestSource.link);
-        } else if (notice != null) {
-          // The link outlived its park window while the user was finding their
-          // password, or the wallet it landed on cannot open it. Landing on
-          // /home with no card and no word is the one silent loss of something
-          // the user deliberately asked for. The toast is asked for before this
-          // screen is torn down; `showAppToast` renders it on the app-level
-          // host, which outlives the navigation.
-          showAppToast(
-            context,
-            notice,
-            duration: const Duration(seconds: 4),
-            iconName: AppIcons.warning,
-          );
-        }
       });
     } catch (e, st) {
       log('UnlockScreen._submit: ERROR: $e\n$st');

--- a/lib/src/features/onboarding/unlock_screen.dart
+++ b/lib/src/features/onboarding/unlock_screen.dart
@@ -4,13 +4,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../main.dart' show log;
+import '../../core/navigation/payment_uri_unlock_claim.dart';
 import '../../core/security/password_policy.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/widgets/app_button.dart';
+import '../../core/widgets/app_icon.dart';
 import '../../core/widgets/app_text_field.dart';
+import '../../core/widgets/app_toast.dart';
 import '../../core/widgets/password_text_field.dart';
 import '../../providers/account_provider.dart';
 import '../../providers/app_security_provider.dart';
+import '../../providers/payment_request_flow_provider.dart';
 import '../../providers/router_refresh_provider.dart';
 import '../../providers/sync_provider.dart';
 import 'shared/onboarding_auth_shell.dart';
@@ -71,7 +75,39 @@ class _UnlockScreenState extends ConsumerState<UnlockScreen> {
         await syncNotifier.refreshAfterUnlock();
         await syncNotifier.startSyncAnyway();
         if (!mounted) return;
+        // Claim the payment-URI prefill (parked while locked) only now, after
+        // the post-unlock work has succeeded. Claiming earlier would drop the
+        // payment if any of the awaits above threw or this screen unmounted —
+        // the prefill would already be cleared with no way to recover it —
+        // and the drain policy inside the claim reads state those awaits
+        // settle.
+        final claimed = claimParkedPaymentUriAfterUnlock(ref);
+        // Desktop has no Gift Card branch here: the desktop runners never
+        // register the HTTPS deeplink, so `/payment-links` is only ever
+        // reached from inside the app.
         context.go('/home');
+        final pendingPrefill = claimed.prefill;
+        final notice = claimed.notice;
+        if (pendingPrefill != null) {
+          // The link becomes a card over the wallet the user just unlocked,
+          // not a jump into the composer.
+          ref
+              .read(paymentRequestFlowProvider.notifier)
+              .present(pendingPrefill, source: PaymentRequestSource.link);
+        } else if (notice != null) {
+          // The link outlived its park window while the user was finding their
+          // password, or the wallet it landed on cannot open it. Landing on
+          // /home with no card and no word is the one silent loss of something
+          // the user deliberately asked for. The toast is asked for before this
+          // screen is torn down; `showAppToast` renders it on the app-level
+          // host, which outlives the navigation.
+          showAppToast(
+            context,
+            notice,
+            duration: const Duration(seconds: 4),
+            iconName: AppIcons.warning,
+          );
+        }
       });
     } catch (e, st) {
       log('UnlockScreen._submit: ERROR: $e\n$st');

--- a/lib/src/features/send/models/send_prefill_args.dart
+++ b/lib/src/features/send/models/send_prefill_args.dart
@@ -28,6 +28,23 @@ class SendPrefillArgs {
 
   String get fingerprint =>
       '$id|$address|${amountText ?? ''}|${memoText ?? ''}|$preserveMemoText';
+
+  /// The memo bytes a send built from this prefill will actually pay, or null
+  /// when it will pay none.
+  ///
+  /// [memoText] is what the request carried; this is what survives
+  /// [preserveMemoText]. One owner, because two of them read it: the
+  /// pre-check proposes exactly these bytes, and the payment-request card
+  /// displays exactly these bytes. A trim on one side and not the other would
+  /// show the payer a memo the transaction does not pay.
+  ///
+  /// Whitespace-only survives when the request said to preserve it: those are
+  /// real bytes the payment carries, so they are a memo, not an absence. The
+  /// card is what has to make them visible.
+  String? get outgoingMemoText {
+    final raw = preserveMemoText ? memoText : memoText?.trim();
+    return (raw == null || raw.isEmpty) ? null : raw;
+  }
 }
 
 SendPrefillArgs sendPrefillArgsFromZip321Payment({

--- a/lib/src/features/send/models/send_prefill_args.dart
+++ b/lib/src/features/send/models/send_prefill_args.dart
@@ -1,3 +1,10 @@
+import '../../../core/zcash/zip321_payment_request.dart';
+
+/// [SendPrefillArgs.source] for a prefill that came from a ZIP-321 payment
+/// request (a `zcash:` link today, an in-app QR scan later). The send flow
+/// reads it to keep the payment-request framing on the review screen.
+const kPaymentUriPrefillSource = 'zcash-uri';
+
 class SendPrefillArgs {
   const SendPrefillArgs({
     required this.id,
@@ -5,6 +12,7 @@ class SendPrefillArgs {
     required this.address,
     this.amountText,
     this.memoText,
+    this.preserveMemoText = false,
     this.label,
     this.message,
   });
@@ -14,9 +22,32 @@ class SendPrefillArgs {
   final String address;
   final String? amountText;
   final String? memoText;
+  final bool preserveMemoText;
   final String? label;
   final String? message;
 
   String get fingerprint =>
-      '$id|$address|${amountText ?? ''}|${memoText ?? ''}';
+      '$id|$address|${amountText ?? ''}|${memoText ?? ''}|$preserveMemoText';
+}
+
+SendPrefillArgs sendPrefillArgsFromZip321Payment({
+  required String id,
+  required Zip321Payment payment,
+}) {
+  final message = payment.message;
+  return SendPrefillArgs(
+    id: id,
+    source: kPaymentUriPrefillSource,
+    address: payment.address,
+    amountText: payment.amount,
+    memoText: payment.memoText,
+    preserveMemoText: payment.memoText != null,
+    label: payment.label,
+    // The parser screens `memo` for characters that can restyle the text
+    // around them, but not `label` or `message`. The label is stripped where
+    // it is sanitised; the message reaches the payment-request card with no
+    // collapse and no clamp at all, so it is stripped here, at the boundary
+    // where an untrusted request turns into something the wallet renders.
+    message: message == null ? null : stripUnsupportedZip321MemoText(message),
+  );
 }

--- a/lib/src/features/send/models/send_scan_result.dart
+++ b/lib/src/features/send/models/send_scan_result.dart
@@ -1,0 +1,177 @@
+/// What a scan taken from inside the send flow turned out to be.
+///
+/// A camera has no idea what it is pointed at. Most of the time it is a bare
+/// address and the composer just fills its recipient field. But a ZIP-321 QR
+/// that asks for anything beyond the address — an amount, a memo, a label, a
+/// message — is the same object a `zcash:` link is, and answering it in the
+/// send composer would throw away the framing the payment request card exists
+/// to give it. So the send scanners classify first and let the caller route:
+/// an address goes in the field, a request goes to the card.
+///
+/// Only the send-context scanners do this. Address book, swap and pay scan for
+/// a destination, not for a payment to answer, so they stay address-only.
+library;
+
+import '../../../core/formatting/zec_amount.dart';
+import '../../../core/zcash/zip321_payment_request.dart';
+import '../../address_scan/domain/address_scan_payload.dart';
+import 'send_prefill_args.dart';
+
+/// A scan the send flow accepted.
+sealed class SendScanResult {
+  const SendScanResult();
+}
+
+/// Why a scanned ZIP-321 request came back as a bare recipient instead of a
+/// request the card could answer.
+///
+/// A QR the parser refuses still surrenders its address, and the scan then
+/// accepts that address on its own. That is the right recovery — the payer can
+/// still pay — but it is not what they scanned, so the scanner names what was
+/// left behind.
+enum SendScanDowngrade {
+  /// The request asked to pay more than one recipient. Only the first was
+  /// taken; the others, and every amount, were dropped.
+  multipleRecipients,
+
+  /// The request carries a memo Vizor cannot read (binary, not text), so the
+  /// reconciliation data the memo existed for is gone.
+  unsupportedMemo,
+
+  /// The request could not be read at all — bad encoding, a malformed amount,
+  /// terms Vizor has no way to honour. Only the address survived.
+  malformedRequest,
+}
+
+/// The one line the scanner shows for [downgrade], or null when nothing was
+/// lost (a plain address QR, or a request whose address is all it asked for).
+String? sendScanDowngradeMessage(SendScanDowngrade? downgrade) =>
+    switch (downgrade) {
+      SendScanDowngrade.multipleRecipients =>
+        'Scanned the first recipient only — this request asks for more '
+            'than one',
+      SendScanDowngrade.unsupportedMemo =>
+        "Scanned the address only — the request's message couldn't be "
+            'read',
+      SendScanDowngrade.malformedRequest =>
+        "Scanned the address only — the payment request couldn't be read",
+      null => null,
+    };
+
+/// A recipient and nothing else — today's behaviour, unchanged.
+class SendScanAddress extends SendScanResult {
+  const SendScanAddress(this.address, {this.downgrade});
+
+  final String address;
+
+  /// Set when this address is what is left of a payment request the scan could
+  /// not answer. Null for a plain address QR: nothing was lost, so the scanner
+  /// says nothing.
+  final SendScanDowngrade? downgrade;
+}
+
+/// A ZIP-321 request carrying an amount, ready for the payment-request card.
+class SendScanPaymentRequest extends SendScanResult {
+  const SendScanPaymentRequest(this.prefill);
+
+  final SendPrefillArgs prefill;
+}
+
+/// Makes each scanned request its own prefill, so a second scan of the same QR
+/// is a new request rather than one the card can mistake for the parked one.
+int _scanSequence = 0;
+
+/// Classifies a raw scanned payload for a send-context scanner.
+///
+/// [acceptedAddress] is the address the scanner already normalized and
+/// validated; passing it keeps the recipient the scanner said yes to rather
+/// than re-deriving a possibly different one here.
+///
+/// Returns null when the payload yields no address at all.
+SendScanResult? resolveSendScanPayload(String raw, {String? acceptedAddress}) {
+  final resolved = _resolveZip321(raw);
+  final payment = resolved.payment;
+  if (payment != null) {
+    return SendScanPaymentRequest(
+      sendPrefillArgsFromZip321Payment(
+        id: 'payment-qr-${++_scanSequence}',
+        payment: payment,
+      ),
+    );
+  }
+
+  final address = (acceptedAddress ?? normalizeAddressScanPayload(raw))?.trim();
+  if (address == null || address.isEmpty) return null;
+  return SendScanAddress(address, downgrade: resolved.downgrade);
+}
+
+/// The single payment of a supported ZIP-321 request that asked for anything
+/// beyond an address, or why the payload could not become one.
+///
+/// Everything without a payment falls through to the address-only path the
+/// scanners already had. What changed is that the reasons are no longer all
+/// the same silence: a request we refuse loses terms the payer scanned, while
+/// a bare address loses nothing the composer does not ask for anyway.
+({Zip321Payment? payment, SendScanDowngrade? downgrade}) _resolveZip321(
+  String raw,
+) {
+  final Zip321PaymentRequest request;
+  try {
+    request = Zip321PaymentRequest.parse(raw);
+  } on Zip321ParseException {
+    // Only a `zcash:` payload had terms to lose. A bare address, or another
+    // chain's URI, was never a payment request.
+    return (
+      payment: null,
+      downgrade: _isZcashUri(raw) ? SendScanDowngrade.malformedRequest : null,
+    );
+  }
+  if (!request.isSupported) {
+    return (payment: null, downgrade: _refusedRequestDowngrade(request));
+  }
+
+  final payment = request.primaryPayment;
+  final amount = parseZecAmount(payment.amount?.trim() ?? '');
+  final hasAmount = amount != null && amount > BigInt.zero;
+  if (!hasAmount && !_carriesTermsBeyondAddress(payment)) {
+    // A request that asked only to be paid at an address has nothing the card
+    // can present that the composer does not present better, and its address
+    // is exactly what it asked for. Nothing to report.
+    return (payment: null, downgrade: null);
+  }
+  return (payment: payment, downgrade: null);
+}
+
+/// Whether the request carries terms the composer would silently drop.
+///
+/// The amount is not the only thing a request can ask for. A merchant's
+/// "pay what you want" QR carries the invoice id in the memo — in shielded
+/// Zcash the memo is the only channel that reconciliation data has — and a
+/// `label` or `message` is consent copy the payer is entitled to read. The
+/// `zcash:` link path for the identical URI keeps all three: an amount-less
+/// request reaches the card as ready, the memo bytes are preserved exactly and
+/// the composer collects only the amount. Collapsing to address-only here
+/// discarded them with no downgrade notice, so the same QR meant two different
+/// things depending on whether it was scanned or tapped.
+bool _carriesTermsBeyondAddress(Zip321Payment payment) =>
+    _isNotBlank(payment.memoBase64Url) ||
+    _isNotBlank(payment.memoText) ||
+    _isNotBlank(payment.label) ||
+    _isNotBlank(payment.message);
+
+bool _isNotBlank(String? value) => value != null && value.trim().isNotEmpty;
+
+/// Why a parsed-but-refused request is a downgrade.
+///
+/// A custom-asset request is neither of the two named cases — it is readable
+/// and single-recipient, Vizor just cannot pay in that asset — so it lands in
+/// the catch-all rather than claiming its memo was unreadable.
+SendScanDowngrade _refusedRequestDowngrade(Zip321PaymentRequest request) {
+  if (request.payments.length > 1) return SendScanDowngrade.multipleRecipients;
+  if (request.payments.any((payment) => payment.memoIsBinary)) {
+    return SendScanDowngrade.unsupportedMemo;
+  }
+  return SendScanDowngrade.malformedRequest;
+}
+
+bool _isZcashUri(String raw) => raw.trim().toLowerCase().startsWith('zcash:');

--- a/lib/src/features/send/screens/mobile/mobile_send_scan_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_scan_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
-import '../../../../core/config/network_config.dart';
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../address_scan/domain/address_scan_payload.dart';
@@ -12,8 +11,14 @@ import '../../../address_scan/widgets/mobile_address_scan_view.dart'
 /// Presents the mobile send scanner over the current send screen — Figma
 /// `QR Scan` (4484:61584): a card-contained back camera scanner over the
 /// dimmed app. Pops the scanned Zcash address string on success.
+///
+/// [networkName] is the wallet's active network, which the caller reads from
+/// `rpcEndpointProvider`. It is required rather than defaulted because the
+/// build constant is only right for a wallet that never moved off it, and a
+/// scanned address is refused outright when it belongs to another network.
 Future<String?> showMobileSendScanSheet(
   BuildContext context, {
+  required String networkName,
   MobileScannerController? controller,
   MobileScanResolver? resolve,
 }) {
@@ -21,21 +26,29 @@ Future<String?> showMobileSendScanSheet(
     context: context,
     builder: (sheetContext) => MobileAddressScanCard(
       controller: controller,
-      resolve: resolve ?? _resolveZcashAddress,
+      resolve:
+          resolve ??
+          (raw) => _resolveZcashAddress(raw, networkName: networkName),
       onScanned: (address) => Navigator.of(sheetContext).pop(address),
       onClose: () => Navigator.of(sheetContext).pop(),
     ),
   );
 }
 
-Future<MobileScanOutcome> _resolveZcashAddress(String raw) async {
+Future<MobileScanOutcome> _resolveZcashAddress(
+  String raw, {
+  required String networkName,
+}) async {
   final address = normalizeAddressScanPayload(raw);
   if (address == null || address.isEmpty) {
     return const MobileScanOutcome.rejected(
       "This QR code isn't a Zcash address.",
     );
   }
-  final result = await rust_sync.validateAddress(address: address, network: kZcashDefaultNetworkName);
+  final result = await rust_sync.validateAddress(
+    address: address,
+    network: networkName,
+  );
   if (result.isValid) return MobileScanOutcome.accepted(address);
   return const MobileScanOutcome.rejected(
     "This QR code isn't a Zcash address.",

--- a/lib/src/features/send/screens/mobile/mobile_send_scan_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_scan_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
+import '../../../../core/config/network_config.dart';
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../address_scan/domain/address_scan_payload.dart';
@@ -34,7 +35,7 @@ Future<MobileScanOutcome> _resolveZcashAddress(String raw) async {
       "This QR code isn't a Zcash address.",
     );
   }
-  final result = await rust_sync.validateAddress(address: address);
+  final result = await rust_sync.validateAddress(address: address, network: kZcashDefaultNetworkName);
   if (result.isValid) return MobileScanOutcome.accepted(address);
   return const MobileScanOutcome.rejected(
     "This QR code isn't a Zcash address.",

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../../main.dart' show log;
+import '../../../../core/config/network_config.dart';
 import '../../../../core/formatting/zec_amount.dart';
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
@@ -104,6 +105,7 @@ class _ReviewRecipientPresentation {
 typedef MobileSendAddressValidator =
     Future<rust_sync.AddressValidationResult> Function({
       required String address,
+      required String network,
     });
 
 typedef MobileSendFeeEstimator =
@@ -527,6 +529,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       final result =
           await (widget.validateAddress ?? rust_sync.validateAddress)(
             address: address,
+            network: kZcashDefaultNetworkName,
           );
       if (!mounted || seq != _addressSeq) return;
       setState(

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -10,7 +10,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../../main.dart' show log;
-import '../../../../core/config/network_config.dart';
 import '../../../../core/formatting/zec_amount.dart';
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
@@ -118,7 +117,13 @@ typedef MobileSendFeeEstimator =
       String? memo,
     });
 
-typedef MobileSendScanner = Future<String?> Function(BuildContext context);
+/// [networkName] is the network the wallet is actually on, not the build
+/// default: the scanner refuses an address that does not belong to it.
+typedef MobileSendScanner =
+    Future<String?> Function(
+      BuildContext context, {
+      required String networkName,
+    });
 
 class _MobileSendMaxQuote {
   const _MobileSendMaxQuote({
@@ -529,7 +534,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       final result =
           await (widget.validateAddress ?? rust_sync.validateAddress)(
             address: address,
-            network: kZcashDefaultNetworkName,
+            network: ref.read(rpcEndpointProvider).networkName,
           );
       if (!mounted || seq != _addressSeq) return;
       setState(
@@ -571,7 +576,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   }
 
   Future<void> _openScanner() async {
-    final scanned = await widget.openScanner(context);
+    final scanned = await widget.openScanner(
+      context,
+      networkName: ref.read(rpcEndpointProvider).networkName,
+    );
     if (scanned == null || scanned.trim().isEmpty || !mounted) return;
     _addressController.value = TextEditingValue(
       text: scanned.trim(),

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -350,7 +350,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       return;
     }
     try {
-      final result = await rust_sync.validateAddress(address: addr);
+      final result = await rust_sync.validateAddress(address: addr, network: kZcashDefaultNetworkName);
       if (!mounted || seq != _addressSeq) return;
       final nextAddressType = result.isValid ? result.addressType : 'invalid';
       setState(() {

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -350,7 +350,10 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       return;
     }
     try {
-      final result = await rust_sync.validateAddress(address: addr, network: kZcashDefaultNetworkName);
+      final result = await rust_sync.validateAddress(
+        address: addr,
+        network: ref.read(rpcEndpointProvider).networkName,
+      );
       if (!mounted || seq != _addressSeq) return;
       final nextAddressType = result.isValid ? result.addressType : 'invalid';
       setState(() {

--- a/lib/src/features/send/services/payment_request_precheck.dart
+++ b/lib/src/features/send/services/payment_request_precheck.dart
@@ -247,7 +247,9 @@ class PaymentRequestPrecheck {
     // through untouched when the prefill says to preserve it — the compose
     // form does the same through `preserveMemoText`, and the two paths have
     // to put identical bytes on chain or "Review" and "Edit then review"
-    // become different payments.
+    // become different payments. `outgoingMemoText` is the single owner of
+    // that rule, and the payment-request card renders the same getter, so
+    // what the payer reads and what this proposal pays cannot drift apart.
     //
     // Nothing here drops a memo for a transparent-like recipient. Every
     // request that reaches this service — link or scanned QR — was built by
@@ -256,9 +258,7 @@ class PaymentRequestPrecheck {
     // the link is invalid before a card exists. One owner for that rule; a
     // second, silent one here would only ever describe a request the parser
     // already refused.
-    final memo = prefill.preserveMemoText
-        ? prefill.memoText
-        : prefill.memoText?.trim();
+    final memo = prefill.outgoingMemoText;
 
     final amountText = prefill.amountText?.trim();
     if (amountText == null || amountText.isEmpty) {
@@ -318,7 +318,7 @@ class PaymentRequestPrecheck {
         address: address,
         addressType: addressType,
         amountZatoshi: amountZatoshi,
-        memo: (memo != null && memo.isNotEmpty) ? memo : null,
+        memo: memo,
         isPaymentRequest: true,
         requestedBy: prefill.label,
         requestedAmountZatoshi: amountZatoshi,

--- a/lib/src/features/send/services/payment_request_precheck.dart
+++ b/lib/src/features/send/services/payment_request_precheck.dart
@@ -17,7 +17,6 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
-import '../../../core/config/network_config.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/migration_send_gate_provider.dart'
@@ -34,6 +33,17 @@ typedef PaymentRequestValidateAddress =
       required String address,
       required String network,
     });
+
+/// The network name the wallet is actually talking to, read at the moment of
+/// the check.
+///
+/// Not the compiled-in default: the endpoint — and with it the network — is
+/// persisted, and bootstrap, sync and proposal creation all read the stored
+/// one. Validating against the build constant instead would tell a wallet
+/// running on another network that every perfectly good address in its own
+/// links belongs to the wrong one. Kept lazy for the same reason
+/// [proposeSendTransferWith]'s `readEndpoint` is: the card outlives the read.
+typedef PaymentRequestReadNetworkName = String Function();
 
 /// Creates the proposal. Matches the shape of [proposeSendTransferWith] minus
 /// the provider reader, which the service does not have.
@@ -177,6 +187,7 @@ final class PaymentRequestPrecheckFailed extends PaymentRequestPrecheckResult {
 class PaymentRequestPrecheck {
   const PaymentRequestPrecheck({
     required this.validateAddress,
+    required this.readNetworkName,
     required this.proposeTransfer,
     required this.discardProposal,
     required this.spendableIsAuthoritativeNow,
@@ -184,6 +195,12 @@ class PaymentRequestPrecheck {
   });
 
   final PaymentRequestValidateAddress validateAddress;
+
+  /// Which network [validateAddress] is asked about. Required, with no
+  /// default: the build constant is the wrong answer for any wallet whose
+  /// stored endpoint moved off it, and a silent default is how it got used.
+  final PaymentRequestReadNetworkName readNetworkName;
+
   final PaymentRequestProposeTransfer proposeTransfer;
   final PaymentRequestDiscardProposal discardProposal;
 
@@ -222,7 +239,7 @@ class PaymentRequestPrecheck {
     try {
       final validation = await validateAddress(
         address: address,
-        network: kZcashDefaultNetworkName,
+        network: readNetworkName(),
       );
       if (!validation.isValid) {
         // A well-formed address for another network is still unpayable, but
@@ -405,6 +422,9 @@ BigInt paymentRequestSpendableOf(
 final paymentRequestPrecheckProvider = Provider<PaymentRequestPrecheck>((ref) {
   return PaymentRequestPrecheck(
     validateAddress: rust_sync.validateAddress,
+    // The same endpoint the proposal below is made against, so a link can
+    // never be refused for a network the wallet is not on.
+    readNetworkName: () => ref.read(rpcEndpointProvider).networkName,
     discardProposal: discardSendProposal,
     // The same predicate the card's own read and its sync watch use, scoped
     // to the active account: an unscoped read answers with the wallet-wide

--- a/lib/src/features/send/services/payment_request_precheck.dart
+++ b/lib/src/features/send/services/payment_request_precheck.dart
@@ -19,6 +19,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../main.dart' show log;
 import '../../../core/config/network_config.dart';
 import '../../../core/formatting/zec_amount.dart';
+import '../../../providers/account_provider.dart';
+import '../../../providers/migration_send_gate_provider.dart'
+    show migrationSendGateProvider;
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
@@ -55,6 +58,15 @@ typedef PaymentRequestProposeTransfer =
 /// at the moment a shortfall would be published — before the proposal goes
 /// out and after it comes back.
 typedef PaymentRequestSpendableIsAuthoritativeNow = bool Function();
+
+/// The account's spendable balance *right now*, in zatoshi.
+///
+/// The figure a shortfall quotes has to come from the same moment as the
+/// [PaymentRequestSpendableIsAuthoritativeNow] read that allowed it: the
+/// balance the check was handed is older than every await it has taken since,
+/// and the propose path in particular blocks until the wallet has an
+/// authoritative spendable, which is exactly when the number moves.
+typedef PaymentRequestSpendableBalanceNow = BigInt Function();
 
 /// Releases a proposal. Matches [discardSendProposal].
 typedef PaymentRequestDiscardProposal =
@@ -168,6 +180,7 @@ class PaymentRequestPrecheck {
     required this.proposeTransfer,
     required this.discardProposal,
     required this.spendableIsAuthoritativeNow,
+    required this.spendableBalanceNow,
   });
 
   final PaymentRequestValidateAddress validateAddress;
@@ -178,6 +191,9 @@ class PaymentRequestPrecheck {
   /// the balance was read. Like [run]'s `spendableIsAuthoritative` it has no
   /// default: getting it wrong is the bug this guards.
   final PaymentRequestSpendableIsAuthoritativeNow spendableIsAuthoritativeNow;
+
+  /// Live re-read of the balance itself, for the figure a shortfall quotes.
+  final PaymentRequestSpendableBalanceNow spendableBalanceNow;
 
   /// [spendableIsAuthoritative] says whether [spendableBalance] is a settled
   /// post-sync figure. It has no default on purpose: getting it wrong is the
@@ -276,9 +292,15 @@ class PaymentRequestPrecheck {
       if (!spendableIsAuthoritativeNow()) {
         return const PaymentRequestPrecheckSyncing();
       }
-      return PaymentRequestPrecheckInsufficientFunds(
-        spendableText: _formatZec(spendableBalance),
-      );
+      // Settled, but not necessarily the same figure: quote what the wallet
+      // holds now, and if a scan landed the funds while this check was in
+      // flight there is nothing to refuse — let the proposal decide.
+      final spendableNow = spendableBalanceNow();
+      if (amountZatoshi > spendableNow) {
+        return PaymentRequestPrecheckInsufficientFunds(
+          spendableText: _formatZec(spendableNow),
+        );
+      }
     }
 
     try {
@@ -301,7 +323,7 @@ class PaymentRequestPrecheck {
       );
     } catch (e) {
       log('PaymentRequest: proposal failed: $e');
-      return _mapProposalError(e.toString(), spendableBalance);
+      return _mapProposalError(e.toString());
     }
   }
 
@@ -310,10 +332,7 @@ class PaymentRequestPrecheck {
   /// "Still syncing" and "not enough" are the two answers a user acts on
   /// differently, so they must not be collapsed into one generic failure — and
   /// a sync-time shortfall must land on syncing, never on insufficient.
-  PaymentRequestPrecheckResult _mapProposalError(
-    String raw,
-    BigInt spendableBalance,
-  ) {
+  PaymentRequestPrecheckResult _mapProposalError(String raw) {
     final lower = raw.toLowerCase();
     if (lower.contains('wallet sync is still finishing') ||
         lower.contains('wallet sync failed before balance refresh') ||
@@ -336,8 +355,12 @@ class PaymentRequestPrecheck {
       if (!spendableIsAuthoritativeNow()) {
         return const PaymentRequestPrecheckSyncing();
       }
+      // And the figure is read now too. The wait this proposal just came back
+      // from is a wait for an authoritative spendable, so the balance the
+      // check started with is the one number guaranteed to predate whatever
+      // the wallet settled on.
       return PaymentRequestPrecheckInsufficientFunds(
-        spendableText: _formatZec(spendableBalance),
+        spendableText: _formatZec(spendableBalanceNow()),
       );
     }
     // Wrong-network addresses are refused up front by the validation above;
@@ -354,6 +377,19 @@ class PaymentRequestPrecheck {
       ZecAmount.fromZatoshi(zatoshi).activityDetail.toString();
 }
 
+/// The spendable figure the payment-request card pays from, out of an
+/// account-scoped sync state.
+///
+/// Mirrors the compose form: while a Private migration holds the balance, the
+/// Ironwood note is what can actually be spent. The card's first read and its
+/// live re-read go through this one function rather than drifting apart.
+BigInt paymentRequestSpendableOf(
+  SyncState scoped, {
+  required bool gatedByMigration,
+}) => gatedByMigration
+    ? scoped.displayIronwoodBalance
+    : scoped.displaySpendableBalance;
+
 /// The live pre-check, wired to Rust and the send pipeline.
 final paymentRequestPrecheckProvider = Provider<PaymentRequestPrecheck>((ref) {
   return PaymentRequestPrecheck(
@@ -363,6 +399,18 @@ final paymentRequestPrecheckProvider = Provider<PaymentRequestPrecheck>((ref) {
     // to the active account: an unscoped read answers with the wallet-wide
     // sync fields of a state that may hold no balance for this account.
     spendableIsAuthoritativeNow: () => activeAccountSpendableIsSettled(ref),
+    // Scoped and gated the same way the card's first read is, so the two can
+    // only ever disagree about the moment, never about which balance.
+    spendableBalanceNow: () {
+      final sync = ref.read(syncProvider).value;
+      if (sync == null) return BigInt.zero;
+      return paymentRequestSpendableOf(
+        sync.scopedToAccount(
+          ref.read(accountProvider).value?.activeAccountUuid,
+        ),
+        gatedByMigration: ref.read(migrationSendGateProvider),
+      );
+    },
     proposeTransfer:
         ({
           required String accountUuid,

--- a/lib/src/features/send/services/payment_request_precheck.dart
+++ b/lib/src/features/send/services/payment_request_precheck.dart
@@ -1,0 +1,380 @@
+/// Pre-check behind the payment-request card.
+///
+/// The card appears the moment a `zcash:` link arrives, over whatever the user
+/// was doing, and immediately says whether the request can be paid. That answer
+/// is exactly what this service produces: validate the recipient, and — when
+/// the link named an amount — go all the way to a real proposal so the card's
+/// "Review" lands on the review screen with a fee already computed, the same
+/// proposal the compose form would have made.
+///
+/// Nothing here reads a provider or touches the widget tree, so the whole
+/// decision table is unit-testable against a fake Rust API. The flow provider
+/// supplies the account and the spendable balance.
+library;
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/config/network_config.dart';
+import '../../../core/formatting/zec_amount.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
+import '../../../providers/sync_provider.dart';
+import '../../../rust/api/sync.dart' as rust_sync;
+import '../models/send_prefill_args.dart';
+import 'send_flow.dart';
+
+/// Validates a recipient address. Matches `rust_sync.validateAddress`.
+typedef PaymentRequestValidateAddress =
+    Future<rust_sync.AddressValidationResult> Function({
+      required String address,
+      required String network,
+    });
+
+/// Creates the proposal. Matches the shape of [proposeSendTransferWith] minus
+/// the provider reader, which the service does not have.
+typedef PaymentRequestProposeTransfer =
+    Future<SendReviewArgs> Function({
+      required String accountUuid,
+      required String sendFlowId,
+      required String address,
+      required String addressType,
+      required BigInt amountZatoshi,
+      String? memo,
+      bool isPaymentRequest,
+      String? requestedBy,
+      BigInt? requestedAmountZatoshi,
+    });
+
+/// Whether the wallet's spendable balance is settled *right now*.
+///
+/// Read after the proposal comes back, not before it goes out: the propose
+/// path waits for an authoritative spendable of its own, so the only way to
+/// tell a real shortfall from a mid-scan one is to ask again afterwards.
+typedef PaymentRequestSpendableIsAuthoritativeNow = bool Function();
+
+/// Releases a proposal. Matches [discardSendProposal].
+typedef PaymentRequestDiscardProposal =
+    Future<void> Function({
+      required BigInt proposalId,
+      required String sendFlowId,
+      required String logContext,
+    });
+
+/// A proposal the card is holding on the user's behalf.
+///
+/// The card is a consent surface: between the pre-check and the user's answer
+/// the wallet is sitting on a live `PROPOSAL_STORE` entry that nothing has
+/// consumed. Every exit that is not "Review" has to hand it back — Edit,
+/// Cancel, the ⨯, a newer link replacing this one, and the flow being cleared
+/// on lock or wallet reset — which is what [discard] is for.
+class PaymentRequestProposalHandle {
+  PaymentRequestProposalHandle({
+    required this.reviewArgs,
+    required PaymentRequestDiscardProposal discardProposal,
+  }) : _discardProposal = discardProposal;
+
+  final SendReviewArgs reviewArgs;
+  final PaymentRequestDiscardProposal _discardProposal;
+
+  var _released = false;
+
+  /// True once the proposal has been handed on to the review screen. A
+  /// released handle never discards: the review screen owns the proposal from
+  /// that point and runs its own discard when it is dismissed.
+  bool get isReleased => _released;
+
+  /// Transfers ownership to the caller without discarding.
+  SendReviewArgs release() {
+    _released = true;
+    return reviewArgs;
+  }
+
+  /// Idempotent. Safe to call from any number of exit paths, and a no-op after
+  /// [release].
+  Future<void> discard({String logContext = 'PaymentRequest'}) async {
+    if (_released) return;
+    _released = true;
+    await _discardProposal(
+      proposalId: reviewArgs.proposalId,
+      sendFlowId: reviewArgs.sendFlowId,
+      logContext: logContext,
+    );
+  }
+}
+
+/// What the pre-check concluded.
+sealed class PaymentRequestPrecheckResult {
+  const PaymentRequestPrecheckResult();
+}
+
+/// The request can be acted on.
+///
+/// [proposal] is null exactly when the link named no amount: there is nothing
+/// to propose yet, so the card drops its amount hero and its primary action
+/// hands the request to the composer instead of the review screen.
+final class PaymentRequestPrecheckReady extends PaymentRequestPrecheckResult {
+  const PaymentRequestPrecheckReady({this.proposal});
+
+  final PaymentRequestProposalHandle? proposal;
+
+  SendReviewArgs? get reviewArgs => proposal?.reviewArgs;
+}
+
+/// The link carries an address this wallet cannot pay.
+final class PaymentRequestPrecheckInvalidAddress
+    extends PaymentRequestPrecheckResult {
+  const PaymentRequestPrecheckInvalidAddress({this.message});
+
+  /// Overrides the card's default "Recipient address doesn't look right".
+  ///
+  /// Set only when the wallet knows something more useful than "bad address" —
+  /// today that is [kWrongNetworkAddressMessage], where the address is real
+  /// but belongs to another network. Null keeps the default copy.
+  final String? message;
+}
+
+/// The requested amount is above what the account can spend.
+final class PaymentRequestPrecheckInsufficientFunds
+    extends PaymentRequestPrecheckResult {
+  const PaymentRequestPrecheckInsufficientFunds({this.spendableText});
+
+  /// Preformatted spendable balance (`0.21 ZEC`) for the card's message.
+  final String? spendableText;
+}
+
+/// Balances are not trustworthy yet, so "not enough" would be a lie.
+///
+/// This is the VZR-42 rule: a low spendable read mid-sync must never surface as
+/// a final insufficient-funds answer.
+final class PaymentRequestPrecheckSyncing extends PaymentRequestPrecheckResult {
+  const PaymentRequestPrecheckSyncing();
+}
+
+/// Anything else, with a message already made friendly.
+final class PaymentRequestPrecheckFailed extends PaymentRequestPrecheckResult {
+  const PaymentRequestPrecheckFailed(this.message);
+
+  final String message;
+}
+
+/// Runs the checks behind the payment-request card.
+class PaymentRequestPrecheck {
+  const PaymentRequestPrecheck({
+    required this.validateAddress,
+    required this.proposeTransfer,
+    required this.discardProposal,
+    required this.spendableIsAuthoritativeNow,
+  });
+
+  final PaymentRequestValidateAddress validateAddress;
+  final PaymentRequestProposeTransfer proposeTransfer;
+  final PaymentRequestDiscardProposal discardProposal;
+
+  /// Live re-read of the VZR-42 condition, for the answers that only come
+  /// back after the proposal has run. Like [run]'s `spendableIsAuthoritative`
+  /// it has no default: getting it wrong is the bug this guards.
+  final PaymentRequestSpendableIsAuthoritativeNow spendableIsAuthoritativeNow;
+
+  /// [spendableIsAuthoritative] says whether [spendableBalance] is a settled
+  /// post-sync figure. It has no default on purpose: getting it wrong is the
+  /// VZR-42 bug, and the one production caller has to state which it holds.
+  Future<PaymentRequestPrecheckResult> run({
+    required SendPrefillArgs prefill,
+    required String sendFlowId,
+    required String? accountUuid,
+    required BigInt spendableBalance,
+    required bool spendableIsAuthoritative,
+  }) async {
+    final address = prefill.address.trim();
+    if (address.isEmpty) {
+      return const PaymentRequestPrecheckInvalidAddress();
+    }
+
+    final String addressType;
+    try {
+      final validation = await validateAddress(
+        address: address,
+        network: kZcashDefaultNetworkName,
+      );
+      if (!validation.isValid) {
+        // A well-formed address for another network is still unpayable, but
+        // it is not a malformed one — say which, so the user is not hunting
+        // for a typo that is not there.
+        return PaymentRequestPrecheckInvalidAddress(
+          message: validation.wrongNetwork ? kWrongNetworkAddressMessage : null,
+        );
+      }
+      addressType = validation.addressType;
+    } catch (e) {
+      log('PaymentRequest: address validation error: $e');
+      return const PaymentRequestPrecheckInvalidAddress();
+    }
+    if (addressType.isEmpty ||
+        addressType == 'invalid' ||
+        addressType == 'error') {
+      return const PaymentRequestPrecheckInvalidAddress();
+    }
+
+    // A ZIP-321 memo is exact bytes the requester encoded, so it is passed
+    // through untouched when the prefill says to preserve it — the compose
+    // form does the same through `preserveMemoText`, and the two paths have
+    // to put identical bytes on chain or "Review" and "Edit then review"
+    // become different payments.
+    //
+    // Nothing here drops a memo for a transparent-like recipient. Every
+    // request that reaches this service — link or scanned QR — was built by
+    // `Zip321PaymentRequest.parse`, which refuses `memo` on a `t`-prefixed
+    // address outright (ZIP-321 forbids the combination), so the payer is told
+    // the link is invalid before a card exists. One owner for that rule; a
+    // second, silent one here would only ever describe a request the parser
+    // already refused.
+    final memo = prefill.preserveMemoText
+        ? prefill.memoText
+        : prefill.memoText?.trim();
+
+    final amountText = prefill.amountText?.trim();
+    if (amountText == null || amountText.isEmpty) {
+      // Amount-less request: nothing to propose, and nothing that could be
+      // insufficient. The composer collects the amount.
+      return const PaymentRequestPrecheckReady();
+    }
+
+    final amountZatoshi = parseZecAmount(amountText);
+    if (amountZatoshi == null) {
+      return const PaymentRequestPrecheckFailed(
+        "This link doesn't ask for a payable amount — enter one to continue",
+      );
+    }
+    if (amountZatoshi <= BigInt.zero) {
+      // `amount=0` parses, so the wallet read it fine — it is simply not a
+      // payment. Treat it as the amount-less request it is and let the
+      // composer collect one, rather than dead-ending the card on it.
+      return const PaymentRequestPrecheckReady();
+    }
+
+    if (accountUuid == null) {
+      return const PaymentRequestPrecheckFailed(
+        'No active account — choose one, then open this link again',
+      );
+    }
+
+    // VZR-42: a shortfall read off a balance that is still being scanned is
+    // not an answer. Only a settled balance may end the check here; otherwise
+    // the proposal decides, and it waits for the authoritative spendable
+    // before Rust reports back through `_mapProposalError`.
+    if (spendableIsAuthoritative && amountZatoshi > spendableBalance) {
+      return PaymentRequestPrecheckInsufficientFunds(
+        spendableText: _formatZec(spendableBalance),
+      );
+    }
+
+    try {
+      final reviewArgs = await proposeTransfer(
+        accountUuid: accountUuid,
+        sendFlowId: sendFlowId,
+        address: address,
+        addressType: addressType,
+        amountZatoshi: amountZatoshi,
+        memo: (memo != null && memo.isNotEmpty) ? memo : null,
+        isPaymentRequest: true,
+        requestedBy: prefill.label,
+        requestedAmountZatoshi: amountZatoshi,
+      );
+      return PaymentRequestPrecheckReady(
+        proposal: PaymentRequestProposalHandle(
+          reviewArgs: reviewArgs,
+          discardProposal: discardProposal,
+        ),
+      );
+    } catch (e) {
+      log('PaymentRequest: proposal failed: $e');
+      return _mapProposalError(e.toString(), spendableBalance);
+    }
+  }
+
+  /// Maps the stable VZR-42 conditions onto the card's status set.
+  ///
+  /// "Still syncing" and "not enough" are the two answers a user acts on
+  /// differently, so they must not be collapsed into one generic failure — and
+  /// a sync-time shortfall must land on syncing, never on insufficient.
+  PaymentRequestPrecheckResult _mapProposalError(
+    String raw,
+    BigInt spendableBalance,
+  ) {
+    final lower = raw.toLowerCase();
+    if (lower.contains('wallet sync is still finishing') ||
+        lower.contains('wallet sync failed before balance refresh') ||
+        // What Rust itself emits when the wallet has no target/anchor
+        // heights yet ("Wallet must sync before …"), which is exactly the
+        // fresh-import state a payment link is most likely to land in.
+        lower.contains('wallet must sync') ||
+        lower.contains('sync_in_progress') ||
+        lower.contains('scan_required')) {
+      return const PaymentRequestPrecheckSyncing();
+    }
+    if (lower.contains('insufficientfunds') ||
+        lower.contains('insufficient_funds') ||
+        lower.contains('insufficient')) {
+      // VZR-42, on the far side of the proposal: a shortfall computed while
+      // the wallet is still short of the tip is not an answer, wherever it
+      // was computed. The propose path waits for a settled spendable before
+      // it decides, so a balance that is still unsettled *now* means the
+      // scan moved under it and the figure the card would quote is stale.
+      if (!spendableIsAuthoritativeNow()) {
+        return const PaymentRequestPrecheckSyncing();
+      }
+      return PaymentRequestPrecheckInsufficientFunds(
+        spendableText: _formatZec(spendableBalance),
+      );
+    }
+    // Wrong-network addresses are refused up front by the validation above;
+    // this maps the remaining propose-time address failures (an address the
+    // transaction builder rejects) onto the card's invalid-address status.
+    if (lower.contains('decoding the address from a payment request') ||
+        lower.contains('bad address')) {
+      return const PaymentRequestPrecheckInvalidAddress();
+    }
+    return PaymentRequestPrecheckFailed(friendlyPaymentRequestCheckError(raw));
+  }
+
+  static String _formatZec(BigInt zatoshi) =>
+      ZecAmount.fromZatoshi(zatoshi).activityDetail.toString();
+}
+
+/// The live pre-check, wired to Rust and the send pipeline.
+final paymentRequestPrecheckProvider = Provider<PaymentRequestPrecheck>((ref) {
+  return PaymentRequestPrecheck(
+    validateAddress: rust_sync.validateAddress,
+    discardProposal: discardSendProposal,
+    // The same predicate the card's own read and its sync watch use, scoped
+    // to the active account: an unscoped read answers with the wallet-wide
+    // sync fields of a state that may hold no balance for this account.
+    spendableIsAuthoritativeNow: () => activeAccountSpendableIsSettled(ref),
+    proposeTransfer:
+        ({
+          required String accountUuid,
+          required String sendFlowId,
+          required String address,
+          required String addressType,
+          required BigInt amountZatoshi,
+          String? memo,
+          bool isPaymentRequest = false,
+          String? requestedBy,
+          BigInt? requestedAmountZatoshi,
+        }) => proposeSendTransferWith(
+          syncNotifier: ref.read(syncProvider.notifier),
+          readEndpoint: () => ref.read(rpcEndpointProvider),
+          accountUuid: accountUuid,
+          sendFlowId: sendFlowId,
+          address: address,
+          addressType: addressType,
+          amountZatoshi: amountZatoshi,
+          memo: memo,
+          isPaymentRequest: isPaymentRequest,
+          requestedBy: requestedBy,
+          requestedAmountZatoshi: requestedAmountZatoshi,
+        ),
+  );
+});

--- a/lib/src/features/send/services/payment_request_precheck.dart
+++ b/lib/src/features/send/services/payment_request_precheck.dart
@@ -49,9 +49,11 @@ typedef PaymentRequestProposeTransfer =
 
 /// Whether the wallet's spendable balance is settled *right now*.
 ///
-/// Read after the proposal comes back, not before it goes out: the propose
-/// path waits for an authoritative spendable of its own, so the only way to
-/// tell a real shortfall from a mid-scan one is to ask again afterwards.
+/// Every answer this service gives about affordability is separated from the
+/// balance it was handed by at least one await, so "settled" as of the start
+/// of the check is a claim about the past. This re-reads the same predicate
+/// at the moment a shortfall would be published — before the proposal goes
+/// out and after it comes back.
 typedef PaymentRequestSpendableIsAuthoritativeNow = bool Function();
 
 /// Releases a proposal. Matches [discardSendProposal].
@@ -172,9 +174,9 @@ class PaymentRequestPrecheck {
   final PaymentRequestProposeTransfer proposeTransfer;
   final PaymentRequestDiscardProposal discardProposal;
 
-  /// Live re-read of the VZR-42 condition, for the answers that only come
-  /// back after the proposal has run. Like [run]'s `spendableIsAuthoritative`
-  /// it has no default: getting it wrong is the bug this guards.
+  /// Live re-read of the VZR-42 condition, for every answer that lands after
+  /// the balance was read. Like [run]'s `spendableIsAuthoritative` it has no
+  /// default: getting it wrong is the bug this guards.
   final PaymentRequestSpendableIsAuthoritativeNow spendableIsAuthoritativeNow;
 
   /// [spendableIsAuthoritative] says whether [spendableBalance] is a settled
@@ -265,6 +267,15 @@ class PaymentRequestPrecheck {
     // the proposal decides, and it waits for the authoritative spendable
     // before Rust reports back through `_mapProposalError`.
     if (spendableIsAuthoritative && amountZatoshi > spendableBalance) {
+      // Both values were read before the address validation above was
+      // awaited, so they say the balance was settled, not that it still is.
+      // A scan that started in between is already moving it, and the two
+      // answers are not equally recoverable: `insufficient` is final and
+      // leaves the card blocked on a figure the scan has outgrown, while
+      // `syncing` re-checks itself the moment the wallet catches up.
+      if (!spendableIsAuthoritativeNow()) {
+        return const PaymentRequestPrecheckSyncing();
+      }
       return PaymentRequestPrecheckInsufficientFunds(
         spendableText: _formatZec(spendableBalance),
       );

--- a/lib/src/features/send/services/payment_request_precheck.dart
+++ b/lib/src/features/send/services/payment_request_precheck.dart
@@ -180,7 +180,7 @@ class PaymentRequestPrecheck {
     required this.proposeTransfer,
     required this.discardProposal,
     required this.spendableIsAuthoritativeNow,
-    required this.spendableBalanceNow,
+    this.spendableBalanceNow,
   });
 
   final PaymentRequestValidateAddress validateAddress;
@@ -193,7 +193,15 @@ class PaymentRequestPrecheck {
   final PaymentRequestSpendableIsAuthoritativeNow spendableIsAuthoritativeNow;
 
   /// Live re-read of the balance itself, for the figure a shortfall quotes.
-  final PaymentRequestSpendableBalanceNow spendableBalanceNow;
+  /// Optional: a caller that omits it quotes the balance [run] started with,
+  /// which is only right when that figure cannot move during the check (the
+  /// production wiring always passes a live reader).
+  final PaymentRequestSpendableBalanceNow? spendableBalanceNow;
+
+  BigInt _spendableNow(BigInt fallback) {
+    final read = spendableBalanceNow;
+    return read == null ? fallback : read();
+  }
 
   /// [spendableIsAuthoritative] says whether [spendableBalance] is a settled
   /// post-sync figure. It has no default on purpose: getting it wrong is the
@@ -295,7 +303,7 @@ class PaymentRequestPrecheck {
       // Settled, but not necessarily the same figure: quote what the wallet
       // holds now, and if a scan landed the funds while this check was in
       // flight there is nothing to refuse — let the proposal decide.
-      final spendableNow = spendableBalanceNow();
+      final spendableNow = _spendableNow(spendableBalance);
       if (amountZatoshi > spendableNow) {
         return PaymentRequestPrecheckInsufficientFunds(
           spendableText: _formatZec(spendableNow),
@@ -323,7 +331,7 @@ class PaymentRequestPrecheck {
       );
     } catch (e) {
       log('PaymentRequest: proposal failed: $e');
-      return _mapProposalError(e.toString());
+      return _mapProposalError(e.toString(), spendableBalance);
     }
   }
 
@@ -332,7 +340,10 @@ class PaymentRequestPrecheck {
   /// "Still syncing" and "not enough" are the two answers a user acts on
   /// differently, so they must not be collapsed into one generic failure — and
   /// a sync-time shortfall must land on syncing, never on insufficient.
-  PaymentRequestPrecheckResult _mapProposalError(String raw) {
+  PaymentRequestPrecheckResult _mapProposalError(
+    String raw,
+    BigInt spendableBalance,
+  ) {
     final lower = raw.toLowerCase();
     if (lower.contains('wallet sync is still finishing') ||
         lower.contains('wallet sync failed before balance refresh') ||
@@ -360,7 +371,7 @@ class PaymentRequestPrecheck {
       // check started with is the one number guaranteed to predate whatever
       // the wallet settled on.
       return PaymentRequestPrecheckInsufficientFunds(
-        spendableText: _formatZec(spendableBalanceNow()),
+        spendableText: _formatZec(_spendableNow(spendableBalance)),
       );
     }
     // Wrong-network addresses are refused up front by the validation above;

--- a/lib/src/features/send/services/send_flow.dart
+++ b/lib/src/features/send/services/send_flow.dart
@@ -14,7 +14,10 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../core/storage/wallet_paths.dart';
+import '../../../core/zcash/zip321_payment_request.dart'
+    show stripUnsupportedZip321MemoText;
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
@@ -22,6 +25,38 @@ import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import 'sapling_params.dart';
+
+/// Longest requester label the review screens will render.
+///
+/// The label comes straight out of a `zcash:` link's `label` parameter, so it
+/// is attacker-controlled. Sanitising is what keeps it a short, single-line
+/// piece of quoted text instead of something that can restyle a review screen.
+const int kPaymentRequestLabelMaxLength = 64;
+
+/// One-line, length-clamped version of an untrusted requester label, or null
+/// when there is nothing left to show.
+///
+/// Drops the code points a ZIP-321 memo may not carry first — bidi overrides
+/// and C0/C1 controls, which `RegExp(r'\s+')` does not match and which the
+/// clamp would otherwise spend on invisible characters — so one rule covers
+/// every untrusted ZIP-321 string the wallet renders. Then collapses every run
+/// of whitespace (newlines included) to a single space so the label cannot
+/// grow the row it sits in, and clamps the length.
+///
+/// The clamp counts grapheme clusters, not UTF-16 code units. `substring`
+/// would cut between a surrogate pair or off a combining mark \u2014 40 emoji is
+/// 80 code units, so index 63 lands mid-pair \u2014 and the row would render a
+/// replacement glyph before the ellipsis. It also makes the limit mean what
+/// it reads as: 64 characters the way the payer counts them.
+String? sanitisePaymentRequestLabel(String? raw) {
+  final stripped = raw == null ? null : stripUnsupportedZip321MemoText(raw);
+  final collapsed = stripped?.replaceAll(RegExp(r'\s+'), ' ').trim();
+  if (collapsed == null || collapsed.isEmpty) return null;
+  final graphemes = collapsed.characters;
+  if (graphemes.length <= kPaymentRequestLabelMaxLength) return collapsed;
+  final kept = graphemes.take(kPaymentRequestLabelMaxLength - 1).string;
+  return '$kept\u2026';
+}
 
 /// Route-extra payload for the review/status legs of the send flow.
 enum SendFlowKind { send, donation }
@@ -37,6 +72,9 @@ class SendReviewArgs {
     required this.feeZatoshi,
     required this.needsSaplingParams,
     this.memo,
+    this.isPaymentRequest = false,
+    this.requestedBy,
+    this.requestedAmountZatoshi,
     this.flowKind = SendFlowKind.send,
   });
 
@@ -51,7 +89,28 @@ class SendReviewArgs {
   final String? memo;
   final SendFlowKind flowKind;
 
+  /// This send answers a ZIP-321 payment request rather than being composed
+  /// from scratch. Only the review framing reads it — the proposal, the
+  /// broadcast and the receipt are identical either way.
+  final bool isPaymentRequest;
+
+  /// Sanitised requester label from the request, when it carried one.
+  final String? requestedBy;
+
+  /// The amount the request asked for, when it named one.
+  ///
+  /// Kept alongside [amountZatoshi] rather than replacing it so the review can
+  /// say what was requested when the user edited the amount before confirming.
+  final BigInt? requestedAmountZatoshi;
+
   bool get isShielded => addressType == 'unified' || addressType == 'sapling';
+
+  /// The requested amount, but only when it differs from what is being sent.
+  BigInt? get differingRequestedAmountZatoshi {
+    final requested = requestedAmountZatoshi;
+    if (requested == null || requested == amountZatoshi) return null;
+    return requested;
+  }
 }
 
 /// Hardware-wallet handoff payload: the phone-side proof PCZT plus the compact
@@ -104,6 +163,64 @@ class SendStatusRoutePayloadNotifier extends Notifier<Object?> {
 final sendStatusRoutePayloadProvider =
     NotifierProvider<SendStatusRoutePayloadNotifier, Object?>(
       SendStatusRoutePayloadNotifier.new,
+    );
+
+/// Whether the send shown on `/send/status` has reached a terminal phase —
+/// succeeded or failed — so nothing is lost by leaving that screen.
+///
+/// The status screens keep owning their own presentation phase; this publishes
+/// only the "safe to leave" bit, which surfaces outside the send flow need.
+/// `decidePaymentUriDrain` reads it as `sendIsInFlight` and holds a `zcash:`
+/// link that arrives mid-broadcast until the receipt is on screen — the card's
+/// Review and Edit unmount the status screen, which aborts the outcome after
+/// the transaction has already gone out.
+///
+/// False is also what a session that has never sent reads, so the drain pairs
+/// it with the `/send/status` location rather than trusting it alone.
+///
+/// A pending-broadcast outcome is deliberately NOT terminal: both status
+/// screens still render it as in progress.
+class SendStatusTerminalNotifier extends Notifier<bool> {
+  var _disposed = false;
+  var _revision = 0;
+
+  @override
+  bool build() {
+    ref.onDispose(() => _disposed = true);
+    return false;
+  }
+
+  /// The send finished (succeeded or failed).
+  void markTerminal() {
+    if (_disposed) return;
+    _revision++;
+    state = true;
+  }
+
+  /// A broadcast is starting: nothing is safe to leave yet.
+  void reset() {
+    if (_disposed) return;
+    _revision++;
+    state = false;
+  }
+
+  /// Releases the flag once the current lifecycle call has returned. The status
+  /// screens call this from `dispose`, where Riverpod forbids a synchronous
+  /// provider write; the revision guard stops a departing screen from clearing
+  /// a newer one's flag. A microtask rather than a timer, so it cannot outlive
+  /// a widget test's tree.
+  void resetAfterNavigation() {
+    final retainedRevision = _revision;
+    scheduleMicrotask(() {
+      if (_disposed || _revision != retainedRevision) return;
+      reset();
+    });
+  }
+}
+
+final sendStatusTerminalProvider =
+    NotifierProvider<SendStatusTerminalNotifier, bool>(
+      SendStatusTerminalNotifier.new,
     );
 
 class SendStatusRoutePayloadObserver extends NavigatorObserver {
@@ -175,27 +292,66 @@ Future<SendReviewArgs> proposeSendTransfer({
   required String addressType,
   required BigInt amountZatoshi,
   String? memo,
+  bool isPaymentRequest = false,
+  String? requestedBy,
+  BigInt? requestedAmountZatoshi,
+  SendFlowKind flowKind = SendFlowKind.send,
+  Future<String> Function() loadDbPath = getWalletDbPath,
+}) => proposeSendTransferWith(
+  syncNotifier: ref.read(syncProvider.notifier),
+  readEndpoint: () => ref.read(rpcEndpointProvider),
+  accountUuid: accountUuid,
+  sendFlowId: sendFlowId,
+  address: address,
+  addressType: addressType,
+  amountZatoshi: amountZatoshi,
+  memo: memo,
+  isPaymentRequest: isPaymentRequest,
+  requestedBy: requestedBy,
+  requestedAmountZatoshi: requestedAmountZatoshi,
+  flowKind: flowKind,
+  loadDbPath: loadDbPath,
+);
+
+/// [proposeSendTransfer] with its two provider reads passed in.
+///
+/// `WidgetRef` and `Ref` share no common type, and the payment-request
+/// pre-check runs from a `Notifier` rather than a widget. Naming the two
+/// dependencies is what lets both callers reach the same proposal code.
+/// [readEndpoint] stays lazy on purpose: the authoritative-spendable wait below
+/// can outlast an endpoint failover, and the proposal must use the endpoint in
+/// effect when it is actually made.
+Future<SendReviewArgs> proposeSendTransferWith({
+  required SyncNotifier syncNotifier,
+  required RpcEndpointConfig Function() readEndpoint,
+  required String accountUuid,
+  required String sendFlowId,
+  required String address,
+  required String addressType,
+  required BigInt amountZatoshi,
+  String? memo,
+  bool isPaymentRequest = false,
+  String? requestedBy,
+  BigInt? requestedAmountZatoshi,
   SendFlowKind flowKind = SendFlowKind.send,
   Future<String> Function() loadDbPath = getWalletDbPath,
 }) async {
-  final proposal = await ref
-      .read(syncProvider.notifier)
-      .runWithAuthoritativeSpendable(
+  final proposal = await syncNotifier.runWithAuthoritativeSpendable(
+    accountUuid: accountUuid,
+    operation: () async {
+      final dbPath = await loadDbPath();
+      final endpoint = readEndpoint();
+      return rust_sync.proposeSend(
+        dbPath: dbPath,
+        network: endpoint.networkName,
         accountUuid: accountUuid,
-        operation: () async {
-          final dbPath = await loadDbPath();
-          final endpoint = ref.read(rpcEndpointProvider);
-          return rust_sync.proposeSend(
-            dbPath: dbPath,
-            network: endpoint.networkName,
-            accountUuid: accountUuid,
-            sendFlowId: sendFlowId,
-            toAddress: address,
-            amountZatoshi: amountZatoshi,
-            memo: (memo != null && memo.isNotEmpty) ? memo : null,
-          );
-        },
+        sendFlowId: sendFlowId,
+        toAddress: address,
+        amountZatoshi: amountZatoshi,
+        memo: (memo != null && memo.isNotEmpty) ? memo : null,
       );
+    },
+  );
   return SendReviewArgs(
     proposalId: proposal.proposalId,
     sendFlowId: sendFlowId,
@@ -206,6 +362,9 @@ Future<SendReviewArgs> proposeSendTransfer({
     feeZatoshi: proposal.feeZatoshi,
     memo: (memo != null && memo.isNotEmpty) ? memo : null,
     needsSaplingParams: proposal.needsSaplingParams,
+    isPaymentRequest: isPaymentRequest,
+    requestedBy: sanitisePaymentRequestLabel(requestedBy),
+    requestedAmountZatoshi: requestedAmountZatoshi,
     flowKind: flowKind,
   );
 }
@@ -254,10 +413,43 @@ Future<void> retainSendProposalLockUntilExpiry({
   }
 }
 
+/// Shown wherever a recipient address is well-formed but belongs to another
+/// Zcash network — a `utest1…` pasted into a mainnet wallet, say.
+///
+/// It has its own sentence because "Invalid address" reads as a typo, and this
+/// is not one: the address is real, it just is not payable from this build.
+/// Before validation was network-aware the wallet accepted these and only
+/// refused them at proposal time, as an opaque "Bad address: IncorrectNetwork".
+const kWrongNetworkAddressMessage =
+    'This address is for a different Zcash network';
+
+/// Propose-time failures as the payment-request card states them.
+///
+/// The card is a pre-send consent surface: nothing has been broadcast, it
+/// holds an unconsumed proposal, and the only control it still offers is
+/// Edit. [friendlyProposeSendError] is written for a screen that actually
+/// sent, so its wording ("Send failed", "Some parts of this transaction were
+/// sent") would assert an event that never happened here.
+///
+/// Follows the card's status-line convention: one line, no trailing period.
+String friendlyPaymentRequestCheckError(String raw) {
+  final lower = raw.toLowerCase();
+  if (lower.contains('grpc connect failed') ||
+      lower.contains('connection refused') ||
+      lower.contains('dns error') ||
+      lower.contains('tls error')) {
+    return "Couldn't reach the network — check your connection and open the "
+        'link again';
+  }
+  return "Couldn't check this request — open Edit to review the details";
+}
+
 String friendlyProposeSendError(String raw) {
   final lower = raw.toLowerCase();
   if (lower.contains('wallet sync is still finishing') ||
-      lower.contains('wallet sync failed before balance refresh')) {
+      lower.contains('wallet sync failed before balance refresh') ||
+      // Rust's own wording when the wallet has no scanned tip yet.
+      lower.contains('wallet must sync')) {
     return 'Finishing wallet sync. Try again shortly.';
   }
   if (lower.contains('insufficientfunds') || lower.contains('insufficient')) {

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -472,9 +472,30 @@ class PaymentRequestView {
     return raw;
   }
 
+  /// The memo exactly as the payment will carry it, or null when the request
+  /// carries none.
+  ///
+  /// Deliberately not trimmed or collapsed, unlike [displayRequesterLabel]
+  /// and [displayNote]. Those two are off-chain text the link says *about*
+  /// itself, so tidying them costs nothing. This is the on-chain memo: the
+  /// pre-check hands these exact bytes to the proposal, so trimming here
+  /// would show the payer a memo their transaction does not pay, and would
+  /// erase a whitespace-only memo from the card while still sending it.
   String? get displayMemo {
-    final raw = memo?.trim();
+    final raw = memo;
     return (raw == null || raw.isEmpty) ? null : raw;
+  }
+
+  /// True when [displayMemo] is present but every character in it is
+  /// whitespace.
+  ///
+  /// Those bytes are still paid, so the memo is present, not absent — but
+  /// rendering them verbatim draws nothing. The card surface uses this to put
+  /// a visible placeholder in the memo's value slot rather than leave a row
+  /// that reads as empty.
+  bool get memoIsWhitespaceOnly {
+    final raw = displayMemo;
+    return raw != null && raw.trim().isEmpty;
   }
 
   String? get displayNote {

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -1,0 +1,1948 @@
+import 'package:flutter/widgets.dart';
+
+import '../../../core/formatting/address_display.dart';
+import '../../../core/layout/app_form_factor.dart';
+import '../../../core/layout/mobile/mobile_bottom_safe_area.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_icon_hover_button.dart';
+import '../../../core/widgets/app_profile_picture.dart';
+import '../../../core/widgets/app_tooltip.dart';
+import '../../../core/widgets/pool_badge.dart';
+import '../../../core/widgets/review_list_row.dart'
+    show kPaymentRequestRequesterTooltip;
+import '../../../core/widgets/review_wrap_card.dart';
+
+/// Desktop width of the payment-request modal card.
+///
+/// Wider than the 312px design-system default because the card carries a
+/// full address row plus memo/note prose; 396 is the width the other wide
+/// desktop modals in this app already use (settings uninstall/endpoint,
+/// the home confirmation cards).
+const double kPaymentRequestCardWidth = 396;
+
+/// Horizontal room the mobile header leaves for the sheet's pinned close.
+///
+/// The card renders no close of its own on mobile — `MobileModalScaffold`
+/// pins its shared 32x32 ⨯ to the top-right of the sheet. This mirrors the
+/// scaffold's own title reservation (32 + an 8px gap) so a long title
+/// ellipsizes instead of sliding under that button.
+const double kPaymentRequestMobileCloseClearance = 40;
+
+/// The one horizontal content inset every group on this card uses.
+///
+/// Sheet/modal chrome (title, actions, status line) sits on the outer
+/// edge; everything inside a card — the requester summary, the
+/// transaction label and amount, the To and memo rows — sits exactly this
+/// far in from that card's edge. One gutter, two left edges.
+const double kPaymentRequestGutter = AppSpacing.sm;
+
+/// Horizontal breathing room inside the two-line disclosure controls.
+/// They stay visually quiet on hover like the existing review rows, while
+/// keeping their labels away from the full-row hit target's edges.
+const _paymentRequestDisclosurePadding = EdgeInsets.symmetric(
+  horizontal: AppSpacing.xs,
+);
+
+/// The scroll region's overlay scrollbar, for tests.
+const kPaymentRequestScrollbarKey = ValueKey('payment_request_scrollbar');
+
+/// The scroll region's scroll view, for tests.
+const kPaymentRequestScrollViewKey = ValueKey('payment_request_scroll_view');
+
+/// The requester note's nested scroll view, for tests.
+const kPaymentRequestRequesterNoteScrollViewKey = ValueKey(
+  'payment_request_requester_note_scroll_view',
+);
+
+/// The requester note's nested scrollbar, for tests.
+const kPaymentRequestRequesterNoteScrollbarKey = ValueKey(
+  'payment_request_requester_note_scrollbar',
+);
+
+/// Which of the two presentations [PaymentRequestCard] lays itself out for.
+///
+/// App code leaves this at [auto], which resolves to [kAppFormFactor] — the
+/// build-time form factor, never a `Platform` check. The explicit values
+/// exist only for tooling that has to show both modes inside one binary
+/// (the Widgetbook gallery and the figma-compare scenarios), the same
+/// exemption the `*Desktop` / `*Mobile` token sets carry.
+enum PaymentRequestLayout { auto, desktop, mobile }
+
+/// Where a payment request reached the wallet from.
+///
+/// Carried by the view model for the routes and logs that care; the card
+/// itself renders no provenance line.
+enum PaymentRequestSource { link, qrCode }
+
+/// The one condition that decides whether the request can be acted on.
+///
+/// Exactly one applies at a time. [ready] is the only value that lets the
+/// primary action fire; everything else disables it and renders the card's
+/// single status line.
+///
+/// Preconditions that are not about *this request* — no wallet yet, an
+/// unfinished Ironwood migration, another signing session holding the
+/// wallet — are settled by the route and the drain policy before the card
+/// is ever built, so they are deliberately absent here.
+enum PaymentRequestStatus {
+  /// Checks passed — the request can be continued.
+  ready,
+
+  /// Address/balance checks are still running.
+  checking,
+
+  /// The request carries an address this wallet cannot pay.
+  invalidAddress,
+
+  /// The requested amount is above the spendable balance.
+  insufficientFunds,
+
+  /// Balances are not trustworthy yet because the wallet is syncing.
+  syncing,
+
+  /// [syncing] that has run out of ways to answer itself.
+  ///
+  /// The card re-checks a `syncing` verdict when the wallet finishes a sync,
+  /// and — because a verdict published while the sync state is *already*
+  /// settled has no completion left to wait for — a bounded number of times
+  /// immediately. When that budget is spent and no real sync cycle follows,
+  /// the wait [syncing]'s copy promises is one the card can no longer keep.
+  /// This is that state said out loud: same blocked request, but the next
+  /// move is the user's, and the primary action becomes "Check again".
+  syncStalled,
+
+  /// The check itself could not complete; the reason always comes through
+  /// [PaymentRequestView.statusMessage].
+  failed,
+}
+
+extension PaymentRequestStatusX on PaymentRequestStatus {
+  /// True while the primary action must stay disabled.
+  bool get blocksContinue => this != PaymentRequestStatus.ready;
+
+  /// Something is wrong rather than merely pending, so the status line takes
+  /// the destructive tone and the warning glyph.
+  ///
+  /// [PaymentRequestStatus.syncing] is deliberately not one of these. It
+  /// blocks Review through [blocksContinue] like the rest, but it is the one
+  /// blocked state that resolves itself: the card watches the sync and
+  /// re-runs its own check, and its copy says so. A warning glyph on a line
+  /// that promises to update itself asks the user to act on a condition they
+  /// have nothing to do about.
+  bool get isError =>
+      this == PaymentRequestStatus.invalidAddress ||
+      this == PaymentRequestStatus.insufficientFunds ||
+      this == PaymentRequestStatus.failed;
+
+  /// The request cannot be reviewed, but the card can ask the wallet again.
+  ///
+  /// The only status whose primary action is neither Review nor Edit: the
+  /// request is fine, the wallet just could not answer, and re-asking is the
+  /// one thing that can change that.
+  bool get offersRecheck => this == PaymentRequestStatus.syncStalled;
+}
+
+/// Default copy for each [PaymentRequestStatus].
+///
+/// One line each, no trailing period: the buttons under them already say
+/// what the user can do, so the message only has to name the condition.
+/// Callers may override any of these through
+/// [PaymentRequestView.statusMessage].
+///
+/// [spendableText] is the preformatted spendable balance (`0.21 ZEC`). When
+/// the caller supplies it, the insufficient-funds message states the amount
+/// the user can actually send, which is the single fact that makes that
+/// error actionable without leaving the card. It names the fee alongside it,
+/// because the shortfall can be the fee alone: a request for exactly the
+/// spendable balance passes the card's own comparison and is refused by the
+/// proposal, and "Not enough ZEC (0.5 available)" beside a 0.5 request reads
+/// as a bug in the balance rather than an instruction.
+String? defaultPaymentRequestStatusMessage(
+  PaymentRequestStatus status, {
+  String? spendableText,
+}) {
+  final spendable = _bareAmount(spendableText);
+  return switch (status) {
+    // Checking is stated by the primary button (a spinner and its own
+    // label), so the status slot stays reserved for the errors.
+    PaymentRequestStatus.ready => null,
+    PaymentRequestStatus.checking => null,
+    PaymentRequestStatus.invalidAddress =>
+      "Recipient address doesn't look right",
+    PaymentRequestStatus.insufficientFunds =>
+      spendable == null
+          ? 'Not enough ZEC for this amount and the network fee'
+          : 'Not enough ZEC for this amount and the network fee '
+                '($spendable available)',
+    // The card watches the sync and re-runs its check when it settles, so the
+    // message promises exactly that rather than sending the user back to the
+    // link they already opened.
+    PaymentRequestStatus.syncing =>
+      'Wallet is still syncing — this will update when it finishes',
+    // The card has stopped promising to update itself, so the copy stops
+    // saying it will: it names the same condition and hands the next move
+    // to the button under it.
+    PaymentRequestStatus.syncStalled =>
+      'Still syncing — check again when the wallet is up to date',
+    // Always overridden in practice: every failure the pre-check publishes
+    // carries its own reason. This is the floor, not the message.
+    PaymentRequestStatus.failed => "Couldn't check this request",
+  };
+}
+
+/// Drops the unit off a preformatted balance, because the sentence around it
+/// already names the currency: `0.21 ZEC` → `0.21`.
+String? _bareAmount(String? text) {
+  final trimmed = text?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+  const unit = ' ZEC';
+  if (trimmed.toUpperCase().endsWith(unit)) {
+    final bare = trimmed.substring(0, trimmed.length - unit.length).trim();
+    return bare.isEmpty ? null : bare;
+  }
+  return trimmed;
+}
+
+/// Whose name the "To" block is showing.
+///
+/// The two are rendered the same way — avatar, name, truncated address — but
+/// they mean different things to the person reading the card, so the own-account
+/// case says so in its own sub-label. Nothing else on the card can tell a user
+/// that the address a stranger's link asked them to pay is one of their own.
+enum PaymentRequestRecipientKind {
+  /// The recipient address is saved in the address book.
+  contact,
+
+  /// The recipient address belongs to one of this wallet's own accounts.
+  ownAccount,
+}
+
+/// A recipient address the wallet could put a name to.
+///
+/// Resolved outside the card (see `paymentRequestRecipientIdentityFor`), so
+/// the widget stays a pure presentation surface that Widgetbook can drive
+/// with literals.
+@immutable
+class PaymentRequestRecipientIdentity {
+  const PaymentRequestRecipientIdentity({
+    required this.kind,
+    required this.name,
+    required this.profilePictureId,
+  });
+
+  const PaymentRequestRecipientIdentity.contact({
+    required String name,
+    required String profilePictureId,
+  }) : this(
+         kind: PaymentRequestRecipientKind.contact,
+         name: name,
+         profilePictureId: profilePictureId,
+       );
+
+  const PaymentRequestRecipientIdentity.ownAccount({
+    required String name,
+    required String profilePictureId,
+  }) : this(
+         kind: PaymentRequestRecipientKind.ownAccount,
+         name: name,
+         profilePictureId: profilePictureId,
+       );
+
+  final PaymentRequestRecipientKind kind;
+
+  /// Contact label or account name. Rendered as the "To" headline, clamped to
+  /// one line — a contact label is user-authored and can be any length.
+  final String name;
+
+  /// Avatar id resolved through [AppProfilePicture].
+  final String profilePictureId;
+
+  bool get isOwnAccount => kind == PaymentRequestRecipientKind.ownAccount;
+
+  /// One-line, whitespace-collapsed name, or null when there is nothing to
+  /// show — a nameless identity is worse than the raw address, so the card
+  /// falls back to the unmapped layout in that case.
+  String? get displayName {
+    final collapsed = name.replaceAll(RegExp(r'\s+'), ' ').trim();
+    return collapsed.isEmpty ? null : collapsed;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is PaymentRequestRecipientIdentity &&
+      other.kind == kind &&
+      other.name == name &&
+      other.profilePictureId == profilePictureId;
+
+  @override
+  int get hashCode => Object.hash(kind, name, profilePictureId);
+}
+
+/// Everything [PaymentRequestCard] renders.
+///
+/// Immutable and free of providers, routing and parsing. The caller
+/// sanitizes untrusted fields (a link can carry anything) before building
+/// this; the widget still clamps every string so a hostile label or memo
+/// cannot stretch, wrap or scroll the card.
+@immutable
+class PaymentRequestView {
+  const PaymentRequestView({
+    required this.source,
+    required this.address,
+    this.amountZecText,
+    this.requesterLabel,
+    this.fiatText,
+    this.memo,
+    this.note,
+    this.spendableText,
+    this.recipientIdentity,
+    this.status = PaymentRequestStatus.ready,
+    this.statusMessage,
+    this.replacedNotice = false,
+  });
+
+  /// Link or QR code. Kept for callers and logging; nothing renders it.
+  final PaymentRequestSource source;
+
+  /// Preformatted amount including the unit, e.g. `0.5 ZEC`.
+  ///
+  /// Null when the request carried no `amount`. The card then renders no
+  /// amount block at all — no hero, no placeholder line — rather than
+  /// inventing a number in its most prominent slot, and the primary action
+  /// becomes "Enter amount", which hands the request to the composer.
+  final String? amountZecText;
+
+  /// Full recipient address. Displayed middle-truncated through
+  /// [truncatedAddress]; the full value expands in place inside the To row.
+  final String address;
+
+  /// Who is asking, when the request carried a label. Null renders no name
+  /// at all — an empty or invented identity would be worse than none.
+  ///
+  /// This string is attacker-controlled: it is whatever the link's `label`
+  /// parameter said. The card keeps it inside the collapsed requester group
+  /// instead of presenting it as verified contact information.
+  final String? requesterLabel;
+
+  /// Preformatted fiat equivalent, e.g. `$35.00`. Null hides the line.
+  final String? fiatText;
+
+  /// Encrypted memo that travels with the payment. The request card calls it
+  /// "Transaction memo" to distinguish it from the requester's link message.
+  final String? memo;
+
+  /// Off-chain message embedded by the requester in the link or QR code.
+  /// It is shown as "Note from requester" and is not copied into the payment.
+  final String? note;
+
+  /// Preformatted spendable balance used by the insufficient-funds message.
+  final String? spendableText;
+
+  /// The name this wallet can put to [address] — a saved contact or one of
+  /// the user's own accounts — or null when the address maps to neither.
+  ///
+  /// Resolved by the host from the address book and the account list, which
+  /// both load asynchronously, so null is also the honest "not looked up
+  /// yet" value: the card renders the plain address until the lookup lands
+  /// rather than blocking on it.
+  final PaymentRequestRecipientIdentity? recipientIdentity;
+
+  final PaymentRequestStatus status;
+
+  /// Overrides [defaultPaymentRequestStatusMessage] for [status].
+  final String? statusMessage;
+
+  /// Renders the "Replaced an earlier link" notice above the amount.
+  final bool replacedNotice;
+
+  /// Same request, different verdict. The pre-check fills the amount and the
+  /// requester in once, up front; only the status (and the two fields the
+  /// status line reads) change as the checks land.
+  PaymentRequestView copyWithStatus(
+    PaymentRequestStatus status, {
+    String? statusMessage,
+    String? spendableText,
+  }) => PaymentRequestView(
+    source: source,
+    address: address,
+    amountZecText: amountZecText,
+    requesterLabel: requesterLabel,
+    fiatText: fiatText,
+    memo: memo,
+    note: note,
+    spendableText: spendableText ?? this.spendableText,
+    recipientIdentity: recipientIdentity,
+    status: status,
+    statusMessage: statusMessage,
+    replacedNotice: replacedNotice,
+  );
+
+  /// Same request, with the "replaced an earlier link" notice shown.
+  ///
+  /// The notice normally comes from `present`, which knows it displaced a
+  /// card. It is applied after the fact for the one case `present` cannot
+  /// see: a newer link arriving while the previous card was mid-hand-back and
+  /// therefore already gone. Without this the user's Review tap disappears
+  /// with nothing on the new card to say why.
+  PaymentRequestView withReplacedNotice() {
+    if (replacedNotice) return this;
+    return PaymentRequestView(
+      source: source,
+      address: address,
+      amountZecText: amountZecText,
+      requesterLabel: requesterLabel,
+      fiatText: fiatText,
+      memo: memo,
+      note: note,
+      spendableText: spendableText,
+      recipientIdentity: recipientIdentity,
+      status: status,
+      statusMessage: statusMessage,
+      replacedNotice: true,
+    );
+  }
+
+  /// Same request, with the fiat sub-line attached (or removed).
+  ///
+  /// The host re-applies this on every build for the same reason as
+  /// [withRecipientIdentity]: the ZEC price provider is autoDispose and
+  /// resolves asynchronously, so a card presented over a screen that holds no
+  /// subscription to it would otherwise keep the null it read at present time
+  /// for the life of the card.
+  PaymentRequestView withFiatText(String? fiatText) {
+    if (fiatText == this.fiatText) return this;
+    return PaymentRequestView(
+      source: source,
+      address: address,
+      amountZecText: amountZecText,
+      requesterLabel: requesterLabel,
+      fiatText: fiatText,
+      memo: memo,
+      note: note,
+      spendableText: spendableText,
+      recipientIdentity: recipientIdentity,
+      status: status,
+      statusMessage: statusMessage,
+      replacedNotice: replacedNotice,
+    );
+  }
+
+  /// Same request, with the recipient's resolved name attached (or removed).
+  ///
+  /// The host re-applies this on every build, because the address book and
+  /// the account addresses resolve after the card is already on screen.
+  PaymentRequestView withRecipientIdentity(
+    PaymentRequestRecipientIdentity? identity,
+  ) {
+    if (identity == recipientIdentity) return this;
+    return PaymentRequestView(
+      source: source,
+      address: address,
+      amountZecText: amountZecText,
+      requesterLabel: requesterLabel,
+      fiatText: fiatText,
+      memo: memo,
+      note: note,
+      spendableText: spendableText,
+      recipientIdentity: identity,
+      status: status,
+      statusMessage: statusMessage,
+      replacedNotice: replacedNotice,
+    );
+  }
+
+  String? get resolvedStatusMessage =>
+      statusMessage ??
+      defaultPaymentRequestStatusMessage(status, spendableText: spendableText);
+
+  /// Amount text with surrounding whitespace removed, or null when the
+  /// request carried no amount.
+  String? get displayAmount {
+    final raw = amountZecText?.trim();
+    return (raw == null || raw.isEmpty) ? null : raw;
+  }
+
+  /// One-line, whitespace-collapsed requester label, or null when there is
+  /// nothing to show.
+  String? get displayRequesterLabel {
+    final raw = requesterLabel?.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (raw == null || raw.isEmpty) return null;
+    return raw;
+  }
+
+  String? get displayMemo {
+    final raw = memo?.trim();
+    return (raw == null || raw.isEmpty) ? null : raw;
+  }
+
+  String? get displayNote {
+    final raw = note?.trim();
+    return (raw == null || raw.isEmpty) ? null : raw;
+  }
+
+  /// The recipient identity the card should actually render, or null when
+  /// the address maps to nothing this wallet can name — which includes an
+  /// identity whose name turned out to be blank.
+  PaymentRequestRecipientIdentity? get displayRecipientIdentity {
+    final identity = recipientIdentity;
+    return identity?.displayName == null ? null : identity;
+  }
+
+  /// Pool of [address], for the Shielded / Transparent badge.
+  ZcashAddressDisplayKind get addressKind => zcashAddressDisplayKind(address);
+
+  /// The card's serif title. Constant: the requester is never promoted into
+  /// it, because a link-supplied name is not this card's identity.
+  String get headerTitle => 'Payment request';
+
+  bool get hasRequesterDetails =>
+      displayRequesterLabel != null || displayNote != null;
+}
+
+/// A payment request someone else sent you, rendered as received content
+/// with a single consent action.
+///
+/// This is deliberately *not* a form: the amount, address, memo and note
+/// are read-only, and the only way to change any of them is "Edit", which
+/// hands the request to the normal send composer. The card supplies no
+/// surface of its own — [PaymentRequestSurface] (or any modal frame)
+/// provides the card/sheet chrome, so the same widget renders in the
+/// desktop modal and the mobile sheet.
+///
+/// The details block uses the send review's card and divider components, so
+/// the request reads as a preview of the screen its primary action lands on.
+class PaymentRequestCard extends StatefulWidget {
+  const PaymentRequestCard({
+    required this.request,
+    required this.onContinue,
+    required this.onEdit,
+    required this.onCancel,
+    this.onRecheck,
+    this.layout = PaymentRequestLayout.auto,
+    this.bottomSafeArea = false,
+    this.initialAddressExpanded = false,
+    this.initialMessageExpanded = false,
+    super.key,
+  });
+
+  final PaymentRequestView request;
+
+  /// Accept the request as it stands and move to the review step. Ignored
+  /// while [PaymentRequestStatusX.blocksContinue] is true.
+  final VoidCallback onContinue;
+
+  /// Open the request in the send composer for editing.
+  final VoidCallback onEdit;
+
+  /// Discard the request. Also backs the desktop close affordance.
+  final VoidCallback onCancel;
+
+  /// Ask the wallet again, for [PaymentRequestStatus.syncStalled].
+  ///
+  /// Null leaves that status's primary action disabled, which is the honest
+  /// answer for a preview or a host that cannot re-run the check.
+  final VoidCallback? onRecheck;
+
+  /// Applies [MobileBottomSafeArea] under the mobile action stack.
+  ///
+  /// Defaults to false because every presentation that ships today
+  /// ([PaymentRequestSurface] and `showPaymentRequestSheet`) puts the card
+  /// inside a `MobileModalScaffold` hosted by `MobileModalCard`, and the
+  /// card already owns that edge — taking the inset here too would add the
+  /// Android navigation bar twice. Pass true only when the card is the
+  /// bottom-most content of its own route.
+  final bool bottomSafeArea;
+
+  /// Tooling-only layout override; see [PaymentRequestLayout].
+  final PaymentRequestLayout layout;
+
+  /// Opens the To row's full-address view on first build.
+  ///
+  /// Tooling-only, the same exemption [layout] carries: a static capture
+  /// cannot tap the toggle, so the expanded state needs a way to be
+  /// rendered directly. App code leaves this false.
+  final bool initialAddressExpanded;
+
+  /// Opens the Message row's full text on first build. Tooling-only, for
+  /// the same reason as [initialAddressExpanded].
+  final bool initialMessageExpanded;
+
+  /// Resolves [layout] against the build-time form factor.
+  bool get isMobileLayout => switch (layout) {
+    PaymentRequestLayout.auto => kAppFormFactor == AppFormFactor.mobile,
+    PaymentRequestLayout.desktop => false,
+    PaymentRequestLayout.mobile => true,
+  };
+
+  @override
+  State<PaymentRequestCard> createState() => _PaymentRequestCardState();
+}
+
+/// Expansion state lives here, above the scrolling region, rather than
+/// inside the rows.
+///
+/// The rows sit inside a scroll region whose fade wrapper used to be added
+/// and removed as the scroll offset changed. That moved the subtree to a
+/// different position in the widget tree, which deactivates and re-inflates
+/// every element under it, so an expanded memo collapsed the moment the
+/// user scrolled. Hoisting the flags above the region makes expansion
+/// immune to any rebuild of the content, and the region itself no longer
+/// swaps its own subtree in and out (see [_FadingScrollRegion]).
+class _PaymentRequestCardState extends State<PaymentRequestCard> {
+  late bool _addressExpanded = widget.initialAddressExpanded;
+  late bool _messageExpanded = widget.initialMessageExpanded;
+  bool _requesterExpanded = false;
+
+  void _toggleAddress() => setState(() => _addressExpanded = !_addressExpanded);
+  void _toggleMessage() => setState(() => _messageExpanded = !_messageExpanded);
+  void _toggleRequester() =>
+      setState(() => _requesterExpanded = !_requesterExpanded);
+
+  PaymentRequestView get _request => widget.request;
+
+  bool get _isMobile => widget.isMobileLayout;
+
+  @override
+  Widget build(BuildContext context) {
+    final request = _request;
+    final status = request.status;
+    final isMobile = _isMobile;
+
+    // Gap between the card's top-level groups. Mobile runs against a fixed
+    // viewport budget, so it takes the tighter step; both stay at least 2x
+    // the 8px gaps used inside a group.
+    final sectionGap = isMobile ? AppSpacing.sm : AppSpacing.md;
+    final statusMessage = request.resolvedStatusMessage;
+    final amount = request.displayAmount;
+
+    // Header, requester, amount, status and actions stay pinned. The
+    // transaction details scroll only when expanded or unusually long.
+    final rows = _detailRows();
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _Header(
+              title: request.headerTitle,
+              isMobileLayout: isMobile,
+              onClose: widget.onCancel,
+            ),
+            if (request.replacedNotice) ...[
+              const SizedBox(height: AppSpacing.xs),
+              const _QuietNotice(
+                key: ValueKey('payment_request_replaced_notice'),
+                message: 'Replaced an earlier link',
+              ),
+            ],
+            if (request.hasRequesterDetails) ...[
+              SizedBox(height: sectionGap),
+              _RequesterDetailsCard(
+                requester: request.displayRequesterLabel,
+                note: request.displayNote,
+                expanded: _requesterExpanded,
+                onToggle: request.displayNote == null ? null : _toggleRequester,
+              ),
+            ],
+            SizedBox(height: sectionGap),
+            if (constraints.maxHeight.isFinite)
+              Flexible(
+                child: _TransactionContentFrame(
+                  amountText: amount,
+                  fiatText: request.fiatText,
+                  rows: rows,
+                  bounded: true,
+                ),
+              )
+            else
+              _TransactionContentFrame(
+                amountText: amount,
+                fiatText: request.fiatText,
+                rows: rows,
+                bounded: false,
+              ),
+            // A request error belongs to the details card, so keep it close
+            // to that surface and leave the full section gap before actions.
+            if (statusMessage != null) ...[
+              SizedBox(height: isMobile ? AppSpacing.xxs : AppSpacing.xs),
+              _StatusMessage(
+                key: const ValueKey('payment_request_status'),
+                status: status,
+                message: statusMessage,
+              ),
+              SizedBox(height: sectionGap),
+            ] else
+              SizedBox(height: sectionGap),
+            _Actions(
+              status: status,
+              statusMessage: statusMessage,
+              hasAmount: amount != null,
+              isMobileLayout: isMobile,
+              bottomSafeArea: widget.bottomSafeArea,
+              onContinue: widget.onContinue,
+              onEdit: widget.onEdit,
+              onRecheck: widget.onRecheck,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  /// Transaction content only. Requester metadata lives in its own disclosure
+  /// above this group so off-chain request text is not confused with the memo.
+  List<Widget> _detailRows() {
+    final request = _request;
+    final memo = request.displayMemo;
+    final addressRow = _AddressRow(
+      key: const ValueKey('payment_request_to_row'),
+      address: request.address,
+      identity: request.displayRecipientIdentity,
+      isMobileLayout: _isMobile,
+      expanded: _addressExpanded,
+      onToggle: _toggleAddress,
+    );
+
+    return [
+      addressRow,
+      if (memo != null) ...[
+        const ReviewWrapDivider(),
+        _ProseRows(
+          key: const ValueKey('payment_request_memo'),
+          label: 'Transaction memo',
+          text: memo,
+          expanded: _messageExpanded,
+          onToggle: _toggleMessage,
+        ),
+      ],
+    ];
+  }
+}
+
+/// Off-chain metadata supplied by the payment link's requester.
+///
+/// The name remains visible as the collapsed summary. A requester note is
+/// progressive disclosure because it is context for the request, not content
+/// that will be included in the Zcash transaction.
+class _RequesterDetailsCard extends StatelessWidget {
+  const _RequesterDetailsCard({
+    required this.requester,
+    required this.note,
+    required this.expanded,
+    required this.onToggle,
+  });
+
+  final String? requester;
+  final String? note;
+  final bool expanded;
+  final VoidCallback? onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final transparent = colors.background.ground.withValues(alpha: 0);
+    final summary = requester ?? 'Note from requester';
+    final scaler = MediaQuery.textScalerOf(context);
+    // Label over value, both at body size: the requester is text the link
+    // supplied, not an identity the wallet verified, so it does not take
+    // the headline the address-book name gets in the To row.
+    final labelStyle = AppTypography.bodyMediumStrong;
+    final valueStyle = AppTypography.bodyMediumStrong;
+    final summaryHeight =
+        (scaler.scale(labelStyle.fontSize!) * labelStyle.height! +
+                AppSpacing.xxs +
+                scaler.scale(valueStyle.fontSize!) * valueStyle.height!)
+            .ceilToDouble() +
+        1;
+    final summaryRow = Row(
+      children: [
+        Expanded(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Flexible(
+                    child: Text(
+                      'Requester',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: labelStyle.copyWith(color: colors.text.secondary),
+                    ),
+                  ),
+                  // Only a link-supplied name needs the caveat; a note-only
+                  // card has no name to be mistaken for a verified sender.
+                  if (requester != null) ...[
+                    const SizedBox(width: AppSpacing.xxs),
+                    AppTooltip(
+                      tapToShow: true,
+                      message: kPaymentRequestRequesterTooltip,
+                      child: AppIcon(
+                        AppIcons.help,
+                        key: const ValueKey('payment_request_requester_help'),
+                        size: AppIconSize.medium,
+                        color: colors.icon.regular,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+              const SizedBox(height: AppSpacing.xxs),
+              Text(
+                summary,
+                key: const ValueKey('payment_request_requester'),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: valueStyle.copyWith(color: colors.text.accent),
+              ),
+            ],
+          ),
+        ),
+        if (onToggle != null) ...[
+          const SizedBox(width: AppSpacing.xs),
+          AppIcon(
+            expanded ? AppIcons.collapsed : AppIcons.expand,
+            color: colors.icon.regular,
+          ),
+        ],
+      ],
+    );
+
+    final toggle = onToggle;
+    final summaryControl = toggle == null
+        ? summaryRow
+        : Semantics(
+            button: true,
+            expanded: expanded,
+            excludeSemantics: true,
+            label: expanded
+                ? 'Hide requester details'
+                : 'Show requester details',
+            value: requester == null
+                ? 'Requester, $summary'
+                : 'Label from link, $summary',
+            onTap: toggle,
+            child: AppButton(
+              key: const ValueKey('payment_request_requester_toggle'),
+              onPressed: toggle,
+              variant: AppButtonVariant.ghost,
+              size: AppButtonSize.small,
+              height: summaryHeight,
+              enabledBackgroundColor: transparent,
+              pressedBackgroundColor: transparent,
+              expand: true,
+              constrainContent: true,
+              contentPadding: _paymentRequestDisclosurePadding,
+              child: summaryRow,
+            ),
+          );
+
+    return ReviewWrapCard(
+      key: const ValueKey('payment_request_requester_group'),
+      mainAxisSize: MainAxisSize.min,
+      // The card's content gutter: the same 16 every group on this card
+      // uses, so the label here, the transaction label, and the rows in
+      // the details card all share one left edge.
+      padding: const EdgeInsets.all(kPaymentRequestGutter),
+      children: [
+        summaryControl,
+        if (expanded && note != null) ...[
+          const ReviewWrapDivider(),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Note from requester',
+                style: labelStyle.copyWith(color: colors.text.secondary),
+              ),
+              const SizedBox(height: AppSpacing.xxs),
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: AppSpacing.xl3),
+                child: _FadingScrollRegion(
+                  scrollViewKey: kPaymentRequestRequesterNoteScrollViewKey,
+                  scrollbarKey: kPaymentRequestRequesterNoteScrollbarKey,
+                  contentPadding: const EdgeInsetsDirectional.only(
+                    end: kPaymentRequestGutter,
+                  ),
+                  child: Text(
+                    note!,
+                    key: const ValueKey('payment_request_requester_note'),
+                    style: AppTypography.bodyMediumStrong.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// The amount and the on-chain destination/memo as one visual group.
+///
+/// Only the inner details region flexes and scrolls. The group label and the
+/// amount being approved remain pinned in every state.
+class _TransactionContentFrame extends StatelessWidget {
+  const _TransactionContentFrame({
+    required this.amountText,
+    required this.fiatText,
+    required this.rows,
+    required this.bounded,
+  });
+
+  final String? amountText;
+  final String? fiatText;
+  final List<Widget> rows;
+  final bool bounded;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final details = bounded
+        ? Flexible(child: _DetailsFrame(rows: rows))
+        : ReviewWrapCard(
+            padding: const EdgeInsets.all(kPaymentRequestGutter),
+            children: rows,
+          );
+
+    final radius = BorderRadius.circular(AppRadii.large);
+    return Container(
+      key: const ValueKey('payment_request_transaction_content'),
+      width: double.infinity,
+      padding: const EdgeInsets.only(top: kPaymentRequestGutter),
+      decoration: BoxDecoration(borderRadius: radius),
+      // Painted over the content rather than as part of the box so the 1px
+      // stroke does not shift the gutter: content sits exactly 16 in from
+      // the frame edge, the same as inside every other card here.
+      foregroundDecoration: BoxDecoration(
+        border: Border.all(color: colors.border.regular),
+        borderRadius: radius,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: kPaymentRequestGutter,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Transaction content',
+                  style: AppTypography.bodyMediumStrong.copyWith(
+                    color: colors.text.secondary,
+                  ),
+                ),
+                if (amountText != null) ...[
+                  const SizedBox(height: AppSpacing.xs),
+                  _AmountHero(amountText: amountText!, fiatText: fiatText),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          // Flush with the frame: same radius at zero inset keeps the two
+          // corners concentric, and the card's own 16 inset lands its rows
+          // on the frame label's left edge.
+          details,
+        ],
+      ),
+    );
+  }
+}
+
+/// The "To" block: pool beside the label, then the address beside its
+/// verification action. Keeping each related pair together saves a row and
+/// makes the privacy status and address action easier to scan.
+///
+/// The full address never leaves this card. "Show full address" swaps the
+/// one-line truncation for the canonical verify grouping — 5-character
+/// groups with the same head/tail emphasis the verify-address modal uses —
+/// so the user can compare characters without losing the request behind a
+/// second modal.
+///
+/// When the wallet can put a name to the address ([identity]) the block leads
+/// with that name and an avatar instead, the way the pay and send reviews
+/// render a known recipient, and the address drops to the sub-line. The pool
+/// badge and the expand control are unchanged in both shapes: a name is not a
+/// reason to stop stating the pool, and the full address still has to be
+/// verifiable from inside the card.
+class _AddressRow extends StatelessWidget {
+  const _AddressRow({
+    required this.address,
+    required this.identity,
+    required this.isMobileLayout,
+    required this.expanded,
+    required this.onToggle,
+    super.key,
+  });
+
+  final String address;
+
+  /// The name behind [address], or null for an address this wallet does not
+  /// recognize — which is also the state while the lookup is still running.
+  final PaymentRequestRecipientIdentity? identity;
+
+  final bool isMobileLayout;
+  final bool expanded;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final isShielded =
+        zcashAddressDisplayKind(address) == ZcashAddressDisplayKind.shielded;
+    final actionLabel = expanded ? 'Hide full address' : 'Show full address';
+    final identity = this.identity;
+    final chunks = _AddressChunks(
+      key: const ValueKey('payment_request_address_chunks'),
+      address: address,
+    );
+
+    final recipient = Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (identity != null) ...[
+          const SizedBox(height: AppSpacing.xs),
+          _RecipientIdentityBlock(identity: identity),
+        ],
+        const SizedBox(height: AppSpacing.xxs),
+        if (expanded) ...[
+          chunks,
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: _addressAction(context, actionLabel),
+          ),
+        ] else
+          Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: AppSpacing.xxs,
+            runSpacing: 0,
+            children: [
+              Text(
+                truncatedAddress(address),
+                key: identity == null
+                    ? null
+                    : const ValueKey('payment_request_recipient_address'),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.codeMedium.copyWith(
+                  color: identity == null
+                      ? colors.text.accent
+                      : colors.text.secondary,
+                ),
+              ),
+              _addressAction(context, actionLabel),
+            ],
+          ),
+      ],
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: AppSpacing.xs,
+          runSpacing: AppSpacing.xxs,
+          children: [
+            Text(
+              'To',
+              maxLines: 1,
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+            // Paying a transparent address is the one detail on this card
+            // with a privacy consequence the review step cannot undo.
+            PoolBadge(
+              key: const ValueKey('payment_request_pool_badge'),
+              isShielded: isShielded,
+            ),
+          ],
+        ),
+        // On touch the whole recipient block toggles the full address —
+        // address line plus pill is 45px, above the 44px floor — so the
+        // pill keeps its 24px Figma height and no transparent ring has
+        // to be padded into the row rhythm. Translucent: the pill's own
+        // detector still wins inside its bounds.
+        if (isMobileLayout)
+          GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            excludeFromSemantics: true,
+            onTap: onToggle,
+            child: recipient,
+          )
+        else
+          recipient,
+      ],
+    );
+  }
+
+  Widget _addressAction(BuildContext context, String label) {
+    final colors = context.colors;
+    final usesLargeText = MediaQuery.textScalerOf(context).scale(1) >= 1.5;
+    final visibleLabel = usesLargeText ? (expanded ? 'Hide' : 'Show') : label;
+    return Semantics(
+      button: true,
+      label: label,
+      onTap: onToggle,
+      excludeSemantics: true,
+      child: MediaQuery.withClampedTextScaling(
+        maxScaleFactor: 1.5,
+        child: AppButton(
+          key: const ValueKey('payment_request_show_full_address'),
+          onPressed: onToggle,
+          variant: AppButtonVariant.ghost,
+          size: AppButtonSize.small,
+          iconGap: 0,
+          leading: usesLargeText
+              ? null
+              : AppIcon(
+                  expanded ? AppIcons.eyeClosed : AppIcons.eye,
+                  color: colors.button.ghost.label,
+                ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+            child: Text(
+              visibleLabel,
+              maxLines: 1,
+              style: AppTypography.labelSmall,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Avatar + name for a recipient the wallet recognizes.
+///
+/// The composition is the pay/send review's contact recipient
+/// (`AppProfilePicture` leading, name headline, address sub-line) fitted to
+/// this card's tighter scale: the name takes the sans headline step rather
+/// than the review's serif, because the serif belongs to the amount and the
+/// card title above it and a third serif line would flatten that hierarchy.
+///
+/// An own-account recipient adds one muted line saying so. Paying yourself is
+/// a legitimate thing to do from a link, but it is also exactly what a
+/// swapped-address attack looks like from the other direction, so the card
+/// states the relationship instead of leaving the user to recognize a name.
+class _RecipientIdentityBlock extends StatelessWidget {
+  const _RecipientIdentityBlock({required this.identity});
+
+  final PaymentRequestRecipientIdentity identity;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Row(
+      // Centered against the whole text block, the way `ReviewInfoRow` seats
+      // its own leading avatar: top-aligning it against the name alone left
+      // the 32px circle visibly high beside a three-line own-account block.
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        AppProfilePicture(
+          key: const ValueKey('payment_request_recipient_avatar'),
+          profilePictureId: identity.profilePictureId,
+          size: AppProfilePictureSize.large,
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                // Non-null: the card only builds this block for an identity
+                // that survived `displayRecipientIdentity`.
+                identity.displayName!,
+                key: const ValueKey('payment_request_recipient_name'),
+                // A contact label is user-authored and unbounded; it is cut,
+                // never wrapped, the same way the requester line is.
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.headlineSmall.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+              if (identity.isOwnAccount) ...[
+                const SizedBox(height: AppSpacing.xxs),
+                Text(
+                  'Your account',
+                  key: const ValueKey('payment_request_own_account_label'),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTypography.labelSmall.copyWith(
+                    color: colors.text.secondary,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The full address in 5-character groups, five groups to a row.
+///
+/// Chunking and the head/tail crimson emphasis come from
+/// [addressVerifyGrid], the same source the verify-address modal renders,
+/// so a user who has compared an address in one place reads the other
+/// identically. The glyphs stay monospace here because the collapsed form
+/// directly above them is monospace too.
+class _AddressChunks extends StatelessWidget {
+  const _AddressChunks({required this.address, super.key});
+
+  final String address;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final rows = addressVerifyGrid(address);
+    final normalStyle = AppTypography.codeMedium.copyWith(
+      color: colors.text.accent,
+    );
+    final highlightedStyle = AppTypography.codeMedium.copyWith(
+      color: colors.text.brandCrimson,
+      fontWeight: FontWeight.w600,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (var row = 0; row < rows.length; row++) ...[
+          if (row > 0) const SizedBox(height: AppSpacing.xxs),
+          // scaleDown keeps wide glyph metrics (and the test environment's
+          // square Ahem font) from overflowing the card column; with the
+          // production Geist Mono metrics the row fits and renders 1:1.
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: AlignmentDirectional.centerStart,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (var i = 0; i < rows[row].length; i++) ...[
+                  if (i > 0) const SizedBox(width: AppSpacing.xs),
+                  Text(
+                    rows[row][i].text,
+                    style: rows[row][i].highlighted
+                        ? highlightedStyle
+                        : normalStyle,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// The card's name in the serif headline scale the send screens use for
+/// their titles, with the desktop close affordance beside it.
+///
+/// The title takes the step below the amount hero: the amount is the value
+/// being consented to and has to stay the largest thing on the card, so a
+/// same-size title would flatten the hierarchy instead of establishing it.
+class _Header extends StatelessWidget {
+  const _Header({
+    required this.title,
+    required this.isMobileLayout,
+    required this.onClose,
+  });
+
+  final String title;
+  final bool isMobileLayout;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Padding(
+      // Mobile has no close of its own; it reserves the room the sheet's
+      // pinned ⨯ occupies instead.
+      padding: EdgeInsetsDirectional.only(
+        end: isMobileLayout ? kPaymentRequestMobileCloseClearance : 0,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Semantics(
+              header: true,
+              child: Text(
+                title,
+                key: const ValueKey('payment_request_title'),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.headlineMedium.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+            ),
+          ),
+          if (!isMobileLayout) ...[
+            const SizedBox(width: AppSpacing.xs),
+            AppIconHoverButton(
+              key: const ValueKey('payment_request_close'),
+              icon: AppIcons.cross,
+              semanticLabel: 'Close payment request',
+              onTap: onClose,
+              size: 32,
+              iconColor: colors.icon.regular,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// The requested amount, with its fiat equivalent underneath.
+///
+/// Both values are read-only on this card, so neither takes tabular figures
+/// — the serif display style is the same one the home balance and every
+/// `ReviewInfoRow` amount already use.
+class _AmountHero extends StatelessWidget {
+  const _AmountHero({required this.amountText, required this.fiatText});
+
+  final String amountText;
+  final String? fiatText;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final fiat = fiatText?.trim();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Align(
+          alignment: AlignmentDirectional.centerStart,
+          // Long amounts scale down rather than ellipsize — a truncated
+          // number is worse than a smaller one.
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: AlignmentDirectional.centerStart,
+            child: Text(
+              amountText,
+              key: const ValueKey('payment_request_amount'),
+              maxLines: 1,
+              // One serif step above the review screens' amount: this card
+              // is a consent surface and the number is what is consented to.
+              style: AppTypography.displayLarge.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+          ),
+        ),
+        if (fiat != null && fiat.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.xxs),
+          Text(
+            fiat,
+            key: const ValueKey('payment_request_fiat'),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.bodyMedium.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// The transaction memo block, in the send review's own message shape.
+///
+/// The label sits above the value so it remains readable at mobile widths and
+/// large text sizes. The value toggles between a one-line preview and the full
+/// memo.
+///
+/// The expanded flag is owned by [_PaymentRequestCardState]; this widget is
+/// stateless on purpose, so no rebuild of the scrolling content can reset it.
+class _ProseRows extends StatelessWidget {
+  const _ProseRows({
+    required this.label,
+    required this.text,
+    required this.expanded,
+    required this.onToggle,
+    super.key,
+  });
+
+  /// Visible label for the encrypted memo that travels with the payment.
+  final String label;
+
+  final String text;
+  final bool expanded;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final transparent = colors.background.ground.withValues(alpha: 0);
+    final valueStyle = AppTypography.bodyMediumStrong;
+    final scaler = MediaQuery.textScalerOf(context);
+    // The control is the whole label-over-value block: 54px on mobile,
+    // 46 on desktop, so it clears the 44px touch floor by itself instead
+    // of padding an oversized box around the value line.
+    final controlHeight =
+        (scaler.scale(valueStyle.fontSize!) * valueStyle.height! * 2 +
+                AppSpacing.xxs)
+            .ceilToDouble() +
+        1;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Semantics(
+          button: true,
+          expanded: expanded,
+          excludeSemantics: true,
+          label: expanded
+              ? 'Collapse transaction memo'
+              : 'Expand transaction memo',
+          value: expanded ? null : '$label, $text',
+          onTap: onToggle,
+          child: AppButton(
+            key: const ValueKey('payment_request_memo_toggle'),
+            onPressed: onToggle,
+            variant: AppButtonVariant.ghost,
+            size: AppButtonSize.small,
+            height: controlHeight,
+            enabledBackgroundColor: transparent,
+            pressedBackgroundColor: transparent,
+            expand: true,
+            constrainContent: true,
+            contentPadding: _paymentRequestDisclosurePadding,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  label,
+                  // Inside a fixed-height control a label must not wrap.
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: valueStyle.copyWith(color: colors.text.secondary),
+                ),
+                const SizedBox(height: AppSpacing.xxs),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        expanded ? 'Collapse' : text,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: valueStyle.copyWith(color: colors.text.accent),
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.xxs),
+                    AppIcon(
+                      expanded ? AppIcons.collapsed : AppIcons.expand,
+                      color: colors.icon.regular,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (expanded) ...[
+          const SizedBox(height: AppSpacing.xxs),
+          Text(text, style: valueStyle.copyWith(color: colors.text.accent)),
+        ],
+      ],
+    );
+  }
+}
+
+/// The card's one status line.
+///
+/// The request errors ([PaymentRequestStatusX.isError]) take the destructive
+/// tone and the warning glyph the text fields already use. The one other line
+/// that reaches this slot is `syncing`, which is a pending state the card
+/// resolves on its own, so it renders as quiet secondary text with no glyph —
+/// the same treatment the replaced-link notice gets. "Checking" says itself
+/// inside the primary button and never comes through here.
+class _StatusMessage extends StatelessWidget {
+  const _StatusMessage({
+    required this.status,
+    required this.message,
+    super.key,
+  });
+
+  final PaymentRequestStatus status;
+  final String? message;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = this.message;
+    if (message == null || message.isEmpty) return const SizedBox.shrink();
+    final colors = context.colors;
+
+    // One rule for the tone, so the enum's own answer and what the card
+    // paints cannot drift apart.
+    final isError = status.isError;
+    final color = isError ? colors.text.destructive : colors.text.secondary;
+    final iconName = isError ? AppIcons.warning : null;
+
+    final textStyle = AppTypography.bodySmall.copyWith(color: color);
+    // The glyph centers on the first line of its own message, so it has to
+    // grow with the text scale rather than sit at the unscaled line height.
+    final lineHeight = MediaQuery.textScalerOf(
+      context,
+    ).scale(textStyle.fontSize! * textStyle.height!);
+    return Semantics(
+      liveRegion: true,
+      container: true,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (iconName != null) ...[
+            SizedBox(
+              height: lineHeight,
+              child: Center(
+                child: AppIcon(
+                  iconName,
+                  size: AppIconSize.medium,
+                  color: color,
+                  animated: false,
+                ),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.xs),
+          ],
+          Expanded(child: Text(message, style: textStyle)),
+        ],
+      ),
+    );
+  }
+}
+
+/// Quiet one-liner above the content (the replaced-link notice).
+class _QuietNotice extends StatelessWidget {
+  const _QuietNotice({required this.message, super.key});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      message,
+      style: AppTypography.bodySmall.copyWith(
+        color: context.colors.text.secondary,
+      ),
+    );
+  }
+}
+
+/// The card's action area: one full-width primary over one full-width ghost
+/// action, the pair `ReviewButtonsStack` already uses on the send review
+/// screens.
+///
+/// "Review" names where the primary lands — the send review step — rather
+/// than the generic "Continue" it replaced; nothing is signed from here.
+/// While checks are running that button carries a spinner and says
+/// "Checking…" instead, so the wait is stated where the action is.
+///
+/// An amount-less request has nothing to review yet, so its primary reads
+/// "Enter amount" and opens the composer — the same destination `Edit`
+/// leads to, which is why the secondary is absent in that state. That also
+/// makes it the only control the card has left when such a request is
+/// blocked, so it stays enabled and says "Edit" instead.
+///
+/// Neither form factor carries a Cancel button: desktop refuses through the
+/// header's close ⨯, mobile through the sheet's pinned ⨯
+/// (`MobileModalScaffold`).
+class _Actions extends StatelessWidget {
+  const _Actions({
+    required this.status,
+    required this.statusMessage,
+    required this.hasAmount,
+    required this.isMobileLayout,
+    required this.bottomSafeArea,
+    required this.onContinue,
+    required this.onEdit,
+    required this.onRecheck,
+  });
+
+  final PaymentRequestStatus status;
+  final String? statusMessage;
+
+  /// False when the request carried no amount: the primary becomes the edit
+  /// action and the secondary is dropped.
+  final bool hasAmount;
+
+  final bool isMobileLayout;
+  final bool bottomSafeArea;
+  final VoidCallback onContinue;
+  final VoidCallback onEdit;
+  final VoidCallback? onRecheck;
+
+  bool get _blocked => status.blocksContinue;
+
+  bool get _checking => status == PaymentRequestStatus.checking;
+
+  /// The request is blocked on the wallet, not on itself, and asking again is
+  /// the move. Only meaningful with an amount: an amount-less request never
+  /// reaches the pre-check answers that can stall.
+  bool get _recheckable => status.offersRecheck && hasAmount;
+
+  String get _primaryLabel => _checking
+      ? 'Checking…'
+      : _recheckable
+      ? 'Check again'
+      : hasAmount
+      ? 'Review'
+      // A blocked amount-less request is not waiting for an amount — the
+      // address or the check is the problem — so naming the button after
+      // the amount would point at the wrong fix.
+      : _blocked
+      ? 'Edit'
+      : 'Enter amount';
+
+  @override
+  Widget build(BuildContext context) {
+    final stack = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _primaryFill(),
+        if (hasAmount) ...[const SizedBox(height: AppSpacing.xs), _editFill()],
+      ],
+    );
+
+    if (!isMobileLayout || !bottomSafeArea) return stack;
+    return MobileBottomSafeArea(
+      bottomPadding: kIosHomeIndicatorClearance,
+      child: stack,
+    );
+  }
+
+  /// Wraps a button so a disabled primary still announces itself and says
+  /// why it cannot be used, instead of disappearing from the accessibility
+  /// tree with no explanation.
+  Widget _semantics({
+    required Widget child,
+    required bool enabled,
+    required String label,
+  }) {
+    if (enabled) {
+      return Semantics(button: true, enabled: true, child: child);
+    }
+    final reason = statusMessage;
+    return Semantics(
+      button: true,
+      enabled: false,
+      label: reason == null
+          ? '$label, unavailable'
+          : '$label, unavailable. '
+                '$reason',
+      excludeSemantics: true,
+      child: child,
+    );
+  }
+
+  /// `AppButton` has no loading variant, so the spinner rides in the
+  /// button's own leading slot beside the label it belongs to.
+  /// `AppLoadingIcon` freezes itself under `MediaQuery.disableAnimations`.
+  Widget? _primaryLeading() {
+    if (!_checking) return null;
+    return const AppIcon(AppIcons.loader, animated: true);
+  }
+
+  /// A 44px pill that fills whatever width it is given — the size the send
+  /// review CTA uses (`ReviewButtonsStack`) and the mobile send steps'
+  /// full-width primary.
+  Widget _fillButton({
+    required Key key,
+    required String label,
+    required VoidCallback? onPressed,
+    required AppButtonVariant variant,
+    Widget? leading,
+  }) {
+    return _semantics(
+      enabled: onPressed != null,
+      label: label,
+      child: AppButton(
+        key: key,
+        onPressed: onPressed,
+        variant: variant,
+        expand: true,
+        constrainContent: true,
+        leading: leading,
+        child: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+      ),
+    );
+  }
+
+  Widget _primaryFill() => _fillButton(
+    key: const ValueKey('payment_request_continue'),
+    label: _primaryLabel,
+    // Without an amount the primary *is* the edit action, and there is no
+    // second Edit under it. Blocking it too would leave the card with no
+    // enabled control at all — a stated error and no way to act on it. Edit
+    // is never blocked; it only waits while the checks run.
+    onPressed: _recheckable
+        ? onRecheck
+        : hasAmount
+        ? (_blocked ? null : onContinue)
+        : (_checking ? null : onEdit),
+    variant: AppButtonVariant.primary,
+    leading: _primaryLeading(),
+  );
+
+  Widget _editFill() => _fillButton(
+    key: const ValueKey('payment_request_edit'),
+    label: 'Edit',
+    onPressed: onEdit,
+    variant: AppButtonVariant.ghost,
+  );
+}
+
+/// The details card as a fixed frame: a [ReviewWrapCard] that takes the
+/// height it is given, with the received content scrolling inside its own
+/// rounded clip.
+///
+/// The card's inner inset moves into the scroll viewport so the content
+/// runs edge to edge under the clip while the scrollbar rides in the
+/// gutter that inset leaves, and the fade cues sit on the card's own top
+/// and bottom edges instead of cutting the content off mid-surface under
+/// the pinned header.
+class _DetailsFrame extends StatelessWidget {
+  const _DetailsFrame({required this.rows});
+
+  final List<Widget> rows;
+
+  @override
+  Widget build(BuildContext context) {
+    return ReviewWrapCard(
+      // The frame hugs short content and fills for long content; the
+      // viewport inside decides which, so the card must not force a height.
+      mainAxisSize: MainAxisSize.min,
+      padding: EdgeInsets.zero,
+      children: [
+        // Flexible, so the viewport inherits the frame's bounded height: a
+        // `Column` hands a plain child unbounded main-axis space, which
+        // would let the content size the scroll view instead of the frame.
+        Flexible(
+          fit: FlexFit.loose,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(AppRadii.large),
+            child: _FadingScrollRegion(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  for (var i = 0; i < rows.length; i++) ...[
+                    // The row gap the wrap card applies to its children.
+                    if (i > 0) const SizedBox(height: AppSpacing.sm),
+                    rows[i],
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Scrolls the received content inside the details frame, dissolves
+/// whichever edge still has content beyond it, and owns the overlay
+/// scrollbar for that scroll.
+///
+/// The fade is a mask on the content itself, not a gradient painted in the
+/// wrap-card color: masking dissolves the glyphs against whatever the card
+/// surface is in the current theme, with no second color to keep in sync.
+///
+/// The [ShaderMask] is present on every build, including while both fades
+/// are fully transparent. An earlier revision returned the bare child at
+/// zero opacity and inserted the mask only once the content overflowed;
+/// that changed the subtree's position in the widget tree, which
+/// deactivates and re-inflates every element under it. The scroll offset
+/// and every expansion state below were discarded on the first scroll as a
+/// result — the reason an expanded memo collapsed the moment the user
+/// scrolled.
+class _FadingScrollRegion extends StatefulWidget {
+  const _FadingScrollRegion({
+    required this.child,
+    this.scrollViewKey = kPaymentRequestScrollViewKey,
+    this.scrollbarKey = kPaymentRequestScrollbarKey,
+    this.contentPadding = defaultContentPadding,
+  });
+
+  final Widget child;
+  final Key scrollViewKey;
+  final Key scrollbarKey;
+  final EdgeInsetsGeometry contentPadding;
+
+  static const _fadeHeight = AppSpacing.md;
+
+  /// The card's inset, moved inside the viewport so the content scrolls
+  /// the full height of the card. The card gutter on every side, not the
+  /// review screen's 24/16 pair: this card sits inside a frame that uses
+  /// 16, and two vertical rhythms one level apart read as a mistake.
+  static const defaultContentPadding = EdgeInsets.all(kPaymentRequestGutter);
+
+  /// Overlay scrollbar geometry: the pane scrollbar's 6px capsule, centered
+  /// in the card's 16px inner gutter so it never rides over text.
+  static const scrollbarThickness = 6.0;
+  static const scrollbarMargin = (AppSpacing.sm - scrollbarThickness) / 2;
+
+  @override
+  State<_FadingScrollRegion> createState() => _FadingScrollRegionState();
+}
+
+class _FadingScrollRegionState extends State<_FadingScrollRegion> {
+  final _controller = ScrollController();
+  bool _hasMoreAbove = false;
+  bool _hasMoreBelow = false;
+  bool _canScroll = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// Seeds and re-seeds the cues from the live scroll position.
+  ///
+  /// A `ScrollNotification` only fires once something scrolls, so at rest —
+  /// which is how the card is first seen — the notification listener alone
+  /// leaves the fade off and the content hard-cut. This runs after every
+  /// frame instead, which also covers the content growing when a memo is
+  /// expanded.
+  void _syncFromPosition() {
+    if (!mounted || !_controller.hasClients) return;
+    final position = _controller.position;
+    if (!position.hasContentDimensions) return;
+    _update(
+      hasMoreAbove: position.extentBefore > 0.5,
+      hasMoreBelow: position.extentAfter > 0.5,
+      canScroll: position.maxScrollExtent > 0.5,
+    );
+  }
+
+  void _update({
+    required bool hasMoreAbove,
+    required bool hasMoreBelow,
+    required bool canScroll,
+  }) {
+    if (hasMoreAbove == _hasMoreAbove &&
+        hasMoreBelow == _hasMoreBelow &&
+        canScroll == _canScroll) {
+      return;
+    }
+    setState(() {
+      _hasMoreAbove = hasMoreAbove;
+      _hasMoreBelow = hasMoreBelow;
+      _canScroll = canScroll;
+    });
+  }
+
+  bool _onScroll(ScrollNotification notification) {
+    if (notification.depth != 0) return false;
+    _update(
+      hasMoreAbove: notification.metrics.extentBefore > 0.5,
+      hasMoreBelow: notification.metrics.extentAfter > 0.5,
+      canScroll: notification.metrics.maxScrollExtent > 0.5,
+    );
+    return false; // Observe only — let the notification bubble on.
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    WidgetsBinding.instance.addPostFrameCallback((_) => _syncFromPosition());
+    final animate = !(MediaQuery.maybeOf(context)?.disableAnimations ?? false);
+    final duration = animate
+        ? const Duration(milliseconds: 120)
+        : Duration.zero;
+
+    final scroller = NotificationListener<ScrollNotification>(
+      onNotification: _onScroll,
+      // Without this the ambient behavior adds a second, platform-default
+      // scrollbar of its own, pinned to the very edge of the region.
+      child: ScrollConfiguration(
+        behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
+        child: SingleChildScrollView(
+          key: widget.scrollViewKey,
+          controller: _controller,
+          padding: widget.contentPadding,
+          child: widget.child,
+        ),
+      ),
+    );
+
+    // The scrollbar stays outside the mask: the thumb is a control, not
+    // content, and a cue that dissolves the control it belongs to reads as
+    // a rendering fault.
+    return RawScrollbar(
+      key: widget.scrollbarKey,
+      controller: _controller,
+      thumbVisibility: _canScroll,
+      thickness: _FadingScrollRegion.scrollbarThickness,
+      radius: const Radius.circular(AppRadii.full),
+      crossAxisMargin: _FadingScrollRegion.scrollbarMargin,
+      mainAxisMargin: AppSpacing.xs,
+      thumbColor: context.colors.surface.scrollbarThumb,
+      child: TweenAnimationBuilder<double>(
+        tween: Tween<double>(begin: 0, end: _hasMoreAbove ? 1 : 0),
+        duration: duration,
+        curve: Curves.easeOut,
+        child: scroller,
+        builder: (context, top, child) => TweenAnimationBuilder<double>(
+          tween: Tween<double>(begin: 0, end: _hasMoreBelow ? 1 : 0),
+          duration: duration,
+          curve: Curves.easeOut,
+          child: child,
+          builder: (context, bottom, child) => ShaderMask(
+            blendMode: BlendMode.dstIn,
+            shaderCallback: (bounds) =>
+                _fadeShader(bounds, top: top, bottom: bottom),
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Shader _fadeShader(
+    Rect bounds, {
+    required double top,
+    required double bottom,
+  }) {
+    const opaque = Color(0xFFFFFFFF);
+    final fade = bounds.height <= 0
+        ? 0.5
+        : (_FadingScrollRegion._fadeHeight / bounds.height).clamp(0.0, 0.5);
+    return LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [
+        opaque.withValues(alpha: 1 - top),
+        opaque,
+        opaque,
+        opaque.withValues(alpha: 1 - bottom),
+      ],
+      stops: [0, fade, 1 - fade, 1],
+    ).createShader(bounds);
+  }
+}

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -736,6 +736,11 @@ class _PaymentRequestCardState extends State<PaymentRequestCard> {
           key: const ValueKey('payment_request_memo'),
           label: 'Transaction memo',
           text: memo,
+          // A memo of nothing but whitespace is still bytes the payment
+          // carries, so the row stays — but drawing those bytes draws
+          // nothing, and a row that looks empty is indistinguishable from a
+          // request that asked for no memo at all.
+          placeholder: request.memoIsWhitespaceOnly ? 'Whitespace only' : null,
           expanded: _messageExpanded,
           onToggle: _toggleMessage,
         ),
@@ -1405,6 +1410,7 @@ class _ProseRows extends StatelessWidget {
     required this.text,
     required this.expanded,
     required this.onToggle,
+    this.placeholder,
     super.key,
   });
 
@@ -1412,6 +1418,16 @@ class _ProseRows extends StatelessWidget {
   final String label;
 
   final String text;
+
+  /// Drawn in place of [text] when [text] would render as nothing.
+  ///
+  /// The memo is still [text] and is still what the payment carries; this
+  /// only replaces the glyphs, so a memo made entirely of whitespace reads as
+  /// a memo the payer can see rather than a blank row they would take for an
+  /// empty one. Muted rather than accent, because it is the card describing
+  /// the memo, not the memo's own words.
+  final String? placeholder;
+
   final bool expanded;
   final VoidCallback onToggle;
 
@@ -1420,6 +1436,10 @@ class _ProseRows extends StatelessWidget {
     final colors = context.colors;
     final transparent = colors.background.ground.withValues(alpha: 0);
     final valueStyle = AppTypography.bodyMediumStrong;
+    final value = placeholder ?? text;
+    final valueColor = placeholder == null
+        ? colors.text.accent
+        : colors.text.muted;
     final scaler = MediaQuery.textScalerOf(context);
     // The control is the whole label-over-value block: 54px on mobile,
     // 46 on desktop, so it clears the 44px touch floor by itself instead
@@ -1440,7 +1460,7 @@ class _ProseRows extends StatelessWidget {
           label: expanded
               ? 'Collapse transaction memo'
               : 'Expand transaction memo',
-          value: expanded ? null : '$label, $text',
+          value: expanded ? null : '$label, $value',
           onTap: onToggle,
           child: AppButton(
             key: const ValueKey('payment_request_memo_toggle'),
@@ -1468,10 +1488,12 @@ class _ProseRows extends StatelessWidget {
                   children: [
                     Expanded(
                       child: Text(
-                        expanded ? 'Collapse' : text,
+                        expanded ? 'Collapse' : value,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: valueStyle.copyWith(color: colors.text.accent),
+                        style: valueStyle.copyWith(
+                          color: expanded ? colors.text.accent : valueColor,
+                        ),
                       ),
                     ),
                     const SizedBox(width: AppSpacing.xxs),
@@ -1487,7 +1509,7 @@ class _ProseRows extends StatelessWidget {
         ),
         if (expanded) ...[
           const SizedBox(height: AppSpacing.xxs),
-          Text(text, style: valueStyle.copyWith(color: colors.text.accent)),
+          Text(value, style: valueStyle.copyWith(color: valueColor)),
         ],
       ],
     );

--- a/lib/src/features/swap/providers/swap_hardware_signing_service.dart
+++ b/lib/src/features/swap/providers/swap_hardware_signing_service.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/config/network_config.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
@@ -283,7 +284,7 @@ String _swapKeystoneRequestId(SwapHardwarePcztDraft draft) =>
     'vizor-${draft.sendFlowId}';
 
 Future<void> _rejectTexDepositForKeystone(String address) async {
-  final validation = await rust_sync.validateAddress(address: address);
+  final validation = await rust_sync.validateAddress(address: address, network: kZcashDefaultNetworkName);
   if (validation.isValid && validation.addressType == 'tex') {
     throw UnsupportedError('Keystone does not support TEX sends yet.');
   }

--- a/lib/src/features/swap/providers/swap_hardware_signing_service.dart
+++ b/lib/src/features/swap/providers/swap_hardware_signing_service.dart
@@ -3,9 +3,9 @@ import 'dart:typed_data';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
-import '../../../core/config/network_config.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../keystone/services/keystone_batch_signing.dart';
@@ -83,7 +83,10 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
     if (depositAddress == null || depositAddress.isEmpty) {
       throw StateError('Swap deposit address is missing');
     }
-    await _rejectTexDepositForKeystone(depositAddress);
+    await _rejectTexDepositForKeystone(
+      depositAddress,
+      networkName: _ref.read(rpcEndpointProvider).networkName,
+    );
     final amountZatoshi = zecDepositAmountZatoshiForIntent(intent);
     final sendFlowId = _newSwapHardwareFlowId('deposit');
     return _ref
@@ -283,8 +286,14 @@ const _swapKeystoneMessageId = 'swap-deposit';
 String _swapKeystoneRequestId(SwapHardwarePcztDraft draft) =>
     'vizor-${draft.sendFlowId}';
 
-Future<void> _rejectTexDepositForKeystone(String address) async {
-  final validation = await rust_sync.validateAddress(address: address, network: kZcashDefaultNetworkName);
+Future<void> _rejectTexDepositForKeystone(
+  String address, {
+  required String networkName,
+}) async {
+  final validation = await rust_sync.validateAddress(
+    address: address,
+    network: networkName,
+  );
   if (validation.isValid && validation.addressType == 'tex') {
     throw UnsupportedError('Keystone does not support TEX sends yet.');
   }

--- a/lib/src/providers/migration_send_gate_provider.dart
+++ b/lib/src/providers/migration_send_gate_provider.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/layout/app_form_factor.dart';
+import '../features/migration/providers/ironwood_migration_announcement_provider.dart';
+import 'account_provider.dart';
+import 'sync_provider.dart';
+
+/// Whether the product currently refuses to start a send because a Private
+/// (Ironwood) migration holds the account's entire spendable balance.
+///
+/// A migration in the `resume` state has moved the funds out of Orchard and
+/// not yet into a spendable Ironwood note, so `ironwoodBalance` is zero and
+/// there is nothing to spend. Mobile Home disables its Send button on exactly
+/// this predicate; the payment-URI drain reads the same provider so a `zcash:`
+/// link cannot walk in through the side door and land the user on a send form
+/// the Home screen would not have opened.
+///
+/// **Deliberately mobile-only.** This is the product's send gate, not a raw
+/// balance predicate, and desktop has no such gate to mirror: the desktop Home
+/// pane's `onSend` is an unconditional `context.push('/send')`, and
+/// `AppMainSidebar` gates Pay (`payNavigationLocked`) and voting during a
+/// migration but never Send. Widening the payment-URI drop to desktop would
+/// therefore be a new desktop behaviour rather than an alignment, so the gate
+/// is scoped to the form factor that actually has it. Flip the guard here —
+/// not at the call sites — if desktop Home ever starts disabling Send.
+final migrationSendGateProvider = Provider<bool>((ref) {
+  if (kAppFormFactor != AppFormFactor.mobile) return false;
+
+  final migrationCta = ref.watch(ironwoodHomeMigrationPresentationProvider);
+  if (migrationCta.mode != IronwoodHomeMigrationCtaMode.resume) return false;
+
+  final activeAccountUuid = ref.watch(
+    accountProvider.select((value) => value.value?.activeAccountUuid),
+  );
+  final ironwoodBalance = ref.watch(
+    syncProvider.select(
+      (value) => (value.value ?? SyncState())
+          .scopedToAccount(activeAccountUuid)
+          .ironwoodBalance,
+    ),
+  );
+  return ironwoodBalance <= BigInt.zero;
+});

--- a/lib/src/providers/payment_request_flow_provider.dart
+++ b/lib/src/providers/payment_request_flow_provider.dart
@@ -492,11 +492,10 @@ class PaymentRequestFlowNotifier extends Notifier<PaymentRequestFlowState?> {
     // it is what stops a startup request from reading a zero balance and
     // telling the user they cannot afford a payment they can.
     final sync = (await _readSyncState()).scopedToAccount(accountUuid);
-    // Mirrors the compose form: while a Private migration holds the balance,
-    // the Ironwood note is what can actually be spent.
-    final spendable = ref.read(migrationSendGateProvider)
-        ? sync.displayIronwoodBalance
-        : sync.displaySpendableBalance;
+    final spendable = paymentRequestSpendableOf(
+      sync,
+      gatedByMigration: ref.read(migrationSendGateProvider),
+    );
     // Only a balance from a finished scan may end the check as "not enough".
     // A restored last-completed snapshot is stale by construction, and a sync
     // still short of the tip has not seen every note yet, so both hand the

--- a/lib/src/providers/payment_request_flow_provider.dart
+++ b/lib/src/providers/payment_request_flow_provider.dart
@@ -1,0 +1,652 @@
+/// The live state of the payment-request card.
+///
+/// A `zcash:` link (and, later, an in-app QR scan) arrives here after the drain
+/// policy has cleared it. The card then owns the request until the user answers
+/// it: Review hands the proposal to the review screen, Edit hands the request
+/// to the composer, Cancel throws it away. The notifier is the only place that
+/// knows a proposal may be alive behind the card, so it is also the only place
+/// that has to release one.
+library;
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/formatting/zec_amount.dart';
+import '../features/send/models/send_prefill_args.dart';
+import '../features/send/services/payment_request_precheck.dart';
+import '../features/send/services/send_flow.dart';
+import '../features/send/widgets/payment_request_card.dart';
+import 'account_provider.dart';
+import 'app_security_provider.dart';
+import 'migration_send_gate_provider.dart' show migrationSendGateProvider;
+import 'payment_uri_prefill_provider.dart';
+import 'sync_provider.dart';
+import 'zec_price_change_provider.dart';
+
+export '../features/send/widgets/payment_request_card.dart'
+    show PaymentRequestSource, PaymentRequestStatus, PaymentRequestView;
+
+/// Everything the host needs to render and act on the current card.
+class PaymentRequestFlowState {
+  const PaymentRequestFlowState({
+    required this.prefill,
+    required this.view,
+    this.proposal,
+  });
+
+  /// The request as parsed, unchanged. This is what Edit hands to the
+  /// composer, so it must keep the untouched link values.
+  final SendPrefillArgs prefill;
+
+  /// What the card renders, including its status.
+  final PaymentRequestView view;
+
+  /// The live proposal, once the pre-check has made one. Null while checking,
+  /// on every failure, and for an amount-less request.
+  final PaymentRequestProposalHandle? proposal;
+
+  SendReviewArgs? get reviewArgs => proposal?.reviewArgs;
+
+  /// Whether the primary action can go straight to the review screen. False
+  /// for an amount-less request, whose primary action is "Enter amount".
+  bool get canReview =>
+      view.status == PaymentRequestStatus.ready && proposal != null;
+
+  PaymentRequestFlowState copyWith({
+    PaymentRequestView? view,
+    PaymentRequestProposalHandle? proposal,
+  }) => PaymentRequestFlowState(
+    prefill: prefill,
+    view: view ?? this.view,
+    proposal: proposal ?? this.proposal,
+  );
+}
+
+/// What a mobile Review tap resolved to.
+///
+/// Three answers, not two: "nothing to review" and "a newer link took over
+/// while the proposal was being handed back" both leave the wizard closed,
+/// but only the second one dropped something the user asked for, and only
+/// the second one has a card left on screen to say so.
+sealed class PaymentRequestReviewHandoff {
+  const PaymentRequestReviewHandoff();
+}
+
+/// The proposal is back with Rust; the wizard can open on [args].
+final class PaymentRequestReviewReady extends PaymentRequestReviewHandoff {
+  const PaymentRequestReviewReady(this.args);
+
+  final SendReviewArgs args;
+}
+
+/// Nothing to review — no card, an amount-less request, or a status that
+/// still blocks. The caller falls back to Edit.
+final class PaymentRequestReviewUnavailable
+    extends PaymentRequestReviewHandoff {
+  const PaymentRequestReviewUnavailable();
+}
+
+/// A newer link replaced the card during the hand-back.
+///
+/// The user is looking at that request now, and opening the first one's
+/// review underneath it would leave a send they did not choose behind the
+/// card they dismiss. The newer card carries the standard replaced notice so
+/// the dropped tap is accounted for.
+final class PaymentRequestReviewOvertaken extends PaymentRequestReviewHandoff {
+  const PaymentRequestReviewOvertaken();
+}
+
+class PaymentRequestFlowNotifier extends Notifier<PaymentRequestFlowState?> {
+  /// Bumped by every state change. A pre-check that finishes after its card is
+  /// gone (replaced, cancelled, reviewed) must not write into the newer card,
+  /// and must release the proposal it just created.
+  var _generation = 0;
+
+  /// Mirrors `state?.proposal`. `onDispose` may not read `state`, and a
+  /// proposal that outlives its scope is exactly the leak this class exists to
+  /// prevent, so the handle is tracked here as well.
+  PaymentRequestProposalHandle? _liveProposal;
+
+  /// Open only while the card is sitting on [PaymentRequestStatus.syncing].
+  ///
+  /// That status is the one verdict that is not about the request at all: it
+  /// says the wallet could not answer yet. Leaving the user to re-open the
+  /// link is asking them to retry a condition the wallet already knows how to
+  /// notice, so the card watches for it instead.
+  ProviderSubscription<AsyncValue<SyncState>>? _syncWatch;
+
+  /// Edge state for [_syncWatch]: the re-check fires on the false→true
+  /// crossing only. Firing on the level would spin the card — a re-check whose
+  /// answer is `syncing` again republishes `syncing` while the sync state is
+  /// still settled, and would immediately ask for another one.
+  var _syncWasSettled = false;
+
+  /// How many times this card may re-check itself against a wallet that is
+  /// *already* settled, before it goes back to waiting for a crossing.
+  ///
+  /// The edge trigger alone cannot answer a `syncing` verdict published while
+  /// the sync state is settled: there is no crossing left to wait for, so the
+  /// card would sit on "this will update when it finishes" forever. That is
+  /// not a corner case — it is what this feature's own re-check loop produces
+  /// whenever Rust's view lags the sync state's. The budget is what keeps the
+  /// answer bounded: a re-check that lands on `syncing` again may ask once
+  /// more, and then the card waits for a real sync cycle rather than spinning.
+  var _immediateRecheckBudget = 0;
+
+  /// How many immediate re-checks one card gets.
+  static const _kImmediateRecheckBudget = 2;
+
+  /// The pre-check currently asking Rust, if any.
+  ///
+  /// A check displaced mid-flight still gets its proposal — Rust does not
+  /// know the card is gone — and hands it back only once its result arrives.
+  /// Until then the inputs that proposal selected are locked, so the
+  /// replacement's check has to wait for this future before it asks.
+  Future<void>? _inFlightPrecheck;
+
+  /// The most recent hand-back of a proposal (dismiss, edit, lock, a
+  /// replacement's displaced card), for the same reason as
+  /// [_inFlightPrecheck]: a check started before the locked inputs are
+  /// released can read a wallet whose funds are all "in use" and answer "not
+  /// enough" for a payment the wallet can afford.
+  Future<void>? _lastRelease;
+
+  @override
+  PaymentRequestFlowState? build() {
+    // The card is consent given by one unlocked account, and it holds that
+    // account's live proposal. Locking, signing out, and switching accounts
+    // all take that consent away without going through any of the card's own
+    // exits, so the flow has to notice them itself: the host renders above the
+    // router, which means a card left standing would sit on top of the unlock
+    // screen with the request's address, amount and memo still on it.
+    ref.listen(appSecurityProvider, (previous, next) {
+      final wasUnlocked = previous?.isUnlocked ?? true;
+      if (wasUnlocked && !next.isUnlocked) {
+        _reparkForUnlock();
+        clear(logContext: 'PaymentRequest(locked)');
+      }
+    });
+    ref.listen(accountProvider, (previous, next) {
+      final previousUuid = previous?.value?.activeAccountUuid;
+      final nextUuid = next.value?.activeAccountUuid;
+      // Only a switch between two real accounts. A wallet reset drops the
+      // active account to null and is already handled by the link listener in
+      // `app.dart`, which also clears the parked prefill.
+      if (previousUuid != null &&
+          nextUuid != null &&
+          previousUuid != nextUuid) {
+        clear(logContext: 'PaymentRequest(account switched)');
+      }
+    });
+    ref.onDispose(() {
+      _stopWatchingSync();
+      final proposal = _liveProposal;
+      _liveProposal = null;
+      if (proposal != null) {
+        unawaited(proposal.discard(logContext: 'PaymentRequest(disposed)'));
+      }
+    });
+    return null;
+  }
+
+  void _publish(PaymentRequestFlowState? next) {
+    // The watch is bound to the two statuses it exists for, and this is the
+    // single choke point every card change goes through: presenting a newer
+    // link, every verdict the pre-check publishes, and every teardown
+    // (dismiss, edit, review, lock, sign-out, account switch) land here.
+    var published = next;
+    final status = published?.view.status;
+    if (_isWaitingOnSync(status)) {
+      // `syncing` copy promises the card will update itself. When the watch
+      // reports that nothing is coming — the sync state is already settled
+      // and the immediate budget is spent — that promise cannot be kept, so
+      // the card publishes the stalled status instead and hands the next
+      // move to the user through "Check again".
+      final answerIsComing = _watchSyncForRecheck();
+      if (!answerIsComing && status == PaymentRequestStatus.syncing) {
+        published = published!.copyWith(
+          view: published.view.copyWithStatus(PaymentRequestStatus.syncStalled),
+        );
+      }
+    } else {
+      _stopWatchingSync();
+    }
+    _liveProposal = published?.proposal;
+    state = published;
+  }
+
+  /// The two statuses that are blocked on the wallet rather than on the
+  /// request, and are therefore the ones a finished sync can answer.
+  static bool _isWaitingOnSync(PaymentRequestStatus? status) =>
+      status == PaymentRequestStatus.syncing ||
+      status == PaymentRequestStatus.syncStalled;
+
+  /// Installs (or keeps) the sync watch, and spends an immediate re-check
+  /// when one is both possible and the only way the card can be answered.
+  ///
+  /// Returns whether an answer is still coming on its own: a sync that has
+  /// not settled yet will cross, and a spent budget means neither will
+  /// happen — which is what turns the card's status from `syncing` into
+  /// `syncStalled`.
+  bool _watchSyncForRecheck() {
+    final settled = _spendableIsSettled(ref.read(syncProvider).value);
+    if (_syncWatch == null) {
+      _syncWasSettled = settled;
+      _syncWatch = ref.listen<AsyncValue<SyncState>>(syncProvider, (_, next) {
+        final wasSettled = _syncWasSettled;
+        final isSettled = _spendableIsSettled(next.value);
+        _syncWasSettled = isSettled;
+        if (wasSettled || !isSettled) return;
+        _recheckAfterSync();
+      });
+    }
+    // Not settled yet: the crossing this watch exists for is still ahead.
+    if (!settled) return true;
+    // Already settled: no crossing is coming, so the wait the copy promises
+    // has to be answered now instead of never.
+    if (_immediateRecheckBudget <= 0) return false;
+    _immediateRecheckBudget--;
+    final generation = _generation;
+    scheduleMicrotask(() {
+      if (generation != _generation) return;
+      _recheckAfterSync();
+    });
+    return true;
+  }
+
+  void _stopWatchingSync() {
+    _syncWatch?.close();
+    _syncWatch = null;
+    _syncWasSettled = false;
+  }
+
+  /// Re-runs the same pre-check on the same request now that the wallet can
+  /// answer it.
+  void _recheckAfterSync() {
+    final current = state;
+    // Only the statuses this watch was installed for. A card that has since
+    // moved on — to a verdict, or to a re-check already in flight, which
+    // renders as `checking` — is not waiting on the sync any more.
+    if (current == null || !_isWaitingOnSync(current.view.status)) {
+      _stopWatchingSync();
+      return;
+    }
+    // Back to the same first-look state `present` publishes: the primary
+    // shows its spinner and the status line clears, so the card says it is
+    // working rather than leaving the old blocked message under a new answer.
+    _publish(
+      current.copyWith(
+        view: current.view.copyWithStatus(PaymentRequestStatus.checking),
+      ),
+    );
+    // No proposal to release first: a `syncing` verdict never holds one.
+    unawaited(_runPrecheck(_generation));
+  }
+
+  /// The card's "Check again", for [PaymentRequestStatus.syncStalled].
+  ///
+  /// The same re-check the sync watch runs, asked for by hand. It does not
+  /// touch the immediate budget: that budget bounds what the card does on its
+  /// own, and a tap is not the card acting on its own.
+  void recheck() {
+    final current = state;
+    if (current == null ||
+        current.view.status != PaymentRequestStatus.syncStalled) {
+      return;
+    }
+    _recheckAfterSync();
+  }
+
+  /// Shows [prefill] as a payment request and starts the pre-check.
+  ///
+  /// A card already on screen is replaced — latest link wins, matching the
+  /// single-slot park in `paymentUriPrefillProvider` — and the replacement says
+  /// so rather than silently swapping under the user.
+  void present(
+    SendPrefillArgs prefill, {
+    required PaymentRequestSource source,
+  }) {
+    final replaced = state;
+    if (replaced?.proposal != null) {
+      _track(
+        replaced!.proposal!.discard(logContext: 'PaymentRequest(replaced)'),
+      );
+    }
+    // The replacement's check is serialized behind whatever is still
+    // releasing inputs: the displaced proposal's discard just started above,
+    // an earlier hand-back that has not finished, and a displaced check that
+    // is still running and will hand its own proposal back when it lands.
+    final after = <Future<void>>[?_lastRelease, ?_inFlightPrecheck];
+
+    final generation = ++_generation;
+    _immediateRecheckBudget = _kImmediateRecheckBudget;
+    _publish(
+      PaymentRequestFlowState(
+        prefill: prefill,
+        view: _buildView(
+          prefill: prefill,
+          source: source,
+          status: PaymentRequestStatus.checking,
+          replacedNotice: replaced != null,
+        ),
+      ),
+    );
+    unawaited(_runPrecheck(generation, after: after));
+  }
+
+  /// Hands the proposal *back* rather than on, for the mobile review step,
+  /// which creates its own proposal on "Confirm & send".
+  ///
+  /// Clears the card at once but completes only when Rust has released the
+  /// proposal: the review step re-quotes the fee as it mounts, and a quote
+  /// asked while the card's proposal still holds its inputs can come back
+  /// short for the very payment the card just found affordable.
+  ///
+  /// The three outcomes are distinct on purpose — see
+  /// [PaymentRequestReviewHandoff].
+  Future<PaymentRequestReviewHandoff> reviewHandingBack() async {
+    final current = state;
+    if (current == null || !current.canReview) {
+      return const PaymentRequestReviewUnavailable();
+    }
+    final proposal = current.proposal!;
+    final generation = ++_generation;
+    _publish(null);
+    final release = proposal.discard(
+      logContext: 'PaymentRequest(mobile review handoff)',
+    );
+    _track(release);
+    await release;
+    if (generation != _generation) {
+      // The tap is being dropped, so it is accounted for on the card that
+      // took its place rather than vanishing with the request it belonged to.
+      _noteReplacedRequest();
+      return const PaymentRequestReviewOvertaken();
+    }
+    return PaymentRequestReviewReady(proposal.reviewArgs);
+  }
+
+  /// Puts the standard "replaced an earlier link" notice on the card that is
+  /// up now.
+  ///
+  /// `present` raises the notice itself when it displaces a visible card. It
+  /// cannot see this case: the displaced card was already cleared by the
+  /// hand-back, so the replacement had nothing to replace.
+  void _noteReplacedRequest() {
+    final current = state;
+    if (current == null || current.view.replacedNotice) return;
+    // Written straight to `state`: the status is unchanged, so the sync watch
+    // that `_publish` owns must not be re-evaluated — re-entering it would
+    // spend an immediate re-check the card never asked for.
+    state = current.copyWith(view: current.view.withReplacedNotice());
+  }
+
+  /// Hands the proposal to the review screen and clears the card.
+  ///
+  /// Returns null when there is nothing to review — an amount-less request, or
+  /// a status that still blocks — so the caller can fall back to Edit.
+  SendReviewArgs? review() {
+    final current = state;
+    if (current == null || !current.canReview) return null;
+    final args = current.proposal!.release();
+    _generation++;
+    _publish(null);
+    return args;
+  }
+
+  /// Clears the card, releases any proposal, and returns the request for the
+  /// composer.
+  SendPrefillArgs? edit() {
+    final current = state;
+    if (current == null) return null;
+    _clear(logContext: 'PaymentRequest(edit)');
+    return current.prefill;
+  }
+
+  /// Cancel, the ⨯, the scrim, and the Android back gesture.
+  void dismiss() => _clear(logContext: 'PaymentRequest(dismissed)');
+
+  /// Drops the card without a user answer — wallet lock, account switch,
+  /// wallet reset.
+  void clear({String logContext = 'PaymentRequest(cleared)'}) =>
+      _clear(logContext: logContext);
+
+  /// Puts a locked-away card's request back in the park.
+  ///
+  /// Taking the card down on lock is not negotiable — the host renders above
+  /// the router, so it would otherwise sit on the unlock screen with the
+  /// address, amount and memo on it. But the prefill was consumed when the
+  /// drain delivered it, so without this the request is gone with nothing to
+  /// say and nothing to claim: the one silent drop left in a pipeline whose
+  /// rule is that no drop is silent. Re-parking hands it back to the path
+  /// that already exists — `claimParkedPaymentUriAfterUnlock` re-presents it
+  /// after a successful unlock, under the same park TTL as a link tapped
+  /// while locked. The proposal is still discarded; only the request survives.
+  void _reparkForUnlock() {
+    final current = state;
+    if (current == null) return;
+    // Latest link wins, the same answer the park itself gives: a link that
+    // arrived while the card was up and is still parked (held behind a busy
+    // surface, say) is the newer request, so it keeps the single slot.
+    if (ref.read(paymentUriPrefillProvider) != null) return;
+    ref.read(paymentUriPrefillProvider.notifier).set(current.prefill);
+  }
+
+  void _clear({required String logContext}) {
+    final current = state;
+    if (current == null) return;
+    final proposal = current.proposal;
+    if (proposal != null) {
+      _track(proposal.discard(logContext: logContext));
+    }
+    _generation++;
+    _publish(null);
+  }
+
+  /// Remembers [release] as the hand-back a later check must wait for.
+  ///
+  /// A discard never throws — `discardSendProposal` swallows its own
+  /// failures — but the future is shielded anyway so a replacement can never
+  /// be wedged in `checking` by its predecessor.
+  void _track(Future<void> release) {
+    final shielded = release.then<void>((_) {}, onError: (Object _) {});
+    _lastRelease = shielded;
+    unawaited(
+      shielded.whenComplete(() {
+        if (identical(_lastRelease, shielded)) _lastRelease = null;
+      }),
+    );
+  }
+
+  /// Runs one pre-check and keeps it in [_inFlightPrecheck] while it runs, so
+  /// a replacement presented mid-check can wait for it.
+  Future<void> _runPrecheck(
+    int generation, {
+    List<Future<void>> after = const [],
+  }) async {
+    final run = _precheck(generation, after: after);
+    _inFlightPrecheck = run;
+    try {
+      await run;
+    } finally {
+      if (identical(_inFlightPrecheck, run)) _inFlightPrecheck = null;
+    }
+  }
+
+  Future<void> _precheck(
+    int generation, {
+    required List<Future<void>> after,
+  }) async {
+    if (after.isNotEmpty) {
+      // Every future here is shielded (`_track`) or is a `_precheck` of our
+      // own, which completes normally on every path.
+      await Future.wait<void>(after);
+    }
+    final current = state;
+    if (current == null || generation != _generation) return;
+
+    final accountState = ref.read(accountProvider).value;
+    final accountUuid = accountState?.activeAccountUuid;
+    // A link can arrive before the first sync state has resolved. Waiting for
+    // it is what stops a startup request from reading a zero balance and
+    // telling the user they cannot afford a payment they can.
+    final sync = (await _readSyncState()).scopedToAccount(accountUuid);
+    // Mirrors the compose form: while a Private migration holds the balance,
+    // the Ironwood note is what can actually be spent.
+    final spendable = ref.read(migrationSendGateProvider)
+        ? sync.displayIronwoodBalance
+        : sync.displaySpendableBalance;
+    // Only a balance from a finished scan may end the check as "not enough".
+    // A restored last-completed snapshot is stale by construction, and a sync
+    // still short of the tip has not seen every note yet, so both hand the
+    // verdict to the proposal instead.
+    final spendableIsAuthoritative = sync.hasSettledSpendableBalance;
+
+    final result = await ref
+        .read(paymentRequestPrecheckProvider)
+        .run(
+          prefill: current.prefill,
+          sendFlowId: newSendFlowId(),
+          accountUuid: accountUuid,
+          spendableBalance: spendable,
+          spendableIsAuthoritative: spendableIsAuthoritative,
+        );
+
+    if (generation != _generation) {
+      // The card this pre-check belonged to is gone. Anything it created has
+      // no owner, so hand it straight back — and only return once it is
+      // back, because a replacement's check is waiting on this future for
+      // exactly that release.
+      if (result is PaymentRequestPrecheckReady && result.proposal != null) {
+        final release = result.proposal!.discard(
+          logContext: 'PaymentRequest(stale check)',
+        );
+        _track(release);
+        await release;
+      }
+      return;
+    }
+
+    final live = state;
+    if (live == null) return;
+
+    switch (result) {
+      case PaymentRequestPrecheckReady(:final proposal):
+        _publish(
+          PaymentRequestFlowState(
+            prefill: live.prefill,
+            view: live.view.copyWithStatus(PaymentRequestStatus.ready),
+            proposal: proposal,
+          ),
+        );
+      case PaymentRequestPrecheckInvalidAddress(:final message):
+        _publish(
+          live.copyWith(
+            view: live.view.copyWithStatus(
+              PaymentRequestStatus.invalidAddress,
+              // Null keeps the status's own default copy; the pre-check only
+              // supplies one when it can say more than "bad address".
+              statusMessage: message,
+            ),
+          ),
+        );
+      case PaymentRequestPrecheckInsufficientFunds(:final spendableText):
+        _publish(
+          live.copyWith(
+            view: live.view.copyWithStatus(
+              PaymentRequestStatus.insufficientFunds,
+              spendableText: spendableText,
+            ),
+          ),
+        );
+      case PaymentRequestPrecheckSyncing():
+        _publish(
+          live.copyWith(
+            view: live.view.copyWithStatus(PaymentRequestStatus.syncing),
+          ),
+        );
+      case PaymentRequestPrecheckFailed(:final message):
+        _publish(
+          live.copyWith(
+            view: live.view.copyWithStatus(
+              // Not `invalidAddress`: the check could not complete, which is
+              // a different condition from a bad recipient. The reason is
+              // always stated in its own words through `statusMessage`.
+              PaymentRequestStatus.failed,
+              statusMessage: message,
+            ),
+          ),
+        );
+    }
+  }
+
+  /// [SyncState.hasSettledSpendableBalance] for the active account, from an
+  /// unscoped state.
+  ///
+  /// The one condition the whole `syncing` status hangs off. The pre-check's
+  /// own read, this watch, and the precheck provider's live re-read all go
+  /// through the same predicate rather than drifting into three nearly
+  /// identical ones.
+  bool _spendableIsSettled(SyncState? sync) => spendableIsSettledForAccount(
+    sync,
+    ref.read(accountProvider).value?.activeAccountUuid,
+  );
+
+  Future<SyncState> _readSyncState() async {
+    final current = ref.read(syncProvider);
+    if (current.hasValue) return current.value!;
+    try {
+      return await ref.read(syncProvider.future);
+    } catch (_) {
+      // A sync that failed to load is not a reason to refuse the request; the
+      // proposal itself is the authoritative balance check.
+      return SyncState();
+    }
+  }
+
+  PaymentRequestView _buildView({
+    required SendPrefillArgs prefill,
+    required PaymentRequestSource source,
+    required PaymentRequestStatus status,
+    required bool replacedNotice,
+  }) {
+    final amountZatoshi = parseZecAmount(prefill.amountText?.trim() ?? '');
+    final hasAmount = amountZatoshi != null && amountZatoshi > BigInt.zero;
+    return PaymentRequestView(
+      source: source,
+      address: prefill.address,
+      amountZecText: hasAmount
+          ? ZecAmount.fromZatoshi(amountZatoshi).activityDetail.toString()
+          : null,
+      // No fiat here: the ZEC price providers are autoDispose and fill
+      // asynchronously, so a one-shot read from a card presented over a screen
+      // that does not subscribe to them returns null and stays null. The host
+      // watches the price and applies `withFiatText` on every build instead.
+      requesterLabel: sanitisePaymentRequestLabel(prefill.label),
+      memo: prefill.memoText,
+      note: prefill.message,
+      status: status,
+      replacedNotice: replacedNotice,
+    );
+  }
+}
+
+/// The fiat sub-line for a request's amount, or null when the request carried
+/// no amount or the price is not known.
+///
+/// Lives here rather than in the host so the parse of the request's amount
+/// text is the same one [PaymentRequestFlowNotifier] uses for the hero.
+String? paymentRequestFiatText({
+  required SendPrefillArgs prefill,
+  required double? zecUsdUnitPrice,
+}) {
+  final amountZatoshi = parseZecAmount(prefill.amountText?.trim() ?? '');
+  if (amountZatoshi == null) return null;
+  return fiatTextForZatoshi(amountZatoshi, zecUsdUnitPrice: zecUsdUnitPrice);
+}
+
+final paymentRequestFlowProvider =
+    NotifierProvider<PaymentRequestFlowNotifier, PaymentRequestFlowState?>(
+      PaymentRequestFlowNotifier.new,
+    );

--- a/lib/src/providers/payment_request_flow_provider.dart
+++ b/lib/src/providers/payment_request_flow_provider.dart
@@ -623,7 +623,10 @@ class PaymentRequestFlowNotifier extends Notifier<PaymentRequestFlowState?> {
       // that does not subscribe to them returns null and stays null. The host
       // watches the price and applies `withFiatText` on every build instead.
       requesterLabel: sanitisePaymentRequestLabel(prefill.label),
-      memo: prefill.memoText,
+      // The bytes the pre-check will propose, not the raw field: the card is
+      // a preview of the payment, so a memo it shows and a memo it pays have
+      // to be the same string.
+      memo: prefill.outgoingMemoText,
       note: prefill.message,
       status: status,
       replacedNotice: replacedNotice,

--- a/lib/src/providers/payment_uri_prefill_provider.dart
+++ b/lib/src/providers/payment_uri_prefill_provider.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/navigation/payment_uri_drain_policy.dart';
+import '../features/send/models/send_prefill_args.dart';
+
+/// Holds a ZIP-321 payment-URI prefill that has been parsed from a `zcash:`
+/// link but not yet delivered.
+///
+/// This exists so the prefill survives the lock screen. A `zcash:` link opened
+/// while the wallet is locked routes to `/unlock` and parks the prefill here;
+/// the unlock flow then claims it (via [PaymentUriPrefillNotifier.takeIfFresh])
+/// and presents it as a card over the wallet it just unlocked, so the payment
+/// intent is not lost. When the wallet is already unlocked the app-level
+/// `_IncomingLinkHost` drains it directly.
+///
+/// **Deliberately not the same store as `paymentLinkIntakeProvider`**, even
+/// though both hold links that arrived on the same native channel. A payment
+/// request is an *instruction to spend this wallet's money*: one at a time
+/// (latest wins, no queue), stale after [kPaymentUriParkTtl] because paying a
+/// forgotten request later is worse than losing it, and dropped by a wallet
+/// reset because the wallet it was going to pay from no longer exists. A Gift
+/// Card is a bearer claim on funds held elsewhere, so it queues, never
+/// expires, and outlives a reset. Merging the two would have to pick one set
+/// of those answers and would be wrong for the other product.
+class PaymentUriPrefillNotifier extends Notifier<SendPrefillArgs?> {
+  /// A parked prefill older than this is treated as stale and dropped on the
+  /// next unlock. Without it, a link opened then left parked (the user never
+  /// unlocks) would fire as a payment on a much later, unrelated unlock.
+  static const parkTtl = kPaymentUriParkTtl;
+
+  DateTime? _parkedAtUtc;
+
+  @override
+  SendPrefillArgs? build() => null;
+
+  /// How long the current prefill has been parked, or null when nothing is
+  /// parked. The drain policy uses this to drop a prefill that outlived
+  /// [parkTtl] before it can navigate anywhere.
+  Duration? get parkedFor {
+    final parkedAt = _parkedAtUtc;
+    if (state == null || parkedAt == null) return null;
+    return DateTime.now().toUtc().difference(parkedAt);
+  }
+
+  /// Parks [prefill], replacing whatever was parked before — latest wins,
+  /// there is no queue.
+  ///
+  /// Returns true when it displaced a prefill that was still parked, so the
+  /// caller can tell the user the earlier link was dropped. A duplicate
+  /// delivery of the same link counts as a replacement too; the caller does
+  /// not compare fingerprints.
+  bool set(SendPrefillArgs prefill) {
+    final replacedParkedPrefill = state != null;
+    _parkedAtUtc = DateTime.now().toUtc();
+    state = prefill;
+    return replacedParkedPrefill;
+  }
+
+  void clear() {
+    _parkedAtUtc = null;
+    state = null;
+  }
+
+  /// Returns the pending prefill and clears it in one step, withholding a
+  /// prefill older than [parkTtl] (while still clearing it) so a stale parked
+  /// link is dropped rather than delivered as a payment on an unrelated later
+  /// unlock.
+  ///
+  /// The TTL is not optional and there is deliberately no unconditional twin:
+  /// a claim path that skipped the age check is exactly the "link opened
+  /// overnight fires as a payment" case [parkTtl] exists to prevent.
+  ///
+  /// `expired` separates the two ways this returns no prefill: nothing was
+  /// parked at all, or a link the user did open sat past its window. Only the
+  /// second is something to tell them about — the unlock flow shows
+  /// `kPaymentUriExpiredMessage` for it, matching what the drain policy does
+  /// with the same age on every other screen.
+  ({SendPrefillArgs? prefill, bool expired}) takeIfFresh() {
+    final prefill = state;
+    final parkedAt = _parkedAtUtc;
+    clear();
+    if (prefill == null || parkedAt == null) {
+      return (prefill: null, expired: false);
+    }
+    if (DateTime.now().toUtc().difference(parkedAt) > parkTtl) {
+      return (prefill: null, expired: true);
+    }
+    return (prefill: prefill, expired: false);
+  }
+
+  /// Test seam: pretends the parked link arrived [age] ago, so the TTL branch
+  /// can be exercised without a ten-minute wait.
+  @visibleForTesting
+  void debugAgePark(Duration age) {
+    final parkedAt = _parkedAtUtc;
+    if (parkedAt == null) return;
+    _parkedAtUtc = parkedAt.subtract(age);
+  }
+}
+
+final paymentUriPrefillProvider =
+    NotifierProvider<PaymentUriPrefillNotifier, SendPrefillArgs?>(
+      PaymentUriPrefillNotifier.new,
+    );

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -180,6 +180,9 @@ class SyncState {
   bool get isUsingCompletedSpendableSnapshot =>
       displaySpendableFreshness == SpendableBalanceFreshness.lastCompletedSync;
 
+  bool get hasSettledSpendableBalance =>
+      hasBalanceData && isSyncedToTip && !isUsingCompletedSpendableSnapshot;
+
   static bool shouldPreserveCompletedSpendable(SyncState? previous) {
     if (previous?.isUsingCompletedSpendableSnapshot ?? false) return true;
     return (previous?.hasBalanceData ?? false) &&
@@ -2953,4 +2956,13 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
 final syncProvider = AsyncNotifierProvider<SyncNotifier, SyncState>(
   () => SyncNotifier(),
+);
+
+bool spendableIsSettledForAccount(SyncState? sync, String? accountUuid) =>
+    sync != null &&
+    sync.scopedToAccount(accountUuid).hasSettledSpendableBalance;
+
+bool activeAccountSpendableIsSettled(Ref ref) => spendableIsSettledForAccount(
+  ref.read(syncProvider).value,
+  ref.read(accountProvider).value?.activeAccountUuid,
 );

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -209,8 +209,18 @@ Future<BigInt> rewindToHeight({
   height: height,
 );
 
-Future<AddressValidationResult> validateAddress({required String address}) =>
-    RustLib.instance.api.crateApiSyncValidateAddress(address: address);
+/// Validate a recipient address against the network this build talks to.
+///
+/// `network` is the usual `"main"` / `"test"` / `"regtest"` name; an unknown
+/// name is a programming error and comes back as an `Err`, not as an invalid
+/// address.
+Future<AddressValidationResult> validateAddress({
+  required String address,
+  required String network,
+}) => RustLib.instance.api.crateApiSyncValidateAddress(
+  address: address,
+  network: network,
+);
 
 /// Step 1: Propose a transfer. Returns proposal info including whether Sapling params are needed.
 Future<ProposalResult> proposeSend({
@@ -1065,17 +1075,27 @@ Future<ExtractAndBroadcastPcztResult> extractAndBroadcastPczt({
   outputParamsPath: outputParamsPath,
 );
 
+/// Flat address-validation result for the Dart side.
+///
+/// `wrong_network` marks the one case where `is_valid` is false but the input
+/// is still a real Zcash address: it decoded fine, and `address_type` carries
+/// the kind it decoded to, but its encoding belongs to a network other than
+/// the one this build talks to. For input that is not an address we can send
+/// to at all, `address_type` is `"invalid"` and `wrong_network` is false.
 class AddressValidationResult {
   final bool isValid;
   final String addressType;
+  final bool wrongNetwork;
 
   const AddressValidationResult({
     required this.isValid,
     required this.addressType,
+    required this.wrongNetwork,
   });
 
   @override
-  int get hashCode => isValid.hashCode ^ addressType.hashCode;
+  int get hashCode =>
+      isValid.hashCode ^ addressType.hashCode ^ wrongNetwork.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1083,7 +1103,8 @@ class AddressValidationResult {
       other is AddressValidationResult &&
           runtimeType == other.runtimeType &&
           isValid == other.isValid &&
-          addressType == other.addressType;
+          addressType == other.addressType &&
+          wrongNetwork == other.wrongNetwork;
 }
 
 /// Event emitted by the mempool observer when a wallet-relevant

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -1244,6 +1244,7 @@ abstract class RustLibApi extends BaseApi {
 
   Future<AddressValidationResult> crateApiSyncValidateAddress({
     required String address,
+    required String network,
   });
 
   bool crateApiWalletValidateMnemonic({required String mnemonic});
@@ -8933,12 +8934,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @override
   Future<AddressValidationResult> crateApiSyncValidateAddress({
     required String address,
+    required String network,
   }) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(address, serializer);
+          sse_encode_String(network, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -8951,14 +8954,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncValidateAddressConstMeta,
-        argValues: [address],
+        argValues: [address, network],
         apiImpl: this,
       ),
     );
   }
 
   TaskConstMeta get kCrateApiSyncValidateAddressConstMeta =>
-      const TaskConstMeta(debugName: "validate_address", argNames: ["address"]);
+      const TaskConstMeta(
+        debugName: "validate_address",
+        argNames: ["address", "network"],
+      );
 
   @override
   bool crateApiWalletValidateMnemonic({required String mnemonic}) {
@@ -9412,11 +9418,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AddressValidationResult dco_decode_address_validation_result(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return AddressValidationResult(
       isValid: dco_decode_bool(arr[0]),
       addressType: dco_decode_String(arr[1]),
+      wrongNetwork: dco_decode_bool(arr[2]),
     );
   }
 
@@ -12215,9 +12222,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_isValid = sse_decode_bool(deserializer);
     var var_addressType = sse_decode_String(deserializer);
+    var var_wrongNetwork = sse_decode_bool(deserializer);
     return AddressValidationResult(
       isValid: var_isValid,
       addressType: var_addressType,
+      wrongNetwork: var_wrongNetwork,
     );
   }
 
@@ -15871,6 +15880,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_bool(self.isValid, serializer);
     sse_encode_String(self.addressType, serializer);
+    sse_encode_bool(self.wrongNetwork, serializer);
   }
 
   @protected

--- a/lib/widgetbook/send_use_cases.dart
+++ b/lib/widgetbook/send_use_cases.dart
@@ -542,16 +542,19 @@ const _mobileSendContacts = [
 
 Future<rust_sync.AddressValidationResult> _widgetbookValidateAddress({
   required String address,
+  required String network,
 }) async {
   if (address.startsWith('t1')) {
     return const rust_sync.AddressValidationResult(
       isValid: true,
       addressType: 'transparent',
+      wrongNetwork: false,
     );
   }
   return const rust_sync.AddressValidationResult(
     isValid: true,
     addressType: 'unified',
+    wrongNetwork: false,
   );
 }
 

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -13,7 +13,6 @@ use crate::wallet::{keys, network::WalletNetwork, secret_store, sync as wallet_s
 pub(crate) static DESIRED_SYNC_MODE: AtomicU8 = AtomicU8::new(0);
 static ACTIVE_SYNC_ACCOUNT: std::sync::LazyLock<sync_engine::ActiveSyncAccountTarget> =
     std::sync::LazyLock::new(|| Arc::new(RwLock::new(None)));
-
 /// Set the desired sync mode. 0=none, 1=foreground, 2=background.
 /// The running sync loop checks this each batch and exits if mismatched.
 #[frb(sync)]
@@ -433,9 +432,17 @@ pub struct BlockMetaInfo {
     pub orchard_actions_count: u32,
 }
 
+/// Flat address-validation result for the Dart side.
+///
+/// `wrong_network` marks the one case where `is_valid` is false but the input
+/// is still a real Zcash address: it decoded fine, and `address_type` carries
+/// the kind it decoded to, but its encoding belongs to a network other than
+/// the one this build talks to. For input that is not an address we can send
+/// to at all, `address_type` is `"invalid"` and `wrong_network` is false.
 pub struct AddressValidationResult {
     pub is_valid: bool,
     pub address_type: String,
+    pub wrong_network: bool,
 }
 
 // ======================== Panic Guard ========================
@@ -671,16 +678,38 @@ pub fn rewind_to_height(db_path: String, network: String, height: u64) -> Result
 
 // ======================== Address Validation ========================
 
-pub fn validate_address(address: String) -> Result<AddressValidationResult, String> {
-    catch(|| match wallet_sync::validate_address(&address) {
-        Ok(addr_type) => Ok(AddressValidationResult {
-            is_valid: true,
-            address_type: addr_type,
-        }),
-        Err(_) => Ok(AddressValidationResult {
-            is_valid: false,
-            address_type: "invalid".into(),
-        }),
+/// Validate a recipient address against the network this build talks to.
+///
+/// `network` is the usual `"main"` / `"test"` / `"regtest"` name; an unknown
+/// name is a programming error and comes back as an `Err`, not as an invalid
+/// address.
+pub fn validate_address(
+    address: String,
+    network: String,
+) -> Result<AddressValidationResult, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        match wallet_sync::validate_address(&address, network) {
+            Ok(wallet_sync::AddressValidation::Valid { address_type }) => {
+                Ok(AddressValidationResult {
+                    is_valid: true,
+                    address_type,
+                    wrong_network: false,
+                })
+            }
+            Ok(wallet_sync::AddressValidation::WrongNetwork { address_type }) => {
+                Ok(AddressValidationResult {
+                    is_valid: false,
+                    address_type,
+                    wrong_network: true,
+                })
+            }
+            Err(_) => Ok(AddressValidationResult {
+                is_valid: false,
+                address_type: "invalid".into(),
+                wrong_network: false,
+            }),
+        }
     })
 }
 
@@ -2757,4 +2786,44 @@ pub async fn extract_and_broadcast_pczt(
         status: result.status,
         message: result.message,
     })
+}
+
+#[cfg(test)]
+mod validate_address_tests {
+    //! The FRB boundary contract every Dart consumer of `wrongNetwork` relies
+    //! on. Needs no DB or network.
+    use super::validate_address;
+
+    const MAINNET_UA: &str = "u1flce76a85e0zvdtrqaqj59mdk2mv35d074lafaeej5s09qjm4vflc9gndayyxt37v6tekfg\
+                              ram4p9209ygugkz7es438hc9gsujwmcm0trr7zt5lcz8xmpfg9rqyfyznc83ax697lc5ur3ne\
+                              m8wwyen732wemtxcg6lxr4n2agm437m2";
+
+    #[test]
+    fn valid_on_its_own_network() {
+        let result = validate_address(MAINNET_UA.into(), "main".into()).unwrap();
+        assert!(result.is_valid);
+        assert!(!result.wrong_network);
+        assert_eq!(result.address_type, "unified");
+    }
+
+    #[test]
+    fn well_formed_but_for_another_network_is_wrong_network_with_its_type() {
+        let result = validate_address(MAINNET_UA.into(), "test".into()).unwrap();
+        assert!(!result.is_valid);
+        assert!(result.wrong_network);
+        assert_eq!(result.address_type, "unified");
+    }
+
+    #[test]
+    fn garbage_is_invalid_not_wrong_network() {
+        let result = validate_address("not-an-address".into(), "main".into()).unwrap();
+        assert!(!result.is_valid);
+        assert!(!result.wrong_network);
+        assert_eq!(result.address_type, "invalid");
+    }
+
+    #[test]
+    fn unknown_network_name_is_a_programming_error() {
+        assert!(validate_address(MAINNET_UA.into(), "moonnet".into()).is_err());
+    }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -7333,10 +7333,11 @@ fn wire__crate__api__sync__validate_address_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_address = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
-                    let output_ok = crate::api::sync::validate_address(api_address)?;
+                    let output_ok = crate::api::sync::validate_address(api_address, api_network)?;
                     Ok(output_ok)
                 })())
             }
@@ -8101,9 +8102,11 @@ impl SseDecode for crate::api::sync::AddressValidationResult {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_isValid = <bool>::sse_decode(deserializer);
         let mut var_addressType = <String>::sse_decode(deserializer);
+        let mut var_wrongNetwork = <bool>::sse_decode(deserializer);
         return crate::api::sync::AddressValidationResult {
             is_valid: var_isValid,
             address_type: var_addressType,
+            wrong_network: var_wrongNetwork,
         };
     }
 }
@@ -11722,6 +11725,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::sync::AddressValidationResult
         [
             self.is_valid.into_into_dart().into_dart(),
             self.address_type.into_into_dart().into_dart(),
+            self.wrong_network.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -14867,6 +14871,7 @@ impl SseEncode for crate::api::sync::AddressValidationResult {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <bool>::sse_encode(self.is_valid, serializer);
         <String>::sse_encode(self.address_type, serializer);
+        <bool>::sse_encode(self.wrong_network, serializer);
     }
 }
 

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -47,7 +47,6 @@ pub(crate) use migration::{
     MigrationPreparationTransactionState, MigrationScheduleEntry, MigrationStatus,
     PreparationTimingPolicy,
 };
-pub(crate) use pczt::extract_compact_sigs_from_pczt;
 pub use pczt::{
     add_proofs_to_pczt, create_pczt_from_proposal, create_tex_pczts_from_proposal,
     discard_proposal, extract_and_broadcast_pczt, prepare_pczt_for_keystone_batch,
@@ -56,6 +55,7 @@ pub use pczt::{
     store_and_broadcast_signed_pczts_for_proposal, ExtractAndBroadcastPcztResult,
     KeystoneBatchPczt, StoreAndBroadcastPcztsResult, TexPcztPair,
 };
+pub(crate) use pczt::extract_compact_sigs_from_pczt;
 pub(crate) use proposal_locks::recover_previous_process as recover_orphaned_send_locks;
 pub(crate) use send::estimate_send_max;
 pub(crate) use send::propose_send;
@@ -466,20 +466,61 @@ pub fn rewind_to_height(db_path: &str, network: WalletNetwork, height: u64) -> R
 
 // ======================== Address Validation ========================
 
-pub fn validate_address(address: &str) -> Result<String, String> {
-    use zcash_address::ZcashAddress;
+/// What checking a user-entered address against the wallet's network found.
+///
+/// The third outcome — the string is not an address this wallet can send to at
+/// all — is the `Err` of [`validate_address`], not a variant here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddressValidation {
+    /// Parses, is a kind we can send to, and is encoded for this network.
+    Valid { address_type: String },
+    /// Parses and is a kind we can send to, but carries another network's
+    /// encoding — a `utest1…` pasted into a mainnet wallet, say.
+    ///
+    /// `address_type` is the kind the string decodes to, not `"invalid"`: the
+    /// address is well-formed, so the caller can say *why* it is refused.
+    WrongNetwork { address_type: String },
+}
+
+/// Validate a recipient address for `network`.
+///
+/// Network matching is delegated entirely to
+/// [`ZcashAddress::convert_if_network`], including its testnet/regtest
+/// tolerance: transparent (and Sprout) encodings share one prefix across
+/// testnet and regtest, so a `tm…` address is accepted while running on
+/// regtest. Sapling, unified and TEX encodings have distinct per-network
+/// prefixes and must match exactly. Nothing here adds prefix logic of its own.
+pub fn validate_address(
+    address: &str,
+    network: WalletNetwork,
+) -> Result<AddressValidation, String> {
+    use zcash_address::{ConversionError, ZcashAddress};
     use zcash_keys::address::Address;
+    use zcash_protocol::consensus::Parameters;
 
-    let addr: Address = ZcashAddress::try_from_encoded(address)
+    let parsed = ZcashAddress::try_from_encoded(address).map_err(|e| format!("Invalid: {e}"))?;
+
+    // Network-agnostic first. This is the check that says whether the string
+    // is a kind of address we can send to at all (it is what rejects Sprout),
+    // and it produces the label we report even when the network is wrong.
+    let address_type = match parsed
+        .clone()
+        .convert::<Address>()
         .map_err(|e| format!("Invalid: {e}"))?
-        .convert()
-        .map_err(|e| format!("Invalid: {e}"))?;
+    {
+        Address::Unified(_) => "unified",
+        Address::Sapling(_) => "sapling",
+        Address::Transparent(_) => "transparent",
+        Address::Tex(_) => "tex",
+    }
+    .to_string();
 
-    match addr {
-        Address::Unified(_) => Ok("unified".into()),
-        Address::Sapling(_) => Ok("sapling".into()),
-        Address::Transparent(_) => Ok("transparent".into()),
-        Address::Tex(_) => Ok("tex".into()),
+    match parsed.convert_if_network::<Address>(network.network_type()) {
+        Ok(_) => Ok(AddressValidation::Valid { address_type }),
+        Err(ConversionError::IncorrectNetwork { .. }) => {
+            Ok(AddressValidation::WrongNetwork { address_type })
+        }
+        Err(e) => Err(format!("Invalid: {e}")),
     }
 }
 
@@ -818,21 +859,139 @@ mod tests {
         COUNTER.fetch_add(1, Ordering::Relaxed)
     }
 
-    #[test]
-    fn validate_address_classifies_tex_addresses() {
+    /// A real mainnet unified address (same vector the account-derivation
+    /// tests in `api::wallet` use).
+    const MAINNET_UA: &str = "u1flce76a85e0zvdtrqaqj59mdk2mv35d074lafaeej5s09qjm4vflc9gndayyxt37v6tekfg\
+                              ram4p9209ygugkz7es438hc9gsujwmcm0trr7zt5lcz8xmpfg9rqyfyznc83ax697lc5ur3ne\
+                              m8wwyen732wemtxcg6lxr4n2agm437m2";
+
+    /// A real regtest unified address (the vector `tests/regtest_import.rs`
+    /// imports).
+    const REGTEST_UA: &str = "uregtest1ykjd398elks624qyz0d0vffn6vpqkl6atp2wsr9795eql4kw47hwlffxyyfakv0\
+                              l2twj635fpmxmeu3tzyrfhf5s9eg9ea8gsa0srdfwjudp3fs0qaaqxvkxr364a8vjy3y9vgl\
+                              m7lf8rs0vsev9p5mzky52rq4wkr5lhc842vuf5lhn";
+
+    fn assert_valid(address: &str, network: WalletNetwork, expected_type: &str) {
         assert_eq!(
-            validate_address("tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte").unwrap(),
-            "tex"
+            validate_address(address, network).unwrap(),
+            AddressValidation::Valid {
+                address_type: expected_type.to_string()
+            }
         );
+    }
+
+    fn assert_wrong_network(address: &str, network: WalletNetwork, expected_type: &str) {
         assert_eq!(
-            validate_address("textest1qyqszqgpqyqszqgpqyqszqgpqyqszqgpfcjgfy").unwrap(),
-            "tex"
+            validate_address(address, network).unwrap(),
+            AddressValidation::WrongNetwork {
+                address_type: expected_type.to_string()
+            }
         );
     }
 
     #[test]
+    fn validate_address_classifies_tex_addresses() {
+        use zcash_address::ToAddress;
+
+        assert_valid(
+            "tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte",
+            WalletNetwork::Main,
+            "tex",
+        );
+        assert_valid(
+            "textest1qyqszqgpqyqszqgpqyqszqgpqyqszqgpfcjgfy",
+            WalletNetwork::Test,
+            "tex",
+        );
+        // TEX has its own regtest encoding and no testnet-on-regtest
+        // tolerance, unlike transparent P2PKH/P2SH.
+        let tex_regtest = zcash_address::ZcashAddress::from_tex(
+            zcash_protocol::consensus::NetworkType::Regtest,
+            [0; 20],
+        )
+        .to_string();
+        assert_valid(&tex_regtest, WalletNetwork::Regtest, "tex");
+        assert_wrong_network(
+            "textest1qyqszqgpqyqszqgpqyqszqgpqyqszqgpfcjgfy",
+            WalletNetwork::Regtest,
+            "tex",
+        );
+    }
+
+    /// Sapling addresses are the one shielded kind with no regtest tolerance
+    /// either: the vector is derived, not hard-coded, so it stays valid if the
+    /// encoding crate changes its own test data.
+    #[test]
+    fn validate_address_classifies_sapling_addresses_per_network() {
+        use zcash_address::ToAddress;
+        use zcash_protocol::consensus::NetworkType;
+
+        let esk = sapling_crypto::zip32::ExtendedSpendingKey::master(&[7u8; 32]);
+        let (_, payment_address) = esk.default_address();
+        let raw = payment_address.to_bytes();
+        let mainnet = zcash_address::ZcashAddress::from_sapling(NetworkType::Main, raw).to_string();
+        let testnet = zcash_address::ZcashAddress::from_sapling(NetworkType::Test, raw).to_string();
+        let regtest =
+            zcash_address::ZcashAddress::from_sapling(NetworkType::Regtest, raw).to_string();
+        assert!(mainnet.starts_with("zs1"));
+        assert!(testnet.starts_with("ztestsapling1"));
+
+        assert_valid(&mainnet, WalletNetwork::Main, "sapling");
+        assert_valid(&testnet, WalletNetwork::Test, "sapling");
+        assert_valid(&regtest, WalletNetwork::Regtest, "sapling");
+        assert_wrong_network(&mainnet, WalletNetwork::Test, "sapling");
+        assert_wrong_network(&testnet, WalletNetwork::Main, "sapling");
+        assert_wrong_network(&testnet, WalletNetwork::Regtest, "sapling");
+    }
+
+    #[test]
+    fn validate_address_accepts_unified_addresses_on_their_own_network() {
+        assert_valid(MAINNET_UA, WalletNetwork::Main, "unified");
+        assert_valid(REGTEST_UA, WalletNetwork::Regtest, "unified");
+    }
+
+    #[test]
+    fn validate_address_reports_wrong_network_for_other_networks() {
+        // The bug this exists for: a mainnet build used to call these valid,
+        // and the send only failed later, at proposal time.
+        assert_wrong_network(MAINNET_UA, WalletNetwork::Test, "unified");
+        assert_wrong_network(MAINNET_UA, WalletNetwork::Regtest, "unified");
+        assert_wrong_network(REGTEST_UA, WalletNetwork::Main, "unified");
+        assert_wrong_network(
+            "tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte",
+            WalletNetwork::Test,
+            "tex",
+        );
+        assert_wrong_network(
+            "textest1qyqszqgpqyqszqgpqyqszqgpqyqszqgpfcjgfy",
+            WalletNetwork::Main,
+            "tex",
+        );
+    }
+
+    /// Testnet and regtest share one transparent prefix, so `convert_if_network`
+    /// deliberately accepts a `tm…` address while running on regtest. We keep
+    /// that tolerance rather than adding prefix rules of our own.
+    #[test]
+    fn validate_address_keeps_transparent_testnet_regtest_tolerance() {
+        use zcash_address::ToAddress;
+
+        let testnet_p2pkh = zcash_address::ZcashAddress::from_transparent_p2pkh(
+            zcash_protocol::consensus::NetworkType::Test,
+            [0; 20],
+        )
+        .to_string();
+
+        assert_valid(&testnet_p2pkh, WalletNetwork::Test, "transparent");
+        assert_valid(&testnet_p2pkh, WalletNetwork::Regtest, "transparent");
+        assert_wrong_network(&testnet_p2pkh, WalletNetwork::Main, "transparent");
+    }
+
+    #[test]
     fn validate_address_rejects_invalid_address() {
-        assert!(validate_address("not-an-address").is_err());
+        assert!(validate_address("not-an-address", WalletNetwork::Main).is_err());
+        assert!(validate_address("", WalletNetwork::Main).is_err());
+        assert!(validate_address(MAINNET_UA.trim_end_matches('2'), WalletNetwork::Main).is_err());
     }
 
     #[test]
@@ -845,7 +1004,9 @@ mod tests {
         )
         .to_string();
 
-        assert!(validate_address(&sprout).is_err());
+        // Sprout is unsupported on every network, including the one it names.
+        assert!(validate_address(&sprout, WalletNetwork::Main).is_err());
+        assert!(validate_address(&sprout, WalletNetwork::Test).is_err());
     }
 
     #[test]

--- a/test/core/navigation/mobile_exit_back_guard_test.dart
+++ b/test/core/navigation/mobile_exit_back_guard_test.dart
@@ -12,6 +12,7 @@ _ExitBackTestRouter _exitBackRouter({
   MobileExitBackGuard? exitBackGuard,
   String initialLocation = '/home',
   List<RouteBase> routes = const [],
+  bool Function()? handleBackAboveRouter,
 }) {
   final navigatorKey = GlobalKey<NavigatorState>();
   final guard =
@@ -23,6 +24,7 @@ _ExitBackTestRouter _exitBackRouter({
     canPop: () => router.canPop(),
     currentLocation: () =>
         router.routerDelegate.currentConfiguration.uri.toString(),
+    handleBackAboveRouter: handleBackAboveRouter,
   );
   addTearDown(dispatcher.dispose);
   router = GoRouter(
@@ -118,6 +120,44 @@ void _clearExitHint(_ExitBackTestRouter testRouter) {
 
 void main() {
   tearDown(MobileExitBackGuard.dismissVisibleHint);
+
+  testWidgets('an above-router modal answers root back before the exit hint', (
+    tester,
+  ) async {
+    final platformCalls = _capturePlatformCalls(tester);
+    var modalIsUp = true;
+    final testRouter = _exitBackRouter(
+      handleBackAboveRouter: () {
+        if (!modalIsUp) return false;
+        modalIsUp = false;
+        return true;
+      },
+    );
+    await tester.pumpWidget(_app(testRouter));
+    await tester.pumpAndSettle();
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+
+    expect(
+      modalIsUp,
+      isFalse,
+      reason: 'the press dismissed the card, not the screen under it',
+    );
+    expect(
+      find.text(MobileExitBackGuard.exitHintMessage),
+      findsNothing,
+      reason: 'a press the card consumed must not arm the exit hint',
+    );
+    expect(_systemNavigatorPopCallCount(platformCalls), 0);
+
+    // With the card gone the next press behaves exactly as before.
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsOneWidget);
+    expect(_systemNavigatorPopCallCount(platformCalls), 0);
+    _clearExitHint(testRouter);
+  });
 
   testWidgets('android root back shows a lower exit hint before exiting', (
     tester,
@@ -358,18 +398,22 @@ void main() {
     expect(_systemNavigatorPopCallCount(platformCalls), 1);
   });
 
-  testWidgets('a non-migration route keeps the immediate exit hint', (
+  testWidgets('android root back reaches a deep-linked send that cannot pop', (
     tester,
   ) async {
+    final platformCalls = _capturePlatformCalls(tester);
     var handledBacks = 0;
+    // A `zcash:` payment URI opens /send with `go`, so it is the whole stack.
+    // Skipping the route layer there shows the exit hint while the screen's
+    // toolbar arrow goes to /home — the two back affordances must agree.
     final testRouter = _exitBackRouter(
-      initialLocation: '/settings',
+      initialLocation: '/send',
       routes: [
         _placeholderRoute('/home', 'Home route'),
         GoRoute(
-          path: '/settings',
+          path: '/send',
           builder: (_, _) => _RouteLevelBackHandler(
-            label: 'Settings route',
+            label: 'Send route',
             onBack: () => handledBacks++,
           ),
         ),
@@ -378,15 +422,102 @@ void main() {
     await tester.pumpWidget(_app(testRouter));
     await tester.pumpAndSettle();
 
+    expect(find.text('Send route'), findsOneWidget);
+    expect(testRouter.router.canPop(), isFalse);
+
     expect(await testRouter.dispatcher.didPopRoute(), isTrue);
     await tester.pump();
 
-    // The delegate-first path is scoped to `/migration`; everywhere else the
-    // root back press goes straight to the exit hint as before.
-    expect(handledBacks, 0);
-    expect(find.text(MobileExitBackGuard.exitHintMessage), findsOneWidget);
-    _clearExitHint(testRouter);
+    expect(handledBacks, 1);
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsNothing);
+    expect(_systemNavigatorPopCallCount(platformCalls), 0);
   });
+
+  testWidgets('a send step that blocks back never shows the exit hint', (
+    tester,
+  ) async {
+    final platformCalls = _capturePlatformCalls(tester);
+    final testRouter = _exitBackRouter(
+      initialLocation: '/send/review',
+      routes: [
+        _placeholderRoute('/home', 'Home route'),
+        GoRoute(
+          path: '/send/review',
+          // No fallback: the screen is holding back while the send is being
+          // prepared.
+          builder: (_, _) =>
+              const _RouteLevelBackHandler(label: 'Send review route'),
+        ),
+      ],
+    );
+    await tester.pumpWidget(_app(testRouter));
+    await tester.pumpAndSettle();
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+
+    expect(find.text('Send review route'), findsOneWidget);
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsNothing);
+    expect(_systemNavigatorPopCallCount(platformCalls), 0);
+  });
+
+  testWidgets('a send route without a back handler still exits', (
+    tester,
+  ) async {
+    final platformCalls = _capturePlatformCalls(tester);
+    final testRouter = _exitBackRouter(
+      initialLocation: '/send/status',
+      routes: [
+        _placeholderRoute('/home', 'Home route'),
+        _placeholderRoute('/send/status', 'Send status route'),
+      ],
+    );
+    await tester.pumpWidget(_app(testRouter));
+    await tester.pumpAndSettle();
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsOneWidget);
+    expect(_systemNavigatorPopCallCount(platformCalls), 0);
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+    expect(_systemNavigatorPopCallCount(platformCalls), 1);
+  });
+
+  testWidgets(
+    'a route outside the listed flows keeps the immediate exit hint',
+    (tester) async {
+      var handledBacks = 0;
+      final testRouter = _exitBackRouter(
+        initialLocation: '/settings',
+        routes: [
+          _placeholderRoute('/home', 'Home route'),
+          GoRoute(
+            path: '/settings',
+            builder: (_, _) => _RouteLevelBackHandler(
+              label: 'Settings route',
+              onBack: () => handledBacks++,
+            ),
+          ),
+        ],
+      );
+      await tester.pumpWidget(_app(testRouter));
+      await tester.pumpAndSettle();
+
+      expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+      await tester.pump();
+
+      // The delegate-first path is scoped to `/migration` and `/send`;
+      // everywhere else the root back press goes straight to the exit hint as
+      // before.
+      expect(handledBacks, 0);
+      expect(find.text(MobileExitBackGuard.exitHintMessage), findsOneWidget);
+      _clearExitHint(testRouter);
+    },
+  );
 
   testWidgets('non-Android mobile platforms do not intercept root back', (
     tester,

--- a/test/core/navigation/payment_uri_busy_surface_provider_test.dart
+++ b/test/core/navigation/payment_uri_busy_surface_provider_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_busy_surface_provider.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() {
+    container = ProviderContainer();
+    addTearDown(container.dispose);
+  });
+
+  PaymentUriBusySurfaceNotifier notifier() =>
+      container.read(paymentUriBusySurfaceProvider.notifier);
+
+  int count() => container.read(paymentUriBusySurfaceProvider);
+
+  test('starts with no hold', () {
+    expect(count(), 0);
+  });
+
+  test('a single acquire/release pair opens and closes the latch', () {
+    notifier().acquire();
+    expect(count(), 1);
+
+    notifier().release();
+    expect(count(), 0);
+  });
+
+  test(
+    'overlapping holders keep the latch closed until the last one leaves',
+    () {
+      notifier()
+        ..acquire()
+        ..acquire();
+      expect(count(), 2);
+
+      notifier().release();
+      expect(count(), 1, reason: 'the second holder still owns a hold');
+
+      notifier().release();
+      expect(count(), 0);
+    },
+  );
+
+  test('a stray release cannot drive the count negative', () {
+    notifier()
+      ..release()
+      ..release();
+    expect(count(), 0);
+
+    notifier().acquire();
+    expect(
+      count(),
+      1,
+      reason: 'an over-release must not leave the latch owing a hold',
+    );
+  });
+
+  test('releaseAfterNavigation defers the release to a microtask', () async {
+    notifier().acquire();
+    notifier().releaseAfterNavigation();
+    expect(count(), 1, reason: 'still held for the rest of this turn');
+
+    await Future<void>.delayed(Duration.zero);
+    expect(count(), 0);
+  });
+
+  test(
+    'a deferred release from a departing holder leaves a newer hold alone',
+    () async {
+      notifier()
+        ..acquire()
+        ..releaseAfterNavigation()
+        ..acquire();
+
+      await Future<void>.delayed(Duration.zero);
+      expect(count(), 1, reason: 'the incoming holder keeps its own hold');
+    },
+  );
+
+  test(
+    'a disposed container drops pending releases without throwing',
+    () async {
+      final scoped = ProviderContainer();
+      final scopedNotifier = scoped.read(
+        paymentUriBusySurfaceProvider.notifier,
+      );
+      scopedNotifier
+        ..acquire()
+        ..releaseAfterNavigation();
+      scoped.dispose();
+
+      await Future<void>.delayed(Duration.zero);
+    },
+  );
+}

--- a/test/core/navigation/payment_uri_drain_policy_test.dart
+++ b/test/core/navigation/payment_uri_drain_policy_test.dart
@@ -1,0 +1,474 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_drain_policy.dart';
+import 'package:zcash_wallet/src/core/zcash/zip321_payment_request.dart';
+
+/// Calls [decidePaymentUriDrain] with the "healthy, unlocked, on /home, link
+/// just arrived" baseline so each test only states the row it exercises.
+PaymentUriDrainDecision decide({
+  bool hasParkedPrefill = true,
+  Duration? parkedFor = Duration.zero,
+  bool hasBlockingFailure = false,
+  bool walletIsLoading = false,
+  bool walletHasError = false,
+  bool hasWallet = true,
+  bool isUnlocked = true,
+  String matchedLocation = '/home',
+  bool hasBusySurface = false,
+  bool hasActiveSendProposal = false,
+  bool sendIsInFlight = false,
+  bool sendGatedByMigration = false,
+}) => decidePaymentUriDrain(
+  hasParkedPrefill: hasParkedPrefill,
+  parkedFor: parkedFor,
+  hasBlockingFailure: hasBlockingFailure,
+  walletIsLoading: walletIsLoading,
+  walletHasError: walletHasError,
+  hasWallet: hasWallet,
+  isUnlocked: isUnlocked,
+  matchedLocation: matchedLocation,
+  hasBusySurface: hasBusySurface,
+  hasActiveSendProposal: hasActiveSendProposal,
+  sendIsInFlight: sendIsInFlight,
+  sendGatedByMigration: sendGatedByMigration,
+);
+
+void main() {
+  group('nothing to deliver', () {
+    test('waits when no prefill is parked', () {
+      expect(
+        decide(hasParkedPrefill: false, parkedFor: null).action,
+        PaymentUriDrainAction.wait,
+      );
+    });
+  });
+
+  group('stale prefill', () {
+    test('drops a prefill parked longer than the TTL, and says so', () {
+      final decision = decide(
+        parkedFor: kPaymentUriParkTtl + const Duration(seconds: 1),
+      );
+      expect(decision.action, PaymentUriDrainAction.dropWithMessage);
+      expect(decision.message, kPaymentUriExpiredMessage);
+    });
+
+    test('the expired notice says the link can just be opened again', () {
+      expect(
+        kPaymentUriExpiredMessage,
+        'That payment link timed out. Open it again to pay.',
+      );
+    });
+
+    test('delivers a prefill parked for exactly the TTL', () {
+      expect(
+        decide(parkedFor: kPaymentUriParkTtl).action,
+        PaymentUriDrainAction.deliver,
+      );
+    });
+
+    test('age outranks every other row, including a busy surface', () {
+      final decision = decide(
+        parkedFor: kPaymentUriParkTtl + const Duration(minutes: 1),
+        hasBusySurface: true,
+        hasWallet: false,
+        isUnlocked: false,
+      );
+      expect(decision.action, PaymentUriDrainAction.dropWithMessage);
+      expect(decision.message, kPaymentUriExpiredMessage);
+    });
+
+    test('no drop is silent any more', () {
+      // Every drop the policy can decide carries a message. The TTL row was
+      // the last one that did not, and it is the one following a deliberate
+      // user action, so a silent drop there was the worst place for it.
+      for (final decision in [
+        decide(parkedFor: kPaymentUriParkTtl + const Duration(seconds: 1)),
+        decide(hasBlockingFailure: true),
+        decide(walletHasError: true),
+        decide(matchedLocation: '/welcome', hasWallet: false),
+        decide(matchedLocation: '/import'),
+        decide(sendGatedByMigration: true),
+        decide(hasWallet: false),
+      ]) {
+        expect(decision.message, isNotNull, reason: '$decision');
+      }
+    });
+  });
+
+  group('the wallet cannot be opened', () {
+    test('a blocking bootstrap failure drops with the unavailable message', () {
+      final decision = decide(hasBlockingFailure: true);
+      expect(decision.action, PaymentUriDrainAction.dropWithMessage);
+      expect(decision.message, kPaymentUriUnavailableMessage);
+    });
+
+    test('a wallet load error drops with the unavailable message', () {
+      final decision = decide(walletHasError: true);
+      expect(decision.action, PaymentUriDrainAction.dropWithMessage);
+      expect(decision.message, kPaymentUriUnavailableMessage);
+    });
+
+    test('waits while wallet existence is still unknown', () {
+      expect(decide(walletIsLoading: true).action, PaymentUriDrainAction.wait);
+    });
+  });
+
+  group('setup flows', () {
+    test('drops on every onboarding location with the onboarding message', () {
+      for (final location in [
+        '/add-account',
+        '/onboarding/create',
+        '/import/seed',
+      ]) {
+        final decision = decide(matchedLocation: location);
+        expect(
+          decision.action,
+          PaymentUriDrainAction.dropWithMessage,
+          reason: location,
+        );
+        expect(
+          decision.message,
+          kPaymentUriOnboardingMessage,
+          reason: location,
+        );
+      }
+    });
+
+    test('/welcome with no wallet gets the plainer no-wallet wording', () {
+      final decision = decide(matchedLocation: '/welcome', hasWallet: false);
+      expect(decision.action, PaymentUriDrainAction.dropWithMessage);
+      expect(decision.message, kPaymentUriNoWalletMessage);
+    });
+
+    test('/welcome with a wallet gets the onboarding wording', () {
+      expect(
+        decide(matchedLocation: '/welcome').message,
+        kPaymentUriOnboardingMessage,
+      );
+    });
+  });
+
+  group('busy surface', () {
+    test('waits rather than dropping while a signing session is up', () {
+      final decision = decide(hasBusySurface: true);
+      expect(decision.action, PaymentUriDrainAction.wait);
+      expect(decision.message, isNull);
+    });
+
+    test('presents once the hold is given back', () {
+      expect(
+        decide(hasBusySurface: false).action,
+        PaymentUriDrainAction.deliver,
+      );
+    });
+
+    test('waiting outranks the migration gate and the wallet rows', () {
+      expect(
+        decide(
+          hasBusySurface: true,
+          sendGatedByMigration: true,
+          hasWallet: false,
+        ).action,
+        PaymentUriDrainAction.wait,
+      );
+    });
+
+    test('onboarding still outranks a busy surface', () {
+      expect(
+        decide(matchedLocation: '/import/seed', hasBusySurface: true).action,
+        PaymentUriDrainAction.dropWithMessage,
+      );
+    });
+  });
+
+  group('an existing send proposal', () {
+    test('waits until the review owner releases its selected inputs', () {
+      expect(
+        decide(
+          matchedLocation: '/send/review',
+          hasActiveSendProposal: true,
+        ).action,
+        PaymentUriDrainAction.wait,
+      );
+    });
+
+    test('the route alone does not block a mobile draft with no proposal', () {
+      expect(
+        decide(matchedLocation: '/send/review').action,
+        PaymentUriDrainAction.deliver,
+      );
+    });
+  });
+
+  // The card's Review and Edit both `go(...)`, which unmounts the status
+  // screen; `runSendBroadcast` then discards the outcome at its
+  // post-`executeProposal` checkpoint, so the transaction is on the network
+  // with no txid and no receipt for the user. The link waits instead.
+  group('a send mid-broadcast', () {
+    test('waits while the broadcast is still running on /send/status', () {
+      final decision = decide(
+        matchedLocation: '/send/status',
+        sendIsInFlight: true,
+      );
+      expect(decision.action, PaymentUriDrainAction.wait);
+      expect(decision.message, isNull);
+    });
+
+    test('presents once the receipt is on screen', () {
+      expect(
+        decide(matchedLocation: '/send/status', sendIsInFlight: false).action,
+        PaymentUriDrainAction.deliver,
+      );
+    });
+
+    test('the flag alone holds nothing off the receipt route', () {
+      // `sendStatusTerminalProvider` also reads false when no send has ever
+      // run, so the flag is only meaningful paired with the location. Without
+      // the pairing every link in a fresh session would park forever.
+      for (final location in ['/home', '/send', '/send/review', '/swap']) {
+        expect(
+          decide(matchedLocation: location, sendIsInFlight: true).action,
+          PaymentUriDrainAction.deliver,
+          reason: location,
+        );
+      }
+    });
+
+    test('the TTL still outranks it, so the wait is bounded', () {
+      final decision = decide(
+        matchedLocation: '/send/status',
+        sendIsInFlight: true,
+        parkedFor: kPaymentUriParkTtl + const Duration(seconds: 1),
+      );
+      expect(decision.action, PaymentUriDrainAction.dropWithMessage);
+      expect(decision.message, kPaymentUriExpiredMessage);
+    });
+
+    test('waiting outranks the migration gate and the wallet rows', () {
+      expect(
+        decide(
+          matchedLocation: '/send/status',
+          sendIsInFlight: true,
+          sendGatedByMigration: true,
+          hasWallet: false,
+          isUnlocked: false,
+        ).action,
+        PaymentUriDrainAction.wait,
+      );
+    });
+
+    test('isSendStatusLocation matches the route both shells register', () {
+      expect(isSendStatusLocation('/send/status'), isTrue);
+      expect(isSendStatusLocation('/send/review'), isFalse);
+      expect(isSendStatusLocation('/send'), isFalse);
+    });
+  });
+
+  group('migration send gate', () {
+    test('drops with the migration message', () {
+      final decision = decide(sendGatedByMigration: true);
+      expect(decision.action, PaymentUriDrainAction.dropWithMessage);
+      expect(decision.message, kPaymentUriMigrationSendGateMessage);
+    });
+
+    test('is not read until the wallet is unlocked and past /unlock', () {
+      // The gate cannot be trusted before that point: lock resets the sync
+      // state, so its `ironwoodBalance <= 0` half is unconditionally true
+      // while locked, and the Home CTA cache keeps answering `resume` across
+      // the gap (measured in `payment_uri_migration_gate_test.dart`). The
+      // link stays parked and `claimParkedPaymentUriAfterUnlock` runs this
+      // same table once the wallet is open.
+      expect(
+        decide(sendGatedByMigration: true, isUnlocked: false).action,
+        PaymentUriDrainAction.routeToUnlock,
+      );
+      expect(
+        decide(
+          sendGatedByMigration: true,
+          isUnlocked: false,
+          matchedLocation: '/unlock',
+        ).action,
+        PaymentUriDrainAction.wait,
+      );
+      expect(
+        decide(sendGatedByMigration: true, matchedLocation: '/unlock').action,
+        PaymentUriDrainAction.wait,
+        reason: 'the unlock screen owns the handoff on its own route',
+      );
+    });
+
+    test('the no-wallet row still outranks it', () {
+      // The gate needs an active account to mean anything, so a wallet-less
+      // app must not answer a link with the migration sentence.
+      final decision = decide(sendGatedByMigration: true, hasWallet: false);
+      expect(decision.action, PaymentUriDrainAction.routeToWelcome);
+      expect(decision.message, kPaymentUriNoWalletMessage);
+    });
+  });
+
+  group('no wallet', () {
+    test('routes to /welcome with the no-wallet message', () {
+      final decision = decide(hasWallet: false);
+      expect(decision.action, PaymentUriDrainAction.routeToWelcome);
+      expect(decision.message, kPaymentUriNoWalletMessage);
+    });
+  });
+
+  group('locked wallet', () {
+    test('routes to /unlock and keeps the prefill parked', () {
+      final decision = decide(isUnlocked: false);
+      expect(decision.action, PaymentUriDrainAction.routeToUnlock);
+      expect(decision.message, isNull);
+    });
+
+    test('waits on the unlock and reset flows instead of navigating', () {
+      for (final location in ['/unlock', '/lost-password']) {
+        expect(
+          decide(isUnlocked: false, matchedLocation: location).action,
+          PaymentUriDrainAction.wait,
+          reason: location,
+        );
+      }
+    });
+
+    test('waits on /unlock after unlocking: the unlock screen presents', () {
+      expect(
+        decide(matchedLocation: '/unlock').action,
+        PaymentUriDrainAction.wait,
+      );
+    });
+  });
+
+  group('no route blocks the card any more', () {
+    test('presents over every surface that used to be blocked', () {
+      for (final location in [
+        // The send flow itself, mid-compose and mid-review.
+        '/send',
+        '/send/review',
+        '/send/status',
+        '/send/amount',
+        // Swap and pay review.
+        '/swap/review',
+        '/pay/review',
+        // The working migration screens.
+        '/migration/prepare',
+        '/migration/private/status',
+        // Voting review and the uninstall flow.
+        '/voting/poll/round-1/review',
+        '/settings/uninstall',
+        // A swap activity detail signing a ZEC deposit.
+        '/activity/swap/swap-1',
+      ]) {
+        expect(
+          decide(matchedLocation: location).action,
+          PaymentUriDrainAction.deliver,
+          reason: location,
+        );
+      }
+    });
+  });
+
+  // These four sentences are the whole of what a user is told when a `zcash:`
+  // link does not arrive. Each names what happened to the link and what to do
+  // about it, so the text is pinned here rather than left to drift.
+  group('notice copy', () {
+    test('the unavailable notice states the recovery, not the cause', () {
+      expect(
+        kPaymentUriUnavailableMessage,
+        "Vizor couldn't open this payment link. "
+        'Open it again once your wallet has loaded.',
+      );
+    });
+
+    test('the replaced notice says how to get the earlier link back', () {
+      expect(
+        kPaymentUriReplacedMessage,
+        'Only the newest payment link was kept. Open the earlier one again to '
+        'pay it.',
+      );
+    });
+
+    test('the migration notice names the migration the user is in', () {
+      expect(
+        kPaymentUriMigrationSendGateMessage,
+        'Finish your Ironwood migration before opening payment links.',
+      );
+    });
+  });
+
+  // A refused `zcash:` link gets one of two sentences, never the parser's own
+  // spec wording: that text is written for us, and it echoes fragments of the
+  // link's own string back at the payer.
+  group('rejection buckets', () {
+    test('a request Vizor cannot answer yet reads as unsupported', () {
+      expect(
+        paymentUriRejectionMessage(
+          const Zip321UnsupportedRequestException(
+            'Multiple-recipient ZIP-321 requests are parsed but not supported '
+            'yet.',
+          ),
+        ),
+        kPaymentUriUnsupportedMessage,
+      );
+    });
+
+    test('every real unsupported reason lands in the unsupported bucket', () {
+      for (final raw in [
+        // Multiple recipients.
+        'zcash:?address=u1first&amount=0.5&address.1=u1second&amount.1=0.25',
+        // A binary memo (0xFF is not valid UTF-8).
+        'zcash:u1recipient?amount=0.5&memo=_w',
+        // A custom asset.
+        'zcash:u1recipient?req-asset=abcd',
+      ]) {
+        final request = Zip321PaymentRequest.parse(raw);
+        expect(request.isSupported, isFalse, reason: raw);
+        expect(
+          paymentUriRejectionMessage(
+            Zip321UnsupportedRequestException(request.unsupportedReason!),
+          ),
+          kPaymentUriUnsupportedMessage,
+          reason: raw,
+        );
+      }
+    });
+
+    test('a parse failure reads as an invalid link, whatever the reason', () {
+      for (final raw in [
+        'zcash://u1recipient',
+        'zcash:u1recipient?amount=not-a-number',
+        'zcash:u1recipient?memo=%zz',
+        'zcash:u1recipient?req-unknown=1',
+        'zcash:u1recipient?amount=1&amount=2',
+        'https://example.com/pay',
+        '',
+      ]) {
+        final error = _parseError(raw);
+        expect(error, isA<Zip321ParseException>(), reason: raw);
+        expect(
+          paymentUriRejectionMessage(error),
+          kPaymentUriMalformedMessage,
+          reason: raw,
+        );
+      }
+    });
+
+    test('the two sentences never leak the parser wording', () {
+      for (final message in [
+        kPaymentUriUnsupportedMessage,
+        kPaymentUriMalformedMessage,
+      ]) {
+        expect(message, isNot(contains('ZIP-321')));
+      }
+    });
+  });
+}
+
+/// The exception [Zip321PaymentRequest.parse] throws for [raw].
+Object _parseError(String raw) {
+  try {
+    Zip321PaymentRequest.parse(raw);
+  } catch (e) {
+    return e;
+  }
+  fail('expected a parse failure for: $raw');
+}

--- a/test/core/navigation/payment_uri_migration_gate_test.dart
+++ b/test/core/navigation/payment_uri_migration_gate_test.dart
@@ -1,0 +1,220 @@
+@Tags(['mobile'])
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart' show ThemeMode;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    as frb;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/chain_upgrade_provider.dart';
+import 'package:zcash_wallet/src/providers/migration_send_gate_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import '../../fakes/fake_sync_notifier.dart';
+
+// Why the drain policy evaluates `sendGatedByMigration` only for an unlocked
+// wallet.
+//
+// `migrationSendGateProvider` is `cta == resume && ironwoodBalance <= 0`, and
+// locking the wallet resets `syncProvider` to a bare `SyncState()`
+// (`SyncNotifier.clearSensitiveStateForLock`). That zeroes the balance half of
+// the predicate unconditionally, so the whole gate collapses to "does the
+// cached Home CTA still say resume" — and
+// `ironwoodHomeMigrationPresentationProvider` is built to keep the last visible
+// CTA across exactly this kind of gap.
+//
+// These tests pin what the gate answers on both sides of a lock, so the drain
+// row's position in `decidePaymentUriDrain` is a decision about a measured
+// value rather than an assumed one.
+void main() {
+  test('a resume migration reads gated while the wallet is unlocked', () async {
+    final harness = await _MigrationGateHarness.create();
+
+    expect(harness.gate, isTrue);
+  });
+
+  test(
+    'the gate still reads gated after a lock zeroes the sync state',
+    () async {
+      final harness = await _MigrationGateHarness.create();
+      expect(harness.gate, isTrue);
+
+      harness.lock();
+
+      expect(
+        harness.cta.mode,
+        IronwoodHomeMigrationCtaMode.resume,
+        reason:
+            'the Home presentation keeps the last visible CTA across a sync '
+            'gap, and a lock is one',
+      );
+      expect(
+        harness.gate,
+        isTrue,
+        reason:
+            'a locked wallet still reads gated, on the strength of an '
+            'Ironwood balance the lock itself zeroed — so the drain policy '
+            'must not drop a parked link on this row before unlock',
+      );
+    },
+  );
+
+  test('an unlocked wallet with a spendable Ironwood note is not '
+      'gated', () async {
+    final harness = await _MigrationGateHarness.create(
+      ironwoodBalance: BigInt.from(100000000),
+    );
+
+    expect(harness.gate, isFalse);
+  });
+}
+
+/// A mobile wallet mid-migration, with a lock that reproduces what
+/// `clearSensitiveStateForLock` leaves behind.
+class _MigrationGateHarness {
+  _MigrationGateHarness._(this._container);
+
+  static Future<_MigrationGateHarness> create({BigInt? ironwoodBalance}) async {
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        accountProvider.overrideWith(_FakeAccountNotifier.new),
+        syncProvider.overrideWith(
+          () =>
+              FakeSyncNotifier(_migratingSync(ironwoodBalance ?? BigInt.zero)),
+        ),
+        // Ironwood is live on this chain; nothing about a lock changes that.
+        chainUpgradeStatusProvider.overrideWith(
+          _IronwoodActiveChainUpgrade.new,
+        ),
+        // The one async input, stubbed with the two values the real loader
+        // produces for these two sync states: a run in progress while the
+        // account has scoped data, and `unavailable` once it does not
+        // (`_loadIronwoodPostMigrationState` returns that for
+        // `!inputs.hasAccountScopedData`, which is what a lock leaves).
+        ironwoodPostMigrationStateProvider.overrideWith(
+          (ref) => ref.watch(_postMigrationStateProvider),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    // Both async inputs are resolved before anything is read: an unresolved
+    // `chainUpgradeStatusProvider` reads as "Ironwood not active", and an
+    // unresolved `syncProvider` answers from the empty `SyncState()` fallback,
+    // so either one would decide these cases for the wrong reason.
+    await container.read(chainUpgradeStatusProvider.future);
+    await container.read(syncProvider.future);
+    final harness = _MigrationGateHarness._(container);
+    // Reading the presentation while unlocked is what fills its cache — the
+    // same thing Home does every build.
+    expect(harness.cta.mode, IronwoodHomeMigrationCtaMode.resume);
+    return harness;
+  }
+
+  final ProviderContainer _container;
+
+  bool get gate => _container.read(migrationSendGateProvider);
+
+  IronwoodHomeMigrationCtaState get cta =>
+      _container.read(ironwoodHomeMigrationPresentationProvider);
+
+  /// What locking the wallet does to everything this gate reads: the sync
+  /// state is wiped, and the post-migration load can no longer answer.
+  void lock() {
+    (_container.read(syncProvider.notifier) as FakeSyncNotifier).emit(
+      SyncState(),
+    );
+    _container
+        .read(_postMigrationStateProvider.notifier)
+        .set(const IronwoodPostMigrationState.unavailable());
+  }
+}
+
+class _PostMigrationStateNotifier extends Notifier<IronwoodPostMigrationState> {
+  @override
+  IronwoodPostMigrationState build() => IronwoodPostMigrationState.inProgress(
+    network: 'main',
+    accountUuid: 'account-1',
+    status: _status(),
+  );
+
+  void set(IronwoodPostMigrationState next) => state = next;
+}
+
+final _postMigrationStateProvider =
+    NotifierProvider<_PostMigrationStateNotifier, IronwoodPostMigrationState>(
+      _PostMigrationStateNotifier.new,
+    );
+
+class _IronwoodActiveChainUpgrade extends ChainUpgradeStatusNotifier {
+  @override
+  Future<ChainUpgradeStatusState> build() async =>
+      ChainUpgradeStatusState.cachedActive(defaultRpcEndpointConfig('main'));
+}
+
+class _FakeAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1migrationgate',
+  );
+}
+
+/// Mid-migration: the Orchard funds are already out, the Ironwood note is not
+/// spendable yet.
+SyncState _migratingSync(BigInt ironwoodBalance) => SyncState(
+  accountUuid: 'account-1',
+  hasAccountScopedData: true,
+  isSyncComplete: true,
+  chainTipHeight: 3000000,
+  scannedHeight: 3000000,
+  ironwoodBalance: ironwoodBalance,
+);
+
+rust_sync.MigrationStatus _status() => rust_sync.MigrationStatus(
+  phase: kIronwoodMigrationBroadcastScheduledPhase,
+  activeRunId: 'run-1',
+  targetValuesZatoshi: frb.Uint64List.fromList([100000000]),
+  preparedNoteCount: 1,
+  denominationConfirmationCount: 3,
+  denominationConfirmationTarget: 3,
+  denominationSplitCompletedCount: 1,
+  denominationSplitTotalCount: 1,
+  pendingTxCount: 1,
+  broadcastedTxCount: 1,
+  confirmedTxCount: 0,
+  totalCount: 1,
+  signedChildPcztCount: 0,
+  pendingSplitStageCount: 0,
+  canAbandon: false,
+  signingBatchLimit: 50,
+  scheduleMeanDelayBlocks: 144,
+  scheduleMaxDelayBlocks: 576,
+  scheduledBroadcasts: const [],
+  parts: const [],
+);
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/home',
+  initialAccountState: const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1migrationgate',
+  ),
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);

--- a/test/core/navigation/payment_uri_prefill_provider_test.dart
+++ b/test/core/navigation/payment_uri_prefill_provider_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+
+// The prefill parks one `zcash:` link at a time — latest wins, no queue — so
+// `set` is the only place that can tell a first arrival from one that
+// displaced a link the user has not seen yet. Its return value is what
+// `_IncomingLinkHost` uses to surface `kPaymentUriReplacedMessage`
+// instead of dropping the earlier link in silence.
+void main() {
+  const first = SendPrefillArgs(
+    id: 'payment-uri-1',
+    source: 'zcash-uri',
+    address: 'u1first',
+    amountText: '0.5',
+  );
+  const second = SendPrefillArgs(
+    id: 'payment-uri-2',
+    source: 'zcash-uri',
+    address: 'u1second',
+    amountText: '0.25',
+  );
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('set reports a replacement only when a prefill is still parked', () {
+    final container = makeContainer();
+    final notifier = container.read(paymentUriPrefillProvider.notifier);
+
+    // Nothing parked: the first link replaces nothing.
+    expect(notifier.set(first), isFalse);
+    expect(container.read(paymentUriPrefillProvider), first);
+
+    // A second link arrives before the first is drained or claimed.
+    expect(notifier.set(second), isTrue);
+    expect(container.read(paymentUriPrefillProvider), second);
+
+    // Once the parked link is gone, the next one is a first arrival again.
+    notifier.clear();
+    expect(notifier.set(first), isFalse);
+    expect(container.read(paymentUriPrefillProvider), first);
+  });
+
+  test(
+    'a duplicate delivery of the same link still counts as a replacement',
+    () {
+      final container = makeContainer();
+      final notifier = container.read(paymentUriPrefillProvider.notifier);
+
+      expect(notifier.set(first), isFalse);
+      expect(notifier.set(first), isTrue);
+    },
+  );
+
+  test('takeIfFresh clears the park, so the next set is not a replacement', () {
+    final container = makeContainer();
+    final notifier = container.read(paymentUriPrefillProvider.notifier);
+
+    notifier.set(first);
+    expect(notifier.takeIfFresh().prefill, first);
+    expect(notifier.set(second), isFalse);
+
+    expect(notifier.takeIfFresh().prefill, second);
+    expect(notifier.set(first), isFalse);
+  });
+
+  // The unlock screens are the only claimant, and they have to tell "nothing
+  // was parked" (say nothing) apart from "a link the user opened sat past its
+  // window" (say so). Both used to come back as a bare null, which is why a
+  // link tapped while locked and unlocked ten minutes later vanished without a
+  // word.
+  group('a stale claim is distinguishable from an empty one', () {
+    test('nothing parked is not an expiry', () {
+      final container = makeContainer();
+      final notifier = container.read(paymentUriPrefillProvider.notifier);
+
+      final claimed = notifier.takeIfFresh();
+      expect(claimed.prefill, isNull);
+      expect(claimed.expired, isFalse);
+    });
+
+    test('a fresh park is handed over and is not an expiry', () {
+      final container = makeContainer();
+      final notifier = container.read(paymentUriPrefillProvider.notifier);
+
+      notifier.set(first);
+      final claimed = notifier.takeIfFresh();
+      expect(claimed.prefill, first);
+      expect(claimed.expired, isFalse);
+    });
+
+    test('a park older than the TTL is withheld and reported as expired', () {
+      final container = makeContainer();
+      final notifier = container.read(paymentUriPrefillProvider.notifier);
+
+      notifier.set(first);
+      notifier.debugAgePark(
+        PaymentUriPrefillNotifier.parkTtl + const Duration(seconds: 1),
+      );
+
+      final claimed = notifier.takeIfFresh();
+      expect(claimed.prefill, isNull);
+      expect(claimed.expired, isTrue);
+      expect(
+        container.read(paymentUriPrefillProvider),
+        isNull,
+        reason: 'a withheld link is still cleared',
+      );
+    });
+
+    test('a park still inside the TTL is handed over', () {
+      final container = makeContainer();
+      final notifier = container.read(paymentUriPrefillProvider.notifier);
+
+      notifier.set(first);
+      notifier.debugAgePark(
+        PaymentUriPrefillNotifier.parkTtl - const Duration(minutes: 1),
+      );
+
+      final claimed = notifier.takeIfFresh();
+      expect(claimed.prefill, first);
+      expect(claimed.expired, isFalse);
+    });
+  });
+}

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -105,6 +105,60 @@ void main() {
     expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
   });
 
+  test(
+    'payment-link secrets stay encrypted across password rotation',
+    () async {
+      const recoveryPayload =
+          '{"link":"https://example.test/payment-links/open#v1=secret-mnemonic-payload"}';
+      const receivedPayload =
+          '{"claimLink":"https://example.test/payment-links/open#v1=received-secret-payload"}';
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(
+        kPaymentLinkRecoveryStorageKey,
+        recoveryPayload,
+      );
+      await store.writeSecretString(
+        kPaymentLinkReceivedStorageKey,
+        receivedPayload,
+      );
+
+      final storedBeforeRotation = await store.readPlain(
+        kPaymentLinkRecoveryStorageKey,
+      );
+      expect(storedBeforeRotation, isNot(contains('secret-mnemonic-payload')));
+      final receivedBeforeRotation = await store.readPlain(
+        kPaymentLinkReceivedStorageKey,
+      );
+      expect(
+        receivedBeforeRotation,
+        isNot(contains('received-secret-payload')),
+      );
+
+      final didChange = await store.changePassword(
+        currentPassword: _oldPassword,
+        newPassword: _newPassword,
+      );
+
+      expect(didChange, isTrue);
+      store.clearSessionPassword();
+      expect(await store.verifyPassword(_newPassword), isTrue);
+      expect(
+        await store.readSecretStringWithOptions(
+          kPaymentLinkRecoveryStorageKey,
+          requireUnlockedSession: true,
+        ),
+        recoveryPayload,
+      );
+      expect(
+        await store.readSecretStringWithOptions(
+          kPaymentLinkReceivedStorageKey,
+          requireUnlockedSession: true,
+        ),
+        receivedPayload,
+      );
+    },
+  );
+
   test('readAccountMnemonicBytes returns mutable mnemonic bytes', () async {
     await store.configurePassword(_oldPassword);
     await store.writeAccountMnemonic(_accountUuid, _mnemonic);

--- a/test/core/zcash/zip321_payment_request_builder_test.dart
+++ b/test/core/zcash/zip321_payment_request_builder_test.dart
@@ -1,0 +1,256 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/zcash/zip321_payment_request.dart';
+import 'package:zcash_wallet/src/core/zcash/zip321_payment_request_builder.dart';
+
+const _shielded =
+    'u1tvg2412a23kshieldedaddress000000000000000000000000k64123hhq6d';
+const _transparent = 't1aWwWwqk3jYGkZc7nLGuTvuM8hDywMZCo';
+const _message = 'Table 4 — two flat whites';
+
+void main() {
+  group('buildZip321PaymentUri', () {
+    test('writes address and amount in ZIP-321 order', () {
+      expect(
+        buildZip321PaymentUri(address: _shielded, amountZec: '0.5'),
+        'zcash:$_shielded?amount=0.5',
+      );
+    });
+
+    test('never emits label or message', () {
+      final uri = buildZip321PaymentUri(
+        address: _shielded,
+        amountZec: '0.5',
+        memoText: _message,
+      );
+
+      // The account name is the only thing the wallet could put in these, and
+      // it would travel to everyone the link reaches.
+      expect(uri, isNot(contains('label=')));
+      expect(uri, isNot(contains('message=')));
+    });
+
+    test('omits the memo parameter when there is no message', () {
+      for (final memo in <String?>[null, '', '   ']) {
+        expect(
+          buildZip321PaymentUri(
+            address: _shielded,
+            amountZec: '0.5',
+            memoText: memo,
+          ),
+          isNot(contains('memo=')),
+        );
+      }
+    });
+
+    test('encodes the memo as unpadded base64url', () {
+      final uri = buildZip321PaymentUri(
+        address: _shielded,
+        amountZec: '0.5',
+        memoText: _message,
+      );
+      final encoded = uri.split('&memo=').last;
+
+      expect(encoded, isNot(contains('=')));
+      expect(encoded, matches(RegExp(r'^[A-Za-z0-9_-]+$')));
+      expect(
+        utf8.decode(base64Url.decode(base64Url.normalize(encoded))),
+        _message,
+      );
+    });
+
+    test('rejects a memo on a transparent address', () {
+      expect(
+        () => buildZip321PaymentUri(
+          address: _transparent,
+          amountZec: '0.5',
+          memoText: _message,
+        ),
+        throwsA(
+          isA<Zip321BuildException>().having(
+            (e) => e.kind,
+            'kind',
+            Zip321BuildErrorKind.memoTransparent,
+          ),
+        ),
+      );
+    });
+
+    test('rejects a memo over 512 bytes', () {
+      // 171 three-byte characters is 513 bytes: over the limit while well
+      // under 512 characters, which is exactly the case a character count
+      // would wave through.
+      final memo = '—' * 171;
+      expect(utf8.encode(memo).length, greaterThan(kZip321MaxMemoBytes));
+      expect(
+        () => buildZip321PaymentUri(
+          address: _shielded,
+          amountZec: '0.5',
+          memoText: memo,
+        ),
+        throwsA(
+          isA<Zip321BuildException>().having(
+            (e) => e.kind,
+            'kind',
+            Zip321BuildErrorKind.memoTooLong,
+          ),
+        ),
+      );
+    });
+
+    test('rejects a memo the parser would refuse', () {
+      expect(
+        () => buildZip321PaymentUri(
+          address: _shielded,
+          amountZec: '0.5',
+          memoText: 'Table\u202E4',
+        ),
+        throwsA(
+          isA<Zip321BuildException>().having(
+            (e) => e.kind,
+            'kind',
+            Zip321BuildErrorKind.memoCharacters,
+          ),
+        ),
+      );
+    });
+
+    test('accepts a memo of exactly 512 bytes', () {
+      final memo = 'a' * kZip321MaxMemoBytes;
+      expect(
+        buildZip321PaymentUri(
+          address: _shielded,
+          amountZec: '0.5',
+          memoText: memo,
+        ),
+        contains('&memo='),
+      );
+    });
+
+    test('rejects an address that is not base-alphanumeric', () {
+      expect(
+        () => buildZip321PaymentUri(address: 'u1 bad', amountZec: '0.5'),
+        throwsA(
+          isA<Zip321BuildException>().having(
+            (e) => e.kind,
+            'kind',
+            Zip321BuildErrorKind.address,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('normalizeZip321Amount', () {
+    test('strips trailing zeros without losing the value', () {
+      expect(normalizeZip321Amount('0.50'), '0.5');
+      expect(normalizeZip321Amount('0.5'), '0.5');
+      expect(normalizeZip321Amount('1.00000000'), '1');
+      expect(normalizeZip321Amount('1'), '1');
+      expect(normalizeZip321Amount('0.000100'), '0.0001');
+      expect(normalizeZip321Amount('00.5'), '0.5');
+      expect(normalizeZip321Amount('0.00000001'), '0.00000001');
+      expect(normalizeZip321Amount(' 0.50 '), '0.5');
+    });
+
+    test('keeps the whole ZEC supply', () {
+      expect(normalizeZip321Amount('21000000'), '21000000');
+    });
+
+    test('rejects more than 8 decimals', () {
+      expect(
+        () => normalizeZip321Amount('0.123456789'),
+        throwsA(
+          isA<Zip321BuildException>().having(
+            (e) => e.kind,
+            'kind',
+            Zip321BuildErrorKind.amountDecimals,
+          ),
+        ),
+      );
+    });
+
+    test('rejects an amount above the ZEC supply', () {
+      expect(
+        () => normalizeZip321Amount('21000000.00000001'),
+        throwsA(
+          isA<Zip321BuildException>().having(
+            (e) => e.kind,
+            'kind',
+            Zip321BuildErrorKind.amountSupply,
+          ),
+        ),
+      );
+    });
+
+    test('rejects zero, blanks, exponents and signs', () {
+      for (final value in ['', '   ', '0', '0.00', '5e2', '-1', '1,5', '.5']) {
+        expect(
+          () => normalizeZip321Amount(value),
+          throwsA(isA<Zip321BuildException>()),
+          reason: 'expected $value to be rejected',
+        );
+      }
+    });
+  });
+
+  group('round trip through Zip321PaymentRequest.parse', () {
+    test('shielded request with a message', () {
+      final uri = buildZip321PaymentUri(
+        address: _shielded,
+        amountZec: '0.50',
+        memoText: _message,
+      );
+      final payment = Zip321PaymentRequest.parse(uri).primaryPayment;
+
+      expect(payment.address, _shielded);
+      expect(payment.amount, '0.5');
+      expect(payment.memoText, _message);
+      expect(payment.memoIsBinary, isFalse);
+      expect(payment.label, isNull);
+      expect(payment.message, isNull);
+    });
+
+    test('shielded request without a message', () {
+      final uri = buildZip321PaymentUri(address: _shielded, amountZec: '1.25');
+      final payment = Zip321PaymentRequest.parse(uri).primaryPayment;
+
+      expect(payment.address, _shielded);
+      expect(payment.amount, '1.25');
+      expect(payment.memoBase64Url, isNull);
+    });
+
+    test('transparent request carries no memo', () {
+      final uri = buildZip321PaymentUri(
+        address: _transparent,
+        amountZec: '0.5',
+        // A transparent request drops the message rather than failing: the
+        // sheet never collects one, so a stale value must not block the link.
+        memoText: null,
+      );
+      final request = Zip321PaymentRequest.parse(uri);
+
+      expect(request.isSupported, isTrue);
+      expect(request.primaryPayment.address, _transparent);
+      expect(request.primaryPayment.amount, '0.5');
+      expect(request.primaryPayment.memoBase64Url, isNull);
+    });
+
+    test('a 512-byte message survives the round trip', () {
+      final memo = 'a' * kZip321MaxMemoBytes;
+      final uri = buildZip321PaymentUri(
+        address: _shielded,
+        amountZec: '0.5',
+        memoText: memo,
+      );
+
+      expect(Zip321PaymentRequest.parse(uri).primaryPayment.memoText, memo);
+    });
+  });
+
+  test('zip321MemoByteLength counts bytes, not characters', () {
+    expect(zip321MemoByteLength(_message), utf8.encode(_message).length);
+    expect(zip321MemoByteLength('—'), 3);
+  });
+}

--- a/test/features/address_scan/address_scan_payload_test.dart
+++ b/test/features/address_scan/address_scan_payload_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/features/address_scan/domain/address_scan_payload.dart';
 
@@ -42,6 +44,176 @@ void main() {
           'zcash:u1k8h8x9g7f6e5d4c3b2a1?amount=0.01&message=hello',
         ),
         'u1k8h8x9g7f6e5d4c3b2a1',
+      );
+    });
+
+    test('extracts bare query address from zcash ZIP-321 URI', () {
+      expect(
+        normalizeAddressScanPayload('zcash:?address=u1k8h8x9g7f6e5d4c3b2a1'),
+        'u1k8h8x9g7f6e5d4c3b2a1',
+      );
+    });
+
+    test('refuses a percent-encoded alias of a repeated address key', () {
+      // The parser refuses the encoded name, and the recovery path must not
+      // let `Uri.queryParameters` decode it into a second `address` that
+      // wins by being last.
+      // Refusal hands the raw payload back unchanged, exactly like the
+      // plainly repeated key below, so nothing downstream sees an address.
+      const encodedAlias = 'zcash:?address=u1real000&%61ddress=u1attacker0';
+      expect(normalizeAddressScanPayload(encodedAlias), encodedAlias);
+      const encodedIndex = 'zcash:?address.1=u1real000&address.%31=u1attacker0';
+      expect(normalizeAddressScanPayload(encodedIndex), encodedIndex);
+    });
+
+    test('a single encoded address key is not a repeat', () {
+      expect(
+        normalizeAddressScanPayload('zcash:?%61ddress=u1real000'),
+        'u1real000',
+      );
+    });
+
+    test('refuses an encoded address key beside a different address key', () {
+      // Two distinct decoded names, so the same-name guard does not fire —
+      // but ZIP-321 forbids an encoded paramname outright, so `%61ddress`
+      // cannot be the paramindex-0 payment and there is no single recipient.
+      const raw = 'zcash:?address.1=u1real000&%61ddress=u1attacker0';
+
+      expect(normalizeAddressScanPayload(raw), raw);
+    });
+
+    test('refuses a query address appended to a positional address', () {
+      // ZIP-321 makes the positional address the address of paramindex 0,
+      // the same slot a bare `address=` names, so this is a repeat: the
+      // victim reads the untampered prefix and the query value would win.
+      const raw = 'zcash:u1real000?amount=0.5&address=u1attacker0';
+
+      expect(normalizeAddressScanPayload(raw), raw);
+    });
+
+    test('refuses a query address appended to a zcash:// authority', () {
+      const raw = 'zcash://u1real000?address=u1attacker0';
+
+      expect(normalizeAddressScanPayload(raw), raw);
+    });
+
+    test('refuses an address key whose paramindex the parser rejects', () {
+      // A paramindex the parser can never accept owns no slot, so beside a
+      // well-formed key it is a second recipient with nothing to anchor it.
+      // Classifying by validity used to let these skip the repeat check
+      // entirely, and `_indexedZcashAddressFromUri` then recovered the one
+      // remaining well-formed key — the appended attacker address.
+      for (final malformed in [
+        'address.0',
+        'address.01',
+        'address.10000',
+        'address.1x',
+        'addr%65ss.01',
+      ]) {
+        final raw = 'zcash:?$malformed=u1real000&address.1=u1attacker0';
+
+        expect(normalizeAddressScanPayload(raw), raw, reason: malformed);
+      }
+    });
+
+    test('refuses a lone address key with a rejected paramindex', () {
+      // Nothing else in the payload names a recipient, so recovery has no
+      // well-formed slot to fall back to either.
+      const raw = 'zcash:u1real000?address.0=u1attacker0';
+
+      expect(normalizeAddressScanPayload(raw), raw);
+    });
+
+    test('keeps a positional address beside a higher indexed one', () {
+      // paramindex 0 plus paramindex 1 is a legitimate multi-payment
+      // request, not a repeat, so the positional address still recovers.
+      expect(
+        normalizeAddressScanPayload(
+          'zcash:u1real000?address.1=u1second000&memo=not-base64url!',
+        ),
+        'u1real000',
+      );
+    });
+
+    test('refuses a payload whose parameter name cannot be decoded', () {
+      // `Uri.decodeQueryComponent('%FF')` throws `FormatException`, not
+      // `ArgumentError`. A crafted QR must fail closed, never throw out of
+      // the scan callback.
+      const raw = 'zcash:?%FFx=y&address=u1real000&address=u1attacker0';
+
+      expect(normalizeAddressScanPayload(raw), raw);
+    });
+
+    test('refuses a payload whose parameter value cannot be decoded', () {
+      const raw = 'zcash:?address=u1real000&label=%FF';
+
+      expect(normalizeAddressScanPayload(raw), raw);
+    });
+
+    test('extracts an indexed-only zcash address', () {
+      expect(
+        normalizeAddressScanPayload('zcash:?address.1=u1k8h8x9g7f6e5d4c3b2a1'),
+        'u1k8h8x9g7f6e5d4c3b2a1',
+      );
+    });
+
+    test('prefers the lowest indexed zcash address', () {
+      expect(
+        normalizeAddressScanPayload(
+          'zcash:?address.5=u1fifthaddress&address.2=u1secondaddress',
+        ),
+        'u1secondaddress',
+      );
+    });
+
+    test('recovers an indexed zcash address when the memo is rejected', () {
+      final memo = base64Url
+          .encode(utf8.encode('Pay \u202Eevil\u202C now'))
+          .replaceAll('=', '');
+
+      expect(
+        normalizeAddressScanPayload(
+          'zcash:?address.1=u1k8h8x9g7f6e5d4c3b2a1&memo.1=$memo',
+        ),
+        'u1k8h8x9g7f6e5d4c3b2a1',
+      );
+    });
+
+    test('refuses to recover an address the parser found ambiguous', () {
+      // `Uri.queryParameters` keeps the last value, so recovering here would
+      // hand the scan the attacker's address instead of the payee's.
+      const raw = 'zcash:?address.1=u1realrecipient&address.1=u1attacker';
+
+      expect(normalizeAddressScanPayload(raw), raw);
+    });
+
+    test('refuses a repeated bare address key too', () {
+      const raw =
+          'zcash:?address=u1realrecipient&address=u1attacker'
+          '&memo=not-base64url!';
+
+      expect(normalizeAddressScanPayload(raw), raw);
+    });
+
+    test('keeps the case of a zcash:// authority address', () {
+      // `uri.host` is lowercased, which corrupts a transparent or TEX address.
+      expect(
+        normalizeAddressScanPayload('zcash://t1KzCK7DjnDLmuFhNBmiZ?amount=1'),
+        't1KzCK7DjnDLmuFhNBmiZ',
+      );
+    });
+
+    test('keeps a zcash:// authority address followed by a slash', () {
+      // Dart parses `zcash://<addr>/` with `path == '/'`. A path of only
+      // separators names no recipient, so the authority still has to win —
+      // returning `/` filled the recipient field with a slash.
+      expect(
+        normalizeAddressScanPayload('zcash://t1KzCK7DjnDLmuFhNBmiZ/'),
+        't1KzCK7DjnDLmuFhNBmiZ',
+      );
+      expect(
+        normalizeAddressScanPayload('zcash://u1real000/?amount=1'),
+        'u1real000',
       );
     });
 

--- a/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
@@ -16,6 +16,7 @@ import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_secret_passph
 import 'package:zcash_wallet/src/features/onboarding/mobile/seed_card.dart';
 import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
 import 'package:zcash_wallet/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart';
+import 'package:zcash_wallet/src/core/clipboard/sensitive_clipboard.dart';
 import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 
 const _mnemonic =
@@ -128,10 +129,20 @@ double _stepsProgress(WidgetTester tester) {
 
 void main() {
   setUp(() {
+    // Copying a secret schedules the real one-minute clipboard auto-clear
+    // timer, which would outlive the widget tree. Hold the expiry open for the
+    // duration of each test; the clearing itself is covered by
+    // test/core/clipboard/sensitive_clipboard_test.dart.
+    SensitiveClipboard.debugExpirationDelay = (_) => Completer<void>().future;
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
     binding.platformDispatcher.views.first
       ..physicalSize = const Size(520, 1100)
       ..devicePixelRatio = 1.0;
+  });
+
+  tearDown(() {
+    SensitiveClipboard.debugExpirationDelay = null;
+    SensitiveClipboard.debugCancelPendingExpiration();
   });
 
   testWidgets('starts obscured, reveals, and enables copy', (tester) async {

--- a/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
@@ -16,7 +16,6 @@ import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_secret_passph
 import 'package:zcash_wallet/src/features/onboarding/mobile/seed_card.dart';
 import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
 import 'package:zcash_wallet/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart';
-import 'package:zcash_wallet/src/core/clipboard/sensitive_clipboard.dart';
 import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 
 const _mnemonic =
@@ -129,20 +128,10 @@ double _stepsProgress(WidgetTester tester) {
 
 void main() {
   setUp(() {
-    // Copying a secret schedules the real one-minute clipboard auto-clear
-    // timer, which would outlive the widget tree. Hold the expiry open for the
-    // duration of each test; the clearing itself is covered by
-    // test/core/clipboard/sensitive_clipboard_test.dart.
-    SensitiveClipboard.debugExpirationDelay = (_) => Completer<void>().future;
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
     binding.platformDispatcher.views.first
       ..physicalSize = const Size(520, 1100)
       ..devicePixelRatio = 1.0;
-  });
-
-  tearDown(() {
-    SensitiveClipboard.debugExpirationDelay = null;
-    SensitiveClipboard.debugCancelPendingExpiration();
   });
 
   testWidgets('starts obscured, reveals, and enables copy', (tester) async {

--- a/test/features/send/mobile_send_scan_sheet_test.dart
+++ b/test/features/send/mobile_send_scan_sheet_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/address_scan/widgets/mobile_address_scan_card.dart';
 import 'package:zcash_wallet/src/features/address_scan/widgets/mobile_address_scan_view.dart'
@@ -34,6 +35,7 @@ void main() {
                         unawaited(
                           showMobileSendScanSheet(
                             context,
+                            networkName: kZcashDefaultNetworkName,
                             controller: controller,
                             resolve: (raw) async =>
                                 MobileScanOutcome.accepted(raw),

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -56,20 +56,22 @@ class _RustApiFake implements RustLibApi {
   @override
   Future<AddressValidationResult> crateApiSyncValidateAddress({
     required String address,
+    required String network,
   }) async {
     if (address == _invalidAddress) {
-      return const AddressValidationResult(isValid: false, addressType: '');
+      return const AddressValidationResult(isValid: false, addressType: '', wrongNetwork: false);
     }
     if (address.startsWith('tex')) {
-      return const AddressValidationResult(isValid: true, addressType: 'tex');
+      return const AddressValidationResult(isValid: true, addressType: 'tex', wrongNetwork: false);
     }
     if (address.startsWith('t1')) {
       return const AddressValidationResult(
         isValid: true,
         addressType: 'transparent',
+        wrongNetwork: false,
       );
     }
-    return const AddressValidationResult(isValid: true, addressType: 'unified');
+    return const AddressValidationResult(isValid: true, addressType: 'unified', wrongNetwork: false);
   }
 
   @override
@@ -646,7 +648,7 @@ void main() {
     await tester.pumpWidget(
       _app(
         initialRecipient: _texAddress,
-        validateAddress: ({required address}) => validation.future,
+        validateAddress: ({required address, required network}) => validation.future,
         accountState: const AccountState(
           accounts: [
             AccountInfo(
@@ -673,7 +675,7 @@ void main() {
     expect(find.text('Enter Amount'), findsNothing);
 
     validation.complete(
-      const AddressValidationResult(isValid: true, addressType: 'tex'),
+      const AddressValidationResult(isValid: true, addressType: 'tex', wrongNetwork: false),
     );
     await tester.pumpAndSettle();
 

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -59,10 +59,18 @@ class _RustApiFake implements RustLibApi {
     required String network,
   }) async {
     if (address == _invalidAddress) {
-      return const AddressValidationResult(isValid: false, addressType: '', wrongNetwork: false);
+      return const AddressValidationResult(
+        isValid: false,
+        addressType: '',
+        wrongNetwork: false,
+      );
     }
     if (address.startsWith('tex')) {
-      return const AddressValidationResult(isValid: true, addressType: 'tex', wrongNetwork: false);
+      return const AddressValidationResult(
+        isValid: true,
+        addressType: 'tex',
+        wrongNetwork: false,
+      );
     }
     if (address.startsWith('t1')) {
       return const AddressValidationResult(
@@ -71,7 +79,11 @@ class _RustApiFake implements RustLibApi {
         wrongNetwork: false,
       );
     }
-    return const AddressValidationResult(isValid: true, addressType: 'unified', wrongNetwork: false);
+    return const AddressValidationResult(
+      isValid: true,
+      addressType: 'unified',
+      wrongNetwork: false,
+    );
   }
 
   @override
@@ -294,7 +306,8 @@ Widget _app({
         path: '/send',
         builder: (_, _) => MobileSendScreen(
           loadWalletDbPath: () async => '/tmp/zcash-test',
-          openScanner: openScanner ?? (_) async => null,
+          openScanner:
+              openScanner ?? (_, {required String networkName}) async => null,
           initialRecipient: initialRecipient,
           validateAddress: validateAddress,
         ),
@@ -423,7 +436,7 @@ Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
         builder: (_, _) => MobileSendScreen(
           useRouteSteps: true,
           loadWalletDbPath: () async => '/tmp/zcash-test',
-          openScanner: (_) async => null,
+          openScanner: (_, {required String networkName}) async => null,
           estimateFee: estimateFee,
         ),
       ),
@@ -440,7 +453,7 @@ Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
             initialContactLabel: args.contactLabel,
             initialContactPictureId: args.contactPictureId,
             loadWalletDbPath: () async => '/tmp/zcash-test',
-            openScanner: (_) async => null,
+            openScanner: (_, {required String networkName}) async => null,
             estimateFee: estimateFee,
           );
         },
@@ -464,7 +477,7 @@ Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
             initialContactLabel: args.contactLabel,
             initialContactPictureId: args.contactPictureId,
             loadWalletDbPath: () async => '/tmp/zcash-test',
-            openScanner: (_) async => null,
+            openScanner: (_, {required String networkName}) async => null,
             estimateFee: estimateFee,
           );
         },
@@ -648,7 +661,8 @@ void main() {
     await tester.pumpWidget(
       _app(
         initialRecipient: _texAddress,
-        validateAddress: ({required address, required network}) => validation.future,
+        validateAddress: ({required address, required network}) =>
+            validation.future,
         accountState: const AccountState(
           accounts: [
             AccountInfo(
@@ -675,7 +689,11 @@ void main() {
     expect(find.text('Enter Amount'), findsNothing);
 
     validation.complete(
-      const AddressValidationResult(isValid: true, addressType: 'tex', wrongNetwork: false),
+      const AddressValidationResult(
+        isValid: true,
+        addressType: 'tex',
+        wrongNetwork: false,
+      ),
     );
     await tester.pumpAndSettle();
 
@@ -1165,7 +1183,7 @@ void main() {
     var scannerOpenCount = 0;
     await tester.pumpWidget(
       _app(
-        openScanner: (_) async {
+        openScanner: (_, {required String networkName}) async {
           scannerOpenCount++;
           return _shieldedAddress;
         },

--- a/test/features/send/payment_request_card_test.dart
+++ b/test/features/send/payment_request_card_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_card.dart';
+
+const _address =
+    'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+    '73d57f73c6dc05121591a83861cd190591';
+
+void main() {
+  group('transaction memo row', () {
+    testWidgets('renders a padded memo exactly as the payment carries it', (
+      tester,
+    ) async {
+      // The pre-check proposes these bytes untouched, so the row may not
+      // tidy them: a payer who reads a trimmed memo is reading a different
+      // memo from the one they are about to pay.
+      await _pump(tester, _view(memo: '  invoice 42  '));
+
+      expect(find.text('Transaction memo'), findsOneWidget);
+      expect(find.text('  invoice 42  '), findsOneWidget);
+      expect(find.text('invoice 42'), findsNothing);
+    });
+
+    testWidgets('keeps the padding when the memo is expanded', (tester) async {
+      await _pump(
+        tester,
+        _view(memo: '  invoice 42  '),
+        initialMessageExpanded: true,
+      );
+
+      expect(find.text('  invoice 42  '), findsOneWidget);
+    });
+
+    testWidgets('names a whitespace-only memo instead of drawing nothing', (
+      tester,
+    ) async {
+      // Those bytes are paid. Rendering them verbatim would leave a row that
+      // reads exactly like a request that asked for no memo at all.
+      await _pump(tester, _view(memo: '   '));
+
+      expect(find.text('Transaction memo'), findsOneWidget);
+      expect(find.text('Whitespace only'), findsOneWidget);
+      expect(find.text('   '), findsNothing);
+    });
+
+    testWidgets('the whitespace placeholder is muted, not memo-colored', (
+      tester,
+    ) async {
+      await _pump(tester, _view(memo: 'invoice 42'));
+      final memoColor = tester
+          .widget<Text>(find.text('invoice 42'))
+          .style!
+          .color;
+
+      await _pump(tester, _view(memo: '   '));
+      final placeholderColor = tester
+          .widget<Text>(find.text('Whitespace only'))
+          .style!
+          .color;
+
+      expect(placeholderColor, AppThemeData.light.colors.text.muted);
+      expect(
+        placeholderColor,
+        isNot(memoColor),
+        reason:
+            'the placeholder is the card describing the memo, not the '
+            "memo's own words, so it must not read as content",
+      );
+    });
+
+    testWidgets('a request with no memo renders no memo row', (tester) async {
+      await _pump(tester, _view());
+
+      expect(find.text('Transaction memo'), findsNothing);
+      expect(find.text('Whitespace only'), findsNothing);
+    });
+
+    testWidgets('an empty memo renders no memo row', (tester) async {
+      await _pump(tester, _view(memo: ''));
+
+      expect(find.text('Transaction memo'), findsNothing);
+      expect(find.text('Whitespace only'), findsNothing);
+    });
+  });
+}
+
+PaymentRequestView _view({String? memo}) => PaymentRequestView(
+  source: PaymentRequestSource.link,
+  address: _address,
+  amountZecText: '0.5 ZEC',
+  memo: memo,
+);
+
+Future<void> _pump(
+  WidgetTester tester,
+  PaymentRequestView request, {
+  bool initialMessageExpanded = false,
+}) async {
+  tester.view.physicalSize = const Size(1080, 1200);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: PaymentRequestCard(
+          request: request,
+          layout: PaymentRequestLayout.desktop,
+          initialMessageExpanded: initialMessageExpanded,
+          onContinue: () {},
+          onEdit: () {},
+          onCancel: () {},
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}

--- a/test/features/send/payment_request_precheck_test.dart
+++ b/test/features/send/payment_request_precheck_test.dart
@@ -494,10 +494,32 @@ void main() {
     },
   );
 
+  test(
+    'a whitespace-only memo the link says to preserve is still proposed',
+    () async {
+      final api = FakeSendApi();
+      await run(api, request: prefill(memoText: '   ', preserveMemoText: true));
+
+      expect(
+        api.lastProposedMemo,
+        '   ',
+        reason:
+            'the payment carries those bytes, so the card cannot treat the '
+            'request as memo-less — see `memoIsWhitespaceOnly`',
+      );
+    },
+  );
+
   test('a shielded recipient keeps the memo', () async {
     final api = FakeSendApi();
     await run(api, request: prefill(memoText: 'thanks'));
     expect(api.lastProposedMemo, 'thanks');
+  });
+
+  test('an empty memo is proposed as no memo at all', () async {
+    final api = FakeSendApi();
+    await run(api, request: prefill(memoText: '', preserveMemoText: true));
+    expect(api.lastProposedMemo, isNull);
   });
 
   group('proposal handle', () {

--- a/test/features/send/payment_request_precheck_test.dart
+++ b/test/features/send/payment_request_precheck_test.dart
@@ -1,0 +1,454 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+/// A fake stand-in for the two Rust calls behind the card: address validation
+/// and proposal creation, plus the discard the handle owns.
+class FakeSendApi {
+  FakeSendApi({
+    this.addressType = 'unified',
+    this.addressIsValid = true,
+    this.addressWrongNetwork = false,
+    this.validateThrows,
+    this.proposeThrows,
+    this.feeZatoshi,
+    this.spendableIsAuthoritativeNow = true,
+  });
+
+  String addressType;
+  bool addressIsValid;
+
+  /// Validation refused the address only because it belongs to another
+  /// network. Implies [addressIsValid] false, the way Rust reports it.
+  bool addressWrongNetwork;
+  Object? validateThrows;
+  Object? proposeThrows;
+  BigInt? feeZatoshi;
+
+  /// What the wallet's spendable balance looks like *after* the proposal has
+  /// run — the VZR-42 gate the card re-reads before quoting a shortfall.
+  bool spendableIsAuthoritativeNow;
+
+  var validateCalls = 0;
+  var proposeCalls = 0;
+  String? lastValidatedNetwork;
+  final discarded = <BigInt>[];
+  String? lastProposedMemo;
+  String? lastRequestedBy;
+
+  Future<rust_sync.AddressValidationResult> validateAddress({
+    required String address,
+    required String network,
+  }) async {
+    validateCalls++;
+    lastValidatedNetwork = network;
+    final failure = validateThrows;
+    if (failure != null) throw failure;
+    return rust_sync.AddressValidationResult(
+      isValid: addressIsValid && !addressWrongNetwork,
+      addressType: addressType,
+      wrongNetwork: addressWrongNetwork,
+    );
+  }
+
+  Future<SendReviewArgs> proposeTransfer({
+    required String accountUuid,
+    required String sendFlowId,
+    required String address,
+    required String addressType,
+    required BigInt amountZatoshi,
+    String? memo,
+    bool isPaymentRequest = false,
+    String? requestedBy,
+    BigInt? requestedAmountZatoshi,
+  }) async {
+    proposeCalls++;
+    lastProposedMemo = memo;
+    lastRequestedBy = requestedBy;
+    final failure = proposeThrows;
+    if (failure != null) throw failure;
+    return SendReviewArgs(
+      proposalId: BigInt.from(7),
+      sendFlowId: sendFlowId,
+      proposalAccountUuid: accountUuid,
+      address: address,
+      addressType: addressType,
+      amountZatoshi: amountZatoshi,
+      feeZatoshi: feeZatoshi ?? BigInt.from(10000),
+      needsSaplingParams: false,
+      memo: memo,
+      isPaymentRequest: isPaymentRequest,
+      requestedBy: sanitisePaymentRequestLabel(requestedBy),
+      requestedAmountZatoshi: requestedAmountZatoshi,
+    );
+  }
+
+  Future<void> discardProposal({
+    required BigInt proposalId,
+    required String sendFlowId,
+    required String logContext,
+  }) async {
+    discarded.add(proposalId);
+  }
+
+  PaymentRequestPrecheck get precheck => PaymentRequestPrecheck(
+    spendableIsAuthoritativeNow: () => spendableIsAuthoritativeNow,
+    validateAddress: validateAddress,
+    proposeTransfer: proposeTransfer,
+    discardProposal: discardProposal,
+  );
+}
+
+SendPrefillArgs prefill({
+  String? amountText = '0.5',
+  String? memoText,
+  bool preserveMemoText = false,
+}) => SendPrefillArgs(
+  id: 'payment-uri-1',
+  source: kPaymentUriPrefillSource,
+  address: 'u1recipient',
+  amountText: amountText,
+  memoText: memoText,
+  preserveMemoText: preserveMemoText,
+  label: 'Coffee  shop\n',
+);
+
+Future<PaymentRequestPrecheckResult> run(
+  FakeSendApi api, {
+  SendPrefillArgs? request,
+  String? accountUuid = 'account-1',
+  BigInt? spendable,
+  bool spendableIsAuthoritative = true,
+}) => api.precheck.run(
+  prefill: request ?? prefill(),
+  sendFlowId: 'flow-1',
+  accountUuid: accountUuid,
+  spendableBalance: spendable ?? BigInt.from(100000000),
+  spendableIsAuthoritative: spendableIsAuthoritative,
+);
+
+void main() {
+  test('a payable request proposes and hands back a live proposal', () async {
+    final api = FakeSendApi();
+    final result = await run(api);
+
+    expect(result, isA<PaymentRequestPrecheckReady>());
+    final ready = result as PaymentRequestPrecheckReady;
+    expect(ready.proposal, isNotNull);
+    expect(api.proposeCalls, 1);
+    expect(ready.reviewArgs!.isPaymentRequest, isTrue);
+    expect(ready.reviewArgs!.amountZatoshi, BigInt.from(50000000));
+    expect(
+      ready.reviewArgs!.requestedAmountZatoshi,
+      ready.reviewArgs!.amountZatoshi,
+      reason: 'an unedited request was requested for exactly this amount',
+    );
+    expect(
+      ready.reviewArgs!.requestedBy,
+      'Coffee shop',
+      reason: 'the untrusted label is collapsed to one line',
+    );
+  });
+
+  test('an amount-less request is ready with nothing proposed', () async {
+    final api = FakeSendApi();
+    final result = await run(api, request: prefill(amountText: null));
+
+    expect(result, isA<PaymentRequestPrecheckReady>());
+    expect((result as PaymentRequestPrecheckReady).proposal, isNull);
+    expect(
+      api.proposeCalls,
+      0,
+      reason: 'there is no amount to propose, so nothing is locked',
+    );
+  });
+
+  test('an unpayable address never reaches the proposal', () async {
+    final api = FakeSendApi(addressIsValid: false);
+    final result = await run(api);
+    expect(result, isA<PaymentRequestPrecheckInvalidAddress>());
+    expect(
+      (result as PaymentRequestPrecheckInvalidAddress).message,
+      isNull,
+      reason: 'a malformed address keeps the card default copy',
+    );
+    expect(api.proposeCalls, 0);
+  });
+
+  test('validation runs against the network this build talks to', () async {
+    final api = FakeSendApi();
+    await run(api);
+    expect(api.lastValidatedNetwork, kZcashDefaultNetworkName);
+  });
+
+  test('an address for another network says so instead of "invalid"', () async {
+    final api = FakeSendApi(addressWrongNetwork: true);
+    final result = await run(api);
+
+    expect(result, isA<PaymentRequestPrecheckInvalidAddress>());
+    expect(
+      (result as PaymentRequestPrecheckInvalidAddress).message,
+      kWrongNetworkAddressMessage,
+    );
+    expect(
+      api.proposeCalls,
+      0,
+      reason: 'the address is unpayable here, so nothing is locked',
+    );
+  });
+
+  test('a validation call that throws is an invalid address', () async {
+    final api = FakeSendApi(validateThrows: Exception('rust exploded'));
+    expect(await run(api), isA<PaymentRequestPrecheckInvalidAddress>());
+    expect(api.proposeCalls, 0);
+  });
+
+  test('an amount above the spendable balance never proposes', () async {
+    final api = FakeSendApi();
+    final result = await run(api, spendable: BigInt.from(21000000));
+
+    expect(result, isA<PaymentRequestPrecheckInsufficientFunds>());
+    expect(
+      (result as PaymentRequestPrecheckInsufficientFunds).spendableText,
+      '0.21 ZEC',
+    );
+    expect(api.proposeCalls, 0);
+  });
+
+  test('a shortfall on a balance that is not settled yet defers to the '
+      'proposal', () async {
+    final api = FakeSendApi();
+    final result = await run(
+      api,
+      spendable: BigInt.zero,
+      spendableIsAuthoritative: false,
+    );
+
+    expect(
+      result,
+      isA<PaymentRequestPrecheckReady>(),
+      reason: 'VZR-42: a mid-scan zero is not an answer about affordability',
+    );
+    expect(
+      api.proposeCalls,
+      1,
+      reason: 'the proposal waits for the authoritative spendable and decides',
+    );
+  });
+
+  test('an unsettled balance still reports the insufficiency Rust '
+      'confirms', () async {
+    final api = FakeSendApi(
+      proposeThrows: StateError('InsufficientFunds: not enough'),
+    );
+    final result = await run(
+      api,
+      spendable: BigInt.from(21000000),
+      spendableIsAuthoritative: false,
+    );
+
+    expect(
+      result,
+      isA<PaymentRequestPrecheckInsufficientFunds>(),
+      reason:
+          'the proposal waited for a settled spendable, and the balance is '
+          'still settled when its answer comes back',
+    );
+    expect(api.proposeCalls, 1);
+  });
+
+  test('a shortfall Rust reports while the balance is still moving is '
+      'syncing', () async {
+    final api = FakeSendApi(
+      proposeThrows: StateError(
+        'Insufficient balance (have 0, need 0.5 including fee)',
+      ),
+      spendableIsAuthoritativeNow: false,
+    );
+    final result = await run(
+      api,
+      spendable: BigInt.zero,
+      spendableIsAuthoritative: false,
+    );
+
+    expect(
+      result,
+      isA<PaymentRequestPrecheckSyncing>(),
+      reason:
+          'VZR-42: a shortfall computed against a partly-scanned wallet is '
+          'not an answer, wherever it was computed',
+    );
+    expect(api.proposeCalls, 1);
+  });
+
+  test('a mid-sync proposal failure is syncing, never insufficient', () async {
+    final api = FakeSendApi(
+      proposeThrows: StateError('Wallet sync is still finishing. Try again.'),
+    );
+    expect(await run(api), isA<PaymentRequestPrecheckSyncing>());
+  });
+
+  test('an insufficient-funds proposal failure states the balance', () async {
+    final api = FakeSendApi(
+      proposeThrows: Exception('InsufficientFunds: available 0.21'),
+    );
+    final result = await run(api, spendable: BigInt.from(21000000));
+    expect(result, isA<PaymentRequestPrecheckInsufficientFunds>());
+    expect(
+      (result as PaymentRequestPrecheckInsufficientFunds).spendableText,
+      '0.21 ZEC',
+    );
+  });
+
+  test('a request with no active account names the fix', () async {
+    final api = FakeSendApi();
+    final result = await run(api, accountUuid: null);
+
+    expect(result, isA<PaymentRequestPrecheckFailed>());
+    expect(
+      (result as PaymentRequestPrecheckFailed).message,
+      'No active account — choose one, then open this link again',
+      reason: 'the same term the composer and Receive already use',
+    );
+    expect(api.proposeCalls, 0);
+  });
+
+  test('a network failure says so in the card\'s own words', () async {
+    final api = FakeSendApi(proposeThrows: Exception('grpc connect failed'));
+    final result = await run(api);
+    expect(result, isA<PaymentRequestPrecheckFailed>());
+    expect(
+      (result as PaymentRequestPrecheckFailed).message,
+      "Couldn't reach the network — check your connection and open the link "
+      'again',
+    );
+  });
+
+  test('any other proposal failure names the exit the card has', () async {
+    final api = FakeSendApi(proposeThrows: Exception('something unmapped'));
+    final result = await run(api);
+    expect(result, isA<PaymentRequestPrecheckFailed>());
+    expect(
+      (result as PaymentRequestPrecheckFailed).message,
+      "Couldn't check this request — open Edit to review the details",
+      reason: 'nothing was sent from this card, so no send wording applies',
+    );
+  });
+
+  test('an address the proposal refuses is an invalid address', () async {
+    for (final raw in const [
+      'Error decoding the address from a payment request',
+      'Bad address: IncorrectNetwork { expected: Main, actual: Test }',
+    ]) {
+      final api = FakeSendApi(proposeThrows: Exception(raw));
+      expect(
+        await run(api),
+        isA<PaymentRequestPrecheckInvalidAddress>(),
+        reason: raw,
+      );
+    }
+  });
+
+  test('the sync message Rust actually emits is syncing', () async {
+    final api = FakeSendApi(
+      proposeThrows: StateError(
+        'Wallet must sync before sending; no chain tip is known yet',
+      ),
+    );
+    expect(await run(api), isA<PaymentRequestPrecheckSyncing>());
+  });
+
+  test('an unreadable amount fails instead of proposing zero', () async {
+    final api = FakeSendApi();
+    final result = await run(api, request: prefill(amountText: 'not-a-number'));
+    expect(result, isA<PaymentRequestPrecheckFailed>());
+    expect(
+      (result as PaymentRequestPrecheckFailed).message,
+      "This link doesn't ask for a payable amount — enter one to continue",
+    );
+    expect(api.proposeCalls, 0);
+  });
+
+  test('a request for zero is treated as a request with no amount', () async {
+    for (final amount in const ['0', '0.00000000']) {
+      final api = FakeSendApi();
+      final result = await run(api, request: prefill(amountText: amount));
+
+      expect(result, isA<PaymentRequestPrecheckReady>(), reason: amount);
+      expect(
+        (result as PaymentRequestPrecheckReady).proposal,
+        isNull,
+        reason: amount,
+      );
+      expect(
+        api.proposeCalls,
+        0,
+        reason: 'zero is not a payment, so there is nothing to propose',
+      );
+    }
+  });
+
+  // A memo on a transparent-like recipient has no branch here on purpose:
+  // `Zip321PaymentRequest.parse` refuses that combination outright, so the
+  // payer is told the link is invalid before a card is built. The end-to-end
+  // proof is `test/app_payment_uri_rejection_test.dart`, "a memo on a
+  // transparent address is refused as an invalid link".
+
+  test(
+    'a memo the link says to preserve reaches the proposal untouched',
+    () async {
+      final api = FakeSendApi();
+      await run(
+        api,
+        request: prefill(memoText: '  order 42\n', preserveMemoText: true),
+      );
+
+      expect(
+        api.lastProposedMemo,
+        '  order 42\n',
+        reason:
+            'the compose form preserves the same bytes through '
+            'preserveMemoText, so both routes must pay the same memo',
+      );
+    },
+  );
+
+  test('a shielded recipient keeps the memo', () async {
+    final api = FakeSendApi();
+    await run(api, request: prefill(memoText: 'thanks'));
+    expect(api.lastProposedMemo, 'thanks');
+  });
+
+  group('proposal handle', () {
+    test('discard is idempotent', () async {
+      final api = FakeSendApi();
+      final ready = await run(api) as PaymentRequestPrecheckReady;
+      final handle = ready.proposal!;
+
+      await handle.discard();
+      await handle.discard();
+      await handle.discard();
+
+      expect(api.discarded, [BigInt.from(7)]);
+    });
+
+    test('release transfers ownership, so discard becomes a no-op', () async {
+      final api = FakeSendApi();
+      final ready = await run(api) as PaymentRequestPrecheckReady;
+      final handle = ready.proposal!;
+
+      expect(handle.release().proposalId, BigInt.from(7));
+      expect(handle.isReleased, isTrue);
+      await handle.discard();
+
+      expect(
+        api.discarded,
+        isEmpty,
+        reason: 'the review screen owns the proposal after a release',
+      );
+    });
+  });
+}

--- a/test/features/send/payment_request_precheck_test.dart
+++ b/test/features/send/payment_request_precheck_test.dart
@@ -33,6 +33,12 @@ class FakeSendApi {
   /// proposal.
   bool spendableIsAuthoritativeNow;
 
+  /// What a live re-read of the spendable balance reports. Defaults through
+  /// [run] to the balance the check started with, which is what an
+  /// undisturbed wallet says; set it to stand in a scan that moved the
+  /// number while the check was in flight.
+  BigInt? spendableBalanceNow;
+
   /// Runs inside the awaited address validation, so a test can move the
   /// wallet under a check that is already in flight.
   void Function()? whileValidating;
@@ -102,6 +108,7 @@ class FakeSendApi {
 
   PaymentRequestPrecheck get precheck => PaymentRequestPrecheck(
     spendableIsAuthoritativeNow: () => spendableIsAuthoritativeNow,
+    spendableBalanceNow: () => spendableBalanceNow ?? BigInt.zero,
     validateAddress: validateAddress,
     proposeTransfer: proposeTransfer,
     discardProposal: discardProposal,
@@ -128,13 +135,18 @@ Future<PaymentRequestPrecheckResult> run(
   String? accountUuid = 'account-1',
   BigInt? spendable,
   bool spendableIsAuthoritative = true,
-}) => api.precheck.run(
-  prefill: request ?? prefill(),
-  sendFlowId: 'flow-1',
-  accountUuid: accountUuid,
-  spendableBalance: spendable ?? BigInt.from(100000000),
-  spendableIsAuthoritative: spendableIsAuthoritative,
-);
+}) {
+  final balance = spendable ?? BigInt.from(100000000);
+  // A wallet nobody disturbed still reads the same balance a moment later.
+  api.spendableBalanceNow ??= balance;
+  return api.precheck.run(
+    prefill: request ?? prefill(),
+    sendFlowId: 'flow-1',
+    accountUuid: accountUuid,
+    spendableBalance: balance,
+    spendableIsAuthoritative: spendableIsAuthoritative,
+  );
+}
 
 void main() {
   test('a payable request proposes and hands back a live proposal', () async {
@@ -325,6 +337,47 @@ void main() {
     expect(
       (result as PaymentRequestPrecheckInsufficientFunds).spendableText,
       '0.21 ZEC',
+    );
+  });
+
+  test('a shortfall the wallet has already outgrown defers to the '
+      'proposal', () async {
+    final api = FakeSendApi();
+    // Settled the whole way through, but the scan that finished under the
+    // check landed more than the request asks for.
+    api.spendableBalanceNow = BigInt.from(100000000);
+
+    final result = await run(api, spendable: BigInt.from(21000000));
+
+    expect(
+      result,
+      isA<PaymentRequestPrecheckReady>(),
+      reason: 'there is nothing to refuse once the funds are there',
+    );
+    expect(api.proposeCalls, 1);
+  });
+
+  test('an insufficient-funds proposal failure quotes the balance the wait '
+      'ended on', () async {
+    final api = FakeSendApi(
+      proposeThrows: Exception('InsufficientFunds: available 0.21'),
+    );
+    // The check started mid-scan on a zero, and `proposeSendTransferWith`
+    // waited for an authoritative spendable before Rust could answer at all
+    // — by which time the scan had found 0.21.
+    api.spendableBalanceNow = BigInt.from(21000000);
+
+    final result = await run(
+      api,
+      spendable: BigInt.zero,
+      spendableIsAuthoritative: false,
+    );
+
+    expect(result, isA<PaymentRequestPrecheckInsufficientFunds>());
+    expect(
+      (result as PaymentRequestPrecheckInsufficientFunds).spendableText,
+      '0.21 ZEC',
+      reason: 'quoting the pre-wait zero would tell the user they have none',
     );
   });
 

--- a/test/features/send/payment_request_precheck_test.dart
+++ b/test/features/send/payment_request_precheck_test.dart
@@ -28,9 +28,14 @@ class FakeSendApi {
   Object? proposeThrows;
   BigInt? feeZatoshi;
 
-  /// What the wallet's spendable balance looks like *after* the proposal has
-  /// run — the VZR-42 gate the card re-reads before quoting a shortfall.
+  /// What the wallet's spendable balance looks like *now* — the VZR-42 gate
+  /// the card re-reads before quoting a shortfall, on either side of the
+  /// proposal.
   bool spendableIsAuthoritativeNow;
+
+  /// Runs inside the awaited address validation, so a test can move the
+  /// wallet under a check that is already in flight.
+  void Function()? whileValidating;
 
   var validateCalls = 0;
   var proposeCalls = 0;
@@ -45,6 +50,7 @@ class FakeSendApi {
   }) async {
     validateCalls++;
     lastValidatedNetwork = network;
+    whileValidating?.call();
     final failure = validateThrows;
     if (failure != null) throw failure;
     return rust_sync.AddressValidationResult(
@@ -214,6 +220,25 @@ void main() {
     expect(
       (result as PaymentRequestPrecheckInsufficientFunds).spendableText,
       '0.21 ZEC',
+    );
+    expect(api.proposeCalls, 0);
+  });
+
+  test('a shortfall whose balance stopped being settled mid-check waits for '
+      'the sync', () async {
+    final api = FakeSendApi();
+    // The wallet starts scanning while the check is awaiting the address
+    // validation, so the settled 0.21 it read is already history.
+    api.whileValidating = () => api.spendableIsAuthoritativeNow = false;
+
+    final result = await run(api, spendable: BigInt.from(21000000));
+
+    expect(
+      result,
+      isA<PaymentRequestPrecheckSyncing>(),
+      reason:
+          'VZR-42: a shortfall against a balance the scan has moved under is '
+          'not a final answer, and only syncing re-checks itself',
     );
     expect(api.proposeCalls, 0);
   });

--- a/test/features/send/payment_request_precheck_test.dart
+++ b/test/features/send/payment_request_precheck_test.dart
@@ -16,7 +16,13 @@ class FakeSendApi {
     this.proposeThrows,
     this.feeZatoshi,
     this.spendableIsAuthoritativeNow = true,
-  });
+    String? networkName,
+  }) : networkName = networkName ?? kZcashDefaultNetworkName;
+
+  /// The network the wallet is on, as the pre-check reads it from the
+  /// persisted endpoint. Defaults to the build's, which is what a wallet that
+  /// never moved off it reports; a stored-endpoint wallet says otherwise.
+  String networkName;
 
   String addressType;
   bool addressIsValid;
@@ -110,6 +116,7 @@ class FakeSendApi {
     spendableIsAuthoritativeNow: () => spendableIsAuthoritativeNow,
     spendableBalanceNow: () => spendableBalanceNow ?? BigInt.zero,
     validateAddress: validateAddress,
+    readNetworkName: () => networkName,
     proposeTransfer: proposeTransfer,
     discardProposal: discardProposal,
   );
@@ -119,10 +126,11 @@ SendPrefillArgs prefill({
   String? amountText = '0.5',
   String? memoText,
   bool preserveMemoText = false,
+  String address = 'u1recipient',
 }) => SendPrefillArgs(
   id: 'payment-uri-1',
   source: kPaymentUriPrefillSource,
-  address: 'u1recipient',
+  address: address,
   amountText: amountText,
   memoText: memoText,
   preserveMemoText: preserveMemoText,
@@ -200,6 +208,23 @@ void main() {
     final api = FakeSendApi();
     await run(api);
     expect(api.lastValidatedNetwork, kZcashDefaultNetworkName);
+  });
+
+  test('validation follows the wallet off the build default network', () async {
+    // A wallet whose stored endpoint is testnet: bootstrap, sync and the
+    // proposal all run against `test`, so a testnet address in a link is
+    // payable and must not come back as wrongNetwork.
+    final api = FakeSendApi(networkName: ZcashNetwork.testnet.name);
+    final result = await run(api, request: prefill(address: 'utest1recipient'));
+
+    expect(
+      api.lastValidatedNetwork,
+      ZcashNetwork.testnet.name,
+      reason: 'the active network decides, not the compiled-in default',
+    );
+    expect(api.lastValidatedNetwork, isNot(kZcashDefaultNetworkName));
+    expect(result, isA<PaymentRequestPrecheckReady>());
+    expect((result as PaymentRequestPrecheckReady).reviewArgs, isNotNull);
   });
 
   test('an address for another network says so instead of "invalid"', () async {

--- a/test/features/send/send_flow_error_copy_test.dart
+++ b/test/features/send/send_flow_error_copy_test.dart
@@ -1,0 +1,113 @@
+import 'package:characters/characters.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+
+void main() {
+  group('friendlyProposeSendError', () {
+    test("maps Rust's own no-tip wording onto the sync message", () {
+      expect(
+        friendlyProposeSendError(
+          'Propose failed: Wallet must sync before sending max',
+        ),
+        'Finishing wallet sync. Try again shortly.',
+      );
+    });
+  });
+
+  group('friendlyPaymentRequestCheckError', () {
+    test('names the network when the check could not reach it', () {
+      expect(
+        friendlyPaymentRequestCheckError('grpc connect failed: dns error'),
+        "Couldn't reach the network — check your connection and open the "
+        'link again',
+      );
+    });
+
+    test('never claims a send happened for an unknown failure', () {
+      final copy = friendlyPaymentRequestCheckError('something odd');
+      expect(
+        copy,
+        "Couldn't check this request — open Edit to review the details",
+      );
+      expect(copy.toLowerCase(), isNot(contains('send failed')));
+    });
+  });
+
+  group('sanitisePaymentRequestLabel', () {
+    test('drops characters that can restyle the review screen', () {
+      // U+202E is not whitespace, so the collapse alone left an unterminated
+      // right-to-left override running through the "Requested by" row on the
+      // surface whose whole job is stating what the user is consenting to.
+      final label = sanitisePaymentRequestLabel('Alice\u202Egnidnep');
+
+      expect(label, 'Alicegnidnep');
+      expect(label, isNot(contains('\u202E')));
+    });
+
+    test('an invisible-only label is nothing to show', () {
+      expect(sanitisePaymentRequestLabel('\u202E\u200F '), isNull);
+    });
+
+    test('still collapses whitespace and clamps the length', () {
+      expect(sanitisePaymentRequestLabel('  Coffee\n shop  '), 'Coffee shop');
+      final long = sanitisePaymentRequestLabel('a' * 100)!;
+      expect(long.length, kPaymentRequestLabelMaxLength);
+      expect(long.endsWith('…'), isTrue);
+    });
+
+    test('never splits a surrogate pair at the clamp boundary', () {
+      // 100 astral-plane code points is 200 UTF-16 code units, so a
+      // `substring` clamp lands mid-pair and leaves an unpaired surrogate
+      // rendering as U+FFFD in the "Requested by" row.
+      const emoji = '\u{1F600}';
+      final clamped = sanitisePaymentRequestLabel(emoji * 100)!;
+
+      expect(clamped.endsWith('…'), isTrue);
+      expect(clamped.characters.length, kPaymentRequestLabelMaxLength);
+      expect(clamped, '${emoji * (kPaymentRequestLabelMaxLength - 1)}…');
+      expect(
+        clamped.runes.any((rune) => rune >= 0xD800 && rune <= 0xDFFF),
+        isFalse,
+      );
+    });
+
+    test('strips the control characters a memo may not carry either', () {
+      // The same rule `stripUnsupportedZip321MemoText` applies to a memo: C0
+      // and C1 controls out, tab/LF/CR left for the whitespace collapse to
+      // fold. A label is rendered text like any other, and these are exactly
+      // the code points that let a link's own string reorder or truncate the
+      // row it sits in.
+      expect(
+        sanitisePaymentRequestLabel('Cof\u0000fee\u0007 shop\u009B'),
+        'Coffee shop',
+      );
+      expect(sanitisePaymentRequestLabel('Coffee\tshop'), 'Coffee shop');
+    });
+
+    test('nothing to show reads as nothing, not as an empty name', () {
+      // Null renders no requester row at all. An empty string would render
+      // the row with nothing in it, which is worse than not naming a
+      // requester the link never named.
+      expect(sanitisePaymentRequestLabel(null), isNull);
+      expect(sanitisePaymentRequestLabel(''), isNull);
+      expect(sanitisePaymentRequestLabel('   \n  '), isNull);
+    });
+
+    test('one grapheme past the limit is the first one clamped', () {
+      final justOver = 'a' * (kPaymentRequestLabelMaxLength + 1);
+      final clamped = sanitisePaymentRequestLabel(justOver)!;
+
+      expect(clamped.characters.length, kPaymentRequestLabelMaxLength);
+      expect(clamped, '${'a' * (kPaymentRequestLabelMaxLength - 1)}…');
+    });
+
+    test('counts a label the way the payer reads it', () {
+      // Exactly at the limit in grapheme clusters, twice it in code units:
+      // nothing to clamp, so nothing is cut and no ellipsis is invented.
+      const emoji = '\u{1F600}';
+      final atLimit = emoji * kPaymentRequestLabelMaxLength;
+
+      expect(sanitisePaymentRequestLabel(atLimit), atLimit);
+    });
+  });
+}

--- a/test/features/send/send_prefill_args_test.dart
+++ b/test/features/send/send_prefill_args_test.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/zcash/zip321_payment_request.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
+
+void main() {
+  test('ZIP-321 memo text is preserved at the send prefill boundary', () {
+    final rawMemo = '  Pay invoice 42\nKeep emoji \u200D  ';
+    final memo = base64Url.encode(utf8.encode(rawMemo)).replaceAll('=', '');
+    final request = Zip321PaymentRequest.parse(
+      'zcash:u1zip321destination?amount=1&memo=$memo',
+    );
+
+    final prefill = sendPrefillArgsFromZip321Payment(
+      id: 'payment-uri-test',
+      payment: request.primaryPayment,
+    );
+
+    expect(prefill.memoText, rawMemo);
+    expect(prefill.preserveMemoText, isTrue);
+  });
+
+  test('ZIP-321 message drops characters the parser refuses in a memo', () {
+    // The parser screens `memo` for these code points but not `message`, and
+    // the payment-request card renders the message with no collapse and no
+    // clamp, so the strip happens here.
+    final request = Zip321PaymentRequest.parse(
+      'zcash:u1zip321destination?amount=1&message=Invoice%20%E2%80%AE42',
+    );
+
+    final prefill = sendPrefillArgsFromZip321Payment(
+      id: 'payment-uri-test',
+      payment: request.primaryPayment,
+    );
+
+    expect(request.primaryPayment.message, contains('\u202E'));
+    expect(prefill.message, 'Invoice 42');
+  });
+}

--- a/test/features/send/send_scan_result_test.dart
+++ b/test/features/send/send_scan_result_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
+import 'package:zcash_wallet/src/features/send/models/send_scan_result.dart';
+
+const _address =
+    'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+    '73d57f73c6dc05121591a83861cd190591';
+
+void main() {
+  group('resolveSendScanPayload', () {
+    test('a bare address scans as a recipient, with nothing lost', () {
+      final result = resolveSendScanPayload(_address);
+      expect(result, isA<SendScanAddress>());
+      expect((result! as SendScanAddress).address, _address);
+      expect((result as SendScanAddress).downgrade, isNull);
+    });
+
+    test('a ZIP-321 request with an amount becomes a payment request', () {
+      final result = resolveSendScanPayload(
+        'zcash:$_address?amount=0.25&label=Coffee%20shop&message=Table%204',
+      );
+      expect(result, isA<SendScanPaymentRequest>());
+      final prefill = (result! as SendScanPaymentRequest).prefill;
+      expect(prefill.source, kPaymentUriPrefillSource);
+      expect(prefill.address, _address);
+      expect(prefill.amountText, '0.25');
+      expect(prefill.label, 'Coffee shop');
+      expect(prefill.message, 'Table 4');
+    });
+
+    test('each scanned request gets its own prefill id', () {
+      const raw = 'zcash:$_address?amount=0.25';
+      final first = resolveSendScanPayload(raw)! as SendScanPaymentRequest;
+      final second = resolveSendScanPayload(raw)! as SendScanPaymentRequest;
+      expect(first.prefill.id, isNot(second.prefill.id));
+    });
+
+    test('an address-only ZIP-321 request stays address-only', () {
+      for (final raw in ['zcash:$_address', 'zcash:?address=$_address']) {
+        final result = resolveSendScanPayload(raw);
+        expect(result, isA<SendScanAddress>(), reason: raw);
+        expect((result! as SendScanAddress).address, _address, reason: raw);
+        expect(
+          (result as SendScanAddress).downgrade,
+          isNull,
+          reason: 'the address is exactly what the request asked to be paid at',
+        );
+      }
+    });
+
+    test('an amount-less request keeps the terms it does carry', () {
+      // The composer collects an amount; it has nowhere to put a memo, a
+      // label or a message, so collapsing to address-only threw them away
+      // with no downgrade notice. The same URI opened as a `zcash:` link
+      // reaches the card, which preserves all three — the two paths have to
+      // read the same QR the same way.
+      const memo = 'aW52b2ljZS0xMjM'; // base64url for `invoice-123`.
+      final result = resolveSendScanPayload(
+        'zcash:$_address?memo=$memo&label=Acme&message=Table%204',
+      );
+      expect(result, isA<SendScanPaymentRequest>());
+      final prefill = (result! as SendScanPaymentRequest).prefill;
+      expect(prefill.address, _address);
+      expect(prefill.amountText, isNull);
+      expect(prefill.memoText, 'invoice-123');
+      expect(prefill.preserveMemoText, isTrue);
+      expect(prefill.label, 'Acme');
+      expect(prefill.message, 'Table 4');
+    });
+
+    test('a memo alone is enough to keep the request', () {
+      const memo = 'aW52b2ljZS0xMjM';
+      final result = resolveSendScanPayload('zcash:$_address?memo=$memo');
+      expect(result, isA<SendScanPaymentRequest>());
+      expect(
+        (result! as SendScanPaymentRequest).prefill.memoText,
+        'invoice-123',
+        reason: 'in shielded Zcash the memo is the only reconciliation channel',
+      );
+    });
+
+    test('a zero amount with no other terms stays address-only', () {
+      final result = resolveSendScanPayload('zcash:$_address?amount=0');
+      expect(result, isA<SendScanAddress>());
+    });
+
+    test('a zero amount beside a memo still becomes a request', () {
+      final result = resolveSendScanPayload(
+        'zcash:$_address?amount=0&memo=aW52b2ljZS0xMjM',
+      );
+      expect(result, isA<SendScanPaymentRequest>());
+    });
+
+    test('a request the parser refuses falls back to the scanned address', () {
+      // Two payments: unsupported, so there is no single request to present.
+      final result = resolveSendScanPayload(
+        'zcash:?address=$_address&amount=0.25'
+        '&address.1=$_address&amount.1=0.5',
+        acceptedAddress: _address,
+      );
+      expect(result, isA<SendScanAddress>());
+      expect((result! as SendScanAddress).address, _address);
+      expect(
+        (result as SendScanAddress).downgrade,
+        SendScanDowngrade.multipleRecipients,
+      );
+    });
+
+    test('the address the scanner validated wins over re-derivation', () {
+      final result = resolveSendScanPayload(
+        'not a uri at all',
+        acceptedAddress: _address,
+      );
+      expect((result! as SendScanAddress).address, _address);
+    });
+
+    test('a payload with no address at all resolves to nothing', () {
+      expect(resolveSendScanPayload('   '), isNull);
+    });
+  });
+
+  // A refused request still surrenders its address, and the composer takes it.
+  // That is the right recovery, but the payer scanned terms that are now gone,
+  // so the reason travels with the address instead of being dropped in
+  // silence. Which reason matters: only the multi-recipient case has a first
+  // recipient the payer might not have meant.
+  group('a refused request reports why only the address survived', () {
+    test('more than one recipient', () {
+      final result =
+          resolveSendScanPayload(
+                'zcash:?address=$_address&amount=0.25'
+                '&address.1=$_address&amount.1=0.5',
+                acceptedAddress: _address,
+              )!
+              as SendScanAddress;
+      expect(result.downgrade, SendScanDowngrade.multipleRecipients);
+    });
+
+    test('a memo Vizor cannot read', () {
+      // `_w` is base64url for 0xFF, which is not valid UTF-8.
+      final result =
+          resolveSendScanPayload(
+                'zcash:$_address?amount=0.25&memo=_w',
+                acceptedAddress: _address,
+              )!
+              as SendScanAddress;
+      expect(result.downgrade, SendScanDowngrade.unsupportedMemo);
+    });
+
+    test('a request that does not parse', () {
+      final result =
+          resolveSendScanPayload(
+                'zcash:$_address?amount=not-a-number',
+                acceptedAddress: _address,
+              )!
+              as SendScanAddress;
+      expect(result.downgrade, SendScanDowngrade.malformedRequest);
+    });
+
+    test('a custom asset lands in the catch-all, not the memo bucket', () {
+      final result =
+          resolveSendScanPayload(
+                'zcash:$_address?req-asset=abcd',
+                acceptedAddress: _address,
+              )!
+              as SendScanAddress;
+      expect(result.downgrade, SendScanDowngrade.malformedRequest);
+    });
+
+    test('a payload that was never a payment request reports nothing', () {
+      for (final raw in [
+        _address,
+        'not a uri at all',
+        'bitcoin:bc1qexample?amount=1',
+      ]) {
+        final result =
+            resolveSendScanPayload(raw, acceptedAddress: _address)!
+                as SendScanAddress;
+        expect(result.downgrade, isNull, reason: raw);
+      }
+    });
+  });
+
+  group('sendScanDowngradeMessage', () {
+    test('names what was left behind, per reason', () {
+      expect(
+        sendScanDowngradeMessage(SendScanDowngrade.multipleRecipients),
+        'Scanned the first recipient only — this request asks for more than '
+        'one',
+      );
+      expect(
+        sendScanDowngradeMessage(SendScanDowngrade.unsupportedMemo),
+        "Scanned the address only — the request's message couldn't be read",
+      );
+      expect(
+        sendScanDowngradeMessage(SendScanDowngrade.malformedRequest),
+        "Scanned the address only — the payment request couldn't be read",
+      );
+    });
+
+    test('a plain address QR says nothing', () {
+      expect(sendScanDowngradeMessage(null), isNull);
+    });
+
+    test('every reason has a line', () {
+      for (final downgrade in SendScanDowngrade.values) {
+        expect(sendScanDowngradeMessage(downgrade), isNotNull);
+      }
+    });
+  });
+}

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -1459,17 +1459,19 @@ class _RustApiFake implements RustLibApi {
   @override
   Future<AddressValidationResult> crateApiSyncValidateAddress({
     required String address,
+    required String network,
   }) async {
     if (address == _texAddress) {
-      return const AddressValidationResult(isValid: true, addressType: 'tex');
+      return const AddressValidationResult(isValid: true, addressType: 'tex', wrongNetwork: false);
     }
     if (address == _transparentAddress) {
       return const AddressValidationResult(
         isValid: true,
         addressType: 'transparent',
+        wrongNetwork: false,
       );
     }
-    return const AddressValidationResult(isValid: true, addressType: 'unified');
+    return const AddressValidationResult(isValid: true, addressType: 'unified', wrongNetwork: false);
   }
 
   @override

--- a/test/features/send/zip321_payment_request_test.dart
+++ b/test/features/send/zip321_payment_request_test.dart
@@ -1,0 +1,202 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/zcash/zip321_payment_request.dart';
+
+void main() {
+  test('parses a CipherPay-style ZIP-321 payment URI', () {
+    final memo = base64Url
+        .encode(utf8.encode('CP-C6CDB775'))
+        .replaceAll('=', '');
+
+    final request = Zip321PaymentRequest.parse(
+      'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez'
+      '?amount=0.12345678&memo=$memo&label=Acme%20Store',
+    );
+
+    expect(request.isSupported, isTrue);
+    expect(request.payments, hasLength(1));
+    expect(
+      request.primaryPayment.address,
+      'ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez',
+    );
+    expect(request.primaryPayment.amount, '0.12345678');
+    expect(request.primaryPayment.memoText, 'CP-C6CDB775');
+    expect(request.primaryPayment.label, 'Acme Store');
+  });
+
+  test('rejects unsupported required parameters', () {
+    expect(
+      () => Zip321PaymentRequest.parse(
+        'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?req-unknown=1',
+      ),
+      throwsA(
+        isA<Zip321ParseException>().having(
+          (e) => e.message,
+          'message',
+          'Required ZIP-321 parameter req-unknown is not supported.',
+        ),
+      ),
+    );
+  });
+
+  test('rejects payment URIs longer than the shared native bound', () {
+    final oversized =
+        'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?message='
+        '${'a' * kMaxPaymentUriLength}';
+
+    expect(oversized.length, greaterThan(kMaxPaymentUriLength));
+    expect(
+      () => Zip321PaymentRequest.parse(oversized),
+      throwsA(
+        isA<Zip321ParseException>().having(
+          (e) => e.message,
+          'message',
+          'Payment link is too long.',
+        ),
+      ),
+    );
+  });
+
+  test('measures the length bound in UTF-8 bytes, not code units', () {
+    // 6,000 CJK characters are 6,000 UTF-16 code units but 18,000 UTF-8 bytes,
+    // so a code-unit bound would accept a URI the Windows byte bound rejects.
+    final message = '\u6f22' * 6000;
+    final oversized =
+        'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?message='
+        '$message';
+
+    expect(oversized.length, lessThan(kMaxPaymentUriLength));
+    expect(utf8.encode(oversized).length, greaterThan(kMaxPaymentUriLength));
+    expect(
+      () => Zip321PaymentRequest.parse(oversized),
+      throwsA(
+        isA<Zip321ParseException>().having(
+          (e) => e.message,
+          'message',
+          'Payment link is too long.',
+        ),
+      ),
+    );
+  });
+
+  test('truncates an over-long echoed parameter name', () {
+    final longName = 'req-${'a' * 60}';
+
+    expect(
+      () => Zip321PaymentRequest.parse(
+        'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?$longName=1',
+      ),
+      throwsA(
+        isA<Zip321ParseException>().having(
+          (e) => e.message,
+          'message',
+          'Required ZIP-321 parameter req-${'a' * 28}… is not supported.',
+        ),
+      ),
+    );
+  });
+
+  test('marks multiple-recipient requests as parsed but unsupported', () {
+    final request = Zip321PaymentRequest.parse(
+      'zcash:?address=u1firstaddress&amount=1'
+      '&address.1=u1secondaddress&amount.1=2',
+    );
+
+    expect(request.payments, hasLength(2));
+    expect(request.isSupported, isFalse);
+    expect(
+      request.unsupportedReason,
+      'Multiple-recipient ZIP-321 requests are parsed but not supported yet.',
+    );
+  });
+
+  test('rejects memo on transparent addresses', () {
+    final memo = base64Url.encode(utf8.encode('hello')).replaceAll('=', '');
+
+    expect(
+      () => Zip321PaymentRequest.parse('zcash:t1transparent?memo=$memo'),
+      throwsA(
+        isA<Zip321ParseException>().having(
+          (e) => e.message,
+          'message',
+          'Transparent ZIP-321 payments cannot include a memo.',
+        ),
+      ),
+    );
+  });
+
+  test('rejects oversized memo before base64 decoding', () {
+    final oversizedMemo = 'A' * 685;
+
+    expect(
+      () => Zip321PaymentRequest.parse(
+        'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?memo=$oversizedMemo',
+      ),
+      throwsA(
+        isA<Zip321ParseException>().having(
+          (e) => e.message,
+          'message',
+          'ZIP-321 memo exceeds 512 bytes.',
+        ),
+      ),
+    );
+  });
+
+  test('accepts a zero-padded full-width ZIP-302 memo field', () {
+    // ZIP-302 memos are a fixed 512-byte field; producers that transmit the
+    // whole field right-pad the text with NULs.
+    final bytes = List<int>.filled(512, 0);
+    bytes.setRange(0, 10, utf8.encode('Invoice 42'));
+    final memo = base64Url.encode(bytes).replaceAll('=', '');
+
+    final request = Zip321PaymentRequest.parse(
+      'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?memo=$memo',
+    );
+
+    expect(request.isSupported, isTrue);
+    expect(request.primaryPayment.memoText, 'Invoice 42');
+    expect(request.primaryPayment.memoIsBinary, isFalse);
+  });
+
+  test('still rejects a memo with an interior NUL byte', () {
+    final bytes = <int>[
+      ...utf8.encode('Inv'),
+      0x00,
+      ...utf8.encode('42'),
+      0x00,
+    ];
+    final memo = base64Url.encode(bytes).replaceAll('=', '');
+
+    expect(
+      () => Zip321PaymentRequest.parse(
+        'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?memo=$memo',
+      ),
+      throwsA(
+        isA<Zip321ParseException>().having(
+          (e) => e.message,
+          'message',
+          'ZIP-321 memo contains unsupported control characters.',
+        ),
+      ),
+    );
+  });
+
+  test('rejects text memo with unsupported control characters', () {
+    final rawMemo = 'Pay \u202Eevil\u202C\u0001 now';
+    final memo = base64Url.encode(utf8.encode(rawMemo)).replaceAll('=', '');
+
+    expect(
+      () => Zip321PaymentRequest.parse(
+        'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?memo=$memo',
+      ),
+      throwsA(
+        isA<Zip321ParseException>().having(
+          (e) => e.message,
+          'message',
+          'ZIP-321 memo contains unsupported control characters.',
+        ),
+      ),
+    );
+  });
+}

--- a/test/features/send/zip321_payment_request_test.dart
+++ b/test/features/send/zip321_payment_request_test.dart
@@ -159,6 +159,66 @@ void main() {
     expect(request.primaryPayment.memoIsBinary, isFalse);
   });
 
+  test('accepts ZIP-302\'s canonical empty memo as no memo at all', () {
+    // `9g` is base64url for the single byte 0xF6, which `librustzcash` reads
+    // as `Memo::Empty`. Refusing it would reject a perfectly payable request
+    // over a memo that says nothing.
+    final request = Zip321PaymentRequest.parse(
+      'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?amount=0.5&memo=9g',
+    );
+
+    expect(request.isSupported, isTrue);
+    expect(request.unsupportedReason, isNull);
+    expect(request.primaryPayment.memoIsBinary, isFalse);
+    expect(request.primaryPayment.memoText, isNull);
+    expect(request.primaryPayment.amount, '0.5');
+  });
+
+  test('accepts a full-width empty ZIP-302 memo field', () {
+    // The same value transmitted at its full 512-byte width: 0xF6 then zeros.
+    final bytes = List<int>.filled(512, 0);
+    bytes[0] = 0xF6;
+    final memo = base64Url.encode(bytes).replaceAll('=', '');
+
+    final request = Zip321PaymentRequest.parse(
+      'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?memo=$memo',
+    );
+
+    expect(request.isSupported, isTrue);
+    expect(request.primaryPayment.memoText, isNull);
+    expect(request.primaryPayment.memoIsBinary, isFalse);
+  });
+
+  test('a 0xF6 followed by a non-zero byte is still an unreadable memo', () {
+    // Not the empty marker — the empty-memo shortcut must not swallow
+    // arbitrary bytes that merely start the same way.
+    final memo = base64Url.encode([0xF6, 0x01]).replaceAll('=', '');
+
+    final request = Zip321PaymentRequest.parse(
+      'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?memo=$memo',
+    );
+
+    expect(request.primaryPayment.memoIsBinary, isTrue);
+    expect(request.isSupported, isFalse);
+    expect(
+      request.unsupportedReason,
+      'Binary ZIP-321 memos are parsed but not supported yet.',
+    );
+  });
+
+  test('ZIP-302\'s reserved future-memo prefix stays unsupported', () {
+    // 0xF5 is reserved for memo formats that do not exist yet; the wallet
+    // cannot claim to have shown the payer one.
+    final memo = base64Url.encode([0xF5, 0x00]).replaceAll('=', '');
+
+    final request = Zip321PaymentRequest.parse(
+      'zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?memo=$memo',
+    );
+
+    expect(request.primaryPayment.memoIsBinary, isTrue);
+    expect(request.isSupported, isFalse);
+  });
+
   test('still rejects a memo with an interior NUL byte', () {
     final bytes = <int>[
       ...utf8.encode('Inv'),

--- a/test/features/settings/settings_viewing_key_screen_test.dart
+++ b/test/features/settings/settings_viewing_key_screen_test.dart
@@ -5,9 +5,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:zcash_wallet/src/core/clipboard/sensitive_clipboard.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/clipboard/sensitive_clipboard.dart';
 import 'package:zcash_wallet/src/core/privacy/sensitive_privacy_overlay.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
@@ -37,19 +37,6 @@ const _accountState = AccountState(
 );
 
 void main() {
-  setUp(() {
-    // Copying a secret schedules the real one-minute clipboard auto-clear
-    // timer, which would outlive the widget tree. Hold the expiry open for the
-    // duration of each test; the clearing itself is covered by
-    // test/core/clipboard/sensitive_clipboard_test.dart.
-    SensitiveClipboard.debugExpirationDelay = (_) => Completer<void>().future;
-  });
-
-  tearDown(() {
-    SensitiveClipboard.debugExpirationDelay = null;
-    SensitiveClipboard.debugCancelPendingExpiration();
-  });
-
   testWidgets(
     'reveals the requested account viewing key without making it active',
     (tester) async {
@@ -61,6 +48,7 @@ void main() {
         initiallySafe: true,
       );
       addTearDown(privacyController.dispose);
+      addTearDown(SensitiveClipboard.debugCancelPendingExpiration);
       final requestedUuids = <String>[];
 
       final copiedText = <String>[];
@@ -131,6 +119,10 @@ void main() {
       await tester.pump();
       expect(copiedText, [_ufvk]);
       expect(find.text('Copied'), findsOneWidget);
+      // Cancel the SensitiveClipboard fallback expiry timer so it does not
+      // outlive the widget tree (the fallback path creates a 1-minute timer
+      // on non-iOS/Android platforms, which the test framework would flag).
+      SensitiveClipboard.debugCancelPendingExpiration();
     },
   );
 

--- a/test/features/swap/swap_deposit_amount_test.dart
+++ b/test/features/swap/swap_deposit_amount_test.dart
@@ -139,13 +139,15 @@ class _RustApiFake implements RustLibApi {
   @override
   Future<AddressValidationResult> crateApiSyncValidateAddress({
     required String address,
+    required String network,
   }) async {
     if (address == _texAddress) {
-      return const AddressValidationResult(isValid: true, addressType: 'tex');
+      return const AddressValidationResult(isValid: true, addressType: 'tex', wrongNetwork: false);
     }
     return const AddressValidationResult(
       isValid: true,
       addressType: 'transparent',
+      wrongNetwork: false,
     );
   }
 

--- a/test/features/swap/swap_deposit_amount_test.dart
+++ b/test/features/swap/swap_deposit_amount_test.dart
@@ -1,5 +1,9 @@
+import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_deposit_sender.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_hardware_signing_service.dart';
@@ -57,7 +61,11 @@ void main() {
   });
 
   test('hardware ZEC deposit rejects TEX before proposal', () async {
-    final container = ProviderContainer();
+    final container = ProviderContainer(
+      // The TEX check validates against the wallet's own network, which it
+      // reads off the persisted endpoint.
+      overrides: [appBootstrapProvider.overrideWithValue(_bootstrap)],
+    );
     addTearDown(container.dispose);
 
     final service = container.read(swapHardwareSigningServiceProvider);
@@ -80,8 +88,31 @@ void main() {
       ),
     );
     expect(rustApi.proposeSendCalls, 0);
+    expect(
+      rustApi.lastValidatedNetwork,
+      _bootstrap.rpcEndpointConfig.networkName,
+      reason:
+          'the deposit address is checked against the network the wallet '
+          'would broadcast on',
+    );
   });
 }
+
+final _bootstrap = AppBootstrapState(
+  initialLocation: '/home',
+  initialAccountState: const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+  ),
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: kZcashDefaultNetworkName,
+  rpcEndpointConfig: defaultRpcEndpointConfig(kZcashDefaultNetworkName),
+  themeMode: ThemeMode.system,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);
 
 SwapQuote _quote({
   String? sellAmountTextOverride,
@@ -132,8 +163,12 @@ SwapIntent _intent({
 class _RustApiFake implements RustLibApi {
   int proposeSendCalls = 0;
 
+  /// The network the last address validation was asked about.
+  String? lastValidatedNetwork;
+
   void reset() {
     proposeSendCalls = 0;
+    lastValidatedNetwork = null;
   }
 
   @override
@@ -141,8 +176,13 @@ class _RustApiFake implements RustLibApi {
     required String address,
     required String network,
   }) async {
+    lastValidatedNetwork = network;
     if (address == _texAddress) {
-      return const AddressValidationResult(isValid: true, addressType: 'tex', wrongNetwork: false);
+      return const AddressValidationResult(
+        isValid: true,
+        addressType: 'tex',
+        wrongNetwork: false,
+      );
     }
     return const AddressValidationResult(
       isValid: true,

--- a/test/providers/migration_send_gate_provider_test.dart
+++ b/test/providers/migration_send_gate_provider_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart' show ThemeMode;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    as frb;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
+import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/migration_send_gate_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import '../fakes/fake_sync_notifier.dart';
+
+/// The gate is the product's send gate, and only mobile Home has one — see the
+/// doc comment on [migrationSendGateProvider]. So the expected "gated" answer
+/// is lane-dependent: true in the mobile lane, false in the desktop lane.
+/// Everything that makes the gate *not* fire must hold in both.
+const _gatedInThisLane = kAppFormFactor == AppFormFactor.mobile;
+
+void main() {
+  test(
+    'gates sending while a migration holds the whole spendable balance',
+    () async {
+      expect(
+        await _gateFor(
+          migrationCta: _resumeCta(),
+          ironwoodBalance: BigInt.zero,
+        ),
+        _gatedInThisLane,
+      );
+    },
+  );
+
+  test(
+    'does not gate once the migration produced a spendable Ironwood note',
+    () async {
+      expect(
+        await _gateFor(
+          migrationCta: _resumeCta(),
+          ironwoodBalance: BigInt.from(100000000),
+        ),
+        isFalse,
+      );
+    },
+  );
+
+  test('does not gate when no migration is running', () async {
+    expect(
+      await _gateFor(
+        migrationCta: const IronwoodHomeMigrationCtaState.hidden(),
+        ironwoodBalance: BigInt.zero,
+      ),
+      isFalse,
+    );
+  });
+
+  test('does not gate when a migration is only offered, not resumed', () async {
+    expect(
+      await _gateFor(
+        migrationCta: const IronwoodHomeMigrationCtaState.start(
+          network: 'main',
+          accountUuid: 'account-1',
+        ),
+        ironwoodBalance: BigInt.zero,
+      ),
+      isFalse,
+    );
+  });
+
+  test("ignores another account's Ironwood balance", () async {
+    expect(
+      await _gateFor(
+        migrationCta: _resumeCta(),
+        ironwoodBalance: BigInt.from(100000000),
+        syncAccountUuid: 'account-2',
+      ),
+      _gatedInThisLane,
+      reason:
+          'sync state scoped to a different account carries no balance for the '
+          'active one',
+    );
+  });
+}
+
+Future<bool> _gateFor({
+  required IronwoodHomeMigrationCtaState migrationCta,
+  required BigInt ironwoodBalance,
+  String syncAccountUuid = 'account-1',
+}) async {
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap()),
+      ironwoodHomeMigrationPresentationProvider.overrideWithValue(migrationCta),
+      syncProvider.overrideWith(
+        () => FakeSyncNotifier(
+          SyncState(
+            accountUuid: syncAccountUuid,
+            hasAccountScopedData: true,
+            ironwoodBalance: ironwoodBalance,
+          ),
+        ),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  // `syncProvider` is an AsyncNotifier: read it out before asking for the
+  // gate, or every case answers from the empty `SyncState()` fallback and the
+  // balance rows pass for the wrong reason.
+  await container.read(syncProvider.future);
+  return container.read(migrationSendGateProvider);
+}
+
+IronwoodHomeMigrationCtaState _resumeCta() =>
+    IronwoodHomeMigrationCtaState.resume(
+      network: 'main',
+      accountUuid: 'account-1',
+      status: _status(),
+    );
+
+rust_sync.MigrationStatus _status() => rust_sync.MigrationStatus(
+  phase: kIronwoodMigrationBroadcastScheduledPhase,
+  activeRunId: 'run-1',
+  targetValuesZatoshi: frb.Uint64List.fromList([100000000]),
+  preparedNoteCount: 1,
+  denominationConfirmationCount: 3,
+  denominationConfirmationTarget: 3,
+  denominationSplitCompletedCount: 1,
+  denominationSplitTotalCount: 1,
+  pendingTxCount: 1,
+  broadcastedTxCount: 1,
+  confirmedTxCount: 0,
+  totalCount: 1,
+  signedChildPcztCount: 0,
+  pendingSplitStageCount: 0,
+  canAbandon: false,
+  signingBatchLimit: 50,
+  scheduleMeanDelayBlocks: 144,
+  scheduleMaxDelayBlocks: 576,
+  scheduledBroadcasts: const [],
+  parts: const [],
+);
+
+const _accountState = AccountState(
+  accounts: [AccountInfo(uuid: 'account-1', name: 'Account1', order: 0)],
+  activeAccountUuid: 'account-1',
+  activeAddress: 'u1migrationgate',
+);
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/home',
+  initialAccountState: _accountState,
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);

--- a/test/providers/payment_request_flow_provider_test.dart
+++ b/test/providers/payment_request_flow_provider_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
 import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
 import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
@@ -72,6 +73,9 @@ class _FakeSendApi {
         gatedByMigration: read.read(migrationSendGateProvider),
       );
     },
+    // The production wiring reads this off `rpcEndpointProvider`; these
+    // cases never vary it, so the build default stands in.
+    readNetworkName: () => kZcashDefaultNetworkName,
     validateAddress:
         ({required String address, required String network}) async {
           whileValidating?.call();

--- a/test/providers/payment_request_flow_provider_test.dart
+++ b/test/providers/payment_request_flow_provider_test.dart
@@ -41,6 +41,10 @@ class _FakeSendApi {
   /// read the balance and before it decides anything.
   void Function()? whileValidating;
 
+  /// Set by [makeContainer], so the live balance re-read answers from the
+  /// providers the production wiring reads.
+  ProviderContainer? container;
+
   /// Holds every discard open until the test releases it, so "the inputs
   /// are still locked" is an observable state rather than a race.
   Completer<void>? discardGate;
@@ -58,6 +62,16 @@ class _FakeSendApi {
 
   PaymentRequestPrecheck get precheck => PaymentRequestPrecheck(
     spendableIsAuthoritativeNow: () => spendableIsAuthoritative,
+    spendableBalanceNow: () {
+      final read = container;
+      if (read == null) return BigInt.zero;
+      return paymentRequestSpendableOf(
+        (read.read(syncProvider).value ?? SyncState()).scopedToAccount(
+          read.read(accountProvider).value?.activeAccountUuid,
+        ),
+        gatedByMigration: read.read(migrationSendGateProvider),
+      );
+    },
     validateAddress:
         ({required String address, required String network}) async {
           whileValidating?.call();
@@ -237,6 +251,7 @@ ProviderContainer makeContainer(_FakeSendApi api, {SyncState? sync}) {
       zecHomeUsdUnitPriceProvider.overrideWithValue(null),
     ],
   );
+  api.container = container;
   addTearDown(container.dispose);
   return container;
 }

--- a/test/providers/payment_request_flow_provider_test.dart
+++ b/test/providers/payment_request_flow_provider_test.dart
@@ -1,0 +1,1173 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/migration_send_gate_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_request_flow_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import '../fakes/fake_sync_notifier.dart';
+
+/// Rust stand-in whose proposal is held open until the test releases it, so
+/// "checking" is an observable state rather than a race.
+class _FakeSendApi {
+  _FakeSendApi({this.addressIsValid = true, this.addressWrongNetwork = false});
+
+  bool addressIsValid;
+
+  /// What Rust calls the recipient. Settable so a test can stand in a
+  /// non-unified recipient; every case here uses the default.
+  var addressType = 'unified';
+
+  /// The address is well-formed but belongs to another Zcash network, which
+  /// Rust reports as not-valid plus a `wrongNetwork` flag.
+  bool addressWrongNetwork;
+  Object? proposeThrows;
+  Completer<void>? gate;
+
+  /// Holds every discard open until the test releases it, so "the inputs
+  /// are still locked" is an observable state rather than a race.
+  Completer<void>? discardGate;
+  var nextProposalId = 1;
+
+  /// Every entry into the propose path, including the ones that throw. What
+  /// the re-check tests count: a card that re-checked itself is one that
+  /// asked again.
+  var proposeAttempts = 0;
+  final discarded = <BigInt>[];
+  final proposed = <BigInt>[];
+
+  /// Proposals and discards in the order Rust would have seen them.
+  final events = <String>[];
+
+  PaymentRequestPrecheck get precheck => PaymentRequestPrecheck(
+    spendableIsAuthoritativeNow: () => true,
+    validateAddress:
+        ({required String address, required String network}) async =>
+            rust_sync.AddressValidationResult(
+              isValid: addressIsValid && !addressWrongNetwork,
+              addressType: addressType,
+              wrongNetwork: addressWrongNetwork,
+            ),
+    proposeTransfer:
+        ({
+          required String accountUuid,
+          required String sendFlowId,
+          required String address,
+          required String addressType,
+          required BigInt amountZatoshi,
+          String? memo,
+          bool isPaymentRequest = false,
+          String? requestedBy,
+          BigInt? requestedAmountZatoshi,
+        }) async {
+          proposeAttempts++;
+          final pending = gate;
+          if (pending != null) await pending.future;
+          final failure = proposeThrows;
+          if (failure != null) throw failure;
+          final id = BigInt.from(nextProposalId++);
+          proposed.add(id);
+          events.add('propose $id');
+          return SendReviewArgs(
+            proposalId: id,
+            sendFlowId: sendFlowId,
+            proposalAccountUuid: accountUuid,
+            address: address,
+            addressType: addressType,
+            amountZatoshi: amountZatoshi,
+            feeZatoshi: BigInt.from(10000),
+            needsSaplingParams: false,
+            isPaymentRequest: isPaymentRequest,
+            requestedBy: requestedBy,
+            requestedAmountZatoshi: requestedAmountZatoshi,
+          );
+        },
+    discardProposal:
+        ({
+          required BigInt proposalId,
+          required String sendFlowId,
+          required String logContext,
+        }) async {
+          final pending = discardGate;
+          if (pending != null) await pending.future;
+          discarded.add(proposalId);
+          events.add('discard $proposalId');
+        },
+  );
+}
+
+class _FakeAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => const AccountState(
+    accounts: [
+      AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0),
+      AccountInfo(uuid: 'account-2', name: 'Account 2', order: 1),
+    ],
+    activeAccountUuid: 'account-1',
+  );
+
+  void switchToForTest(String uuid) {
+    state = AsyncData(state.value!.copyWith(activeAccountUuid: uuid));
+  }
+}
+
+class _FakeSecurityNotifier extends AppSecurityNotifier {
+  @override
+  AppSecurityState build() =>
+      const AppSecurityState(isPasswordConfigured: true, isUnlocked: true);
+
+  void lockForTest() => state = const AppSecurityState(
+    isPasswordConfigured: true,
+    isUnlocked: false,
+  );
+}
+
+SendPrefillArgs request(
+  String address, {
+  String? amountText = '0.5',
+  String? memoText,
+}) => SendPrefillArgs(
+  id: 'payment-uri-$address',
+  source: kPaymentUriPrefillSource,
+  address: address,
+  amountText: amountText,
+  memoText: memoText,
+  preserveMemoText: memoText != null,
+  label: 'Coffee shop',
+);
+
+/// A sync state whose spendable balance is settled: scanned to a real tip,
+/// nothing running, nothing failed.
+SyncState syncedState({required BigInt spendable}) => SyncState(
+  accountUuid: 'account-1',
+  hasAccountScopedData: true,
+  isSyncComplete: true,
+  chainTipHeight: 3000000,
+  scannedHeight: 3000000,
+  spendableBalance: spendable,
+);
+
+/// Mid-scan: nothing about the balance can be trusted yet.
+SyncState scanningState() => SyncState(
+  accountUuid: 'account-1',
+  hasAccountScopedData: true,
+  isSyncing: true,
+  chainTipHeight: 3000000,
+  scannedHeight: 12000,
+);
+
+/// Scanned to the tip, nothing running — and no balance for the account.
+///
+/// What `withoutAccountScopedData` leaves behind, and what a sync-progress
+/// event whose balance fetch failed publishes for an account that never had
+/// one: the wallet-wide sync fields say "settled" while `displaySpendable` is
+/// a zero nobody read.
+SyncState settledWithoutBalanceState() => SyncState(
+  accountUuid: 'account-1',
+  hasBalanceData: false,
+  hasRecentTransactionsData: false,
+  isSyncComplete: true,
+  chainTipHeight: 3000000,
+  scannedHeight: 3000000,
+);
+
+/// What Rust says when it has no anchor heights yet — the error the pre-check
+/// maps onto [PaymentRequestStatus.syncing].
+Exception get walletMustSync => Exception('Wallet must sync before sending');
+
+FakeSyncNotifier syncNotifier(ProviderContainer container) =>
+    container.read(syncProvider.notifier) as FakeSyncNotifier;
+
+_FakeAccountNotifier _accountNotifier(ProviderContainer container) =>
+    container.read(accountProvider.notifier) as _FakeAccountNotifier;
+
+_FakeSecurityNotifier _securityNotifier(ProviderContainer container) =>
+    container.read(appSecurityProvider.notifier) as _FakeSecurityNotifier;
+
+PaymentRequestFlowState? flowState(ProviderContainer container) =>
+    container.read(paymentRequestFlowProvider);
+
+/// Presents [address] and settles on the `syncing` status: the wallet could
+/// not answer, so the card is left waiting on the sync.
+Future<void> _presentSyncingCard(
+  ProviderContainer container,
+  _FakeSendApi api, {
+  String address = 'u1a',
+}) async {
+  api.proposeThrows = walletMustSync;
+  container
+      .read(paymentRequestFlowProvider.notifier)
+      .present(request(address), source: PaymentRequestSource.link);
+  await pumpEventQueue();
+  expect(flowState(container)!.view.status, PaymentRequestStatus.syncing);
+}
+
+// ignore: library_private_types_in_public_api
+ProviderContainer makeContainer(_FakeSendApi api, {SyncState? sync}) {
+  final container = ProviderContainer(
+    overrides: [
+      paymentRequestPrecheckProvider.overrideWithValue(api.precheck),
+      accountProvider.overrideWith(_FakeAccountNotifier.new),
+      appSecurityProvider.overrideWith(_FakeSecurityNotifier.new),
+      syncProvider.overrideWith(
+        () => FakeSyncNotifier(
+          sync ?? syncedState(spendable: BigInt.from(100000000)),
+        ),
+      ),
+      migrationSendGateProvider.overrideWithValue(false),
+      zecHomeUsdUnitPriceProvider.overrideWithValue(null),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  test('present starts in checking and lands on ready', () async {
+    final api = _FakeSendApi()..gate = Completer<void>();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1a'), source: PaymentRequestSource.link);
+
+    var state = container.read(paymentRequestFlowProvider)!;
+    expect(state.view.status, PaymentRequestStatus.checking);
+    expect(state.view.amountZecText, '0.50 ZEC');
+    expect(state.view.requesterLabel, 'Coffee shop');
+    expect(state.canReview, isFalse);
+
+    api.gate!.complete();
+    await pumpEventQueue();
+
+    state = container.read(paymentRequestFlowProvider)!;
+    expect(state.view.status, PaymentRequestStatus.ready);
+    expect(state.canReview, isTrue);
+    expect(state.reviewArgs!.proposalId, BigInt.one);
+  });
+
+  test('an amount-less request is ready but cannot go to review', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(
+          request('u1a', amountText: null),
+          source: PaymentRequestSource.link,
+        );
+    await pumpEventQueue();
+
+    final state = container.read(paymentRequestFlowProvider)!;
+    expect(state.view.status, PaymentRequestStatus.ready);
+    expect(state.view.amountZecText, isNull);
+    expect(state.canReview, isFalse);
+  });
+
+  test('an unpayable address renders the invalid-address status', () async {
+    final api = _FakeSendApi(addressIsValid: false);
+    final container = makeContainer(api);
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    final state = container.read(paymentRequestFlowProvider)!;
+    expect(state.view.status, PaymentRequestStatus.invalidAddress);
+    expect(
+      state.view.resolvedStatusMessage,
+      "Recipient address doesn't look right",
+      reason: 'a malformed address keeps the status default copy',
+    );
+    expect(state.canReview, isFalse);
+  });
+
+  test(
+    'an address for another network publishes its own status message',
+    () async {
+      final api = _FakeSendApi(addressWrongNetwork: true);
+      final container = makeContainer(api);
+
+      container
+          .read(paymentRequestFlowProvider.notifier)
+          .present(request('utest1a'), source: PaymentRequestSource.link);
+      await pumpEventQueue();
+
+      final state = container.read(paymentRequestFlowProvider)!;
+      expect(state.view.status, PaymentRequestStatus.invalidAddress);
+      expect(state.view.resolvedStatusMessage, kWrongNetworkAddressMessage);
+      expect(state.canReview, isFalse);
+    },
+  );
+
+  test('a check that could not complete is failed, not invalid '
+      'address', () async {
+    final api = _FakeSendApi()..proposeThrows = Exception('something unmapped');
+    final container = makeContainer(api);
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    final state = container.read(paymentRequestFlowProvider)!;
+    expect(state.view.status, PaymentRequestStatus.failed);
+    expect(
+      state.view.resolvedStatusMessage,
+      "Couldn't check this request — open Edit to review the details",
+    );
+    expect(state.canReview, isFalse);
+  });
+
+  test('a newer link replaces the card, says so, and frees the old '
+      'proposal', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1first'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    expect(api.proposed, [BigInt.one]);
+
+    notifier.present(request('u1second'), source: PaymentRequestSource.link);
+    expect(
+      container.read(paymentRequestFlowProvider)!.view.replacedNotice,
+      isTrue,
+    );
+    await pumpEventQueue();
+
+    final state = container.read(paymentRequestFlowProvider)!;
+    expect(state.prefill.address, 'u1second');
+    expect(state.reviewArgs!.proposalId, BigInt.two);
+    expect(
+      api.discarded,
+      [BigInt.one],
+      reason: 'the displaced request must not leave a proposal behind',
+    );
+  });
+
+  test('edit clears the card, frees the proposal, and returns the '
+      'request', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    final prefill = notifier.edit();
+    await pumpEventQueue();
+
+    expect(prefill!.address, 'u1a');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(api.discarded, [BigInt.one]);
+  });
+
+  test('dismiss frees the proposal', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    notifier.dismiss();
+    await pumpEventQueue();
+
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(api.discarded, [BigInt.one]);
+  });
+
+  test('review hands the proposal on without discarding it', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    final args = notifier.review();
+    await pumpEventQueue();
+
+    expect(args!.proposalId, BigInt.one);
+    expect(args.isPaymentRequest, isTrue);
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(
+      api.discarded,
+      isEmpty,
+      reason: 'the review screen owns the proposal from here',
+    );
+  });
+
+  test('a pre-check that finishes after its card is gone frees its own '
+      'proposal', () async {
+    final api = _FakeSendApi()..gate = Completer<void>();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1a'), source: PaymentRequestSource.link);
+    notifier.dismiss();
+    api.gate!.complete();
+    await pumpEventQueue();
+
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(api.discarded, [BigInt.one]);
+  });
+
+  test('a replacement waits for the displaced proposal to be handed back '
+      'before it asks', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1first'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    expect(api.proposed, [BigInt.one]);
+
+    // The first card's inputs stay locked until Rust answers the discard.
+    api.discardGate = Completer<void>();
+    notifier.present(request('u1second'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    final waiting = container.read(paymentRequestFlowProvider)!;
+    expect(waiting.prefill.address, 'u1second');
+    expect(waiting.view.status, PaymentRequestStatus.checking);
+    expect(
+      api.proposeAttempts,
+      1,
+      reason:
+          'a check against still-locked inputs would read a shortfall '
+          'that is not there',
+    );
+
+    api.discardGate!.complete();
+    await pumpEventQueue();
+
+    final state = container.read(paymentRequestFlowProvider)!;
+    expect(state.view.status, PaymentRequestStatus.ready);
+    expect(state.reviewArgs!.proposalId, BigInt.two);
+    expect(api.events, ['propose 1', 'discard 1', 'propose 2']);
+  });
+
+  test('a replacement waits for a displaced check that is still running '
+      'to hand its proposal back', () async {
+    final api = _FakeSendApi()..gate = Completer<void>();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1first'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    expect(api.proposeAttempts, 1);
+
+    notifier.present(request('u1second'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    expect(
+      api.proposeAttempts,
+      1,
+      reason:
+          'the displaced check has not created, let alone released, '
+          'its proposal yet',
+    );
+
+    // Rust answers the first check: its proposal has no card, is handed
+    // back, and only then does the second check ask.
+    api.gate!.complete();
+    await pumpEventQueue();
+
+    final state = container.read(paymentRequestFlowProvider)!;
+    expect(state.prefill.address, 'u1second');
+    expect(state.reviewArgs!.proposalId, BigInt.two);
+    expect(api.events, ['propose 1', 'discard 1', 'propose 2']);
+  });
+
+  test('a link arriving right after a dismiss waits for that discard '
+      'too', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1first'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    api.discardGate = Completer<void>();
+    notifier.dismiss();
+    notifier.present(request('u1second'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    expect(api.proposeAttempts, 1);
+
+    api.discardGate!.complete();
+    await pumpEventQueue();
+
+    expect(
+      container.read(paymentRequestFlowProvider)!.view.status,
+      PaymentRequestStatus.ready,
+    );
+    expect(api.events, ['propose 1', 'discard 1', 'propose 2']);
+  });
+
+  test('handing the proposal back for mobile review completes only once '
+      'Rust has released it', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    api.discardGate = Completer<void>();
+    var handedBack = false;
+    final pending = notifier.reviewHandingBack().then((args) {
+      handedBack = true;
+      return args;
+    });
+    await pumpEventQueue();
+
+    // The card is gone at once; the caller is still waiting on the release.
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(handedBack, isFalse);
+    expect(api.discarded, isEmpty);
+
+    api.discardGate!.complete();
+    final handoff = await pending;
+
+    final args = (handoff as PaymentRequestReviewReady).args;
+    expect(args.proposalId, BigInt.one);
+    expect(args.isPaymentRequest, isTrue);
+    expect(api.discarded, [BigInt.one]);
+  });
+
+  test('a mobile hand-back overtaken by a newer link opens nothing', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1first'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    api.discardGate = Completer<void>();
+    final pending = notifier.reviewHandingBack();
+    await pumpEventQueue();
+    expect(container.read(paymentRequestFlowProvider), isNull);
+
+    // A second link lands while the first proposal is still being released.
+    notifier.present(request('u1second'), source: PaymentRequestSource.link);
+    api.discardGate!.complete();
+    await pumpEventQueue();
+
+    expect(
+      await pending,
+      isA<PaymentRequestReviewOvertaken>(),
+      reason:
+          'the review of a request the user is no longer looking at must '
+          'not open under the newer card — and the caller has to be able to '
+          'tell that from "there was nothing to review"',
+    );
+    final state = container.read(paymentRequestFlowProvider)!;
+    expect(state.prefill.address, 'u1second');
+    expect(state.reviewArgs!.proposalId, BigInt.two);
+    expect(
+      state.view.replacedNotice,
+      isTrue,
+      reason:
+          'the dropped Review tap is accounted for on the card that took '
+          "its place; `present` could not raise the notice itself because "
+          'the hand-back had already cleared the card it replaced',
+    );
+    expect(api.events, ['propose 1', 'discard 1', 'propose 2']);
+  });
+
+  // There is no "the card drops a memo the recipient cannot receive" case:
+  // `Zip321PaymentRequest.parse` refuses `memo` on a `t`-prefixed address, so
+  // no such request ever becomes a card. See
+  // `test/app_payment_uri_rejection_test.dart`.
+
+  test('a memo a shielded recipient can receive stays on the card', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(
+          request('u1a', memoText: 'invoice 42'),
+          source: PaymentRequestSource.link,
+        );
+    await pumpEventQueue();
+
+    expect(container.read(paymentRequestFlowProvider)!.view.memo, 'invoice 42');
+  });
+
+  test('a shortfall read mid-sync never lands on insufficient funds', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(
+      api,
+      sync: SyncState(
+        accountUuid: 'account-1',
+        hasAccountScopedData: true,
+        isSyncing: true,
+        chainTipHeight: 3000000,
+        scannedHeight: 12000,
+      ),
+    );
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    final state = container.read(paymentRequestFlowProvider)!;
+    expect(
+      state.view.status,
+      PaymentRequestStatus.ready,
+      reason: 'VZR-42: a balance still being scanned cannot say "not enough"',
+    );
+    expect(api.proposed, [BigInt.one]);
+  });
+
+  test('a shortfall on a settled balance is insufficient funds', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(
+      api,
+      sync: syncedState(spendable: BigInt.from(21000000)),
+    );
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    final state = container.read(paymentRequestFlowProvider)!;
+    expect(state.view.status, PaymentRequestStatus.insufficientFunds);
+    expect(state.view.spendableText, '0.21 ZEC');
+    expect(api.proposed, isEmpty);
+  });
+
+  test('locking the wallet takes the card down and frees the '
+      'proposal', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    (container.read(appSecurityProvider.notifier) as _FakeSecurityNotifier)
+        .lockForTest();
+    await pumpEventQueue();
+
+    expect(
+      container.read(paymentRequestFlowProvider),
+      isNull,
+      reason:
+          'the host renders above the router, so a card left standing '
+          'would sit on the unlock screen with the request still on it',
+    );
+    expect(api.discarded, [BigInt.one]);
+  });
+
+  test('a lock during the pre-check frees the proposal it was still '
+      'making', () async {
+    final api = _FakeSendApi()..gate = Completer<void>();
+    final container = makeContainer(api);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+
+    (container.read(appSecurityProvider.notifier) as _FakeSecurityNotifier)
+        .lockForTest();
+    api.gate!.complete();
+    await pumpEventQueue();
+
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(api.discarded, [BigInt.one]);
+  });
+
+  test('switching accounts takes the card down and frees the '
+      'proposal', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    (container.read(accountProvider.notifier) as _FakeAccountNotifier)
+        .switchToForTest('account-2');
+    await pumpEventQueue();
+
+    expect(
+      container.read(paymentRequestFlowProvider),
+      isNull,
+      reason: 'the proposal belongs to the account that made it',
+    );
+    expect(api.discarded, [BigInt.one]);
+  });
+
+  test('clear frees the proposal without a user answer', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    notifier.clear();
+    await pumpEventQueue();
+
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(api.discarded, [BigInt.one]);
+  });
+
+  test('a syncing card re-checks itself once the wallet finishes '
+      'syncing', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api, sync: scanningState());
+    await _presentSyncingCard(container, api);
+    expect(api.proposeAttempts, 1);
+
+    // The wallet settles, and the request that could not be answered can be.
+    api.proposeThrows = null;
+    api.gate = Completer<void>();
+    syncNotifier(
+      container,
+    ).emit(syncedState(spendable: BigInt.from(100000000)));
+    await pumpEventQueue();
+
+    var state = flowState(container)!;
+    expect(
+      state.view.status,
+      PaymentRequestStatus.checking,
+      reason: 'the card says it is working again, not that it is blocked',
+    );
+    expect(state.view.resolvedStatusMessage, isNull);
+    expect(api.proposeAttempts, 2);
+
+    api.gate!.complete();
+    await pumpEventQueue();
+
+    state = flowState(container)!;
+    expect(state.view.status, PaymentRequestStatus.ready);
+    expect(state.canReview, isTrue);
+    expect(state.reviewArgs!.proposalId, BigInt.one);
+    expect(api.discarded, isEmpty);
+  });
+
+  test('a re-check that is still syncing spends its budget, then waits for '
+      'the next sync', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api, sync: scanningState());
+    final sync = syncNotifier(container);
+    await _presentSyncingCard(container, api);
+
+    // First completion: the wallet reports settled, but the propose path has
+    // not caught up, so the card lands back on syncing — with the sync state
+    // still settled, so no further crossing is coming. The card answers that
+    // itself for as long as its budget lasts (2), and then stops: the first
+    // look, the crossing's re-check, and the two immediate ones.
+    sync.emit(syncedState(spendable: BigInt.from(100000000)));
+    await pumpEventQueue();
+    expect(
+      flowState(container)!.view.status,
+      PaymentRequestStatus.syncStalled,
+      reason:
+          'the budget is spent and the wallet is settled, so nothing is '
+          'coming — the card stops promising an update it cannot make',
+    );
+    expect(
+      flowState(container)!.view.resolvedStatusMessage,
+      'Still syncing — check again when the wallet is up to date',
+    );
+    expect(api.proposeAttempts, 4);
+
+    // A settled state that was already settled is not a new completion, and
+    // the immediate budget is spent — this is where the spin would show.
+    sync.emit(syncedState(spendable: BigInt.from(100000001)));
+    await pumpEventQueue();
+    await pumpEventQueue();
+    expect(
+      api.proposeAttempts,
+      4,
+      reason:
+          'at most one re-check per sync completion, and the immediate '
+          'budget is bounded',
+    );
+
+    // A real second cycle: back to scanning, then settled again.
+    sync.emit(scanningState());
+    await pumpEventQueue();
+    api.proposeThrows = null;
+    sync.emit(syncedState(spendable: BigInt.from(100000000)));
+    await pumpEventQueue();
+
+    final state = flowState(container)!;
+    expect(state.view.status, PaymentRequestStatus.ready);
+    expect(api.proposeAttempts, 5);
+    expect(state.reviewArgs!.proposalId, BigInt.one);
+  });
+
+  test('a syncing verdict on an already-settled wallet re-checks itself '
+      'rather than waiting for a crossing that cannot come', () async {
+    final api = _FakeSendApi()..proposeThrows = walletMustSync;
+    final container = makeContainer(
+      api,
+      sync: syncedState(spendable: BigInt.from(100000000)),
+    );
+    final sync = syncNotifier(container);
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    // The wallet was settled before the link arrived, so the watch has no
+    // false→true crossing left to fire on. The card says it will update
+    // itself when the sync finishes, so it has to ask again now.
+    expect(flowState(container)!.view.status, PaymentRequestStatus.syncStalled);
+    expect(
+      api.proposeAttempts,
+      3,
+      reason:
+          'the first look, plus one immediate re-check, plus one more '
+          'because that landed on syncing again',
+    );
+
+    // Budget spent. Further already-settled states are not a crossing, so
+    // nothing else runs: the card waits instead of spinning.
+    sync.emit(syncedState(spendable: BigInt.from(100000001)));
+    await pumpEventQueue();
+    await pumpEventQueue();
+    expect(api.proposeAttempts, 3);
+
+    // A real sync cycle still re-checks it.
+    sync.emit(scanningState());
+    await pumpEventQueue();
+    api.proposeThrows = null;
+    sync.emit(syncedState(spendable: BigInt.from(100000000)));
+    await pumpEventQueue();
+
+    final state = flowState(container)!;
+    expect(state.view.status, PaymentRequestStatus.ready);
+    expect(state.canReview, isTrue);
+    expect(api.proposeAttempts, 4);
+  });
+
+  test('a settled state carrying no balance for the account is not a '
+      'sync completion', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api, sync: scanningState());
+    final sync = syncNotifier(container);
+    await _presentSyncingCard(container, api);
+    expect(api.proposeAttempts, 1);
+
+    // Scanned to the tip with no balance read for this account. The
+    // wallet-wide fields alone would call this settled, and the re-check
+    // would then hand the card a shortfall computed against a zero.
+    sync.emit(settledWithoutBalanceState());
+    await pumpEventQueue();
+
+    expect(
+      flowState(container)!.view.status,
+      PaymentRequestStatus.syncing,
+      reason: 'a balance nobody fetched cannot answer the request',
+    );
+    expect(api.proposeAttempts, 1);
+
+    // The same tip, now with the account's balance actually in hand.
+    api.proposeThrows = null;
+    sync.emit(syncedState(spendable: BigInt.from(100000000)));
+    await pumpEventQueue();
+
+    final state = flowState(container)!;
+    expect(state.view.status, PaymentRequestStatus.ready);
+    expect(api.proposeAttempts, 2);
+  });
+
+  test('a card that is not syncing never re-checks on sync '
+      'completion', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(
+      api,
+      sync: syncedState(spendable: BigInt.from(21000000)),
+    );
+    final sync = syncNotifier(container);
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    expect(
+      flowState(container)!.view.status,
+      PaymentRequestStatus.insufficientFunds,
+    );
+    expect(api.proposeAttempts, 0);
+
+    // A full sync cycle underneath a settled verdict.
+    sync.emit(scanningState());
+    await pumpEventQueue();
+    sync.emit(syncedState(spendable: BigInt.from(21000000)));
+    await pumpEventQueue();
+
+    expect(
+      flowState(container)!.view.status,
+      PaymentRequestStatus.insufficientFunds,
+      reason: 'only the syncing status is waiting on the sync',
+    );
+    expect(api.proposeAttempts, 0);
+  });
+
+  test('dismissing during a re-check publishes nothing and frees the late '
+      'proposal', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api, sync: scanningState());
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+    await _presentSyncingCard(container, api);
+
+    api.proposeThrows = null;
+    api.gate = Completer<void>();
+    syncNotifier(
+      container,
+    ).emit(syncedState(spendable: BigInt.from(100000000)));
+    await pumpEventQueue();
+    expect(flowState(container)!.view.status, PaymentRequestStatus.checking);
+
+    notifier.dismiss();
+    api.gate!.complete();
+    await pumpEventQueue();
+
+    expect(flowState(container), isNull);
+    expect(
+      api.discarded,
+      [BigInt.one],
+      reason:
+          'the re-check made a proposal for a card that no longer exists, '
+          'so nothing would ever consume it',
+    );
+  });
+
+  test('switching accounts while syncing stops the re-check '
+      'listener', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api, sync: scanningState());
+    await _presentSyncingCard(container, api);
+
+    _accountNotifier(container).switchToForTest('account-2');
+    await pumpEventQueue();
+    expect(flowState(container), isNull);
+
+    api.proposeThrows = null;
+    syncNotifier(
+      container,
+    ).emit(syncedState(spendable: BigInt.from(100000000)));
+    await pumpEventQueue();
+
+    expect(flowState(container), isNull);
+    expect(
+      api.proposeAttempts,
+      1,
+      reason: 'the request belonged to the account that is no longer active',
+    );
+  });
+
+  test('locking while syncing clears the card without re-checking', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api, sync: scanningState());
+    await _presentSyncingCard(container, api);
+
+    _securityNotifier(container).lockForTest();
+    await pumpEventQueue();
+    expect(flowState(container), isNull);
+
+    api.proposeThrows = null;
+    syncNotifier(
+      container,
+    ).emit(syncedState(spendable: BigInt.from(100000000)));
+    await pumpEventQueue();
+
+    expect(flowState(container), isNull);
+    expect(
+      api.proposeAttempts,
+      1,
+      reason: 'a locked wallet must not run a payment check of its own',
+    );
+  });
+
+  test('a newer link replaces a syncing card and takes over the '
+      'watch', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api, sync: scanningState());
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+    await _presentSyncingCard(container, api);
+
+    api.proposeThrows = null;
+    notifier.present(request('u1second'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    final state = flowState(container)!;
+    expect(state.prefill.address, 'u1second');
+    expect(state.view.status, PaymentRequestStatus.ready);
+    expect(api.proposeAttempts, 2);
+
+    // The replaced card's watch must be gone with it.
+    syncNotifier(
+      container,
+    ).emit(syncedState(spendable: BigInt.from(100000000)));
+    await pumpEventQueue();
+    expect(api.proposeAttempts, 2);
+  });
+
+  test('a stalled card answers "Check again" by asking Rust again', () async {
+    final api = _FakeSendApi()..proposeThrows = walletMustSync;
+    final container = makeContainer(
+      api,
+      sync: syncedState(spendable: BigInt.from(100000000)),
+    );
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    expect(flowState(container)!.view.status, PaymentRequestStatus.syncStalled);
+    expect(api.proposeAttempts, 3);
+
+    // The wallet caught up between the stall and the tap, which is the whole
+    // reason the card offers the tap.
+    api.proposeThrows = null;
+    notifier.recheck();
+    await pumpEventQueue();
+
+    final state = flowState(container)!;
+    expect(state.view.status, PaymentRequestStatus.ready);
+    expect(state.canReview, isTrue);
+    expect(
+      api.proposeAttempts,
+      4,
+      reason: 'a tap is one more ask, and it does not need the budget',
+    );
+  });
+
+  test('a re-check that stalls again leaves the card askable', () async {
+    final api = _FakeSendApi()..proposeThrows = walletMustSync;
+    final container = makeContainer(
+      api,
+      sync: syncedState(spendable: BigInt.from(100000000)),
+    );
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    expect(api.proposeAttempts, 3);
+
+    notifier.recheck();
+    await pumpEventQueue();
+
+    expect(
+      flowState(container)!.view.status,
+      PaymentRequestStatus.syncStalled,
+      reason: 'still nothing to answer with, and still the user\'s move',
+    );
+    expect(
+      api.proposeAttempts,
+      4,
+      reason: 'one ask per tap: the card must not spin on its own',
+    );
+  });
+
+  test('recheck does nothing for a card that is not stalled', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    expect(flowState(container)!.view.status, PaymentRequestStatus.ready);
+
+    notifier.recheck();
+    await pumpEventQueue();
+
+    expect(flowState(container)!.view.status, PaymentRequestStatus.ready);
+    expect(api.proposeAttempts, 1);
+  });
+
+  test('a stalled card still takes the answer a real sync brings', () async {
+    final api = _FakeSendApi()..proposeThrows = walletMustSync;
+    final container = makeContainer(
+      api,
+      sync: syncedState(spendable: BigInt.from(100000000)),
+    );
+    final sync = syncNotifier(container);
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    expect(flowState(container)!.view.status, PaymentRequestStatus.syncStalled);
+
+    // The stall is not a dead end: the watch is still installed, so a real
+    // sync cycle answers the card without the user touching it.
+    sync.emit(scanningState());
+    await pumpEventQueue();
+    api.proposeThrows = null;
+    sync.emit(syncedState(spendable: BigInt.from(100000000)));
+    await pumpEventQueue();
+
+    expect(flowState(container)!.view.status, PaymentRequestStatus.ready);
+  });
+
+  test('locking re-parks the request so the unlock claim can present it '
+      'again', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    _securityNotifier(container).lockForTest();
+    await pumpEventQueue();
+
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(
+      api.discarded,
+      [BigInt.one],
+      reason: 'the proposal is still handed back; only the request survives',
+    );
+
+    final claimed = container
+        .read(paymentUriPrefillProvider.notifier)
+        .takeIfFresh();
+    expect(
+      claimed.prefill?.address,
+      'u1a',
+      reason:
+          'the unlock claim is what re-presents it, so the request has to be '
+          'back in the park the claim reads',
+    );
+    expect(claimed.expired, isFalse);
+  });
+
+  test('a lock does not displace a newer link already parked', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1card'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+    // A second link arrived while the card was up and is still parked — held
+    // behind a busy surface, say.
+    container.read(paymentUriPrefillProvider.notifier).set(request('u1newer'));
+
+    _securityNotifier(container).lockForTest();
+    await pumpEventQueue();
+
+    expect(
+      container.read(paymentUriPrefillProvider)?.address,
+      'u1newer',
+      reason: 'latest link wins, the same answer the park gives everywhere',
+    );
+  });
+}

--- a/test/providers/payment_request_flow_provider_test.dart
+++ b/test/providers/payment_request_flow_provider_test.dart
@@ -629,6 +629,59 @@ void main() {
     expect(container.read(paymentRequestFlowProvider)!.view.memo, 'invoice 42');
   });
 
+  test('a memo keeps its surrounding whitespace on the card', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(
+          request('u1a', memoText: '  invoice 42\n'),
+          source: PaymentRequestSource.link,
+        );
+    await pumpEventQueue();
+
+    final view = container.read(paymentRequestFlowProvider)!.view;
+    expect(
+      view.memo,
+      '  invoice 42\n',
+      reason:
+          'the pre-check proposes these exact bytes, so the card has to '
+          'show them unchanged or the payer reads a memo they do not pay',
+    );
+    expect(view.displayMemo, '  invoice 42\n');
+    expect(view.memoIsWhitespaceOnly, isFalse);
+  });
+
+  test('a whitespace-only memo still reaches the card, flagged', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(
+          request('u1a', memoText: '   '),
+          source: PaymentRequestSource.link,
+        );
+    await pumpEventQueue();
+
+    final view = container.read(paymentRequestFlowProvider)!.view;
+    expect(
+      view.displayMemo,
+      '   ',
+      reason:
+          'those bytes are paid, so the memo is present — dropping it here '
+          'would hide from the payer a memo their transaction carries',
+    );
+    expect(
+      view.memoIsWhitespaceOnly,
+      isTrue,
+      reason:
+          'rendering the value verbatim draws nothing, so the surface needs '
+          'to be told to show a placeholder instead',
+    );
+  });
+
   test('a shortfall read mid-sync never lands on insufficient funds', () async {
     final api = _FakeSendApi();
     final container = makeContainer(

--- a/test/providers/payment_request_flow_provider_test.dart
+++ b/test/providers/payment_request_flow_provider_test.dart
@@ -33,6 +33,14 @@ class _FakeSendApi {
   Object? proposeThrows;
   Completer<void>? gate;
 
+  /// The VZR-42 gate as the pre-check re-reads it. Settable so a test can
+  /// start a scan under a check that is already in flight.
+  var spendableIsAuthoritative = true;
+
+  /// Runs inside the awaited address validation, i.e. after the check has
+  /// read the balance and before it decides anything.
+  void Function()? whileValidating;
+
   /// Holds every discard open until the test releases it, so "the inputs
   /// are still locked" is an observable state rather than a race.
   Completer<void>? discardGate;
@@ -49,14 +57,16 @@ class _FakeSendApi {
   final events = <String>[];
 
   PaymentRequestPrecheck get precheck => PaymentRequestPrecheck(
-    spendableIsAuthoritativeNow: () => true,
+    spendableIsAuthoritativeNow: () => spendableIsAuthoritative,
     validateAddress:
-        ({required String address, required String network}) async =>
-            rust_sync.AddressValidationResult(
-              isValid: addressIsValid && !addressWrongNetwork,
-              addressType: addressType,
-              wrongNetwork: addressWrongNetwork,
-            ),
+        ({required String address, required String network}) async {
+          whileValidating?.call();
+          return rust_sync.AddressValidationResult(
+            isValid: addressIsValid && !addressWrongNetwork,
+            addressType: addressType,
+            wrongNetwork: addressWrongNetwork,
+          );
+        },
     proposeTransfer:
         ({
           required String accountUuid,
@@ -722,6 +732,45 @@ void main() {
 
     expect(container.read(paymentRequestFlowProvider), isNull);
     expect(api.discarded, [BigInt.one]);
+  });
+
+  test('a shortfall found after the wallet started scanning waits for the '
+      'sync instead of blocking the card', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(
+      api,
+      sync: syncedState(spendable: BigInt.from(21000000)),
+    );
+    // 0.5 is more than the 0.21 the check reads, but the wallet starts
+    // scanning while the address is being validated, so that 0.21 is stale
+    // by the time the shortfall would be published.
+    api.whileValidating = () {
+      api.spendableIsAuthoritative = false;
+      syncNotifier(container).emit(scanningState());
+    };
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    expect(
+      flowState(container)!.view.status,
+      PaymentRequestStatus.syncing,
+      reason: 'a final insufficient would strand the card on a stale figure',
+    );
+    expect(api.proposeAttempts, 0);
+
+    // And it really is waiting on the sync: the completion re-checks it.
+    api.whileValidating = null;
+    api.spendableIsAuthoritative = true;
+    syncNotifier(
+      container,
+    ).emit(syncedState(spendable: BigInt.from(100000000)));
+    await pumpEventQueue();
+
+    expect(flowState(container)!.view.status, PaymentRequestStatus.ready);
+    expect(api.proposeAttempts, 1);
   });
 
   test('a syncing card re-checks itself once the wallet finishes '


### PR DESCRIPTION
## Summary

The ZIP-321 payment-request lane, logic only. It parses and builds `zcash:` requests, parks a delivered one with a TTL, and answers "what should happen to this link right now?" from a single policy table instead of scattered checks at each call site. It is its own layer because all of that is reviewable as pure logic — the desktop card that presents a request is #611, the mobile one #612 — and because the pre-check it introduces builds a live Rust proposal, which must not run before there is a surface to show it on.

## Changes

**Dart core — ZIP-321**
- `core/zcash/zip321_payment_request.dart` (+117) parser; `zip321_payment_request_builder.dart` (197) the outbound builder.

**Dart core — drain and parking**
- `core/navigation/payment_uri_drain_policy.dart` (324) — the outcome table (`wait`, `deliver`, `dropWithMessage`, `routeToUnlock`, `routeToWelcome`).
- `providers/payment_uri_prefill_provider.dart` — park with TTL; `core/navigation/payment_uri_unlock_claim.dart` — the after-unlock claim.
- `core/navigation/payment_uri_busy_surface_provider.dart` + `payment_uri_busy_surface_hold.dart` — surfaces (Keystone scanning, signing) that a link must not interrupt.
- `core/navigation/mobile_exit_back_guard.dart`, `lib/app.dart` (+295) drain wiring.

**Send**
- `send/services/payment_request_precheck.dart` (380) and `providers/payment_request_flow_provider.dart` (652) — the request's own state machine and its proposal pre-check.
- `send/widgets/payment_request_card.dart` (1948) — the card widget itself; nothing mounts it in this PR.
- `send/models/send_prefill_args.dart` (adds `preserveMemoText`), `send_scan_result.dart` (177), `send/services/send_flow.dart` (+226), `address_scan/domain/address_scan_payload.dart` (+169).
- `providers/migration_send_gate_provider.dart` — one owner for "send is disabled during migration", shared by the drain and the send button.

**Rust + generated bindings**
- `wallet/sync/mod.rs` / `api/sync.rs`: `validate_address` returning `AddressValidation` with a `wrong_network` flag, so a request for another network is rejected with a reason rather than as a malformed address. Regenerated `frb_generated.rs` / `frb_generated.dart`.

**Tests** (~3.9k lines)
- `payment_request_flow_provider_test.dart` (1173), `payment_uri_drain_policy_test.dart` (474), `payment_request_precheck_test.dart` (454), `zip321_payment_request_builder_test.dart` (256), `zip321_payment_request_test.dart` (202), `send_scan_result_test.dart` (211), `payment_uri_migration_gate_test.dart` (220), plus busy-surface, prefill-provider and secure-store tests.

## Behaviour at this point of the stack

- The drain is live for four of its five outcomes. **`deliver` deliberately does nothing here**: no route mounts `PaymentRequestCard` or `PaymentRequestHost`, and presenting would run the pre-check, which builds a live Rust proposal and reserves the wallet's inputs behind a card the user can neither see, review, edit nor dismiss. The link stays parked and is drained again on the next pass; #611 mounts the host and turns delivery on.
- For the same reason both unlock screens stop claiming the parked prefill after a successful unlock — landing on `/home` re-runs the drain, so any message the policy has to give is still given.
- `preserveMemoText` is written here and has no reader yet: desktop `send_screen.dart` reads it in #611, mobile `mobile_routes.dart` in #612.

## Verification

- `fvm flutter analyze` clean.
- Desktop lane (`fvm flutter test`) green.
- Mobile lane (`--tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`): 20 failures, all pre-existing — the identical set fails at the base of this stack. Files: `ironwood_migration_coordinator_provider_test.dart` (15), `mobile_import_birthday_screen_test.dart` (2), `mobile_onboarding_progress_test.dart`, `mobile_keystone_use_cases_test.dart`, `mobile_receive_use_cases_test.dart`.
- `cargo test --lib`: 741 passing.

## Stack

Part 2/9 · base: `rowan/links-01-intake` (#608) · next: #611 — [stack #618](https://github.com/chainapsis/vizor-wallet/pull/608)

https://claude.ai/code/session_01Uybjg6JVS5RFEG8B9GHi3s
