### PR TITLE
[3/10] ZIP-321 payment requests: desktop card, send review, and Receive request

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1346,7 +1346,6 @@ const _kIncomingLinkNoticeDuration = Duration(seconds: 4);
 class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   StreamSubscription<String>? _subscription;
 
-
   // --- payment request lane ---
   var _paymentSequence = 0;
 
@@ -1378,7 +1377,6 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   void didUpdateWidget(covariant _IncomingLinkHost oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.router == widget.router) return;
-
   }
 
   @override
@@ -1576,6 +1574,22 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
         widget.router.go('/welcome');
         _showPaymentUriMessage(decision.message!);
       case PaymentUriDrainAction.deliver:
+        if (kAppFormFactor == AppFormFactor.mobile) {
+          // Nothing on mobile can answer the card yet. The surface already
+          // draws a mobile sheet, so presenting here would look right — but
+          // the host still hands over the desktop route payloads, and the
+          // mobile routes reject both: `/send/review` takes only a
+          // `MobileSendReviewDraftArgs` and `/send` only a recipient string,
+          // so either answer opens an empty composer. Review does it after
+          // handing off the live proposal the pre-check just built, which
+          // that composer never consumes or discards — the wallet's inputs
+          // stay reserved behind a card that is gone.
+          //
+          // The mobile handoff lands in the next PR of this stack. Until then
+          // the link stays parked, exactly as it did before any host existed,
+          // and a parked link is drained again on the next pass.
+          return;
+        }
         prefillNotifier.clear();
         // The request is presented over the current screen, not navigated to.
         ref
@@ -1681,7 +1695,6 @@ class _WindowsUpdatePromptHostState
   void didUpdateWidget(covariant _WindowsUpdatePromptHost oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.router == widget.router) return;
-
   }
 
   @override

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -72,6 +72,7 @@ import 'src/features/send/models/send_prefill_args.dart';
 import 'src/features/send/screens/send_review_screen.dart';
 import 'src/features/send/screens/send_screen.dart';
 import 'src/features/send/screens/send_status_screen.dart';
+import 'src/features/send/widgets/payment_request_host.dart';
 import 'src/features/send/services/send_flow.dart'
     show
         SendReviewArgs,
@@ -1242,7 +1243,10 @@ class ZcashWalletApp extends ConsumerWidget {
                                   // and the keep-awake hosts above it. The
                                   // link intake that feeds it lives further
                                   // up, in `_IncomingLinkHost`.
-                                  child: child!,
+                                  child: PaymentRequestHost(
+                                    router: router,
+                                    child: child!,
+                                  ),
                                 ),
                               ),
                             ),

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1572,13 +1572,11 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
         widget.router.go('/welcome');
         _showPaymentUriMessage(decision.message!);
       case PaymentUriDrainAction.deliver:
-        // Nothing to deliver onto yet. The presenting surface — the payment
-        // request card and its host — arrives in the next PR of this stack;
-        // presenting here would run the precheck and leave a live Rust
-        // proposal holding the wallet's inputs behind a card the user can
-        // neither see nor dismiss. So the link stays parked: a parked link is
-        // drained on the next pass, once a host exists.
-        return;
+        prefillNotifier.clear();
+        // The request is presented over the current screen, not navigated to.
+        ref
+            .read(paymentRequestFlowProvider.notifier)
+            .present(prefill!, source: PaymentRequestSource.link);
     }
   }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -18,6 +18,7 @@ import 'src/core/navigation/mobile_routes.dart';
 import 'src/core/navigation/incoming_link_dispatch.dart';
 import 'src/core/navigation/payment_uri_busy_surface_provider.dart';
 import 'src/core/navigation/payment_uri_drain_policy.dart';
+import 'src/core/navigation/payload_page_key.dart';
 import 'src/core/motion/onboarding_motion.dart';
 import 'src/core/theme/app_theme.dart';
 import 'src/core/theme/app_theme_host.dart';
@@ -73,8 +74,8 @@ import 'src/features/send/screens/send_screen.dart';
 import 'src/features/send/screens/send_status_screen.dart';
 import 'src/features/send/services/send_flow.dart'
     show
-        resolveSendStatusRoutePayload,
         SendReviewArgs,
+        resolveSendStatusRoutePayload,
         SendStatusRoutePayloadObserver,
         sendStatusRoutePayloadProvider,
         sendStatusTerminalProvider;
@@ -106,6 +107,8 @@ import 'src/providers/network_privacy_provider.dart';
 import 'src/providers/rpc_endpoint_failover_provider.dart';
 import 'src/providers/rpc_endpoint_provider.dart';
 import 'src/providers/router_refresh_provider.dart';
+import 'src/providers/migration_send_gate_provider.dart';
+import 'src/providers/payment_uri_prefill_provider.dart';
 import 'src/providers/voting/voting_share_tracking_restorer_provider.dart';
 import 'src/providers/wallet_provider.dart';
 import 'src/providers/windows_update_provider.dart';
@@ -113,9 +116,7 @@ import 'src/rust/api/sync.dart' as rust_sync;
 import 'src/rust/frb_generated.dart';
 import 'src/rust/api/simple.dart' as rust_simple;
 import 'src/services/incoming_uri_service.dart';
-import 'src/providers/migration_send_gate_provider.dart';
 import 'src/providers/payment_request_flow_provider.dart';
-import 'src/providers/payment_uri_prefill_provider.dart';
 
 void log(String message) => debugPrint('[zcash] $message');
 
@@ -254,10 +255,9 @@ final _routerProvider = Provider<_AppRouter>((ref) {
     canPop: () => router.canPop(),
     currentLocation: () =>
         router.routerDelegate.currentConfiguration.uri.toString(),
-    // `PaymentRequestHost` is mounted above the `Router`, where a `PopScope`
-    // finds no `ModalRoute` to register with and is therefore inert. Back has
-    // to reach the card here or it would navigate — and on the second press
-    // exit the app — underneath a modal the user is still looking at.
+    // The payment request card is presented over the `Router`, where a
+    // `PopScope` finds no `ModalRoute` to register with. Back must reach the
+    // card first or it would navigate underneath a modal the user is looking at.
     handleBackAboveRouter: () {
       if (ref.read(paymentRequestFlowProvider) == null) return false;
       ref.read(paymentRequestFlowProvider.notifier).dismiss();
@@ -792,6 +792,68 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
   ),
 ];
 
+/// A desktop page whose identity carries its payload, not just its path.
+///
+/// Mirrors what go_router builds for a `builder:` route under a `MaterialApp`
+/// (`pageBuilderForMaterialApp`) in everything but the key — see
+/// [payloadScopedPageKey] for why the key has to widen.
+MaterialPage<void> _payloadKeyedDesktopPage(
+  GoRouterState state, {
+  required String? payloadId,
+  required Widget child,
+}) {
+  final key = payloadScopedPageKey(state, payloadId);
+  return MaterialPage<void>(
+    key: key,
+    name: state.name ?? state.path,
+    arguments: <String, String>{
+      ...state.pathParameters,
+      ...state.uri.queryParameters,
+    },
+    restorationId: key.value,
+    child: child,
+  );
+}
+
+/// The desktop `/send` page.
+///
+/// Exposed so a router test can drive the real page identity without
+/// rebuilding the whole desktop tree.
+@visibleForTesting
+Page<dynamic> buildDesktopSendPage(BuildContext context, GoRouterState state) {
+  final extra = state.extra;
+  final prefill = extra is SendPrefillArgs ? extra : null;
+  return _payloadKeyedDesktopPage(
+    state,
+    payloadId: prefill?.id,
+    child: SendScreen(prefill: prefill),
+  );
+}
+
+/// The desktop `/send/review` page.
+///
+/// Keyed by `sendFlowId` so answering a second payment request while a review
+/// is already on screen replaces the page: `_SendReviewScreenState.dispose` is
+/// the only thing that hands the outgoing proposal back.
+@visibleForTesting
+Page<dynamic> buildDesktopSendReviewPage(
+  BuildContext context,
+  GoRouterState state,
+) {
+  final args = state.extra;
+  if (args is! SendReviewArgs) {
+    return _payloadKeyedDesktopPage(
+      state,
+      payloadId: null,
+      child: const SendScreen(),
+    );
+  }
+  return _payloadKeyedDesktopPage(
+    state,
+    payloadId: args.sendFlowId,
+    child: SendReviewScreen(args: args),
+  );
+}
 
 /// Main application routes for the desktop (large-form-factor) tree.
 List<RouteBase> _desktopRoutes(Ref ref) => [
@@ -942,13 +1004,7 @@ List<RouteBase> _desktopRoutes(Ref ref) => [
       );
     },
   ),
-  GoRoute(
-    path: '/send',
-    builder: (_, state) {
-      final extra = state.extra;
-      return SendScreen(prefill: extra is SendPrefillArgs ? extra : null);
-    },
-  ),
+  GoRoute(path: '/send', pageBuilder: buildDesktopSendPage),
   GoRoute(
     path: '/donation',
     redirect: (_, _) =>
@@ -976,14 +1032,7 @@ List<RouteBase> _desktopRoutes(Ref ref) => [
   ),
   GoRoute(path: '/swap', builder: (_, _) => const SwapScreen()),
   GoRoute(path: '/swap/review', builder: (_, _) => const SwapReviewScreen()),
-  GoRoute(
-    path: '/send/review',
-    builder: (_, state) {
-      final args = state.extra;
-      if (args is! SendReviewArgs) return const SendScreen();
-      return SendReviewScreen(args: args);
-    },
-  ),
+  GoRoute(path: '/send/review', pageBuilder: buildDesktopSendReviewPage),
   GoRoute(
     path: '/send/keystone/scan',
     builder: (_, state) => KeystoneSendScanScreen(
@@ -1187,6 +1236,12 @@ class ZcashWalletApp extends ConsumerWidget {
                                     }
                                   },
                                   behavior: HitTestBehavior.translucent,
+                                  // Innermost app-level layer: the payment
+                                  // request card sits directly over the
+                                  // router's content, under the privacy lock
+                                  // and the keep-awake hosts above it. The
+                                  // link intake that feeds it lives further
+                                  // up, in `_IncomingLinkHost`.
                                   child: child!,
                                 ),
                               ),
@@ -1258,25 +1313,16 @@ Widget buildIncomingLinkHostForTest({
 
 /// The single subscriber to the native incoming-link stream.
 ///
-/// Both products that arrive on `com.zcash.wallet/payment_uri` are dispatched
-/// from here, because there is only one method-call handler to go around and
-/// because two independent listeners would each hand every link to their own
-/// parser — which is how a Gift Card link's mnemonic-bearing fragment ends up
-/// in the ZIP-321 rejection snackbar. `classifyIncomingLink` picks the lane;
-/// everything below is per-lane and unchanged from the two hosts this replaced:
+/// Incoming URIs are dispatched here. `classifyIncomingLink` picks the lane:
 ///
 /// * **payment request** (`zcash:`) — parks in `paymentUriPrefillProvider` and
 ///   drains through `decidePaymentUriDrain` into a card over the current
 ///   screen. Route-agnostic: it never navigates on delivery.
-/// * **gift card** (`https://` on the Vizor origin) — queues in
-///   `paymentLinkIntakeProvider` and navigates to `/payment-links`.
+/// * **gift card** (`https://` on the Vizor origin) — no-op in this prefix;
+///   the gift card lane is wired in a later PR.
 /// * **vizor home** — brings an unlocked wallet to `/home`, unless the user is
 ///   part-way through onboarding, import, or add-account, where the link is
 ///   dropped rather than allowed to discard widget-only state.
-///
-/// The two intakes defer to each other: a Gift Card waits while a request card
-/// is up (`paymentLinkEntryDeferredMessageAtLocation`), and a request waits
-/// while a Gift Card signing round holds the busy-surface latch.
 class _IncomingLinkHost extends ConsumerStatefulWidget {
   const _IncomingLinkHost({required this.router, required this.child});
 
@@ -1295,6 +1341,7 @@ const _kIncomingLinkNoticeDuration = Duration(seconds: 4);
 
 class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   StreamSubscription<String>? _subscription;
+
 
   // --- payment request lane ---
   var _paymentSequence = 0;
@@ -1318,7 +1365,6 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
     _lastKnownHasWallet =
         ref.read(walletProvider).value?.hasWallet ??
         ref.read(appBootstrapProvider).hasWallet;
-    widget.router.routerDelegate.addListener(_handleRouteChanged);
     final service = ref.read(incomingUriServiceProvider);
     _subscription = service.uriStream.listen(_handleIncomingUri);
     unawaited(service.initialize());
@@ -1328,13 +1374,11 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   void didUpdateWidget(covariant _IncomingLinkHost oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.router == widget.router) return;
-    oldWidget.router.routerDelegate.removeListener(_handleRouteChanged);
-    widget.router.routerDelegate.addListener(_handleRouteChanged);
+
   }
 
   @override
   void dispose() {
-    widget.router.routerDelegate.removeListener(_handleRouteChanged);
     unawaited(_subscription?.cancel());
     super.dispose();
   }
@@ -1353,8 +1397,6 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
           // Wallet reset (uninstall, lost-password reset). Drop the parked
           // ZIP-321 link quietly: draining it here would follow the wipe with
           // a "Set up or import a wallet" notice and a jump to /welcome.
-          //
-          // Only the ZIP-321 park and its card.
           ref.read(paymentUriPrefillProvider.notifier).clear();
           ref.read(paymentRequestFlowProvider.notifier).clear();
           return;
@@ -1387,7 +1429,8 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
       case IncomingPaymentRequestLink(:final raw):
         _handlePaymentRequestLink(raw);
       case IncomingGiftCardLink():
-        _handleGiftCardLink(rawUri);
+        // gift card lane not yet active in this prefix
+        return;
       case IncomingVizorHomeLink():
         if (ref.read(appSecurityProvider).requiresUnlock) return;
         // Onboarding, import, and add-account keep their state only in the
@@ -1404,11 +1447,6 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
         return;
     }
   }
-
-  // Gift card lane placeholder (PR 5+).
-  void _handleGiftCardLink(String rawUri) {}
-
-  void _handleRouteChanged() {}
 
   // ---------------------------------------------------------------------
   // Payment request lane
@@ -1641,8 +1679,7 @@ class _WindowsUpdatePromptHostState
   void didUpdateWidget(covariant _WindowsUpdatePromptHost oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.router == widget.router) return;
-    oldWidget.router.routerDelegate.removeListener(_handleRouteChanged);
-    widget.router.routerDelegate.addListener(_handleRouteChanged);
+
   }
 
   @override

--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -7,11 +7,15 @@ import '../widgetbook/home_use_cases.dart';
 import '../widgetbook/donation_use_cases.dart';
 import '../widgetbook/mobile_pay_use_cases.dart';
 import '../widgetbook/pay_use_cases.dart';
+import '../widgetbook/payment_request_use_cases.dart';
+import '../widgetbook/receive_use_cases.dart';
+import '../widgetbook/request_amount_use_cases.dart';
 import '../widgetbook/send_review_status_use_cases.dart';
 import '../widgetbook/carousel_use_cases.dart';
 import '../widgetbook/screen_use_cases.dart';
 import '../widgetbook/swap_use_cases.dart';
 import '../widgetbook/voting_use_cases.dart';
+import 'zip321_prefill_use_cases.dart';
 
 typedef FigmaCompareScenarioBuilder = Widget Function(BuildContext context);
 
@@ -879,6 +883,322 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     id: 'mobile-ironwood-migration-keystone-scanner',
     description: 'Mobile Ironwood Keystone signature scanner screen',
     builder: buildMobileIronwoodMigrationKeystoneScannerUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'zip321-desktop-send-prefill',
+    description: 'Desktop /send opened from a ZIP-321 payment link',
+    builder: buildZip321DesktopSendPrefillUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'zip321-desktop-send-prefill-no-memo',
+    description: 'Desktop /send from a ZIP-321 link without a memo',
+    builder: buildZip321DesktopSendPrefillNoMemoUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'zip321-mobile-send-amount-step',
+    description: 'Mobile /send jumped to the amount step from a payment link',
+    builder: buildZip321MobileSendAmountStepUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'zip321-mobile-send-recipient-fallback',
+    description: 'Mobile /send bounced back to the recipient step',
+    builder: buildZip321MobileSendRecipientFallbackUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'send-review-payment-request-contact',
+    description:
+        'Desktop review of a payment request paying a saved contact, with '
+        'the link label on its own row',
+    builder: buildSendReviewPaymentRequestContactUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'send-review-payment-request-address',
+    description:
+        'Desktop review of a payment request paying a raw address, with the '
+        'link label on its own row',
+    builder: buildSendReviewPaymentRequestAddressUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-send-review-payment-request',
+    description: 'Mobile review of a payment request with the link label row',
+    builder: buildZip321MobileSendReviewRequestUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-full',
+    description: 'Desktop payment request card with label, message and note',
+    builder: buildPaymentRequestFullUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-minimal',
+    description: 'Desktop payment request card with amount and address only',
+    builder: buildPaymentRequestMinimalUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-long-values',
+    description:
+        'Desktop payment request card with 80-char label and 512-byte message',
+    builder: buildPaymentRequestLongValuesUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-long-values-expanded',
+    description: 'Desktop payment request card with the long message expanded',
+    builder: buildPaymentRequestLongValuesExpandedUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-address-expanded',
+    description: 'Desktop payment request card with the full address open',
+    builder: buildPaymentRequestAddressExpandedUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-checking',
+    description: 'Desktop payment request card while checks are running',
+    builder: buildPaymentRequestCheckingUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-error',
+    description: 'Desktop payment request card with an invalid address',
+    builder: buildPaymentRequestInvalidAddressUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-insufficient',
+    description: 'Desktop payment request card with not enough ZEC',
+    builder: buildPaymentRequestInsufficientUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-syncing',
+    description: 'Desktop payment request card while the wallet is syncing',
+    builder: buildPaymentRequestSyncingUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-sync-stalled',
+    description:
+        'Desktop payment request card once the sync re-check budget is spent',
+    builder: buildPaymentRequestSyncStalledUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-replaced',
+    description: 'Desktop payment request card with the replaced-link notice',
+    builder: buildPaymentRequestReplacedUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-transparent',
+    description: 'Desktop payment request card paying a transparent address',
+    builder: buildPaymentRequestTransparentUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-contact',
+    description: 'Desktop payment request card paying a saved contact',
+    builder: buildPaymentRequestContactUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-own-account',
+    description: "Desktop payment request card paying the user's own account",
+    builder: buildPaymentRequestOwnAccountUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-own-account-expanded',
+    description: 'Desktop payment request card, own account, address open',
+    builder: buildPaymentRequestOwnAccountExpandedUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-note-only',
+    description: 'Desktop payment request card with a note and no message',
+    builder: buildPaymentRequestNoteOnlyUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'payment-request-no-amount',
+    description: 'Desktop payment request card for a link with no amount',
+    builder: buildPaymentRequestNoAmountUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-full',
+    description: 'Mobile payment request sheet with label, message and note',
+    builder: buildMobilePaymentRequestFullUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-minimal',
+    description: 'Mobile payment request sheet with amount and address only',
+    builder: buildMobilePaymentRequestMinimalUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-long-values',
+    description:
+        'Mobile payment request sheet with 80-char label and 512-byte message',
+    builder: buildMobilePaymentRequestLongValuesUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-long-values-expanded',
+    description: 'Mobile payment request sheet with the long message expanded',
+    builder: buildMobilePaymentRequestLongValuesExpandedUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-address-expanded',
+    description: 'Mobile payment request sheet with the full address open',
+    builder: buildMobilePaymentRequestAddressExpandedUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-checking',
+    description: 'Mobile payment request sheet while checks are running',
+    builder: buildMobilePaymentRequestCheckingUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-error',
+    description: 'Mobile payment request sheet with an invalid address',
+    builder: buildMobilePaymentRequestInvalidAddressUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-insufficient',
+    description: 'Mobile payment request sheet with not enough ZEC',
+    builder: buildMobilePaymentRequestInsufficientUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-syncing',
+    description: 'Mobile payment request sheet while the wallet is syncing',
+    builder: buildMobilePaymentRequestSyncingUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-replaced',
+    description: 'Mobile payment request sheet with the replaced-link notice',
+    builder: buildMobilePaymentRequestReplacedUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-transparent',
+    description: 'Mobile payment request sheet paying a transparent address',
+    builder: buildMobilePaymentRequestTransparentUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-contact',
+    description: 'Mobile payment request sheet paying a saved contact',
+    builder: buildMobilePaymentRequestContactUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-own-account',
+    description: "Mobile payment request sheet paying the user's own account",
+    builder: buildMobilePaymentRequestOwnAccountUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-own-account-expanded',
+    description: 'Mobile payment request sheet, own account, address open',
+    builder: buildMobilePaymentRequestOwnAccountExpandedUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-no-amount',
+    description: 'Mobile payment request sheet for a link with no amount',
+    builder: buildMobilePaymentRequestNoAmountUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-request-note-only',
+    description: 'Mobile payment request sheet with a note and no message',
+    builder: buildMobilePaymentRequestNoteOnlyUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'receive-request-modal-step-1',
+    description: 'Desktop request modal step one with an open message',
+    builder: buildRequestModalStepOneMessageUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'receive-request-modal-step-2',
+    description: 'Desktop request modal step two with the request QR',
+    builder: buildRequestModalStepTwoShieldedUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'receive-request-modal-step-2-dense',
+    description: 'Desktop request modal step two with a 512-byte message',
+    builder: buildRequestModalStepTwoDenseUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-receive-shielded',
+    description: 'Mobile receive screen with the request entry beside share',
+    builder: buildReceiveMobileShieldedUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'receive-request-compose-no-price',
+    description: 'Desktop request modal step one with no live price',
+    builder: buildRequestModalStepOnePriceUnavailableUseCase,
+    desktop: true,
+    mobile: false,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-receive-request-compose-no-price',
+    description: 'Mobile request sheet step one with no live price',
+    builder: buildRequestMobileComposePriceUnavailableUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-receive-request-compose',
+    description: 'Mobile request sheet step one with an amount and a message',
+    builder: buildRequestMobileComposeMessageUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-receive-request-compose-error',
+    description: 'Mobile request sheet step one with an invalid amount',
+    builder: buildRequestMobileComposeAmountErrorUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'receive-desktop-shielded',
+    description: 'Desktop receive pane with the request entry beside copy',
+    builder: buildReceiveDesktopRequestEntryUseCase,
+    desktop: true,
+    mobile: false,
+  ),
+  FigmaCompareScenario(
+    id: 'receive-request-result',
+    description: 'Desktop request modal step two with the shielded request QR',
+    builder: buildRequestModalStepTwoShieldedUseCase,
+    desktop: true,
+    mobile: false,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-receive-request-result',
+    description: 'Mobile request sheet step two with the shielded request QR',
+    builder: buildRequestMobileResultShieldedUseCase,
     desktop: false,
     mobile: true,
   ),

--- a/lib/figma_compare/zip321_prefill_use_cases.dart
+++ b/lib/figma_compare/zip321_prefill_use_cases.dart
@@ -1,0 +1,332 @@
+// ignore_for_file: depend_on_referenced_packages
+// DEV-ONLY, UNCOMMITTED. Deterministic captures of what a user actually sees
+// after opening a ZIP-321 `zcash:` payment link. Mirrors the provider/Rust
+// fakes already used by test/features/send/send_screen_test.dart and the
+// Widgetbook mobile send harness, so nothing here touches production storage,
+// network, wallet, or Rust state.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../src/app_bootstrap.dart';
+import '../src/core/config/rpc_endpoint_config.dart';
+import '../src/features/address_book/models/address_book_contact.dart';
+import '../src/features/address_book/providers/address_book_provider.dart';
+import '../src/features/migration/providers/ironwood_migration_announcement_provider.dart';
+import '../src/features/send/models/send_prefill_args.dart';
+import '../src/features/send/screens/mobile/mobile_send_screen.dart';
+import '../src/features/send/screens/send_screen.dart';
+import '../src/features/send/services/send_proving_key_warmup.dart';
+import '../src/features/send/widgets/send_recipient_resolver.dart';
+import '../src/providers/account_models.dart';
+import '../src/providers/sync_provider.dart';
+import '../src/providers/zec_price_change_provider.dart';
+import '../src/rust/api/sync.dart' as rust_sync;
+import '../src/rust/frb_generated.dart';
+
+/// The exact payment link used for the OS-level runtime evidence.
+const zip321UnifiedAddress =
+    'u1l8xunezsvhq8fgzfl7404m450nwnd76zshscn6nfys7vyz2ywyh4cc5daaq0c7q2su5l'
+    'qfh23sp7fkf3kt27ve5948mzpfutvdxs8yzc5r8c2t6p6al2ucw2t8xjzyt7j4mhv3hd0g'
+    '4v3v99ggxzxnzk7v0k3ghpt8tqxa8ge87j9xmpva6wafxffgws5l6ts3plhjmnl4lsg3d3'
+    'drl2vxs3ah8p99d0sg50s8kvg38w2wr9n6qe';
+
+/// `memo=` decoded from the link, whitespace-preserving (`preserveMemoText`).
+const zip321MemoText = '  Invoice #42\nThanks  ';
+
+const _zip321Prefill = SendPrefillArgs(
+  id: 'zip321-capture',
+  source: 'zcash-uri',
+  address: zip321UnifiedAddress,
+  amountText: '0.5',
+  memoText: zip321MemoText,
+  preserveMemoText: true,
+  label: 'Coffee shop',
+  message: 'Thank you',
+);
+
+/// The same link without `memo=`, which is the only way the desktop compose
+/// screen lands with the message card collapsed (`_applyPrefill` sets
+/// `_messageExpanded = true` whenever the memo is non-empty).
+const _zip321PrefillNoMemo = SendPrefillArgs(
+  id: 'zip321-capture-no-memo',
+  source: 'zcash-uri',
+  address: zip321UnifiedAddress,
+  amountText: '0.5',
+  label: 'Coffee shop',
+  message: 'Thank you',
+);
+
+// --- (a) desktop /send prefilled from a ZIP-321 link ------------------------
+
+Widget buildZip321DesktopSendPrefillUseCase(BuildContext context) {
+  return const _DesktopSendPrefillHarness(prefill: _zip321Prefill);
+}
+
+// --- (b) desktop /send, memo card collapsed (link carried no memo) ----------
+
+Widget buildZip321DesktopSendPrefillNoMemoUseCase(BuildContext context) {
+  return const _DesktopSendPrefillHarness(prefill: _zip321PrefillNoMemo);
+}
+
+// --- (c) mobile /send, route-step mode, jumped to the amount step -----------
+
+Widget buildZip321MobileSendAmountStepUseCase(BuildContext context) {
+  return const _MobileSendPrefillHarness();
+}
+
+// --- (d) mobile recipient step after the in-place fallback ------------------
+
+Widget buildZip321MobileSendRecipientFallbackUseCase(BuildContext context) {
+  return const _MobileSendPrefillHarness(addressValidates: false);
+}
+
+// --- (e) mobile /send review answering a labelled payment request ----------
+
+Widget buildZip321MobileSendReviewRequestUseCase(BuildContext context) {
+  return const _MobileSendReviewRequestHarness();
+}
+
+// --- harnesses --------------------------------------------------------------
+
+const _accountState = AccountState(
+  accounts: [
+    AccountInfo(
+      uuid: 'capture-account',
+      name: 'Account 1',
+      order: 0,
+      profilePictureId: 'pfp-01',
+    ),
+  ],
+  activeAccountUuid: 'capture-account',
+  activeAddress: 'u1activeaddress',
+);
+
+final _bootstrap = AppBootstrapState(
+  initialLocation: '/send',
+  initialAccountState: _accountState,
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: kZcashDefaultNetworkName,
+  rpcEndpointConfig: defaultRpcEndpointConfig(kZcashDefaultNetworkName),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);
+
+class _CaptureSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncState> build() async => SyncState(
+    accountUuid: 'capture-account',
+    hasAccountScopedData: true,
+    spendableBalance: BigInt.from(500000000),
+    totalBalance: BigInt.from(500000000),
+    percentage: 1,
+  );
+}
+
+class _CaptureAddressBookRepository implements AddressBookRepository {
+  const _CaptureAddressBookRepository();
+
+  @override
+  Future<List<AddressBookContact>> loadContacts() async => const [];
+
+  @override
+  Future<void> saveContacts(List<AddressBookContact> contacts) async {}
+}
+
+Widget _captureScope({required Widget child}) => ProviderScope(
+  overrides: [
+    appBootstrapProvider.overrideWithValue(_bootstrap),
+    sendWalletDbPathProvider.overrideWithValue(() async => '/tmp/capture.db'),
+    sendProvingKeyWarmupProvider.overrideWithValue(() {}),
+    ironwoodHomeMigrationCtaProvider.overrideWithValue(
+      const AsyncValue.data(IronwoodHomeMigrationCtaState.hidden()),
+    ),
+    zecLiveUsdUnitPriceProvider.overrideWithValue(70),
+    syncProvider.overrideWith(_CaptureSyncNotifier.new),
+    addressBookRepositoryProvider.overrideWithValue(
+      const _CaptureAddressBookRepository(),
+    ),
+    ownAccountAddressesProvider.overrideWith((ref) async => const {}),
+  ],
+  child: child,
+);
+
+/// Desktop `SendScreen` calls `rust_sync.validateAddress` directly (no
+/// injection seam), so the capture installs the same FRB mock the desktop send
+/// widget tests use.
+class _DesktopSendPrefillHarness extends StatefulWidget {
+  const _DesktopSendPrefillHarness({required this.prefill});
+
+  final SendPrefillArgs prefill;
+
+  @override
+  State<_DesktopSendPrefillHarness> createState() =>
+      _DesktopSendPrefillHarnessState();
+}
+
+class _DesktopSendPrefillHarnessState
+    extends State<_DesktopSendPrefillHarness> {
+  late final GoRouter _router;
+
+  @override
+  void initState() {
+    super.initState();
+    _ensureRustMock();
+    _router = GoRouter(
+      initialLocation: '/send',
+      routes: [
+        GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+        GoRoute(
+          path: '/send',
+          builder: (_, _) => SendScreen(prefill: widget.prefill),
+        ),
+        GoRoute(
+          path: '/send/review',
+          builder: (_, _) => const SizedBox.shrink(),
+        ),
+      ],
+    );
+  }
+
+  @override
+  void dispose() {
+    _router.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _captureScope(child: Router.withConfig(config: _router));
+  }
+}
+
+class _MobileSendPrefillHarness extends StatelessWidget {
+  const _MobileSendPrefillHarness({this.addressValidates = true});
+
+  final bool addressValidates;
+
+  @override
+  Widget build(BuildContext context) {
+    return _captureScope(
+      child: SizedBox(
+        width: 393,
+        height: 852,
+        child: MobileSendScreen(
+          // Exactly what lib/src/core/navigation/mobile_routes.dart:152-159
+          // hands MobileSendScreen for a SendPrefillArgs on /send.
+          useRouteSteps: true,
+          initialRecipient: _zip321Prefill.address,
+          initialAmount: _zip321Prefill.amountText,
+          initialMemo: _zip321Prefill.memoText,
+          loadWalletDbPath: () async => '/tmp/capture.db',
+          validateAddress: addressValidates
+              ? _captureValidateAddress
+              : _captureRejectAddress,
+          estimateFee: _captureEstimateFee,
+        ),
+      ),
+    );
+  }
+}
+
+/// The mobile review step of a send that answers a ZIP-321 request.
+///
+/// `initialReview` is the screen's own preview seam, so the whole step is
+/// reachable from a single static frame — no taps, storage, network, or Rust.
+class _MobileSendReviewRequestHarness extends StatelessWidget {
+  const _MobileSendReviewRequestHarness();
+
+  @override
+  Widget build(BuildContext context) {
+    return _captureScope(
+      child: SizedBox(
+        width: 393,
+        height: 852,
+        child: MobileSendScreen(
+          initialReview: true,
+          initialAmountReady: true,
+          refreshReviewFeeOnInit: false,
+          initialRecipient: _zip321Prefill.address,
+          initialAddressType: 'unified',
+          initialAmount: _zip321Prefill.amountText,
+          initialFeeZatoshi: BigInt.from(10000),
+          loadWalletDbPath: () async => '/tmp/capture.db',
+          validateAddress: _captureValidateAddress,
+          estimateFee: _captureEstimateFee,
+        ),
+      ),
+    );
+  }
+}
+
+Future<rust_sync.AddressValidationResult> _captureValidateAddress({
+  required String address,
+}) async {
+  return const rust_sync.AddressValidationResult(
+    isValid: true,
+    addressType: 'unified',
+    wrongNetwork: false,
+  );
+}
+
+Future<rust_sync.AddressValidationResult> _captureRejectAddress({
+  required String address,
+}) async {
+  return const rust_sync.AddressValidationResult(
+    isValid: false,
+    addressType: '',
+    wrongNetwork: false,
+  );
+}
+
+Future<BigInt> _captureEstimateFee({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+  required String toAddress,
+  required BigInt amountZatoshi,
+  String? memo,
+}) async {
+  return BigInt.from(10000);
+}
+
+bool _rustMockInstalled = false;
+
+void _ensureRustMock() {
+  if (_rustMockInstalled) return;
+  _rustMockInstalled = true;
+  RustLib.initMock(api: _CaptureRustApi());
+}
+
+class _CaptureRustApi implements RustLibApi {
+  @override
+  Future<rust_sync.AddressValidationResult> crateApiSyncValidateAddress({
+    required String address,
+    required String network,
+  }) async {
+    return const rust_sync.AddressValidationResult(
+      isValid: true,
+      addressType: 'unified',
+      wrongNetwork: false,
+    );
+  }
+
+  @override
+  Future<BigInt> crateApiSyncEstimateFee({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+  }) async {
+    return BigInt.from(10000);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/lib/src/core/layout/app_desktop_shell.dart
+++ b/lib/src/core/layout/app_desktop_shell.dart
@@ -10,13 +10,27 @@ import '../widgets/app_icon.dart';
 import '../widgets/app_toast.dart';
 import 'content_overlay_inset.dart';
 
+/// Width the desktop shell reserves for its main sidebar.
+///
+/// Named rather than repeated because window-level overlays derive the
+/// content pane's geometry from it — see [contentOverlayInsets].
+const double kAppDesktopSidebarWidth = 256;
+
+/// Margin the shell leaves around the sidebar/pane row: outer padding on both
+/// window edges, and the same gap again between the two columns.
+const double kAppDesktopShellMargin = AppSpacing.xs;
+
+/// Where the trailing pane begins: outer padding + [sidebarWidth] + the gap.
+double appDesktopPaneLeftInset(double sidebarWidth) =>
+    kAppDesktopShellMargin * 2 + sidebarWidth;
+
 class AppDesktopShell extends StatelessWidget {
   const AppDesktopShell({
     required this.sidebar,
     required this.pane,
     this.background,
     this.backgroundColor,
-    this.sidebarWidth = 256,
+    this.sidebarWidth = kAppDesktopSidebarWidth,
     super.key,
   });
 
@@ -29,11 +43,11 @@ class AppDesktopShell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final background = this.background;
-    // Where the trailing pane begins: outer padding + sidebar + the gap.
-    // Window-level overlays clear this so they align with the pane.
-    final paneLeftInset = AppSpacing.xs + sidebarWidth + AppSpacing.xs;
+    // Window-level overlays clear these so they align with the pane rather
+    // than with the whole window.
     return ContentOverlayInset(
-      leftInset: paneLeftInset,
+      leftInset: appDesktopPaneLeftInset(sidebarWidth),
+      rightInset: kAppDesktopShellMargin,
       child: Scaffold(
         backgroundColor: backgroundColor ?? context.colors.macosUtility.window,
         body: SafeArea(
@@ -43,12 +57,12 @@ class AppDesktopShell extends StatelessWidget {
               if (background != null)
                 Positioned.fill(child: IgnorePointer(child: background)),
               Padding(
-                padding: const EdgeInsets.all(AppSpacing.xs),
+                padding: const EdgeInsets.all(kAppDesktopShellMargin),
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     SizedBox(width: sidebarWidth, child: sidebar),
-                    const SizedBox(width: AppSpacing.xs),
+                    const SizedBox(width: kAppDesktopShellMargin),
                     Expanded(child: pane),
                   ],
                 ),

--- a/lib/src/core/layout/app_pane_floating_bar.dart
+++ b/lib/src/core/layout/app_pane_floating_bar.dart
@@ -18,6 +18,7 @@ class AppPaneFloatingBar extends StatefulWidget {
     required this.bar,
     required this.builder,
     this.visible = true,
+    this.fadeVisible = true,
     this.overlayWidth,
     super.key,
   });
@@ -38,6 +39,11 @@ class AppPaneFloatingBar extends StatefulWidget {
   final Widget Function(BuildContext context, double bottomReserve) builder;
 
   final bool visible;
+
+  /// Whether content below the floating actions should be obscured by the
+  /// bottom fade. Screens with an external scroll controller can turn this
+  /// off once the scroll position reaches the end.
+  final bool fadeVisible;
 
   /// Width of the gradient band + bar. Null spans the full pane width;
   /// a value centers the overlay in a fixed-width column (the settings
@@ -88,15 +94,21 @@ class _AppPaneFloatingBarState extends State<AppPaneFloatingBar> {
         // gradient band).
         Positioned.fill(
           child: IgnorePointer(
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    context.colors.macosUtility.windowTransparent,
-                    context.colors.macosUtility.window,
-                  ],
+            child: AnimatedOpacity(
+              key: const ValueKey('app_pane_floating_bar_fade'),
+              opacity: widget.fadeVisible ? 1 : 0,
+              duration: const Duration(milliseconds: 120),
+              curve: Curves.easeOut,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      context.colors.macosUtility.windowTransparent,
+                      context.colors.macosUtility.window,
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/src/core/layout/content_overlay_inset.dart
+++ b/lib/src/core/layout/content_overlay_inset.dart
@@ -1,24 +1,32 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-/// Left inset (logical px) that top-anchored, window-level content overlays —
-/// e.g. the network-fallback toast — should leave clear so they align with the
-/// content pane instead of the whole window.
+/// Horizontal insets (logical px) that window-level content overlays — the
+/// network-fallback toast, the app-level payment-request card — should leave
+/// clear so they align with the content pane instead of the whole window.
 ///
-/// The value is `0` when no sidebar shell is mounted (welcome, unlock, mobile)
-/// and the sidebar's reserved width when one is (so overlays center over the
-/// trailing pane). Shells publish their inset by mounting a
+/// Both sides are `EdgeInsets.zero` when no sidebar shell is mounted (welcome,
+/// unlock, mobile) and the pane's own margins when one is: the left inset
+/// covers the outer padding plus the sidebar plus the gap, the right inset the
+/// pane's trailing margin. Shells publish their insets by mounting a
 /// [ContentOverlayInset]; the most recently mounted shell wins, which during a
 /// route transition is the incoming screen.
 ///
 /// Kept as a process-global [ValueListenable] (rather than a provider) so the
 /// publishing shells stay free of any `ProviderScope` requirement.
+ValueListenable<EdgeInsets> get contentOverlayInsets => _insets;
+
+/// Just the left inset, for overlays that pin themselves to the pane's leading
+/// edge rather than centering inside it.
 ValueListenable<double> get contentOverlayLeftInset => _leftInset;
 
+final ValueNotifier<EdgeInsets> _insets = ValueNotifier<EdgeInsets>(
+  EdgeInsets.zero,
+);
 final ValueNotifier<double> _leftInset = ValueNotifier<double>(0);
 final List<_InsetEntry> _entries = <_InsetEntry>[];
 
-void _pushInset(Object token, double inset) {
+void _pushInset(Object token, EdgeInsets inset) {
   final index = _entries.indexWhere((entry) => entry.token == token);
   if (index >= 0) {
     _entries[index].inset = inset;
@@ -34,17 +42,20 @@ void _releaseInset(Object token) {
 }
 
 void _sync() {
-  _leftInset.value = _entries.isEmpty ? 0 : _entries.last.inset;
+  final inset = _entries.isEmpty ? EdgeInsets.zero : _entries.last.inset;
+  _insets.value = inset;
+  _leftInset.value = inset.left;
 }
 
 class _InsetEntry {
   _InsetEntry(this.token, this.inset);
 
   final Object token;
-  double inset;
+  EdgeInsets inset;
 }
 
-/// Publishes [leftInset] to [contentOverlayLeftInset] while mounted.
+/// Publishes [leftInset] and [rightInset] to [contentOverlayInsets] while
+/// mounted.
 ///
 /// Wrap a sidebar shell with this so window-level overlays can clear the
 /// sidebar. Mutations are deferred to post-frame callbacks so the global
@@ -54,11 +65,20 @@ class ContentOverlayInset extends StatefulWidget {
   const ContentOverlayInset({
     required this.leftInset,
     required this.child,
+    this.rightInset = 0,
     super.key,
   });
 
   final double leftInset;
+
+  /// The pane's trailing margin. Only overlays that center themselves inside
+  /// the pane need it; leading-pinned overlays read [leftInset] alone.
+  final double rightInset;
+
   final Widget child;
+
+  EdgeInsets get _edgeInsets =>
+      EdgeInsets.only(left: leftInset, right: rightInset);
 
   @override
   State<ContentOverlayInset> createState() => _ContentOverlayInsetState();
@@ -76,7 +96,7 @@ class _ContentOverlayInsetState extends State<ContentOverlayInset> {
   @override
   void didUpdateWidget(ContentOverlayInset oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.leftInset != widget.leftInset) {
+    if (oldWidget._edgeInsets != widget._edgeInsets) {
       _schedulePush();
     }
   }
@@ -84,7 +104,7 @@ class _ContentOverlayInsetState extends State<ContentOverlayInset> {
   void _schedulePush() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      _pushInset(_token, widget.leftInset);
+      _pushInset(_token, widget._edgeInsets);
     });
   }
 
@@ -97,4 +117,29 @@ class _ContentOverlayInsetState extends State<ContentOverlayInset> {
 
   @override
   Widget build(BuildContext context) => widget.child;
+}
+
+/// Pads [child] with the mounted shell's pane insets so that a *centering*
+/// parent — an `Align`, a `Center`, `AppPaneModalOverlay` — lands it on the
+/// content pane's center rather than the window's.
+///
+/// Centering a box padded by `left` and `right` inside a window of width `W`
+/// puts its center at `W / 2 + (left - right) / 2`, which is exactly
+/// `left + (W - left - right) / 2` — the pane's center. With no shell mounted
+/// both insets are zero and this is a no-op, which is what onboarding, unlock
+/// and every mobile route get.
+class ContentPaneCenteringPadding extends StatelessWidget {
+  const ContentPaneCenteringPadding({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<EdgeInsets>(
+      valueListenable: contentOverlayInsets,
+      builder: (context, insets, child) =>
+          Padding(padding: insets, child: child),
+      child: child,
+    );
+  }
 }

--- a/lib/src/core/storage/png_save_location.dart
+++ b/lib/src/core/storage/png_save_location.dart
@@ -1,0 +1,37 @@
+import 'package:file_selector/file_selector.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Asks the platform's own save panel where a PNG the user is exporting
+/// should go, and returns the chosen absolute path (null when cancelled).
+///
+/// On sandboxed macOS the panel is the only way to reach a folder outside the
+/// app container, and it is also where the user confirms replacing a file they
+/// already have.
+Future<String?> pickPngSaveLocation({required String suggestedName}) async {
+  final location = await getSaveLocation(
+    suggestedName: suggestedName,
+    // Open on Downloads rather than wherever the panel last was: an exported
+    // image is something the user is about to hand to someone else.
+    initialDirectory: await _downloadsDirectoryPath(),
+    canCreateDirectories: true,
+    acceptedTypeGroups: const [
+      XTypeGroup(
+        label: 'PNG image',
+        extensions: ['png'],
+        mimeTypes: ['image/png'],
+        uniformTypeIdentifiers: ['public.png'],
+      ),
+    ],
+  );
+  return location?.path;
+}
+
+/// The platform Downloads folder, or null when the platform has none — the
+/// panel then opens wherever it would have anyway.
+Future<String?> _downloadsDirectoryPath() async {
+  try {
+    return (await getDownloadsDirectory())?.path;
+  } on Object {
+    return null;
+  }
+}

--- a/lib/src/core/widgets/amount_price_loading_bar.dart
+++ b/lib/src/core/widgets/amount_price_loading_bar.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/widgets.dart';
+
+import '../theme/app_theme.dart';
+
+/// The "price not here yet" placeholder that stands in for a converted amount
+/// under an amount field: a small pill where the `$ 12.34` readout would be.
+///
+/// Shared by both send composers and both request composers so every surface
+/// that waits on a price reads the same. Desktop keeps it static; mobile
+/// sweeps a highlight across it ([animated]) — and only while tickers run and
+/// the platform has not asked for reduced motion.
+class AmountPriceLoadingBar extends StatefulWidget {
+  const AmountPriceLoadingBar({
+    this.animated = false,
+    this.width = 48,
+    this.height = 12,
+    super.key,
+  });
+
+  final bool animated;
+  final double width;
+  final double height;
+
+  static const sweepPeriod = Duration(milliseconds: 1200);
+
+  @override
+  State<AmountPriceLoadingBar> createState() => _AmountPriceLoadingBarState();
+}
+
+class _AmountPriceLoadingBarState extends State<AmountPriceLoadingBar>
+    with SingleTickerProviderStateMixin {
+  AnimationController? _controller;
+
+  AnimationController get _activeController {
+    return _controller ??= AnimationController(
+      vsync: this,
+      duration: AmountPriceLoadingBar.sweepPeriod,
+    );
+  }
+
+  bool get _shouldAnimate {
+    if (!widget.animated) return false;
+    if (MediaQuery.maybeOf(context)?.disableAnimations ?? false) return false;
+    return TickerMode.valuesOf(context).enabled;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _syncAnimation();
+  }
+
+  @override
+  void didUpdateWidget(AmountPriceLoadingBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _syncAnimation();
+  }
+
+  void _syncAnimation() {
+    if (_shouldAnimate) {
+      if (!_activeController.isAnimating) _activeController.repeat();
+      return;
+    }
+    final controller = _controller;
+    if (controller != null) {
+      controller
+        ..stop()
+        ..value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final baseColor = colors.background.overlay.withValues(alpha: 0.15);
+    final highlightColor = colors.background.raised;
+
+    if (!widget.animated) {
+      return Container(
+        width: widget.width,
+        height: widget.height,
+        decoration: BoxDecoration(
+          color: baseColor,
+          borderRadius: BorderRadius.circular(AppRadii.full),
+        ),
+      );
+    }
+
+    return SizedBox(
+      width: widget.width,
+      height: widget.height,
+      child: _shouldAnimate
+          ? AnimatedBuilder(
+              animation: _activeController,
+              builder: (context, _) => CustomPaint(
+                painter: _AmountPriceLoadingPainter(
+                  progress: _activeController.value,
+                  baseColor: baseColor,
+                  highlightColor: highlightColor,
+                ),
+              ),
+            )
+          : CustomPaint(
+              painter: _AmountPriceLoadingPainter(
+                progress: 0,
+                baseColor: baseColor,
+                highlightColor: highlightColor,
+                animate: false,
+              ),
+            ),
+    );
+  }
+}
+
+class _AmountPriceLoadingPainter extends CustomPainter {
+  const _AmountPriceLoadingPainter({
+    required this.progress,
+    required this.baseColor,
+    required this.highlightColor,
+    this.animate = true,
+  });
+
+  final double progress;
+  final Color baseColor;
+  final Color highlightColor;
+  final bool animate;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Offset.zero & size;
+    final rrect = RRect.fromRectAndRadius(rect, Radius.circular(AppRadii.full));
+    if (!animate) {
+      final shader = LinearGradient(
+        begin: Alignment.centerLeft,
+        end: Alignment.centerRight,
+        colors: [highlightColor, baseColor],
+      ).createShader(rect);
+      canvas.drawRRect(rrect, Paint()..shader = shader);
+      return;
+    }
+    canvas.drawRRect(rrect, Paint()..color = baseColor);
+    canvas.save();
+    canvas.clipRRect(rrect);
+    final sweepWidth = size.width * 1.6;
+    final left = -sweepWidth + progress * (size.width + sweepWidth);
+    final sweepRect = Rect.fromLTWH(left, 0, sweepWidth, size.height);
+    final shader = LinearGradient(
+      begin: Alignment.centerLeft,
+      end: Alignment.centerRight,
+      colors: [
+        baseColor.withValues(alpha: 0),
+        highlightColor,
+        baseColor.withValues(alpha: 0),
+      ],
+      stops: const [0, 0.5, 1],
+    ).createShader(sweepRect);
+    canvas.drawRect(sweepRect, Paint()..shader = shader);
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(covariant _AmountPriceLoadingPainter oldDelegate) {
+    return progress != oldDelegate.progress ||
+        baseColor != oldDelegate.baseColor ||
+        highlightColor != oldDelegate.highlightColor ||
+        animate != oldDelegate.animate;
+  }
+}

--- a/lib/src/core/widgets/review_list_row.dart
+++ b/lib/src/core/widgets/review_list_row.dart
@@ -10,8 +10,12 @@ import 'app_tooltip.dart';
 const kTxFeeHelpTooltip =
     'Fee paid to the Zcash network to process this transaction.';
 
-/// Tooltip for the requester name on a payment-request card. The name is
-/// supplied by the payment link, not verified by Vizor.
+/// Help copy for the payment request card's requester name.
+///
+/// ZIP-321 calls `label` a name for an address, and a wallet must keep it
+/// identifiable as something distinct from the address. It is text the link
+/// supplied, never a sender the wallet verified — so the one surface that
+/// shows it says so. The send review never renders it at all.
 const kPaymentRequestRequesterTooltip =
     "Name supplied by the payment link. Vizor can't verify who sent it.";
 

--- a/lib/src/core/widgets/review_wrap_card.dart
+++ b/lib/src/core/widgets/review_wrap_card.dart
@@ -32,8 +32,9 @@ class ReviewWrapCard extends StatelessWidget {
   final EdgeInsetsGeometry padding;
 
   /// Whether the card hugs its content when its parent bounds the height.
-  /// The default fills; a card in a `Flexible` passes [MainAxisSize.min] to
-  /// shrink to short content instead.
+  /// The default fills, which is what every fixed-height-free caller gets
+  /// today; a card in a `Flexible` passes [MainAxisSize.min] to shrink to
+  /// short content instead.
   final MainAxisSize mainAxisSize;
 
   /// Fixed surface override. The failed status screen keeps the dark

--- a/lib/src/features/home/widgets/keystone_shield_signing_overlay.dart
+++ b/lib/src/features/home/widgets/keystone_shield_signing_overlay.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../main.dart' show log;
 import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../core/layout/app_layout.dart';
+import '../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
@@ -42,7 +43,8 @@ class KeystoneShieldSigningOverlay extends ConsumerStatefulWidget {
 }
 
 class _KeystoneShieldSigningOverlayState
-    extends ConsumerState<KeystoneShieldSigningOverlay> {
+    extends ConsumerState<KeystoneShieldSigningOverlay>
+    with PaymentUriBusySurfaceHoldMixin {
   _KeystoneShieldPhase _phase = _KeystoneShieldPhase.preparing;
   bool _showSaplingParamsPrompt = false;
   Completer<bool>? _saplingParamsPromptCompleter;

--- a/lib/src/features/keystone/widgets/keystone_scan_help_overlay.dart
+++ b/lib/src/features/keystone/widgets/keystone_scan_help_overlay.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -91,7 +92,17 @@ class _KeystoneScanHelpOverlayState extends State<KeystoneScanHelpOverlay> {
   }
 
   void _hide() {
-    if (_overlayController.isShowing) _overlayController.hide();
+    if (!_overlayController.isShowing) return;
+    if (SchedulerBinding.instance.schedulerPhase ==
+        SchedulerPhase.persistentCallbacks) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _overlayController.isShowing) {
+          _overlayController.hide();
+        }
+      });
+      return;
+    }
+    _overlayController.hide();
   }
 
   @override

--- a/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
@@ -439,8 +439,13 @@ enum _KeystoneDenominationSignStage {
   failed,
 }
 
+// Every step this screen drives — combined, immediate, denomination, batch,
+// desktop or mobile — is an animated migration QR the device is reading, or a
+// scan of the signed result coming back. The hold covers the whole screen so
+// no card lands between the two halves of a round.
 class _IronwoodMigrationKeystonePrivateSignScreenState
-    extends ConsumerState<_IronwoodMigrationKeystonePrivateSignScreen> {
+    extends ConsumerState<_IronwoodMigrationKeystonePrivateSignScreen>
+    with PaymentUriBusySurfaceHoldMixin {
   _KeystoneDenominationSignStage _stage =
       _KeystoneDenominationSignStage.preparing;
   late final IronwoodMigrationService _migrationService;

--- a/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
@@ -27,6 +27,7 @@ import '../../../core/layout/app_desktop_backdrop_shell.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_pane_scroll_scaffold.dart';
+import '../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../core/profile_pictures.dart';

--- a/lib/src/features/onboarding/create/onboarding_split_view.dart
+++ b/lib/src/features/onboarding/create/onboarding_split_view.dart
@@ -142,7 +142,7 @@ class OnboardingSplitViewShell extends ConsumerWidget {
     ).animate(entrance);
 
     return AppDesktopShell(
-      sidebarWidth: 256,
+      sidebarWidth: kAppDesktopSidebarWidth,
       background: _OnboardingWindowBackground(activeStep: activeStep),
       sidebar: SlideTransition(
         position: sidebarOffset,

--- a/lib/src/features/onboarding/import/import_split_view.dart
+++ b/lib/src/features/onboarding/import/import_split_view.dart
@@ -70,7 +70,7 @@ class ImportOnboardingShell extends StatelessWidget {
     );
 
     return AppDesktopShell(
-      sidebarWidth: 256,
+      sidebarWidth: kAppDesktopSidebarWidth,
       background: _ImportOnboardingWindowBackground(activeStep: activeStep),
       sidebar: SlideTransition(
         position: Tween<Offset>(

--- a/lib/src/features/onboarding/keystone/keystone_onboarding_flow.dart
+++ b/lib/src/features/onboarding/keystone/keystone_onboarding_flow.dart
@@ -161,7 +161,7 @@ class KeystoneOnboardingShell extends StatelessWidget {
     );
 
     return AppDesktopShell(
-      sidebarWidth: 256,
+      sidebarWidth: kAppDesktopSidebarWidth,
       background: _KeystoneOnboardingWindowBackground(activeStep: activeStep),
       sidebar: SlideTransition(
         position: Tween<Offset>(

--- a/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
@@ -8,16 +8,13 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/layout/mobile/app_mobile_sheet.dart';
-import '../../../core/navigation/payment_uri_unlock_claim.dart';
 import '../../../core/feedback/app_haptics.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
-import '../../../core/widgets/app_toast.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
 import '../../../providers/biometric_unlock_provider.dart';
 import '../../../providers/device_owner_auth_provider.dart';
-import '../../../providers/payment_request_flow_provider.dart';
 import '../../../providers/router_refresh_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../services/biometric_unlock.dart';
@@ -216,36 +213,15 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
         await syncNotifier.refreshAfterUnlock();
         await syncNotifier.startSyncAnyway();
         if (!mounted) return;
-        // Claim the payment-URI prefill (parked while locked) only now, after
-        // the post-unlock work has succeeded. Claiming earlier would drop the
-        // payment if any of the awaits above threw or this screen unmounted —
-        // the prefill would already be cleared with no way to recover it —
-        // and the drain policy inside the claim reads state those awaits
-        // settle.
-        final claimed = claimParkedPaymentUriAfterUnlock(ref);
+        // No payment-URI claim here yet. Mobile's answer to a payment request
+        // card — the handoff from Review and Edit into the send wizard —
+        // arrives in the next PR of this stack, and the app-level drain keeps
+        // a delivered link parked on this form factor until it does. Claiming
+        // here would clear that park to present a card whose two answers both
+        // land on an empty composer. The link stays parked instead: `/home`
+        // re-runs the app-level drain, which still says whatever the policy
+        // has to say about a link this wallet cannot open.
         context.go('/home');
-        final pendingPrefill = claimed.prefill;
-        final notice = claimed.notice;
-        if (pendingPrefill != null) {
-          // The link becomes a card over the wallet the user just unlocked,
-          // not a jump into the composer.
-          ref
-              .read(paymentRequestFlowProvider.notifier)
-              .present(pendingPrefill, source: PaymentRequestSource.link);
-        } else if (notice != null) {
-          // The link outlived its park window while the user was finding their
-          // passcode, or the wallet it landed on cannot open it. Landing with
-          // no card and no word is the one silent loss of something the user
-          // deliberately asked for. The toast is asked for before this screen
-          // is torn down; `showAppToast` renders it on the app-level host,
-          // which outlives the navigation.
-          showAppToast(
-            context,
-            notice,
-            duration: const Duration(seconds: 4),
-            iconName: AppIcons.warning,
-          );
-        }
       });
     } catch (e, st) {
       log('MobileUnlockScreen._submit: ERROR: $e\n$st');

--- a/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
@@ -8,13 +8,16 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../core/navigation/payment_uri_unlock_claim.dart';
 import '../../../core/feedback/app_haptics.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_toast.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
 import '../../../providers/biometric_unlock_provider.dart';
 import '../../../providers/device_owner_auth_provider.dart';
+import '../../../providers/payment_request_flow_provider.dart';
 import '../../../providers/router_refresh_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../services/biometric_unlock.dart';
@@ -213,13 +216,36 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
         await syncNotifier.refreshAfterUnlock();
         await syncNotifier.startSyncAnyway();
         if (!mounted) return;
-        // No payment-URI claim here yet. The surface that presents a claimed
-        // link — the payment request card and its host — arrives in the next
-        // PR of this stack, and claiming without one would clear the park to
-        // present nothing. The link stays parked instead: `/home` re-runs the
-        // app-level drain, which still says whatever the policy has to say
-        // about a link this wallet cannot open.
+        // Claim the payment-URI prefill (parked while locked) only now, after
+        // the post-unlock work has succeeded. Claiming earlier would drop the
+        // payment if any of the awaits above threw or this screen unmounted —
+        // the prefill would already be cleared with no way to recover it —
+        // and the drain policy inside the claim reads state those awaits
+        // settle.
+        final claimed = claimParkedPaymentUriAfterUnlock(ref);
         context.go('/home');
+        final pendingPrefill = claimed.prefill;
+        final notice = claimed.notice;
+        if (pendingPrefill != null) {
+          // The link becomes a card over the wallet the user just unlocked,
+          // not a jump into the composer.
+          ref
+              .read(paymentRequestFlowProvider.notifier)
+              .present(pendingPrefill, source: PaymentRequestSource.link);
+        } else if (notice != null) {
+          // The link outlived its park window while the user was finding their
+          // passcode, or the wallet it landed on cannot open it. Landing with
+          // no card and no word is the one silent loss of something the user
+          // deliberately asked for. The toast is asked for before this screen
+          // is torn down; `showAppToast` renders it on the app-level host,
+          // which outlives the navigation.
+          showAppToast(
+            context,
+            notice,
+            duration: const Duration(seconds: 4),
+            iconName: AppIcons.warning,
+          );
+        }
       });
     } catch (e, st) {
       log('MobileUnlockScreen._submit: ERROR: $e\n$st');

--- a/lib/src/features/onboarding/unlock_screen.dart
+++ b/lib/src/features/onboarding/unlock_screen.dart
@@ -4,13 +4,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../main.dart' show log;
+import '../../core/navigation/payment_uri_unlock_claim.dart';
 import '../../core/security/password_policy.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/widgets/app_button.dart';
+import '../../core/widgets/app_icon.dart';
 import '../../core/widgets/app_text_field.dart';
+import '../../core/widgets/app_toast.dart';
 import '../../core/widgets/password_text_field.dart';
 import '../../providers/account_provider.dart';
 import '../../providers/app_security_provider.dart';
+import '../../providers/payment_request_flow_provider.dart';
 import '../../providers/router_refresh_provider.dart';
 import '../../providers/sync_provider.dart';
 import 'shared/onboarding_auth_shell.dart';
@@ -71,17 +75,39 @@ class _UnlockScreenState extends ConsumerState<UnlockScreen> {
         await syncNotifier.refreshAfterUnlock();
         await syncNotifier.startSyncAnyway();
         if (!mounted) return;
-        // No payment-URI claim here yet. The surface that presents a claimed
-        // link — the payment request card and its host — arrives in the next
-        // PR of this stack, and claiming without one would clear the park to
-        // present nothing. The link stays parked instead: `/home` re-runs the
-        // app-level drain, which still says whatever the policy has to say
-        // about a link this wallet cannot open.
-        //
+        // Claim the payment-URI prefill (parked while locked) only now, after
+        // the post-unlock work has succeeded. Claiming earlier would drop the
+        // payment if any of the awaits above threw or this screen unmounted —
+        // the prefill would already be cleared with no way to recover it —
+        // and the drain policy inside the claim reads state those awaits
+        // settle.
+        final claimed = claimParkedPaymentUriAfterUnlock(ref);
         // Desktop has no Gift Card branch here: the desktop runners never
         // register the HTTPS deeplink, so `/payment-links` is only ever
         // reached from inside the app.
         context.go('/home');
+        final pendingPrefill = claimed.prefill;
+        final notice = claimed.notice;
+        if (pendingPrefill != null) {
+          // The link becomes a card over the wallet the user just unlocked,
+          // not a jump into the composer.
+          ref
+              .read(paymentRequestFlowProvider.notifier)
+              .present(pendingPrefill, source: PaymentRequestSource.link);
+        } else if (notice != null) {
+          // The link outlived its park window while the user was finding their
+          // password, or the wallet it landed on cannot open it. Landing on
+          // /home with no card and no word is the one silent loss of something
+          // the user deliberately asked for. The toast is asked for before this
+          // screen is torn down; `showAppToast` renders it on the app-level
+          // host, which outlives the navigation.
+          showAppToast(
+            context,
+            notice,
+            duration: const Duration(seconds: 4),
+            iconName: AppIcons.warning,
+          );
+        }
       });
     } catch (e, st) {
       log('UnlockScreen._submit: ERROR: $e\n$st');

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -572,7 +572,7 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
                   );
                 },
                 onSaveQrImage: (png) =>
-                    unawaited(_saveRequestQrImage(png, shownRequest.amountZec)),
+                    _saveRequestQrImage(png, shownRequest.amountZec),
                 onSaveQrImageError: _reportRequestQrSaveFailed,
               ),
             if (infoDialogType != null)

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart'
     show CircularProgressIndicator, Colors, ScaffoldMessenger, SnackBar;
@@ -17,11 +18,18 @@ import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
+import '../../../core/widgets/app_toast.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/receive_address_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
+import '../../../providers/zec_price_change_provider.dart';
+import '../services/request_qr_export.dart';
+import '../services/zec_request_draft.dart';
 import '../widgets/receive_address_widgets.dart';
+import '../widgets/request/request_amount_card.dart';
+import '../widgets/request/request_amount_model.dart';
+import '../../../core/widgets/app_tooltip.dart';
 
 const _renewShieldedAddressErrorMessage =
     "We couldn't refresh your shielded address. Try again, or use your current one.";
@@ -54,9 +62,29 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
   String? _transparentErrorText;
   String? _transparentLoadingAccountUuid;
   ReceiveAddressType? _infoDialogType;
+  ZecRequestDraft? _requestDraft;
+  RequestModalStep _requestStep = RequestModalStep.compose;
+
+  /// The request as it was when the user pressed Next. The result step
+  /// renders this snapshot, not the live draft: a USD request converts at the
+  /// live price, and a price tick after the user confirmed must not rewrite
+  /// the QR they are already showing someone.
+  ZecRequestView? _requestResult;
+  bool _requestMessageExpanded = false;
+  final TextEditingController _requestAmountController =
+      TextEditingController();
+  final TextEditingController _requestMessageController =
+      TextEditingController();
   bool _isLoading = true;
   bool _isLoadingTransparent = false;
   bool _isRenewingShielded = false;
+
+  @override
+  void dispose() {
+    _requestAmountController.dispose();
+    _requestMessageController.dispose();
+    super.dispose();
+  }
 
   @override
   void initState() {
@@ -277,6 +305,169 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
     };
   }
 
+  /// Opens the request modal against the address currently on screen.
+  ///
+  /// The address is snapshotted here rather than read live: renewing the
+  /// shielded address afterwards must not repoint a link already handed out,
+  /// and switching tabs behind the modal must not silently change the pool
+  /// the request is asking to be paid into.
+  void _openRequest() {
+    final address = _selectedAddress;
+    if (address.isEmpty) return;
+    _requestAmountController.clear();
+    _requestMessageController.clear();
+    setState(() {
+      _requestDraft = ZecRequestDraft(address: address);
+      _requestStep = RequestModalStep.compose;
+      _requestResult = null;
+      _requestMessageExpanded = false;
+    });
+  }
+
+  void _closeRequest() {
+    if (_requestDraft == null) return;
+    setState(() {
+      _requestDraft = null;
+      _requestStep = RequestModalStep.compose;
+      _requestResult = null;
+      _requestMessageExpanded = false;
+    });
+  }
+
+  /// Moves to the artefact step.
+  ///
+  /// Guarded on the same `isReady` the button is disabled by, so a stray
+  /// programmatic call cannot land on a QR of the bare address.
+  void _showRequestResult() {
+    final draft = _requestDraft;
+    if (draft == null) return;
+    final result = draft.resolve(
+      zecUsdUnitPrice: ref.read(zecLiveUsdUnitPriceProvider),
+    );
+    if (!result.isReady) return;
+    setState(() {
+      _requestResult = result;
+      _requestStep = RequestModalStep.result;
+    });
+  }
+
+  /// Returns to the form with the composed amount and message intact. The
+  /// form is live again from here: the next Next takes a fresh snapshot.
+  void _editRequestAgain() {
+    if (_requestStep == RequestModalStep.compose) return;
+    setState(() {
+      _requestResult = null;
+      _requestStep = RequestModalStep.compose;
+      _requestResult = null;
+    });
+  }
+
+  void _handleRequestAmountChanged(String value) {
+    final draft = _requestDraft;
+    if (draft == null) return;
+    // Through the draft's own setter, not `copyWith`: in USD mode it also
+    // records the ZEC the dollars currently mean, so a price that expires
+    // before the user switches back does not take the amount with it.
+    setState(
+      () => _requestDraft = draft.withInput(
+        value,
+        zecUsdUnitPrice: ref.read(zecLiveUsdUnitPriceProvider),
+      ),
+    );
+  }
+
+  void _handleRequestMessageChanged(String value) {
+    final draft = _requestDraft;
+    if (draft == null) return;
+    final next = draft.copyWith(message: value);
+    // The draft drops the characters a ZIP-321 memo cannot carry. The field
+    // keeps whatever was typed unless it is told, so write the result back:
+    // the field, the byte counter and the link have to be the same string.
+    final stripped = next.message ?? '';
+    if (stripped != value) {
+      final offset = _requestMessageController.selection.baseOffset;
+      _requestMessageController.value = TextEditingValue(
+        text: stripped,
+        selection: TextSelection.collapsed(
+          offset: offset < 0 || offset > stripped.length
+              ? stripped.length
+              : offset,
+        ),
+      );
+    }
+    setState(() => _requestDraft = next);
+  }
+
+  void _toggleRequestAmountUnit() {
+    final draft = _requestDraft;
+    if (draft == null) return;
+    final next = draft.toggledUnit(
+      zecUsdUnitPrice: ref.read(zecLiveUsdUnitPriceProvider),
+    );
+    if (next.inputIsUsd == draft.inputIsUsd) return;
+    _requestAmountController.value = TextEditingValue(
+      text: next.input,
+      selection: TextSelection.collapsed(offset: next.input.length),
+    );
+    setState(() => _requestDraft = next);
+  }
+
+  void _expandRequestMessage() {
+    if (_requestMessageExpanded) return;
+    setState(() => _requestMessageExpanded = true);
+  }
+
+  /// Closes the memo editor, which is what its clear button says it does.
+  ///
+  /// The field's own clear already emptied the text and reported it through
+  /// [_handleRequestMessageChanged]; the draft is cleared here as well so the
+  /// collapse never leaves a message the prompt no longer shows.
+  void _closeRequestMessage() {
+    final draft = _requestDraft;
+    _requestMessageController.clear();
+    setState(() {
+      _requestMessageExpanded = false;
+      if (draft != null) {
+        _requestDraft = draft.copyWith(clearMessage: true);
+      }
+    });
+  }
+
+  Future<void> _saveRequestQrImage(Uint8List png, String amountZec) async {
+    try {
+      final saved = await saveRequestQrPng(
+        png: png,
+        amountZec: amountZec,
+        pickSaveLocation: ref.read(requestQrSaveLocationPickerProvider),
+      );
+      // Cancelling the save dialog is not an outcome worth a toast.
+      if (saved == null) return;
+      if (!mounted) return;
+      showAppToast(context, 'QR image saved to ${saved.folderName}');
+    } catch (e) {
+      log('Receive: ERROR saving request QR image: $e');
+      if (!mounted) return;
+      _reportRequestQrSaveFailed();
+    }
+  }
+
+  /// The one thing there is to say when the QR does not reach a file, whether
+  /// the encode or the write is what failed.
+  ///
+  /// The exception stays in the log: a FileSystemException with a path and an
+  /// errno pushes the one actionable sentence off the toast. Two lines need
+  /// longer than the two-second default to read.
+  void _reportRequestQrSaveFailed() {
+    showAppToast(
+      context,
+      "We couldn't save the QR image. Try another folder, or copy the "
+      'request link instead.',
+      iconName: AppIcons.cancel,
+      tone: AppToastTone.destructive,
+      duration: const Duration(seconds: 4),
+    );
+  }
+
   void _showAddressInfo(ReceiveAddressType type) {
     setState(() => _infoDialogType = type);
   }
@@ -291,6 +482,13 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
     ref.listen(accountProvider, (previous, next) {
       final nextUuid = next.value?.activeAccountUuid;
       if (nextUuid != null && nextUuid != _activeAccountUuid) {
+        // The request modal covers only the trailing pane, so the sidebar's
+        // account selector stays reachable behind it. A draft snapshotted
+        // for the previous account would keep handing out that account's
+        // address — on the QR, the copied link, the saved image — under the
+        // new account's name. Close it rather than repoint it: the user
+        // opened it for the account they were looking at.
+        _closeRequest();
         unawaited(_loadAddresses());
       }
     });
@@ -314,6 +512,14 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
         : _isLoadingTransparent;
     final selectedErrorText = isShielded ? _errorText : _transparentErrorText;
     final infoDialogType = _infoDialogType;
+    final zecUsdUnitPrice = ref.watch(zecLiveUsdUnitPriceProvider);
+    final requestDraft = _requestDraft;
+    final requestView = requestDraft?.resolve(zecUsdUnitPrice: zecUsdUnitPrice);
+    // What the result step shows, copies and saves is the confirmed snapshot;
+    // the compose step is the live draft.
+    final shownRequest = _requestStep == RequestModalStep.result
+        ? (_requestResult ?? requestView)
+        : requestView;
 
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
@@ -331,8 +537,44 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
               onTypeChanged: _selectAddressType,
               onRenewShielded: isShielded ? _renewShieldedAddress : null,
               onCopy: _copySelectedAddress,
+              onRequest: _openRequest,
               onShowHelp: () => _showAddressInfo(_selectedType),
             ),
+            if (requestDraft != null && requestView != null)
+              RequestAmountSurface(
+                key: const ValueKey('receive_request_modal'),
+                // The receive pane stays visible under the scrim: the request
+                // is composed on top of the address it pays to, not on a
+                // screen that replaced it.
+                background: const SizedBox.expand(),
+                request: shownRequest!,
+                step: _requestStep,
+                messageExpanded: _requestMessageExpanded,
+                amountController: _requestAmountController,
+                messageController: _requestMessageController,
+                onClose: _closeRequest,
+                onNext: _showRequestResult,
+                onBack: _editRequestAgain,
+                onAmountChanged: _handleRequestAmountChanged,
+                onMessageChanged: _handleRequestMessageChanged,
+                onCloseMessage: _closeRequestMessage,
+                onToggleAmountUnit: requestDraft.canToggleUnit(zecUsdUnitPrice)
+                    ? _toggleRequestAmountUnit
+                    : null,
+                onAddMessage: _expandRequestMessage,
+                onCopyLink: () {
+                  final uri = shownRequest.requestUri;
+                  if (uri == null) return;
+                  copyTextWithToast(
+                    context,
+                    text: uri,
+                    toastMessage: kRequestLinkCopiedToast,
+                  );
+                },
+                onSaveQrImage: (png) =>
+                    unawaited(_saveRequestQrImage(png, shownRequest.amountZec)),
+                onSaveQrImageError: _reportRequestQrSaveFailed,
+              ),
             if (infoDialogType != null)
               AppPaneModalOverlay(
                 onDismiss: _dismissAddressInfo,
@@ -358,6 +600,7 @@ class _ReceivePane extends StatelessWidget {
     required this.onTypeChanged,
     required this.onRenewShielded,
     required this.onCopy,
+    required this.onRequest,
     required this.onShowHelp,
   });
 
@@ -369,6 +612,7 @@ class _ReceivePane extends StatelessWidget {
   final ValueChanged<ReceiveAddressType> onTypeChanged;
   final VoidCallback? onRenewShielded;
   final VoidCallback onCopy;
+  final VoidCallback onRequest;
   final VoidCallback onShowHelp;
 
   @override
@@ -392,6 +636,7 @@ class _ReceivePane extends StatelessWidget {
             onTypeChanged: onTypeChanged,
             onRenewShielded: onRenewShielded,
             onCopy: onCopy,
+            onRequest: onRequest,
             onShowHelp: onShowHelp,
           ),
         ),
@@ -410,12 +655,24 @@ class _ReceiveContentLayout extends StatelessWidget {
     required this.onTypeChanged,
     required this.onRenewShielded,
     required this.onCopy,
+    required this.onRequest,
     required this.onShowHelp,
   });
 
   static const _contentWidth = 420.0;
+
+  /// One action row: the copy pill and, beside it, the compact request
+  /// button — the home card's "Pay" shape — so the fixed-coordinate content
+  /// keeps the single-button screen's height instead of growing a second row.
   static const _contentHeight = 656.0;
   static const _contentHeightWithError = 724.0;
+  static const _actionsTop = 596.0;
+  static const _actionButtonWidth = 230.0;
+  static const _actionButtonHeight = 44.0;
+  static const _requestButtonWidth = 60.0;
+  static const _actionsWidth =
+      _actionButtonWidth + AppSpacing.xs + _requestButtonWidth;
+  static const _actionsLeft = (_contentWidth - _actionsWidth) / 2;
 
   final ReceiveAddressType selectedType;
   final String address;
@@ -425,6 +682,7 @@ class _ReceiveContentLayout extends StatelessWidget {
   final ValueChanged<ReceiveAddressType> onTypeChanged;
   final VoidCallback? onRenewShielded;
   final VoidCallback onCopy;
+  final VoidCallback onRequest;
   final VoidCallback onShowHelp;
 
   bool get _isShielded => selectedType == ReceiveAddressType.shielded;
@@ -506,28 +764,60 @@ class _ReceiveContentLayout extends StatelessWidget {
                       ),
                     ),
                     Positioned(
-                      left: 95,
-                      top: 596,
-                      width: 230,
-                      height: 44,
-                      child: ReceiveCopyAddressButton(
-                        key: ValueKey(
-                          _isShielded
-                              ? 'receive_copy_shielded_address_button'
-                              : 'receive_copy_transparent_address_button',
-                        ),
-                        label: _isShielded
-                            ? 'Copy shielded address'
-                            : 'Copy transparent address',
-                        type: selectedType,
-                        enabled: address.isNotEmpty && !isLoading,
-                        onTap: onCopy,
+                      left: _actionsLeft,
+                      top: _actionsTop,
+                      width: _actionsWidth,
+                      height: _actionButtonHeight,
+                      child: Row(
+                        children: [
+                          SizedBox(
+                            width: _actionButtonWidth,
+                            height: _actionButtonHeight,
+                            child: ReceiveCopyAddressButton(
+                              key: ValueKey(
+                                _isShielded
+                                    ? 'receive_copy_shielded_address_button'
+                                    : 'receive_copy_transparent_address_button',
+                              ),
+                              label: _isShielded
+                                  ? 'Copy shielded address'
+                                  : 'Copy transparent address',
+                              type: selectedType,
+                              enabled: address.isNotEmpty && !isLoading,
+                              onTap: onCopy,
+                            ),
+                          ),
+                          const SizedBox(width: AppSpacing.xs),
+                          // Icon only, like the home card's "Pay" button: the
+                          // request is the secondary way to hand out this
+                          // address, and a second labelled pill under the
+                          // copy button pushed the screen past its frame.
+                          AppTooltip(
+                            message: 'Request $kZcashDefaultCurrencyTicker',
+                            child: Semantics(
+                              button: true,
+                              label: 'Request $kZcashDefaultCurrencyTicker',
+                              excludeSemantics: true,
+                              child: AppButton(
+                                key: const ValueKey('receive_request_button'),
+                                variant: AppButtonVariant.secondary,
+                                height: _actionButtonHeight,
+                                minWidth: _requestButtonWidth,
+                                contentPadding: EdgeInsets.zero,
+                                onPressed: address.isNotEmpty && !isLoading
+                                    ? onRequest
+                                    : null,
+                                child: const AppIcon(AppIcons.qr, size: 20),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                     if (errorText != null)
                       Positioned(
                         left: 12,
-                        top: 656,
+                        top: _contentHeight,
                         width: 396,
                         child: Text(
                           errorText!,

--- a/lib/src/features/receive/services/request_qr_export.dart
+++ b/lib/src/features/receive/services/request_qr_export.dart
@@ -1,0 +1,116 @@
+/// Where a request QR goes once it has been rendered: a file the user picks
+/// on desktop, a share sheet on mobile.
+///
+/// Both sides are injected rather than called directly so a widget test can
+/// answer with a temporary path and record a share instead of talking to the
+/// operating system.
+library;
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../../core/storage/png_save_location.dart';
+
+/// Base name of an exported request QR, before the amount and the extension.
+const _requestQrFileStem = 'vizor-request';
+
+/// File name the mobile share attaches. Mobile shares one request at a time
+/// into another app's inbox, so it does not carry the amount the desktop
+/// file name uses to keep several saved requests apart.
+const kRequestQrShareFileName = '$_requestQrFileStem.png';
+
+/// Asks the user where a saved request QR should go. Returns the chosen
+/// absolute path, or null when the dialog was cancelled.
+typedef RequestQrSaveLocationPicker =
+    Future<String?> Function({required String suggestedName});
+
+/// Hands [png] to the platform share sheet alongside [text].
+typedef RequestShareHandler =
+    Future<void> Function({
+      required String text,
+      required Uint8List png,
+      required String fileName,
+    });
+
+/// The platform's own save panel, shared with the Gift Card QR export.
+Future<String?> defaultRequestQrSaveLocation({required String suggestedName}) =>
+    pickPngSaveLocation(suggestedName: suggestedName);
+
+Future<void> defaultRequestShare({
+  required String text,
+  required Uint8List png,
+  required String fileName,
+}) async {
+  await SharePlus.instance.share(
+    ShareParams(
+      text: text,
+      files: [XFile.fromData(png, mimeType: 'image/png')],
+      fileNameOverrides: [fileName],
+    ),
+  );
+}
+
+final requestQrSaveLocationPickerProvider =
+    Provider<RequestQrSaveLocationPicker>(
+      (ref) => defaultRequestQrSaveLocation,
+    );
+
+final requestShareHandlerProvider = Provider<RequestShareHandler>(
+  (ref) => defaultRequestShare,
+);
+
+/// A request QR that reached disk.
+class SavedRequestQr {
+  const SavedRequestQr({required this.path, required this.folderName});
+
+  /// Absolute path of the written PNG.
+  final String path;
+
+  /// Name of the folder the user picked, for the confirmation toast.
+  final String folderName;
+}
+
+/// Asks [pickSaveLocation] where the QR should go and writes [png] there.
+///
+/// Returns null when the user cancelled the dialog. An existing file at the
+/// chosen path is replaced: the save panel already asked the user about that.
+Future<SavedRequestQr?> saveRequestQrPng({
+  required Uint8List png,
+  required String amountZec,
+  required RequestQrSaveLocationPicker pickSaveLocation,
+}) async {
+  final path = await pickSaveLocation(
+    suggestedName: requestQrFileName(amountZec),
+  );
+  if (path == null) return null;
+
+  final file = File(path);
+  await file.parent.create(recursive: true);
+  await file.writeAsBytes(png, flush: true);
+  return SavedRequestQr(
+    path: file.path,
+    folderName: _folderNameOf(file.parent.path),
+  );
+}
+
+/// `vizor-request-0.5.png`, or `vizor-request.png` when there is no amount.
+///
+/// Anything outside digits and a decimal point is dropped rather than escaped:
+/// the amount is only in the name so a person can tell two saved requests
+/// apart, and it is not worth a file name a shell has to quote.
+String requestQrFileName(String amountZec) {
+  final sanitized = amountZec.trim().replaceAll(RegExp(r'[^0-9.]'), '');
+  if (sanitized.isEmpty) return '$_requestQrFileStem.png';
+  return '$_requestQrFileStem-$sanitized.png';
+}
+
+String _folderNameOf(String directoryPath) {
+  final segments = directoryPath
+      .split(RegExp(r'[/\\]'))
+      .where((segment) => segment.isNotEmpty)
+      .toList();
+  return segments.isEmpty ? directoryPath : segments.last;
+}

--- a/lib/src/features/receive/services/zec_request_draft.dart
+++ b/lib/src/features/receive/services/zec_request_draft.dart
@@ -1,0 +1,282 @@
+/// The editable half of the "Request ZEC" flow.
+///
+/// [ZecRequestView] is what the widgets draw; this is what the screen holds
+/// while the user is still typing. Keeping the two apart is what lets the
+/// desktop modal and the mobile sheet share one set of rules — which unit the
+/// field is collecting, what the other-unit line says, and when an amount is
+/// wrong — without either screen re-deriving them.
+///
+/// Pure: no providers, no widgets. The live ZEC/USD price is passed in, so a
+/// missing price is an argument rather than a hidden dependency.
+library;
+
+import 'package:flutter/foundation.dart';
+
+import '../../../core/config/network_config.dart'
+    show kZcashDefaultCurrencyTicker;
+import '../../../core/formatting/zec_amount.dart';
+import '../../../core/zcash/zip321_payment_request_builder.dart';
+import '../../../core/zcash/zip321_payment_request.dart'
+    show stripUnsupportedZip321MemoText;
+import '../../send/services/send_amount_conversion.dart';
+import '../widgets/request/request_amount_model.dart';
+
+/// True when [zecUsdUnitPrice] can actually convert an amount.
+bool zecRequestPriceIsUsable(double? zecUsdUnitPrice) =>
+    zecUsdUnitPrice != null && zecUsdUnitPrice.isFinite && zecUsdUnitPrice > 0;
+
+@immutable
+class ZecRequestDraft {
+  const ZecRequestDraft({
+    required this.address,
+    this.input = '',
+    this.inputIsUsd = false,
+    this.message,
+    this.usdModeZecInput = '',
+    this.usdInputIsDerived = false,
+  });
+
+  /// The address the request pays to, snapshotted when the flow opened: a
+  /// shielded address the user renews mid-flow must not silently repoint a
+  /// link they are about to hand out.
+  final String address;
+
+  /// Raw field text, in whichever unit [inputIsUsd] says.
+  final String input;
+
+  /// True while the field is collecting USD.
+  final bool inputIsUsd;
+
+  /// The optional encrypted memo, shielded addresses only.
+  final String? message;
+
+  /// The canonical ZEC text behind a USD-mode field.
+  ///
+  /// In ZEC mode the field itself is canonical and this is ignored; in USD
+  /// mode it is the last ZEC value the typed dollars converted to. It exists
+  /// so leaving USD mode does not need a price: the live price can expire
+  /// while the composer is open, and a unit switch that answers that by
+  /// erasing the number the user typed is worse than the stale unit was.
+  /// The desktop send composer keeps `_amountText` alive across the same
+  /// switch for the same reason.
+  final String usdModeZecInput;
+
+  /// True while the USD field shows a number the draft wrote there itself —
+  /// the ZEC amount converted on a unit switch — rather than one the user
+  /// typed.
+  ///
+  /// The distinction decides what the request means. Dollars the user typed
+  /// are the amount, and the ZEC they buy floats with the live price until
+  /// the request is created. Dollars the switch derived are only a rendering
+  /// of the ZEC the user typed, rounded to a cent, so the request keeps that
+  /// ZEC exactly rather than converting the rounding back. The first
+  /// keystroke on the USD field ends the derived state.
+  final bool usdInputIsDerived;
+
+  ZecRequestDraft copyWith({
+    String? address,
+    String? input,
+    bool? inputIsUsd,
+    String? message,
+    String? usdModeZecInput,
+    bool? usdInputIsDerived,
+    bool clearMessage = false,
+  }) {
+    return ZecRequestDraft(
+      address: address ?? this.address,
+      input: input ?? this.input,
+      inputIsUsd: inputIsUsd ?? this.inputIsUsd,
+      usdModeZecInput: usdModeZecInput ?? this.usdModeZecInput,
+      usdInputIsDerived: usdInputIsDerived ?? this.usdInputIsDerived,
+      // Invisible bidi/control characters cannot travel in a ZIP-321 memo,
+      // so they are dropped at the input boundary; the visible text is
+      // unchanged and the request the composer hands out always parses.
+      message: clearMessage
+          ? null
+          : (message == null
+                ? this.message
+                : stripUnsupportedZip321MemoText(message)),
+    );
+  }
+
+  bool get isShielded => !zip321AddressIsTransparent(address);
+
+  /// The ZEC value a switch back to ZEC mode would restore.
+  String get zecInput => inputIsUsd ? usdModeZecInput : input.trim();
+
+  /// The same draft with [value] in the field and the canonical ZEC value
+  /// kept in step with it.
+  ///
+  /// Every keystroke goes through here rather than through `copyWith` so USD
+  /// mode always carries the ZEC it last meant. A keystroke typed while the
+  /// price is missing cannot be converted, so it leaves the previous
+  /// canonical value standing — clearing the field is the one thing that
+  /// clears it too.
+  ZecRequestDraft withInput(String value, {required double? zecUsdUnitPrice}) {
+    if (!inputIsUsd) {
+      return copyWith(input: value, usdModeZecInput: '');
+    }
+    final zatoshi = sendZatoshiFromUsdText(value, zecUsdUnitPrice);
+    if (zatoshi != null) {
+      return copyWith(
+        input: value,
+        usdModeZecInput: ZecAmount.fromZatoshi(zatoshi).pretty().amountText,
+        usdInputIsDerived: false,
+      );
+    }
+    return copyWith(
+      input: value,
+      usdModeZecInput: value.trim().isEmpty ? '' : usdModeZecInput,
+      usdInputIsDerived: false,
+    );
+  }
+
+  /// Whether the unit switch can be taken. USD mode needs a live price; ZEC
+  /// mode always works, so a price that disappears never traps the field in a
+  /// unit it can no longer convert.
+  bool canToggleUnit(double? zecUsdUnitPrice) =>
+      inputIsUsd || zecRequestPriceIsUsable(zecUsdUnitPrice);
+
+  /// The same draft with the units swapped and [input] rewritten in the new
+  /// unit, so the number on screen keeps meaning what it meant.
+  ZecRequestDraft toggledUnit({required double? zecUsdUnitPrice}) {
+    if (!canToggleUnit(zecUsdUnitPrice)) return this;
+
+    if (inputIsUsd) {
+      // Dollars the switch itself wrote are a rounding of the ZEC the user
+      // typed (0.5 ZEC at $35.123 shows as $17.56, which converts back to
+      // 0.49995729), so the switch back restores that ZEC rather than the
+      // rounding. Dollars the user typed convert at the live price; without
+      // one, the switch restores the ZEC the draft has been carrying rather
+      // than emptying the field.
+      final converted = _convertedZec(zecUsdUnitPrice);
+      final next = usdInputIsDerived || converted.isEmpty
+          ? usdModeZecInput
+          : converted;
+      return copyWith(
+        inputIsUsd: false,
+        input: next,
+        usdModeZecInput: '',
+        usdInputIsDerived: false,
+      );
+    }
+
+    final zatoshi = parseZecAmount(input.trim());
+    final hasAmount = zatoshi != null && zatoshi > BigInt.zero;
+    return copyWith(
+      inputIsUsd: true,
+      input: hasAmount
+          ? sendSendableUsdInputTextForZatoshi(zatoshi, zecUsdUnitPrice!)
+          : '',
+      usdModeZecInput: input.trim(),
+      // Only dollars that actually came from an amount are derived; an empty
+      // or half-typed ZEC field switches to an empty USD field that means
+      // nothing yet.
+      usdInputIsDerived: hasAmount,
+    );
+  }
+
+  /// The canonical ZEC amount this draft encodes, empty when there is not one
+  /// yet. In ZEC mode it is what was typed. In USD mode it is what the
+  /// dollars in the field mean: typed dollars convert at [zecUsdUnitPrice],
+  /// dollars a unit switch derived stand for the ZEC that was typed before
+  /// it ([usdModeZecInput]), so that merely switching units never changes
+  /// the request — the field shows a cent rounding, and converting *that*
+  /// back would encode a payment a few zatoshi away from the typed one.
+  ///
+  /// Derived dollars need no price to answer: the ZEC behind them is already
+  /// known, so a price that expires while they are on screen does not take
+  /// "Create request" away from an amount the user finished typing.
+  String amountZec({required double? zecUsdUnitPrice}) {
+    if (!inputIsUsd) return input.trim();
+    if (usdInputIsDerived) return usdModeZecInput;
+    return _convertedZec(zecUsdUnitPrice);
+  }
+
+  /// [input] converted from dollars at [zecUsdUnitPrice], empty when it does
+  /// not convert.
+  String _convertedZec(double? zecUsdUnitPrice) {
+    final zatoshi = sendZatoshiFromUsdText(input, zecUsdUnitPrice);
+    if (zatoshi == null) return '';
+    return ZecAmount.fromZatoshi(zatoshi).pretty().amountText;
+  }
+
+  /// Everything the request widgets draw for this draft.
+  ZecRequestView resolve({required double? zecUsdUnitPrice}) {
+    final amount = amountZec(zecUsdUnitPrice: zecUsdUnitPrice);
+    return ZecRequestView(
+      address: address,
+      amountZec: amount,
+      amountDisplayText: input,
+      amountInputIsUsd: inputIsUsd,
+      conversionText: _conversionText(
+        amountZec: amount,
+        zecUsdUnitPrice: zecUsdUnitPrice,
+      ),
+      messageText: message,
+      amountError: _amountError(amount),
+    );
+  }
+
+  /// The other-unit line under the field.
+  ///
+  /// Null means "not known yet" — in ZEC mode with an amount typed and no
+  /// live price, the widget shows its price-unavailable placeholder rather
+  /// than a converted number nobody can vouch for.
+  String? _conversionText({
+    required String amountZec,
+    required double? zecUsdUnitPrice,
+  }) {
+    if (inputIsUsd) {
+      final zecText = amountZec.isEmpty ? '0' : amountZec;
+      return '$zecText $kZcashDefaultCurrencyTicker';
+    }
+
+    final zatoshi = parseZecAmount(amountZec);
+    if (zatoshi == null || zatoshi <= BigInt.zero) return r'$ 0';
+    if (!zecRequestPriceIsUsable(zecUsdUnitPrice)) return null;
+    return r'$ ' + sendUsdDisplayTextForZatoshi(zatoshi, zecUsdUnitPrice!);
+  }
+
+  /// Inline amount error, or null.
+  ///
+  /// A half-typed number ("0.", "0", "") is not an error, it is an amount
+  /// that is not finished, and the flow already refuses to build a URI from
+  /// it. Anything else the builder refuses is said out loud: without that, an
+  /// amount the conversion line happily prices leaves "Create request"
+  /// disabled with nothing on screen accounting for it.
+  String? _amountError(String amountZec) {
+    final raw = amountZec.trim();
+    if (raw.isEmpty) return null;
+    try {
+      normalizeZip321Amount(raw);
+      return null;
+    } on Zip321BuildException catch (e) {
+      return switch (e.kind) {
+        Zip321BuildErrorKind.amountDecimals => kRequestAmountDecimalsError,
+        Zip321BuildErrorKind.amountSupply => kRequestAmountSupplyError,
+        // `amountFormat` covers two unrelated rejections: a number still
+        // being typed, and text that is not a number. Only the second is
+        // something the user can be asked to correct.
+        Zip321BuildErrorKind.amountFormat =>
+          _amountIsUnfinished(raw) ? null : kRequestAmountFormatError,
+        _ => null,
+      };
+    }
+  }
+}
+
+/// The grammar `normalizeZip321Amount` accepts, so text that matches it can
+/// only have been refused for being zero.
+final _plainDecimal = RegExp(r'^[0-9]+(?:\.[0-9]*)?$');
+
+/// True while [amount] is a number the builder refuses only because it is not
+/// a positive one *yet*: "0", "0.", "0.00", and the lone separator a field
+/// passes through on the way to "0.5".
+///
+/// `.5` is deliberately not on this list. It is a finished number the field's
+/// formatters would have completed to `0.5`, so reaching the draft in that
+/// shape means something bypassed them — and the builder's refusal of it is
+/// exactly what the user needs told.
+bool _amountIsUnfinished(String amount) =>
+    amount.isEmpty || amount == '.' || _plainDecimal.hasMatch(amount);

--- a/lib/src/features/receive/services/zec_request_draft.dart
+++ b/lib/src/features/receive/services/zec_request_draft.dart
@@ -134,8 +134,20 @@ class ZecRequestDraft {
   /// Whether the unit switch can be taken. USD mode needs a live price; ZEC
   /// mode always works, so a price that disappears never traps the field in a
   /// unit it can no longer convert.
-  bool canToggleUnit(double? zecUsdUnitPrice) =>
-      inputIsUsd || zecRequestPriceIsUsable(zecUsdUnitPrice);
+  ///
+  /// A ZEC amount that rounds to \$0.00 at the live price has no dollar form
+  /// the field can show, and a switch would leave an empty-looking field over
+  /// a request that still encodes the amount — so such an amount stays in ZEC.
+  bool canToggleUnit(double? zecUsdUnitPrice) {
+    if (inputIsUsd) return true;
+    if (!zecRequestPriceIsUsable(zecUsdUnitPrice)) return false;
+    final zatoshi = parseZecAmount(input.trim());
+    if (zatoshi == null || zatoshi <= BigInt.zero) return true;
+    return sendSendableUsdInputTextForZatoshi(
+      zatoshi,
+      zecUsdUnitPrice!,
+    ).isNotEmpty;
+  }
 
   /// The same draft with the units swapped and [input] rewritten in the new
   /// unit, so the number on screen keeps meaning what it meant.

--- a/lib/src/features/receive/widgets/receive_desktop_preview.dart
+++ b/lib/src/features/receive/widgets/receive_desktop_preview.dart
@@ -14,6 +14,12 @@ enum ReceiveDesktopPreviewState {
   transparent,
   shieldedModal,
   transparentModal,
+
+  /// Shielded receive with the "Request ZEC" entry beside the copy button,
+  /// which is where the live pane puts it. The plain [shielded] state keeps
+  /// the single-CTA row the pane had before the request flow landed, so the
+  /// two can still be compared.
+  shieldedRequestEntry,
 }
 
 class ReceiveDesktopPreview extends StatelessWidget {
@@ -25,7 +31,11 @@ class ReceiveDesktopPreview extends StatelessWidget {
 
   bool get _isShielded =>
       state == ReceiveDesktopPreviewState.shielded ||
-      state == ReceiveDesktopPreviewState.shieldedModal;
+      state == ReceiveDesktopPreviewState.shieldedModal ||
+      state == ReceiveDesktopPreviewState.shieldedRequestEntry;
+
+  bool get _showsRequestEntry =>
+      state == ReceiveDesktopPreviewState.shieldedRequestEntry;
 
   bool get _showsModal =>
       state == ReceiveDesktopPreviewState.shieldedModal ||
@@ -41,6 +51,7 @@ class ReceiveDesktopPreview extends StatelessWidget {
         isDark: isDark,
         isShielded: _isShielded,
         showsModal: _showsModal,
+        showsRequestEntry: _showsRequestEntry,
       ),
     );
   }
@@ -51,11 +62,13 @@ class _ReceiveWindow extends StatelessWidget {
     required this.isDark,
     required this.isShielded,
     required this.showsModal,
+    this.showsRequestEntry = false,
   });
 
   final bool isDark;
   final bool isShielded;
   final bool showsModal;
+  final bool showsRequestEntry;
 
   @override
   Widget build(BuildContext context) {
@@ -94,6 +107,7 @@ class _ReceiveWindow extends StatelessWidget {
                         child: _ReceiveTrailingPane(
                           isShielded: isShielded,
                           showsModal: showsModal,
+                          showsRequestEntry: showsRequestEntry,
                         ),
                       ),
                     ],
@@ -326,17 +340,24 @@ class _ReceiveTrailingPane extends StatelessWidget {
   const _ReceiveTrailingPane({
     required this.isShielded,
     required this.showsModal,
+    this.showsRequestEntry = false,
   });
 
   final bool isShielded;
   final bool showsModal;
+  final bool showsRequestEntry;
 
   @override
   Widget build(BuildContext context) {
     return Stack(
       clipBehavior: Clip.antiAlias,
       children: [
-        Positioned.fill(child: _ReceivePaneContent(isShielded: isShielded)),
+        Positioned.fill(
+          child: _ReceivePaneContent(
+            isShielded: isShielded,
+            showsRequestEntry: showsRequestEntry,
+          ),
+        ),
         if (showsModal)
           Positioned.fill(child: _ReceiveInfoOverlay(isShielded: isShielded)),
       ],
@@ -345,9 +366,13 @@ class _ReceiveTrailingPane extends StatelessWidget {
 }
 
 class _ReceivePaneContent extends StatelessWidget {
-  const _ReceivePaneContent({required this.isShielded});
+  const _ReceivePaneContent({
+    required this.isShielded,
+    this.showsRequestEntry = false,
+  });
 
   final bool isShielded;
+  final bool showsRequestEntry;
 
   @override
   Widget build(BuildContext context) {
@@ -371,7 +396,10 @@ class _ReceivePaneContent extends StatelessWidget {
           top: 48,
           width: 420,
           height: 656,
-          child: _ReceiveContentArea(isShielded: isShielded),
+          child: _ReceiveContentArea(
+            isShielded: isShielded,
+            showsRequestEntry: showsRequestEntry,
+          ),
         ),
       ],
     );
@@ -379,9 +407,13 @@ class _ReceivePaneContent extends StatelessWidget {
 }
 
 class _ReceiveContentArea extends StatelessWidget {
-  const _ReceiveContentArea({required this.isShielded});
+  const _ReceiveContentArea({
+    required this.isShielded,
+    this.showsRequestEntry = false,
+  });
 
   final bool isShielded;
+  final bool showsRequestEntry;
 
   @override
   Widget build(BuildContext context) {
@@ -418,13 +450,35 @@ class _ReceiveContentArea extends StatelessWidget {
             ],
           ),
         ),
-        Positioned(
-          left: 95,
-          top: 596,
-          width: 230,
-          height: 44,
-          child: _CopyAddressButton(isShielded: isShielded),
-        ),
+        if (showsRequestEntry)
+          // The request entry shares the copy pill's row as a compact icon
+          // button — the home card's "Pay" shape — so the pane keeps the
+          // single-button height.
+          Positioned(
+            left: (420 - (230 + AppSpacing.xs + 60)) / 2,
+            top: 596,
+            width: 230 + AppSpacing.xs + 60,
+            height: 44,
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 230,
+                  height: 44,
+                  child: _CopyAddressButton(isShielded: isShielded),
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                const SizedBox(width: 60, height: 44, child: _RequestButton()),
+              ],
+            ),
+          )
+        else
+          Positioned(
+            left: 95,
+            top: 596,
+            width: 230,
+            height: 44,
+            child: _CopyAddressButton(isShielded: isShielded),
+          ),
       ],
     );
   }
@@ -858,6 +912,27 @@ class _CopyAddressButton extends StatelessWidget {
   }
 }
 
+/// The request entry: a compact secondary pill beside the copy action.
+///
+/// Secondary rather than primary because copying the address is still what
+/// most visits to this screen are for; icon only because a second labelled
+/// pill under the copy button pushed the pane past its frame.
+class _RequestButton extends StatelessWidget {
+  const _RequestButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return const _FixedPillButton(
+      width: 60,
+      height: 44,
+      label: '',
+      iconName: AppIcons.qr,
+      iconSize: 20,
+      variant: _FixedPillButtonVariant.secondary,
+    );
+  }
+}
+
 enum _FixedPillButtonVariant { primary, secondary, ghost }
 
 class _FixedPillButton extends StatelessWidget {
@@ -866,13 +941,17 @@ class _FixedPillButton extends StatelessWidget {
     required this.height,
     required this.label,
     this.iconName,
+    this.iconSize = 20,
     this.variant = _FixedPillButtonVariant.primary,
   });
 
   final double width;
   final double height;
+
+  /// Empty for an icon-only pill.
   final String label;
   final String? iconName;
+  final double iconSize;
   final _FixedPillButtonVariant variant;
 
   @override
@@ -919,24 +998,27 @@ class _FixedPillButton extends StatelessWidget {
           width: width,
           height: height,
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+            padding: label.isEmpty
+                ? EdgeInsets.zero
+                : const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                if (iconName != null) ...[
-                  AppIcon(iconName!, size: 20, color: labelColor),
+                if (iconName != null)
+                  AppIcon(iconName!, size: iconSize, color: labelColor),
+                if (iconName != null && label.isNotEmpty)
                   const SizedBox(width: AppSpacing.xs),
-                ],
-                Flexible(
-                  child: Text(
-                    label,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: AppTypography.labelMedium.copyWith(
-                      color: labelColor,
+                if (label.isNotEmpty)
+                  Flexible(
+                    child: Text(
+                      label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.labelMedium.copyWith(
+                        color: labelColor,
+                      ),
                     ),
                   ),
-                ),
               ],
             ),
           ),

--- a/lib/src/features/receive/widgets/request/request_amount_card.dart
+++ b/lib/src/features/receive/widgets/request/request_amount_card.dart
@@ -1,0 +1,771 @@
+/// Desktop "Request ZEC" modal, in two steps.
+///
+/// Step one composes the request (amount, optional message); step two is the
+/// artefact it produces (QR, summary, and the two ways of handing it over).
+/// They are separate steps for the same reason the mobile sheet splits them,
+/// plus one the desktop window makes sharper: a single card carrying the form
+/// *and* a scannable QR is taller than the app's minimum window, so it either
+/// overflows or turns the modal into a scrolling page.
+///
+/// Presentation only: every value is a prop, every action is a callback, and
+/// nothing here reads a provider or builds a transaction. The QR on step two
+/// is the one thing that computes — it re-encodes whatever [ZecRequestView]
+/// describes, so the code on screen always matches the link the buttons copy.
+library;
+
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_button.dart';
+import '../../../../core/widgets/amount_price_loading_bar.dart';
+import '../../../../core/widgets/app_icon.dart';
+import '../../../../core/widgets/app_icon_hover_button.dart';
+import '../../../../core/widgets/app_modal_card.dart';
+import '../../../../core/widgets/app_pane_modal_overlay.dart';
+import '../../../../core/widgets/app_text_field.dart';
+import '../../../../core/zcash/zip321_payment_request_builder.dart';
+import 'request_amount_formatters.dart';
+import 'request_amount_model.dart';
+import 'request_qr_surface.dart';
+
+/// Width of the request modal.
+///
+/// The same 396 the payment request card uses: a request and the request it
+/// produces are two halves of one conversation, and they should not arrive in
+/// differently sized frames.
+const double kRequestModalCardWidth = 396;
+
+/// Narrowest the result step goes.
+///
+/// The result is a QR with two actions under it. At the compose width the
+/// buttons stretched far past the code and the frame read as empty, so the
+/// step takes the narrowest frame the header (back, title, close) and the
+/// action labels fit in, and the code fills that frame edge to edge.
+const double kRequestModalResultCardWidth = 288;
+
+/// Side of the QR code itself inside the desktop modal: the result frame
+/// minus the modal card's horizontal inset and the code's own white margin,
+/// so the surface spans the full content width.
+const double kRequestModalQrSize =
+    kRequestModalResultCardWidth - AppSpacing.sm * 2 - AppSpacing.sm * 2;
+
+/// What the frame adds around the code's own side: the modal card's
+/// horizontal inset plus the surface's white margin.
+const double _kRequestResultCardInsets = AppSpacing.sm * 4;
+
+/// Width the result step needs to draw [qrData] legibly, never under
+/// [kRequestModalResultCardWidth] and never over [maxWidth].
+///
+/// A bare address and a short amount fit the fixed frame with room to spare;
+/// a 512-byte message pushes the symbol to version 24 and 113 modules, which
+/// at the two-pixel floor needs more width than that frame has.
+/// [RequestQrSurface] can only grow into the width it is given, so a fixed
+/// frame answers a dense symbol by squeezing its modules under the floor —
+/// which in debug is `pretty_qr_code`'s own assertion and in release is a
+/// code a stranger's camera has to work for. The frame grows for the codes
+/// that need it and stays put for the ones that do not.
+double requestModalResultCardWidth(
+  String qrData, {
+  double maxWidth = double.infinity,
+}) {
+  final needed = requestQrSideFor(qrData) + _kRequestResultCardInsets;
+  return math.min(
+    math.max(kRequestModalResultCardWidth, needed),
+    math.max(kRequestModalResultCardWidth, maxWidth),
+  );
+}
+
+/// Step one: what you are asking for.
+///
+/// Reading order top to bottom is the order the request is assembled: what you
+/// are asking for, what you want to say about it, and then the one action that
+/// turns those into a request. Nothing on this step is the request yet, so
+/// nothing here shows a QR.
+class RequestAmountCard extends StatelessWidget {
+  const RequestAmountCard({
+    required this.request,
+    this.onClose,
+    this.onNext,
+    this.onAddMessage,
+    this.onToggleAmountUnit,
+    this.onAmountChanged,
+    this.onMessageChanged,
+    this.onCloseMessage,
+    this.amountController,
+    this.messageController,
+    this.messageExpanded = false,
+    this.amountFocused = false,
+    super.key,
+  });
+
+  final ZecRequestView request;
+  final VoidCallback? onClose;
+
+  /// Advances to [RequestResultCard]. Disabled until the amount is usable.
+  final VoidCallback? onNext;
+  final VoidCallback? onAddMessage;
+  final VoidCallback? onToggleAmountUnit;
+  final ValueChanged<String>? onAmountChanged;
+  final ValueChanged<String>? onMessageChanged;
+
+  /// Collapses the memo editor back to [RequestAddMessageCard].
+  final VoidCallback? onCloseMessage;
+
+  /// Owns the amount text when the caller needs to rewrite it — switching
+  /// units replaces the number in place, which a field holding its own
+  /// initial value cannot do.
+  final TextEditingController? amountController;
+
+  /// Owns the message text, for the same reason.
+  final TextEditingController? messageController;
+
+  /// Renders the memo editor instead of the collapsed prompt.
+  final bool messageExpanded;
+
+  /// Autofocuses the amount field so a static preview shows the focus ring.
+  final bool amountFocused;
+
+  bool get _showsMessage => request.isShielded;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        RequestModalHeader(onClose: onClose),
+        const SizedBox(height: AppSpacing.sm),
+        RequestAmountField(
+          request: request,
+          focused: amountFocused,
+          controller: amountController,
+          onChanged: onAmountChanged,
+          onToggleUnit: onToggleAmountUnit,
+        ),
+        if (_showsMessage) ...[
+          const SizedBox(height: AppSpacing.s),
+          if (messageExpanded)
+            RequestMessageField(
+              text: request.messageText ?? '',
+              controller: messageController,
+              onChanged: onMessageChanged,
+              onClose: onCloseMessage,
+            )
+          else
+            RequestAddMessageCard(onTap: onAddMessage),
+        ],
+        const SizedBox(height: AppSpacing.sm),
+        AppButton(
+          key: const ValueKey('request_next_button'),
+          expand: true,
+          constrainContent: true,
+          // Disabled, not hidden: the step's one action stays visible while
+          // the amount is still being typed, so nothing appears to arrive
+          // late once the number is valid.
+          onPressed: request.isReady ? (onNext ?? _noop) : null,
+          // The same label the mobile sheet uses: one commitment should not
+          // have two names, and this press is the moment the address in the
+          // link is fixed — worth naming rather than pointing at.
+          child: const Text(
+            'Create request',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+
+  static void _noop() {}
+}
+
+/// Step two: the request itself.
+///
+/// The QR, what it is asking for, and the two ways of handing it over. The
+/// back chevron returns to step one with the composed amount and message
+/// intact — this step edits nothing, it only publishes.
+class RequestResultCard extends StatelessWidget {
+  const RequestResultCard({
+    required this.request,
+    this.onBack,
+    this.onClose,
+    this.onCopyLink,
+    this.onSaveQrImage,
+    this.onSaveQrImageError,
+    super.key,
+  });
+
+  final ZecRequestView request;
+  final VoidCallback? onBack;
+  final VoidCallback? onClose;
+  final VoidCallback? onCopyLink;
+
+  /// Receives the request QR as PNG bytes. Presentation only: writing the
+  /// file is the caller's job.
+  final ValueChanged<Uint8List>? onSaveQrImage;
+
+  /// Called when the QR could not be encoded at all, so the press is
+  /// reported rather than swallowed.
+  final VoidCallback? onSaveQrImageError;
+
+  @override
+  Widget build(BuildContext context) {
+    final uri = request.requestUri;
+    final summary = request.summaryAmountText;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        RequestModalHeader(onBack: onBack, onClose: onClose),
+        const SizedBox(height: AppSpacing.sm),
+        Center(
+          child: RequestQrSurface(
+            data: request.qrData,
+            size: kRequestModalQrSize,
+            padding: AppSpacing.sm,
+          ),
+        ),
+        if (summary != null) ...[
+          const SizedBox(height: AppSpacing.s),
+          RequestSummaryRow(
+            amountText: summary,
+            isShielded: request.isShielded,
+          ),
+        ],
+        const SizedBox(height: AppSpacing.sm),
+        AppButton(
+          key: const ValueKey('request_copy_link_button'),
+          expand: true,
+          constrainContent: true,
+          leading: const AppIcon(AppIcons.copy),
+          onPressed: request.isReady ? (onCopyLink ?? _noop) : null,
+          child: const Text(
+            'Copy request link',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        // Secondary, under the link: a picture of the request is the fallback
+        // for the places a link cannot go — a printed sheet, a slide, a chat
+        // that mangles URIs.
+        RequestQrExportButton(
+          key: const ValueKey('request_save_qr_button'),
+          uri: uri,
+          label: 'Save QR image',
+          icon: AppIcons.arrowDownCircle,
+          variant: AppButtonVariant.secondary,
+          onBytes: onSaveQrImage,
+          onError: onSaveQrImageError,
+        ),
+      ],
+    );
+  }
+
+  static void _noop() {}
+}
+
+/// The title row both steps share: one title for the whole flow, the step's
+/// own back affordance on the left when there is somewhere to go back to, and
+/// the modal's ⨯ pinned right.
+class RequestModalHeader extends StatelessWidget {
+  const RequestModalHeader({this.onBack, this.onClose, super.key});
+
+  final VoidCallback? onBack;
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final onBack = this.onBack;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (onBack != null) ...[
+          AppIconHoverButton(
+            key: const ValueKey('request_modal_back'),
+            icon: AppIcons.chevronBackward,
+            semanticLabel: 'Back',
+            onTap: onBack,
+            iconColor: colors.icon.accent,
+          ),
+          const SizedBox(width: AppSpacing.xs),
+        ],
+        Expanded(
+          child: Semantics(
+            header: true,
+            child: Text(
+              kRequestFlowTitle,
+              key: const ValueKey('request_modal_title'),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.headlineMedium.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.xs),
+        AppIconHoverButton(
+          key: const ValueKey('request_modal_close'),
+          icon: AppIcons.cross,
+          semanticLabel: 'Close request',
+          onTap: onClose ?? RequestAmountCard._noop,
+          iconColor: colors.icon.regular,
+        ),
+      ],
+    );
+  }
+}
+
+/// The amount input plus the two rows beneath it, mirroring the send
+/// composer's amount block minus its Max affordance.
+///
+/// Max has no meaning in a request: the wallet is not spending, and offering
+/// to request your entire balance is not a thing anyone asks for.
+class RequestAmountField extends StatelessWidget {
+  const RequestAmountField({
+    required this.request,
+    this.focused = false,
+    this.controller,
+    this.onChanged,
+    this.onToggleUnit,
+    super.key,
+  });
+
+  final ZecRequestView request;
+  final bool focused;
+  final TextEditingController? controller;
+  final ValueChanged<String>? onChanged;
+  final VoidCallback? onToggleUnit;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final text = request.fieldText;
+    final hasText = text.isNotEmpty;
+    final error = _trimmedOrNull(request.amountError);
+    final isError = error != null;
+    final valueColor = isError
+        ? colors.text.destructive
+        : hasText
+        ? colors.text.accent
+        : colors.text.muted;
+    final affixStyle = AppTypography.labelLarge.copyWith(color: valueColor);
+    final iconColor = isError
+        ? colors.icon.destructive
+        : hasText
+        ? colors.icon.accent
+        : colors.icon.regular;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppTextField(
+          key: const ValueKey('request_amount_field'),
+          label: 'Amount',
+          labelStyle: AppTypography.labelLarge.copyWith(
+            color: colors.text.secondary,
+          ),
+          controller: controller,
+          initialValue: controller == null ? text : null,
+          hintText: '0.00',
+          autofocus: focused,
+          tone: isError
+              ? AppTextFieldTone.destructive
+              : AppTextFieldTone.neutral,
+          borderColor: isError ? colors.border.utilityDestructive : null,
+          textStyle: AppTypography.labelLarge.copyWith(
+            color: isError ? colors.text.destructive : colors.text.accent,
+          ),
+          hintStyle: AppTypography.labelLarge.copyWith(
+            color: isError ? colors.text.destructive : colors.text.muted,
+          ),
+          leading: AppIcon(
+            request.amountInputIsUsd ? AppIcons.moneyBag : AppIcons.zcash,
+            size: 20,
+            color: iconColor,
+          ),
+          inlinePrefixText: request.amountInputIsUsd ? r'$' : null,
+          inlinePrefixStyle: affixStyle,
+          inlineSuffixText: request.amountInputIsUsd ? null : 'ZEC',
+          inlineSuffixStyle: affixStyle,
+          showClearButton: true,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          // A desktop keyboard can type — and a paste can deliver — anything
+          // at all, so the field refuses what a ZIP-321 amount cannot be
+          // rather than letting the CTA go dead over it.
+          inputFormatters: requestAmountInputFormatters(
+            isUsd: request.amountInputIsUsd,
+          ),
+          onChanged: onChanged,
+        ),
+        const SizedBox(height: AppSpacing.xxs),
+        if (isError) ...[
+          RequestAmountErrorRow(text: error),
+          const SizedBox(height: AppSpacing.xxs),
+        ],
+        _RequestAmountConversionRow(
+          text: request.conversionText,
+          enterUsdMode: !request.amountInputIsUsd,
+          onTap: onToggleUnit,
+        ),
+      ],
+    );
+  }
+}
+
+/// The inline amount error: the warning glyph and the correction to make.
+///
+/// Public because the mobile sheet renders the same pair under its serif
+/// amount — the two lanes read the identical draft, so they should say the
+/// identical thing when it cannot be turned into a request.
+class RequestAmountErrorRow extends StatelessWidget {
+  const RequestAmountErrorRow({required this.text, super.key});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppIcon(AppIcons.warning, size: 16, color: colors.text.destructive),
+        const SizedBox(width: AppSpacing.xxs),
+        Flexible(
+          child: Text(
+            text,
+            key: const ValueKey('request_amount_error_text'),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.labelMedium.copyWith(
+              color: colors.text.destructive,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The unit switch, which doubles as the converted-value readout — the same
+/// control the send composer uses, so the gesture transfers.
+class _RequestAmountConversionRow extends StatelessWidget {
+  const _RequestAmountConversionRow({
+    required this.text,
+    required this.enterUsdMode,
+    required this.onTap,
+  });
+
+  final String? text;
+  final bool enterUsdMode;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final text = this.text;
+    final enabled = onTap != null;
+    return Align(
+      alignment: AlignmentDirectional.centerStart,
+      child: Semantics(
+        button: true,
+        enabled: enabled,
+        label: enterUsdMode ? 'Enter amount in USD' : 'Enter amount in ZEC',
+        child: GestureDetector(
+          key: const ValueKey('request_amount_mode_toggle'),
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AppIcon(
+                AppIcons.doubleArrowVertical,
+                size: 16,
+                color: enabled ? colors.icon.muted : colors.icon.disabled,
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              // No price for the typed amount yet: the same placeholder the
+              // send composer shows, not a number nobody can vouch for.
+              if (text == null) ...[
+                Text(
+                  r'$',
+                  style: AppTypography.labelLarge.copyWith(
+                    color: colors.text.muted,
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.xxs),
+                const AmountPriceLoadingBar(
+                  key: ValueKey('request_amount_price_loading'),
+                ),
+              ] else
+                Text(
+                  text,
+                  key: const ValueKey('request_amount_conversion_text'),
+                  style: AppTypography.labelLarge.copyWith(
+                    color: enabled ? colors.text.muted : colors.text.disabled,
+                    fontWeight: FontWeight.w400,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The collapsed message prompt — the send composer's memo card, without its
+/// fixed height so a translated help line can wrap instead of clipping.
+class RequestAddMessageCard extends StatelessWidget {
+  const RequestAddMessageCard({this.onTap, super.key});
+
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final card = Container(
+      key: const ValueKey('request_add_message_card'),
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: colors.surface.input.primary,
+        borderRadius: BorderRadius.circular(AppRadii.medium),
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.s,
+        vertical: AppSpacing.sm,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AppIcon(AppIcons.scroll, size: 16, color: colors.icon.accent),
+              const SizedBox(width: AppSpacing.xxs),
+              Flexible(
+                child: Text(
+                  kRequestAddMessageLabel,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTypography.labelLarge.copyWith(
+                    fontWeight: FontWeight.w400,
+                    color: colors.text.accent,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            kRequestMessageHelpText,
+            textAlign: TextAlign.center,
+            style: AppTypography.labelLarge.copyWith(
+              fontWeight: FontWeight.w400,
+              color: colors.text.muted,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (onTap == null) return card;
+    return Semantics(
+      button: true,
+      label: kRequestAddMessageLabel,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: card,
+        ),
+      ),
+    );
+  }
+}
+
+/// The expanded memo editor with the protocol's own byte counter.
+///
+/// The counter is bytes, not characters, because that is the limit the memo
+/// field actually has — a message that fits on screen can still be over.
+class RequestMessageField extends StatelessWidget {
+  const RequestMessageField({
+    required this.text,
+    this.controller,
+    this.onChanged,
+    this.onClose,
+    super.key,
+  });
+
+  final String text;
+  final TextEditingController? controller;
+  final ValueChanged<String>? onChanged;
+
+  /// Collapses the editor back to the prompt. The clear button announces
+  /// itself as "Close message", so it has to actually close it — emptying the
+  /// text and leaving the editor open is not the action the label names.
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final used = zip321MemoByteLength(text);
+    final overLimit = used > kZip321MaxMemoBytes;
+
+    return AppTextField(
+      key: const ValueKey('request_message_field'),
+      label: 'Message',
+      labelStyle: AppTypography.labelLarge.copyWith(
+        color: colors.text.secondary,
+      ),
+      rightSlot: Text(
+        '$used/$kZip321MaxMemoBytes',
+        key: const ValueKey('request_message_counter'),
+        style: AppTypography.labelLarge.copyWith(
+          color: overLimit ? colors.text.destructive : colors.text.secondary,
+        ),
+      ),
+      controller: controller,
+      initialValue: controller == null ? text : null,
+      hintText: 'Anyone you send the link to can read this',
+      tone: overLimit ? AppTextFieldTone.destructive : AppTextFieldTone.neutral,
+      borderColor: overLimit ? colors.border.utilityDestructive : null,
+      leading: AppIcon(AppIcons.scroll, size: 20, color: colors.icon.regular),
+      messageText: overLimit ? 'Message is too long' : null,
+      minLines: 3,
+      maxLines: 3,
+      textStyle: AppTypography.bodyMedium.copyWith(color: colors.text.accent),
+      showClearButton: true,
+      clearButtonRequiresText: false,
+      clearButtonSemanticLabel: 'Close message',
+      onClear: onClose,
+      onChanged: onChanged,
+    );
+  }
+}
+
+/// Modal chrome for the desktop request steps: the pane scrim plus the
+/// centered card, rendered inline so previews do not have to push a route.
+class RequestAmountSurface extends StatelessWidget {
+  const RequestAmountSurface({
+    required this.request,
+    this.step = RequestModalStep.compose,
+    this.onClose,
+    this.onNext,
+    this.onBack,
+    this.onCopyLink,
+    this.onSaveQrImage,
+    this.onSaveQrImageError,
+    this.onAddMessage,
+    this.onToggleAmountUnit,
+    this.onAmountChanged,
+    this.onMessageChanged,
+    this.onCloseMessage,
+    this.amountController,
+    this.messageController,
+    this.messageExpanded = false,
+    this.background,
+    super.key,
+  });
+
+  final ZecRequestView request;
+
+  /// Which of the two cards is on screen.
+  final RequestModalStep step;
+
+  final VoidCallback? onClose;
+  final VoidCallback? onNext;
+  final VoidCallback? onBack;
+  final VoidCallback? onCopyLink;
+  final ValueChanged<Uint8List>? onSaveQrImage;
+  final VoidCallback? onSaveQrImageError;
+  final VoidCallback? onAddMessage;
+  final VoidCallback? onToggleAmountUnit;
+  final ValueChanged<String>? onAmountChanged;
+  final ValueChanged<String>? onMessageChanged;
+  final VoidCallback? onCloseMessage;
+  final TextEditingController? amountController;
+  final TextEditingController? messageController;
+  final bool messageExpanded;
+
+  /// What the modal sits on. Defaults to the flat window colour.
+  final Widget? background;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final card = switch (step) {
+      RequestModalStep.compose => RequestAmountCard(
+        request: request,
+        onClose: onClose,
+        onNext: onNext,
+        onAddMessage: onAddMessage,
+        onToggleAmountUnit: onToggleAmountUnit,
+        onAmountChanged: onAmountChanged,
+        onMessageChanged: onMessageChanged,
+        onCloseMessage: onCloseMessage,
+        amountController: amountController,
+        messageController: messageController,
+        messageExpanded: messageExpanded,
+      ),
+      RequestModalStep.result => RequestResultCard(
+        request: request,
+        onBack: onBack,
+        onClose: onClose,
+        onCopyLink: onCopyLink,
+        onSaveQrImage: onSaveQrImage,
+        onSaveQrImageError: onSaveQrImageError,
+      ),
+    };
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        background ?? ColoredBox(color: colors.background.window),
+        AppPaneModalOverlay(
+          onDismiss: onClose ?? RequestAmountCard._noop,
+          // Either step fits the app's minimum window on its own. The scroll
+          // view is the floor under a bigger text scale or a translation that
+          // wraps: the card grows into a scroll rather than into overflow.
+          child: LayoutBuilder(
+            builder: (context, constraints) => SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: constraints.maxHeight.isFinite
+                      ? math.max(0, constraints.maxHeight - AppSpacing.sm * 2)
+                      : 0,
+                ),
+                child: Center(
+                  child: AppModalCard(
+                    width: step == RequestModalStep.result
+                        ? requestModalResultCardWidth(
+                            request.qrData,
+                            maxWidth: constraints.maxWidth,
+                          )
+                        : kRequestModalCardWidth,
+                    child: card,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+String? _trimmedOrNull(String? value) {
+  final trimmed = value?.trim();
+  return (trimmed == null || trimmed.isEmpty) ? null : trimmed;
+}

--- a/lib/src/features/receive/widgets/request/request_amount_card.dart
+++ b/lib/src/features/receive/widgets/request/request_amount_card.dart
@@ -14,6 +14,7 @@
 library;
 
 import 'dart:math' as math;
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/widgets.dart';
@@ -205,7 +206,7 @@ class RequestResultCard extends StatelessWidget {
 
   /// Receives the request QR as PNG bytes. Presentation only: writing the
   /// file is the caller's job.
-  final ValueChanged<Uint8List>? onSaveQrImage;
+  final FutureOr<void> Function(Uint8List png)? onSaveQrImage;
 
   /// Called when the QR could not be encoded at all, so the press is
   /// reported rather than swallowed.
@@ -686,7 +687,7 @@ class RequestAmountSurface extends StatelessWidget {
   final VoidCallback? onNext;
   final VoidCallback? onBack;
   final VoidCallback? onCopyLink;
-  final ValueChanged<Uint8List>? onSaveQrImage;
+  final FutureOr<void> Function(Uint8List png)? onSaveQrImage;
   final VoidCallback? onSaveQrImageError;
   final VoidCallback? onAddMessage;
   final VoidCallback? onToggleAmountUnit;

--- a/lib/src/features/receive/widgets/request/request_amount_formatters.dart
+++ b/lib/src/features/receive/widgets/request/request_amount_formatters.dart
@@ -1,0 +1,101 @@
+/// Keystroke guards for the two "Request ZEC" amount fields.
+///
+/// Every other amount field in the app installs these; the request field was
+/// the one exception, and it is the field least able to afford it. A ZIP-321
+/// amount has a stricter grammar than the parser that draws the conversion
+/// line, so text the screen happily converts (`.5`) and text a comma-decimal
+/// keypad emits on its own (`0,5`) both reach the builder as a rejection the
+/// user never asked for — a dead "Create request" and no way to see why.
+///
+/// Same rules and same order as the send composers
+/// (`send_screen.dart`, `mobile_send_screen.dart`): comma first, so the
+/// decimal validator only ever sees a period.
+library;
+
+import 'package:flutter/services.dart';
+
+import '../../../../core/widgets/comma_to_dot_input_formatter.dart';
+
+/// A zatoshi is the eighth decimal place; cents are the second.
+const int _kZecFractionDigits = 8;
+const int _kUsdFractionDigits = 2;
+
+/// `21000000.00000000` is 17 characters, and no ZEC amount is longer. The
+/// dollar cap is the send composer's.
+const int _kZecMaxLength = 17;
+const int _kUsdMaxLength = 12;
+
+const List<TextInputFormatter> _zecAmountFormatters = [
+  CommaToDotInputFormatter(),
+  RequestDecimalAmountInputFormatter(
+    maxFractionDigits: _kZecFractionDigits,
+    maxLength: _kZecMaxLength,
+  ),
+];
+
+const List<TextInputFormatter> _usdAmountFormatters = [
+  CommaToDotInputFormatter(),
+  RequestDecimalAmountInputFormatter(
+    maxFractionDigits: _kUsdFractionDigits,
+    maxLength: _kUsdMaxLength,
+  ),
+];
+
+/// The formatters a request amount field installs for the unit it is
+/// currently collecting.
+List<TextInputFormatter> requestAmountInputFormatters({required bool isUsd}) =>
+    isUsd ? _usdAmountFormatters : _zecAmountFormatters;
+
+/// Keeps a field to one plain decimal number.
+///
+/// Everything that is not a digit or the first period is dropped, a leading
+/// period is completed to `0.`, and both the whole length and the fraction
+/// are capped. Paste goes through this as well as typing, which is what the
+/// desktop field needs: its keyboard has every character on it.
+class RequestDecimalAmountInputFormatter extends TextInputFormatter {
+  const RequestDecimalAmountInputFormatter({
+    required this.maxFractionDigits,
+    required this.maxLength,
+  });
+
+  final int maxFractionDigits;
+  final int maxLength;
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    var text = newValue.text;
+    if (text.isEmpty) return newValue;
+
+    final buffer = StringBuffer();
+    var hasDecimal = false;
+    for (final codeUnit in text.codeUnits) {
+      final ch = String.fromCharCode(codeUnit);
+      if (ch == '.') {
+        if (hasDecimal) continue;
+        hasDecimal = true;
+        buffer.write(ch);
+        continue;
+      }
+      if (codeUnit >= 0x30 && codeUnit <= 0x39) {
+        buffer.write(ch);
+      }
+    }
+
+    text = buffer.toString();
+    if (text.startsWith('.')) text = '0$text';
+    if (text.length > maxLength) text = text.substring(0, maxLength);
+    final decimalIndex = text.indexOf('.');
+    if (decimalIndex >= 0) {
+      final maxEnd = decimalIndex + 1 + maxFractionDigits;
+      if (text.length > maxEnd) text = text.substring(0, maxEnd);
+    }
+
+    return TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+  }
+}

--- a/lib/src/features/receive/widgets/request/request_amount_model.dart
+++ b/lib/src/features/receive/widgets/request/request_amount_model.dart
@@ -1,0 +1,189 @@
+/// The immutable snapshot every "Request ZEC" widget renders, plus the
+/// copy the flow shares between form factors.
+///
+/// Nothing here reads a provider, touches storage, or calls Rust. The desktop
+/// modal and the mobile sheet are both pure functions of a [ZecRequestView],
+/// which is what lets the whole flow be reviewed in Widgetbook before it is
+/// wired to the Receive screen.
+library;
+
+import 'package:flutter/foundation.dart';
+
+import '../../../../core/config/network_config.dart'
+    show kZcashDefaultCurrencyTicker;
+import '../../../../core/zcash/zip321_payment_request_builder.dart';
+
+/// Toast shown after the request link reaches the clipboard.
+const kRequestLinkCopiedToast = 'Request link copied';
+
+/// Header for both the desktop modal and the mobile sheet.
+///
+/// One title for the whole flow: the mobile result step keeps it and adds a
+/// back chevron, so the two steps read as one task rather than two screens.
+final String kRequestFlowTitle = 'Request $kZcashDefaultCurrencyTicker';
+
+/// The collapsed message prompt, worded as the action it starts.
+const kRequestAddMessageLabel = 'Add a message';
+
+/// The two steps both form factors present the request flow in.
+///
+/// Named here rather than beside either presentation because the desktop
+/// modal and the mobile sheet are the same two steps in different chrome, and
+/// the screen that drives them holds one step value for whichever is mounted.
+enum RequestModalStep {
+  /// Amount and optional message. Nothing is a request yet.
+  compose,
+
+  /// The request itself: QR, summary, and the ways of handing it over.
+  result,
+}
+
+/// Why the message exists and who can read it.
+///
+/// Deliberately *not* the send composer's memo line: there the memo goes on
+/// chain encrypted to the recipient, but a request writes it into the link the
+/// user is about to hand out, where it is only base64url-encoded. Anyone who
+/// sees the link, the QR or the chat it was pasted into can read it.
+const kRequestMessageHelpText =
+    'Shielded addresses only — anyone with this link can read it.';
+
+/// Inline amount errors. All three are phrased as the correction to make, not
+/// as a verdict on what was typed.
+const kRequestAmountDecimalsError = 'Enter up to 8 decimals';
+const kRequestAmountSupplyError = 'Amount exceeds the ZEC supply';
+
+/// Shown when the field holds something that is not a decimal number at all.
+///
+/// The field's own formatters make this hard to reach by typing, so it is the
+/// backstop for the paths they do not cover — a controller written to
+/// programmatically, or a platform that slips a character past them. Silence
+/// there would be a permanently disabled "Create request" with nothing on
+/// screen explaining it.
+const kRequestAmountFormatError = 'Enter an amount like 0.5';
+
+/// Body of the share sheet a mobile request opens.
+///
+/// Deliberately a full templated sentence rather than fragments concatenated
+/// around the amount — word order changes per language, and this string is
+/// destined for translation.
+String buildRequestShareText({required String amountZec, required String uri}) {
+  return 'Pay me $amountZec $kZcashDefaultCurrencyTicker with Vizor\n$uri';
+}
+
+/// Everything the request widgets draw.
+///
+/// [amountZec] is the canonical ZEC value as typed, independent of which unit
+/// the field is currently showing; [amountDisplayText] is what the field
+/// itself renders, so a USD-mode preview can show `35.00` while the request
+/// still encodes `0.5`.
+@immutable
+class ZecRequestView {
+  const ZecRequestView({
+    required this.address,
+    this.amountZec = '',
+    this.amountDisplayText = '',
+    this.amountInputIsUsd = false,
+    this.conversionText,
+    this.messageText,
+    this.amountError,
+  });
+
+  /// The receiving address the request pays to. Snapshotted by the caller at
+  /// the moment the request is created — a shielded address the user renews
+  /// afterwards must not silently change a link already handed out.
+  final String address;
+
+  /// Canonical ZEC amount as typed (`'0.5'`), empty when nothing is entered.
+  final String amountZec;
+
+  /// What the amount field shows. Defaults to [amountZec] when blank.
+  final String amountDisplayText;
+
+  /// True while the field is collecting USD rather than ZEC.
+  final bool amountInputIsUsd;
+
+  /// The other-unit line under the field (`$35.00`, or `0.5 ZEC` in USD
+  /// mode). Null renders the price-unavailable placeholder.
+  final String? conversionText;
+
+  /// The optional memo the link carries. Shielded requests only.
+  final String? messageText;
+
+  /// Inline error under the amount field, or null.
+  final String? amountError;
+
+  bool get isShielded => !zip321AddressIsTransparent(address);
+
+  /// The message the request will carry, or null when there is none to carry.
+  ///
+  /// A transparent address can never carry one, so the getter refuses it here
+  /// rather than leaving every caller to remember the rule.
+  String? get effectiveMessage {
+    if (!isShielded) return null;
+    final trimmed = messageText?.trim();
+    return (trimmed == null || trimmed.isEmpty) ? null : messageText;
+  }
+
+  bool get hasMessage => effectiveMessage != null;
+
+  /// The text shown in the amount field.
+  String get fieldText =>
+      amountDisplayText.isNotEmpty ? amountDisplayText : amountZec;
+
+  /// The ZIP-321 URI this request encodes, or null when the amount is not yet
+  /// a usable number.
+  ///
+  /// Errors are swallowed on purpose: an in-progress amount is not a failure
+  /// state, it is simply not a request yet. The field's own inline error is
+  /// what tells the user something is wrong.
+  String? get requestUri {
+    if (amountZec.trim().isEmpty) return null;
+    try {
+      return buildZip321PaymentUri(
+        address: address,
+        amountZec: amountZec,
+        memoText: effectiveMessage,
+      );
+    } on Zip321BuildException {
+      return null;
+    }
+  }
+
+  /// What the QR encodes.
+  ///
+  /// With no valid amount this falls back to the bare address, so the code on
+  /// screen is always scannable and always means something: before an amount
+  /// is entered the request QR *is* the address QR.
+  String get qrData => requestUri ?? address;
+
+  /// `0.5 ZEC` for the line under the QR, or null before there is an amount.
+  String? get summaryAmountText {
+    final uri = requestUri;
+    if (uri == null) return null;
+    try {
+      return '${normalizeZip321Amount(amountZec)} $kZcashDefaultCurrencyTicker';
+    } on Zip321BuildException {
+      return null;
+    }
+  }
+
+  /// The message a share sheet sends, or null before there is a request.
+  ///
+  /// Composed here rather than at each call site so the desktop and mobile
+  /// flows can never drift into two differently worded shares.
+  String? get shareText {
+    final uri = requestUri;
+    if (uri == null) return null;
+    try {
+      return buildRequestShareText(
+        amountZec: normalizeZip321Amount(amountZec),
+        uri: uri,
+      );
+    } on Zip321BuildException {
+      return null;
+    }
+  }
+
+  /// True once the request can be copied or shared.
+  bool get isReady => requestUri != null;
+}

--- a/lib/src/features/receive/widgets/request/request_amount_sheet.dart
+++ b/lib/src/features/receive/widgets/request/request_amount_sheet.dart
@@ -1,0 +1,585 @@
+/// Mobile "Request ZEC" sheet, in two steps.
+///
+/// Step one composes the request (amount, optional message); step two is the
+/// artefact (QR, summary, link) with the two ways of handing it over. They are
+/// separate steps rather than one long sheet because a phone cannot show a
+/// scannable QR and a focused numeric keypad at the same time, and because
+/// "Create request" is the moment worth confirming — after it, the address in
+/// the link is fixed.
+///
+/// Presentation only: no providers, no routing, no clipboard or share calls.
+library;
+
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart' show InputDecoration, TextField;
+import 'package:flutter/services.dart' show TextInputAction, TextInputType;
+import 'package:flutter/widgets.dart';
+
+import '../../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_button.dart';
+import '../../../../core/widgets/amount_price_loading_bar.dart';
+import '../../../../core/widgets/app_icon.dart';
+import 'request_amount_card.dart'
+    show RequestAmountErrorRow, RequestMessageField;
+import 'request_amount_formatters.dart';
+import 'request_amount_model.dart';
+import 'request_qr_surface.dart';
+
+/// The serif amount metrics from the mobile send amount step, mirrored so the
+/// two "type an amount" screens are the same screen to a user's eye.
+const double _kRequestAmountFontSize = 48;
+const double _kRequestAmountLineHeightPx = 40;
+const double _kRequestAmountUnitFontSize = 38;
+const double _kRequestAmountUsdPrefixFontSize = 40;
+
+/// Side of the QR on the result step.
+const double kRequestSheetQrSize = 236;
+
+/// Step one: what you are asking for.
+class RequestAmountSheetCompose extends StatelessWidget {
+  const RequestAmountSheetCompose({
+    required this.request,
+    this.onClose,
+    this.onToggleAmountUnit,
+    this.onAddMessage,
+    this.onCreateRequest,
+    this.onAmountChanged,
+    this.onMessageChanged,
+    this.onCloseMessage,
+    this.amountController,
+    this.messageController,
+    this.messageExpanded = false,
+    super.key,
+  });
+
+  final ZecRequestView request;
+  final VoidCallback? onClose;
+  final VoidCallback? onToggleAmountUnit;
+  final VoidCallback? onAddMessage;
+  final VoidCallback? onCreateRequest;
+  final ValueChanged<String>? onAmountChanged;
+  final ValueChanged<String>? onMessageChanged;
+
+  /// Collapses the memo editor back to [RequestMessageRow].
+  final VoidCallback? onCloseMessage;
+
+  /// Supplied by the live sheet, which owns the text so a unit switch can
+  /// rewrite the number in place. Without one the amount is a static display,
+  /// which is what the previews want.
+  final TextEditingController? amountController;
+  final TextEditingController? messageController;
+
+  /// Renders the memo editor in place of the collapsed row.
+  final bool messageExpanded;
+
+  @override
+  Widget build(BuildContext context) {
+    final amountError = request.amountError?.trim();
+
+    return MobileModalScaffold(
+      title: kRequestFlowTitle,
+      onClose: onClose ?? _noop,
+      bottomPadding: AppSpacing.base,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: AppSpacing.sm),
+          _SerifAmountDisplay(
+            request: request,
+            controller: amountController,
+            onChanged: onAmountChanged,
+          ),
+          // Said next to where it broke, in the desktop card's words: red
+          // digits and a dead CTA state that something is wrong without
+          // saying what, and the two causes need opposite corrections.
+          if (amountError != null && amountError.isNotEmpty) ...[
+            const SizedBox(height: AppSpacing.xs),
+            Center(child: RequestAmountErrorRow(text: amountError)),
+          ],
+          const SizedBox(height: AppSpacing.s),
+          _AmountUnitToggle(
+            text: request.conversionText,
+            enterUsdMode: !request.amountInputIsUsd,
+            onTap: onToggleAmountUnit,
+          ),
+          const SizedBox(height: AppSpacing.base),
+          // A transparent address cannot carry a memo at all, so the row is
+          // absent rather than disabled: an inert control invites a tap that
+          // can never do anything.
+          if (request.isShielded) ...[
+            if (messageExpanded)
+              RequestMessageField(
+                text: request.messageText ?? '',
+                controller: messageController,
+                onChanged: onMessageChanged,
+                onClose: onCloseMessage,
+              )
+            else
+              RequestMessageRow(
+                message: request.effectiveMessage,
+                onTap: onAddMessage,
+              ),
+            const SizedBox(height: AppSpacing.md),
+          ],
+          AppButton(
+            key: const ValueKey('request_create_button'),
+            expand: true,
+            constrainContent: true,
+            onPressed: request.isReady ? (onCreateRequest ?? _noop) : null,
+            child: const Text(
+              'Create request',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static void _noop() {}
+}
+
+/// Step two: the request itself.
+class RequestAmountSheetResult extends StatelessWidget {
+  const RequestAmountSheetResult({
+    required this.request,
+    this.onBack,
+    this.onClose,
+    this.onShareRequest,
+    this.onShareError,
+    this.onCopyLink,
+    super.key,
+  });
+
+  final ZecRequestView request;
+  final VoidCallback? onBack;
+  final VoidCallback? onClose;
+
+  /// Receives the share message and the request QR as PNG bytes, so the
+  /// caller can hand a payer both at once — some apps show the picture, some
+  /// only carry the link, and a request should survive either.
+  final void Function(String text, Uint8List png)? onShareRequest;
+
+  /// Called when the QR could not be encoded, so the share that never
+  /// happened says so instead of looking like one that did.
+  final VoidCallback? onShareError;
+
+  final VoidCallback? onCopyLink;
+
+  @override
+  Widget build(BuildContext context) {
+    final uri = request.requestUri;
+    final summary = request.summaryAmountText;
+    final onShare = onShareRequest;
+
+    return MobileModalScaffold(
+      title: kRequestFlowTitle,
+      onClose: onClose ?? _noop,
+      leading: _BackChevron(onTap: onBack),
+      bottomPadding: AppSpacing.base,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: AppSpacing.xs),
+          Center(
+            child: RequestQrSurface(
+              data: request.qrData,
+              size: kRequestSheetQrSize,
+            ),
+          ),
+          if (summary != null) ...[
+            const SizedBox(height: AppSpacing.sm),
+            RequestSummaryRow(
+              amountText: summary,
+              isShielded: request.isShielded,
+            ),
+          ],
+          const SizedBox(height: AppSpacing.md),
+          RequestQrExportButton(
+            key: const ValueKey('request_share_button'),
+            uri: uri,
+            label: 'Share request',
+            icon: AppIcons.share,
+            onBytes: onShare == null
+                ? null
+                : (png) => onShare(request.shareText ?? uri!, png),
+            onError: onShareError,
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Semantics(
+            button: true,
+            label: 'Copy link',
+            excludeSemantics: true,
+            child: AppButton(
+              key: const ValueKey('request_copy_link_button'),
+              variant: AppButtonVariant.secondary,
+              expand: true,
+              constrainContent: true,
+              onPressed: request.isReady ? (onCopyLink ?? _noop) : null,
+              child: const Text(
+                'Copy link',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static void _noop() {}
+}
+
+/// The big serif amount, in the mobile send step's exact type.
+class _SerifAmountDisplay extends StatelessWidget {
+  const _SerifAmountDisplay({
+    required this.request,
+    this.controller,
+    this.onChanged,
+  });
+
+  final ZecRequestView request;
+
+  /// When present the number is a live field; when absent it is text.
+  final TextEditingController? controller;
+  final ValueChanged<String>? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final hasError = request.amountError?.trim().isNotEmpty ?? false;
+    final text = request.fieldText.trim();
+    final amountStyle = AppTypography.displayLarge.copyWith(
+      color: hasError
+          ? colors.text.destructive
+          : text.isEmpty
+          ? colors.text.disabled
+          : colors.text.accent,
+      fontSize: _kRequestAmountFontSize,
+      height: _kRequestAmountLineHeightPx / _kRequestAmountFontSize,
+      fontWeight: FontWeight.w500,
+    );
+    final unitStyle = amountStyle.copyWith(
+      color: amountStyle.color?.withValues(alpha: 0.5),
+      fontSize: _kRequestAmountUnitFontSize,
+      height: _kRequestAmountLineHeightPx / _kRequestAmountUnitFontSize,
+    );
+    final prefixStyle = unitStyle.copyWith(
+      fontSize: _kRequestAmountUsdPrefixFontSize,
+      height: _kRequestAmountLineHeightPx / _kRequestAmountUsdPrefixFontSize,
+    );
+    final display = text.isEmpty ? '0' : text;
+
+    return Row(
+      key: const ValueKey('request_amount_display'),
+      crossAxisAlignment: CrossAxisAlignment.baseline,
+      mainAxisAlignment: MainAxisAlignment.center,
+      mainAxisSize: MainAxisSize.max,
+      textBaseline: TextBaseline.alphabetic,
+      children: [
+        if (request.amountInputIsUsd) ...[
+          Text(r'$', style: prefixStyle),
+          const SizedBox(width: AppSpacing.xs),
+        ],
+        // A long amount shrinks rather than truncating: half a number is
+        // worse than a small one. The editable form sizes itself to its text
+        // instead, so the unit stays beside the number rather than being
+        // pushed to the far edge of the sheet.
+        Flexible(
+          child: controller == null
+              ? FittedBox(
+                  fit: BoxFit.scaleDown,
+                  child: Text(display, maxLines: 1, style: amountStyle),
+                )
+              : _SerifAmountInput(
+                  controller: controller!,
+                  onChanged: onChanged,
+                  style: amountStyle,
+                  hintStyle: amountStyle.copyWith(color: colors.text.disabled),
+                  cursorColor: colors.text.accent,
+                  isUsd: request.amountInputIsUsd,
+                ),
+        ),
+        if (!request.amountInputIsUsd) ...[
+          const SizedBox(width: AppSpacing.xs),
+          Text('ZEC', style: unitStyle),
+        ],
+      ],
+    );
+  }
+}
+
+/// The amount field behind the serif display: the same type, sized to its own
+/// text so the `ZEC` suffix stays attached to the number.
+class _SerifAmountInput extends StatelessWidget {
+  const _SerifAmountInput({
+    required this.controller,
+    required this.onChanged,
+    required this.style,
+    required this.hintStyle,
+    required this.cursorColor,
+    required this.isUsd,
+  });
+
+  final TextEditingController controller;
+  final ValueChanged<String>? onChanged;
+  final TextStyle style;
+  final TextStyle hintStyle;
+  final Color cursorColor;
+
+  /// Which unit the field is collecting, which is all the formatters need:
+  /// dollars stop at cents, ZEC at a zatoshi.
+  final bool isUsd;
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicWidth(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minWidth: _kRequestAmountMinWidth),
+        child: TextField(
+          key: const ValueKey('request_amount_input'),
+          controller: controller,
+          onChanged: onChanged,
+          autofocus: true,
+          textAlign: TextAlign.center,
+          maxLines: 1,
+          style: style,
+          cursorColor: cursorColor,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          // A comma-decimal keypad emits `,` for the decimal key, which the
+          // ZIP-321 builder refuses; without this the field is a dead end on
+          // every phone set to such a locale.
+          inputFormatters: requestAmountInputFormatters(isUsd: isUsd),
+          textInputAction: TextInputAction.done,
+          decoration: InputDecoration.collapsed(
+            hintText: '0',
+            hintStyle: hintStyle,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Enough width for a single digit plus its caret, so an empty field is still
+/// a place to type rather than a hairline.
+const double _kRequestAmountMinWidth = 40;
+
+class _AmountUnitToggle extends StatelessWidget {
+  const _AmountUnitToggle({
+    required this.text,
+    required this.enterUsdMode,
+    required this.onTap,
+  });
+
+  final String? text;
+  final bool enterUsdMode;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final text = this.text;
+    // Without a live price the switch cannot be taken, so it is drawn as the
+    // inert control it is — the desktop row already does this, and a
+    // full-strength arrow invites a tap that does nothing and says nothing.
+    final enabled = onTap != null;
+    final labelColor = enabled ? colors.text.secondary : colors.text.disabled;
+    return Center(
+      child: Semantics(
+        button: true,
+        enabled: enabled,
+        label: enterUsdMode ? 'Enter amount in USD' : 'Enter amount in ZEC',
+        child: GestureDetector(
+          key: const ValueKey('request_amount_mode_toggle'),
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AppIcon(
+                AppIcons.doubleArrowVertical,
+                size: 20,
+                color: enabled ? colors.text.secondary : colors.icon.disabled,
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              // No price for the typed amount yet: the same placeholder the
+              // send composer shows, not a number nobody can vouch for.
+              if (text == null) ...[
+                Text(
+                  r'$',
+                  style: AppTypography.labelLarge.copyWith(color: labelColor),
+                ),
+                const SizedBox(width: AppSpacing.xxs),
+                const AmountPriceLoadingBar(
+                  key: ValueKey('request_amount_price_loading'),
+                  animated: true,
+                ),
+              ] else
+                Text(
+                  text,
+                  key: const ValueKey('request_amount_conversion_text'),
+                  style: AppTypography.labelLarge.copyWith(color: labelColor),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The message row on step one.
+///
+/// Empty it is the prompt; filled it shows the message it will attach, so the
+/// user can see what a payer will read without opening the editor again.
+class RequestMessageRow extends StatelessWidget {
+  const RequestMessageRow({required this.message, this.onTap, super.key});
+
+  final String? message;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final text = message?.trim();
+    final hasMessage = text != null && text.isNotEmpty;
+
+    final row = Container(
+      key: const ValueKey('request_message_row'),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.s,
+        vertical: AppSpacing.s,
+      ),
+      decoration: BoxDecoration(
+        color: colors.surface.input.primary,
+        borderRadius: BorderRadius.circular(AppRadii.medium),
+      ),
+      child: Row(
+        children: [
+          AppIcon(
+            AppIcons.scroll,
+            size: AppIconSize.medium,
+            color: colors.icon.accent,
+          ),
+          const SizedBox(width: AppSpacing.xs),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  kRequestAddMessageLabel,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTypography.labelLarge.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+                if (hasMessage) ...[
+                  const SizedBox(height: AppSpacing.xxs),
+                  Text(
+                    text,
+                    key: const ValueKey('request_message_preview'),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: colors.text.secondary,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: AppSpacing.xs),
+          AppIcon(
+            AppIcons.chevronForward,
+            size: AppIconSize.medium,
+            color: colors.icon.regular,
+          ),
+        ],
+      ),
+    );
+
+    if (onTap == null) return row;
+    return Semantics(
+      button: true,
+      label: kRequestAddMessageLabel,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: row,
+      ),
+    );
+  }
+}
+
+class _BackChevron extends StatelessWidget {
+  const _BackChevron({required this.onTap});
+
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Semantics(
+      button: true,
+      label: 'Back',
+      child: GestureDetector(
+        key: const ValueKey('request_sheet_back'),
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: SizedBox(
+          width: AppSpacing.md,
+          height: AppSpacing.md,
+          child: Center(
+            child: AppIcon(
+              AppIcons.chevronBackward,
+              size: AppIconSize.medium,
+              color: colors.icon.accent,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Inline sheet presentation used by previews: the scrim plus the bottom-
+/// anchored card, without pushing a route.
+class RequestAmountSheetSurface extends StatelessWidget {
+  const RequestAmountSheetSurface({
+    required this.child,
+    this.background,
+    super.key,
+  });
+
+  final Widget child;
+  final Widget? background;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        background ?? ColoredBox(color: colors.background.window),
+        ColoredBox(color: colors.background.neutralScrim),
+        SafeArea(
+          bottom: false,
+          minimum: const EdgeInsets.only(top: AppSpacing.base),
+          child: Align(
+            alignment: Alignment.bottomCenter,
+            child: MobileModalCard(child: child),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/features/receive/widgets/request/request_amount_sheet.dart
+++ b/lib/src/features/receive/widgets/request/request_amount_sheet.dart
@@ -10,6 +10,7 @@
 /// Presentation only: no providers, no routing, no clipboard or share calls.
 library;
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart' show InputDecoration, TextField;
@@ -162,7 +163,7 @@ class RequestAmountSheetResult extends StatelessWidget {
   /// Receives the share message and the request QR as PNG bytes, so the
   /// caller can hand a payer both at once — some apps show the picture, some
   /// only carry the link, and a request should survive either.
-  final void Function(String text, Uint8List png)? onShareRequest;
+  final FutureOr<void> Function(String text, Uint8List png)? onShareRequest;
 
   /// Called when the QR could not be encoded, so the share that never
   /// happened says so instead of looking like one that did.

--- a/lib/src/features/receive/widgets/request/request_qr_surface.dart
+++ b/lib/src/features/receive/widgets/request/request_qr_surface.dart
@@ -3,6 +3,7 @@
 library;
 
 import 'dart:math' as math;
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart' show CircularProgressIndicator;
@@ -275,7 +276,11 @@ class RequestQrExportButton extends StatefulWidget {
   final String label;
 
   /// Receives the encoded PNG. Nothing is written or shared here.
-  final ValueChanged<Uint8List>? onBytes;
+  /// Receives the rendered PNG. Awaited: the button stays busy until the
+  /// hand-off — a native save dialog, a share sheet — has completed, so a
+  /// second press cannot start a second export while the first is still
+  /// pending. A synchronous callback is fine too.
+  final FutureOr<void> Function(Uint8List png)? onBytes;
 
   /// Called instead of [onBytes] when the encode fails.
   ///
@@ -306,7 +311,7 @@ class _RequestQrExportButtonState extends State<RequestQrExportButton> {
     try {
       final png = await renderRequestQrPng(uri);
       if (!mounted) return;
-      onBytes(png);
+      await onBytes(png);
     } catch (e) {
       // The exception stays in the log; the callback is what the user sees.
       log('RequestQr: ERROR rendering the request QR: $e');

--- a/lib/src/features/receive/widgets/request/request_qr_surface.dart
+++ b/lib/src/features/receive/widgets/request/request_qr_surface.dart
@@ -1,0 +1,341 @@
+/// The QR block a created request is read from: the code itself, the one-line
+/// summary under it, and the PNG export both form factors hand out.
+library;
+
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart' show CircularProgressIndicator;
+import 'package:flutter/widgets.dart';
+import 'package:pretty_qr_code/pretty_qr_code.dart';
+
+import '../../../../../main.dart' show log;
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_button.dart';
+import '../../../../core/widgets/app_icon.dart';
+import '../../../../core/widgets/pool_badge.dart';
+
+/// Ink for a request QR. Theme-invariant black, paired with the theme-
+/// invariant `surface.qrCode` white behind it.
+const _requestQrInk = Color(0xFF000000);
+
+/// Quiet zone in modules. Four is the QR specification's own margin; the
+/// decorative receive code can drop it to zero because a wallet address is
+/// short and forgiving, but a request URI pushes the symbol several versions
+/// higher and a camera needs the border back.
+const double _requestQrQuietZoneModules = 4;
+
+/// Smallest side, in logical pixels, a single module may be drawn at.
+///
+/// Two is not an aesthetic floor, it is the renderer's: `PrettyQrSquaresSymbol`
+/// clamps its module density into `[1, moduleDimension / 2]`, which is an
+/// empty range — and an assertion — as soon as a module is under 2px. A memo
+/// pushes a ZIP-321 URI into the high symbol versions, so a request QR pinned
+/// to a fixed side hits that long before the code becomes unscannable.
+const double _requestQrMinModuleSize = 2;
+
+/// The side, in logical pixels, the code for [data] needs before its modules
+/// fall under [minModulePx] — quiet zone included, [RequestQrSurface]'s own
+/// white padding excluded.
+///
+/// Public because a fixed-width container has to ask *before* it lays the
+/// surface out: [RequestQrSurface] can only grow into the width it is given,
+/// so a caller that hands it too little turns the floor this file exists to
+/// enforce into a clamp against it. Zero for an empty request, which draws no
+/// code at all.
+double requestQrSideFor(
+  String data, {
+  double minModulePx = _requestQrMinModuleSize,
+}) {
+  if (data.isEmpty) return 0;
+  final qrImage = QrImage(
+    QrCode.fromData(data: data, errorCorrectLevel: QrErrorCorrectLevel.M),
+  );
+  return _requestQrSide(qrImage, minModulePx);
+}
+
+double _requestQrSide(QrImage qrImage, double minModulePx) =>
+    (qrImage.moduleCount + _requestQrQuietZoneModules * 2) * minModulePx;
+
+/// A request QR: black square modules on white, with a real quiet zone and no
+/// embedded badge.
+///
+/// This deliberately does not reuse `ReceiveQrSurface`. That one is the
+/// decorative address code — dot modules, zero quiet zone, a pool badge
+/// covering the middle — which survives because an address is a short,
+/// low-version symbol. A ZIP-321 URI carries the address *plus* an amount and
+/// up to 512 bytes of memo, so the same treatment would be asking a stranger's
+/// camera to read a dense code through a hole in the middle of it. Scan
+/// reliability wins here, exactly as it does for the Keystone PCZT codes.
+///
+/// [size] is a floor, not a fixed side: a dense request grows the code up to
+/// the width it is given rather than shrinking its modules below
+/// [_requestQrMinModuleSize]. The surface is square either way.
+class RequestQrSurface extends StatelessWidget {
+  const RequestQrSurface({
+    required this.data,
+    required this.size,
+    this.padding = AppSpacing.sm,
+    super.key,
+  });
+
+  /// What the code encodes: the request URI, or the bare address before an
+  /// amount has been entered.
+  final String data;
+
+  /// Smallest side length of the code itself, excluding [padding].
+  final double size;
+
+  /// White margin drawn around the code, on top of its module quiet zone.
+  final double padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final qrImage = data.isEmpty
+        ? null
+        : QrImage(
+            QrCode.fromData(
+              data: data,
+              // M is the level the rest of the app scans at, and it keeps
+              // the symbol a version lower than Q would for the same URI.
+              errorCorrectLevel: QrErrorCorrectLevel.M,
+            ),
+          );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final side = _resolveSide(qrImage, constraints);
+        return Container(
+          key: const ValueKey('request_qr_surface'),
+          width: side + padding * 2,
+          height: side + padding * 2,
+          padding: EdgeInsets.all(padding),
+          decoration: BoxDecoration(
+            color: colors.surface.qrCode,
+            borderRadius: BorderRadius.circular(AppRadii.large),
+            border: Border.all(color: colors.border.subtle),
+          ),
+          child: qrImage == null
+              ? Center(
+                  child: Text(
+                    'QR unavailable',
+                    style: AppTypography.bodySmall.copyWith(
+                      color: _requestQrInk,
+                    ),
+                  ),
+                )
+              : PrettyQrView(
+                  qrImage: qrImage,
+                  decoration: const PrettyQrDecoration(
+                    quietZone: PrettyQrQuietZone.modules(
+                      _requestQrQuietZoneModules,
+                    ),
+                    shape: PrettyQrSquaresSymbol(color: _requestQrInk),
+                  ),
+                ),
+        );
+      },
+    );
+  }
+
+  /// The side this code is actually drawn at: [size], grown to whatever the
+  /// symbol needs to keep its modules legible, and capped by the space the
+  /// caller has. The cap can only bite in a layout narrower than any symbol
+  /// version needs, which is well under the width both request surfaces give.
+  double _resolveSide(QrImage? qrImage, BoxConstraints constraints) {
+    if (qrImage == null) return size;
+
+    final needed = _requestQrSide(qrImage, _requestQrMinModuleSize);
+
+    var available = double.infinity;
+    if (constraints.hasBoundedWidth) {
+      available = math.min(available, constraints.maxWidth - padding * 2);
+    }
+    if (constraints.hasBoundedHeight) {
+      available = math.min(available, constraints.maxHeight - padding * 2);
+    }
+    if (!available.isFinite) return math.max(size, needed);
+    return math.max(size, math.min(needed, math.max(size, available)));
+  }
+}
+
+/// The one line under a request QR: `0.5 ZEC · Shielded`.
+///
+/// The amount is the value being asked for and takes the accent colour; the
+/// pool badge beside it is the privacy fact a payer cannot infer from the
+/// amount, and it is stated in the same badge every other surface uses.
+class RequestSummaryRow extends StatelessWidget {
+  const RequestSummaryRow({
+    required this.amountText,
+    required this.isShielded,
+    super.key,
+  });
+
+  final String amountText;
+  final bool isShielded;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Row(
+      key: const ValueKey('request_summary_row'),
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Flexible(
+          child: Text(
+            amountText,
+            key: const ValueKey('request_summary_amount'),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.bodyMediumStrong.copyWith(
+              color: colors.text.accent,
+            ),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.xs),
+        Text(
+          '·',
+          style: AppTypography.bodyMedium.copyWith(color: colors.text.muted),
+        ),
+        const SizedBox(width: AppSpacing.xs),
+        PoolBadge(isShielded: isShielded),
+      ],
+    );
+  }
+}
+
+/// Side of the exported QR bitmap, in pixels.
+///
+/// The same 1536 the receive screen renders its cached bitmap at: large
+/// enough that the PNG survives being pasted into a chat, a slide or a
+/// printed sheet without the modules turning to mush.
+const int kRequestQrExportSize = 1536;
+
+/// Paper the exported code is printed on.
+///
+/// Export is theme-invariant black on white even in dark mode: the file
+/// leaves the app and is scanned somewhere we do not control, and a
+/// light-on-dark code is the one thing many camera pipelines refuse.
+const Color _requestQrExportPaper = Color(0xFFFFFFFF);
+
+/// Renders [uri] as a standalone PNG of the same square-module code
+/// [RequestQrSurface] draws, quiet zone included.
+///
+/// Pure: no context, no theme, no storage. The caller decides what to do
+/// with the bytes — write them to a file, or attach them to a share sheet.
+Future<Uint8List> renderRequestQrPng(
+  String uri, {
+  int size = kRequestQrExportSize,
+  double quietZoneModules = _requestQrQuietZoneModules,
+}) async {
+  if (uri.isEmpty) {
+    throw ArgumentError.value(uri, 'uri', 'There is no request to export');
+  }
+
+  final qrImage = QrImage(
+    QrCode.fromData(data: uri, errorCorrectLevel: QrErrorCorrectLevel.M),
+  );
+  final bytes = await qrImage.toImageAsBytes(
+    size: size,
+    decoration: PrettyQrDecoration(
+      background: _requestQrExportPaper,
+      quietZone: PrettyQrQuietZone.modules(quietZoneModules),
+      shape: const PrettyQrSquaresSymbol(color: _requestQrInk),
+    ),
+  );
+  if (bytes == null) {
+    throw StateError('Could not encode the request QR as an image');
+  }
+  return bytes.buffer.asUint8List(bytes.offsetInBytes, bytes.lengthInBytes);
+}
+
+/// A button whose action needs the request as a PNG.
+///
+/// It owns the render so neither the modal nor the sheet has to become
+/// stateful for it, and so both get the same double-tap guard: the encode is
+/// near-instant, but "near" is not "always", and a second tap must not start
+/// a second encode or fire the action twice.
+class RequestQrExportButton extends StatefulWidget {
+  const RequestQrExportButton({
+    required this.uri,
+    required this.label,
+    required this.onBytes,
+    this.onError,
+    this.variant = AppButtonVariant.primary,
+    this.icon,
+    super.key,
+  });
+
+  /// The request to encode, or null while there is not one yet — which
+  /// renders the button disabled rather than hiding it.
+  final String? uri;
+
+  final String label;
+
+  /// Receives the encoded PNG. Nothing is written or shared here.
+  final ValueChanged<Uint8List>? onBytes;
+
+  /// Called instead of [onBytes] when the encode fails.
+  ///
+  /// Without it the press is a silent no-op: the spinner blinks, the future
+  /// this button is invoked as is never awaited, and the user is left looking
+  /// at a share they have every reason to think they made. The caller says
+  /// what failed and names the hand-off still available.
+  final VoidCallback? onError;
+
+  final AppButtonVariant variant;
+
+  /// Icon name from [AppIcons], or null for a bare label.
+  final String? icon;
+
+  @override
+  State<RequestQrExportButton> createState() => _RequestQrExportButtonState();
+}
+
+class _RequestQrExportButtonState extends State<RequestQrExportButton> {
+  bool _busy = false;
+
+  Future<void> _run() async {
+    final uri = widget.uri;
+    final onBytes = widget.onBytes;
+    if (_busy || uri == null || uri.isEmpty || onBytes == null) return;
+
+    setState(() => _busy = true);
+    try {
+      final png = await renderRequestQrPng(uri);
+      if (!mounted) return;
+      onBytes(png);
+    } catch (e) {
+      // The exception stays in the log; the callback is what the user sees.
+      log('RequestQr: ERROR rendering the request QR: $e');
+      if (!mounted) return;
+      widget.onError?.call();
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled =
+        !_busy && widget.onBytes != null && (widget.uri?.isNotEmpty ?? false);
+    final icon = widget.icon;
+
+    return AppButton(
+      expand: true,
+      constrainContent: true,
+      variant: widget.variant,
+      onPressed: enabled ? _run : null,
+      leading: _busy
+          ? const SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : (icon == null ? null : AppIcon(icon)),
+      child: Text(widget.label, maxLines: 1, overflow: TextOverflow.ellipsis),
+    );
+  }
+}

--- a/lib/src/features/send/screens/keystone_send_scan_screen.dart
+++ b/lib/src/features/send/screens/keystone_send_scan_screen.dart
@@ -8,6 +8,7 @@ import '../../../../main.dart' show log;
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../rust/api/keystone.dart' as rust_keystone;
@@ -48,8 +49,11 @@ class KeystoneSendScanScreen extends ConsumerStatefulWidget {
       _KeystoneSendScanScreenState();
 }
 
-class _KeystoneSendScanScreenState
-    extends ConsumerState<KeystoneSendScanScreen> {
+// The device is showing the signed-transaction QR this screen's camera is
+// reading. A payment-request card over it would scrim a live scan, so the
+// screen holds the busy-surface latch for as long as it is mounted.
+class _KeystoneSendScanScreenState extends ConsumerState<KeystoneSendScanScreen>
+    with PaymentUriBusySurfaceHoldMixin {
   bool _decoding = false;
   String? _error;
 

--- a/lib/src/features/send/screens/mobile/mobile_send_scan_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_scan_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../../core/config/network_config.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../address_scan/domain/address_scan_payload.dart';
 import '../../../address_scan/widgets/mobile_address_scan_card.dart';

--- a/lib/src/features/send/screens/mobile/mobile_send_scan_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_scan_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/widgets.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
-import '../../../../core/config/network_config.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../address_scan/domain/address_scan_payload.dart';
 import '../../../address_scan/widgets/mobile_address_scan_card.dart';

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -26,6 +26,7 @@ import '../../../../core/widgets/mobile/mobile_surface_card.dart';
 import '../../../../core/widgets/mobile/mobile_tx_fee_info_sheet.dart';
 import '../../../../core/widgets/mobile_text_field.dart';
 import '../../../../providers/account_provider.dart';
+import '../../../../core/config/network_config.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
 import '../../../../providers/sync_provider.dart';
 import '../../../../providers/zec_price_change_provider.dart';
@@ -104,7 +105,6 @@ class _ReviewRecipientPresentation {
 typedef MobileSendAddressValidator =
     Future<rust_sync.AddressValidationResult> Function({
       required String address,
-      required String network,
     });
 
 typedef MobileSendFeeEstimator =
@@ -532,9 +532,12 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     }
     try {
       final result =
-          await (widget.validateAddress ?? rust_sync.validateAddress)(
+          await (widget.validateAddress ??
+              ({required String address}) => rust_sync.validateAddress(
+                address: address,
+                network: ref.read(rpcEndpointProvider).networkName,
+              ))(
             address: address,
-            network: ref.read(rpcEndpointProvider).networkName,
           );
       if (!mounted || seq != _addressSeq) return;
       setState(

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -26,7 +26,6 @@ import '../../../../core/widgets/mobile/mobile_surface_card.dart';
 import '../../../../core/widgets/mobile/mobile_tx_fee_info_sheet.dart';
 import '../../../../core/widgets/mobile_text_field.dart';
 import '../../../../providers/account_provider.dart';
-import '../../../../core/config/network_config.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
 import '../../../../providers/sync_provider.dart';
 import '../../../../providers/zec_price_change_provider.dart';

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -18,6 +18,8 @@ import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/zec_price_change_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
+import '../../../core/navigation/payment_uri_busy_surface_hold.dart';
+import '../../../core/navigation/payment_uri_busy_surface_provider.dart';
 import '../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../address_book/models/address_book_contact.dart';
@@ -45,7 +47,9 @@ class SendReviewScreen extends ConsumerStatefulWidget {
 }
 
 class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
-  bool _discardScheduled = false;
+  late final PaymentUriBusySurfaceNotifier _paymentUriBusySurface;
+  bool _holdsPaymentUriBusySurface = false;
+  Future<void>? _discardFuture;
   bool _handoffToKeystone = false;
   bool _showSaplingParamsPrompt = false;
   bool _messageExpanded = false;
@@ -64,8 +68,13 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   @override
   void initState() {
     super.initState();
+    _paymentUriBusySurface = ref.read(paymentUriBusySurfaceProvider.notifier);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      if (!_holdsPaymentUriBusySurface) {
+        _paymentUriBusySurface.acquire();
+        _holdsPaymentUriBusySurface = true;
+      }
       ref.read(appLayoutProvider.notifier).setMode(AppLayoutMode.large);
     });
   }
@@ -77,22 +86,29 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     if (promptCompleter != null && !promptCompleter.isCompleted) {
       promptCompleter.complete(false);
     }
-    if (!_handoffToKeystone) {
-      _scheduleDiscard();
-    }
+    final discard = _handoffToKeystone ? null : _scheduleDiscard();
+    _releasePaymentUriBusySurface(after: discard);
     super.dispose();
   }
 
-  void _scheduleDiscard() {
-    if (_discardScheduled) return;
-    _discardScheduled = true;
-    unawaited(
-      discardSendProposal(
-        proposalId: widget.args.proposalId,
-        sendFlowId: widget.args.sendFlowId,
-        logContext: 'SendReview',
-      ),
+  Future<void> _scheduleDiscard() {
+    return _discardFuture ??= discardSendProposal(
+      proposalId: widget.args.proposalId,
+      sendFlowId: widget.args.sendFlowId,
+      logContext: 'SendReview',
     );
+  }
+
+  void _releasePaymentUriBusySurface({Future<void>? after}) {
+    if (!_holdsPaymentUriBusySurface) return;
+    _holdsPaymentUriBusySurface = false;
+    if (after == null) {
+      _paymentUriBusySurface.releaseAfterNavigation();
+      return;
+    }
+    // The route is already gone, but Rust may still hold the selected inputs.
+    // Do not re-drain the parked request until that release has completed.
+    unawaited(after.whenComplete(_paymentUriBusySurface.release));
   }
 
   String _formatAmount(BigInt zatoshi) {
@@ -119,6 +135,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     }
 
     ref.read(sendStatusRoutePayloadProvider.notifier).retain(widget.args);
+    _releasePaymentUriBusySurface();
     await context.push(
       sendStatusRouteLocation(widget.args.sendFlowId),
       extra: widget.args,
@@ -126,7 +143,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   }
 
   void _handleCancel() {
-    _scheduleDiscard();
+    unawaited(_scheduleDiscard());
     if (!mounted) return;
     context.go(
       widget.args.flowKind == SendFlowKind.donation ? '/donation' : '/send',
@@ -195,7 +212,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
       if (widget.args.needsSaplingParams && !saplingParams.complete) {
         final confirmed = await _showDownloadPrompt();
         if (!confirmed) {
-          _scheduleDiscard();
+          unawaited(_scheduleDiscard());
           if (!mounted) return;
           setState(() {
             _keystonePhase = KeystoneSigningModalPhase.failed;
@@ -293,7 +310,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
       });
     } catch (e, st) {
       log('SendReview._prepareKeystonePczt: ERROR: $e\n$st');
-      _scheduleDiscard();
+      unawaited(_scheduleDiscard());
       if (!mounted) return;
       setState(() {
         _keystonePhase = KeystoneSigningModalPhase.failed;
@@ -317,7 +334,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   }
 
   Future<void> _cancelKeystoneSigning() async {
-    _scheduleDiscard();
+    unawaited(_scheduleDiscard());
     if (!mounted) return;
     context.go(
       widget.args.flowKind == SendFlowKind.donation ? '/donation' : '/send',
@@ -372,6 +389,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     if (!mounted) return;
 
     _handoffToKeystone = true;
+    _releasePaymentUriBusySurface();
     final statusArgs = KeystoneBroadcastArgs(
       reviewArgs: widget.args,
       pcztWithProofs: _keystonePcztsWithProofs,
@@ -404,6 +422,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     final zecUsdUnitPrice = ref.watch(zecHomeUsdUnitPriceProvider);
     final memo = widget.args.memo;
     final hasMemo = memo != null && memo.trim().isNotEmpty;
+    final requestedAmountZatoshi = widget.args.differingRequestedAmountZatoshi;
 
     return AppDesktopShell(
       sidebar: AppMainSidebar(
@@ -442,6 +461,10 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
                       onConfirm: () => unawaited(_handleSend()),
                     )
                   : SendReviewContentView(
+                      isPaymentRequest: widget.args.isPaymentRequest,
+                      requestedAmountText: requestedAmountZatoshi == null
+                          ? null
+                          : _formatAmount(requestedAmountZatoshi),
                       amountText: _formatAmount(widget.args.amountZatoshi),
                       fiatText: fiatTextForZatoshi(
                         widget.args.amountZatoshi,
@@ -473,32 +496,37 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
                 isShieldedAddress: widget.args.isShielded,
                 onClose: () => setState(() => _showVerifyAddress = false),
               ),
+            // The review's outer hold protects its proposal inputs. This
+            // nested hold protects the live QR as well, so the latch cannot
+            // briefly open while signing subtrees change.
             if (keystonePhase != null)
-              AppPaneModalOverlay(
-                onDismiss: () => unawaited(_cancelKeystoneSigning()),
-                child: KeystoneSigningModal(
-                  phase: keystonePhase,
-                  urParts: _keystoneUrParts,
-                  error: _keystoneError,
-                  title: 'Confirm with Keystone',
-                  subtitle: _keystoneUrPartsByRound.length == 2
-                      ? 'Transaction ${_keystoneRound + 1} of 2'
-                      : 'Scan with your Keystone',
-                  instruction:
-                      _keystoneError ??
-                      (_keystonePcztsWithProofs.isEmpty
-                          ? 'Scan now. Signature import unlocks after proofs are ready.'
-                          : 'After you scanned, click Get signature.'),
-                  primaryLabel: _keystonePcztsWithProofs.isEmpty
-                      ? 'Preparing'
-                      : 'Get signature',
-                  onPrimary:
-                      keystonePhase == KeystoneSigningModalPhase.ready &&
-                          _keystonePcztsWithProofs.isNotEmpty
-                      ? () => unawaited(_getKeystoneSignature())
-                      : null,
-                  secondaryLabel: 'Cancel',
-                  onSecondary: () => unawaited(_cancelKeystoneSigning()),
+              PaymentUriBusySurfaceHold(
+                child: AppPaneModalOverlay(
+                  onDismiss: () => unawaited(_cancelKeystoneSigning()),
+                  child: KeystoneSigningModal(
+                    phase: keystonePhase,
+                    urParts: _keystoneUrParts,
+                    error: _keystoneError,
+                    title: 'Confirm with Keystone',
+                    subtitle: _keystoneUrPartsByRound.length == 2
+                        ? 'Transaction ${_keystoneRound + 1} of 2'
+                        : 'Scan with your Keystone',
+                    instruction:
+                        _keystoneError ??
+                        (_keystonePcztsWithProofs.isEmpty
+                            ? 'Scan now. Signature import unlocks after proofs are ready.'
+                            : 'After you scanned, click Get signature.'),
+                    primaryLabel: _keystonePcztsWithProofs.isEmpty
+                        ? 'Preparing'
+                        : 'Get signature',
+                    onPrimary:
+                        keystonePhase == KeystoneSigningModalPhase.ready &&
+                            _keystonePcztsWithProofs.isNotEmpty
+                        ? () => unawaited(_getKeystoneSignature())
+                        : null,
+                    secondaryLabel: 'Cancel',
+                    onSecondary: () => unawaited(_cancelKeystoneSigning()),
+                  ),
                 ),
               ),
             if (_showSaplingParamsPrompt)

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -421,7 +421,10 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     );
     final zecUsdUnitPrice = ref.watch(zecHomeUsdUnitPriceProvider);
     final memo = widget.args.memo;
-    final hasMemo = memo != null && memo.trim().isNotEmpty;
+    // Present means non-empty, not non-blank: an edited request whose memo is
+    // only whitespace still sends that memo, so the row has to say so rather
+    // than omit a memo the transaction carries.
+    final hasMemo = memo != null && memo.isNotEmpty;
     final requestedAmountZatoshi = widget.args.differingRequestedAmountZatoshi;
 
     return AppDesktopShell(

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -15,6 +15,7 @@ import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/privacy/privacy_mask.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/amount_price_loading_bar.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -54,9 +55,12 @@ class SendScreen extends ConsumerStatefulWidget {
 }
 
 class _SendScreenState extends ConsumerState<SendScreen> {
+  SendPrefillArgs? _retainedPrefill;
+
   @override
   void initState() {
     super.initState();
+    _retainedPrefill = widget.prefill;
     try {
       ref.read(sendProvingKeyWarmupProvider).call();
     } catch (error) {
@@ -65,7 +69,17 @@ class _SendScreenState extends ConsumerState<SendScreen> {
   }
 
   @override
+  void didUpdateWidget(covariant SendScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final prefill = widget.prefill;
+    if (prefill != null) {
+      _retainedPrefill = prefill;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final prefill = widget.prefill ?? _retainedPrefill;
     final walletAsync = ref.watch(walletProvider);
     final accountState = ref.watch(accountProvider).value;
     final activeAccountUuid = accountState?.activeAccountUuid;
@@ -90,14 +104,14 @@ class _SendScreenState extends ConsumerState<SendScreen> {
         sync.isUsingCompletedSpendableSnapshot;
 
     return _SendComposeBody(
-      key: ValueKey('$activeAccountUuid:${widget.prefill?.fingerprint ?? ''}'),
+      key: ValueKey('$activeAccountUuid:${prefill?.fingerprint ?? ''}'),
       walletAsync: walletAsync,
       activeAccountUuid: activeAccountUuid,
       activeAccountIsHardware: activeAccountIsHardware,
       spendableBalance: spendableBalance,
       displaySpendableBalance: displaySpendableBalance,
       isUsingCompletedSpendableSnapshot: isUsingCompletedSpendableSnapshot,
-      prefill: widget.prefill,
+      prefill: prefill,
     );
   }
 }
@@ -206,6 +220,12 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   bool _contactPickerOpen = false;
   String? _error;
   String _addressType = '';
+
+  /// True when the last validation refused the address only because it belongs
+  /// to another Zcash network. `_addressType` stays `'invalid'` in that case so
+  /// every gate that already refuses bad addresses keeps refusing this one;
+  /// this flag changes nothing but the sentence under the field.
+  bool _addressWrongNetwork = false;
   String?
   _amountError; // null = no error, empty string = silent invalid (empty/dot)
   // Canonical wallet amount used for validation and Rust calls. The controller
@@ -217,16 +237,25 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   bool _isMaxMode = false;
   bool _isResolvingMax = false;
   bool _programmaticAmountEdit = false;
+  bool _programmaticMemoEdit = false;
+  bool _preserveMemoWhitespace = false;
+  // Last memo text this widget observed. TextEditingController notifies on
+  // selection-only changes too (focusing the field, moving the caret), which
+  // must not count as the user editing the memo.
+  String _lastMemoText = '';
   _MaxQuote? _maxQuote;
   Timer? _maxDebounceTimer;
   int _addressSeq = 0;
   int _maxSeq = 0;
   int _validateSeq = 0;
+  String? _appliedPrefillFingerprint;
 
   @override
   void initState() {
     super.initState();
     _applyPrefill(widget.prefill);
+    // _applyPrefill may have seeded the memo before the listener existed.
+    _lastMemoText = _memoController.text;
     _memoController.addListener(_handleMemoChanged);
     _addressFocusNode.addListener(_handleFieldVisualStateChanged);
     _amountFocusNode.addListener(_handleFieldVisualStateChanged);
@@ -234,24 +263,6 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       ref.read(appLayoutProvider.notifier).setMode(AppLayoutMode.large);
-    });
-  }
-
-  void _applyPrefill(SendPrefillArgs? prefill) {
-    if (prefill == null) return;
-    _addressController.text = prefill.address;
-    if (prefill.amountText != null) {
-      _amountText = prefill.amountText!.trim();
-      _amountController.text = _amountText;
-      _amountError = null;
-    }
-    if (prefill.memoText != null && prefill.memoText!.isNotEmpty) {
-      _memoController.text = prefill.memoText!;
-      _messageExpanded = true;
-    }
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      unawaited(_validateAddress());
     });
   }
 
@@ -273,7 +284,15 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   }
 
   void _handleMemoChanged() {
-    if (_memoController.text.isNotEmpty && !_messageExpanded) {
+    final text = _memoController.text;
+    // Selection-only notification: tapping into the memo field must not drop
+    // the ZIP-321 whitespace the link asked us to preserve.
+    if (text == _lastMemoText) return;
+    _lastMemoText = text;
+    if (!_programmaticMemoEdit) {
+      _preserveMemoWhitespace = false;
+    }
+    if (text.isNotEmpty && !_messageExpanded) {
       _messageExpanded = true;
     }
     if (_isMaxMode) {
@@ -322,9 +341,42 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     _handleAddressChanged();
   }
 
+  void _applyPrefill(SendPrefillArgs? prefill) {
+    if (prefill == null || _appliedPrefillFingerprint == prefill.fingerprint) {
+      return;
+    }
+    _appliedPrefillFingerprint = prefill.fingerprint;
+    _maxDebounceTimer?.cancel();
+    _addressController.text = prefill.address;
+    if (prefill.amountText != null) {
+      _amountText = prefill.amountText!.trim();
+      _amountController.text = _amountText;
+      _amountError = null;
+    }
+    final memoText = prefill.memoText;
+    if (memoText != null && memoText.isNotEmpty) {
+      _preserveMemoWhitespace = prefill.preserveMemoText;
+      _programmaticMemoEdit = true;
+      _memoController.text = memoText;
+      _programmaticMemoEdit = false;
+      _messageExpanded = true;
+    } else {
+      _preserveMemoWhitespace = false;
+    }
+    _isMaxMode = false;
+    _isResolvingMax = false;
+    _maxQuote = null;
+    _error = null;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_validateAddress());
+    });
+  }
+
   @override
   void didUpdateWidget(covariant _SendComposeBody oldWidget) {
     super.didUpdateWidget(oldWidget);
+    _applyPrefill(widget.prefill);
     if (oldWidget.spendableBalance != widget.spendableBalance ||
         oldWidget.displaySpendableBalance != widget.displaySpendableBalance ||
         oldWidget.isUsingCompletedSpendableSnapshot !=
@@ -345,7 +397,10 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     final addr = _addressController.text.trim();
     if (addr.isEmpty) {
       if (!mounted || seq != _addressSeq) return;
-      setState(() => _addressType = '');
+      setState(() {
+        _addressType = '';
+        _addressWrongNetwork = false;
+      });
       _handleAddressValidationSettled();
       return;
     }
@@ -358,8 +413,10 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       final nextAddressType = result.isValid ? result.addressType : 'invalid';
       setState(() {
         _addressType = nextAddressType;
+        _addressWrongNetwork = result.wrongNetwork;
         if (_isTransparentLikeType(nextAddressType)) {
           _messageExpanded = false;
+          _preserveMemoWhitespace = false;
         }
       });
       if (_isTransparentLikeType(nextAddressType) &&
@@ -370,7 +427,10 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     } catch (e) {
       log('Send: address validation error: $e');
       if (!mounted || seq != _addressSeq) return;
-      setState(() => _addressType = 'error');
+      setState(() {
+        _addressType = 'error';
+        _addressWrongNetwork = false;
+      });
       _handleAddressValidationSettled();
     }
   }
@@ -388,6 +448,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     _maxDebounceTimer?.cancel();
     setState(() {
       _addressType = '';
+      _addressWrongNetwork = false;
       _error = null;
       if (_isMaxMode) {
         _validateSeq++;
@@ -556,8 +617,11 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   bool _isTransparentLikeType(String addressType) =>
       addressType == 'transparent' || addressType == 'tex';
 
-  String get _effectiveMemo =>
-      _isTransparentLikeAddress ? '' : _memoController.text.trim();
+  String get _effectiveMemo {
+    if (_isTransparentLikeAddress) return '';
+    final memo = _memoController.text;
+    return _preserveMemoWhitespace ? memo : memo.trim();
+  }
 
   BigInt get _availableBalanceForCurrentAddress =>
       widget.displaySpendableBalance;
@@ -841,8 +905,12 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       }
     } catch (e) {
       if (!mounted || seq != _validateSeq) return;
-      final msg = e.toString();
-      if (msg.contains('InsufficientFunds') || msg.contains('insufficient')) {
+      // Lowercase first, like the max estimate above: what Rust actually
+      // sends up is "Propose failed: Insufficient balance (have …, need …
+      // including fee)", so a case-sensitive match on either literal never
+      // fired and this warning could not reach the composer at all.
+      final msg = e.toString().toLowerCase();
+      if (msg.contains('insufficientfunds') || msg.contains('insufficient')) {
         setState(() => _amountError = _insufficientBalanceIncludingFeeText);
       } else {
         log('Send: fee estimation failed (non-blocking): $e');
@@ -852,6 +920,16 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   }
 
   bool get _isAmountValid => _amountError == null;
+
+  /// The prefill this compose form was opened from, when it came from a
+  /// payment request and still points at the same recipient.
+  SendPrefillArgs? _activePaymentRequest(String address) {
+    final prefill = widget.prefill;
+    if (prefill == null) return null;
+    if (prefill.source != kPaymentUriPrefillSource) return null;
+    if (prefill.address.trim() != address) return null;
+    return prefill;
+  }
 
   Future<void> _openReview() async {
     setState(() {
@@ -920,6 +998,10 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         });
         return;
       }
+      // A payment request that was edited rather than accepted as-is keeps
+      // its framing — but only while the recipient is still the one the
+      // request named. Retype the address and this is an ordinary send again.
+      final request = _activePaymentRequest(address);
       final reviewArgs = await proposeSendTransfer(
         ref: ref,
         loadDbPath: ref.read(sendWalletDbPathProvider),
@@ -929,6 +1011,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         addressType: _addressType,
         amountZatoshi: amountZatoshi,
         memo: memo.isNotEmpty ? memo : null,
+        isPaymentRequest: request != null,
+        requestedBy: request?.label,
+        requestedAmountZatoshi: parseZecAmount(request?.amountText ?? ''),
       );
       activeProposalId = reviewArgs.proposalId;
 
@@ -1043,7 +1128,10 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       }
     }
     final addressMessage = switch (_addressType) {
-      'invalid' => 'Invalid address',
+      // A wrong-network address is well-formed, so "Invalid address" would
+      // send the user hunting for a typo that is not there.
+      'invalid' =>
+        _addressWrongNetwork ? kWrongNetworkAddressMessage : 'Invalid address',
       'error' => 'Address validation failed',
       _ => matchedRecipientName,
     };
@@ -1222,6 +1310,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                       _maxDebounceTimer?.cancel();
                                       setState(() {
                                         _addressType = '';
+                                        _addressWrongNetwork = false;
                                         _error = null;
                                         if (_isMaxMode) {
                                           _validateSeq++;
@@ -2048,7 +2137,9 @@ class _SendAmountConversionRow extends StatelessWidget {
               ),
             ),
             const SizedBox(width: AppSpacing.xxs),
-            const _SendAmountPriceLoadingBar(),
+            const AmountPriceLoadingBar(
+              key: ValueKey('send_amount_price_loading'),
+            ),
           ] else
             Text(
               text ?? r'$ 0',
@@ -2079,24 +2170,6 @@ class _SendAmountConversionRow extends StatelessWidget {
             child: content,
           ),
         ),
-      ),
-    );
-  }
-}
-
-class _SendAmountPriceLoadingBar extends StatelessWidget {
-  const _SendAmountPriceLoadingBar();
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Container(
-      key: const ValueKey('send_amount_price_loading'),
-      width: 48,
-      height: 12,
-      decoration: BoxDecoration(
-        color: colors.background.overlay.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(AppRadii.full),
       ),
     );
   }

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -298,7 +298,10 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     );
     final zecUsdUnitPrice = ref.watch(zecHomeUsdUnitPriceProvider);
     final memo = widget.args.memo;
-    final hasMemo = memo != null && memo.trim().isNotEmpty;
+    // Present means non-empty, not non-blank: an edited request whose memo is
+    // only whitespace still sends that memo, so the row has to say so rather
+    // than omit a memo the transaction carries.
+    final hasMemo = memo != null && memo.isNotEmpty;
     final canOpenExplorer =
         (_phase == _SendStatusPhase.succeeded ||
             _phase == _SendStatusPhase.pendingBroadcast) &&

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -55,12 +55,16 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   bool _showVerifyAddress = false;
   Completer<bool>? _saplingParamsPromptCompleter;
 
+  /// Captured in [initState] so [dispose] can release the flag without reading
+  /// from `ref` after the element is gone.
+  late final SendStatusTerminalNotifier _sendStatusTerminal;
   bool get _suppressSidebarSelection =>
       widget.args.flowKind == SendFlowKind.donation;
 
   @override
   void initState() {
     super.initState();
+    _sendStatusTerminal = ref.read(sendStatusTerminalProvider.notifier);
     _proposalConsumed = widget.keystone != null;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -79,6 +83,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     if (_phase != _SendStatusPhase.sending) {
       _scheduleDiscardIfNeeded();
     }
+    _sendStatusTerminal.resetAfterNavigation();
     super.dispose();
   }
 
@@ -160,6 +165,8 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   }
 
   Future<void> _startBroadcast() async {
+    // A broadcast is starting: nothing is safe to leave yet.
+    _sendStatusTerminal.reset();
     final outcome = await runSendBroadcast(
       ref: ref,
       args: widget.args,
@@ -184,6 +191,10 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
         _completedAt = DateTime.now();
       }
     });
+    if (_phase == _SendStatusPhase.succeeded ||
+        _phase == _SendStatusPhase.failed) {
+      _sendStatusTerminal.markTerminal();
+    }
   }
 
   Widget _buildKeystoneSubmittingScreen(BuildContext context) {

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -31,11 +31,30 @@ import '../widgets/send_verify_address_overlay.dart';
 
 enum _SendStatusPhase { sending, pendingBroadcast, succeeded, failed }
 
+typedef SendStatusBroadcastRunner =
+    Future<SendBroadcastOutcome> Function({
+      required WidgetRef ref,
+      required SendReviewArgs args,
+      KeystoneBroadcastArgs? keystone,
+      required Future<bool> Function() confirmSaplingParamsDownload,
+      Future<bool> Function()? shouldAbort,
+    });
+
 class SendStatusScreen extends ConsumerStatefulWidget {
-  const SendStatusScreen({super.key, required this.args, this.keystone});
+  const SendStatusScreen({
+    super.key,
+    required this.args,
+    this.keystone,
+    this.broadcastRunner,
+  });
 
   final SendReviewArgs args;
   final KeystoneBroadcastArgs? keystone;
+
+  /// The software send's missing-mnemonic branch is `!Platform.isMacOS`, so a
+  /// macOS test host cannot reach it through the real runner.
+  @visibleForTesting
+  final SendStatusBroadcastRunner? broadcastRunner;
 
   @override
   ConsumerState<SendStatusScreen> createState() => _SendStatusScreenState();
@@ -81,21 +100,25 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
       promptCompleter.complete(false);
     }
     if (_phase != _SendStatusPhase.sending) {
-      _scheduleDiscardIfNeeded();
+      unawaited(_discardProposalIfNeeded('SendStatus(dispose)'));
     }
     _sendStatusTerminal.resetAfterNavigation();
     super.dispose();
   }
 
-  void _scheduleDiscardIfNeeded() {
+  /// Releases the proposal unless the broadcast already consumed it.
+  ///
+  /// Idempotent by claim rather than by retry: the first caller — the failed
+  /// outcome below or [dispose] — takes the discard and every later call is a
+  /// no-op, so a failure that releases the proposal on screen does not get a
+  /// second release when the receipt is finally left.
+  Future<void> _discardProposalIfNeeded(String logContext) async {
     if (_proposalConsumed || _discardScheduled) return;
     _discardScheduled = true;
-    unawaited(
-      discardSendProposal(
-        proposalId: widget.args.proposalId,
-        sendFlowId: widget.args.sendFlowId,
-        logContext: 'SendStatus(dispose)',
-      ),
+    await discardSendProposal(
+      proposalId: widget.args.proposalId,
+      sendFlowId: widget.args.sendFlowId,
+      logContext: logContext,
     );
   }
 
@@ -167,7 +190,8 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   Future<void> _startBroadcast() async {
     // A broadcast is starting: nothing is safe to leave yet.
     _sendStatusTerminal.reset();
-    final outcome = await runSendBroadcast(
+    final runner = widget.broadcastRunner ?? runSendBroadcast;
+    final outcome = await runner(
       ref: ref,
       args: widget.args,
       keystone: widget.keystone,
@@ -193,6 +217,20 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     });
     if (_phase == _SendStatusPhase.succeeded ||
         _phase == _SendStatusPhase.failed) {
+      if (_phase == _SendStatusPhase.failed) {
+        // A failed outcome does not always hand the proposal back: the
+        // software send's missing-mnemonic branch returns
+        // `proposalConsumed: false` without touching Rust's PROPOSAL_STORE,
+        // and until now the release waited for `dispose`. Marking the send
+        // terminal first lets `_IncomingLinkHost` drain a parked `zcash:`
+        // request against inputs this dead send still locks, which the
+        // request pre-check reads as insufficient funds. So: release, then
+        // publish "safe to leave".
+        await _discardProposalIfNeeded('SendStatus(failed)');
+        // Leaving during the release means `dispose` already reset the flag;
+        // re-raising it here would strand it for the next screen.
+        if (!mounted) return;
+      }
       _sendStatusTerminal.markTerminal();
     }
   }

--- a/lib/src/features/send/services/send_flow.dart
+++ b/lib/src/features/send/services/send_flow.dart
@@ -209,10 +209,18 @@ class SendStatusTerminalNotifier extends Notifier<bool> {
   /// provider write; the revision guard stops a departing screen from clearing
   /// a newer one's flag. A microtask rather than a timer, so it cannot outlive
   /// a widget test's tree.
+  ///
+  /// A receipt left before its send went terminal — a pending broadcast the
+  /// user walked away from — publishes terminal first. The payment-URI drain
+  /// parks a `zcash:` link behind a running send and re-runs only on this
+  /// flag's false → true edge; once the receipt is gone the route no longer
+  /// blocks delivery, and a false → false release would leave the link parked
+  /// until some unrelated wallet event happened to run the drain.
   void resetAfterNavigation() {
     final retainedRevision = _revision;
     scheduleMicrotask(() {
       if (_disposed || _revision != retainedRevision) return;
+      if (!state) markTerminal();
       reset();
     });
   }

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -13,6 +13,7 @@ import '../../../core/widgets/pool_badge.dart';
 import '../../../core/widgets/review_list_row.dart'
     show kPaymentRequestRequesterTooltip;
 import '../../../core/widgets/review_wrap_card.dart';
+import 'send_review_layout.dart';
 
 /// Desktop width of the payment-request modal card.
 ///
@@ -740,7 +741,9 @@ class _PaymentRequestCardState extends State<PaymentRequestCard> {
           // carries, so the row stays — but drawing those bytes draws
           // nothing, and a row that looks empty is indistinguishable from a
           // request that asked for no memo at all.
-          placeholder: request.memoIsWhitespaceOnly ? 'Whitespace only' : null,
+          placeholder: request.memoIsWhitespaceOnly
+              ? kWhitespaceOnlyMemoPlaceholder
+              : null,
           expanded: _messageExpanded,
           onToggle: _toggleMessage,
         ),

--- a/lib/src/features/send/widgets/payment_request_host.dart
+++ b/lib/src/features/send/widgets/payment_request_host.dart
@@ -38,7 +38,17 @@ class PaymentRequestHost extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final flow = ref.watch(paymentRequestFlowProvider);
-    if (flow == null) return child;
+    // [child] is the router's content, and it holds route-local state — a
+    // half-typed Send form, a scroll offset, an expanded row. So it keeps one
+    // position in the tree whether or not a card is up: always this `Stack`'s
+    // first layer, with the request laid over it as a second layer. Handing it
+    // to the surface as its background instead re-parented it on every show
+    // and every dismiss, and Flutter answers a subtree that moved by disposing
+    // and remounting it — which emptied the form the card was supposed to be
+    // sitting harmlessly on top of.
+    if (flow == null) {
+      return Stack(fit: StackFit.passthrough, children: [child]);
+    }
 
     final notifier = ref.read(paymentRequestFlowProvider.notifier);
 
@@ -109,15 +119,20 @@ class PaymentRequestHost extends ConsumerWidget {
     // Pointer-driven dismissal (the scrim, the ⨯, and — because the scrim is
     // an opaque hit-test target over the whole app — the iOS edge swipe) is
     // owned by `PaymentRequestSurface`.
-    return PaymentRequestSurface(
-      key: const ValueKey('payment_request_host_surface'),
-      cardKey: ValueKey(flow.prefill.id),
-      request: request,
-      onContinue: review,
-      onEdit: edit,
-      onCancel: notifier.dismiss,
-      onRecheck: notifier.recheck,
-      background: child,
+    return Stack(
+      fit: StackFit.passthrough,
+      children: [
+        child,
+        PaymentRequestSurface.overlay(
+          key: const ValueKey('payment_request_host_surface'),
+          cardKey: ValueKey(flow.prefill.id),
+          request: request,
+          onContinue: review,
+          onEdit: edit,
+          onCancel: notifier.dismiss,
+          onRecheck: notifier.recheck,
+        ),
+      ],
     );
   }
 

--- a/lib/src/features/send/widgets/payment_request_host.dart
+++ b/lib/src/features/send/widgets/payment_request_host.dart
@@ -8,6 +8,8 @@
 /// `paymentRequestFlowProvider` clears.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -88,15 +90,30 @@ class PaymentRequestHost extends ConsumerWidget {
         );
 
     void edit() {
-      final prefill = notifier.edit();
-      if (prefill == null) return;
-      _releaseRetainedSendStatus(ref);
-      // Both `/send` pages are keyed on the prefill's id, so this remounts the
-      // composer and discards anything already typed there. That is intended:
-      // Edit is the user asking for this request to be loaded, and a composer
-      // that kept half of a different payment's fields would be the more
-      // dangerous outcome of the two.
-      router.go('/send', extra: prefill);
+      // The card comes down at once, but the composer opens only when Rust
+      // has released the card's proposal: the composer re-quotes the fee as
+      // it mounts, and Rust cannot select inputs a proposal still holds, so a
+      // wallet whose funds sit in those inputs would answer that quote with
+      // "not enough ZEC" for the very payment the card just found affordable.
+      unawaited(() async {
+        switch (await notifier.editHandingBack()) {
+          case PaymentRequestEditReady(:final prefill):
+            _releaseRetainedSendStatus(ref);
+            // Both `/send` pages are keyed on the prefill's id, so this
+            // remounts the composer and discards anything already typed
+            // there. That is intended: Edit is the user asking for this
+            // request to be loaded, and a composer that kept half of a
+            // different payment's fields would be the more dangerous outcome
+            // of the two.
+            router.go('/send', extra: prefill);
+          case PaymentRequestEditOvertaken():
+            // A newer link owns the card now, and it carries the replaced
+            // notice that accounts for this tap.
+            break;
+          case PaymentRequestEditUnavailable():
+            break;
+        }
+      }());
     }
 
     void review() {

--- a/lib/src/features/send/widgets/payment_request_host.dart
+++ b/lib/src/features/send/widgets/payment_request_host.dart
@@ -1,0 +1,130 @@
+/// Mounts the payment-request card above the whole app.
+///
+/// A payment request is not a destination — it arrives over whatever the user
+/// was already doing and asks one question. So the card is hosted once, at the
+/// app level, above the router's content, rather than being a route of its own.
+/// That is also what makes "the card stays until it is answered" true across a
+/// route change, and what makes it disappear the instant
+/// `paymentRequestFlowProvider` clears.
+library;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../providers/account_models.dart';
+import '../../../providers/payment_request_flow_provider.dart';
+import '../../../providers/zec_price_change_provider.dart';
+import '../../address_book/models/address_book_contact.dart';
+import '../../address_book/providers/address_book_provider.dart';
+import '../services/send_flow.dart';
+import 'payment_request_surface.dart';
+import 'send_recipient_resolver.dart';
+
+class PaymentRequestHost extends ConsumerWidget {
+  const PaymentRequestHost({
+    required this.router,
+    required this.child,
+    super.key,
+  });
+
+  /// Passed in rather than looked up: the host is mounted from
+  /// `MaterialApp.router`'s `builder`, whose context sits *above* the
+  /// `Router`, so `GoRouter.of(context)` finds nothing there.
+  final GoRouter router;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final flow = ref.watch(paymentRequestFlowProvider);
+    if (flow == null) return child;
+
+    final notifier = ref.read(paymentRequestFlowProvider.notifier);
+
+    // Who the request is actually addressed to, when the wallet can say. Both
+    // sources load asynchronously and are read for their settled value only:
+    // an address book still reading from secure storage, or an own-account
+    // lookup still asking Rust for each account's addresses, leaves the card
+    // showing the plain address until it lands rather than holding the card
+    // back. These are watched below the early return above, so a wallet with
+    // no request on screen never pays for the lookup.
+    final contacts =
+        ref.watch(addressBookProvider).value?.contacts ??
+        const <AddressBookContact>[];
+    final ownAccounts =
+        ref.watch(ownAccountAddressesProvider).value ??
+        const <String, AccountInfo>{};
+    // Same story for the price: `zecHomeUsdUnitPriceProvider` is autoDispose
+    // and its market data fills asynchronously, so a request that arrives over
+    // Settings or Activity — screens that subscribe to neither — would read
+    // null once and never show a fiat line, while the same request opened from
+    // Home would. Watching it here both keeps it alive for the card's lifetime
+    // and re-applies the value when it lands.
+    final zecUsdUnitPrice = ref.watch(zecHomeUsdUnitPriceProvider);
+    final request = flow.view
+        .withRecipientIdentity(
+          paymentRequestRecipientIdentityFor(
+            contacts: contacts,
+            address: flow.view.address,
+            ownAccounts: ownAccounts,
+          ),
+        )
+        .withFiatText(
+          paymentRequestFiatText(
+            prefill: flow.prefill,
+            zecUsdUnitPrice: zecUsdUnitPrice,
+          ),
+        );
+
+    void edit() {
+      final prefill = notifier.edit();
+      if (prefill == null) return;
+      _releaseRetainedSendStatus(ref);
+      // Both `/send` pages are keyed on the prefill's id, so this remounts the
+      // composer and discards anything already typed there. That is intended:
+      // Edit is the user asking for this request to be loaded, and a composer
+      // that kept half of a different payment's fields would be the more
+      // dangerous outcome of the two.
+      router.go('/send', extra: prefill);
+    }
+
+    void review() {
+      // An amount-less request has nothing to review: its primary action is
+      // "Enter amount", which is Edit under a different label.
+      if (!flow.canReview) {
+        edit();
+        return;
+      }
+      final args = notifier.review();
+      if (args == null) return;
+      _releaseRetainedSendStatus(ref);
+      router.go('/send/review', extra: args);
+    }
+
+    // The Android system back press is answered by
+    // `MobileExitBackDispatcher.handleBackAboveRouter`, not by a `PopScope`
+    // here: this host is mounted from `MaterialApp.router`'s builder, above
+    // the `Router`, and a `PopScope` with no `ModalRoute` ancestor never runs.
+    // Pointer-driven dismissal (the scrim, the ⨯, and — because the scrim is
+    // an opaque hit-test target over the whole app — the iOS edge swipe) is
+    // owned by `PaymentRequestSurface`.
+    return PaymentRequestSurface(
+      key: const ValueKey('payment_request_host_surface'),
+      cardKey: ValueKey(flow.prefill.id),
+      request: request,
+      onContinue: review,
+      onEdit: edit,
+      onCancel: notifier.dismiss,
+      onRecheck: notifier.recheck,
+      background: child,
+    );
+  }
+
+  /// A finished `/send/status` keeps its route payload retained so a router
+  /// refresh can restore it. Navigating the card's answer onto `/send` or
+  /// `/send/review` would let that stale receipt be restored over it.
+  void _releaseRetainedSendStatus(WidgetRef ref) {
+    ref.read(sendStatusRoutePayloadProvider.notifier).clear();
+  }
+}

--- a/lib/src/features/send/widgets/payment_request_surface.dart
+++ b/lib/src/features/send/widgets/payment_request_surface.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart' show Material, MaterialType;
+import 'package:flutter/widgets.dart';
+
+import '../../../core/layout/app_form_factor.dart';
+import '../../../core/layout/content_overlay_inset.dart';
+import '../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_modal_card.dart';
+import '../../../core/widgets/app_pane_modal_overlay.dart';
+import 'payment_request_card.dart';
+
+/// Modal chrome for [PaymentRequestCard].
+///
+/// A payment request always arrives over whatever the user was already
+/// doing, so it presents as a modal in both form factors: a centered card
+/// above the pane scrim on desktop, a bottom-anchored sheet card on mobile.
+/// This widget renders that presentation inline (no route push), which is
+/// what the Widgetbook and figma-compare previews use; the live mobile
+/// route can use [showPaymentRequestSheet] instead.
+class PaymentRequestSurface extends StatelessWidget {
+  const PaymentRequestSurface({
+    required this.request,
+    required this.onContinue,
+    required this.onEdit,
+    required this.onCancel,
+    this.onRecheck,
+    this.layout = PaymentRequestLayout.auto,
+    this.initialAddressExpanded = false,
+    this.initialMessageExpanded = false,
+    this.cardKey,
+    this.background,
+    super.key,
+  });
+
+  final PaymentRequestView request;
+  final VoidCallback onContinue;
+  final VoidCallback onEdit;
+  final VoidCallback onCancel;
+
+  /// Ask the wallet again; see [PaymentRequestCard.onRecheck].
+  final VoidCallback? onRecheck;
+
+  /// Tooling-only layout override; see [PaymentRequestLayout].
+  final PaymentRequestLayout layout;
+
+  /// Tooling-only: renders the To row already expanded to the full address.
+  final bool initialAddressExpanded;
+
+  /// Tooling-only: renders the Message row already expanded to its full text.
+  final bool initialMessageExpanded;
+
+  /// Identity of the request whose disclosure state the card owns.
+  final Key? cardKey;
+
+  /// What the modal sits on top of. Defaults to the flat window color so a
+  /// preview does not have to supply a whole screen.
+  final Widget? background;
+
+  bool get _isMobile => switch (layout) {
+    PaymentRequestLayout.auto => kAppFormFactor == AppFormFactor.mobile,
+    PaymentRequestLayout.desktop => false,
+    PaymentRequestLayout.mobile => true,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    // Hosted above the router there is no Material ancestor, so without this
+    // the card's text falls back to the framework default style (and the
+    // debug yellow underline). Transparent, so nothing else changes.
+    final card = Material(
+      type: MaterialType.transparency,
+      child: PaymentRequestCard(
+        key: cardKey,
+        request: request,
+        onContinue: onContinue,
+        onEdit: onEdit,
+        onCancel: onCancel,
+        onRecheck: onRecheck,
+        layout: layout,
+        initialAddressExpanded: initialAddressExpanded,
+        initialMessageExpanded: initialMessageExpanded,
+        // The surrounding modal frame owns the bottom edge in both form
+        // factors.
+        bottomSafeArea: false,
+      ),
+    );
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        background ?? ColoredBox(color: colors.background.window),
+        _ModalOverlayScope(
+          child: _isMobile
+              ? _mobileModal(context, card)
+              : _desktopModal(context, card),
+        ),
+      ],
+    );
+  }
+
+  Widget _mobileModal(BuildContext context, Widget card) {
+    final colors = context.colors;
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        // Same dismissal contract as the desktop branch, which gets
+        // scrim-tap and Escape from `AppPaneModalOverlay`. The Android
+        // back gesture belongs to the route host — `showAppMobileSheet`
+        // already provides it, and a `PopScope` here would also swallow
+        // back for whatever route embeds this inline.
+        GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onCancel,
+          child: ColoredBox(color: colors.background.neutralScrim),
+        ),
+        // `showAppMobileSheet` gets this from `useSafeArea`; the inline
+        // presentation has to keep the same clearance itself so a tall
+        // request never runs into the status bar.
+        SafeArea(
+          bottom: false,
+          minimum: const EdgeInsets.only(top: AppSpacing.base),
+          child: Align(
+            alignment: Alignment.bottomCenter,
+            child: MobileModalCard(
+              child: Material(
+                type: MaterialType.transparency,
+                child: paymentRequestSheetBody(card, onClose: onCancel),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _desktopModal(BuildContext context, Widget card) {
+    return AppPaneModalOverlay(
+      onDismiss: onCancel,
+      // The card is hosted above the router, so its scrim covers the
+      // whole window — but the request is content, and content belongs
+      // over the content pane. The shell's published pane insets move
+      // the card off the sidebar's half of the window; with no shell
+      // mounted they are zero and this centers on the window as before.
+      child: ContentPaneCenteringPadding(
+        child: AppModalCard(width: kPaymentRequestCardWidth, child: card),
+      ),
+    );
+  }
+}
+
+/// Gives the scrim-and-card branch an [Overlay] ancestor.
+///
+/// The live host mounts this surface from `MaterialApp.router`'s `builder`,
+/// above the `Router` — so there is no `Navigator`, and therefore no
+/// `Overlay`, anywhere above the card. The requester help tooltip needs one,
+/// for the same reason the card needs its transparent [Material].
+///
+/// Only the modal branch goes inside. The background stays where it was in
+/// the outer stack, so the app underneath is not re-parented.
+class _ModalOverlayScope extends StatefulWidget {
+  const _ModalOverlayScope({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_ModalOverlayScope> createState() => _ModalOverlayScopeState();
+}
+
+class _ModalOverlayScopeState extends State<_ModalOverlayScope> {
+  // `initialEntries` is read once, so the entry has to read `widget.child`
+  // at build time and be told when a new request replaces it.
+  late final OverlayEntry _entry = OverlayEntry(builder: (_) => widget.child);
+
+  @override
+  void didUpdateWidget(covariant _ModalOverlayScope oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.child, widget.child)) _entry.markNeedsBuild();
+  }
+
+  @override
+  Widget build(BuildContext context) => Overlay(initialEntries: [_entry]);
+}
+
+/// The mobile sheet body: the app's shared modal chrome around the card.
+///
+/// [MobileModalScaffold] owns the standard top 32 / sides 16 padding and the
+/// pinned 32x32 top-right close every mobile sheet has, which is why the
+/// card carries no Cancel button of its own. The card renders its own serif
+/// title (and the requester line under it), so the scaffold's title row is
+/// off — the shared reservation for the pinned close lives in the card's
+/// header instead ([kPaymentRequestMobileCloseClearance]).
+///
+/// [bottomPadding] is the Figma modal base's 32 under the action stack; the
+/// bottom safe area itself stays with `MobileModalCard`, so it is never
+/// applied twice.
+Widget paymentRequestSheetBody(Widget card, {required VoidCallback onClose}) {
+  return MobileModalScaffold(
+    title: '',
+    showTitle: false,
+    onClose: onClose,
+    // Figma `_Modal Type` (4638:74505): 32 between the button stack and
+    // the sheet's bottom edge.
+    bottomPadding: AppSpacing.base,
+    // The scaffold lays its body out in a min-size Column, which hands a
+    // plain child unbounded height. The card needs a bounded one — that is
+    // what makes its details region scroll instead of overflowing the sheet.
+    child: Flexible(child: card),
+  );
+}
+
+/// Presents the payment request as a mobile bottom sheet.
+///
+/// Resolves to `'continue'`, `'edit'`, or null when dismissed, so the
+/// caller decides what each answer routes to. Nothing here reads providers
+/// or parses the request.
+Future<String?> showPaymentRequestSheet({
+  required BuildContext context,
+  required PaymentRequestView request,
+}) {
+  return showAppMobileSheet<String>(
+    context: context,
+    builder: (sheetContext) => paymentRequestSheetBody(
+      PaymentRequestCard(
+        request: request,
+        bottomSafeArea: false,
+        onContinue: () => Navigator.of(sheetContext).pop('continue'),
+        onEdit: () => Navigator.of(sheetContext).pop('edit'),
+        onCancel: () => Navigator.of(sheetContext).pop(),
+      ),
+      onClose: () => Navigator.of(sheetContext).pop(),
+    ),
+  );
+}

--- a/lib/src/features/send/widgets/payment_request_surface.dart
+++ b/lib/src/features/send/widgets/payment_request_surface.dart
@@ -30,7 +30,28 @@ class PaymentRequestSurface extends StatelessWidget {
     this.cardKey,
     this.background,
     super.key,
-  });
+  }) : _paintsBackground = true;
+
+  /// Just the scrim and the card, over whatever is already on screen.
+  ///
+  /// The live host renders the app underneath itself and layers this on top,
+  /// so that the routed content keeps one position in the widget tree whether
+  /// or not a request is up. Handing that content in as [background] instead
+  /// would re-parent it every time a card appears or is dismissed, which
+  /// disposes and remounts the whole routed subtree.
+  const PaymentRequestSurface.overlay({
+    required this.request,
+    required this.onContinue,
+    required this.onEdit,
+    required this.onCancel,
+    this.onRecheck,
+    this.layout = PaymentRequestLayout.auto,
+    this.initialAddressExpanded = false,
+    this.initialMessageExpanded = false,
+    this.cardKey,
+    super.key,
+  }) : background = null,
+       _paintsBackground = false;
 
   final PaymentRequestView request;
   final VoidCallback onContinue;
@@ -53,8 +74,13 @@ class PaymentRequestSurface extends StatelessWidget {
   final Key? cardKey;
 
   /// What the modal sits on top of. Defaults to the flat window color so a
-  /// preview does not have to supply a whole screen.
+  /// preview does not have to supply a whole screen. Always null on
+  /// [PaymentRequestSurface.overlay], which paints no background at all.
   final Widget? background;
+
+  /// False on [PaymentRequestSurface.overlay]: the caller already owns what is
+  /// underneath, so painting the fallback window color would cover it.
+  final bool _paintsBackground;
 
   bool get _isMobile => switch (layout) {
     PaymentRequestLayout.auto => kAppFormFactor == AppFormFactor.mobile,
@@ -86,15 +112,18 @@ class PaymentRequestSurface extends StatelessWidget {
       ),
     );
 
+    final modal = _ModalOverlayScope(
+      child: _isMobile
+          ? _mobileModal(context, card)
+          : _desktopModal(context, card),
+    );
+    if (!_paintsBackground) return modal;
+
     return Stack(
       fit: StackFit.expand,
       children: [
         background ?? ColoredBox(color: colors.background.window),
-        _ModalOverlayScope(
-          child: _isMobile
-              ? _mobileModal(context, card)
-              : _desktopModal(context, card),
-        ),
+        modal,
       ],
     );
   }

--- a/lib/src/features/send/widgets/send_compose_view.dart
+++ b/lib/src/features/send/widgets/send_compose_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/amount_price_loading_bar.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_text_field.dart';
 
@@ -528,7 +529,9 @@ class _AmountConversionRow extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: AppSpacing.xxs),
-                const _AmountPriceLoadingBar(),
+                const AmountPriceLoadingBar(
+                  key: ValueKey('send_amount_price_loading'),
+                ),
               ] else
                 Text(
                   text ?? r'$ 0',
@@ -541,24 +544,6 @@ class _AmountConversionRow extends StatelessWidget {
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-class _AmountPriceLoadingBar extends StatelessWidget {
-  const _AmountPriceLoadingBar();
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Container(
-      key: const ValueKey('send_amount_price_loading'),
-      width: 48,
-      height: 12,
-      decoration: BoxDecoration(
-        color: colors.background.overlay.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(AppRadii.full),
       ),
     );
   }

--- a/lib/src/features/send/widgets/send_recipient_resolver.dart
+++ b/lib/src/features/send/widgets/send_recipient_resolver.dart
@@ -7,6 +7,7 @@ import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../rust/api/wallet.dart' as rust_wallet;
 import '../../address_book/models/address_book_contact.dart';
 import '../../address_book/models/address_book_label_lookup.dart';
+import 'payment_request_card.dart';
 import 'send_review_layout.dart';
 
 const _selfSendTransparentLookbackLimit = 20;
@@ -144,4 +145,40 @@ SendReviewRecipient sendReviewRecipientFor({
     );
   }
   return SendReviewAddressRecipient(address: address);
+}
+
+/// Maps a payment-request recipient [address] to the name the card should
+/// show above it, or null when the wallet cannot name the address at all.
+///
+/// Same precedence as [sendReviewRecipientFor]: a saved contact wins over an
+/// own-account match. The card hands off to the review screen for the same
+/// address, and the two must not name it differently. An own account that is
+/// not also a saved contact renders under its account name with the
+/// `Your account` sub-label.
+///
+/// An identity with a blank name is not one: the caller falls back to the
+/// next match, and then to the plain address.
+PaymentRequestRecipientIdentity? paymentRequestRecipientIdentityFor({
+  required Iterable<AddressBookContact> contacts,
+  required String address,
+  Map<String, AccountInfo> ownAccounts = const {},
+}) {
+  final contact = sendRecipientContactFor(contacts: contacts, address: address);
+  final contactName = contact?.label.trim() ?? '';
+  if (contact != null && contactName.isNotEmpty) {
+    return PaymentRequestRecipientIdentity.contact(
+      name: contactName,
+      profilePictureId: contact.profilePictureId,
+    );
+  }
+
+  final ownAccount = ownAccounts[address.trim()];
+  final ownAccountName = ownAccount?.name.trim() ?? '';
+  if (ownAccount != null && ownAccountName.isNotEmpty) {
+    return PaymentRequestRecipientIdentity.ownAccount(
+      name: ownAccountName,
+      profilePictureId: ownAccount.profilePictureId,
+    );
+  }
+  return null;
 }

--- a/lib/src/features/send/widgets/send_review_content_view.dart
+++ b/lib/src/features/send/widgets/send_review_content_view.dart
@@ -28,6 +28,8 @@ class SendReviewContentView extends StatelessWidget {
     this.fiatText,
     this.memoText,
     this.memoExpanded = false,
+    this.requestedAmountText,
+    this.isPaymentRequest = false,
     this.confirmLabel = 'Confirm & send',
     this.confirmLeadingIconName = AppIcons.plane,
     this.onConfirm,
@@ -63,6 +65,14 @@ class SendReviewContentView extends StatelessWidget {
   /// Whether the Message row shows the full memo (see [ReviewMemoRows]).
   final bool memoExpanded;
 
+  /// Preformatted requested amount, shown only when it differs from what is
+  /// about to be sent.
+  final String? requestedAmountText;
+
+  /// Retitles the screen "Review payment request" and the recipient row
+  /// "Requested by". The link's own `label=` is never shown here.
+  final bool isPaymentRequest;
+
   /// Primary CTA label. The hardware-account wiring swaps in
   /// "Confirm with Keystone" while keeping the shared layout.
   final String confirmLabel;
@@ -81,7 +91,7 @@ class SendReviewContentView extends StatelessWidget {
     final colors = context.colors;
 
     return SendReviewContentColumn(
-      title: 'Review send',
+      title: isPaymentRequest ? 'Review payment request' : 'Review send',
       children: [
         SendReviewInfoSection(
           amountText: amountText,
@@ -89,6 +99,8 @@ class SendReviewContentView extends StatelessWidget {
           recipient: recipient,
           isShieldedRecipient: isShieldedRecipient,
           recipientAddressType: recipientAddressType,
+          isPaymentRequest: isPaymentRequest,
+          requestedAmountText: requestedAmountText,
           onShowFullAddress: onShowFullAddress,
         ),
         ReviewWrapCard(

--- a/lib/src/features/send/widgets/send_review_layout.dart
+++ b/lib/src/features/send/widgets/send_review_layout.dart
@@ -278,6 +278,14 @@ class SendReviewContentColumn extends StatelessWidget {
 /// Collapsed, it is a single `ReviewListRow` whose pill holds the truncated
 /// memo and the expand glyph. Expanded, the pill swaps to a "Collapse"
 /// affordance and the full memo renders underneath the row.
+/// Drawn in the memo's value slot when the memo would render as nothing.
+///
+/// A memo made entirely of whitespace is still a memo — it is what the
+/// payment carries and what the recipient decrypts — so the row stays and says
+/// so, instead of a blank value the payer would take for an empty one. The
+/// payment-request card uses the same words for the same memo.
+const kWhitespaceOnlyMemoPlaceholder = 'Whitespace only';
+
 class ReviewMemoRows extends StatelessWidget {
   const ReviewMemoRows({
     required this.memoText,
@@ -286,7 +294,10 @@ class ReviewMemoRows extends StatelessWidget {
     super.key,
   });
 
-  /// Full memo text; the collapsed row truncates it to one line.
+  /// Full memo text; the collapsed row truncates it to one line. Non-empty:
+  /// a memo made only of whitespace is shown as
+  /// [kWhitespaceOnlyMemoPlaceholder], muted, because it is the screen
+  /// describing the memo rather than the memo's own words.
   final String memoText;
 
   final bool expanded;
@@ -296,10 +307,16 @@ class ReviewMemoRows extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = context.colors;
+    final placeholder = memoText.trim().isEmpty
+        ? kWhitespaceOnlyMemoPlaceholder
+        : null;
+    final valueColor = placeholder == null ? null : colors.text.muted;
     if (!expanded) {
       return ReviewListRow(
         label: 'Message',
-        value: memoText,
+        value: placeholder ?? memoText,
+        valueColor: valueColor,
         trailingIconName: AppIcons.expand,
         onPressed: onToggle,
       );
@@ -317,9 +334,9 @@ class ReviewMemoRows extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
           child: Text(
-            memoText,
+            placeholder ?? memoText,
             style: AppTypography.bodyMediumStrong.copyWith(
-              color: context.colors.text.accent,
+              color: valueColor ?? colors.text.accent,
             ),
           ),
         ),

--- a/lib/src/features/send/widgets/send_review_layout.dart
+++ b/lib/src/features/send/widgets/send_review_layout.dart
@@ -52,6 +52,8 @@ class SendReviewInfoSection extends StatelessWidget {
     this.isShieldedRecipient = true,
     this.recipientAddressType,
     this.fiatText,
+    this.isPaymentRequest = false,
+    this.requestedAmountText,
     this.connectorIconName = AppIcons.arrowDown,
     this.recipientStruckThrough = false,
     this.recipientRow,
@@ -76,6 +78,19 @@ class SendReviewInfoSection extends StatelessWidget {
 
   /// Optional fiat sub-label under the amount; hidden when null.
   final String? fiatText;
+
+  /// This send answers a ZIP-321 payment request.
+  ///
+  /// It only retitles the recipient row to "Requested by". The value stays
+  /// the verified recipient the ordinary "To" row shows (contact name, own
+  /// account, or truncated address). The link's own `label=` is unverified
+  /// text and is never rendered on the review — the payment request card is
+  /// the one surface that shows it.
+  final bool isPaymentRequest;
+
+  /// Preformatted amount the request asked for ("0.5 ZEC"), shown as a muted
+  /// line under the amount when the user changed it before reviewing.
+  final String? requestedAmountText;
 
   /// Connector between the Amount and To rows — arrow-down on review /
   /// in-progress / completed, uturn-up on failed.
@@ -129,6 +144,17 @@ class SendReviewInfoSection extends StatelessWidget {
             leading: const ReviewZecCoinImage(),
             bottomLeftText: fiatText,
           ),
+          if (requestedAmountText != null)
+            Padding(
+              padding: const EdgeInsets.only(left: AppSpacing.xl),
+              child: Text(
+                'Requested $requestedAmountText',
+                key: const ValueKey('send_review_requested_amount'),
+                style: AppTypography.bodySmall.copyWith(
+                  color: context.colors.text.secondary,
+                ),
+              ),
+            ),
           ReviewConnectorIcon(iconName: connectorIconName),
           recipientRow ?? _recipientRow(context),
         ],
@@ -137,9 +163,17 @@ class SendReviewInfoSection extends StatelessWidget {
   }
 
   Widget _recipientRow(BuildContext context) {
+    // A request only changes what the row is called. The value stays the
+    // recipient the wallet resolved, so an unverified link label can never
+    // stand in for the identity the user is consenting to pay.
+    final rowLabel = isPaymentRequest ? 'Requested by' : 'To';
+    final rowKey = isPaymentRequest
+        ? const ValueKey('send_review_requested_by')
+        : null;
     return switch (recipient) {
       SendReviewAddressRecipient(:final address) => ReviewInfoRow(
-        label: 'To',
+        key: rowKey,
+        label: rowLabel,
         value: truncatedAddress(address),
         leading: const ReviewInfoIconCircle(iconName: AppIcons.wallet),
         struckThrough: recipientStruckThrough,
@@ -159,7 +193,8 @@ class SendReviewInfoSection extends StatelessWidget {
         :final address,
       ) =>
         ReviewInfoRow(
-          label: 'To',
+          key: rowKey,
+          label: rowLabel,
           value: name,
           leading: AppProfilePicture(
             profilePictureId: profilePictureId,

--- a/lib/src/features/swap/widgets/swap_keystone_signing_overlay.dart
+++ b/lib/src/features/swap/widgets/swap_keystone_signing_overlay.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../keystone/services/keystone_batch_signing.dart';
@@ -37,7 +38,8 @@ class SwapKeystoneSigningOverlay extends ConsumerStatefulWidget {
 enum _SwapKeystonePhase { preparing, ready, broadcasting, failed }
 
 class _SwapKeystoneSigningOverlayState
-    extends ConsumerState<SwapKeystoneSigningOverlay> {
+    extends ConsumerState<SwapKeystoneSigningOverlay>
+    with PaymentUriBusySurfaceHoldMixin {
   _SwapKeystonePhase _phase = _SwapKeystonePhase.preparing;
   bool _showSaplingParamsPrompt = false;
   Completer<bool>? _saplingParamsPromptCompleter;

--- a/lib/src/features/voting/screens/keystone_voting_scan_screen.dart
+++ b/lib/src/features/voting/screens/keystone_voting_scan_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../services/qr_scanner.dart';
@@ -18,8 +19,11 @@ class KeystoneVotingScanScreen extends ConsumerStatefulWidget {
       _KeystoneVotingScanScreenState();
 }
 
+// Same live-scan reason as the send scan screen: the Keystone is displaying
+// the signed voting QR while this camera reads it.
 class _KeystoneVotingScanScreenState
-    extends ConsumerState<KeystoneVotingScanScreen> {
+    extends ConsumerState<KeystoneVotingScanScreen>
+    with PaymentUriBusySurfaceHoldMixin {
   bool _decoding = false;
   String? _error;
 

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -841,17 +842,22 @@ class _StatusContent extends StatelessWidget {
               if (isHardwareAccount &&
                   phase == VotingSessionPhase.keystoneSigning &&
                   keystoneSigningBundleIndex != null) ...[
-                _KeystoneSigningPanel(
-                  bundleIndex: keystoneSigningBundleIndex!,
-                  urParts: keystoneUrParts,
-                  batchMemos: keystoneBatchMemos,
-                  batchMessageCount: keystoneBatchMessageCount,
-                  batchTotalCount: keystoneBatchTotalCount,
-                  qrError: keystoneQrError,
-                  scanError: keystoneScanError,
-                  canSkipRemainingBundles: canSkipRemainingKeystoneBundles,
-                  onScan: onScanKeystone,
-                  onSkipRemainingBundles: onSkipKeystoneBundles,
+                // Only the signing panel is a live QR the device is reading.
+                // The hold sits above it rather than on the status screen, so
+                // a request still lands while the vote is merely submitting.
+                PaymentUriBusySurfaceHold(
+                  child: _KeystoneSigningPanel(
+                    bundleIndex: keystoneSigningBundleIndex!,
+                    urParts: keystoneUrParts,
+                    batchMemos: keystoneBatchMemos,
+                    batchMessageCount: keystoneBatchMessageCount,
+                    batchTotalCount: keystoneBatchTotalCount,
+                    qrError: keystoneQrError,
+                    scanError: keystoneScanError,
+                    canSkipRemainingBundles: canSkipRemainingKeystoneBundles,
+                    onScan: onScanKeystone,
+                    onSkipRemainingBundles: onSkipKeystoneBundles,
+                  ),
                 ),
                 const SizedBox(height: AppSpacing.md),
               ],

--- a/lib/src/features/wallet_link/screens/wallet_link_desktop_screen.dart
+++ b/lib/src/features/wallet_link/screens/wallet_link_desktop_screen.dart
@@ -13,6 +13,7 @@ import '../../../core/layout/app_desktop_backdrop_shell.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_pane_scroll_scaffold.dart';
+import '../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../core/security/password_policy.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
@@ -42,8 +43,12 @@ class WalletLinkDesktopScreen extends ConsumerStatefulWidget {
       _WalletLinkDesktopScreenState();
 }
 
+// The pairing QR is live: a phone's camera is reading it while the session
+// runs, and a payment-request card would scrim it mid-transfer. The screen is
+// the session, so the hold lasts as long as the screen.
 class _WalletLinkDesktopScreenState
-    extends ConsumerState<WalletLinkDesktopScreen> {
+    extends ConsumerState<WalletLinkDesktopScreen>
+    with PaymentUriBusySurfaceHoldMixin {
   final _passwordController = TextEditingController();
   bool _accessConfirmed = false;
   bool _isSubmittingPassword = false;

--- a/lib/src/providers/payment_request_flow_provider.dart
+++ b/lib/src/providers/payment_request_flow_provider.dart
@@ -97,6 +97,34 @@ final class PaymentRequestReviewOvertaken extends PaymentRequestReviewHandoff {
   const PaymentRequestReviewOvertaken();
 }
 
+/// What an Edit tap resolved to — the same three answers as
+/// [PaymentRequestReviewHandoff], for the same reason: the composer that Edit
+/// opens re-quotes the fee as it mounts, and a quote asked while the card's
+/// proposal still holds its inputs can come back "not enough ZEC" for the very
+/// payment the card just found affordable.
+sealed class PaymentRequestEditHandoff {
+  const PaymentRequestEditHandoff();
+}
+
+/// The proposal is back with Rust (or there was none); the composer can open
+/// on [prefill].
+final class PaymentRequestEditReady extends PaymentRequestEditHandoff {
+  const PaymentRequestEditReady(this.prefill);
+
+  final SendPrefillArgs prefill;
+}
+
+/// No card to edit.
+final class PaymentRequestEditUnavailable extends PaymentRequestEditHandoff {
+  const PaymentRequestEditUnavailable();
+}
+
+/// A newer link replaced the card during the hand-back; the composer must not
+/// open on the request the user is no longer looking at.
+final class PaymentRequestEditOvertaken extends PaymentRequestEditHandoff {
+  const PaymentRequestEditOvertaken();
+}
+
 class PaymentRequestFlowNotifier extends Notifier<PaymentRequestFlowState?> {
   /// Bumped by every state change. A pre-check that finishes after its card is
   /// gone (replaced, cancelled, reviewed) must not write into the newer card,
@@ -395,13 +423,29 @@ class PaymentRequestFlowNotifier extends Notifier<PaymentRequestFlowState?> {
     return args;
   }
 
-  /// Clears the card, releases any proposal, and returns the request for the
-  /// composer.
-  SendPrefillArgs? edit() {
+  /// Hands the request to the composer, completing only once Rust has
+  /// released the card's proposal.
+  ///
+  /// Clears the card at once, like [dismiss]; the caller navigates only when
+  /// the returned future says the composer is safe to open — see
+  /// [PaymentRequestEditHandoff] for why waiting matters and why the three
+  /// outcomes are distinct.
+  Future<PaymentRequestEditHandoff> editHandingBack() async {
     final current = state;
-    if (current == null) return null;
-    _clear(logContext: 'PaymentRequest(edit)');
-    return current.prefill;
+    if (current == null) return const PaymentRequestEditUnavailable();
+    final proposal = current.proposal;
+    final generation = ++_generation;
+    _publish(null);
+    if (proposal != null) {
+      final release = proposal.discard(logContext: 'PaymentRequest(edit)');
+      _track(release);
+      await release;
+      if (generation != _generation) {
+        _noteReplacedRequest();
+        return const PaymentRequestEditOvertaken();
+      }
+    }
+    return PaymentRequestEditReady(current.prefill);
   }
 
   /// Cancel, the ⨯, the scrim, and the Android back gesture.

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -180,6 +180,9 @@ class SyncState {
   bool get isUsingCompletedSpendableSnapshot =>
       displaySpendableFreshness == SpendableBalanceFreshness.lastCompletedSync;
 
+  /// True when the spendable balance is authoritative (scanned to tip, has
+  /// balance data, not using a completed-sync snapshot). The single predicate
+  /// for "is a shortfall real?".
   bool get hasSettledSpendableBalance =>
       hasBalanceData && isSyncedToTip && !isUsingCompletedSpendableSnapshot;
 
@@ -2958,10 +2961,14 @@ final syncProvider = AsyncNotifierProvider<SyncNotifier, SyncState>(
   () => SyncNotifier(),
 );
 
+/// [SyncState.hasSettledSpendableBalance] for [accountUuid], from an unscoped
+/// state. Scoping first is mandatory: an unscoped read answers with another
+/// account's balance, or with wallet-wide fields of a state with no balance.
 bool spendableIsSettledForAccount(SyncState? sync, String? accountUuid) =>
     sync != null &&
     sync.scopedToAccount(accountUuid).hasSettledSpendableBalance;
 
+/// [spendableIsSettledForAccount] for the active account, read live.
 bool activeAccountSpendableIsSettled(Ref ref) => spendableIsSettledForAccount(
   ref.read(syncProvider).value,
   ref.read(accountProvider).value?.activeAccountUuid,

--- a/lib/widgetbook/payment_request_use_cases.dart
+++ b/lib/widgetbook/payment_request_use_cases.dart
@@ -1,0 +1,401 @@
+// ignore_for_file: depend_on_referenced_packages
+// widgetbook is dev-only; see `widgetbook.dart` for the boundary.
+
+import 'package:flutter/widgets.dart';
+
+import '../src/core/theme/app_theme.dart';
+import '../src/features/send/widgets/payment_request_card.dart';
+import '../src/features/send/widgets/payment_request_surface.dart';
+
+const _sampleAddress =
+    'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+    '73d57f73c6dc05121591a83861cd190591';
+
+/// A transparent (`t1…`) recipient — the pool the "To" badge has to call out,
+/// because paying it is the one detail on this card the review step cannot
+/// undo for you.
+const _transparentAddress = 't1PZ4vMuLdt2wRfDGGKS1qXfBpJt5CJHhNz';
+
+const _sampleMemo =
+    'Table 4 — two flat whites and a pastry. Thanks for stopping by, '
+    'see you next week.';
+
+const _sampleNote = 'Saved from the invoice link you opened.';
+
+/// 80 characters, the worst realistic label a link can carry.
+const _longLabel =
+    'Shielded Coffee Roasters International Wholesale and Retail Trading '
+    'Company Ltd';
+
+/// A 512-byte memo — the Zcash protocol maximum.
+final _longMemo = () {
+  const paragraph =
+      'Invoice 2026-0917. Settlement for the September wholesale order, '
+      'including the two pallets held over from August and the revised '
+      'delivery surcharge we agreed on the call. Payment in ZEC is due '
+      'within seven days; the reference above must stay attached to the '
+      'transaction or reconciliation will miss it. Questions go to the '
+      'accounts desk, not to the shop. ';
+  final buffer = StringBuffer();
+  while (buffer.length < 512) {
+    buffer.write(paragraph);
+  }
+  return buffer.toString().substring(0, 512).trim();
+}();
+
+const _longNote =
+    'This link replaced an earlier one from the same sender, and the amount '
+    'was recalculated against the exchange rate quoted at the time the '
+    'invoice was issued rather than the rate showing right now.';
+
+const _fullRequest = PaymentRequestView(
+  source: PaymentRequestSource.link,
+  requesterLabel: 'Blue Door Coffee',
+  amountZecText: '0.5 ZEC',
+  fiatText: r'$35.00',
+  address: _sampleAddress,
+  memo: _sampleMemo,
+  note: _sampleNote,
+  spendableText: '0.21 ZEC',
+);
+
+const _minimalRequest = PaymentRequestView(
+  source: PaymentRequestSource.link,
+  amountZecText: '0.5 ZEC',
+  address: _sampleAddress,
+);
+
+final _longValuesRequest = PaymentRequestView(
+  source: PaymentRequestSource.qrCode,
+  requesterLabel: _longLabel,
+  amountZecText: '1234.567891234567 ZEC',
+  fiatText: r'$86,419.075308642 (indicative, refreshed a moment ago)',
+  address: _sampleAddress,
+  memo: _longMemo,
+  note: _longNote,
+);
+
+PaymentRequestView _statusRequest(
+  PaymentRequestStatus status, {
+  String? statusMessage,
+}) {
+  return PaymentRequestView(
+    source: _fullRequest.source,
+    requesterLabel: _fullRequest.requesterLabel,
+    amountZecText: _fullRequest.amountZecText,
+    fiatText: _fullRequest.fiatText,
+    address: _fullRequest.address,
+    memo: _fullRequest.memo,
+    note: _fullRequest.note,
+    spendableText: _fullRequest.spendableText,
+    status: status,
+    statusMessage: statusMessage,
+  );
+}
+
+/// A check that could not complete. Every real failure overrides the default
+/// message with its own reason, so the gallery shows one that does.
+const _failedStatusMessage =
+    "Couldn't check this request — open Edit to review the details";
+
+const _replacedRequest = PaymentRequestView(
+  source: PaymentRequestSource.link,
+  requesterLabel: 'Blue Door Coffee',
+  amountZecText: '0.75 ZEC',
+  fiatText: r'$52.50',
+  address: _sampleAddress,
+  memo: _sampleMemo,
+  replacedNotice: true,
+);
+
+/// A link that carried no `amount`. There is no hero to render and nothing
+/// to review yet, so the primary becomes the edit action.
+const _noAmountRequest = PaymentRequestView(
+  source: PaymentRequestSource.link,
+  requesterLabel: 'Blue Door Coffee',
+  address: _sampleAddress,
+  memo: _sampleMemo,
+);
+
+/// Transparent recipient — the badge under the address is the only place the
+/// pool is stated.
+const _transparentRequest = PaymentRequestView(
+  source: PaymentRequestSource.link,
+  requesterLabel: 'Hardware supplier',
+  amountZecText: '2.4 ZEC',
+  fiatText: r'$168.00',
+  address: _transparentAddress,
+  note: 'Transparent payout address from the supplier portal.',
+);
+
+/// The recipient is saved in the address book: the contact's name and avatar
+/// take the "To" headline and the address drops to the sub-line.
+const _contactRequest = PaymentRequestView(
+  source: PaymentRequestSource.link,
+  requesterLabel: 'Blue Door Coffee',
+  amountZecText: '0.5 ZEC',
+  fiatText: r'$35.00',
+  address: _sampleAddress,
+  memo: _sampleMemo,
+  recipientIdentity: PaymentRequestRecipientIdentity.contact(
+    name: 'Blue Door Coffee',
+    profilePictureId: 'pfp-03',
+  ),
+);
+
+/// The link is asking the user to pay one of their own accounts. Same shape
+/// as the contact case plus the one muted line that says which relationship
+/// this is — the card's only way to tell the user that.
+const _ownAccountRequest = PaymentRequestView(
+  source: PaymentRequestSource.qrCode,
+  amountZecText: '1.25 ZEC',
+  fiatText: r'$87.50',
+  address: _sampleAddress,
+  note: 'Moving funds between your own accounts.',
+  recipientIdentity: PaymentRequestRecipientIdentity.ownAccount(
+    name: 'Savings',
+    profilePictureId: 'pfp-07',
+  ),
+);
+
+/// Requester note without a requester name or transaction memo.
+const _noteOnlyRequest = PaymentRequestView(
+  source: PaymentRequestSource.link,
+  amountZecText: '0.5 ZEC',
+  fiatText: r'$35.00',
+  address: _sampleAddress,
+  note: _sampleNote,
+);
+
+// ─── Desktop ─────────────────────────────────────────────────────────
+
+Widget buildPaymentRequestFullUseCase(BuildContext context) =>
+    _desktop(_fullRequest);
+
+Widget buildPaymentRequestAddressExpandedUseCase(BuildContext context) =>
+    _desktop(_fullRequest, addressExpanded: true);
+
+Widget buildPaymentRequestMinimalUseCase(BuildContext context) =>
+    _desktop(_minimalRequest);
+
+Widget buildPaymentRequestLongValuesUseCase(BuildContext context) =>
+    _desktop(_longValuesRequest);
+
+Widget buildPaymentRequestLongValuesExpandedUseCase(BuildContext context) =>
+    _desktop(_longValuesRequest, messageExpanded: true);
+
+Widget buildPaymentRequestCheckingUseCase(BuildContext context) =>
+    _desktop(_statusRequest(PaymentRequestStatus.checking));
+
+Widget buildPaymentRequestInvalidAddressUseCase(BuildContext context) =>
+    _desktop(_statusRequest(PaymentRequestStatus.invalidAddress));
+
+Widget buildPaymentRequestInsufficientUseCase(BuildContext context) =>
+    _desktop(_statusRequest(PaymentRequestStatus.insufficientFunds));
+
+Widget buildPaymentRequestSyncingUseCase(BuildContext context) =>
+    _desktop(_statusRequest(PaymentRequestStatus.syncing));
+
+/// The syncing card once it has run out of ways to answer itself: same
+/// blocked request, but the primary action becomes an enabled "Check again"
+/// rather than a Review that can never fire.
+Widget buildPaymentRequestSyncStalledUseCase(BuildContext context) =>
+    _desktop(_statusRequest(PaymentRequestStatus.syncStalled));
+
+Widget buildPaymentRequestFailedUseCase(BuildContext context) => _desktop(
+  _statusRequest(
+    PaymentRequestStatus.failed,
+    statusMessage: _failedStatusMessage,
+  ),
+);
+
+Widget buildPaymentRequestReplacedUseCase(BuildContext context) =>
+    _desktop(_replacedRequest);
+
+Widget buildPaymentRequestTransparentUseCase(BuildContext context) =>
+    _desktop(_transparentRequest);
+
+Widget buildPaymentRequestContactUseCase(BuildContext context) =>
+    _desktop(_contactRequest);
+
+Widget buildPaymentRequestOwnAccountUseCase(BuildContext context) =>
+    _desktop(_ownAccountRequest);
+
+Widget buildPaymentRequestOwnAccountExpandedUseCase(BuildContext context) =>
+    _desktop(_ownAccountRequest, addressExpanded: true);
+
+Widget buildPaymentRequestNoteOnlyUseCase(BuildContext context) =>
+    _desktop(_noteOnlyRequest);
+
+Widget buildPaymentRequestNoAmountUseCase(BuildContext context) =>
+    _desktop(_noAmountRequest);
+
+Widget buildPaymentRequestLargeTextUseCase(BuildContext context) =>
+    _desktop(_fullRequest, textScale: 1.5);
+
+Widget buildPaymentRequestRtlUseCase(BuildContext context) =>
+    _desktop(_fullRequest, textDirection: TextDirection.rtl);
+
+// ─── Mobile ──────────────────────────────────────────────────────────
+
+Widget buildMobilePaymentRequestFullUseCase(BuildContext context) =>
+    _mobile(_fullRequest);
+
+Widget buildMobilePaymentRequestAddressExpandedUseCase(BuildContext context) =>
+    _mobile(_fullRequest, addressExpanded: true);
+
+Widget buildMobilePaymentRequestMinimalUseCase(BuildContext context) =>
+    _mobile(_minimalRequest);
+
+Widget buildMobilePaymentRequestLongValuesUseCase(BuildContext context) =>
+    _mobile(_longValuesRequest);
+
+Widget buildMobilePaymentRequestLongValuesExpandedUseCase(
+  BuildContext context,
+) => _mobile(_longValuesRequest, messageExpanded: true);
+
+Widget buildMobilePaymentRequestCheckingUseCase(BuildContext context) =>
+    _mobile(_statusRequest(PaymentRequestStatus.checking));
+
+Widget buildMobilePaymentRequestInvalidAddressUseCase(BuildContext context) =>
+    _mobile(_statusRequest(PaymentRequestStatus.invalidAddress));
+
+Widget buildMobilePaymentRequestInsufficientUseCase(BuildContext context) =>
+    _mobile(_statusRequest(PaymentRequestStatus.insufficientFunds));
+
+Widget buildMobilePaymentRequestSyncingUseCase(BuildContext context) =>
+    _mobile(_statusRequest(PaymentRequestStatus.syncing));
+
+Widget buildMobilePaymentRequestFailedUseCase(BuildContext context) => _mobile(
+  _statusRequest(
+    PaymentRequestStatus.failed,
+    statusMessage: _failedStatusMessage,
+  ),
+);
+
+Widget buildMobilePaymentRequestReplacedUseCase(BuildContext context) =>
+    _mobile(_replacedRequest);
+
+Widget buildMobilePaymentRequestTransparentUseCase(BuildContext context) =>
+    _mobile(_transparentRequest);
+
+Widget buildMobilePaymentRequestContactUseCase(BuildContext context) =>
+    _mobile(_contactRequest);
+
+Widget buildMobilePaymentRequestOwnAccountUseCase(BuildContext context) =>
+    _mobile(_ownAccountRequest);
+
+Widget buildMobilePaymentRequestOwnAccountExpandedUseCase(
+  BuildContext context,
+) => _mobile(_ownAccountRequest, addressExpanded: true);
+
+Widget buildMobilePaymentRequestNoteOnlyUseCase(BuildContext context) =>
+    _mobile(_noteOnlyRequest);
+
+Widget buildMobilePaymentRequestNoAmountUseCase(BuildContext context) =>
+    _mobile(_noAmountRequest);
+
+Widget buildMobilePaymentRequestLargeTextUseCase(BuildContext context) =>
+    _mobile(_fullRequest, textScale: 1.5);
+
+Widget buildMobilePaymentRequestRtlUseCase(BuildContext context) =>
+    _mobile(_fullRequest, textDirection: TextDirection.rtl);
+
+// ─── Frames ──────────────────────────────────────────────────────────
+
+Widget _desktop(
+  PaymentRequestView request, {
+  double textScale = 1,
+  TextDirection? textDirection,
+  bool addressExpanded = false,
+  bool messageExpanded = false,
+}) {
+  return _PaymentRequestFrame(
+    // A desktop pane is the surface a payment link interrupts.
+    size: const Size(AppWindowSizing.contentAreaMaxWidth + AppSpacing.xl2, 720),
+    textScale: textScale,
+    textDirection: textDirection,
+    child: PaymentRequestSurface(
+      layout: PaymentRequestLayout.desktop,
+      request: request,
+      initialAddressExpanded: addressExpanded,
+      initialMessageExpanded: messageExpanded,
+      onContinue: () {},
+      onEdit: () {},
+      onCancel: () {},
+      // Non-null so the stalled card's primary renders the way it does in the
+      // app — enabled. A preview that left it null would show the one status
+      // whose whole point is an actionable button with a dead one.
+      onRecheck: () {},
+    ),
+  );
+}
+
+Widget _mobile(
+  PaymentRequestView request, {
+  double textScale = 1,
+  TextDirection? textDirection,
+  bool addressExpanded = false,
+  bool messageExpanded = false,
+}) {
+  return _PaymentRequestFrame(
+    size: const Size(393, 852),
+    textScale: textScale,
+    textDirection: textDirection,
+    child: PaymentRequestSurface(
+      layout: PaymentRequestLayout.mobile,
+      request: request,
+      initialAddressExpanded: addressExpanded,
+      initialMessageExpanded: messageExpanded,
+      onContinue: () {},
+      onEdit: () {},
+      onCancel: () {},
+      // Non-null so the stalled card's primary renders the way it does in the
+      // app — enabled. A preview that left it null would show the one status
+      // whose whole point is an actionable button with a dead one.
+      onRecheck: () {},
+    ),
+  );
+}
+
+/// Fixed preview viewport so the modal is measured against a real screen
+/// rather than the Widgetbook chrome.
+///
+/// [textScale] and [textDirection] exist so the two environment variants the
+/// card is riskiest in — a large accessibility text size and an RTL mirror —
+/// are inspectable states rather than assumptions.
+class _PaymentRequestFrame extends StatelessWidget {
+  const _PaymentRequestFrame({
+    required this.size,
+    required this.child,
+    this.textScale = 1,
+    this.textDirection,
+  });
+
+  final Size size;
+  final Widget child;
+  final double textScale;
+  final TextDirection? textDirection;
+
+  @override
+  Widget build(BuildContext context) {
+    final direction = textDirection;
+    Widget framed = MediaQuery(
+      data: MediaQuery.of(
+        context,
+      ).copyWith(size: size, textScaler: TextScaler.linear(textScale)),
+      child: child,
+    );
+    if (direction != null) {
+      framed = Directionality(textDirection: direction, child: framed);
+    }
+    return Center(
+      child: SizedBox(
+        key: const ValueKey('payment_request_preview_frame'),
+        width: size.width,
+        height: size.height,
+        child: framed,
+      ),
+    );
+  }
+}

--- a/lib/widgetbook/receive_use_cases.dart
+++ b/lib/widgetbook/receive_use_cases.dart
@@ -44,6 +44,16 @@ Widget buildReceiveDesktopTransparentModalUseCase(BuildContext context) {
   );
 }
 
+/// Receive with the "Request ZEC" entry under the copy button.
+///
+/// Entry mock only — the live screen is untouched, so this is the one place
+/// the second CTA and its re-tuned coordinates can be reviewed.
+Widget buildReceiveDesktopRequestEntryUseCase(BuildContext context) {
+  return const _ReceiveDesktopHarness(
+    state: ReceiveDesktopPreviewState.shieldedRequestEntry,
+  );
+}
+
 Widget buildReceiveMobileShieldedUseCase(BuildContext context) {
   return const _ReceiveMobileHarness(type: ReceiveAddressType.shielded);
 }

--- a/lib/widgetbook/request_amount_use_cases.dart
+++ b/lib/widgetbook/request_amount_use_cases.dart
@@ -1,0 +1,233 @@
+// ignore_for_file: depend_on_referenced_packages
+// widgetbook is dev-only; see `widgetbook.dart` for the boundary.
+
+/// Widgetbook states for the Receive "Request ZEC" flow.
+///
+/// Every state is a pure function of a [ZecRequestView], so what is reviewed
+/// here is exactly what the widgets will render once they are wired.
+library;
+
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+
+import '../src/core/theme/app_theme.dart';
+import '../src/features/receive/widgets/request/request_amount_card.dart';
+import '../src/features/receive/widgets/request/request_amount_model.dart';
+import '../src/features/receive/widgets/request/request_amount_sheet.dart';
+import 'receive_use_cases.dart';
+
+/// The addresses the Receive use cases already preview, so the request states
+/// and the address states describe the same wallet.
+const _shieldedAddress =
+    'u1tvg2412a23kshieldedaddress000000000000000000000000k64123hhq6d';
+const _transparentAddress = 't1aWwWwqk3jYGkZc7nLGuTvuM8hDywMZCo';
+
+const _amountZec = '0.5';
+const _amountUsd = '35.00';
+const _fiatText = r'$35.00';
+const _message = 'Table 4 — two flat whites';
+
+const _emptyRequest = ZecRequestView(address: _shieldedAddress);
+
+const _amountRequest = ZecRequestView(
+  address: _shieldedAddress,
+  amountZec: _amountZec,
+  conversionText: _fiatText,
+);
+
+const _amountWithMessageRequest = ZecRequestView(
+  address: _shieldedAddress,
+  amountZec: _amountZec,
+  conversionText: _fiatText,
+  messageText: _message,
+);
+
+const _transparentRequest = ZecRequestView(
+  address: _transparentAddress,
+  amountZec: _amountZec,
+  conversionText: _fiatText,
+);
+
+/// The amount error state: more decimals than a zatoshi can hold.
+const _amountErrorRequest = ZecRequestView(
+  address: _shieldedAddress,
+  amountZec: '',
+  amountDisplayText: '0.123456789',
+  conversionText: _fiatText,
+  amountError: kRequestAmountDecimalsError,
+);
+
+/// USD entry mode — the amount is still 0.5 ZEC, the field just shows the
+/// dollars it was typed in.
+const _usdRequest = ZecRequestView(
+  address: _shieldedAddress,
+  amountZec: _amountZec,
+  amountDisplayText: _amountUsd,
+  amountInputIsUsd: true,
+  conversionText: '$_amountZec ZEC',
+);
+
+/// The densest request the flow can produce: a real software account's UA
+/// (178 characters) with the 512-byte message ZIP-321 allows, which pushes
+/// the symbol to 113 modules. The result step has to widen for it rather
+/// than draw its modules under the scan-reliability floor.
+final _denseRequest = ZecRequestView(
+  address: 'u1${'q' * 176}',
+  amountZec: _amountZec,
+  conversionText: _fiatText,
+  messageText:
+      'A table booking that runs to the full five hundred and twelve bytes '
+      'a ZIP-321 memo is allowed to carry, because that is exactly the '
+      'request the fixed result frame could not draw. '
+      '${'m' * 333}',
+);
+
+/// ZEC typed but no live price to convert it: the readout is the same
+/// placeholder the send composer shows, and the unit switch is inert.
+const _priceUnavailableRequest = ZecRequestView(
+  address: _shieldedAddress,
+  amountZec: _amountZec,
+);
+
+// ─── Desktop ─────────────────────────────────────────────────────────
+
+Widget buildRequestModalStepOneEmptyUseCase(BuildContext context) =>
+    _desktop(_emptyRequest);
+
+Widget buildRequestModalStepOneAmountUseCase(BuildContext context) =>
+    _desktop(_amountRequest);
+
+Widget buildRequestModalStepOnePriceUnavailableUseCase(BuildContext context) =>
+    _desktop(_priceUnavailableRequest, toggleEnabled: false);
+Widget buildRequestModalStepOneMessageUseCase(BuildContext context) =>
+    _desktop(_amountWithMessageRequest, messageExpanded: true);
+
+Widget buildRequestModalStepOneTransparentUseCase(BuildContext context) =>
+    _desktop(_transparentRequest);
+
+Widget buildRequestModalStepOneAmountErrorUseCase(BuildContext context) =>
+    _desktop(_amountErrorRequest);
+
+Widget buildRequestModalStepTwoShieldedUseCase(BuildContext context) =>
+    _desktop(_amountWithMessageRequest, step: RequestModalStep.result);
+
+Widget buildRequestModalStepTwoTransparentUseCase(BuildContext context) =>
+    _desktop(_transparentRequest, step: RequestModalStep.result);
+
+Widget buildRequestModalStepTwoDenseUseCase(BuildContext context) =>
+    _desktop(_denseRequest, step: RequestModalStep.result);
+
+// ─── Mobile ──────────────────────────────────────────────────────────
+
+/// Where the request flow starts on mobile.
+///
+/// This is the shipped Receive screen, not a mock of it: the entry is an
+/// icon-only button beside Share, and a fixture that redrew it as a labelled
+/// third tier would be reviewing an arrangement the app does not have.
+Widget buildRequestMobileEntryUseCase(BuildContext context) =>
+    buildReceiveMobileShieldedUseCase(context);
+
+Widget buildRequestMobileComposeEmptyUseCase(BuildContext context) =>
+    _mobileCompose(_emptyRequest);
+
+Widget buildRequestMobileComposeUsdUseCase(BuildContext context) =>
+    _mobileCompose(_usdRequest);
+
+Widget buildRequestMobileComposePriceUnavailableUseCase(BuildContext context) =>
+    _mobileCompose(_priceUnavailableRequest, toggleEnabled: false);
+Widget buildRequestMobileComposeMessageUseCase(BuildContext context) =>
+    _mobileCompose(_amountWithMessageRequest);
+
+Widget buildRequestMobileComposeAmountErrorUseCase(BuildContext context) =>
+    _mobileCompose(_amountErrorRequest);
+
+Widget buildRequestMobileResultShieldedUseCase(BuildContext context) =>
+    _mobileResult(_amountWithMessageRequest);
+
+Widget buildRequestMobileResultTransparentUseCase(BuildContext context) =>
+    _mobileResult(_transparentRequest);
+
+// ─── Frames ──────────────────────────────────────────────────────────
+
+Widget _desktop(
+  ZecRequestView request, {
+  RequestModalStep step = RequestModalStep.compose,
+  bool messageExpanded = false,
+  bool toggleEnabled = true,
+}) {
+  return _frame(
+    // A desktop pane is the surface the request modal opens over.
+    const Size(AppWindowSizing.contentAreaMaxWidth + AppSpacing.xl2, 720),
+    RequestAmountSurface(
+      request: request,
+      step: step,
+      messageExpanded: messageExpanded,
+      onClose: _noop,
+      onNext: _noop,
+      onBack: _noop,
+      onCopyLink: _noop,
+      onSaveQrImage: _logPng('save QR image'),
+      onAddMessage: _noop,
+      onToggleAmountUnit: toggleEnabled ? _noop : null,
+    ),
+  );
+}
+
+Widget _mobileCompose(ZecRequestView request, {bool toggleEnabled = true}) {
+  return _frame(
+    const Size(393, 852),
+    RequestAmountSheetSurface(
+      child: RequestAmountSheetCompose(
+        request: request,
+        onClose: _noop,
+        onToggleAmountUnit: toggleEnabled ? _noop : null,
+        onAddMessage: _noop,
+        onCreateRequest: _noop,
+      ),
+    ),
+  );
+}
+
+Widget _mobileResult(ZecRequestView request) {
+  return _frame(
+    const Size(393, 852),
+    RequestAmountSheetSurface(
+      child: RequestAmountSheetResult(
+        request: request,
+        onBack: _noop,
+        onClose: _noop,
+        onShareRequest: (text, png) => debugPrint(
+          'request: share ${png.length} byte PNG with '
+          '${text.length} chars of text',
+        ),
+        onCopyLink: _noop,
+      ),
+    ),
+  );
+}
+
+/// Fixed preview viewport so the modal is measured against a real screen
+/// rather than against the Widgetbook chrome.
+Widget _frame(Size size, Widget child) {
+  return Center(
+    child: SizedBox(
+      key: const ValueKey('request_preview_frame'),
+      width: size.width,
+      height: size.height,
+      child: Builder(
+        builder: (context) => MediaQuery(
+          data: MediaQuery.of(context).copyWith(size: size),
+          child: child,
+        ),
+      ),
+    ),
+  );
+}
+
+void _noop() {}
+
+/// Fixtures log rather than act: the flow is presentation-only until it is
+/// wired, and a Widgetbook tap should still show that the bytes arrived.
+ValueChanged<Uint8List> _logPng(String action) =>
+    (png) => debugPrint('request: $action (${png.length} bytes)');

--- a/lib/widgetbook/send_review_status_use_cases.dart
+++ b/lib/widgetbook/send_review_status_use_cases.dart
@@ -22,6 +22,12 @@ const _contactRecipient = SendReviewContactRecipient(
   profilePictureId: 'pfp-02',
 );
 
+const _requestContactRecipient = SendReviewContactRecipient(
+  address: _sampleAddress,
+  name: 'Blue Door Coffee',
+  profilePictureId: 'pfp-02',
+);
+
 /// Review send — raw shielded address recipient. (Toggle the Widgetbook
 /// theme for dark mode.)
 Widget buildSendReviewAddressUseCase(BuildContext context) {
@@ -51,6 +57,46 @@ Widget buildSendReviewContactUseCase(BuildContext context) {
       recipient: _contactRecipient,
       memoText: _sampleMemo,
       feeText: '0.012 ZEC',
+      onConfirm: () {},
+      onCancel: () {},
+      onShowFullAddress: () {},
+      onExpandMemo: () {},
+      onFeeHelp: () {},
+    ),
+  );
+}
+
+/// Review payment request — the recipient is a saved contact. Only the row
+/// title changes; the link's own `label=` is never shown on the review.
+Widget buildSendReviewPaymentRequestContactUseCase(BuildContext context) {
+  return _SendReviewStatusFrame(
+    child: SendReviewContentView(
+      amountText: '0.50 ZEC',
+      fiatText: r'$35.00',
+      recipient: _requestContactRecipient,
+      memoText: _sampleMemo,
+      feeText: '0.012 ZEC',
+      isPaymentRequest: true,
+      onConfirm: () {},
+      onCancel: () {},
+      onShowFullAddress: () {},
+      onExpandMemo: () {},
+      onFeeHelp: () {},
+    ),
+  );
+}
+
+/// Review payment request — no address-book match, so the truncated address
+/// and its pool badge head the "Requested by" row.
+Widget buildSendReviewPaymentRequestAddressUseCase(BuildContext context) {
+  return _SendReviewStatusFrame(
+    child: SendReviewContentView(
+      amountText: '0.50 ZEC',
+      fiatText: r'$35.00',
+      recipient: _addressRecipient,
+      memoText: _sampleMemo,
+      feeText: '0.012 ZEC',
+      isPaymentRequest: true,
       onConfirm: () {},
       onCancel: () {},
       onShowFullAddress: () {},

--- a/lib/widgetbook/send_use_cases.dart
+++ b/lib/widgetbook/send_use_cases.dart
@@ -542,7 +542,6 @@ const _mobileSendContacts = [
 
 Future<rust_sync.AddressValidationResult> _widgetbookValidateAddress({
   required String address,
-  required String network,
 }) async {
   if (address.startsWith('t1')) {
     return const rust_sync.AddressValidationResult(

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -19,6 +19,8 @@ import 'icon_use_cases.dart';
 import 'keystone_use_cases.dart';
 import 'mobile_pay_use_cases.dart';
 import 'mobile_shell_use_cases.dart';
+import 'payment_request_use_cases.dart';
+import 'request_amount_use_cases.dart';
 import 'pay_use_cases.dart';
 import 'receive_use_cases.dart';
 import 'received_receipt_use_cases.dart';
@@ -769,6 +771,46 @@ class WidgetbookApp extends StatelessWidget {
                       name: 'Transparent modal',
                       builder: buildReceiveDesktopTransparentModalUseCase,
                     ),
+                    WidgetbookUseCase(
+                      name: 'Entry - Request ZEC button',
+                      builder: buildReceiveDesktopRequestEntryUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request modal - step 1 - empty',
+                      builder: buildRequestModalStepOneEmptyUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request modal - step 1 - amount',
+                      builder: buildRequestModalStepOneAmountUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request modal - step 1 - price unavailable',
+                      builder: buildRequestModalStepOnePriceUnavailableUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request modal - step 1 - amount + message',
+                      builder: buildRequestModalStepOneMessageUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request modal - step 1 - transparent',
+                      builder: buildRequestModalStepOneTransparentUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request modal - step 1 - amount error',
+                      builder: buildRequestModalStepOneAmountErrorUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request modal - step 2 - shielded',
+                      builder: buildRequestModalStepTwoShieldedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request modal - step 2 - transparent',
+                      builder: buildRequestModalStepTwoTransparentUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request modal - step 2 - 512-byte message',
+                      builder: buildRequestModalStepTwoDenseUseCase,
+                    ),
                   ],
                 ),
                 WidgetbookComponent(
@@ -789,6 +831,38 @@ class WidgetbookApp extends StatelessWidget {
                     WidgetbookUseCase(
                       name: 'Transparent sheet',
                       builder: buildReceiveMobileTransparentSheetUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Entry - Request ZEC button',
+                      builder: buildRequestMobileEntryUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request step 1 - empty',
+                      builder: buildRequestMobileComposeEmptyUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request step 1 - amount (USD mode)',
+                      builder: buildRequestMobileComposeUsdUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request step 1 - price unavailable',
+                      builder: buildRequestMobileComposePriceUnavailableUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request step 1 - message added',
+                      builder: buildRequestMobileComposeMessageUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request step 1 - amount error',
+                      builder: buildRequestMobileComposeAmountErrorUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request step 2 - shielded QR',
+                      builder: buildRequestMobileResultShieldedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Request step 2 - transparent QR',
+                      builder: buildRequestMobileResultTransparentUseCase,
                     ),
                   ],
                 ),
@@ -1148,6 +1222,14 @@ class WidgetbookApp extends StatelessWidget {
                       name: 'Contact',
                       builder: buildSendReviewContactUseCase,
                     ),
+                    WidgetbookUseCase(
+                      name: 'Payment request, contact',
+                      builder: buildSendReviewPaymentRequestContactUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Payment request, address',
+                      builder: buildSendReviewPaymentRequestAddressUseCase,
+                    ),
                   ],
                 ),
                 WidgetbookComponent(
@@ -1181,6 +1263,174 @@ class WidgetbookApp extends StatelessWidget {
                     WidgetbookUseCase(
                       name: 'Known contact',
                       builder: buildVerifyAddressKnownContactUseCase,
+                    ),
+                  ],
+                ),
+                WidgetbookComponent(
+                  name: 'Payment request card',
+                  useCases: [
+                    WidgetbookUseCase(
+                      name: 'Full',
+                      builder: buildPaymentRequestFullUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Minimal',
+                      builder: buildPaymentRequestMinimalUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Long values',
+                      builder: buildPaymentRequestLongValuesUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Long values - message expanded',
+                      builder: buildPaymentRequestLongValuesExpandedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Address expanded',
+                      builder: buildPaymentRequestAddressExpandedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Checking',
+                      builder: buildPaymentRequestCheckingUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Error - address',
+                      builder: buildPaymentRequestInvalidAddressUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Error - not enough ZEC',
+                      builder: buildPaymentRequestInsufficientUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Error - syncing',
+                      builder: buildPaymentRequestSyncingUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Error - syncing stalled',
+                      builder: buildPaymentRequestSyncStalledUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Error - check failed',
+                      builder: buildPaymentRequestFailedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Replaced notice',
+                      builder: buildPaymentRequestReplacedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Transparent recipient',
+                      builder: buildPaymentRequestTransparentUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Saved contact recipient',
+                      builder: buildPaymentRequestContactUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Own account recipient',
+                      builder: buildPaymentRequestOwnAccountUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Own account, address expanded',
+                      builder: buildPaymentRequestOwnAccountExpandedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Note without message',
+                      builder: buildPaymentRequestNoteOnlyUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'No amount',
+                      builder: buildPaymentRequestNoAmountUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Text scale 1.5x',
+                      builder: buildPaymentRequestLargeTextUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'RTL mirror',
+                      builder: buildPaymentRequestRtlUseCase,
+                    ),
+                  ],
+                ),
+                WidgetbookComponent(
+                  name: 'Mobile payment request card',
+                  useCases: [
+                    WidgetbookUseCase(
+                      name: 'Full',
+                      builder: buildMobilePaymentRequestFullUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Minimal',
+                      builder: buildMobilePaymentRequestMinimalUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Long values',
+                      builder: buildMobilePaymentRequestLongValuesUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Long values - message expanded',
+                      builder:
+                          buildMobilePaymentRequestLongValuesExpandedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Address expanded',
+                      builder: buildMobilePaymentRequestAddressExpandedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Checking',
+                      builder: buildMobilePaymentRequestCheckingUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Error - address',
+                      builder: buildMobilePaymentRequestInvalidAddressUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Error - not enough ZEC',
+                      builder: buildMobilePaymentRequestInsufficientUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Error - syncing',
+                      builder: buildMobilePaymentRequestSyncingUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Error - check failed',
+                      builder: buildMobilePaymentRequestFailedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Replaced notice',
+                      builder: buildMobilePaymentRequestReplacedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Transparent recipient',
+                      builder: buildMobilePaymentRequestTransparentUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Saved contact recipient',
+                      builder: buildMobilePaymentRequestContactUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Own account recipient',
+                      builder: buildMobilePaymentRequestOwnAccountUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Own account, address expanded',
+                      builder:
+                          buildMobilePaymentRequestOwnAccountExpandedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Note without message',
+                      builder: buildMobilePaymentRequestNoteOnlyUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'No amount',
+                      builder: buildMobilePaymentRequestNoAmountUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Text scale 1.5x',
+                      builder: buildMobilePaymentRequestLargeTextUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'RTL mirror',
+                      builder: buildMobilePaymentRequestRtlUseCase,
                     ),
                   ],
                 ),

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <desktop_window_bootstrap/desktop_window_bootstrap_plugin.h>
+#include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <mobile_scanner/mobile_scanner_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
@@ -17,6 +18,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) desktop_window_bootstrap_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopWindowBootstrapPlugin");
   desktop_window_bootstrap_plugin_register_with_registrar(desktop_window_bootstrap_registrar);
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   desktop_window_bootstrap
+  file_selector_linux
   flutter_secure_storage_linux
   mobile_scanner
   screen_retriever_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import desktop_window_bootstrap
+import file_selector_macos
 import flutter_secure_storage_darwin
 import mobile_scanner
 import screen_retriever_macos
@@ -16,6 +17,7 @@ import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DesktopWindowBootstrapPlugin.register(with: registry.registrar(forPlugin: "DesktopWindowBootstrapPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -258,6 +258,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector:
+    dependency: "direct main"
+    description:
+      name: file_selector
+      sha256: bd15e43e9268db636b53eeaca9f56324d1622af30e5c34d6e267649758c84d9a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  file_selector_android:
+    dependency: transitive
+    description:
+      name: file_selector_android
+      sha256: "89243030ea4b3463fb402b44d5eeacc4ccb1c46a88870cb2a5080d693200c1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2+6"
+  file_selector_ios:
+    dependency: transitive
+    description:
+      name: file_selector_ios
+      sha256: "97269e5307a0ab813b1fa2430bada0a96e0afb74848417f8676f64ba5de0051c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.3+6"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: da76400e7872ce7637ffdce12749ec24169c25f6195c28372208e65a24bcd2ab
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+1"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: d57c62362766b5e7ae739448650b66c6aab7a68ba7ecc65e04018652645ae0f4
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5+1"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_web:
+    dependency: transitive
+    description:
+      name: file_selector_web
+      sha256: "73181fbc5257776d8ecaa6a94ab3c8e920ad143b9132a6d984a9271dfc6928d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: fbefc5fb92c6d3cbe8d284a2cd971b593bb07d2cd6da8557b81a862250b4acec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+6"
   fixnum:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,10 @@ dependencies:
   # Platform share sheet for the receive screen's share action.
   share_plus: ^12.0.1
   shared_preferences: ^2.5.3
+  # Native save dialog for the desktop "Save QR image" action. The macOS app
+  # is sandboxed, so a resolved Downloads path would land inside the app
+  # container — only an NSSavePanel result is a folder the user can reach.
+  file_selector: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/app_payment_request_mobile_park_test.dart
+++ b/test/app_payment_request_mobile_park_test.dart
@@ -152,6 +152,7 @@ class _EmptyAddressBookNotifier extends AddressBookNotifier {
 
 PaymentRequestPrecheck _readyPrecheck({required VoidCallback onPropose}) =>
     PaymentRequestPrecheck(
+      readNetworkName: () => kZcashDefaultNetworkName,
       spendableIsAuthoritativeNow: () => true,
       validateAddress:
           ({required String address, required String network}) async =>

--- a/test/app_payment_request_mobile_park_test.dart
+++ b/test/app_payment_request_mobile_park_test.dart
@@ -1,0 +1,222 @@
+@Tags(['mobile'])
+/// Mobile has no answer for a payment request card yet, so the shell must not
+/// present one.
+///
+/// `PaymentRequestSurface` draws a mobile sheet already, and the host is
+/// mounted on both form factors, so a delivered request *would* render here.
+/// But the host's two answers still carry the desktop route payloads that the
+/// mobile routes reject, and Review hands off a live Rust proposal on the way
+/// out. This test is the desktop mount test's opposite number: the same link,
+/// on the same shell, has to leave the link parked and nothing on screen.
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_surface.dart';
+import 'package:zcash_wallet/src/features/send/widgets/send_recipient_resolver.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/migration_send_gate_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_request_flow_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/services/incoming_uri_service.dart';
+
+import 'fakes/fake_sync_notifier.dart';
+
+const _address =
+    'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+    '73d57f73c6dc05121591a83861cd190591';
+
+const _link = 'zcash:$_address?amount=0.5&label=Coffee%20shop';
+
+void main() {
+  testWidgets('a delivered payment request stays parked on mobile', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final incomingUris = _FakeIncomingUriService();
+    addTearDown(incomingUris.dispose);
+
+    var proposals = 0;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(_bootstrap()),
+          accountProvider.overrideWith(_FakeAccountNotifier.new),
+          syncProvider.overrideWith(() => FakeSyncNotifier(_syncedSyncState)),
+          incomingUriServiceProvider.overrideWithValue(incomingUris),
+          paymentRequestPrecheckProvider.overrideWithValue(
+            _readyPrecheck(onPropose: () => proposals++),
+          ),
+          addressBookProvider.overrideWith(_EmptyAddressBookNotifier.new),
+          ownAccountAddressesProvider.overrideWith((ref) async => const {}),
+          zecHomeUsdUnitPriceProvider.overrideWithValue(null),
+          migrationSendGateProvider.overrideWithValue(false),
+        ],
+        child: const ZcashWalletApp(),
+      ),
+    );
+    await _pumpUntilPresent(tester, find.byType(ZcashWalletApp));
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ZcashWalletApp)),
+      listen: false,
+    );
+
+    incomingUris.emit(_link);
+    // Long enough for the drain's post-frame pass *and* for a pre-check to
+    // have finished, so "nothing on screen" cannot just mean "not yet".
+    for (var i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+
+    expect(
+      container.read(paymentUriPrefillProvider),
+      isNotNull,
+      reason: 'the link has to stay parked, not be dropped',
+    );
+    expect(
+      container.read(paymentRequestFlowProvider),
+      isNull,
+      reason: 'no card may take ownership of the link on mobile yet',
+    );
+    expect(
+      proposals,
+      0,
+      reason:
+          'the pre-check reserves the wallet inputs; nothing may hold them '
+          'behind a card mobile cannot answer',
+    );
+    expect(find.byType(PaymentRequestSurface), findsNothing);
+    expect(
+      find.byKey(const ValueKey('payment_request_host_surface')),
+      findsNothing,
+    );
+    expect(find.text('Payment request'), findsNothing);
+  });
+}
+
+Future<void> _pumpUntilPresent(WidgetTester tester, Finder finder) async {
+  for (var i = 0; i < 40; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+    if (finder.evaluate().isNotEmpty) return;
+  }
+}
+
+class _FakeIncomingUriService extends IncomingUriService {
+  final StreamController<String> _uris = StreamController<String>.broadcast();
+
+  @override
+  Stream<String> get uriStream => _uris.stream;
+
+  @override
+  Future<void> initialize() async {}
+
+  void emit(String uri) => _uris.add(uri);
+
+  @override
+  Future<void> dispose() async {
+    await _uris.close();
+  }
+}
+
+class _FakeAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1active',
+  );
+}
+
+class _EmptyAddressBookNotifier extends AddressBookNotifier {
+  @override
+  Future<AddressBookState> build() async => const AddressBookState();
+}
+
+PaymentRequestPrecheck _readyPrecheck({required VoidCallback onPropose}) =>
+    PaymentRequestPrecheck(
+      spendableIsAuthoritativeNow: () => true,
+      validateAddress:
+          ({required String address, required String network}) async =>
+              rust_sync.AddressValidationResult(
+                isValid: true,
+                addressType: 'unified',
+                wrongNetwork: false,
+              ),
+      proposeTransfer:
+          ({
+            required String accountUuid,
+            required String sendFlowId,
+            required String address,
+            required String addressType,
+            required BigInt amountZatoshi,
+            String? memo,
+            bool isPaymentRequest = false,
+            String? requestedBy,
+            BigInt? requestedAmountZatoshi,
+          }) async {
+            onPropose();
+            return SendReviewArgs(
+              proposalId: BigInt.from(11),
+              sendFlowId: sendFlowId,
+              proposalAccountUuid: accountUuid,
+              address: address,
+              addressType: addressType,
+              amountZatoshi: amountZatoshi,
+              feeZatoshi: BigInt.from(10000),
+              needsSaplingParams: false,
+              isPaymentRequest: isPaymentRequest,
+              requestedBy: requestedBy,
+              requestedAmountZatoshi: requestedAmountZatoshi,
+            );
+          },
+      discardProposal:
+          ({
+            required BigInt proposalId,
+            required String sendFlowId,
+            required String logContext,
+          }) async {},
+    );
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/home',
+  initialAccountState: const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1active',
+  ),
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);
+
+final _syncedSyncState = SyncState(
+  accountUuid: 'account-1',
+  hasAccountScopedData: true,
+  isSyncComplete: true,
+  chainTipHeight: 3000000,
+  scannedHeight: 3000000,
+  spendableBalance: BigInt.from(100000000),
+);

--- a/test/app_payment_request_mount_test.dart
+++ b/test/app_payment_request_mount_test.dart
@@ -1,0 +1,197 @@
+/// The app shell has to actually mount the payment-request host.
+///
+/// Every other test in this lane drives `PaymentRequestHost` directly, or
+/// asserts on `paymentRequestFlowProvider`, so a shell that presents a request
+/// and then renders nothing over the screen would pass all of them. This one
+/// pumps the real `ZcashWalletApp`, hands the native link stream a `zcash:`
+/// URI, and requires the card to appear over the desktop shell.
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_surface.dart';
+import 'package:zcash_wallet/src/features/send/widgets/send_recipient_resolver.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/migration_send_gate_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_request_flow_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/services/incoming_uri_service.dart';
+
+import 'fakes/fake_sync_notifier.dart';
+
+const _address =
+    'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+    '73d57f73c6dc05121591a83861cd190591';
+
+const _link = 'zcash:$_address?amount=0.5&label=Coffee%20shop';
+
+void main() {
+  testWidgets('a delivered payment request is presented over the shell', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final incomingUris = _FakeIncomingUriService();
+    addTearDown(incomingUris.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(_bootstrap()),
+          accountProvider.overrideWith(_FakeAccountNotifier.new),
+          syncProvider.overrideWith(() => FakeSyncNotifier(_syncedSyncState)),
+          incomingUriServiceProvider.overrideWithValue(incomingUris),
+          paymentRequestPrecheckProvider.overrideWithValue(_readyPrecheck()),
+          addressBookProvider.overrideWith(_EmptyAddressBookNotifier.new),
+          ownAccountAddressesProvider.overrideWith((ref) async => const {}),
+          zecHomeUsdUnitPriceProvider.overrideWithValue(null),
+          migrationSendGateProvider.overrideWithValue(false),
+        ],
+        child: const ZcashWalletApp(),
+      ),
+    );
+    await _pumpUntilPresent(tester, find.byType(ZcashWalletApp));
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ZcashWalletApp)),
+      listen: false,
+    );
+
+    incomingUris.emit(_link);
+    await _pumpUntilPresent(tester, find.byType(PaymentRequestSurface));
+
+    expect(
+      container.read(paymentRequestFlowProvider),
+      isNotNull,
+      reason: 'the link has to reach the flow before the mount can be blamed',
+    );
+    expect(
+      find.byType(PaymentRequestSurface),
+      findsOneWidget,
+      reason: 'the shell must mount PaymentRequestHost over the router',
+    );
+    expect(
+      find.byKey(const ValueKey('payment_request_host_surface')),
+      findsOneWidget,
+    );
+    expect(find.text('Payment request'), findsOneWidget);
+  });
+}
+
+Future<void> _pumpUntilPresent(WidgetTester tester, Finder finder) async {
+  for (var i = 0; i < 40; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+    if (finder.evaluate().isNotEmpty) return;
+  }
+}
+
+class _FakeIncomingUriService extends IncomingUriService {
+  final StreamController<String> _uris = StreamController<String>.broadcast();
+
+  @override
+  Stream<String> get uriStream => _uris.stream;
+
+  @override
+  Future<void> initialize() async {}
+
+  void emit(String uri) => _uris.add(uri);
+
+  @override
+  Future<void> dispose() async {
+    await _uris.close();
+  }
+}
+
+class _FakeAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1active',
+  );
+}
+
+class _EmptyAddressBookNotifier extends AddressBookNotifier {
+  @override
+  Future<AddressBookState> build() async => const AddressBookState();
+}
+
+PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  spendableIsAuthoritativeNow: () => true,
+  validateAddress: ({required String address, required String network}) async =>
+      rust_sync.AddressValidationResult(
+        isValid: true,
+        addressType: 'unified',
+        wrongNetwork: false,
+      ),
+  proposeTransfer:
+      ({
+        required String accountUuid,
+        required String sendFlowId,
+        required String address,
+        required String addressType,
+        required BigInt amountZatoshi,
+        String? memo,
+        bool isPaymentRequest = false,
+        String? requestedBy,
+        BigInt? requestedAmountZatoshi,
+      }) async => SendReviewArgs(
+        proposalId: BigInt.from(11),
+        sendFlowId: sendFlowId,
+        proposalAccountUuid: accountUuid,
+        address: address,
+        addressType: addressType,
+        amountZatoshi: amountZatoshi,
+        feeZatoshi: BigInt.from(10000),
+        needsSaplingParams: false,
+        isPaymentRequest: isPaymentRequest,
+        requestedBy: requestedBy,
+        requestedAmountZatoshi: requestedAmountZatoshi,
+      ),
+  discardProposal:
+      ({
+        required BigInt proposalId,
+        required String sendFlowId,
+        required String logContext,
+      }) async {},
+);
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/home',
+  initialAccountState: const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1active',
+  ),
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);
+
+final _syncedSyncState = SyncState(
+  accountUuid: 'account-1',
+  hasAccountScopedData: true,
+  isSyncComplete: true,
+  chainTipHeight: 3000000,
+  scannedHeight: 3000000,
+  spendableBalance: BigInt.from(100000000),
+);

--- a/test/app_payment_request_mount_test.dart
+++ b/test/app_payment_request_mount_test.dart
@@ -131,6 +131,7 @@ class _EmptyAddressBookNotifier extends AddressBookNotifier {
 }
 
 PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  readNetworkName: () => kZcashDefaultNetworkName,
   spendableIsAuthoritativeNow: () => true,
   validateAddress: ({required String address, required String network}) async =>
       rust_sync.AddressValidationResult(

--- a/test/app_payment_uri_busy_surface_first_frame_test.dart
+++ b/test/app_payment_uri_busy_surface_first_frame_test.dart
@@ -1,0 +1,210 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_busy_surface_hold.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_busy_surface_provider.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_request_flow_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import 'fakes/fake_sync_notifier.dart';
+
+// A busy surface takes its hold from a post-frame callback registered in its
+// own initState. A link that arrives in the same turn as the navigation that
+// mounts the surface schedules its drain *before* that initState runs, so a
+// drain that is itself a plain post-frame callback runs first, reads a hold
+// count of zero, and presents the card over the signing surface. The drain
+// has to run after every post-frame callback of the frame instead.
+void main() {
+  const account = AccountInfo(
+    uuid: 'account-1',
+    name: 'Account 1',
+    order: 0,
+    isSeedAnchor: true,
+  );
+
+  const walletState = AccountState(
+    accounts: [account],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1active',
+  );
+
+  Future<(ProviderContainer, GoRouter)> pumpApp(WidgetTester tester) async {
+    final router = GoRouter(
+      initialLocation: '/home',
+      routes: [
+        for (final path in ['/home', '/send', '/welcome', '/unlock'])
+          GoRoute(
+            path: path,
+            builder: (_, _) => Scaffold(body: Text('screen $path')),
+          ),
+        // Stands in for every Keystone signing screen: the whole screen is
+        // the protected session.
+        GoRoute(
+          path: '/busy',
+          builder: (_, _) => const PaymentUriBusySurfaceHold(
+            child: Scaffold(body: Text('screen /busy')),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    late ProviderContainer container;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(
+            _unlockedBootstrapWithWallet(walletState),
+          ),
+          accountProvider.overrideWith(
+            () => _ControllableAccountNotifier(walletState),
+          ),
+          syncProvider.overrideWith(FakeSyncNotifier.new),
+          paymentRequestPrecheckProvider.overrideWithValue(_readyPrecheck()),
+        ],
+        child: Consumer(
+          builder: (context, ref, _) {
+            container = ProviderScope.containerOf(context, listen: false);
+            return MaterialApp.router(
+              routerConfig: router,
+              // AppTheme, because the host's notices render as app toasts.
+              builder: (context, child) => AppTheme(
+                data: AppThemeData.dark,
+                child: buildIncomingLinkHostForTest(
+                  router: router,
+                  child: child!,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return (container, router);
+  }
+
+  testWidgets(
+    'a link arriving in the frame a signing surface mounts stays parked',
+    (tester) async {
+      final (container, router) = await pumpApp(tester);
+
+      // Navigation requested and the link delivered before the frame that
+      // builds the signing screen — the order a QR scan that opens a signing
+      // screen while a link lands produces.
+      router.go('/busy');
+      await _pushNativeUris(tester, const ['zcash:u1recipient?amount=1']);
+      await tester.pump();
+
+      // Built this frame; its page transition has not brought it on stage.
+      expect(find.text('screen /busy', skipOffstage: false), findsOneWidget);
+      expect(container.read(paymentUriBusySurfaceProvider), 1);
+      expect(
+        container.read(paymentRequestFlowProvider),
+        isNull,
+        reason: 'the card must not be presented over the signing surface',
+      );
+      expect(
+        container.read(paymentUriPrefillProvider),
+        isNotNull,
+        reason: 'the link waits for the surface, it is not dropped',
+      );
+
+      // Leaving the surface gives the hold back and the parked link lands.
+      router.go('/home');
+      await tester.pumpAndSettle();
+
+      expect(container.read(paymentUriBusySurfaceProvider), 0);
+      expect(container.read(paymentRequestFlowProvider), isNotNull);
+      expect(container.read(paymentUriPrefillProvider), isNull);
+    },
+  );
+}
+
+/// Delivers [uris] the way the native runner does: an `onUris` method call on
+/// the incoming-link channel, which `IncomingUriService` — installed by the
+/// host under test in its `initState` — forwards to its stream.
+Future<void> _pushNativeUris(WidgetTester tester, List<String> uris) async {
+  const codec = StandardMethodCodec();
+  await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+    'com.zcash.wallet/payment_uri',
+    codec.encodeMethodCall(MethodCall('onUris', uris)),
+    (_) {},
+  );
+}
+
+PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  spendableIsAuthoritativeNow: () => true,
+  validateAddress: ({required String address, required String network}) async =>
+      rust_sync.AddressValidationResult(
+        isValid: true,
+        addressType: 'unified',
+        wrongNetwork: false,
+      ),
+  proposeTransfer:
+      ({
+        required String accountUuid,
+        required String sendFlowId,
+        required String address,
+        required String addressType,
+        required BigInt amountZatoshi,
+        String? memo,
+        bool isPaymentRequest = false,
+        String? requestedBy,
+        BigInt? requestedAmountZatoshi,
+      }) async => SendReviewArgs(
+        proposalId: BigInt.from(11),
+        sendFlowId: sendFlowId,
+        proposalAccountUuid: accountUuid,
+        address: address,
+        addressType: addressType,
+        amountZatoshi: amountZatoshi,
+        feeZatoshi: BigInt.from(10000),
+        needsSaplingParams: false,
+        isPaymentRequest: isPaymentRequest,
+        requestedBy: requestedBy,
+        requestedAmountZatoshi: requestedAmountZatoshi,
+      ),
+  discardProposal:
+      ({
+        required BigInt proposalId,
+        required String sendFlowId,
+        required String logContext,
+      }) async {},
+);
+
+AppBootstrapState _unlockedBootstrapWithWallet(AccountState accountState) =>
+    AppBootstrapState(
+      initialLocation: '/home',
+      initialAccountState: accountState,
+      initialSyncSnapshot: AppSyncSnapshot.empty,
+      network: 'main',
+      rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+      themeMode: ThemeMode.dark,
+      privacyModeEnabled: false,
+      isPasswordConfigured: true,
+      isUnlocked: true,
+      passwordRotationRecoveryFailed: false,
+    );
+
+class _ControllableAccountNotifier extends AccountNotifier {
+  _ControllableAccountNotifier(this._initial);
+
+  final AccountState _initial;
+
+  @override
+  FutureOr<AccountState> build() => _initial;
+}

--- a/test/app_payment_uri_busy_surface_first_frame_test.dart
+++ b/test/app_payment_uri_busy_surface_first_frame_test.dart
@@ -147,6 +147,7 @@ Future<void> _pushNativeUris(WidgetTester tester, List<String> uris) async {
 }
 
 PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  readNetworkName: () => kZcashDefaultNetworkName,
   spendableIsAuthoritativeNow: () => true,
   validateAddress: ({required String address, required String network}) async =>
       rust_sync.AddressValidationResult(

--- a/test/app_payment_uri_rejection_test.dart
+++ b/test/app_payment_uri_rejection_test.dart
@@ -1,0 +1,201 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_drain_policy.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import 'fakes/fake_sync_notifier.dart';
+
+// A refused `zcash:` link is answered with one of two sentences, never with
+// the parser's own message: that text is spec wording written for us, and it
+// echoes back up to 32 characters of the link's own string.
+//
+// The split the payer cares about is what to do next — wait for Vizor to
+// support the feature, or ask the sender for a link that works — so the two
+// buckets are pinned end to end, from the native push to the snackbar.
+void main() {
+  const account = AccountInfo(
+    uuid: 'account-1',
+    name: 'Account 1',
+    order: 0,
+    isSeedAnchor: true,
+  );
+
+  const walletState = AccountState(
+    accounts: [account],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1active',
+  );
+
+  Future<ProviderContainer> pumpApp(WidgetTester tester) async {
+    final router = GoRouter(
+      initialLocation: '/home',
+      routes: [
+        for (final path in ['/home', '/send', '/welcome', '/unlock'])
+          GoRoute(
+            path: path,
+            builder: (_, _) => Scaffold(body: Text('screen $path')),
+          ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    late ProviderContainer container;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(
+            _unlockedBootstrapWithWallet(walletState),
+          ),
+          accountProvider.overrideWith(
+            () => _ControllableAccountNotifier(walletState),
+          ),
+          syncProvider.overrideWith(FakeSyncNotifier.new),
+        ],
+        child: Consumer(
+          builder: (context, ref, _) {
+            container = ProviderScope.containerOf(context, listen: false);
+            return MaterialApp.router(
+              routerConfig: router,
+              // AppTheme, because the host's notices render as app toasts.
+              builder: (context, child) => AppTheme(
+                data: AppThemeData.dark,
+                child: buildIncomingLinkHostForTest(
+                  router: router,
+                  child: child!,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return container;
+  }
+
+  testWidgets('a multiple-recipient link reads as an unsupported feature', (
+    tester,
+  ) async {
+    final container = await pumpApp(tester);
+
+    await _pushNativeUris(tester, const [
+      'zcash:?address=u1firstaddress&amount=1'
+          '&address.1=u1secondaddress&amount.1=2',
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.text(kPaymentUriUnsupportedMessage), findsOneWidget);
+    expect(find.text(kPaymentUriMalformedMessage), findsNothing);
+    expect(
+      container.read(paymentUriPrefillProvider),
+      isNull,
+      reason: 'a refused link parks nothing',
+    );
+  });
+
+  testWidgets('a malformed link reads as an invalid link', (tester) async {
+    final container = await pumpApp(tester);
+
+    await _pushNativeUris(tester, const [
+      'zcash:u1recipient?amount=not-a-number',
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.text(kPaymentUriMalformedMessage), findsOneWidget);
+    expect(find.text(kPaymentUriUnsupportedMessage), findsNothing);
+    expect(container.read(paymentUriPrefillProvider), isNull);
+  });
+
+  // The one owner of "a transparent recipient cannot carry a memo" is the
+  // parser: ZIP-321 forbids the combination, so the link never becomes a card
+  // that could explain a dropped memo. The pre-check therefore has no
+  // memo-dropping branch, and this is the test that keeps the two halves from
+  // drifting apart again — they used to be tested only in isolation, each
+  // passing while the combination they described was impossible.
+  testWidgets('a memo on a transparent address is refused as an invalid link', (
+    tester,
+  ) async {
+    final container = await pumpApp(tester);
+
+    await _pushNativeUris(tester, const [
+      'zcash:t1RecipientAddress?amount=0.5&memo=aW52b2ljZSA0Mg',
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.text(kPaymentUriMalformedMessage), findsOneWidget);
+    expect(find.text(kPaymentUriUnsupportedMessage), findsNothing);
+    expect(
+      container.read(paymentUriPrefillProvider),
+      isNull,
+      reason: 'the link is refused before anything is parked',
+    );
+    expect(
+      find.textContaining('memo'),
+      findsNothing,
+      reason:
+          'no card exists to explain a dropped memo, so nothing may promise '
+          'one',
+    );
+  });
+
+  testWidgets('the parser wording never reaches the payer', (tester) async {
+    await pumpApp(tester);
+
+    await _pushNativeUris(tester, const ['zcash:u1recipient?req-secret=1']);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('ZIP-321'), findsNothing);
+    expect(
+      find.textContaining('req-secret'),
+      findsNothing,
+      reason: 'the link must not echo its own text back at the payer',
+    );
+    expect(find.text(kPaymentUriMalformedMessage), findsOneWidget);
+  });
+}
+
+/// Delivers [uris] the way the native runner does: an `onUris` method call on
+/// the incoming-link channel, which `IncomingUriService` — installed by the
+/// host under test in its `initState` — forwards to its stream.
+Future<void> _pushNativeUris(WidgetTester tester, List<String> uris) async {
+  const codec = StandardMethodCodec();
+  await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+    'com.zcash.wallet/payment_uri',
+    codec.encodeMethodCall(MethodCall('onUris', uris)),
+    (_) {},
+  );
+}
+
+AppBootstrapState _unlockedBootstrapWithWallet(AccountState accountState) =>
+    AppBootstrapState(
+      initialLocation: '/home',
+      initialAccountState: accountState,
+      initialSyncSnapshot: AppSyncSnapshot.empty,
+      network: 'main',
+      rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+      themeMode: ThemeMode.dark,
+      privacyModeEnabled: false,
+      isPasswordConfigured: true,
+      isUnlocked: true,
+      passwordRotationRecoveryFailed: false,
+    );
+
+class _ControllableAccountNotifier extends AccountNotifier {
+  _ControllableAccountNotifier(this._initial);
+
+  final AccountState _initial;
+
+  @override
+  FutureOr<AccountState> build() => _initial;
+}

--- a/test/app_payment_uri_unlock_claim_test.dart
+++ b/test/app_payment_uri_unlock_claim_test.dart
@@ -157,6 +157,7 @@ Future<void> _pushNativeUris(WidgetTester tester, List<String> uris) async {
 }
 
 PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  readNetworkName: () => kZcashDefaultNetworkName,
   spendableIsAuthoritativeNow: () => true,
   validateAddress: ({required String address, required String network}) async =>
       rust_sync.AddressValidationResult(

--- a/test/app_payment_uri_unlock_claim_test.dart
+++ b/test/app_payment_uri_unlock_claim_test.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_unlock_claim.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/migration_send_gate_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_request_flow_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import 'fakes/fake_sync_notifier.dart';
+
+// `decidePaymentUriDrain` answers `wait` for a link that arrives while the
+// app is on `/unlock`, whether or not the wallet is already unlocked, because
+// the unlock flow owns that handoff. Nothing re-runs the drain on a route
+// change — the payment lane's only re-drain triggers are a wallet emission,
+// the busy count reaching zero, and the send reaching a terminal phase — so
+// `claimParkedPaymentUriAfterUnlock` is not one of two ways the link can be
+// delivered from there. It is the only way.
+//
+// That makes it worth pinning at app level: an unlock path that ever stops
+// calling the claim strands the link until the park TTL, and no drain-policy
+// unit test can see that.
+void main() {
+  const account = AccountInfo(
+    uuid: 'account-1',
+    name: 'Account 1',
+    order: 0,
+    isSeedAnchor: true,
+  );
+
+  const walletState = AccountState(
+    accounts: [account],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1active',
+  );
+
+  testWidgets(
+    'a link parked on /unlock is delivered by the claim, not by leaving the '
+    'route',
+    (tester) async {
+      final router = GoRouter(
+        initialLocation: '/unlock',
+        routes: [
+          for (final path in ['/home', '/send', '/welcome', '/unlock'])
+            GoRoute(
+              path: path,
+              builder: (_, _) => Scaffold(body: Text('screen $path')),
+            ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      late ProviderContainer container;
+      late WidgetRef unlockScreenRef;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appBootstrapProvider.overrideWithValue(
+              _unlockedBootstrapWithWallet(walletState),
+            ),
+            accountProvider.overrideWith(
+              () => _ControllableAccountNotifier(walletState),
+            ),
+            paymentRequestPrecheckProvider.overrideWithValue(_readyPrecheck()),
+            syncProvider.overrideWith(FakeSyncNotifier.new),
+            migrationSendGateProvider.overrideWithValue(false),
+          ],
+          child: Consumer(
+            builder: (context, ref, _) {
+              container = ProviderScope.containerOf(context, listen: false);
+              // Stands in for the unlock screen's own `ref`: the claim is a
+              // `WidgetRef` call the two unlock screens share.
+              unlockScreenRef = ref;
+              return MaterialApp.router(
+                routerConfig: router,
+                builder: (context, child) => AppTheme(
+                  data: AppThemeData.dark,
+                  child: buildIncomingLinkHostForTest(
+                    router: router,
+                    child: child!,
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The wallet is already unlocked, but the app is still sitting on the
+      // unlock route: the drain waits rather than presenting under the screen
+      // that is about to navigate.
+      await _pushNativeUris(tester, const ['zcash:u1parked?amount=0.5']);
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(paymentUriPrefillProvider)?.address,
+        'u1parked',
+        reason: 'the link stays parked for the unlock flow to claim',
+      );
+      expect(container.read(paymentRequestFlowProvider), isNull);
+
+      // Leaving the route is not a delivery. The payment lane has no
+      // route-change re-drain, so nothing happens here — which is exactly why
+      // the claim below has to be the thing that delivers.
+      router.go('/home');
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(paymentUriPrefillProvider)?.address,
+        'u1parked',
+        reason: 'a route change alone must not be mistaken for a claim',
+      );
+      expect(container.read(paymentRequestFlowProvider), isNull);
+
+      // What the unlock screens actually do once the post-unlock work has
+      // succeeded.
+      final claim = claimParkedPaymentUriAfterUnlock(unlockScreenRef);
+      expect(claim.notice, isNull);
+      container
+          .read(paymentRequestFlowProvider.notifier)
+          .present(claim.prefill!, source: PaymentRequestSource.link);
+      await tester.pumpAndSettle();
+
+      expect(container.read(paymentUriPrefillProvider), isNull);
+      expect(
+        container.read(paymentRequestFlowProvider)!.prefill.address,
+        'u1parked',
+      );
+    },
+  );
+}
+
+/// Delivers [uris] the way the native runner does: an `onUris` method call on
+/// the incoming-link channel, which `IncomingUriService` — installed by the
+/// host under test in its `initState` — forwards to its stream.
+Future<void> _pushNativeUris(WidgetTester tester, List<String> uris) async {
+  const codec = StandardMethodCodec();
+  await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+    'com.zcash.wallet/payment_uri',
+    codec.encodeMethodCall(MethodCall('onUris', uris)),
+    (_) {},
+  );
+}
+
+PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  spendableIsAuthoritativeNow: () => true,
+  validateAddress: ({required String address, required String network}) async =>
+      rust_sync.AddressValidationResult(
+        isValid: true,
+        addressType: 'unified',
+        wrongNetwork: false,
+      ),
+  proposeTransfer:
+      ({
+        required String accountUuid,
+        required String sendFlowId,
+        required String address,
+        required String addressType,
+        required BigInt amountZatoshi,
+        String? memo,
+        bool isPaymentRequest = false,
+        String? requestedBy,
+        BigInt? requestedAmountZatoshi,
+      }) async => SendReviewArgs(
+        proposalId: BigInt.one,
+        sendFlowId: sendFlowId,
+        proposalAccountUuid: accountUuid,
+        address: address,
+        addressType: addressType,
+        amountZatoshi: amountZatoshi,
+        feeZatoshi: BigInt.from(10000),
+        needsSaplingParams: false,
+        isPaymentRequest: isPaymentRequest,
+        requestedBy: requestedBy,
+        requestedAmountZatoshi: requestedAmountZatoshi,
+      ),
+  discardProposal:
+      ({
+        required BigInt proposalId,
+        required String sendFlowId,
+        required String logContext,
+      }) async {},
+);
+
+AppBootstrapState _unlockedBootstrapWithWallet(AccountState accountState) =>
+    AppBootstrapState(
+      initialLocation: '/unlock',
+      initialAccountState: accountState,
+      initialSyncSnapshot: AppSyncSnapshot.empty,
+      network: 'main',
+      rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+      themeMode: ThemeMode.dark,
+      privacyModeEnabled: false,
+      isPasswordConfigured: true,
+      isUnlocked: true,
+      passwordRotationRecoveryFailed: false,
+    );
+
+class _ControllableAccountNotifier extends AccountNotifier {
+  _ControllableAccountNotifier(this._initial);
+
+  final AccountState _initial;
+
+  @override
+  FutureOr<AccountState> build() => _initial;
+}

--- a/test/app_payment_uri_wallet_reset_test.dart
+++ b/test/app_payment_uri_wallet_reset_test.dart
@@ -1,0 +1,554 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_busy_surface_provider.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_drain_policy.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_request_flow_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import 'fakes/fake_sync_notifier.dart';
+
+// A `zcash:` link parked while the wallet is locked must disappear quietly
+// when the user resets the wallet from the locked screens — no "Set up or
+// import a wallet" snackbar, no jump to /welcome.
+//
+// The regression this pins is the *cold locked start*: `AccountNotifier.build`
+// returns the bootstrap snapshot synchronously, so `ref.listen(walletProvider)`
+// in the listener never fires before the reset. Unless the listener seeds its
+// wallet-existence baseline up front, the reset emission is the first value it
+// ever sees and it cannot tell a reset from a fresh install.
+void main() {
+  const parkedPrefill = SendPrefillArgs(
+    id: 'payment-uri-1',
+    source: kPaymentUriPrefillSource,
+    address: 'u1parked',
+    amountText: '0.5',
+  );
+
+  const account = AccountInfo(
+    uuid: 'account-1',
+    name: 'Account 1',
+    order: 0,
+    isSeedAnchor: true,
+  );
+
+  const walletState = AccountState(
+    accounts: [account],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1active',
+  );
+
+  testWidgets(
+    'a wallet reset from a cold locked start drops the parked link quietly',
+    (tester) async {
+      final accounts = _ControllableAccountNotifier(walletState);
+      final router = GoRouter(
+        initialLocation: '/home',
+        routes: [
+          for (final path in ['/home', '/send', '/welcome', '/unlock'])
+            GoRoute(
+              path: path,
+              builder: (_, _) => Scaffold(body: Text('screen $path')),
+            ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      late ProviderContainer container;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            // Locked, but a wallet exists: the shape of every mobile
+            // forgot-passcode reset and of a desktop /lost-password reset.
+            appBootstrapProvider.overrideWithValue(
+              _lockedBootstrapWithWallet(walletState),
+            ),
+            accountProvider.overrideWith(() => accounts),
+            paymentRequestPrecheckProvider.overrideWithValue(_readyPrecheck()),
+            syncProvider.overrideWith(FakeSyncNotifier.new),
+          ],
+          child: Consumer(
+            builder: (context, ref, _) {
+              container = ProviderScope.containerOf(context, listen: false);
+              return MaterialApp.router(
+                routerConfig: router,
+                // AppTheme, because the host's notices render as app toasts.
+                builder: (context, child) => AppTheme(
+                  data: AppThemeData.dark,
+                  child: buildIncomingLinkHostForTest(
+                    router: router,
+                    child: child!,
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // A link arrives and parks: locked, so nothing is presented yet.
+      container.read(paymentUriPrefillProvider.notifier).set(parkedPrefill);
+      await tester.pumpAndSettle();
+      expect(container.read(paymentUriPrefillProvider), parkedPrefill);
+
+      // And a card left over from before the lock is torn down by the same
+      // reset — a request cannot outlive the wallet it was going to pay from.
+      container
+          .read(paymentRequestFlowProvider.notifier)
+          .present(parkedPrefill, source: PaymentRequestSource.link);
+      await tester.pumpAndSettle();
+      expect(container.read(paymentRequestFlowProvider), isNotNull);
+
+      // The user resets the wallet. `resetWallet` ends with an empty
+      // AccountState, which is the only wallet emission this session has had.
+      accounts.emit(const AccountState());
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(paymentUriPrefillProvider),
+        isNull,
+        reason: 'the parked link must be dropped by the reset',
+      );
+      expect(
+        container.read(paymentRequestFlowProvider),
+        isNull,
+        reason: 'the card must be dropped by the reset too',
+      );
+      expect(
+        find.text(kPaymentUriNoWalletMessage),
+        findsNothing,
+        reason: 'the wipe must not be followed by a no-wallet snackbar',
+      );
+      expect(
+        router.routerDelegate.currentConfiguration.uri.path,
+        '/home',
+        reason: 'the reset must not be redirected to /welcome by the link',
+      );
+    },
+  );
+
+  // Two `zcash:` links delivered back-to-back while the wallet is locked: the
+  // first parks for the unlock screen, the second displaces it. The prefill
+  // holds one link at a time on purpose (latest wins, no queue), so the user
+  // has to be told the earlier link is gone instead of silently getting the
+  // wrong payment on the next unlock.
+  testWidgets(
+    'a second link arriving while the first is parked says so and keeps the '
+    'newer one',
+    (tester) async {
+      const firstUri = 'zcash:u1firstlink?amount=0.5';
+      const secondUri = 'zcash:u1secondlink?amount=0.25';
+
+      final accounts = _ControllableAccountNotifier(walletState);
+      final router = GoRouter(
+        initialLocation: '/home',
+        routes: [
+          for (final path in ['/home', '/send', '/welcome', '/unlock'])
+            GoRoute(
+              path: path,
+              builder: (_, _) => Scaffold(body: Text('screen $path')),
+            ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      late ProviderContainer container;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appBootstrapProvider.overrideWithValue(
+              _lockedBootstrapWithWallet(walletState),
+            ),
+            accountProvider.overrideWith(() => accounts),
+            paymentRequestPrecheckProvider.overrideWithValue(_readyPrecheck()),
+            syncProvider.overrideWith(FakeSyncNotifier.new),
+          ],
+          child: Consumer(
+            builder: (context, ref, _) {
+              container = ProviderScope.containerOf(context, listen: false);
+              return MaterialApp.router(
+                routerConfig: router,
+                // AppTheme, because the host's notices render as app toasts.
+                builder: (context, child) => AppTheme(
+                  data: AppThemeData.dark,
+                  child: buildIncomingLinkHostForTest(
+                    router: router,
+                    child: child!,
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The native side flushes both links in one batch — the cold-start
+      // shape, and the same code path as two separate pushes.
+      await _pushNativeUris(tester, const [firstUri, secondUri]);
+      await tester.pumpAndSettle();
+
+      final parked = container.read(paymentUriPrefillProvider);
+      expect(
+        parked?.address,
+        'u1secondlink',
+        reason: 'latest wins: the second link must be the parked one',
+      );
+      expect(
+        find.text(kPaymentUriReplacedMessage),
+        findsOneWidget,
+        reason: 'the dropped first link must be visible to the user',
+      );
+      // Locked with a wallet: the drain parks and routes to the unlock screen,
+      // which claims the prefill after a successful unlock.
+      expect(router.routerDelegate.currentConfiguration.uri.path, '/unlock');
+    },
+  );
+
+  // The delivered link no longer navigates to /send. It becomes a card over
+  // whatever the user was already looking at.
+  testWidgets('a delivered link presents the card without navigating', (
+    tester,
+  ) async {
+    final accounts = _ControllableAccountNotifier(walletState);
+    final router = GoRouter(
+      initialLocation: '/home',
+      routes: [
+        for (final path in ['/home', '/send', '/welcome', '/unlock'])
+          GoRoute(
+            path: path,
+            builder: (_, _) => Scaffold(body: Text('screen $path')),
+          ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    late ProviderContainer container;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(
+            _unlockedBootstrapWithWallet(walletState),
+          ),
+          accountProvider.overrideWith(() => accounts),
+          paymentRequestPrecheckProvider.overrideWithValue(_readyPrecheck()),
+          syncProvider.overrideWith(FakeSyncNotifier.new),
+        ],
+        child: Consumer(
+          builder: (context, ref, _) {
+            container = ProviderScope.containerOf(context, listen: false);
+            return MaterialApp.router(
+              routerConfig: router,
+              // AppTheme, because the host's notices render as app toasts.
+              builder: (context, child) => AppTheme(
+                data: AppThemeData.dark,
+                child: buildIncomingLinkHostForTest(
+                  router: router,
+                  child: child!,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _pushNativeUris(tester, const ['zcash:u1parked?amount=0.5']);
+    await tester.pumpAndSettle();
+
+    expect(
+      container.read(paymentUriPrefillProvider),
+      isNull,
+      reason: 'the park is handed to the card',
+    );
+    expect(container.read(paymentRequestFlowProvider), isNotNull);
+    expect(
+      router.routerDelegate.currentConfiguration.uri.path,
+      '/home',
+      reason: 'the card arrives over the current screen, it is not a route',
+    );
+  });
+
+  testWidgets(
+    'a link on send review waits until the existing proposal is released',
+    (tester) async {
+      final accounts = _ControllableAccountNotifier(walletState);
+      final router = GoRouter(
+        initialLocation: '/home',
+        routes: [
+          for (final path in ['/home', '/send/review', '/welcome', '/unlock'])
+            GoRoute(
+              path: path,
+              builder: (_, _) => Scaffold(body: Text('screen $path')),
+            ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      late ProviderContainer container;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appBootstrapProvider.overrideWithValue(
+              _unlockedBootstrapWithWallet(walletState),
+            ),
+            accountProvider.overrideWith(() => accounts),
+            paymentRequestPrecheckProvider.overrideWithValue(_readyPrecheck()),
+            syncProvider.overrideWith(FakeSyncNotifier.new),
+          ],
+          child: Consumer(
+            builder: (context, ref, _) {
+              container = ProviderScope.containerOf(context, listen: false);
+              return MaterialApp.router(
+                routerConfig: router,
+                // AppTheme, because the host's notices render as app toasts.
+                builder: (context, child) => AppTheme(
+                  data: AppThemeData.dark,
+                  child: buildIncomingLinkHostForTest(
+                    router: router,
+                    child: child!,
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      router.go(
+        '/send/review',
+        extra: SendReviewArgs(
+          proposalId: BigInt.from(7),
+          sendFlowId: 'existing-flow',
+          proposalAccountUuid: 'account-1',
+          address: 'u1existing',
+          addressType: 'unified',
+          amountZatoshi: BigInt.from(50000000),
+          feeZatoshi: BigInt.from(10000),
+          needsSaplingParams: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await _pushNativeUris(tester, const ['zcash:u1parked?amount=0.5']);
+      await tester.pumpAndSettle();
+
+      expect(container.read(paymentRequestFlowProvider), isNull);
+      expect(container.read(paymentUriPrefillProvider), isNotNull);
+
+      // The real review screen acquires this hold after its first frame, then
+      // releases it only after discardProposal has completed.
+      final busy = container.read(paymentUriBusySurfaceProvider.notifier);
+      busy.acquire();
+      router.go('/home');
+      await tester.pumpAndSettle();
+      busy.release();
+      await tester.pumpAndSettle();
+
+      expect(container.read(paymentUriPrefillProvider), isNull);
+      expect(container.read(paymentRequestFlowProvider), isNotNull);
+      expect(router.routerDelegate.currentConfiguration.uri.path, '/home');
+    },
+  );
+
+  // A link that arrives while a broadcast is still running waits for the
+  // receipt. The card's Review and Edit both `go(...)`, which unmounts
+  // `/send/status`; `runSendBroadcast`'s `shouldAbort: () async => !mounted`
+  // then discards the outcome at its post-`executeProposal` checkpoint, so the
+  // transaction is on the network with no txid and no receipt for the user.
+  testWidgets('a link arriving mid-broadcast waits for the receipt', (
+    tester,
+  ) async {
+    final accounts = _ControllableAccountNotifier(walletState);
+    final router = GoRouter(
+      initialLocation: '/send/status',
+      routes: [
+        for (final path in [
+          '/home',
+          '/send',
+          '/send/status',
+          '/welcome',
+          '/unlock',
+        ])
+          GoRoute(
+            path: path,
+            builder: (_, _) => Scaffold(body: Text('screen $path')),
+          ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    late ProviderContainer container;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(
+            _unlockedBootstrapWithWallet(walletState),
+          ),
+          accountProvider.overrideWith(() => accounts),
+          paymentRequestPrecheckProvider.overrideWithValue(_readyPrecheck()),
+          syncProvider.overrideWith(FakeSyncNotifier.new),
+        ],
+        child: Consumer(
+          builder: (context, ref, _) {
+            container = ProviderScope.containerOf(context, listen: false);
+            return MaterialApp.router(
+              routerConfig: router,
+              // AppTheme, because the host's notices render as app toasts.
+              builder: (context, child) => AppTheme(
+                data: AppThemeData.dark,
+                child: buildIncomingLinkHostForTest(
+                  router: router,
+                  child: child!,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // `sendStatusTerminalProvider` starts false, which is what a broadcast in
+    // progress reads as.
+    expect(container.read(sendStatusTerminalProvider), isFalse);
+
+    await _pushNativeUris(tester, const ['zcash:u1parked?amount=0.5']);
+    await tester.pumpAndSettle();
+
+    expect(
+      container.read(paymentRequestFlowProvider),
+      isNull,
+      reason: 'no card over a send that has not finished broadcasting',
+    );
+    expect(
+      container.read(paymentUriPrefillProvider),
+      isNotNull,
+      reason: 'the link waits rather than being dropped',
+    );
+
+    // The send reaches a terminal phase. The listener on the flag re-drains.
+    container.read(sendStatusTerminalProvider.notifier).markTerminal();
+    await tester.pumpAndSettle();
+
+    expect(container.read(paymentRequestFlowProvider), isNotNull);
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    expect(
+      router.routerDelegate.currentConfiguration.uri.path,
+      '/send/status',
+      reason: 'the card arrives over the receipt, it does not navigate',
+    );
+  });
+}
+
+/// A pre-check that always resolves "ready", so the delivery test can assert
+/// the card's arrival without a Rust bridge.
+PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  spendableIsAuthoritativeNow: () => true,
+  validateAddress: ({required String address, required String network}) async =>
+      rust_sync.AddressValidationResult(
+        isValid: true,
+        addressType: 'unified',
+        wrongNetwork: false,
+      ),
+  proposeTransfer:
+      ({
+        required String accountUuid,
+        required String sendFlowId,
+        required String address,
+        required String addressType,
+        required BigInt amountZatoshi,
+        String? memo,
+        bool isPaymentRequest = false,
+        String? requestedBy,
+        BigInt? requestedAmountZatoshi,
+      }) async => SendReviewArgs(
+        proposalId: BigInt.one,
+        sendFlowId: sendFlowId,
+        proposalAccountUuid: accountUuid,
+        address: address,
+        addressType: addressType,
+        amountZatoshi: amountZatoshi,
+        feeZatoshi: BigInt.from(10000),
+        needsSaplingParams: false,
+        isPaymentRequest: isPaymentRequest,
+      ),
+  discardProposal:
+      ({
+        required BigInt proposalId,
+        required String sendFlowId,
+        required String logContext,
+      }) async {},
+);
+
+/// Delivers [uris] the way the native runner does: an `onUris` method call on
+/// the incoming-link channel, which `IncomingUriService` — installed by the
+/// host under test in its `initState` — forwards to its stream.
+Future<void> _pushNativeUris(WidgetTester tester, List<String> uris) async {
+  const codec = StandardMethodCodec();
+  await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+    'com.zcash.wallet/payment_uri',
+    codec.encodeMethodCall(MethodCall('onUris', uris)),
+    (_) {},
+  );
+}
+
+AppBootstrapState _unlockedBootstrapWithWallet(AccountState accountState) =>
+    AppBootstrapState(
+      initialLocation: '/home',
+      initialAccountState: accountState,
+      initialSyncSnapshot: AppSyncSnapshot.empty,
+      network: 'main',
+      rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+      themeMode: ThemeMode.dark,
+      privacyModeEnabled: false,
+      isPasswordConfigured: true,
+      isUnlocked: true,
+      passwordRotationRecoveryFailed: false,
+    );
+
+AppBootstrapState _lockedBootstrapWithWallet(AccountState accountState) =>
+    AppBootstrapState(
+      initialLocation: '/unlock',
+      initialAccountState: accountState,
+      initialSyncSnapshot: AppSyncSnapshot.empty,
+      network: 'main',
+      rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+      themeMode: ThemeMode.dark,
+      privacyModeEnabled: false,
+      isPasswordConfigured: true,
+      isUnlocked: false,
+      passwordRotationRecoveryFailed: false,
+    );
+
+class _ControllableAccountNotifier extends AccountNotifier {
+  _ControllableAccountNotifier(this._initial);
+
+  final AccountState _initial;
+
+  @override
+  FutureOr<AccountState> build() => _initial;
+
+  void emit(AccountState next) => state = AsyncData(next);
+}

--- a/test/app_payment_uri_wallet_reset_test.dart
+++ b/test/app_payment_uri_wallet_reset_test.dart
@@ -465,6 +465,7 @@ void main() {
 /// A pre-check that always resolves "ready", so the delivery test can assert
 /// the card's arrival without a Rust bridge.
 PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  readNetworkName: () => kZcashDefaultNetworkName,
   spendableIsAuthoritativeNow: () => true,
   validateAddress: ({required String address, required String network}) async =>
       rust_sync.AddressValidationResult(

--- a/test/features/keystone/keystone_scan_screen_busy_surface_test.dart
+++ b/test/features/keystone/keystone_scan_screen_busy_surface_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/send/screens/keystone_send_scan_screen.dart';
+import 'package:zcash_wallet/src/features/voting/screens/keystone_voting_scan_screen.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+import '../../support/payment_uri_busy_surface_expectations.dart';
+
+/// Both desktop scan screens point a camera at a QR the Keystone is holding on
+/// its own screen. A payment-request card over that is exactly the
+/// interruption `paymentUriBusySurfaceProvider` exists to park.
+void main() {
+  testWidgets('the send scan screen holds the payment-URI busy latch', (
+    tester,
+  ) async {
+    final container = _container();
+    await expectPaymentUriBusySurfaceHeldWhileMounted(
+      tester,
+      container: container,
+      host: _host(container),
+      surface: const KeystoneSendScanScreen(),
+      drainExceptions: true,
+    );
+  });
+
+  testWidgets('the voting scan screen holds the payment-URI busy latch', (
+    tester,
+  ) async {
+    final container = _container();
+    await expectPaymentUriBusySurfaceHeldWhileMounted(
+      tester,
+      container: container,
+      host: _host(container),
+      surface: const KeystoneVotingScanScreen(),
+      drainExceptions: true,
+    );
+  });
+}
+
+ProviderContainer _container() {
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap()),
+      // The desktop shell around the scan pane reads sync state, and the real
+      // notifier calls into Rust when the container is disposed.
+      syncProvider.overrideWith(FakeSyncNotifier.new),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+Widget Function(Widget) _host(ProviderContainer container) =>
+    (child) => UncontrolledProviderScope(
+      container: container,
+      child: AppTheme(
+        data: AppThemeData.dark,
+        child: MaterialApp(home: Scaffold(body: child)),
+      ),
+    );
+
+const _accountState = AccountState(
+  accounts: [AccountInfo(uuid: 'account-1', name: 'Account1', order: 0)],
+  activeAccountUuid: 'account-1',
+  activeAddress: 'u1scanscreen',
+);
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/home',
+  initialAccountState: _accountState,
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);

--- a/test/features/keystone/keystone_signing_overlays_busy_surface_test.dart
+++ b/test/features/keystone/keystone_signing_overlays_busy_surface_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/home/widgets/keystone_shield_signing_overlay.dart';
+import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
+import 'package:zcash_wallet/src/features/swap/widgets/swap_keystone_signing_overlay.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+import '../../support/payment_uri_busy_surface_expectations.dart';
+
+/// The two desktop Keystone signing sessions that own no route of their own:
+/// transparent shielding signs over `/home`, a hardware swap deposit over the
+/// swap activity pane. Both show the animated signing QR the device is
+/// reading, so a payment-request card landing on top would scrim it — and
+/// answering the card navigates away and disposes the signing flow. The
+/// overlays hold the latch for their whole mounted lifetime, like the
+/// route-owning scan screens do.
+void main() {
+  testWidgets('the shield signing overlay holds the payment-URI busy latch', (
+    tester,
+  ) async {
+    final container = _container();
+    await expectPaymentUriBusySurfaceHeldWhileMounted(
+      tester,
+      container: container,
+      host: _host(container),
+      surface: KeystoneShieldSigningOverlay(onCancel: () {}, onComplete: () {}),
+      // Preparing the PCZT calls into Rust, which is not running here; the
+      // failure lands in the overlay's own error state and says nothing about
+      // the latch.
+      drainExceptions: true,
+    );
+  });
+
+  testWidgets('the swap signing overlay holds the payment-URI busy latch', (
+    tester,
+  ) async {
+    final container = _container();
+    await expectPaymentUriBusySurfaceHeldWhileMounted(
+      tester,
+      container: container,
+      host: _host(container),
+      surface: SwapKeystoneSigningOverlay(
+        intent: _hardwareSwapIntent,
+        onCancel: () {},
+        onDepositBroadcast: (_) async {},
+      ),
+      drainExceptions: true,
+    );
+  });
+}
+
+ProviderContainer _container() {
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap()),
+      // Both overlays read sync state, and the real notifier calls into Rust
+      // when the container is disposed.
+      syncProvider.overrideWith(FakeSyncNotifier.new),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+Widget Function(Widget) _host(ProviderContainer container) =>
+    (child) => UncontrolledProviderScope(
+      container: container,
+      child: AppTheme(
+        data: AppThemeData.dark,
+        child: MaterialApp(home: Scaffold(body: child)),
+      ),
+    );
+
+const _accountState = AccountState(
+  accounts: [
+    AccountInfo(
+      uuid: 'account-1',
+      name: 'Keystone',
+      order: 0,
+      isHardware: true,
+    ),
+  ],
+  activeAccountUuid: 'account-1',
+  activeAddress: 'u1keystoneoverlay',
+);
+
+final _hardwareSwapIntent = SwapIntent(
+  id: 'swap-overlay-hardware',
+  pair: 'ZEC -> USDC',
+  sellAmount: '0.003 ZEC',
+  receiveEstimate: '0.21 USDC',
+  provider: 'NEAR Intents',
+  status: SwapIntentStatus.awaitingDeposit,
+  nextAction: 'Deposit ZEC',
+  sellAmountBaseUnits: BigInt.from(300000),
+  direction: SwapDirection.zecToExternal,
+  externalAsset: SwapAsset.usdc,
+  depositAddress: 't1overlay-deposit',
+  accountUuid: 'account-1',
+);
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/home',
+  initialAccountState: _accountState,
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);

--- a/test/features/migration/ironwood_keystone_sign_busy_surface_test.dart
+++ b/test/features/migration/ironwood_keystone_sign_busy_surface_test.dart
@@ -1,0 +1,112 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/migration/screens/ironwood_migration_flow_screen.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import '../../fakes/fake_sync_notifier.dart';
+import '../../support/payment_uri_busy_surface_expectations.dart';
+
+/// Every migration signing step — desktop or mobile — is an animated migration
+/// QR the Keystone is reading, or the scan of the signed result coming back.
+/// The screen holds the latch across both halves so no card lands between
+/// them.
+void main() {
+  testWidgets('the desktop migration signing screen holds the payment-URI '
+      'busy latch', (tester) async {
+    final container = _container();
+    await expectPaymentUriBusySurfaceHeldWhileMounted(
+      tester,
+      container: container,
+      host: _host(container),
+      surface: IronwoodMigrationKeystoneCombinedSignScreen(
+        approvedSchedule: const [],
+        previewRequest: _previewRequest,
+        previewUrParts: _previewUrParts,
+      ),
+      drainExceptions: true,
+    );
+  });
+
+  testWidgets('the mobile migration signing screen holds the payment-URI '
+      'busy latch', (tester) async {
+    final container = _container();
+    await expectPaymentUriBusySurfaceHeldWhileMounted(
+      tester,
+      container: container,
+      host: _host(container),
+      surface: MobileIronwoodMigrationKeystoneBatchSignScreen(
+        previewRequest: _previewRequest,
+        previewUrParts: _previewUrParts,
+      ),
+      drainExceptions: true,
+    );
+  });
+}
+
+ProviderContainer _container() {
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap()),
+      syncProvider.overrideWith(FakeSyncNotifier.new),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+Widget Function(Widget) _host(ProviderContainer container) =>
+    (child) => UncontrolledProviderScope(
+      container: container,
+      child: AppTheme(
+        data: AppThemeData.dark,
+        child: MaterialApp(home: Scaffold(body: child)),
+      ),
+    );
+
+final _previewRequest = rust_sync.KeystoneMigrationSigningRequest(
+  requestId: 'busy-surface-preview',
+  messages: [
+    rust_sync.KeystoneMigrationMessage(
+      id: 'busy-surface-preview-1',
+      redactedPczt: Uint8List.fromList(const [1, 2, 3]),
+      expectedSignatureCount: 0,
+    ),
+  ],
+  signingBatchLimit: 1,
+);
+
+const _previewUrParts = ['ur:zcash-sign-request/busy-surface-preview-1'];
+
+const _accountState = AccountState(
+  accounts: [
+    AccountInfo(
+      uuid: 'account-1',
+      name: 'Account1',
+      order: 0,
+      isHardware: true,
+    ),
+  ],
+  activeAccountUuid: 'account-1',
+  activeAddress: 'u1migrationsign',
+);
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/migration',
+  initialAccountState: _accountState,
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);

--- a/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/clipboard/sensitive_clipboard.dart';
 import 'package:zcash_wallet/src/core/privacy/sensitive_privacy_overlay.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/onboarding/create/onboarding_split_view.dart';

--- a/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
@@ -17,7 +17,6 @@ import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_secret_passph
 import 'package:zcash_wallet/src/features/onboarding/mobile/seed_card.dart';
 import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
 import 'package:zcash_wallet/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart';
-import 'package:zcash_wallet/src/core/clipboard/sensitive_clipboard.dart';
 import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 
 const _mnemonic =

--- a/test/features/receive/receive_request_modal_layout_test.dart
+++ b/test/features/receive/receive_request_modal_layout_test.dart
@@ -1,0 +1,311 @@
+/// Whether the desktop request modal fits the windows the app actually opens.
+///
+/// The modal mounts inside the real `AppDesktopShell` here rather than in a
+/// bare `SizedBox`, so the height it gets is the height the pane gets: the
+/// window minus the shell's own margins. Both sizes are the ones the product
+/// ships with — `windows/runner/main.cpp` opens at 1095x726, and
+/// `AppLayoutMode.large.minimumSize` in `app_layout.dart` is the smallest
+/// drag-resize the window allows.
+///
+/// A RenderFlex overflow throws in debug, so `tester.takeException()` being
+/// null is the overflow assertion; the card-inside-viewport check is what
+/// catches the softer failure the two-step split was for — a card that fits
+/// only because the surface silently scrolled it.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_modal_card.dart';
+import 'package:zcash_wallet/src/core/zcash/zip321_payment_request_builder.dart';
+import 'package:zcash_wallet/src/features/receive/screens/receive_screen.dart';
+import 'package:zcash_wallet/src/features/receive/widgets/request/request_amount_card.dart';
+import 'package:zcash_wallet/src/features/receive/widgets/request/request_amount_model.dart';
+import 'package:zcash_wallet/src/features/receive/widgets/request/request_qr_surface.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/receive_address_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+
+/// The default window `windows/runner/main.cpp` opens.
+const _defaultWindow = Size(1095, 726);
+
+/// The smallest window `AppLayoutMode.large.minimumSize` allows.
+const _minimumWindow = Size(1080, 720);
+
+/// An amount whose USD conversion is seven figures, so the conversion row
+/// under the field is as wide as it ever gets.
+const _longAmount = '123456.12345678';
+
+/// A memo at the ZIP-321 limit: the tallest step one can be.
+final _longMessage = 'a memo that keeps going and going. ' * 14;
+
+/// Exactly the 512 bytes ZIP-321 allows, which is the densest QR the result
+/// step can be asked to draw.
+final _maxMessage = 'm' * kZip321MaxMemoBytes;
+
+void main() {
+  for (final size in const [_defaultWindow, _minimumWindow]) {
+    testWidgets('the request modal fits at $size, both steps', (tester) async {
+      await _pumpReceive(tester, size);
+
+      await _openRequest(tester);
+      _expectFits(tester, 'step one, empty');
+
+      await _enterAmount(tester, '0.5');
+      _expectFits(tester, 'step one, amount');
+
+      await tester.tap(find.byKey(const ValueKey('request_next_button')));
+      await tester.pump();
+      _expectFits(tester, 'step two, shielded');
+
+      await tester.tap(find.byKey(const ValueKey('request_modal_back')));
+      await tester.pump();
+      _expectFits(tester, 'step one, returned');
+    });
+
+    testWidgets('the request modal fits at $size with a long message', (
+      tester,
+    ) async {
+      await _pumpReceive(tester, size);
+
+      await _openRequest(tester);
+      await _enterAmount(tester, _longAmount);
+      _expectFits(tester, 'step one, long fiat');
+
+      await tester.tap(find.byKey(const ValueKey('request_add_message_card')));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey('request_message_field')),
+        _longMessage,
+      );
+      await tester.pump();
+      _expectFits(tester, 'step one, message expanded');
+
+      await tester.tap(find.byKey(const ValueKey('request_next_button')));
+      await tester.pump();
+      _expectFits(tester, 'step two, long request');
+    });
+
+    testWidgets('the request modal fits at $size with the densest request', (
+      tester,
+    ) async {
+      // A real software account's UA plus the longest memo the protocol
+      // allows: 113 modules, which needs more than the fixed 288 frame can
+      // give at the two-pixel floor.
+      await _pumpReceive(tester, size, shieldedAddress: _longShieldedAddress);
+
+      await _openRequest(tester);
+      await _enterAmount(tester, '0.5');
+      await tester.tap(find.byKey(const ValueKey('request_add_message_card')));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey('request_message_field')),
+        _maxMessage,
+      );
+      await tester.pump();
+      _expectFits(tester, 'dense, step one');
+
+      await tester.tap(find.byKey(const ValueKey('request_next_button')));
+      await tester.pump();
+      _expectFits(tester, 'dense, step two');
+
+      // The frame grew rather than squeezing the modules under the floor.
+      final card = tester.getRect(find.byType(AppModalCard));
+      expect(card.width, greaterThan(kRequestModalResultCardWidth));
+      final qr = tester.getRect(
+        find.byKey(const ValueKey('request_qr_surface')),
+      );
+      expect(
+        qr.width - AppSpacing.sm * 2,
+        greaterThanOrEqualTo(requestQrSideFor(_denseQrData) - 0.01),
+      );
+    });
+
+    testWidgets('the request modal fits at $size for a transparent address', (
+      tester,
+    ) async {
+      await _pumpReceive(tester, size);
+
+      await tester.tap(find.text('Transparent'));
+      await tester.pump();
+      await tester.pump();
+
+      await _openRequest(tester);
+      await _enterAmount(tester, _longAmount);
+      _expectFits(tester, 'transparent, step one');
+
+      await tester.tap(find.byKey(const ValueKey('request_next_button')));
+      await tester.pump();
+      _expectFits(tester, 'transparent, step two');
+    });
+  }
+}
+
+/// No overflow, and the card is whole inside the pane rather than scrolled.
+void _expectFits(WidgetTester tester, String state) {
+  expect(tester.takeException(), isNull, reason: 'overflow at: $state');
+
+  final card = tester.getRect(find.byType(AppModalCard));
+  final surface = tester.getRect(find.byType(RequestAmountSurface));
+  expect(
+    card.height,
+    lessThanOrEqualTo(surface.height),
+    reason: 'the card outgrew its pane at: $state',
+  );
+  expect(
+    card.width,
+    lessThanOrEqualTo(surface.width),
+    reason: 'the card outgrew its pane sideways at: $state',
+  );
+  expect(
+    card.top,
+    greaterThanOrEqualTo(surface.top - 0.01),
+    reason: 'the card is clipped at the top at: $state',
+  );
+  expect(
+    card.bottom,
+    lessThanOrEqualTo(surface.bottom + 0.01),
+    reason: 'the card is clipped at the bottom at: $state',
+  );
+}
+
+Future<void> _openRequest(WidgetTester tester) async {
+  // The Receive screen's own fixed-coordinate content is taller than the
+  // minimum window, so at that size its action column sits below the fold —
+  // it scrolls there, which is the pane's business, not the modal's.
+  final button = find.byKey(const ValueKey('receive_request_button'));
+  await tester.ensureVisible(button);
+  await tester.pump();
+  await tester.tap(button);
+  await tester.pump();
+}
+
+Future<void> _enterAmount(WidgetTester tester, String amount) async {
+  await tester.enterText(
+    find.byKey(const ValueKey('request_amount_field')),
+    amount,
+  );
+  await tester.pump();
+}
+
+Future<void> _pumpReceive(
+  WidgetTester tester,
+  Size size, {
+  String shieldedAddress = _shieldedAddress,
+}) async {
+  await tester.binding.setSurfaceSize(size);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpWidget(_receiveHarness(shieldedAddress: shieldedAddress));
+  await tester.pump();
+  await tester.pump();
+}
+
+const _shieldedAddress =
+    'u1testshieldedaddress000000000000000000000000000000000000000000000000000';
+
+/// The length a real software account's Orchard+Sapling UA actually is (178
+/// characters), so the URI the QR encodes is the one the app hands out.
+final _longShieldedAddress = 'u1${'q' * 176}';
+
+const _transparentAddress =
+    't1testtransparentaddress111111111111111111111111111111111111';
+
+/// What the densest request's QR encodes, for the module-pitch assertion.
+final _denseQrData = ZecRequestView(
+  address: _longShieldedAddress,
+  amountZec: '0.5',
+  messageText: _maxMessage,
+).qrData;
+
+AppBootstrapState _bootstrapFor(String shieldedAddress) => AppBootstrapState(
+  initialLocation: '/receive',
+  initialAccountState: AccountState(
+    accounts: const [
+      AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0),
+    ],
+    activeAccountUuid: 'account-1',
+    activeAddress: shieldedAddress,
+  ),
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.system,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);
+
+Widget _receiveHarness({
+  String shieldedAddress = _shieldedAddress,
+  List<Override> extraOverrides = const [],
+}) {
+  final router = GoRouter(
+    initialLocation: '/receive',
+    routes: [
+      GoRoute(path: '/receive', builder: (_, _) => const ReceiveScreen()),
+      GoRoute(
+        path: '/activity',
+        builder: (_, _) => const Text('activity route'),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrapFor(shieldedAddress)),
+      syncProvider.overrideWith(
+        () => FakeSyncNotifier(
+          SyncState(
+            accountUuid: 'account-1',
+            hasAccountScopedData: true,
+            percentage: 1,
+          ),
+        ),
+      ),
+      receiveAddressServiceProvider.overrideWith(
+        (ref) => _FakeReceiveAddressService(ref, shieldedAddress),
+      ),
+      zecLiveUsdUnitPriceProvider.overrideWithValue(70),
+      ...extraOverrides,
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+    ),
+  );
+}
+
+class _FakeReceiveAddressService extends ReceiveAddressService {
+  _FakeReceiveAddressService(super.ref, this.shieldedAddress);
+
+  final String shieldedAddress;
+
+  @override
+  Future<String> loadShieldedAddress({
+    required String accountUuid,
+    String? currentShieldedAddress,
+  }) async => currentShieldedAddress ?? shieldedAddress;
+
+  @override
+  String? getCachedTransparentAddress(String accountUuid) =>
+      _transparentAddress;
+
+  @override
+  Future<String> loadTransparentReceiveAddress({
+    required String accountUuid,
+  }) async => _transparentAddress;
+
+  @override
+  Future<String> renewShieldedAddress({required String accountUuid}) async =>
+      shieldedAddress;
+}

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -1,21 +1,42 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/core/widgets/app_toast.dart';
+import 'package:zcash_wallet/src/core/widgets/app_tooltip.dart';
 import 'package:zcash_wallet/src/features/receive/screens/receive_screen.dart';
+import 'package:zcash_wallet/src/features/receive/services/request_qr_export.dart';
 import 'package:zcash_wallet/src/features/receive/widgets/receive_address_widgets.dart';
+import 'package:zcash_wallet/src/features/receive/widgets/request/request_qr_surface.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/receive_address_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 
 import '../../fakes/fake_sync_notifier.dart';
+
+/// A price the test can move after the request was created.
+class _PriceNotifier extends Notifier<double?> {
+  @override
+  double? build() => 70;
+
+  void set(double? value) => state = value;
+}
+
+final _priceProvider = NotifierProvider<_PriceNotifier, double?>(
+  _PriceNotifier.new,
+);
 
 void main() {
   testWidgets('shows shielded renew button for software accounts', (
@@ -543,6 +564,53 @@ void main() {
     expect(find.text('activity route'), findsOneWidget);
   });
 
+  testWidgets('switching accounts closes a request drafted for the previous '
+      'one', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final bootstrap = _twoAccountBootstrap;
+    await tester.pumpWidget(
+      _receiveHarness(
+        bootstrap: bootstrap,
+        extraOverrides: [
+          accountProvider.overrideWith(
+            () => _FakeAccountNotifier(bootstrap.initialAccountState, {
+              'account-1': _accountOneAddress,
+              'account-2': _accountTwoAddress,
+            }),
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('receive_request_button')));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('receive_request_modal')), findsOneWidget);
+
+    // The modal covers only the trailing pane; the sidebar's account
+    // selector is still reachable behind it.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ReceiveScreen)),
+      listen: false,
+    );
+    await container.read(accountProvider.notifier).switchAccount('account-2');
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('receive_request_modal')),
+      findsNothing,
+      reason:
+          'a request drafted for account 1 must not be handed out under '
+          'account 2',
+    );
+  });
+
   testWidgets('ignores stale shielded load failure after account switch', (
     tester,
   ) async {
@@ -591,7 +659,541 @@ void main() {
 
     expect(_findAddressRichText('u1accounttwo'), findsOneWidget);
   });
+
+  testWidgets('offers a request entry under copy without losing the error '
+      'slot', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(
+      _receiveHarness(receiveAddressService: _FailingReceiveAddressService.new),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final copy = find.byKey(
+      const ValueKey('receive_copy_shielded_address_button'),
+    );
+    final request = find.byKey(const ValueKey('receive_request_button'));
+    expect(request, findsOneWidget);
+    // Icon only: the label lives in the tooltip, not on the pill.
+    expect(find.text('Request ZEC'), findsNothing);
+    expect(
+      find.ancestor(of: request, matching: find.byType(AppTooltip)),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .widget<AppTooltip>(
+            find.ancestor(of: request, matching: find.byType(AppTooltip)).first,
+          )
+          .message,
+      'Request ZEC',
+    );
+    expect(tester.getSize(request), const Size(60, 44));
+    expect(tester.getSize(copy), const Size(230, 44));
+    // Beside the copy pill on one row, not under it.
+    expect(
+      tester.getTopLeft(request).dy,
+      moreOrLessEquals(tester.getTopLeft(copy).dy, epsilon: 0.1),
+    );
+    expect(
+      tester.getTopLeft(request).dx - tester.getTopRight(copy).dx,
+      moreOrLessEquals(AppSpacing.xs, epsilon: 0.1),
+    );
+
+    // The error slot still sits below the action row.
+    final error = find.textContaining('shielded address is unavailable');
+    expect(error, findsOneWidget);
+    expect(
+      tester.getTopLeft(error).dy,
+      greaterThan(tester.getBottomLeft(request).dy),
+    );
+  });
+
+  testWidgets('opens the request modal on the selected pool address', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(_receiveHarness());
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('receive_request_button')));
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('receive_request_modal')), findsOneWidget);
+    expect(find.byKey(const ValueKey('request_modal_title')), findsOneWidget);
+    // Step one composes the request, so there is no QR on it yet.
+    expect(find.byType(RequestQrSurface), findsNothing);
+    expect(_button(tester, 'request_next_button').onPressed, isNull);
+    // Shielded requests can carry a message.
+    expect(
+      find.byKey(const ValueKey('request_add_message_card')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('request_modal_close')));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('receive_request_modal')), findsNothing);
+
+    await tester.tap(find.text('Transparent'));
+    await tester.pump();
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('receive_request_button')));
+    await tester.pump();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('request_amount_field')),
+      '0.5',
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('request_next_button')));
+    await tester.pump();
+
+    expect(_requestQrData(tester), startsWith('zcash:$_transparentAddress'));
+    expect(
+      find.byKey(const ValueKey('request_add_message_card')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('closing the request message collapses it and drops the text', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(_receiveHarness());
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('receive_request_button')));
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const ValueKey('request_amount_field')),
+      '0.5',
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('request_add_message_card')));
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const ValueKey('request_message_field')),
+      'Table 4',
+    );
+    await tester.pump();
+
+    // The control is labelled "Close message", so it has to close it.
+    final close = find.bySemanticsLabel('Close message');
+    expect(close, findsOneWidget);
+    await tester.tap(close);
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('request_message_field')), findsNothing);
+    expect(
+      find.byKey(const ValueKey('request_add_message_card')),
+      findsOneWidget,
+    );
+
+    // And the message is gone from the request, not just from the editor.
+    await tester.tap(find.byKey(const ValueKey('request_next_button')));
+    await tester.pump();
+    expect(_requestQrData(tester), 'zcash:$_shieldedAddress?amount=0.5');
+  });
+
+  testWidgets('a message character a memo cannot carry leaves the field too', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(_receiveHarness());
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('receive_request_button')));
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const ValueKey('request_amount_field')),
+      '0.5',
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('request_add_message_card')));
+    await tester.pump();
+    // U+202E cannot travel in a ZIP-321 memo, so the draft drops it. The
+    // field has to say so: a link that differs from what is on screen is a
+    // silent, unrecoverable edit.
+    await tester.enterText(
+      find.byKey(const ValueKey('request_message_field')),
+      'Table\u202E 4',
+    );
+    await tester.pump();
+
+    expect(_requestMessageFieldText(tester), 'Table 4');
+    expect(_text(tester, 'request_message_counter'), '7/512');
+
+    await tester.tap(find.byKey(const ValueKey('request_next_button')));
+    await tester.pump();
+    expect(
+      _requestQrData(tester),
+      'zcash:$_shieldedAddress?amount=0.5&memo=VGFibGUgNA',
+    );
+  });
+
+  testWidgets('the request steps carry the composed amount both ways', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(
+      _receiveHarness(
+        extraOverrides: [zecLiveUsdUnitPriceProvider.overrideWithValue(70)],
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('receive_request_button')));
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const ValueKey('request_amount_field')),
+      '0.5',
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('request_next_button')));
+    await tester.pump();
+
+    expect(_requestQrData(tester), 'zcash:$_shieldedAddress?amount=0.5');
+    expect(find.text('0.5 ZEC'), findsOneWidget);
+    expect(find.byKey(const ValueKey('request_amount_field')), findsNothing);
+
+    // Back returns to the form with the amount still in it.
+    await tester.tap(find.byKey(const ValueKey('request_modal_back')));
+    await tester.pump();
+
+    expect(find.byType(RequestQrSurface), findsNothing);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('request_amount_conversion_text')),
+          )
+          .data,
+      r'$ 35.00',
+    );
+    expect(_button(tester, 'request_next_button').onPressed, isNotNull);
+  });
+
+  testWidgets('a USD request keeps the ZEC it was created with when the price '
+      'moves', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+    final copied = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied.add(
+            (call.arguments as Map<Object?, Object?>)['text']! as String,
+          );
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+
+    await tester.pumpWidget(
+      _receiveHarness(
+        extraOverrides: [
+          zecLiveUsdUnitPriceProvider.overrideWith(
+            (ref) => ref.watch(_priceProvider),
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('receive_request_button')));
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('request_amount_mode_toggle')));
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const ValueKey('request_amount_field')),
+      '35',
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('request_next_button')));
+    await tester.pump();
+
+    // $35 at $70/ZEC.
+    expect(_requestQrData(tester), 'zcash:$_shieldedAddress?amount=0.5');
+    expect(find.text('0.5 ZEC'), findsOneWidget);
+
+    // The market moves while the QR is on screen: the artefact the user
+    // confirmed must not change under them.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byKey(const ValueKey('receive_request_modal'))),
+    );
+    container.read(_priceProvider.notifier).set(35);
+    await tester.pump();
+    await tester.pump();
+
+    expect(_requestQrData(tester), 'zcash:$_shieldedAddress?amount=0.5');
+    expect(find.text('0.5 ZEC'), findsOneWidget);
+    // Copy hands out the same snapshot the QR shows.
+    await tester.tap(find.byKey(const ValueKey('request_copy_link_button')));
+    await tester.pump();
+    expect(copied, ['zcash:$_shieldedAddress?amount=0.5']);
+
+    // Back on the form the draft is live again, and the next Next takes a
+    // fresh snapshot at the new price.
+    await tester.tap(find.byKey(const ValueKey('request_modal_back')));
+    await tester.pump();
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('request_amount_conversion_text')),
+          )
+          .data,
+      '1 ZEC',
+    );
+    await tester.tap(find.byKey(const ValueKey('request_next_button')));
+    await tester.pump();
+    expect(_requestQrData(tester), 'zcash:$_shieldedAddress?amount=1');
+  });
+
+  testWidgets('turns a typed amount into a live request link and copies it', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final copied = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied.add(
+            (call.arguments as Map<Object?, Object?>)['text']! as String,
+          );
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+
+    await tester.pumpWidget(
+      _receiveHarness(
+        extraOverrides: [zecLiveUsdUnitPriceProvider.overrideWithValue(70)],
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('receive_request_button')));
+    await tester.pump();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('request_amount_field')),
+      '0.5',
+    );
+    await tester.pump();
+
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('request_amount_conversion_text')),
+          )
+          .data,
+      r'$ 35.00',
+    );
+
+    await tester.tap(find.byKey(const ValueKey('request_next_button')));
+    await tester.pump();
+
+    expect(_requestQrData(tester), 'zcash:$_shieldedAddress?amount=0.5');
+
+    await tester.tap(find.byKey(const ValueKey('request_copy_link_button')));
+    await tester.pump();
+    await tester.pump();
+
+    expect(copied, ['zcash:$_shieldedAddress?amount=0.5']);
+    expect(find.text('Request link copied'), findsOneWidget);
+  });
+
+  testWidgets('writes the request QR where the save dialog pointed it', (
+    tester,
+  ) async {
+    // Synchronous file APIs throughout: a real async I/O future created
+    // inside the test zone never completes outside runAsync.
+    final directory = Directory.systemTemp.createTempSync('vizor-request');
+    addTearDown(() {
+      if (directory.existsSync()) directory.deleteSync(recursive: true);
+    });
+    final target =
+        '${directory.path}${Platform.pathSeparator}picked-request.png';
+    final suggested = <String>[];
+
+    await _saveRequestQr(
+      tester,
+      picker: ({required String suggestedName}) async {
+        suggested.add(suggestedName);
+        return target;
+      },
+    );
+
+    expect(suggested, ['vizor-request-0.5.png']);
+    final saved = File(target);
+    expect(saved.existsSync(), isTrue);
+    expect(saved.readAsBytesSync().take(4), [
+      0x89,
+      0x50,
+      0x4E,
+      0x47,
+    ], reason: 'the saved file is a PNG');
+    expect(
+      find.textContaining('QR image saved to ${_folderName(directory.path)}'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('says nothing when the save dialog is cancelled', (tester) async {
+    final directory = Directory.systemTemp.createTempSync('vizor-request');
+    addTearDown(() {
+      if (directory.existsSync()) directory.deleteSync(recursive: true);
+    });
+
+    await _saveRequestQr(
+      tester,
+      picker: ({required String suggestedName}) async => null,
+    );
+
+    expect(directory.listSync(), isEmpty);
+    expect(find.textContaining('QR image saved to'), findsNothing);
+    expect(find.textContaining("We couldn't save the QR image"), findsNothing);
+  });
+
+  testWidgets('reports a failing save dialog without the raw exception', (
+    tester,
+  ) async {
+    await _saveRequestQr(
+      tester,
+      picker: ({required String suggestedName}) async =>
+          throw StateError('no panel'),
+    );
+
+    final toast = tester.widget<AppToast>(find.byType(AppToast));
+    expect(
+      toast.message,
+      "We couldn't save the QR image. Try another folder, or copy the request "
+      'link instead.',
+    );
+    // The diagnostic belongs in the log, not on a two-line toast.
+    expect(toast.message, isNot(contains('no panel')));
+    expect(toast.message, isNot(contains('StateError')));
+    // A failure must not arrive under the success check.
+    expect(toast.tone, AppToastTone.destructive);
+    expect(toast.iconName, AppIcons.cancel);
+    expect(find.textContaining('QR image saved to'), findsNothing);
+  });
 }
+
+/// Drives the request modal to its result step and taps "Save QR image" with
+/// [picker] standing in for the platform save dialog.
+Future<void> _saveRequestQr(
+  WidgetTester tester, {
+  required RequestQrSaveLocationPicker picker,
+}) async {
+  await tester.binding.setSurfaceSize(const Size(1512, 982));
+  addTearDown(() async {
+    await tester.binding.setSurfaceSize(null);
+  });
+
+  await tester.pumpWidget(
+    _receiveHarness(
+      extraOverrides: [
+        zecLiveUsdUnitPriceProvider.overrideWithValue(70),
+        requestQrSaveLocationPickerProvider.overrideWithValue(picker),
+      ],
+    ),
+  );
+  await tester.pump();
+  await tester.pump();
+
+  await tester.tap(find.byKey(const ValueKey('receive_request_button')));
+  await tester.pump();
+  await tester.enterText(
+    find.byKey(const ValueKey('request_amount_field')),
+    '0.5',
+  );
+  await tester.pump();
+  await tester.tap(find.byKey(const ValueKey('request_next_button')));
+  await tester.pump();
+
+  await tester.runAsync(() async {
+    await tester.tap(find.byKey(const ValueKey('request_save_qr_button')));
+    await tester.pump();
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    await tester.pump();
+  });
+  await tester.pump();
+}
+
+String _requestQrData(WidgetTester tester) {
+  return tester.widget<RequestQrSurface>(find.byType(RequestQrSurface)).data;
+}
+
+String _text(WidgetTester tester, String key) =>
+    tester.widget<Text>(find.byKey(ValueKey(key))).data!;
+
+/// What the message editor actually holds, not what the draft was given.
+String _requestMessageFieldText(WidgetTester tester) {
+  return tester
+      .widget<EditableText>(
+        find.descendant(
+          of: find.byKey(const ValueKey('request_message_field')),
+          matching: find.byType(EditableText),
+        ),
+      )
+      .controller
+      .text;
+}
+
+AppButton _button(WidgetTester tester, String key) =>
+    tester.widget<AppButton>(find.byKey(ValueKey(key)));
+
+String _folderName(String path) =>
+    path.split(Platform.pathSeparator).where((s) => s.isNotEmpty).last;
 
 Finder _findAddressRichText(String fragment) {
   return find.byWidgetPredicate(
@@ -623,6 +1225,7 @@ Widget _receiveHarness({
   AppBootstrapState? bootstrap,
   ReceiveAddressService Function(Ref ref)? receiveAddressService,
   AppThemeData themeData = AppThemeData.light,
+  List<Override> extraOverrides = const [],
 }) {
   final effectiveBootstrap = bootstrap ?? _bootstrap;
   final router = GoRouter(
@@ -647,6 +1250,7 @@ Widget _receiveHarness({
       receiveAddressServiceProvider.overrideWith(
         receiveAddressService ?? _FakeReceiveAddressService.new,
       ),
+      ...extraOverrides,
     ],
     child: MaterialApp.router(
       routerConfig: router,
@@ -792,6 +1396,18 @@ class _FakeReceiveAddressService extends ReceiveAddressService {
   @override
   Future<String> renewShieldedAddress({required String accountUuid}) async {
     return _shieldedAddress;
+  }
+}
+
+class _FailingReceiveAddressService extends _FakeReceiveAddressService {
+  _FailingReceiveAddressService(super.ref);
+
+  @override
+  Future<String> loadShieldedAddress({
+    required String accountUuid,
+    String? currentShieldedAddress,
+  }) async {
+    throw StateError('shielded address is unavailable');
   }
 }
 

--- a/test/features/receive/request_amount_widgets_test.dart
+++ b/test/features/receive/request_amount_widgets_test.dart
@@ -1,0 +1,938 @@
+// Lane-agnostic: this file runs in the plain desktop lane and, with the
+// mobile define, in the mobile lane. Nothing here asserts a literal metric —
+// only token constants, copy and structure, all of which hold in both.
+
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart' show Colors, Material, MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/core/widgets/app_modal_card.dart';
+import 'package:zcash_wallet/src/core/widgets/pool_badge.dart';
+import 'package:zcash_wallet/src/features/receive/widgets/request/request_amount_card.dart';
+import 'package:zcash_wallet/src/features/receive/widgets/request/request_amount_model.dart';
+import 'package:zcash_wallet/src/features/receive/widgets/request/request_amount_sheet.dart';
+import 'package:zcash_wallet/src/features/receive/widgets/request/request_qr_surface.dart';
+
+const _shielded =
+    'u1tvg2412a23kshieldedaddress000000000000000000000000k64123hhq6d';
+const _transparent = 't1aWwWwqk3jYGkZc7nLGuTvuM8hDywMZCo';
+const _message = 'Table 4 — two flat whites';
+
+const _empty = ZecRequestView(address: _shielded);
+const _withAmount = ZecRequestView(
+  address: _shielded,
+  amountZec: '0.5',
+  conversionText: r'$35.00',
+);
+const _withMessage = ZecRequestView(
+  address: _shielded,
+  amountZec: '0.5',
+  conversionText: r'$35.00',
+  messageText: _message,
+);
+const _transparentRequest = ZecRequestView(
+  address: _transparent,
+  amountZec: '0.5',
+  conversionText: r'$35.00',
+);
+
+/// ZEC typed with no live price to convert it.
+const _priceUnavailable = ZecRequestView(address: _shielded, amountZec: '0.5');
+
+const _withError = ZecRequestView(
+  address: _shielded,
+  amountDisplayText: '0.123456789',
+  amountError: kRequestAmountDecimalsError,
+);
+
+/// Text the ZIP-321 builder cannot read as a number at all.
+const _withFormatError = ZecRequestView(
+  address: _shielded,
+  amountDisplayText: '0,5',
+  amountError: kRequestAmountFormatError,
+);
+
+/// A real software account's UA length (178) with the longest memo ZIP-321
+/// allows: 113 modules, the densest code the flow can produce.
+final _denseRequest = ZecRequestView(
+  address: 'u1${'q' * 176}',
+  amountZec: '0.5',
+  conversionText: r'$35.00',
+  messageText: 'm' * 512,
+);
+
+/// The field collecting dollars, so its formatters cap at cents.
+const _usdMode = ZecRequestView(
+  address: _shielded,
+  amountInputIsUsd: true,
+  conversionText: '0 ZEC',
+);
+
+void main() {
+  group('ZecRequestView', () {
+    test('an empty amount encodes the plain address, not a request', () {
+      expect(_empty.qrData, _shielded);
+      expect(_empty.requestUri, isNull);
+      expect(_empty.isReady, isFalse);
+      expect(_empty.summaryAmountText, isNull);
+    });
+
+    test('an amount turns the address QR into a request QR', () {
+      expect(_withAmount.qrData, startsWith('zcash:$_shielded?amount=0.5'));
+      expect(_withAmount.isReady, isTrue);
+      expect(_withAmount.summaryAmountText, '0.5 ZEC');
+    });
+
+    test('a transparent request drops the message entirely', () {
+      const withStaleMessage = ZecRequestView(
+        address: _transparent,
+        amountZec: '0.5',
+        messageText: _message,
+      );
+
+      expect(withStaleMessage.effectiveMessage, isNull);
+      expect(withStaleMessage.requestUri, isNot(contains('memo=')));
+    });
+
+    test('an unusable amount is not a request yet, and is not an error', () {
+      expect(_withError.requestUri, isNull);
+      expect(_withError.qrData, _shielded);
+    });
+
+    test('the share text is null until there is a request to share', () {
+      expect(_empty.shareText, isNull);
+      expect(_withError.shareText, isNull);
+      expect(_withAmount.shareText, startsWith('Pay me 0.5 ZEC with Vizor\n'));
+    });
+
+    test('the share text names the amount and carries the link', () {
+      expect(
+        buildRequestShareText(amountZec: '0.5', uri: 'zcash:$_shielded'),
+        'Pay me 0.5 ZEC with Vizor\nzcash:$_shielded',
+      );
+    });
+  });
+
+  group('desktop request modal step one', () {
+    testWidgets('empty amount shows no QR and a disabled Next', (tester) async {
+      await _pump(tester, const RequestAmountCard(request: _empty));
+
+      expect(tester.takeException(), isNull);
+      expect(find.text(kRequestFlowTitle), findsOneWidget);
+      // The artefact belongs to step two: nothing here is a request yet.
+      expect(find.byType(RequestQrSurface), findsNothing);
+      // No error while the field is simply still empty.
+      expect(
+        find.byKey(const ValueKey('request_amount_error_text')),
+        findsNothing,
+      );
+      expect(find.byType(RequestSummaryRow), findsNothing);
+      expect(find.text('Create request'), findsOneWidget);
+      expect(_button(tester, 'request_next_button').onPressed, isNull);
+      expect(find.byKey(const ValueKey('request_modal_back')), findsNothing);
+    });
+
+    testWidgets('no live price shows the loading pill, not a number', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        const RequestAmountCard(
+          request: _priceUnavailable,
+          onToggleAmountUnit: null,
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byKey(const ValueKey('request_amount_price_loading')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('request_amount_conversion_text')),
+        findsNothing,
+      );
+      expect(find.text(r'$ 0'), findsNothing);
+      // Next still works: the request is in ZEC and needs no conversion.
+      expect(_button(tester, 'request_next_button').onPressed, isNotNull);
+    });
+
+    testWidgets('an amount enables Create request', (tester) async {
+      var advanced = 0;
+      await _pump(
+        tester,
+        RequestAmountCard(request: _withAmount, onNext: () => advanced++),
+      );
+
+      expect(tester.takeException(), isNull);
+      // One label for one commitment, on both form factors.
+      expect(find.text('Create request'), findsOneWidget);
+      expect(find.text('Next'), findsNothing);
+      expect(_button(tester, 'request_next_button').onPressed, isNotNull);
+
+      await tester.tap(find.byKey(const ValueKey('request_next_button')));
+      await tester.pump();
+      expect(advanced, 1);
+    });
+
+    testWidgets('the message prompt says the link is readable, not encrypted', (
+      tester,
+    ) async {
+      await _pump(tester, const RequestAmountCard(request: _empty));
+
+      // The request memo rides in the shareable link, so the send composer's
+      // "Encrypted" promise must not be repeated here.
+      expect(
+        kRequestMessageHelpText,
+        'Shielded addresses only — anyone with this link can read it.',
+      );
+      expect(find.text(kRequestMessageHelpText), findsOneWidget);
+      expect(find.textContaining('Encrypted'), findsNothing);
+    });
+
+    testWidgets('the expanded message hints who can read it', (tester) async {
+      await _pump(
+        tester,
+        const RequestAmountCard(request: _empty, messageExpanded: true),
+      );
+
+      expect(
+        find.text('Anyone you send the link to can read this'),
+        findsOneWidget,
+      );
+      expect(find.text('Only the recipient can read this'), findsNothing);
+    });
+
+    testWidgets('the expanded message carries the byte counter', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        const RequestAmountCard(request: _withMessage, messageExpanded: true),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byKey(const ValueKey('request_message_field')),
+        findsOneWidget,
+      );
+      expect(_text(tester, 'request_message_counter'), endsWith('/512'));
+      expect(find.text(kRequestAddMessageLabel), findsNothing);
+    });
+
+    testWidgets('a transparent request offers no message at all', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        const RequestAmountCard(request: _transparentRequest),
+      );
+
+      expect(tester.takeException(), isNull);
+      // Absent, not disabled: a transparent memo can never be sent.
+      expect(
+        find.byKey(const ValueKey('request_add_message_card')),
+        findsNothing,
+      );
+      expect(find.byKey(const ValueKey('request_message_field')), findsNothing);
+    });
+
+    testWidgets('an invalid amount errors inline and blocks the action', (
+      tester,
+    ) async {
+      await _pump(tester, const RequestAmountCard(request: _withError));
+
+      expect(tester.takeException(), isNull);
+      expect(
+        _text(tester, 'request_amount_error_text'),
+        kRequestAmountDecimalsError,
+      );
+      expect(_button(tester, 'request_next_button').onPressed, isNull);
+      expect(find.byType(RequestSummaryRow), findsNothing);
+    });
+
+    testWidgets('an amount the builder cannot read says what to type', (
+      tester,
+    ) async {
+      await _pump(tester, const RequestAmountCard(request: _withFormatError));
+
+      expect(
+        _text(tester, 'request_amount_error_text'),
+        kRequestAmountFormatError,
+      );
+      expect(_button(tester, 'request_next_button').onPressed, isNull);
+    });
+
+    testWidgets('the amount field normalises a comma to a decimal point', (
+      tester,
+    ) async {
+      final typed = <String>[];
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await _pump(
+        tester,
+        RequestAmountCard(
+          request: _empty,
+          amountController: controller,
+          onAmountChanged: typed.add,
+        ),
+      );
+
+      await tester.enterText(
+        find.byKey(const ValueKey('request_amount_field')),
+        '0,5',
+      );
+      await tester.pump();
+
+      expect(controller.text, '0.5');
+      expect(typed.last, '0.5');
+    });
+
+    testWidgets('the amount field stops at a zatoshi', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await _pump(
+        tester,
+        RequestAmountCard(request: _empty, amountController: controller),
+      );
+
+      await tester.enterText(
+        find.byKey(const ValueKey('request_amount_field')),
+        '0.123456789',
+      );
+      await tester.pump();
+
+      expect(controller.text, '0.12345678');
+    });
+
+    testWidgets('the amount field refuses what is not part of a number', (
+      tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await _pump(
+        tester,
+        RequestAmountCard(request: _empty, amountController: controller),
+      );
+
+      await tester.enterText(
+        find.byKey(const ValueKey('request_amount_field')),
+        '.5 ZEC',
+      );
+      await tester.pump();
+
+      // The leading dot is completed rather than dropped, and the letters
+      // that would have made the URI unbuildable never land.
+      expect(controller.text, '0.5');
+    });
+
+    testWidgets('a USD-mode field stops at cents', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await _pump(
+        tester,
+        RequestAmountCard(request: _usdMode, amountController: controller),
+      );
+
+      await tester.enterText(
+        find.byKey(const ValueKey('request_amount_field')),
+        '35,499',
+      );
+      await tester.pump();
+
+      expect(controller.text, '35.49');
+    });
+  });
+
+  group('desktop request modal step two', () {
+    testWidgets('shows the request QR, its summary and a way back', (
+      tester,
+    ) async {
+      var back = 0;
+      await _pump(
+        tester,
+        RequestResultCard(request: _withAmount, onBack: () => back++),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text(kRequestFlowTitle), findsOneWidget);
+      expect(find.byType(RequestQrSurface), findsOneWidget);
+      expect(find.text('0.5 ZEC'), findsOneWidget);
+      expect(find.text('Shielded'), findsOneWidget);
+      expect(find.byType(PoolBadge), findsOneWidget);
+      // The link itself is carried by the actions, not printed under the QR.
+      expect(find.byKey(const ValueKey('request_uri_line')), findsNothing);
+      expect(_button(tester, 'request_copy_link_button').onPressed, isNotNull);
+
+      await tester.tap(find.byKey(const ValueKey('request_modal_back')));
+      await tester.pump();
+      expect(back, 1);
+    });
+
+    testWidgets('a transparent request states its pool', (tester) async {
+      await _pump(
+        tester,
+        const RequestResultCard(request: _transparentRequest),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Transparent'), findsOneWidget);
+    });
+
+    testWidgets('saving the QR hands the caller PNG bytes once', (
+      tester,
+    ) async {
+      final saved = <Uint8List>[];
+      await _pump(
+        tester,
+        RequestResultCard(request: _withAmount, onSaveQrImage: saved.add),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('request_save_qr_button')));
+      await tester.pump();
+      // While the encode is in flight the button is inert, so a second tap
+      // cannot start a second one.
+      expect(_exportButton(tester, 'request_save_qr_button').onPressed, isNull);
+
+      await _settleEncode(tester);
+
+      expect(saved, hasLength(1));
+      expect(saved.single.sublist(0, 8), _pngSignature);
+      expect(
+        _exportButton(tester, 'request_save_qr_button').onPressed,
+        isNotNull,
+      );
+    }, timeout: _encodeTimeout);
+
+    testWidgets('an empty request cannot be saved as an image', (tester) async {
+      await _pump(
+        tester,
+        RequestResultCard(request: _empty, onSaveQrImage: (_) {}),
+      );
+
+      expect(_exportButton(tester, 'request_save_qr_button').onPressed, isNull);
+      expect(_button(tester, 'request_copy_link_button').onPressed, isNull);
+    });
+
+    testWidgets('a dense request widens the frame instead of the modules', (
+      tester,
+    ) async {
+      final width = requestModalResultCardWidth(_denseRequest.qrData);
+      expect(width, greaterThan(kRequestModalResultCardWidth));
+
+      await _pump(
+        tester,
+        Center(
+          child: AppModalCard(
+            width: width,
+            child: RequestResultCard(request: _denseRequest),
+          ),
+        ),
+      );
+
+      // A 288 frame squeezes this symbol under the two-pixel module floor,
+      // which is an assertion in debug and a hard-to-scan code in release.
+      expect(tester.takeException(), isNull);
+      final qr = tester.getRect(
+        find.byKey(const ValueKey('request_qr_surface')),
+      );
+      expect(
+        qr.width - AppSpacing.sm * 2,
+        greaterThanOrEqualTo(requestQrSideFor(_denseRequest.qrData) - 0.01),
+      );
+    });
+
+    testWidgets('an ordinary request keeps the fixed frame', (tester) async {
+      expect(
+        requestModalResultCardWidth(_withAmount.qrData),
+        kRequestModalResultCardWidth,
+      );
+      expect(
+        requestModalResultCardWidth(_empty.qrData),
+        kRequestModalResultCardWidth,
+      );
+      // A pane too narrow for the code it holds caps rather than overflows.
+      expect(
+        requestModalResultCardWidth(_denseRequest.qrData, maxWidth: 300),
+        300,
+      );
+    });
+
+    testWidgets('a failed save encode is reported, not swallowed', (
+      tester,
+    ) async {
+      var reported = 0;
+      await _pump(
+        tester,
+        RequestResultCard(
+          request: _withAmount,
+          onSaveQrImage: (_) {},
+          onSaveQrImageError: () => reported++,
+        ),
+      );
+
+      final export = tester.widget<RequestQrExportButton>(
+        find.byKey(const ValueKey('request_save_qr_button')),
+      );
+      expect(export.onError, isNotNull);
+      export.onError!();
+      expect(reported, 1);
+    });
+  });
+
+  group('mobile request sheet', () {
+    testWidgets('no live price shows the loading pill, not a number', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        const RequestAmountSheetCompose(
+          request: _priceUnavailable,
+          onToggleAmountUnit: null,
+        ),
+        size: _mobileSize,
+      );
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byKey(const ValueKey('request_amount_price_loading')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('request_amount_conversion_text')),
+        findsNothing,
+      );
+      expect(find.text(r'$ 0'), findsNothing);
+    });
+
+    testWidgets('step one gates the CTA on a usable amount', (tester) async {
+      await _pump(
+        tester,
+        const RequestAmountSheetCompose(request: _empty),
+        size: _mobileSize,
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text(kRequestFlowTitle), findsOneWidget);
+      expect(find.text('Create request'), findsOneWidget);
+      expect(_button(tester, 'request_create_button').onPressed, isNull);
+      // No Max: a request is not a spend.
+      expect(find.text('Max'), findsNothing);
+    });
+
+    testWidgets('step one shows the message it will attach', (tester) async {
+      await _pump(
+        tester,
+        const RequestAmountSheetCompose(request: _withMessage),
+        size: _mobileSize,
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(_button(tester, 'request_create_button').onPressed, isNotNull);
+      expect(_text(tester, 'request_message_preview'), _message);
+    });
+
+    testWidgets('step one hides the message row for a transparent address', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        const RequestAmountSheetCompose(request: _transparentRequest),
+        size: _mobileSize,
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byKey(const ValueKey('request_message_row')), findsNothing);
+    });
+
+    testWidgets('an invalid amount states the correction to make', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        const RequestAmountSheetCompose(request: _withError),
+        size: _mobileSize,
+      );
+
+      expect(tester.takeException(), isNull);
+      // Red digits alone say something is wrong without saying what, and the
+      // two causes need opposite fixes.
+      expect(
+        _text(tester, 'request_amount_error_text'),
+        kRequestAmountDecimalsError,
+      );
+      expect(_button(tester, 'request_create_button').onPressed, isNull);
+    });
+
+    testWidgets('a valid amount shows no error row', (tester) async {
+      await _pump(
+        tester,
+        const RequestAmountSheetCompose(request: _withAmount),
+        size: _mobileSize,
+      );
+
+      expect(
+        find.byKey(const ValueKey('request_amount_error_text')),
+        findsNothing,
+      );
+    });
+
+    testWidgets('the serif field normalises a comma-decimal keypad', (
+      tester,
+    ) async {
+      final typed = <String>[];
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await _pump(
+        tester,
+        RequestAmountSheetCompose(
+          request: _empty,
+          amountController: controller,
+          onAmountChanged: typed.add,
+        ),
+        size: _mobileSize,
+      );
+
+      await tester.enterText(
+        find.byKey(const ValueKey('request_amount_input')),
+        '0,5',
+      );
+      await tester.pump();
+
+      expect(controller.text, '0.5');
+      expect(typed.last, '0.5');
+    });
+
+    testWidgets('the serif field stops at a zatoshi', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await _pump(
+        tester,
+        RequestAmountSheetCompose(
+          request: _empty,
+          amountController: controller,
+        ),
+        size: _mobileSize,
+      );
+
+      await tester.enterText(
+        find.byKey(const ValueKey('request_amount_input')),
+        '0.123456789',
+      );
+      await tester.pump();
+
+      expect(controller.text, '0.12345678');
+    });
+
+    testWidgets('a USD-mode serif field stops at cents', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      await _pump(
+        tester,
+        RequestAmountSheetCompose(
+          request: _usdMode,
+          amountController: controller,
+        ),
+        size: _mobileSize,
+      );
+
+      await tester.enterText(
+        find.byKey(const ValueKey('request_amount_input')),
+        '35,499',
+      );
+      await tester.pump();
+
+      expect(controller.text, '35.49');
+    });
+
+    testWidgets('an untakeable unit switch is drawn as disabled', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        const RequestAmountSheetCompose(
+          request: _priceUnavailable,
+          onToggleAmountUnit: null,
+        ),
+        size: _mobileSize,
+      );
+
+      final colors = AppThemeData.dark.colors;
+      final icon = tester.widget<AppIcon>(
+        find.descendant(
+          of: find.byKey(const ValueKey('request_amount_mode_toggle')),
+          matching: find.byType(AppIcon),
+        ),
+      );
+      expect(icon.color, colors.icon.disabled);
+      expect(
+        tester
+            .widget<Text>(
+              find.descendant(
+                of: find.byKey(const ValueKey('request_amount_mode_toggle')),
+                matching: find.text(r'$'),
+              ),
+            )
+            .style
+            ?.color,
+        colors.text.disabled,
+      );
+    });
+
+    testWidgets('a takeable unit switch keeps its live colours', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        RequestAmountSheetCompose(
+          request: _withAmount,
+          onToggleAmountUnit: () {},
+        ),
+        size: _mobileSize,
+      );
+
+      final colors = AppThemeData.dark.colors;
+      final icon = tester.widget<AppIcon>(
+        find.descendant(
+          of: find.byKey(const ValueKey('request_amount_mode_toggle')),
+          matching: find.byType(AppIcon),
+        ),
+      );
+      expect(icon.color, colors.text.secondary);
+      expect(
+        _textStyle(tester, 'request_amount_conversion_text').color,
+        colors.text.secondary,
+      );
+    });
+
+    testWidgets('step two offers share, copy and a way back', (tester) async {
+      await _pump(
+        tester,
+        const RequestAmountSheetResult(request: _withMessage),
+        size: _mobileSize,
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(RequestQrSurface), findsOneWidget);
+      expect(find.text('0.5 ZEC'), findsOneWidget);
+      expect(find.text('Shielded'), findsOneWidget);
+      expect(find.text('Share request'), findsOneWidget);
+      expect(find.text('Copy link'), findsOneWidget);
+      expect(find.byKey(const ValueKey('request_uri_line')), findsNothing);
+      expect(find.byKey(const ValueKey('request_sheet_back')), findsOneWidget);
+    });
+
+    testWidgets('sharing hands over both the message and the PNG', (
+      tester,
+    ) async {
+      String? sharedText;
+      Uint8List? sharedPng;
+      await _pump(
+        tester,
+        RequestAmountSheetResult(
+          request: _withMessage,
+          onShareRequest: (text, png) {
+            sharedText = text;
+            sharedPng = png;
+          },
+        ),
+        size: _mobileSize,
+      );
+
+      await tester.tap(find.byKey(const ValueKey('request_share_button')));
+      await tester.pump();
+      await _settleEncode(tester);
+
+      expect(sharedText, _withMessage.shareText);
+      expect(sharedPng, isNotNull);
+      expect(sharedPng!.sublist(0, 8), _pngSignature);
+    }, timeout: _encodeTimeout);
+
+    testWidgets('the sheet draws the densest request without squeezing it', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        RequestAmountSheetResult(request: _denseRequest),
+        size: _mobileSize,
+      );
+
+      expect(tester.takeException(), isNull);
+      final qr = tester.getRect(
+        find.byKey(const ValueKey('request_qr_surface')),
+      );
+      expect(
+        qr.width - AppSpacing.sm * 2,
+        greaterThanOrEqualTo(requestQrSideFor(_denseRequest.qrData) - 0.01),
+      );
+    });
+
+    testWidgets('a failed share encode is reported, not swallowed', (
+      tester,
+    ) async {
+      var reported = 0;
+      await _pump(
+        tester,
+        RequestAmountSheetResult(
+          request: _withMessage,
+          onShareRequest: (_, _) {},
+          onShareError: () => reported++,
+        ),
+        size: _mobileSize,
+      );
+
+      final export = tester.widget<RequestQrExportButton>(
+        find.byKey(const ValueKey('request_share_button')),
+      );
+      expect(export.onError, isNotNull);
+      export.onError!();
+      expect(reported, 1);
+    });
+
+    testWidgets('step two reports a transparent request as transparent', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        const RequestAmountSheetResult(request: _transparentRequest),
+        size: _mobileSize,
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Transparent'), findsOneWidget);
+    });
+  });
+
+  group('renderRequestQrPng', () {
+    testWidgets('encodes a request as a deterministic square PNG', (
+      tester,
+    ) async {
+      final uri = _withAmount.requestUri!;
+      await tester.runAsync(() async {
+        final png = await renderRequestQrPng(uri, size: 256);
+        final again = await renderRequestQrPng(uri, size: 256);
+
+        expect(png, isNotEmpty);
+        expect(png.sublist(0, 8), _pngSignature);
+        // Same request, same bytes: nothing theme- or time-dependent leaks in.
+        expect(again, png);
+
+        final decoded = await decodeImageFromList(png);
+        expect(decoded.width, 256);
+        expect(decoded.height, 256);
+        decoded.dispose();
+      });
+    }, timeout: _encodeTimeout);
+
+    testWidgets('refuses an empty request rather than encoding nothing', (
+      tester,
+    ) async {
+      await expectLater(renderRequestQrPng(''), throwsArgumentError);
+    });
+  });
+
+  group('RequestQrExportButton', () {
+    testWidgets(
+      'an encode that fails calls onError and frees the button',
+      (tester) async {
+        final delivered = <Uint8List>[];
+        var errors = 0;
+        await _pump(
+          tester,
+          RequestQrExportButton(
+            key: const ValueKey('export_button'),
+            // Past the byte capacity of every symbol version, so the encoder
+            // refuses it. Before this the press was a silent no-op: the future
+            // is unawaited, so the throw escaped as a zone error and the user
+            // saw the spinner blink and nothing else.
+            uri: 'zcash:${'u' * 4000}',
+            label: 'Save QR image',
+            onBytes: delivered.add,
+            onError: () => errors++,
+          ),
+        );
+
+        await tester.tap(find.byKey(const ValueKey('export_button')));
+        await tester.pump();
+        await _settleEncode(tester);
+
+        expect(delivered, isEmpty);
+        expect(errors, 1);
+        expect(tester.takeException(), isNull);
+        // Still pressable: the failure is reported, not terminal.
+        expect(_exportButton(tester, 'export_button').onPressed, isNotNull);
+      },
+      timeout: _encodeTimeout,
+    );
+  });
+}
+
+/// Encoding a QR is real async work off the fake-async clock, so these tests
+/// must not be able to hang the whole file for the default ten minutes.
+const _encodeTimeout = Timeout(Duration(seconds: 30));
+
+/// The eight bytes every PNG starts with.
+const _pngSignature = <int>[137, 80, 78, 71, 13, 10, 26, 10];
+
+const _desktopSize = Size(900, 1000);
+const _mobileSize = Size(393, 852);
+
+AppButton _button(WidgetTester tester, String key) =>
+    tester.widget<AppButton>(find.byKey(ValueKey(key)));
+
+/// The [AppButton] inside a [RequestQrExportButton], which owns the key.
+AppButton _exportButton(WidgetTester tester, String key) =>
+    tester.widget<AppButton>(
+      find.descendant(
+        of: find.byKey(ValueKey(key)),
+        matching: find.byType(AppButton),
+      ),
+    );
+
+/// Lets an in-flight PNG encode finish: it runs on real time, which the
+/// widget tester's fake clock never advances on its own.
+Future<void> _settleEncode(WidgetTester tester) async {
+  for (var i = 0; i < 40; i++) {
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 25)),
+    );
+    await tester.pump();
+  }
+}
+
+String _text(WidgetTester tester, String key) =>
+    tester.widget<Text>(find.byKey(ValueKey(key))).data!;
+
+TextStyle _textStyle(WidgetTester tester, String key) =>
+    tester.widget<Text>(find.byKey(ValueKey(key))).style!;
+
+Future<void> _pump(
+  WidgetTester tester,
+  Widget child, {
+  Size size = _desktopSize,
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.dark,
+        child: Center(
+          child: SizedBox(
+            width: size.width,
+            height: size.height,
+            // The modal card is presented inside a Material surface in the
+            // app; the text fields need that ancestor here too.
+            child: Material(color: Colors.transparent, child: child),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}

--- a/test/features/receive/request_amount_widgets_test.dart
+++ b/test/features/receive/request_amount_widgets_test.dart
@@ -2,6 +2,7 @@
 // mobile define, in the mobile lane. Nothing here asserts a literal metric —
 // only token constants, copy and structure, all of which hold in both.
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart' show Colors, Material, MaterialApp;
@@ -834,6 +835,42 @@ void main() {
   });
 
   group('RequestQrExportButton', () {
+    testWidgets(
+      'the button stays busy until the hand-off completes',
+      (tester) async {
+        // The desktop save dialog and the mobile share sheet both outlive the
+        // PNG render; a second press while one is open would start a second
+        // export.
+        final handoff = Completer<void>();
+        var delivered = 0;
+        await _pump(
+          tester,
+          RequestQrExportButton(
+            key: const ValueKey('export_button'),
+            uri: 'zcash:u1exportbusy',
+            label: 'Save QR image',
+            onBytes: (_) {
+              delivered++;
+              return handoff.future;
+            },
+          ),
+        );
+
+        await tester.tap(find.byKey(const ValueKey('export_button')));
+        await tester.pump();
+        await _settleEncode(tester);
+
+        expect(delivered, 1);
+        expect(_exportButton(tester, 'export_button').onPressed, isNull);
+
+        handoff.complete();
+        await tester.pump();
+
+        expect(_exportButton(tester, 'export_button').onPressed, isNotNull);
+      },
+      timeout: _encodeTimeout,
+    );
+
     testWidgets(
       'an encode that fails calls onError and frees the button',
       (tester) async {

--- a/test/features/receive/zec_request_draft_test.dart
+++ b/test/features/receive/zec_request_draft_test.dart
@@ -139,6 +139,26 @@ void main() {
       expect(typed.resolve(zecUsdUnitPrice: null).isReady, isFalse);
     });
 
+    test('a ZEC amount below a cent stays in ZEC', () {
+      // 0.00000001 ZEC at \$70 is \$0.0000007: the dollar field would round it
+      // to nothing while the request kept encoding the amount, so the switch
+      // is refused rather than taken.
+      const draft = ZecRequestDraft(address: _shielded, input: '0.00000001');
+
+      expect(draft.canToggleUnit(70), isFalse);
+      final same = draft.toggledUnit(zecUsdUnitPrice: 70);
+      expect(same.inputIsUsd, isFalse);
+      expect(same.input, '0.00000001');
+      expect(
+        same.resolve(zecUsdUnitPrice: 70).requestUri,
+        'zcash:$_shielded?amount=0.00000001',
+      );
+
+      // An amount that does have a cent form still switches.
+      const payable = ZecRequestDraft(address: _shielded, input: '0.5');
+      expect(payable.canToggleUnit(70), isTrue);
+    });
+
     test('switching an unfinished ZEC field to USD derives nothing', () {
       for (final input in ['', '0', '0.', 'abc']) {
         final usdDraft = ZecRequestDraft(

--- a/test/features/receive/zec_request_draft_test.dart
+++ b/test/features/receive/zec_request_draft_test.dart
@@ -1,0 +1,337 @@
+// Lane-agnostic: no widgets, no metrics — only the request flow's rules.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/receive/services/request_qr_export.dart';
+import 'package:zcash_wallet/src/core/zcash/zip321_payment_request.dart';
+import 'package:zcash_wallet/src/features/receive/services/zec_request_draft.dart';
+import 'package:zcash_wallet/src/features/receive/widgets/request/request_amount_model.dart';
+
+const _shielded =
+    'u1tvg2412a23kshieldedaddress000000000000000000000000k64123hhq6d';
+const _transparent = 't1aWwWwqk3jYGkZc7nLGuTvuM8hDywMZCo';
+
+void main() {
+  group('ZecRequestDraft', () {
+    test('a ZEC amount becomes the request URI and its dollar line', () {
+      const draft = ZecRequestDraft(address: _shielded, input: '0.5');
+      final view = draft.resolve(zecUsdUnitPrice: 70);
+
+      expect(view.requestUri, 'zcash:$_shielded?amount=0.5');
+      expect(view.conversionText, r'$ 35.00');
+      expect(view.amountError, isNull);
+      expect(view.isReady, isTrue);
+    });
+
+    test('a USD amount converts into the ZEC the request encodes', () {
+      const draft = ZecRequestDraft(
+        address: _shielded,
+        input: '35',
+        inputIsUsd: true,
+      );
+      final view = draft.resolve(zecUsdUnitPrice: 70);
+
+      expect(view.amountZec, '0.5');
+      expect(view.fieldText, '35');
+      expect(view.conversionText, '0.5 ZEC');
+      expect(view.requestUri, 'zcash:$_shielded?amount=0.5');
+    });
+
+    test('the dollar line waits rather than guessing without a price', () {
+      const draft = ZecRequestDraft(address: _shielded, input: '0.5');
+
+      expect(draft.resolve(zecUsdUnitPrice: null).conversionText, isNull);
+      // With nothing typed there is nothing to wait for.
+      expect(
+        const ZecRequestDraft(
+          address: _shielded,
+        ).resolve(zecUsdUnitPrice: null).conversionText,
+        r'$ 0',
+      );
+    });
+
+    test('only actionable amount rejections surface as errors', () {
+      String? errorFor(String input) => ZecRequestDraft(
+        address: _shielded,
+        input: input,
+      ).resolve(zecUsdUnitPrice: 70).amountError;
+
+      expect(errorFor('0.123456789'), kRequestAmountDecimalsError);
+      expect(errorFor('21000001'), kRequestAmountSupplyError);
+      // In-progress input is not a failure state.
+      expect(errorFor('0.'), isNull);
+      expect(errorFor(''), isNull);
+      expect(errorFor('0'), isNull);
+      expect(errorFor('.'), isNull);
+      expect(errorFor('0.00'), isNull);
+    });
+
+    test('an amount that is not a number says so instead of going quiet', () {
+      String? errorFor(String input) => ZecRequestDraft(
+        address: _shielded,
+        input: input,
+      ).resolve(zecUsdUnitPrice: 70).amountError;
+
+      // The comma a French or German decimal keypad emits, and the leading
+      // dot the conversion line happily prices: both build a URI of null, so
+      // silence here is a permanently disabled CTA with no cause on screen.
+      expect(errorFor('0,5'), kRequestAmountFormatError);
+      expect(errorFor('.5'), kRequestAmountFormatError);
+      expect(errorFor('1e3'), kRequestAmountFormatError);
+      expect(errorFor('half a zec'), kRequestAmountFormatError);
+    });
+
+    test('switching units rewrites the field in the new unit', () {
+      const zecDraft = ZecRequestDraft(address: _shielded, input: '0.5');
+      final usdDraft = zecDraft.toggledUnit(zecUsdUnitPrice: 70);
+      expect(usdDraft.inputIsUsd, isTrue);
+      expect(usdDraft.input, '35.00');
+
+      final backToZec = usdDraft.toggledUnit(zecUsdUnitPrice: 70);
+      expect(backToZec.inputIsUsd, isFalse);
+      expect(backToZec.input, '0.5');
+    });
+
+    test('a unit switch never changes the ZEC the request asks for', () {
+      // $35.123 does not divide 0.5 ZEC into whole cents: the field shows
+      // the rounding, the request must keep the number that was typed.
+      const price = 35.123;
+      const zecDraft = ZecRequestDraft(address: _shielded, input: '0.5');
+      final usdDraft = zecDraft.toggledUnit(zecUsdUnitPrice: price);
+      expect(usdDraft.input, '17.56');
+
+      final view = usdDraft.resolve(zecUsdUnitPrice: price);
+      expect(view.amountZec, '0.5');
+      expect(view.conversionText, '0.5 ZEC');
+      expect(view.requestUri, 'zcash:$_shielded?amount=0.5');
+
+      // The market moves while the derived dollars are on screen: they still
+      // stand for the ZEC that was typed, so the request does not drift.
+      expect(usdDraft.resolve(zecUsdUnitPrice: 40).amountZec, '0.5');
+
+      final backToZec = usdDraft.toggledUnit(zecUsdUnitPrice: price);
+      expect(backToZec.input, '0.5');
+      expect(
+        backToZec.resolve(zecUsdUnitPrice: price).requestUri,
+        'zcash:$_shielded?amount=0.5',
+      );
+    });
+
+    test('derived dollars stay creatable after the price expires', () {
+      final usdDraft = const ZecRequestDraft(
+        address: _shielded,
+        input: '0.5',
+      ).toggledUnit(zecUsdUnitPrice: 70);
+
+      // The dollars on screen came from 0.5 ZEC; losing the price does not
+      // lose that.
+      final view = usdDraft.resolve(zecUsdUnitPrice: null);
+      expect(view.amountZec, '0.5');
+      expect(view.conversionText, '0.5 ZEC');
+      expect(view.isReady, isTrue);
+      expect(view.requestUri, 'zcash:$_shielded?amount=0.5');
+
+      // Typed dollars are dollars, and dollars need a price.
+      final typed = usdDraft.withInput('40', zecUsdUnitPrice: 70);
+      expect(typed.resolve(zecUsdUnitPrice: null).amountZec, '');
+      expect(typed.resolve(zecUsdUnitPrice: null).isReady, isFalse);
+    });
+
+    test('switching an unfinished ZEC field to USD derives nothing', () {
+      for (final input in ['', '0', '0.', 'abc']) {
+        final usdDraft = ZecRequestDraft(
+          address: _shielded,
+          input: input,
+        ).toggledUnit(zecUsdUnitPrice: 70);
+        final view = usdDraft.resolve(zecUsdUnitPrice: null);
+        expect(usdDraft.input, '', reason: input);
+        expect(view.amountZec, '', reason: input);
+        expect(view.isReady, isFalse, reason: input);
+        expect(view.amountError, isNull, reason: input);
+      }
+    });
+
+    test('an edited USD field re-derives the ZEC the request asks for', () {
+      const price = 35.123;
+      final usdDraft = const ZecRequestDraft(address: _shielded, input: '0.5')
+          .toggledUnit(zecUsdUnitPrice: price)
+          .withInput('20', zecUsdUnitPrice: price);
+
+      // Typed dollars mean dollars: the carried ZEC follows the field.
+      final view = usdDraft.resolve(zecUsdUnitPrice: price);
+      expect(view.amountZec, usdDraft.zecInput);
+      expect(view.amountZec, isNot('0.5'));
+      expect(view.requestUri, 'zcash:$_shielded?amount=${view.amountZec}');
+
+      // Text that does not convert encodes nothing, whatever was carried.
+      expect(
+        usdDraft
+            .withInput('abc', zecUsdUnitPrice: price)
+            .resolve(zecUsdUnitPrice: price)
+            .amountZec,
+        '',
+      );
+    });
+
+    test('USD mode is refused while there is no price to convert at', () {
+      const draft = ZecRequestDraft(address: _shielded, input: '0.5');
+      expect(draft.canToggleUnit(null), isFalse);
+      expect(draft.toggledUnit(zecUsdUnitPrice: null).inputIsUsd, isFalse);
+
+      // Leaving USD mode never needs a price.
+      const usdDraft = ZecRequestDraft(
+        address: _shielded,
+        input: '35',
+        inputIsUsd: true,
+      );
+      expect(usdDraft.canToggleUnit(null), isTrue);
+    });
+
+    test('a price that expires mid-compose does not erase the amount', () {
+      const zecDraft = ZecRequestDraft(address: _shielded, input: '0.5');
+      final usdDraft = zecDraft.toggledUnit(zecUsdUnitPrice: 70);
+      expect(usdDraft.input, '35.00');
+
+      // The price goes away while the sheet is open: the switch is still
+      // offered, and taking it hands back the ZEC that was typed.
+      final backToZec = usdDraft.toggledUnit(zecUsdUnitPrice: null);
+      expect(backToZec.inputIsUsd, isFalse);
+      expect(backToZec.input, '0.5');
+      expect(backToZec.resolve(zecUsdUnitPrice: null).isReady, isTrue);
+    });
+
+    test('USD keystrokes keep the canonical ZEC in step', () {
+      final usdDraft = const ZecRequestDraft(
+        address: _shielded,
+        input: '0.5',
+      ).toggledUnit(zecUsdUnitPrice: 70).withInput('70', zecUsdUnitPrice: 70);
+
+      expect(usdDraft.input, '70');
+      expect(usdDraft.zecInput, '1');
+
+      // Edited at the live price, switched back without one: the restored
+      // value is what the dollars last meant, not what they meant on entry.
+      expect(usdDraft.toggledUnit(zecUsdUnitPrice: null).input, '1');
+    });
+
+    test('clearing a USD field clears what a switch back would restore', () {
+      final cleared = const ZecRequestDraft(
+        address: _shielded,
+        input: '0.5',
+      ).toggledUnit(zecUsdUnitPrice: 70).withInput('', zecUsdUnitPrice: 70);
+
+      expect(cleared.zecInput, '');
+      expect(cleared.toggledUnit(zecUsdUnitPrice: null).input, '');
+    });
+
+    test('a ZEC keystroke is its own canonical value', () {
+      final draft = const ZecRequestDraft(
+        address: _shielded,
+      ).withInput('0.25', zecUsdUnitPrice: null);
+
+      expect(draft.zecInput, '0.25');
+      expect(draft.resolve(zecUsdUnitPrice: null).amountZec, '0.25');
+    });
+
+    test('a pasted bidi override never reaches the request link', () {
+      final view = const ZecRequestDraft(
+        address: _shielded,
+        input: '0.5',
+      ).copyWith(message: 'Table\u202E 4').resolve(zecUsdUnitPrice: null);
+
+      final uri = view.requestUri;
+
+      expect(uri, isNotNull);
+
+      final parsed = Zip321PaymentRequest.parse(uri!);
+
+      expect(parsed.primaryPayment.memoText, 'Table 4');
+    });
+
+    test('a transparent request drops the message it cannot carry', () {
+      const draft = ZecRequestDraft(
+        address: _transparent,
+        input: '0.5',
+        message: 'Table 4',
+      );
+      final view = draft.resolve(zecUsdUnitPrice: 70);
+
+      expect(draft.isShielded, isFalse);
+      expect(view.effectiveMessage, isNull);
+      expect(view.requestUri, 'zcash:$_transparent?amount=0.5');
+    });
+  });
+
+  group('request QR export', () {
+    test('names the file after the amount, or nothing when there is none', () {
+      expect(requestQrFileName('0.5'), 'vizor-request-0.5.png');
+      expect(requestQrFileName(''), 'vizor-request.png');
+      expect(requestQrFileName('1 ZEC'), 'vizor-request-1.png');
+    });
+
+    test('writes the PNG where the save dialog pointed it', () async {
+      final directory = await Directory.systemTemp.createTemp('vizor-request');
+      addTearDown(() async {
+        if (directory.existsSync()) await directory.delete(recursive: true);
+      });
+
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      final suggested = <String>[];
+      final saved = await saveRequestQrPng(
+        png: bytes,
+        amountZec: '0.5',
+        pickSaveLocation: ({required String suggestedName}) async {
+          suggested.add(suggestedName);
+          return '${directory.path}${Platform.pathSeparator}chosen.png';
+        },
+      );
+
+      expect(suggested, ['vizor-request-0.5.png']);
+      expect(saved, isNotNull);
+      expect(saved!.path, endsWith('chosen.png'));
+      expect(
+        saved.folderName,
+        directory.path.split(Platform.pathSeparator).last,
+      );
+      expect(File(saved.path).readAsBytesSync(), bytes);
+    });
+
+    test('replaces a file the user chose to overwrite', () async {
+      final directory = await Directory.systemTemp.createTemp('vizor-request');
+      addTearDown(() async {
+        if (directory.existsSync()) await directory.delete(recursive: true);
+      });
+
+      final path = '${directory.path}${Platform.pathSeparator}chosen.png';
+      File(path).writeAsBytesSync(Uint8List.fromList([9, 9, 9]));
+
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      final saved = await saveRequestQrPng(
+        png: bytes,
+        amountZec: '0.5',
+        pickSaveLocation: ({required String suggestedName}) async => path,
+      );
+
+      expect(saved?.path, path);
+      expect(File(path).readAsBytesSync(), bytes);
+    });
+
+    test('writes nothing when the save dialog was cancelled', () async {
+      final directory = await Directory.systemTemp.createTemp('vizor-request');
+      addTearDown(() async {
+        if (directory.existsSync()) await directory.delete(recursive: true);
+      });
+
+      final saved = await saveRequestQrPng(
+        png: Uint8List.fromList([1, 2, 3]),
+        amountZec: '0.5',
+        pickSaveLocation: ({required String suggestedName}) async => null,
+      );
+
+      expect(saved, isNull);
+      expect(directory.listSync(), isEmpty);
+    });
+  });
+}

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -661,8 +661,7 @@ void main() {
     await tester.pumpWidget(
       _app(
         initialRecipient: _texAddress,
-        validateAddress: ({required address, required network}) =>
-            validation.future,
+        validateAddress: ({required address}) => validation.future,
         accountState: const AccountState(
           accounts: [
             AccountInfo(

--- a/test/features/send/payment_request_host_test.dart
+++ b/test/features/send/payment_request_host_test.dart
@@ -81,6 +81,10 @@ class _FakeAccountNotifier extends AccountNotifier {
 
 final _discarded = <BigInt>[];
 
+/// Holds the pre-check's `discardProposal` open so a test can look at the
+/// router while the card's proposal is still being released.
+Completer<void>? _discardGate;
+
 PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
   readNetworkName: () => kZcashDefaultNetworkName,
   spendableIsAuthoritativeNow: () => true,
@@ -119,7 +123,11 @@ PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
-      }) async => _discarded.add(proposalId),
+      }) async {
+        _discarded.add(proposalId);
+        final gate = _discardGate;
+        if (gate != null) await gate.future;
+      },
 );
 
 /// A pre-check whose propose leg can be made to fail with the error Rust
@@ -334,6 +342,7 @@ String _location(ProviderContainer container) =>
 void main() {
   setUp(() {
     _discarded.clear();
+    _discardGate = null;
     _probeMounts = 0;
     _probeDeactivations = 0;
   });
@@ -528,6 +537,32 @@ void main() {
     expect(_location(container), '/send');
     expect(container.read(paymentRequestFlowProvider), isNull);
     expect(_discarded, [BigInt.from(11)]);
+  });
+
+  testWidgets('Edit opens the composer only once the proposal is released', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    _discardGate = gate;
+    final container = await _pumpHost(tester);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Edit'));
+    await tester.pump();
+
+    // The card is gone at once, but the composer — which re-quotes the fee
+    // as it mounts — must not open against inputs the proposal still holds.
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(_discarded, [BigInt.from(11)]);
+    expect(_location(container), '/home');
+
+    gate.complete();
+    await tester.pumpAndSettle();
+
+    expect(_location(container), '/send');
   });
 
   testWidgets('Cancel dismisses the card and releases the proposal', (

--- a/test/features/send/payment_request_host_test.dart
+++ b/test/features/send/payment_request_host_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
@@ -81,6 +82,7 @@ class _FakeAccountNotifier extends AccountNotifier {
 final _discarded = <BigInt>[];
 
 PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  readNetworkName: () => kZcashDefaultNetworkName,
   spendableIsAuthoritativeNow: () => true,
   validateAddress: ({required String address, required String network}) async =>
       rust_sync.AddressValidationResult(
@@ -128,6 +130,7 @@ class _StallingSendApi {
   var proposeAttempts = 0;
 
   PaymentRequestPrecheck get precheck => PaymentRequestPrecheck(
+    readNetworkName: () => kZcashDefaultNetworkName,
     // Settled: a shortfall would be final, so the only way to `syncing` here
     // is the propose leg — and with the sync settled there is no completion
     // left for the card to wait for, which is what makes it stall.

--- a/test/features/send/payment_request_host_test.dart
+++ b/test/features/send/payment_request_host_test.dart
@@ -183,6 +183,7 @@ Future<ProviderContainer> _pumpHost(
   Map<String, AccountInfo> ownAccounts = const {},
   bool addressBookPending = false,
   PaymentRequestPrecheck? precheck,
+  WidgetBuilder? homeScreen,
 }) async {
   tester.view.physicalSize = const Size(1280, 900);
   tester.view.devicePixelRatio = 1.0;
@@ -195,7 +196,9 @@ Future<ProviderContainer> _pumpHost(
       for (final path in ['/home', '/send', '/send/review'])
         GoRoute(
           path: path,
-          builder: (_, _) => Scaffold(body: Text('screen $path')),
+          builder: (context, _) => path == '/home' && homeScreen != null
+              ? homeScreen(context)
+              : Scaffold(body: Text('screen $path')),
         ),
     ],
   );
@@ -259,6 +262,57 @@ Future<ProviderContainer> _pumpHost(
 
 final _routers = <ProviderContainer, GoRouter>{};
 
+/// How many times [_StatefulScreenProbe] has been built from scratch.
+var _probeMounts = 0;
+
+/// How many times it has been unhooked from the element tree.
+///
+/// This is the assertion with teeth. `go_router` gives its `Navigator` a
+/// `GlobalKey`, so even a routed subtree that gets re-parented is *retaken*
+/// rather than rebuilt: screen state survives either way, and `find.text`
+/// alone would pass either way. What re-parenting still costs is a
+/// deactivate/activate cycle through every element under the router — plus a
+/// fresh `Router` state above them, which is not global-keyed — on every show
+/// and every dismiss, for a card that is only supposed to be sitting on top.
+/// Zero here is the whole point.
+var _probeDeactivations = 0;
+
+/// A screen that owns route-local state, standing in for a half-typed
+/// Send form.
+class _StatefulScreenProbe extends StatefulWidget {
+  const _StatefulScreenProbe();
+
+  @override
+  State<_StatefulScreenProbe> createState() => _StatefulScreenProbeState();
+}
+
+class _StatefulScreenProbeState extends State<_StatefulScreenProbe> {
+  final _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _probeMounts++;
+  }
+
+  @override
+  void deactivate() {
+    _probeDeactivations++;
+    super.deactivate();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    body: Center(child: TextField(controller: _controller)),
+  );
+}
+
 class _TestZecUsdPriceNotifier extends Notifier<double?> {
   @override
   double? build() => null;
@@ -275,7 +329,11 @@ String _location(ProviderContainer container) =>
     _routers[container]!.routerDelegate.currentConfiguration.uri.path;
 
 void main() {
-  setUp(_discarded.clear);
+  setUp(() {
+    _discarded.clear();
+    _probeMounts = 0;
+    _probeDeactivations = 0;
+  });
 
   testWidgets('the card renders over the current screen', (tester) async {
     final container = await _pumpHost(tester);
@@ -294,6 +352,66 @@ void main() {
       reason: 'the screen underneath stays mounted',
     );
     expect(_location(container), '/home');
+  });
+
+  testWidgets('the screen under the card stays put across show and dismiss', (
+    tester,
+  ) async {
+    final container = await _pumpHost(
+      tester,
+      homeScreen: (_) => const _StatefulScreenProbe(),
+    );
+    await tester.enterText(find.byType(TextField), 'half typed');
+    await tester.pumpAndSettle();
+    expect(_probeMounts, 1);
+    expect(_probeDeactivations, 0);
+    final screen = tester.state<_StatefulScreenProbeState>(
+      find.byType(_StatefulScreenProbe),
+    );
+    final router = tester.state(find.byType(Router<Object>));
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Payment request'), findsOneWidget);
+    expect(
+      _probeDeactivations,
+      0,
+      reason: 'showing the card must not move the routed subtree',
+    );
+    expect(
+      tester.state(find.byType(Router<Object>)),
+      same(router),
+      reason: 'the router above it is not global-keyed, so it would be rebuilt',
+    );
+    expect(_probeMounts, 1);
+    expect(screen.mounted, isTrue);
+    expect(find.text('half typed'), findsOneWidget);
+
+    container.read(paymentRequestFlowProvider.notifier).dismiss();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Payment request'), findsNothing);
+    expect(
+      _probeDeactivations,
+      0,
+      reason: 'dismissing it must not move the subtree back',
+    );
+    expect(tester.state(find.byType(Router<Object>)), same(router));
+    expect(_probeMounts, 1);
+    expect(
+      tester.state<_StatefulScreenProbeState>(
+        find.byType(_StatefulScreenProbe),
+      ),
+      same(screen),
+    );
+    expect(
+      find.text('half typed'),
+      findsOneWidget,
+      reason: 'a link arriving over the composer cannot empty it',
+    );
   });
 
   // Hosted above the router there is no `Navigator`, so the caveat tooltip

--- a/test/features/send/payment_request_host_test.dart
+++ b/test/features/send/payment_request_host_test.dart
@@ -1,0 +1,611 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
+import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_host.dart';
+import 'package:zcash_wallet/src/features/send/widgets/send_recipient_resolver.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/migration_send_gate_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_request_flow_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import '../../fakes/fake_sync_notifier.dart';
+
+const _address =
+    'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+    '73d57f73c6dc05121591a83861cd190591';
+
+const _request = SendPrefillArgs(
+  id: 'payment-uri-1',
+  source: kPaymentUriPrefillSource,
+  address: _address,
+  amountText: '0.5',
+  label: 'Coffee shop',
+);
+
+const _replacementRequest = SendPrefillArgs(
+  id: 'payment-uri-2',
+  source: kPaymentUriPrefillSource,
+  address: _address,
+  amountText: '0.75',
+  label: 'Bakery',
+  message: 'Second request note',
+);
+
+AddressBookContact _contact(String label, String address) => AddressBookContact(
+  id: 'contact-$label',
+  label: label,
+  network: AddressBookNetwork.zcash,
+  address: address,
+  profilePictureId: 'pfp-03',
+  createdAtMs: 0,
+  updatedAtMs: 0,
+);
+
+/// Address book that never finishes loading, so the host has to render the
+/// request before it knows who the recipient is.
+class _PendingAddressBookNotifier extends AddressBookNotifier {
+  @override
+  Future<AddressBookState> build() => Completer<AddressBookState>().future;
+}
+
+class _FakeAddressBookNotifier extends AddressBookNotifier {
+  _FakeAddressBookNotifier(this.contacts);
+
+  final List<AddressBookContact> contacts;
+
+  @override
+  Future<AddressBookState> build() async =>
+      AddressBookState(contacts: contacts);
+}
+
+class _FakeAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+  );
+}
+
+final _discarded = <BigInt>[];
+
+PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  spendableIsAuthoritativeNow: () => true,
+  validateAddress: ({required String address, required String network}) async =>
+      rust_sync.AddressValidationResult(
+        isValid: true,
+        addressType: 'unified',
+        wrongNetwork: false,
+      ),
+  proposeTransfer:
+      ({
+        required String accountUuid,
+        required String sendFlowId,
+        required String address,
+        required String addressType,
+        required BigInt amountZatoshi,
+        String? memo,
+        bool isPaymentRequest = false,
+        String? requestedBy,
+        BigInt? requestedAmountZatoshi,
+      }) async => SendReviewArgs(
+        proposalId: BigInt.from(11),
+        sendFlowId: sendFlowId,
+        proposalAccountUuid: accountUuid,
+        address: address,
+        addressType: addressType,
+        amountZatoshi: amountZatoshi,
+        feeZatoshi: BigInt.from(10000),
+        needsSaplingParams: false,
+        isPaymentRequest: isPaymentRequest,
+        requestedBy: requestedBy,
+        requestedAmountZatoshi: requestedAmountZatoshi,
+      ),
+  discardProposal:
+      ({
+        required BigInt proposalId,
+        required String sendFlowId,
+        required String logContext,
+      }) async => _discarded.add(proposalId),
+);
+
+/// A pre-check whose propose leg can be made to fail with the error Rust
+/// emits before it has anchor heights — the one the card maps onto its
+/// syncing statuses.
+class _StallingSendApi {
+  Object? proposeThrows = Exception('Wallet must sync before sending');
+  var proposeAttempts = 0;
+
+  PaymentRequestPrecheck get precheck => PaymentRequestPrecheck(
+    // Settled: a shortfall would be final, so the only way to `syncing` here
+    // is the propose leg — and with the sync settled there is no completion
+    // left for the card to wait for, which is what makes it stall.
+    spendableIsAuthoritativeNow: () => true,
+    validateAddress:
+        ({required String address, required String network}) async =>
+            rust_sync.AddressValidationResult(
+              isValid: true,
+              addressType: 'unified',
+              wrongNetwork: false,
+            ),
+    proposeTransfer:
+        ({
+          required String accountUuid,
+          required String sendFlowId,
+          required String address,
+          required String addressType,
+          required BigInt amountZatoshi,
+          String? memo,
+          bool isPaymentRequest = false,
+          String? requestedBy,
+          BigInt? requestedAmountZatoshi,
+        }) async {
+          proposeAttempts++;
+          final failure = proposeThrows;
+          if (failure != null) throw failure;
+          return SendReviewArgs(
+            proposalId: BigInt.from(11),
+            sendFlowId: sendFlowId,
+            proposalAccountUuid: accountUuid,
+            address: address,
+            addressType: addressType,
+            amountZatoshi: amountZatoshi,
+            feeZatoshi: BigInt.from(10000),
+            needsSaplingParams: false,
+            isPaymentRequest: isPaymentRequest,
+            requestedBy: requestedBy,
+            requestedAmountZatoshi: requestedAmountZatoshi,
+          );
+        },
+    discardProposal:
+        ({
+          required BigInt proposalId,
+          required String sendFlowId,
+          required String logContext,
+        }) async => _discarded.add(proposalId),
+  );
+}
+
+Future<ProviderContainer> _pumpHost(
+  WidgetTester tester, {
+  List<AddressBookContact> contacts = const [],
+  Map<String, AccountInfo> ownAccounts = const {},
+  bool addressBookPending = false,
+  PaymentRequestPrecheck? precheck,
+}) async {
+  tester.view.physicalSize = const Size(1280, 900);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final router = GoRouter(
+    initialLocation: '/home',
+    routes: [
+      for (final path in ['/home', '/send', '/send/review'])
+        GoRoute(
+          path: path,
+          builder: (_, _) => Scaffold(body: Text('screen $path')),
+        ),
+    ],
+  );
+  addTearDown(router.dispose);
+
+  late ProviderContainer container;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        paymentRequestPrecheckProvider.overrideWithValue(
+          precheck ?? _readyPrecheck(),
+        ),
+        accountProvider.overrideWith(_FakeAccountNotifier.new),
+        syncProvider.overrideWith(
+          () => FakeSyncNotifier(
+            SyncState(
+              accountUuid: 'account-1',
+              hasAccountScopedData: true,
+              isSyncComplete: true,
+              chainTipHeight: 3000000,
+              scannedHeight: 3000000,
+              spendableBalance: BigInt.from(100000000),
+            ),
+          ),
+        ),
+        migrationSendGateProvider.overrideWithValue(false),
+        // Backed by a state provider so a test can land the price *after*
+        // the card is already on screen, which is what the real autoDispose
+        // market-data providers do.
+        zecHomeUsdUnitPriceProvider.overrideWith(
+          (ref) => ref.watch(_testZecUsdPriceProvider),
+        ),
+        addressBookProvider.overrideWith(
+          addressBookPending
+              ? _PendingAddressBookNotifier.new
+              : () => _FakeAddressBookNotifier(contacts),
+        ),
+        // The real provider asks Rust for every account's addresses; the host
+        // only ever reads its settled value.
+        ownAccountAddressesProvider.overrideWith((ref) async => ownAccounts),
+      ],
+      child: Consumer(
+        builder: (context, ref, _) {
+          container = ProviderScope.containerOf(context, listen: false);
+          return MaterialApp.router(
+            routerConfig: router,
+            builder: (context, child) => AppTheme(
+              data: AppThemeData.light,
+              child: PaymentRequestHost(router: router, child: child!),
+            ),
+          );
+        },
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  addTearDown(() => _routers.remove(container));
+  _routers[container] = router;
+  return container;
+}
+
+final _routers = <ProviderContainer, GoRouter>{};
+
+class _TestZecUsdPriceNotifier extends Notifier<double?> {
+  @override
+  double? build() => null;
+
+  void setPrice(double? price) => state = price;
+}
+
+final _testZecUsdPriceProvider =
+    NotifierProvider<_TestZecUsdPriceNotifier, double?>(
+      _TestZecUsdPriceNotifier.new,
+    );
+
+String _location(ProviderContainer container) =>
+    _routers[container]!.routerDelegate.currentConfiguration.uri.path;
+
+void main() {
+  setUp(_discarded.clear);
+
+  testWidgets('the card renders over the current screen', (tester) async {
+    final container = await _pumpHost(tester);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Payment request'), findsOneWidget);
+    expect(find.text('Requester'), findsOneWidget);
+    expect(find.text('Coffee shop'), findsOneWidget);
+    expect(find.text('Requested by Coffee shop'), findsNothing);
+    expect(
+      find.text('screen /home'),
+      findsOneWidget,
+      reason: 'the screen underneath stays mounted',
+    );
+    expect(_location(container), '/home');
+  });
+
+  // Hosted above the router there is no `Navigator`, so the caveat tooltip
+  // only works because the surface carries its own `Overlay`.
+  testWidgets('the requester caveat opens over the live host', (tester) async {
+    final container = await _pumpHost(tester);
+    final semantics = tester.ensureSemantics();
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_replacementRequest, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .getSemantics(find.bySemanticsLabel('Show requester details'))
+          .value,
+      'Label from link, Bakery',
+      reason: 'the summary announces a link label, not a verified sender',
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('payment_request_requester_help')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        "Name supplied by the payment link. Vizor can't verify who sent it.",
+      ),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+    semantics.dispose();
+  });
+
+  testWidgets('a replacement request starts with disclosures collapsed', (
+    tester,
+  ) async {
+    final container = await _pumpHost(tester);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(
+          const SendPrefillArgs(
+            id: 'payment-uri-1-with-note',
+            source: kPaymentUriPrefillSource,
+            address: _address,
+            amountText: '0.5',
+            label: 'Coffee shop',
+            message: 'First request note',
+          ),
+          source: PaymentRequestSource.link,
+        );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey('payment_request_requester_toggle')),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('payment_request_requester_note')),
+      findsOneWidget,
+    );
+
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_replacementRequest, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Bakery'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('payment_request_requester_note')),
+      findsNothing,
+    );
+    expect(find.text('screen /home'), findsOneWidget);
+    expect(_location(container), '/home');
+  });
+
+  testWidgets('Review routes to the review screen and keeps the proposal', (
+    tester,
+  ) async {
+    final container = await _pumpHost(tester);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Review'));
+    await tester.pumpAndSettle();
+
+    expect(_location(container), '/send/review');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(
+      _discarded,
+      isEmpty,
+      reason: 'the review screen owns the proposal from here',
+    );
+  });
+
+  testWidgets('Edit routes to the composer and releases the proposal', (
+    tester,
+  ) async {
+    final container = await _pumpHost(tester);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Edit'));
+    await tester.pumpAndSettle();
+
+    expect(_location(container), '/send');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(_discarded, [BigInt.from(11)]);
+  });
+
+  testWidgets('Cancel dismisses the card and releases the proposal', (
+    tester,
+  ) async {
+    final container = await _pumpHost(tester);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('payment_request_close')));
+    await tester.pumpAndSettle();
+
+    expect(_location(container), '/home');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(_discarded, [BigInt.from(11)]);
+  });
+
+  testWidgets('a saved contact names the recipient on the card', (
+    tester,
+  ) async {
+    final container = await _pumpHost(
+      tester,
+      contacts: [_contact('Blue Door Coffee', _address)],
+    );
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('payment_request_recipient_name')),
+          )
+          .data,
+      'Blue Door Coffee',
+    );
+    expect(find.text('Your account'), findsNothing);
+  });
+
+  testWidgets('an own account is named as the user own account', (
+    tester,
+  ) async {
+    final container = await _pumpHost(
+      tester,
+      ownAccounts: const {
+        _address: AccountInfo(
+          uuid: 'account-1',
+          name: 'Account 1',
+          profilePictureId: 'pfp-07',
+          order: 0,
+        ),
+      },
+    );
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('payment_request_recipient_name')),
+          )
+          .data,
+      'Account 1',
+    );
+    expect(find.text('Your account'), findsOneWidget);
+  });
+
+  testWidgets('a contact saved for an own account wins, as on the review', (
+    tester,
+  ) async {
+    final container = await _pumpHost(
+      tester,
+      contacts: [_contact('Blue Door Coffee', _address)],
+      ownAccounts: const {
+        _address: AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0),
+      },
+    );
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Your account'), findsNothing);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('payment_request_recipient_name')),
+          )
+          .data,
+      'Blue Door Coffee',
+    );
+  });
+
+  testWidgets('an unresolved lookup renders the plain address, not a wait', (
+    tester,
+  ) async {
+    final container = await _pumpHost(tester, addressBookPending: true);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    // The card is up and answerable while the address book is still loading.
+    expect(find.text('Payment request'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('payment_request_recipient_name')),
+      findsNothing,
+    );
+    expect(find.text('u195091 ... 190591'), findsOneWidget);
+  });
+
+  testWidgets('the fiat line lands when the price arrives after the card', (
+    tester,
+  ) async {
+    // A link that arrives over Settings or Activity finds the autoDispose
+    // price providers with no subscriber, so the value is null at present
+    // time and fills a moment later.
+    final container = await _pumpHost(tester);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(find.text(r'$50.00'), findsNothing);
+
+    container.read(_testZecUsdPriceProvider.notifier).setPrice(100);
+    await tester.pumpAndSettle();
+
+    expect(find.text(r'$50.00'), findsOneWidget);
+  });
+
+  testWidgets('an address in neither source keeps the plain address', (
+    tester,
+  ) async {
+    final container = await _pumpHost(
+      tester,
+      contacts: [
+        _contact('Someone else', 't1PZ4vMuLdt2wRfDGGKS1qXfBpJt5CJHhNz'),
+      ],
+    );
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('payment_request_recipient_name')),
+      findsNothing,
+    );
+    expect(find.text('u195091 ... 190591'), findsOneWidget);
+  });
+
+  // A card that has run out of ways to answer itself stops promising an
+  // update and hands the next move to the user.
+  testWidgets('a stalled check offers Check again instead of a dead Review', (
+    tester,
+  ) async {
+    final api = _StallingSendApi();
+    final container = await _pumpHost(tester, precheck: api.precheck);
+    container
+        .read(paymentRequestFlowProvider.notifier)
+        .present(_request, source: PaymentRequestSource.link);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Still syncing — check again when the wallet is up to date'),
+      findsOneWidget,
+    );
+    expect(find.text('Check again'), findsOneWidget);
+    expect(find.text('Review'), findsNothing);
+    final primary = tester.widget<AppButton>(
+      find.byKey(const ValueKey('payment_request_continue')),
+    );
+    expect(
+      primary.onPressed,
+      isNotNull,
+      reason: 'the one control that can change the answer must be usable',
+    );
+    final asked = api.proposeAttempts;
+
+    // The wallet caught up; the tap is what asks again.
+    api.proposeThrows = null;
+    await tester.tap(find.byKey(const ValueKey('payment_request_continue')));
+    await tester.pumpAndSettle();
+
+    expect(api.proposeAttempts, asked + 1);
+    expect(find.text('Review'), findsOneWidget);
+    expect(find.text('Check again'), findsNothing);
+    expect(
+      container.read(paymentRequestFlowProvider)!.canReview,
+      isTrue,
+      reason: 'the re-check made the proposal the review screen needs',
+    );
+    expect(_location(container), '/home');
+  });
+}

--- a/test/features/send/payment_request_pane_layout_test.dart
+++ b/test/features/send/payment_request_pane_layout_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_modal_card.dart';
@@ -171,6 +172,7 @@ class _FakeAccountNotifier extends AccountNotifier {
 }
 
 PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  readNetworkName: () => kZcashDefaultNetworkName,
   spendableIsAuthoritativeNow: () => true,
   validateAddress: ({required String address, required String network}) async =>
       rust_sync.AddressValidationResult(

--- a/test/features/send/payment_request_pane_layout_test.dart
+++ b/test/features/send/payment_request_pane_layout_test.dart
@@ -1,0 +1,272 @@
+/// Where the app-level payment-request card lands, and whether it fits.
+///
+/// The card is hosted above the router, so nothing in the route tree bounds
+/// it: these tests mount the real desktop shell under it at the window sizes
+/// `windows/runner/main.cpp` opens at (1095x726) and `app_layout.dart` allows
+/// as the smallest drag-resize (1080x720), and assert both the pane-centered
+/// geometry and the absence of any overflow.
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_modal_card.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_card.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_host.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/migration_send_gate_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_request_flow_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import '../../fakes/fake_sync_notifier.dart';
+
+/// The default window `windows/runner/main.cpp` opens.
+const _defaultWindow = Size(1095, 726);
+
+/// The smallest window `AppLayoutMode.large.minimumSize` allows.
+const _minimumWindow = Size(1080, 720);
+
+const _address =
+    'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+    '73d57f73c6dc05121591a83861cd190591';
+
+/// A 512-byte memo and an 80-character label: the widest a request can be.
+final _longMessage = 'a memo that keeps going. ' * 20;
+const _longLabel =
+    'A payment requester with a name long enough to fill eighty characters '
+    'exactly!!';
+
+final _shortRequest = SendPrefillArgs(
+  id: 'payment-uri-short',
+  source: kPaymentUriPrefillSource,
+  address: _address,
+  amountText: '0.5',
+  label: 'Coffee shop',
+);
+
+final _longRequest = SendPrefillArgs(
+  id: 'payment-uri-long',
+  source: kPaymentUriPrefillSource,
+  address: _address,
+  amountText: '123456.12345678',
+  label: _longLabel,
+  memoText: _longMessage,
+  message: 'A note the requester attached to the link, kept local.',
+);
+
+void main() {
+  testWidgets('the card centers on the content pane, not on the window', (
+    tester,
+  ) async {
+    final container = await _pumpHost(tester, size: _defaultWindow);
+    await _present(tester, container, _shortRequest);
+
+    // The geometry the shell itself lays the pane out with.
+    final paneLeft = appDesktopPaneLeftInset(kAppDesktopSidebarWidth);
+    final paneWidth = _defaultWindow.width - paneLeft - kAppDesktopShellMargin;
+
+    final card = find.byType(AppModalCard);
+    expect(
+      tester.getCenter(card).dx,
+      moreOrLessEquals(paneLeft + paneWidth / 2, epsilon: 0.01),
+    );
+    // Not the window's center — that is what the sidebar was pushing it to.
+    expect(
+      tester.getCenter(card).dx,
+      isNot(moreOrLessEquals(_defaultWindow.width / 2, epsilon: 1)),
+    );
+    // And it agrees with where the shell actually put the pane.
+    expect(
+      tester.getCenter(card).dx,
+      moreOrLessEquals(
+        tester.getCenter(find.byType(AppDesktopPane)).dx,
+        epsilon: 0.01,
+      ),
+    );
+  });
+
+  testWidgets('a card with no shell mounted still centers on the window', (
+    tester,
+  ) async {
+    final container = await _pumpHost(
+      tester,
+      size: _defaultWindow,
+      shell: false,
+    );
+    await _present(tester, container, _shortRequest);
+
+    expect(
+      tester.getCenter(find.byType(AppModalCard)).dx,
+      moreOrLessEquals(_defaultWindow.width / 2, epsilon: 0.01),
+    );
+  });
+
+  for (final size in const [_defaultWindow, _minimumWindow]) {
+    testWidgets('the card fits at $size, plain and with long values', (
+      tester,
+    ) async {
+      final container = await _pumpHost(tester, size: size);
+
+      await _present(tester, container, _shortRequest);
+      _expectFits(tester, size);
+
+      container.read(paymentRequestFlowProvider.notifier).dismiss();
+      await tester.pumpAndSettle();
+
+      await _present(tester, container, _longRequest);
+      _expectFits(tester, size);
+
+      // The disclosures are what make the card grow past its own frame.
+      await tester.tap(find.text('Show full address'));
+      await tester.pumpAndSettle();
+      _expectFits(tester, size);
+
+      await tester.tap(
+        find.byKey(const ValueKey('payment_request_memo_toggle')),
+      );
+      await tester.pumpAndSettle();
+      _expectFits(tester, size);
+    });
+  }
+}
+
+/// No overflow, and the card is inside the window it was drawn in.
+void _expectFits(WidgetTester tester, Size window) {
+  expect(tester.takeException(), isNull);
+  final card = tester.getRect(find.byType(AppModalCard));
+  expect(card.top, greaterThanOrEqualTo(-0.01));
+  expect(card.bottom, lessThanOrEqualTo(window.height + 0.01));
+  expect(card.left, greaterThanOrEqualTo(-0.01));
+  expect(card.right, lessThanOrEqualTo(window.width + 0.01));
+  expect(card.width, moreOrLessEquals(kPaymentRequestCardWidth, epsilon: 0.01));
+}
+
+Future<void> _present(
+  WidgetTester tester,
+  ProviderContainer container,
+  SendPrefillArgs request,
+) async {
+  container
+      .read(paymentRequestFlowProvider.notifier)
+      .present(request, source: PaymentRequestSource.link);
+  await tester.pumpAndSettle();
+}
+
+class _FakeAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+  );
+}
+
+PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  spendableIsAuthoritativeNow: () => true,
+  validateAddress: ({required String address, required String network}) async =>
+      rust_sync.AddressValidationResult(
+        isValid: true,
+        addressType: 'unified',
+        wrongNetwork: false,
+      ),
+  proposeTransfer:
+      ({
+        required String accountUuid,
+        required String sendFlowId,
+        required String address,
+        required String addressType,
+        required BigInt amountZatoshi,
+        String? memo,
+        bool isPaymentRequest = false,
+        String? requestedBy,
+        BigInt? requestedAmountZatoshi,
+      }) async => SendReviewArgs(
+        proposalId: BigInt.from(11),
+        sendFlowId: sendFlowId,
+        proposalAccountUuid: accountUuid,
+        address: address,
+        addressType: addressType,
+        amountZatoshi: amountZatoshi,
+        feeZatoshi: BigInt.from(10000),
+        needsSaplingParams: false,
+        isPaymentRequest: isPaymentRequest,
+        requestedBy: requestedBy,
+        requestedAmountZatoshi: requestedAmountZatoshi,
+      ),
+  discardProposal:
+      ({
+        required BigInt proposalId,
+        required String sendFlowId,
+        required String logContext,
+      }) async {},
+);
+
+Future<ProviderContainer> _pumpHost(
+  WidgetTester tester, {
+  required Size size,
+  bool shell = true,
+}) async {
+  await tester.binding.setSurfaceSize(size);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  final router = GoRouter(
+    initialLocation: '/home',
+    routes: [
+      for (final path in ['/home', '/send', '/send/review'])
+        GoRoute(
+          path: path,
+          builder: (_, _) => shell
+              ? const AppDesktopShell(
+                  sidebar: ColoredBox(color: Color(0xFF202020)),
+                  pane: AppDesktopPane(child: SizedBox.expand()),
+                )
+              : const Scaffold(body: SizedBox.expand()),
+        ),
+    ],
+  );
+  addTearDown(router.dispose);
+
+  late ProviderContainer container;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        paymentRequestPrecheckProvider.overrideWithValue(_readyPrecheck()),
+        accountProvider.overrideWith(_FakeAccountNotifier.new),
+        syncProvider.overrideWith(
+          () => FakeSyncNotifier(
+            SyncState(
+              accountUuid: 'account-1',
+              hasAccountScopedData: true,
+              spendableBalance: BigInt.from(100000000),
+            ),
+          ),
+        ),
+        migrationSendGateProvider.overrideWithValue(false),
+        zecHomeUsdUnitPriceProvider.overrideWithValue(null),
+      ],
+      child: Consumer(
+        builder: (context, ref, _) {
+          container = ProviderScope.containerOf(context, listen: false);
+          return MaterialApp.router(
+            routerConfig: router,
+            builder: (context, child) => AppTheme(
+              data: AppThemeData.light,
+              child: PaymentRequestHost(router: router, child: child!),
+            ),
+          );
+        },
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return container;
+}

--- a/test/features/send/send_recipient_resolver_test.dart
+++ b/test/features/send/send_recipient_resolver_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_card.dart';
 import 'package:zcash_wallet/src/features/send/widgets/send_recipient_resolver.dart';
 import 'package:zcash_wallet/src/features/send/widgets/send_review_layout.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
@@ -59,6 +60,8 @@ void main() {
     expect(recipient, isA<SendReviewContactRecipient>());
   });
 
+  group('paymentRequestRecipientIdentityFor', _paymentRequestIdentityTests);
+
   test('a saved contact wins over the own-account match', () {
     final recipient = sendReviewRecipientFor(
       contacts: [_contact('Mike', _address)],
@@ -71,5 +74,127 @@ void main() {
       recipient,
       isA<SendReviewContactRecipient>().having((r) => r.name, 'name', 'Mike'),
     );
+  });
+}
+
+void _paymentRequestIdentityTests() {
+  test('an unknown address gets no identity at all', () {
+    expect(
+      paymentRequestRecipientIdentityFor(contacts: const [], address: _address),
+      isNull,
+    );
+  });
+
+  test('a saved contact resolves to the contact identity', () {
+    final identity = paymentRequestRecipientIdentityFor(
+      contacts: [_contact('Mike', _address)],
+      address: _address,
+    );
+    expect(
+      identity,
+      isA<PaymentRequestRecipientIdentity>()
+          .having((i) => i.kind, 'kind', PaymentRequestRecipientKind.contact)
+          .having((i) => i.name, 'name', 'Mike')
+          .having((i) => i.profilePictureId, 'pfp', 'pfp-03')
+          .having((i) => i.isOwnAccount, 'isOwnAccount', isFalse),
+    );
+  });
+
+  test('an own account resolves to the own-account identity', () {
+    final identity = paymentRequestRecipientIdentityFor(
+      contacts: const [],
+      address: _address,
+      ownAccounts: {
+        _address: const AccountInfo(
+          uuid: 'uuid-1',
+          name: 'Savings',
+          profilePictureId: 'pfp-07',
+          order: 0,
+        ),
+      },
+    );
+    expect(
+      identity,
+      isA<PaymentRequestRecipientIdentity>()
+          .having((i) => i.kind, 'kind', PaymentRequestRecipientKind.ownAccount)
+          .having((i) => i.name, 'name', 'Savings')
+          .having((i) => i.profilePictureId, 'pfp', 'pfp-07')
+          .having((i) => i.isOwnAccount, 'isOwnAccount', isTrue),
+    );
+  });
+
+  test('a saved contact wins over the own-account match', () {
+    // Same precedence as `sendReviewRecipientFor`: the card hands off to the
+    // review screen for this address, and the two must not name it
+    // differently.
+    final identity = paymentRequestRecipientIdentityFor(
+      contacts: [_contact('Mike', _address)],
+      address: _address,
+      ownAccounts: {
+        _address: const AccountInfo(
+          uuid: 'uuid-1',
+          name: 'Savings',
+          profilePictureId: 'pfp-07',
+          order: 0,
+        ),
+      },
+    );
+    expect(identity!.isOwnAccount, isFalse);
+    expect(identity.name, 'Mike');
+  });
+
+  test('the own-account match trims the recipient address', () {
+    final identity = paymentRequestRecipientIdentityFor(
+      contacts: const [],
+      address: '  $_address  ',
+      ownAccounts: {
+        _address: const AccountInfo(uuid: 'uuid-1', name: 'Savings', order: 0),
+      },
+    );
+    expect(identity?.isOwnAccount, isTrue);
+  });
+
+  test('a case-shifted address matches neither source', () {
+    // Zcash addresses are case-sensitive; a near-miss is a different address.
+    final shifted = _address.toUpperCase();
+    expect(
+      paymentRequestRecipientIdentityFor(
+        contacts: [_contact('Mike', _address)],
+        address: shifted,
+        ownAccounts: {
+          _address: const AccountInfo(
+            uuid: 'uuid-1',
+            name: 'Savings',
+            order: 0,
+          ),
+        },
+      ),
+      isNull,
+    );
+  });
+
+  test('a blank-labelled contact falls back to the own account', () {
+    final identity = paymentRequestRecipientIdentityFor(
+      contacts: [_contact('   ', _address)],
+      address: _address,
+      ownAccounts: {
+        _address: const AccountInfo(uuid: 'uuid-1', name: 'Savings', order: 0),
+      },
+    );
+    expect(identity!.isOwnAccount, isTrue);
+    expect(identity.name, 'Savings');
+  });
+
+  test('a blank name is not an identity the card will render', () {
+    const view = PaymentRequestView(
+      source: PaymentRequestSource.link,
+      address: _address,
+      recipientIdentity: PaymentRequestRecipientIdentity.contact(
+        name: '  ',
+        profilePictureId: 'pfp-03',
+      ),
+    );
+    expect(view.recipientIdentity, isNotNull);
+    expect(view.displayRecipientIdentity, isNull);
   });
 }

--- a/test/features/send/send_review_content_view_test.dart
+++ b/test/features/send/send_review_content_view_test.dart
@@ -7,6 +7,7 @@ import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_profile_picture.dart';
 import 'package:zcash_wallet/src/core/widgets/review_buttons_stack.dart';
 import 'package:zcash_wallet/src/core/widgets/review_info_row.dart';
+import 'package:zcash_wallet/src/core/widgets/review_list_row.dart';
 import 'package:zcash_wallet/src/core/widgets/review_wrap_card.dart';
 import 'package:zcash_wallet/src/features/send/widgets/send_review_content_view.dart';
 import 'package:zcash_wallet/src/features/send/widgets/send_review_layout.dart';
@@ -313,6 +314,109 @@ void main() {
       find.byType(ReviewButtonsStack),
     );
     expect(stack.onPrimaryPressed, isNull);
+  });
+
+  group('payment request framing', () {
+    testWidgets('retitles the screen and keeps the verified recipient', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        const SendReviewContentView(
+          amountText: '0.50 ZEC',
+          recipient: SendReviewAddressRecipient(address: _address),
+          feeText: '0.012 ZEC',
+          isPaymentRequest: true,
+        ),
+      );
+
+      expect(find.text('Review payment request'), findsOneWidget);
+      expect(find.text('Review send'), findsNothing);
+      expect(find.text('Requested by'), findsOneWidget);
+      expect(
+        find.text('To'),
+        findsNothing,
+        reason: 'the row is retitled, not duplicated',
+      );
+
+      final row = tester.widget<ReviewInfoRow>(
+        find.byKey(const ValueKey('send_review_requested_by')),
+      );
+      expect(
+        row.value,
+        truncatedAddress(_address),
+        reason: 'the request only renames the row it does not fill it',
+      );
+      expect(row.bottomLeftText, 'Shielded');
+    });
+
+    testWidgets('a contact recipient still heads the request row', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        const SendReviewContentView(
+          amountText: '0.50 ZEC',
+          recipient: SendReviewContactRecipient(
+            address: _address,
+            name: 'Blue Door Coffee',
+            profilePictureId: 'pfp-02',
+          ),
+          feeText: '0.012 ZEC',
+          isPaymentRequest: true,
+        ),
+      );
+
+      final row = tester.widget<ReviewInfoRow>(
+        find.byKey(const ValueKey('send_review_requested_by')),
+      );
+      expect(row.label, 'Requested by');
+      expect(row.value, 'Blue Door Coffee');
+      expect(
+        find.descendant(
+          of: find.byType(SendReviewInfoSection),
+          matching: find.byType(AppProfilePicture),
+        ),
+        findsOneWidget,
+      );
+      // The link's `label=` belongs to the payment request card only.
+      expect(find.text('Label from link'), findsNothing);
+      expect(find.byType(ReviewListRow), findsOneWidget);
+    });
+
+    testWidgets('states the requested amount when it was edited', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        const SendReviewContentView(
+          amountText: '0.75 ZEC',
+          recipient: SendReviewAddressRecipient(address: _address),
+          feeText: '0.012 ZEC',
+          isPaymentRequest: true,
+          requestedAmountText: '0.50 ZEC',
+        ),
+      );
+
+      expect(find.text('0.75 ZEC'), findsOneWidget);
+      expect(find.text('Requested 0.50 ZEC'), findsOneWidget);
+    });
+
+    testWidgets('an ordinary send is untouched', (tester) async {
+      await _pump(
+        tester,
+        const SendReviewContentView(
+          amountText: '0.50 ZEC',
+          recipient: SendReviewAddressRecipient(address: _address),
+          feeText: '0.012 ZEC',
+        ),
+      );
+
+      expect(find.text('Review send'), findsOneWidget);
+      expect(find.text('To'), findsOneWidget);
+      expect(find.textContaining('Requested'), findsNothing);
+      expect(find.text('Label from link'), findsNothing);
+    });
   });
 }
 

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -74,6 +74,20 @@ void main() {
     PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
   });
 
+  testWidgets('a whitespace-only memo keeps its Message row, with a '
+      'placeholder', (tester) async {
+    // An edited ZIP-321 request can carry a memo made only of whitespace, and
+    // the proposal sends it verbatim — so the review must not drop the row.
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _harness(_reviewArgs(addressType: 'unified', memo: '   ')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Message'), findsOneWidget);
+    expect(find.text('Whitespace only'), findsOneWidget);
+  });
+
   testWidgets('renders the address-variant review layout', (tester) async {
     await _setDesktopViewport(tester);
     await tester.pumpWidget(

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -2,22 +2,28 @@
 // flow (wallet DB path + Sapling params status).
 // ignore_for_file: depend_on_referenced_packages
 
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:zcash_wallet/app.dart'
+    show buildDesktopSendPage, buildDesktopSendReviewPage;
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/formatting/address_display.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_busy_surface_provider.dart';
 import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_profile_picture.dart';
+import 'package:zcash_wallet/src/core/widgets/review_info_row.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
 import 'package:zcash_wallet/src/features/keystone/widgets/keystone_signing_modal.dart';
@@ -89,6 +95,115 @@ void main() {
     expect(find.text('0.00012 ZEC'), findsOneWidget);
     expect(find.text('Confirm & send'), findsOneWidget);
     expect(find.text('Cancel'), findsOneWidget);
+  });
+
+  // The three-line args -> view threading at send_review_screen.dart:402-405.
+  // Without a screen-level test, dropping `requestedByLabel` or the
+  // `requestedAmountText` ternary leaves every unit, widget and regtest suite
+  // green while desktop payers lose the consent information the card promised.
+  testWidgets('renders a labelled request whose amount was edited', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _harness(
+        _reviewArgs(
+          addressType: 'unified',
+          isPaymentRequest: true,
+          requestedBy: 'Acme coffee',
+          requestedAmountZatoshi: BigInt.from(2000000000),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review payment request'), findsOneWidget);
+    expect(find.text('Review send'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('send_review_requested_by')),
+      findsOneWidget,
+    );
+    expect(find.text('Requested by'), findsOneWidget);
+    expect(
+      find.text('Acme coffee'),
+      findsNothing,
+      reason: "the link's own label never reaches the review",
+    );
+    expect(
+      find.byKey(const ValueKey('send_review_requested_amount')),
+      findsOneWidget,
+    );
+    expect(find.text('Requested 20.00 ZEC'), findsOneWidget);
+    expect(
+      find.text('15.12 ZEC'),
+      findsOneWidget,
+      reason: 'the edited amount is still what is being sent',
+    );
+  });
+
+  testWidgets('a request paid at the amount it asked for states it once', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _harness(
+        _reviewArgs(
+          addressType: 'unified',
+          isPaymentRequest: true,
+          requestedBy: 'Acme coffee',
+          requestedAmountZatoshi: BigInt.from(1512000000),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review payment request'), findsOneWidget);
+    expect(find.text('Acme coffee'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('send_review_requested_amount')),
+      findsNothing,
+      reason: 'nothing differs, so there is nothing to restate',
+    );
+  });
+
+  // A labelled request paying someone the wallet already knows: the contact
+  // heads the row and the link's own name is nowhere on the screen.
+  testWidgets('a labelled request keeps the contact as the recipient', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _harness(
+        _reviewArgs(
+          addressType: 'unified',
+          isPaymentRequest: true,
+          requestedBy: 'Coinbase Support',
+        ),
+        addressBookRepository: _FakeAddressBookRepository([
+          _contact(
+            id: 'coffee',
+            label: 'Blue Door Coffee',
+            address: _longAddress,
+          ),
+        ]),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final row = tester.widget<ReviewInfoRow>(
+      find.byKey(const ValueKey('send_review_requested_by')),
+    );
+    expect(row.label, 'Requested by');
+    expect(row.value, 'Blue Door Coffee');
+    expect(
+      find.descendant(
+        of: find.byType(SendReviewContentView),
+        matching: find.byType(AppProfilePicture),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Coinbase Support'), findsNothing);
+    expect(find.text('Label from link'), findsNothing);
   });
 
   testWidgets('donation review links back to Support Vizor', (tester) async {
@@ -214,6 +329,78 @@ void main() {
 
     expect(rustApi.discardCalls, hasLength(1));
   });
+
+  testWidgets(
+    'a second request answered onto /send/review replaces the page and '
+    'discards the first proposal',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final first = _reviewArgs(addressType: 'unified');
+      final second = SendReviewArgs(
+        proposalId: BigInt.two,
+        sendFlowId: 'second-send-flow',
+        proposalAccountUuid: 'test-account',
+        address: _longAddress,
+        addressType: 'unified',
+        amountZatoshi: BigInt.from(2512000000),
+        feeZatoshi: BigInt.from(12000),
+        needsSaplingParams: false,
+      );
+      final router = GoRouter(
+        initialLocation: '/home',
+        routes: [
+          GoRoute(path: '/home', builder: (_, _) => const Text('home-route')),
+          GoRoute(path: '/send', pageBuilder: buildDesktopSendPage),
+          GoRoute(
+            path: '/send/review',
+            pageBuilder: buildDesktopSendReviewPage,
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+      await tester.pumpWidget(_routerHarness(router));
+      await tester.pumpAndSettle();
+
+      router.go('/send/review', extra: first);
+      await tester.pumpAndSettle();
+      final firstPageKey =
+          (ModalRoute.of(
+                    tester.element(find.byType(SendReviewScreen)),
+                  )!.settings
+                  as Page<dynamic>)
+              .key;
+
+      // What the payment-request card's Review does when a review is already
+      // on screen: a `go` to the location the user is standing on.
+      router.go('/send/review', extra: second);
+      await tester.pumpAndSettle();
+
+      final secondPageKey =
+          (ModalRoute.of(
+                    tester.element(find.byType(SendReviewScreen)),
+                  )!.settings
+                  as Page<dynamic>)
+              .key;
+      // A shared page key would have updated the page in place, leaving the
+      // first proposal alive: `dispose` is the only thing that releases it.
+      expect(secondPageKey, isNot(firstPageKey));
+      expect(
+        rustApi.discardCalls,
+        contains((first.proposalId, first.sendFlowId)),
+      );
+      expect(
+        rustApi.discardCalls,
+        isNot(contains((second.proposalId, second.sendFlowId))),
+      );
+      expect(
+        tester
+            .widget<SendReviewScreen>(find.byType(SendReviewScreen))
+            .args
+            .sendFlowId,
+        second.sendFlowId,
+      );
+    },
+  );
 
   testWidgets('verify modal shows the full address grid for unknown address', (
     tester,
@@ -434,6 +621,69 @@ void main() {
     expect(rustApi.prepareBatchCalls, 1);
     expect(rustApi.encodeBatchCalls, 1);
     expect(rustApi.encodeFullPcztCalls, 0);
+  });
+
+  testWidgets('review and Keystone signing hold the payment-URI busy latch', (
+    tester,
+  ) async {
+    // Review owns a proposal whose inputs must be released before another
+    // request can be checked. The nested modal adds its live-QR hold.
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _harness(
+        _reviewArgs(addressType: 'unified'),
+        bootstrap: _bootstrap(isHardware: true),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(MaterialApp)),
+    );
+    expect(container.read(paymentUriBusySurfaceProvider), 1);
+
+    await tester.tap(find.text('Confirm with Keystone'));
+    await _flushRealAsync(tester);
+
+    expect(find.byType(KeystoneSigningModal), findsOneWidget);
+    expect(container.read(paymentUriBusySurfaceProvider), 2);
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(KeystoneSigningModal),
+        matching: find.text('Cancel'),
+      ),
+    );
+    await _flushRealAsync(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(KeystoneSigningModal), findsNothing);
+    expect(find.text('send-route'), findsOneWidget);
+    expect(container.read(paymentUriBusySurfaceProvider), 0);
+  });
+
+  testWidgets('review keeps the latch held until proposal discard completes', (
+    tester,
+  ) async {
+    final discardCompleter = Completer<void>();
+    rustApi.discardCompleter = discardCompleter;
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_harness(_reviewArgs(addressType: 'unified')));
+    await tester.pumpAndSettle();
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(MaterialApp)),
+    );
+    expect(container.read(paymentUriBusySurfaceProvider), 1);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(find.text('send-route'), findsOneWidget);
+    expect(container.read(paymentUriBusySurfaceProvider), 1);
+
+    discardCompleter.complete();
+    await tester.pump();
+    expect(container.read(paymentUriBusySurfaceProvider), 0);
   });
 
   testWidgets('Keystone signature limit fails before showing a QR', (
@@ -824,6 +1074,33 @@ Future<void> _flushRealAsync(WidgetTester tester) async {
   }
 }
 
+/// Everything a `SendReviewScreen` needs from providers, shared by the fixed
+/// harness below and by the router harness that drives the real `/send/review`
+/// page builder.
+List<Override> _harnessOverrides({
+  AppBootstrapState? bootstrap,
+  AddressBookRepository? addressBookRepository,
+}) => [
+  appBootstrapProvider.overrideWithValue(bootstrap ?? _bootstrap()),
+  zecMarketDataSourceProvider.overrideWithValue(const _FakeMarketDataSource()),
+  zecMarketDataCacheProvider.overrideWithValue(FakeZecMarketDataCache()),
+  addressBookRepositoryProvider.overrideWithValue(
+    addressBookRepository ?? _FakeAddressBookRepository(),
+  ),
+  syncProvider.overrideWith(_FakeSyncNotifier.new),
+];
+
+/// Drives [router] — built from the app's own `/send/review` page builder — so
+/// a test can navigate onto the route twice the way the payment-request card
+/// does.
+Widget _routerHarness(GoRouter router) => ProviderScope(
+  overrides: _harnessOverrides(),
+  child: MaterialApp.router(
+    routerConfig: router,
+    builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+  ),
+);
+
 Widget _harness(
   SendReviewArgs args, {
   AppBootstrapState? bootstrap,
@@ -877,17 +1154,10 @@ Widget _harness(
   );
 
   return ProviderScope(
-    overrides: [
-      appBootstrapProvider.overrideWithValue(bootstrap ?? _bootstrap()),
-      zecMarketDataSourceProvider.overrideWithValue(
-        const _FakeMarketDataSource(),
-      ),
-      zecMarketDataCacheProvider.overrideWithValue(FakeZecMarketDataCache()),
-      addressBookRepositoryProvider.overrideWithValue(
-        addressBookRepository ?? _FakeAddressBookRepository(),
-      ),
-      syncProvider.overrideWith(_FakeSyncNotifier.new),
-    ],
+    overrides: _harnessOverrides(
+      bootstrap: bootstrap,
+      addressBookRepository: addressBookRepository,
+    ),
     child: MaterialApp.router(
       routerConfig: router,
       builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
@@ -959,6 +1229,9 @@ SendReviewArgs _reviewArgs({
   String? memo,
   String address = _longAddress,
   BigInt? amountZatoshi,
+  bool isPaymentRequest = false,
+  String? requestedBy,
+  BigInt? requestedAmountZatoshi,
   SendFlowKind flowKind = SendFlowKind.send,
 }) {
   return SendReviewArgs(
@@ -971,6 +1244,9 @@ SendReviewArgs _reviewArgs({
     feeZatoshi: BigInt.from(12000),
     needsSaplingParams: false,
     memo: memo,
+    isPaymentRequest: isPaymentRequest,
+    requestedBy: requestedBy,
+    requestedAmountZatoshi: requestedAmountZatoshi,
     flowKind: flowKind,
   );
 }
@@ -1035,6 +1311,7 @@ class _RustApiFake implements RustLibApi {
   int decodeBatchCalls = 0;
   int previousTransactionCount = 0;
   Object? prepareBatchError;
+  Completer<void>? discardCompleter;
   String unifiedAddress = 'u1ownaccountaddressnotmatchingrecipient';
   String transparentAddress = 't1ownaccountaddressnotmatchingrecipient';
 
@@ -1047,6 +1324,7 @@ class _RustApiFake implements RustLibApi {
     decodeBatchCalls = 0;
     previousTransactionCount = 0;
     prepareBatchError = null;
+    discardCompleter = null;
     unifiedAddress = 'u1ownaccountaddressnotmatchingrecipient';
     transparentAddress = 't1ownaccountaddressnotmatchingrecipient';
   }
@@ -1057,6 +1335,7 @@ class _RustApiFake implements RustLibApi {
     required String sendFlowId,
   }) async {
     discardCalls.add((proposalId, sendFlowId));
+    await discardCompleter?.future;
   }
 
   @override

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:zcash_wallet/src/features/address_book/providers/address_book_pr
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
 import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
 import 'package:zcash_wallet/src/features/send/screens/send_screen.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
 import 'package:zcash_wallet/src/features/send/services/send_proving_key_warmup.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
@@ -113,6 +114,78 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('send_review_button')), findsOneWidget);
+  });
+
+  testWidgets('preserves ZIP-321 memo whitespace when proposing send', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    const rawMemo = '  Donation note  ';
+    await tester.pumpWidget(
+      _sendHarness(
+        prefill: const SendPrefillArgs(
+          id: 'zip321-whitespace',
+          source: 'zcash-uri',
+          address: _shieldedAddress,
+          amountText: '1.25',
+          memoText: rawMemo,
+          preserveMemoText: true,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('send_review_button')));
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump();
+
+    expect(rustApi.proposeSendCalls, 1);
+    expect(rustApi.lastProposeMemo, rawMemo);
+  });
+
+  testWidgets('keeps ZIP-321 memo whitespace when the memo field is focused', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    const rawMemo = '  Donation note  ';
+    await tester.pumpWidget(
+      _sendHarness(
+        prefill: const SendPrefillArgs(
+          id: 'zip321-whitespace-focus',
+          source: 'zcash-uri',
+          address: _shieldedAddress,
+          amountText: '1.25',
+          memoText: rawMemo,
+          preserveMemoText: true,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+
+    // Clicking into the memo field moves the caret, which notifies the
+    // controller without changing a single character. That must not count as
+    // the user editing the memo away from the link's exact text.
+    await tester.tap(find.byKey(const ValueKey('send_memo_field')));
+    await tester.pumpAndSettle();
+
+    expect(find.text(rawMemo), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('send_review_button')));
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump();
+
+    expect(rustApi.proposeSendCalls, 1);
+    expect(rustApi.lastProposeMemo, rawMemo);
   });
 
   testWidgets('contacts label fills the send address from zcash contacts', (
@@ -903,6 +976,62 @@ void main() {
     expect(rustApi.proposeSendCalls, 0);
   });
 
+  testWidgets('an address for another network says so, and blocks review', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(_sendHarness());
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      _editableIn('send_address_field'),
+      _otherNetworkAddress,
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      rustApi.lastValidateNetwork,
+      kZcashDefaultNetworkName,
+      reason: 'validation has to be asked about the network we actually pay on',
+    );
+    expect(find.text(kWrongNetworkAddressMessage), findsOneWidget);
+    expect(
+      find.text('Invalid address'),
+      findsNothing,
+      reason: 'the address is well-formed, so "invalid" would misdirect',
+    );
+
+    await tester.enterText(_editableIn('send_amount_field'), '0.5');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('send_review_button')));
+    await tester.pumpAndSettle();
+
+    expect(
+      rustApi.proposeSendCalls,
+      0,
+      reason: 'review stays gated exactly as for any unusable address',
+    );
+  });
+
+  testWidgets('a malformed address keeps the plain invalid copy', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(_sendHarness());
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      _editableIn('send_address_field'),
+      _malformedAddress,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Invalid address'), findsOneWidget);
+    expect(find.text(kWrongNetworkAddressMessage), findsNothing);
+  });
+
   testWidgets('fee-specific balance error copy is preserved', (tester) async {
     await _setDesktopViewport(tester);
 
@@ -1159,6 +1288,106 @@ void main() {
       contains('6 for funds received from others'),
     );
   });
+
+  // The desktop mirror of mobile_send_screen_test's request-framing group.
+  // `_activePaymentRequest` decides whether the review screen says "Requested
+  // by <label>", and the label is attacker-controlled: it must not survive
+  // being pointed at a recipient the request never named.
+  group('payment-request framing on the desktop composer', () {
+    Future<SendReviewArgs?> pumpAndReview(
+      WidgetTester tester, {
+      required SendPrefillArgs prefill,
+      Future<void> Function(WidgetTester tester)? edit,
+    }) async {
+      await _setDesktopViewport(tester);
+      SendReviewArgs? captured;
+
+      await tester.pumpWidget(
+        _sendHarness(prefill: prefill, onReviewArgs: (args) => captured = args),
+      );
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+
+      if (edit != null) {
+        await edit(tester);
+        await tester.pump(const Duration(milliseconds: 500));
+        await tester.pumpAndSettle();
+      }
+
+      await tester.tap(find.byKey(const ValueKey('send_review_button')));
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pumpAndSettle();
+
+      return captured;
+    }
+
+    const request = SendPrefillArgs(
+      id: 'payment-uri-framing',
+      source: kPaymentUriPrefillSource,
+      address: _shieldedAddress,
+      amountText: '1.25',
+      label: 'Acme coffee',
+    );
+
+    testWidgets('an accepted request reaches review as a request', (
+      tester,
+    ) async {
+      final args = await pumpAndReview(tester, prefill: request);
+
+      expect(args, isNotNull);
+      expect(args!.isPaymentRequest, isTrue);
+      expect(args.requestedBy, 'Acme coffee');
+      expect(args.requestedAmountZatoshi, BigInt.from(125000000));
+      expect(args.amountZatoshi, BigInt.from(125000000));
+    });
+
+    testWidgets('the framing survives editing the amount', (tester) async {
+      final args = await pumpAndReview(
+        tester,
+        prefill: request,
+        edit: (tester) async {
+          await tester.enterText(_editableIn('send_amount_field'), '0.5');
+        },
+      );
+
+      expect(args, isNotNull);
+      expect(args!.isPaymentRequest, isTrue);
+      expect(args.requestedBy, 'Acme coffee');
+      expect(
+        args.requestedAmountZatoshi,
+        BigInt.from(125000000),
+        reason: 'the review states what was asked for beside what is sent',
+      );
+      expect(args.amountZatoshi, BigInt.from(50000000));
+    });
+
+    testWidgets('retyping the recipient drops the framing', (tester) async {
+      // Otherwise the review says "Requested by Acme coffee" over an address
+      // that merchant never named — an attacker-controlled label attached to
+      // an unrelated recipient.
+      final args = await pumpAndReview(
+        tester,
+        prefill: request,
+        edit: (tester) async {
+          await tester.enterText(
+            _editableIn('send_address_field'),
+            _otherShieldedAddress,
+          );
+        },
+      );
+
+      expect(args, isNotNull);
+      expect(args!.address, _otherShieldedAddress);
+      expect(args.isPaymentRequest, isFalse);
+      expect(args.requestedBy, isNull);
+      expect(args.requestedAmountZatoshi, isNull);
+    });
+  });
 }
 
 const _figmaModalSurfaceShadows = [
@@ -1209,6 +1438,7 @@ Widget _sendHarness({
       const IronwoodHomeMigrationCtaState.hidden(),
   _FakeSyncNotifier? syncNotifier,
   void Function()? warmProvingKey,
+  void Function(SendReviewArgs?)? onReviewArgs,
 }) {
   final router = GoRouter(
     initialLocation: '/send',
@@ -1217,7 +1447,13 @@ Widget _sendHarness({
         path: '/send',
         builder: (_, _) => SendScreen(prefill: prefill),
       ),
-      GoRoute(path: '/send/review', builder: (_, _) => const SizedBox.shrink()),
+      GoRoute(
+        path: '/send/review',
+        builder: (_, state) {
+          onReviewArgs?.call(state.extra as SendReviewArgs?);
+          return const SizedBox.shrink();
+        },
+      ),
     ],
   );
 
@@ -1439,6 +1675,7 @@ class _TestZecUsdPriceNotifier extends Notifier<double?> {
 
 class _RustApiFake implements RustLibApi {
   int proposeSendCalls = 0;
+  String? lastValidateNetwork;
   int estimateSendMaxCalls = 0;
   String? lastProposeToAddress;
   String? lastProposeMemo;
@@ -1447,6 +1684,7 @@ class _RustApiFake implements RustLibApi {
   String? lastEstimateSendMaxMemo;
 
   void reset() {
+    lastValidateNetwork = null;
     proposeSendCalls = 0;
     estimateSendMaxCalls = 0;
     lastProposeToAddress = null;
@@ -1461,8 +1699,27 @@ class _RustApiFake implements RustLibApi {
     required String address,
     required String network,
   }) async {
+    lastValidateNetwork = network;
+    if (address == _otherNetworkAddress) {
+      return const AddressValidationResult(
+        isValid: false,
+        addressType: 'unified',
+        wrongNetwork: true,
+      );
+    }
+    if (address == _malformedAddress) {
+      return const AddressValidationResult(
+        isValid: false,
+        addressType: 'invalid',
+        wrongNetwork: false,
+      );
+    }
     if (address == _texAddress) {
-      return const AddressValidationResult(isValid: true, addressType: 'tex', wrongNetwork: false);
+      return const AddressValidationResult(
+        isValid: true,
+        addressType: 'tex',
+        wrongNetwork: false,
+      );
     }
     if (address == _transparentAddress) {
       return const AddressValidationResult(
@@ -1471,7 +1728,11 @@ class _RustApiFake implements RustLibApi {
         wrongNetwork: false,
       );
     }
-    return const AddressValidationResult(isValid: true, addressType: 'unified', wrongNetwork: false);
+    return const AddressValidationResult(
+      isValid: true,
+      addressType: 'unified',
+      wrongNetwork: false,
+    );
   }
 
   @override
@@ -1531,5 +1792,16 @@ class _RustApiFake implements RustLibApi {
 
 const _shieldedAddress =
     'u1testshieldedaddress000000000000000000000000000000000000000000000000000';
+
+/// A second address the fake validates as an ordinary unified recipient, so a
+/// test can retype the recipient away from the one a request named.
+const _otherShieldedAddress =
+    'u1othershieldedaddress00000000000000000000000000000000000000000000000000';
 const _transparentAddress = 't1transparentdestination0000000000000000000';
 const _texAddress = 'tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte';
+
+/// A real address that this build cannot pay because it belongs to another
+/// Zcash network — Rust reports it as not-valid plus `wrongNetwork`.
+const _otherNetworkAddress =
+    'utest1testnetshieldedaddress0000000000000000000000000000000000000000000';
+const _malformedAddress = 'not-an-address';

--- a/test/features/send/send_status_screen_test.dart
+++ b/test/features/send/send_status_screen_test.dart
@@ -89,6 +89,21 @@ void main() {
     expect(_sendStatusTerminal(tester), isTrue);
   });
 
+  testWidgets('a whitespace-only memo keeps its Message row on the receipt', (
+    tester,
+  ) async {
+    rustApi.executeResult = _executeResult(status: 'broadcasted');
+
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_harness(_reviewArgs(memo: '   ')));
+    await tester.pump();
+    await _flushBroadcast(tester);
+
+    expect(find.text('Sent successfully'), findsOneWidget);
+    expect(find.text('Message'), findsOneWidget);
+    expect(find.text('Whitespace only'), findsOneWidget);
+  });
+
   testWidgets('donation status keeps every sidebar section inactive', (
     tester,
   ) async {

--- a/test/features/send/send_status_screen_test.dart
+++ b/test/features/send/send_status_screen_test.dart
@@ -2,6 +2,7 @@
 // path resolution and Sapling params status checks.
 // ignore_for_file: depend_on_referenced_packages
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -228,6 +229,55 @@ void main() {
     );
     expect(_sendStatusTerminal(tester), isTrue);
   });
+
+  testWidgets(
+    'failed outcome releases an unconsumed proposal before going terminal',
+    (tester) async {
+      // The software send's missing-mnemonic branch: the broadcast fails and
+      // Rust still owns the proposal. It is `!Platform.isMacOS`-only in
+      // `runSendBroadcast`, so the outcome is injected rather than provoked.
+      final discardGate = Completer<void>();
+      rustApi.discardGate = discardGate;
+
+      await _setDesktopViewport(tester);
+      await tester.pumpWidget(
+        _harness(
+          _reviewArgs(),
+          broadcastRunner:
+              ({
+                required ref,
+                required args,
+                keystone,
+                required confirmSaplingParamsDownload,
+                shouldAbort,
+              }) async => const SendBroadcastOutcome(
+                phase: SendBroadcastPhase.failed,
+                proposalConsumed: false,
+                error: 'Mnemonic not found for the proposal account.',
+              ),
+        ),
+      );
+      await tester.pump();
+      await _flushBroadcast(tester);
+
+      // The receipt already reads as failed, but the proposal — and with it
+      // the input lock a parked `zcash:` request would propose against — is
+      // still held, so the drain must not be told the send is safe to leave.
+      expect(find.text('Send failed'), findsOneWidget);
+      expect(rustApi.discardCalls, [(BigInt.one, 'test-send-flow')]);
+      expect(_sendStatusTerminal(tester), isFalse);
+
+      discardGate.complete();
+      await _flushBroadcast(tester);
+
+      expect(_sendStatusTerminal(tester), isTrue);
+      // Leaving the receipt must not release the proposal a second time.
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+      expect(find.text('home-route'), findsOneWidget);
+      expect(rustApi.discardCalls, hasLength(1));
+    },
+  );
 
   testWidgets('blocked pop routes home instead of popping', (tester) async {
     rustApi.executeResult = _executeResult(status: 'broadcasted');
@@ -743,6 +793,7 @@ Widget _harness(
   SendReviewArgs args, {
   KeystoneBroadcastArgs? keystone,
   bool isHardware = false,
+  SendStatusBroadcastRunner? broadcastRunner,
 }) {
   final router = GoRouter(
     initialLocation: '/send/status',
@@ -751,7 +802,11 @@ Widget _harness(
       GoRoute(path: '/send', builder: (_, _) => const Text('send-route')),
       GoRoute(
         path: '/send/status',
-        builder: (_, _) => SendStatusScreen(args: args, keystone: keystone),
+        builder: (_, _) => SendStatusScreen(
+          args: args,
+          keystone: keystone,
+          broadcastRunner: broadcastRunner,
+        ),
       ),
     ],
   );
@@ -899,6 +954,10 @@ class _RustApiFake implements RustLibApi {
   Object? executeError;
   StoreAndBroadcastPcztsResult? storeResult;
   int discardFailuresRemaining = 0;
+
+  /// Holds `discardProposal` open so a test can read the terminal flag while
+  /// the release is still in flight.
+  Completer<void>? discardGate;
   int macosExecuteCalls = 0;
   int mnemonicExecuteCalls = 0;
   String unifiedAddress = 'u1ownaccountaddressnotmatchingrecipient';
@@ -913,6 +972,7 @@ class _RustApiFake implements RustLibApi {
     executeError = null;
     storeResult = null;
     discardFailuresRemaining = 0;
+    discardGate = null;
     macosExecuteCalls = 0;
     mnemonicExecuteCalls = 0;
     unifiedAddress = 'u1ownaccountaddressnotmatchingrecipient';
@@ -931,6 +991,8 @@ class _RustApiFake implements RustLibApi {
     required String sendFlowId,
   }) async {
     discardCalls.add((proposalId, sendFlowId));
+    final gate = discardGate;
+    if (gate != null) await gate.future;
     if (discardFailuresRemaining > 0) {
       discardFailuresRemaining--;
       throw Exception('transient wallet DB unlock failure');

--- a/test/features/send/send_status_screen_test.dart
+++ b/test/features/send/send_status_screen_test.dart
@@ -68,6 +68,8 @@ void main() {
     expect(find.text('Send in progress...'), findsOneWidget);
     expect(find.text('In progress'), findsOneWidget);
     expect(find.text('Tx ID'), findsNothing);
+    // An in-flight send must stay blocked for arriving payment URIs.
+    expect(_sendStatusTerminal(tester), isFalse);
 
     await _flushBroadcast(tester);
 
@@ -83,6 +85,7 @@ void main() {
     expect(rustApi.discardCalls, isEmpty);
     expect(rustApi.macosExecuteCalls, Platform.isMacOS ? 1 : 0);
     expect(rustApi.mnemonicExecuteCalls, Platform.isMacOS ? 0 : 1);
+    expect(_sendStatusTerminal(tester), isTrue);
   });
 
   testWidgets('donation status keeps every sidebar section inactive', (
@@ -195,6 +198,8 @@ void main() {
     expect(find.text(truncatedTxid(_txid)), findsOneWidget);
     expect(find.textContaining("didn't reach the network"), findsOneWidget);
     expect(rustApi.discardCalls, isEmpty);
+    // A pending broadcast still renders as in progress, so it is not terminal.
+    expect(_sendStatusTerminal(tester), isFalse);
   });
 
   testWidgets('failed broadcast shows the failed layout with the reason', (
@@ -221,6 +226,7 @@ void main() {
           .where((icon) => icon.name == AppIcons.uturnUp),
       hasLength(1),
     );
+    expect(_sendStatusTerminal(tester), isTrue);
   });
 
   testWidgets('blocked pop routes home instead of popping', (tester) async {
@@ -232,10 +238,14 @@ void main() {
     await _flushBroadcast(tester);
     await tester.pumpAndSettle();
 
+    expect(_sendStatusTerminal(tester), isTrue);
+
     await tester.binding.handlePopRoute();
     await tester.pumpAndSettle();
 
     expect(find.text('home-route'), findsOneWidget);
+    // Leaving the receipt releases the flag again.
+    expect(_sendStatusTerminal(tester), isFalse);
   });
 
   testWidgets('Keystone broadcast extracts the PCZT pair and succeeds', (
@@ -675,6 +685,16 @@ Future<void> _setDesktopViewport(WidgetTester tester) async {
 /// params status) resolve — they cannot complete inside the FakeAsync test
 /// zone on their own. Bounded pumps afterwards because the in-progress
 /// loader animation repeats forever (pumpAndSettle would hang).
+/// The "safe to leave this receipt" flag the payment-URI drain reads. Taken
+/// from the MaterialApp element so it stays readable after the status screen
+/// itself is gone.
+bool _sendStatusTerminal(WidgetTester tester) {
+  return ProviderScope.containerOf(
+    tester.element(find.byType(MaterialApp)),
+    listen: false,
+  ).read(sendStatusTerminalProvider);
+}
+
 Future<void> _flushBroadcast(WidgetTester tester) async {
   // Several rounds because the chain interleaves real-IO awaits with
   // fake-zone microtasks that only run during pump.

--- a/test/features/send/send_status_terminal_notifier_test.dart
+++ b/test/features/send/send_status_terminal_notifier_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+
+/// `_IncomingLinkHost` re-runs the payment-URI drain on this flag's
+/// false → true edge and nowhere else, so what the notifier publishes when a
+/// receipt is left decides whether a `zcash:` link parked behind a running
+/// send ever gets delivered.
+void main() {
+  late ProviderContainer container;
+  late SendStatusTerminalNotifier notifier;
+  late List<bool> published;
+
+  setUp(() {
+    container = ProviderContainer();
+    published = [];
+    container.listen<bool>(
+      sendStatusTerminalProvider,
+      (_, next) => published.add(next),
+    );
+    notifier = container.read(sendStatusTerminalProvider.notifier);
+  });
+
+  tearDown(() => container.dispose());
+
+  Future<void> flushMicrotasks() => Future<void>.delayed(Duration.zero);
+
+  test('a receipt left before its send went terminal publishes terminal, '
+      'then clears', () async {
+    // A broadcast started and came back pending; the user left the receipt.
+    notifier.reset();
+    notifier.resetAfterNavigation();
+    await flushMicrotasks();
+
+    expect(
+      published,
+      [true, false],
+      reason:
+          'the drain listener needs the false → true edge to re-run, and '
+          'the next send needs a clear flag',
+    );
+    expect(container.read(sendStatusTerminalProvider), isFalse);
+  });
+
+  test('a receipt that already went terminal only clears', () async {
+    notifier.reset();
+    notifier.markTerminal();
+    published.clear();
+
+    notifier.resetAfterNavigation();
+    await flushMicrotasks();
+
+    expect(published, [false]);
+  });
+
+  test('a departing receipt leaves a newer send\'s flag alone', () async {
+    notifier.reset();
+    notifier.resetAfterNavigation();
+    // A new status screen started its broadcast before the microtask ran.
+    notifier.reset();
+    await flushMicrotasks();
+
+    expect(published, isEmpty);
+    expect(container.read(sendStatusTerminalProvider), isFalse);
+  });
+}

--- a/test/features/settings/settings_viewing_key_screen_test.dart
+++ b/test/features/settings/settings_viewing_key_screen_test.dart
@@ -37,6 +37,19 @@ const _accountState = AccountState(
 );
 
 void main() {
+  setUp(() {
+    // Copying a secret schedules the real one-minute clipboard auto-clear
+    // timer, which would outlive the widget tree. Hold the expiry open for the
+    // duration of each test; the clearing itself is covered by
+    // test/core/clipboard/sensitive_clipboard_test.dart.
+    SensitiveClipboard.debugExpirationDelay = (_) => Completer<void>().future;
+  });
+
+  tearDown(() {
+    SensitiveClipboard.debugExpirationDelay = null;
+    SensitiveClipboard.debugCancelPendingExpiration();
+  });
+
   testWidgets(
     'reveals the requested account viewing key without making it active',
     (tester) async {
@@ -48,7 +61,6 @@ void main() {
         initiallySafe: true,
       );
       addTearDown(privacyController.dispose);
-      addTearDown(SensitiveClipboard.debugCancelPendingExpiration);
       final requestedUuids = <String>[];
 
       final copiedText = <String>[];
@@ -119,10 +131,6 @@ void main() {
       await tester.pump();
       expect(copiedText, [_ufvk]);
       expect(find.text('Copied'), findsOneWidget);
-      // Cancel the SensitiveClipboard fallback expiry timer so it does not
-      // outlive the widget tree (the fallback path creates a 1-minute timer
-      // on non-iOS/Android platforms, which the test framework would flag).
-      SensitiveClipboard.debugCancelPendingExpiration();
     },
   );
 

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:zcash_wallet/src/core/security/software_wallet_secret.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_busy_surface_provider.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/voting/screens/voting_proposal_detail_screen.dart';
@@ -3631,6 +3632,76 @@ void main() {
       ),
       isTrue,
     );
+  });
+
+  testWidgets('the desktop voting signing panel holds the payment-URI busy '
+      'latch', (tester) async {
+    // The bundle QR in the panel is the one a Keystone camera is reading. The
+    // status screen around it takes no hold, so a payment request still lands
+    // while the vote is merely submitting.
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final round = _roundStatusJson()
+      ..['proposals'] = [
+        _proposalJson(1, 'First proposal', ['Yes', 'No']),
+      ];
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
+    );
+    final recoveryApi = _MutableVotingRecoveryApi();
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _HardwareAccountNotifier.new,
+      activeAccountUuid: () async => 'hardware-1',
+      accountIsHardware: true,
+      hardwareAccountUuids: const {'hardware-1'},
+      recoveryApi: recoveryApi,
+      rust: _VotingStatusRustApi(recoveryApi),
+      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
+    );
+    addTearDown(container.dispose);
+    container
+        .read(
+          votingDraftProvider(
+            const VotingSessionKey(
+              roundId: _roundId,
+              accountUuid: 'hardware-1',
+            ),
+          ).notifier,
+        )
+        .setChoice(1, 0);
+
+    expect(container.read(paymentUriBusySurfaceProvider), 0);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _statusHarness(keystoneScanResult: const [3]),
+      ),
+    );
+    await _pumpUntilFound(tester, find.text('Sign 1 voting bundle'));
+    await tester.pump();
+
+    expect(container.read(paymentUriBusySurfaceProvider), 1);
+
+    // The scan screen is pushed over the status screen, so the panel is still
+    // mounted and the session is still live: the hold stays.
+    await tester.tap(find.text('Scan signature'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('keystone scan route'), findsOneWidget);
+    expect(container.read(paymentUriBusySurfaceProvider), 1);
+
+    // Signing done: the panel goes away and the hold comes back with it.
+    await tester.tap(find.text('Return Signature'));
+    await _pumpUntilFound(tester, find.text('submission confirmed route'));
+    await tester.pump();
+
+    expect(container.read(paymentUriBusySurfaceProvider), 0);
   });
 
   testWidgets('hardware status screen scans Keystone signature and submits', (

--- a/test/features/wallet_link/wallet_link_desktop_screen_busy_surface_test.dart
+++ b/test/features/wallet_link/wallet_link_desktop_screen_busy_surface_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/wallet_link/models/wallet_link_models.dart';
+import 'package:zcash_wallet/src/features/wallet_link/screens/wallet_link_desktop_screen.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+import '../../support/payment_uri_busy_surface_expectations.dart';
+
+/// The pairing QR here is live in the same sense a Keystone signing QR is: a
+/// phone's camera is reading it while the transfer runs. A payment-request
+/// card would scrim it mid-pairing, so the screen holds the latch for its
+/// whole lifetime rather than for one phase of it.
+void main() {
+  testWidgets('the desktop wallet-link screen holds the payment-URI busy '
+      'latch', (tester) async {
+    final container = _container();
+    await expectPaymentUriBusySurfaceHeldWhileMounted(
+      tester,
+      container: container,
+      host: _host(container),
+      // A ready pairing session — the state in which the QR is on screen and
+      // a phone is scanning it.
+      surface: const WalletLinkDesktopScreen(
+        previewState: WalletLinkState(
+          phase: WalletLinkPhase.ready,
+          qrPayload: 'vizor-link-preview-payload',
+          remaining: Duration(minutes: 4),
+        ),
+      ),
+      drainExceptions: true,
+    );
+  });
+}
+
+ProviderContainer _container() {
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap()),
+      syncProvider.overrideWith(FakeSyncNotifier.new),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+Widget Function(Widget) _host(ProviderContainer container) =>
+    (child) => UncontrolledProviderScope(
+      container: container,
+      child: AppTheme(
+        data: AppThemeData.dark,
+        child: MaterialApp(home: Scaffold(body: child)),
+      ),
+    );
+
+const _accountState = AccountState(
+  accounts: [AccountInfo(uuid: 'account-1', name: 'Account1', order: 0)],
+  activeAccountUuid: 'account-1',
+  activeAddress: 'u1walletlink',
+);
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/settings/link-mobile',
+  initialAccountState: _accountState,
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);

--- a/test/providers/payment_request_flow_provider_test.dart
+++ b/test/providers/payment_request_flow_provider_test.dart
@@ -393,12 +393,63 @@ void main() {
     notifier.present(request('u1a'), source: PaymentRequestSource.link);
     await pumpEventQueue();
 
-    final prefill = notifier.edit();
-    await pumpEventQueue();
+    final handoff = await notifier.editHandingBack();
 
-    expect(prefill!.address, 'u1a');
+    expect((handoff as PaymentRequestEditReady).prefill.address, 'u1a');
     expect(container.read(paymentRequestFlowProvider), isNull);
     expect(api.discarded, [BigInt.one]);
+  });
+
+  test('handing the request to the composer completes only once Rust has '
+      'released the proposal', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1a'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    api.discardGate = Completer<void>();
+    var handedBack = false;
+    final pending = notifier.editHandingBack().then((handoff) {
+      handedBack = true;
+      return handoff;
+    });
+    await pumpEventQueue();
+
+    // The card is gone at once; the caller is still waiting on the release.
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(handedBack, isFalse);
+    expect(api.discarded, isEmpty);
+
+    api.discardGate!.complete();
+    final handoff = await pending;
+
+    expect((handoff as PaymentRequestEditReady).prefill.address, 'u1a');
+    expect(api.discarded, [BigInt.one]);
+  });
+
+  test('an edit hand-back overtaken by a newer link opens nothing', () async {
+    final api = _FakeSendApi();
+    final container = makeContainer(api);
+    final notifier = container.read(paymentRequestFlowProvider.notifier);
+
+    notifier.present(request('u1first'), source: PaymentRequestSource.link);
+    await pumpEventQueue();
+
+    api.discardGate = Completer<void>();
+    final pending = notifier.editHandingBack();
+    await pumpEventQueue();
+    expect(container.read(paymentRequestFlowProvider), isNull);
+
+    notifier.present(request('u1second'), source: PaymentRequestSource.link);
+    api.discardGate!.complete();
+    await pumpEventQueue();
+
+    expect(await pending, isA<PaymentRequestEditOvertaken>());
+    final state = container.read(paymentRequestFlowProvider)!;
+    expect(state.prefill.address, 'u1second');
+    expect(state.view.replacedNotice, isTrue);
   });
 
   test('dismiss frees the proposal', () async {

--- a/test/support/payment_uri_busy_surface_expectations.dart
+++ b/test/support/payment_uri_busy_surface_expectations.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_busy_surface_provider.dart';
+
+/// Asserts that [surface] holds `paymentUriBusySurfaceProvider` for exactly as
+/// long as it is mounted: the count is 1 while it is up and back to 0 once it
+/// is gone.
+///
+/// [host] wraps the surface in whatever app shell the screen needs; it is
+/// called again with a placeholder to unmount the surface while keeping the
+/// container (and therefore the count) alive.
+///
+/// [drainExceptions] is for surfaces whose camera preview or Rust calls cannot
+/// run in a widget test. Those failures happen inside the scanner and say
+/// nothing about the latch.
+Future<void> expectPaymentUriBusySurfaceHeldWhileMounted(
+  WidgetTester tester, {
+  required ProviderContainer container,
+  required Widget Function(Widget child) host,
+  required Widget surface,
+  Widget unmounted = const SizedBox.shrink(),
+  bool drainExceptions = false,
+  int settlePumps = 1,
+
+  /// Advanced after the surface is gone, so one-shot timers a torn-down
+  /// signing flow left behind fire inside the test rather than tripping the
+  /// binding's "timer still pending" invariant.
+  Duration postUnmountSettle = Duration.zero,
+}) async {
+  expect(container.read(paymentUriBusySurfaceProvider), 0);
+
+  await tester.pumpWidget(host(surface));
+  for (var i = 0; i < settlePumps; i++) {
+    await tester.pump();
+  }
+  if (drainExceptions) _drainExceptions(tester);
+
+  expect(
+    container.read(paymentUriBusySurfaceProvider),
+    1,
+    reason:
+        'a mounted Keystone signing surface makes the payment-URI '
+        'drain wait instead of covering it with a card',
+  );
+
+  await tester.pumpWidget(host(unmounted));
+  // The release is deferred to a microtask because `dispose` is one of the
+  // places Riverpod forbids a synchronous provider write.
+  await tester.pump();
+  if (drainExceptions) _drainExceptions(tester);
+
+  expect(container.read(paymentUriBusySurfaceProvider), 0);
+
+  if (postUnmountSettle > Duration.zero) {
+    await tester.pump(postUnmountSettle);
+    if (drainExceptions) _drainExceptions(tester);
+  }
+}
+
+void _drainExceptions(WidgetTester tester) {
+  while (tester.takeException() != null) {}
+}

--- a/test/widgetbook/payment_request_use_cases_test.dart
+++ b/test/widgetbook/payment_request_use_cases_test.dart
@@ -1,0 +1,1302 @@
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/mobile/app_mobile_sheet.dart';
+import 'package:zcash_wallet/src/core/layout/mobile/mobile_bottom_safe_area.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/core/widgets/app_profile_picture.dart';
+import 'package:zcash_wallet/src/core/widgets/app_tooltip.dart';
+import 'package:zcash_wallet/src/core/widgets/review_wrap_card.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_card.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_surface.dart';
+import 'package:zcash_wallet/widgetbook/payment_request_use_cases.dart';
+
+void main() {
+  testWidgets('full use case renders the whole request', (tester) async {
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Payment request'), findsOneWidget);
+    expect(find.text('Requester'), findsOneWidget);
+    expect(find.text('Blue Door Coffee'), findsOneWidget);
+    expect(find.text('Requested by Blue Door Coffee'), findsNothing);
+    expect(find.textContaining('From a link'), findsNothing);
+    expect(find.text('0.5 ZEC'), findsOneWidget);
+    expect(find.text('u195091 ... 190591'), findsOneWidget);
+    expect(find.text('Show full address'), findsOneWidget);
+    expect(find.text('Shielded'), findsOneWidget);
+    expect(find.text('Transaction memo'), findsOneWidget);
+    expect(find.text('Message'), findsNothing);
+    expect(find.text('Note'), findsNothing);
+    // Requester notes are progressive disclosure and start hidden.
+    expect(find.text('Note from requester'), findsNothing);
+    expect(_key('payment_request_requester_note'), findsNothing);
+    expect(find.text('Review'), findsOneWidget);
+    expect(find.text('Edit'), findsOneWidget);
+    // Desktop refuses through the header's close, not a third pill in the
+    // action row.
+    expect(find.text('Cancel'), findsNothing);
+    expect(find.byKey(const ValueKey('payment_request_close')), findsOneWidget);
+  });
+
+  testWidgets('the only help affordance is the requester caveat', (
+    tester,
+  ) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildPaymentRequestFullUseCase, _desktopSize),
+      (buildMobilePaymentRequestFullUseCase, _mobileSize),
+    ]) {
+      await _pumpUseCase(tester, builder, size: size);
+
+      expect(tester.takeException(), isNull);
+      // The requester name is text the link supplied, so it carries the one
+      // ⓘ on the card. Transaction content still carries none.
+      expect(find.byType(AppTooltip), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byKey(const ValueKey('payment_request_requester_group')),
+          matching: find.byType(AppTooltip),
+        ),
+        findsOneWidget,
+      );
+    }
+  });
+
+  testWidgets('the requester help shows the caveat without toggling', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    expect(_key('payment_request_requester_note'), findsNothing);
+
+    await tester.tap(_key('payment_request_requester_help'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        "Name supplied by the payment link. Vizor can't verify who sent it.",
+      ),
+      findsOneWidget,
+    );
+    expect(
+      _key('payment_request_requester_note'),
+      findsNothing,
+      reason: 'the help affordance must not open the requester disclosure',
+    );
+
+    // The rest of the summary row still toggles the group.
+    await tester.tap(_key('payment_request_requester_toggle'));
+    await tester.pumpAndSettle();
+    expect(_key('payment_request_requester_note'), findsOneWidget);
+  });
+
+  testWidgets('a note-only requester group carries no name caveat', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestNoteOnlyUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(_key('payment_request_requester_help'), findsNothing);
+    expect(find.byType(AppTooltip), findsNothing);
+  });
+
+  testWidgets('the title and requester group stay separate', (tester) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildPaymentRequestFullUseCase, _desktopSize),
+      (buildMobilePaymentRequestFullUseCase, _mobileSize),
+    ]) {
+      await _pumpUseCase(tester, builder, size: size);
+
+      expect(tester.takeException(), isNull);
+      expect(_titleText(tester), 'Payment request');
+      expect(
+        find.byKey(const ValueKey('payment_request_requester_group')),
+        findsOneWidget,
+      );
+      expect(find.text('Requested by Blue Door Coffee'), findsNothing);
+      expect(
+        find.byKey(const ValueKey('payment_request_eyebrow')),
+        findsNothing,
+      );
+    }
+  });
+
+  testWidgets('requester note expands from the collapsed requester group', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    expect(_key('payment_request_requester_note'), findsNothing);
+    expect(find.bySemanticsLabel('Show requester details'), findsOneWidget);
+
+    await tester.tap(_key('payment_request_requester_toggle'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Note from requester'), findsOneWidget);
+    expect(_key('payment_request_requester_note'), findsOneWidget);
+    expect(find.bySemanticsLabel('Hide requester details'), findsOneWidget);
+    semantics.dispose();
+  });
+
+  testWidgets('requester and memo disclosures expose one semantics action', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    final requester = tester.getSemantics(
+      find.bySemanticsLabel('Show requester details'),
+    );
+    final memo = tester.getSemantics(
+      find.bySemanticsLabel('Expand transaction memo'),
+    );
+
+    expect(requester.childrenCountInTraversalOrder, 0);
+    expect(memo.childrenCountInTraversalOrder, 0);
+    semantics.dispose();
+  });
+
+  testWidgets('expanded memo is not announced by its disclosure twice', (
+    tester,
+  ) async {
+    const memoText =
+        'Table 4 — two flat whites and a pastry. Thanks for stopping by, '
+        'see you next week.';
+    final semantics = tester.ensureSemantics();
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    final collapsed = tester.getSemantics(
+      find.bySemanticsLabel('Expand transaction memo'),
+    );
+    expect(collapsed.value, 'Transaction memo, $memoText');
+
+    await tester.tap(_key('payment_request_memo_toggle'));
+    await tester.pumpAndSettle();
+
+    final expanded = tester.getSemantics(
+      find.bySemanticsLabel('Collapse transaction memo'),
+    );
+    expect(expanded.value, isEmpty);
+    semantics.dispose();
+  });
+
+  testWidgets('a very long requester note scrolls inside its existing card', (
+    tester,
+  ) async {
+    final note = List.filled(12000, 'a').join();
+    await _pumpUseCase(
+      tester,
+      (_) => PaymentRequestSurface(
+        layout: PaymentRequestLayout.mobile,
+        request: PaymentRequestView(
+          source: PaymentRequestSource.link,
+          requesterLabel: 'Blue Door Coffee',
+          amountZecText: '0.5 ZEC',
+          address:
+              'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+              '73d57f73c6dc05121591a83861cd190591',
+          note: note,
+        ),
+        onContinue: () {},
+        onEdit: () {},
+        onCancel: () {},
+      ),
+      size: _mobileSize,
+    );
+
+    await tester.tap(_key('payment_request_requester_toggle'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Review'), findsOneWidget);
+    expect(find.text('Edit'), findsOneWidget);
+    expect(_requesterNoteMaxScrollExtent(tester), greaterThan(0));
+    expect(
+      tester
+          .widget<SingleChildScrollView>(
+            find.byKey(kPaymentRequestRequesterNoteScrollViewKey),
+          )
+          .padding,
+      const EdgeInsetsDirectional.only(end: kPaymentRequestGutter),
+      reason: 'the overlay scrollbar needs its own trailing gutter',
+    );
+    final noteViewport = tester.getRect(
+      find.byKey(kPaymentRequestRequesterNoteScrollViewKey),
+    );
+    final noteText = tester.getRect(_key('payment_request_requester_note'));
+    expect(
+      noteViewport.right - noteText.right,
+      greaterThanOrEqualTo(kPaymentRequestGutter),
+    );
+
+    await tester.drag(
+      find.byKey(kPaymentRequestRequesterNoteScrollViewKey),
+      const Offset(0, -80),
+    );
+    await tester.pumpAndSettle();
+
+    expect(_requesterNoteScrollOffset(tester), greaterThan(0));
+  });
+
+  testWidgets('a requester name without a note is not an empty accordion', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestContactUseCase);
+
+    expect(_key('payment_request_requester_group'), findsOneWidget);
+    expect(_key('payment_request_requester_toggle'), findsNothing);
+    expect(find.text('Note from requester'), findsNothing);
+  });
+
+  testWidgets('the request rows use the send review row treatment', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    expect(tester.takeException(), isNull);
+    // Requester metadata and transaction content are separate visual groups.
+    expect(_key('payment_request_requester_group'), findsOneWidget);
+    expect(_key('payment_request_transaction_content'), findsOneWidget);
+    expect(find.byType(ReviewWrapCard), findsNWidgets(2));
+    expect(find.byType(ReviewWrapDivider), findsOneWidget);
+
+    final labelStyle = AppTypography.bodyMediumStrong;
+    for (final label in const ['To', 'Transaction memo']) {
+      final text = tester.widget<Text>(find.text(label));
+      expect(text.style!.fontSize, labelStyle.fontSize, reason: label);
+      expect(text.style!.fontWeight, labelStyle.fontWeight, reason: label);
+      // One colour step off the value beside it, never a tiny muted caption.
+      expect(
+        text.style!.color,
+        AppThemeData.light.colors.text.secondary,
+        reason: label,
+      );
+    }
+  });
+
+  testWidgets('disclosures do not add a hover fill', (tester) async {
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer();
+
+    for (final key in const [
+      'payment_request_requester_toggle',
+      'payment_request_memo_toggle',
+    ]) {
+      final button = _key(key);
+      await mouse.moveTo(tester.getCenter(button));
+      await tester.pump();
+
+      final decoration =
+          tester
+                  .widget<AnimatedContainer>(
+                    find.descendant(
+                      of: button,
+                      matching: find.byType(AnimatedContainer),
+                    ),
+                  )
+                  .decoration!
+              as ShapeDecoration;
+      final container = tester.widget<AnimatedContainer>(
+        find.descendant(of: button, matching: find.byType(AnimatedContainer)),
+      );
+      expect(
+        decoration.color,
+        AppThemeData.light.colors.background.ground.withValues(alpha: 0),
+      );
+      expect(
+        container.padding,
+        const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+      );
+    }
+  });
+
+  testWidgets('the full address expands inside the card, not out of it', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    expect(find.text('u195091 ... 190591'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('payment_request_address_chunks')),
+      findsNothing,
+    );
+
+    await tester.tap(find.text('Show full address'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Hide full address'), findsOneWidget);
+    expect(find.text('Show full address'), findsNothing);
+    expect(find.text('u195091 ... 190591'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('payment_request_address_chunks')),
+      findsOneWidget,
+    );
+    // 5-character groups, taken from the verify-address grid.
+    expect(find.text('u1950'), findsOneWidget);
+    expect(find.text('591'), findsOneWidget);
+    // Nothing left the card: the actions are still on screen.
+    expect(find.text('Review'), findsOneWidget);
+
+    await tester.tap(find.text('Hide full address'));
+    await tester.pumpAndSettle();
+    expect(find.text('Show full address'), findsOneWidget);
+    expect(find.text('u195091 ... 190591'), findsOneWidget);
+  });
+
+  testWidgets('the expanded-address use cases render both lanes', (
+    tester,
+  ) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildPaymentRequestAddressExpandedUseCase, _desktopSize),
+      (buildMobilePaymentRequestAddressExpandedUseCase, _mobileSize),
+    ]) {
+      await _pumpUseCase(tester, builder, size: size);
+      expect(tester.takeException(), isNull);
+      expect(find.text('Hide full address'), findsOneWidget);
+      expect(find.text('u1950'), findsOneWidget);
+    }
+  });
+
+  testWidgets('minimal use case renders transaction content only', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestMinimalUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Blue Door Coffee'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('payment_request_requester_group')),
+      findsNothing,
+    );
+    expect(find.text('Transaction content'), findsOneWidget);
+    expect(_key('payment_request_transaction_content'), findsOneWidget);
+    expect(find.text('Message'), findsNothing);
+    expect(find.text('Note'), findsNothing);
+    expect(find.byType(ReviewWrapDivider), findsNothing);
+    expect(find.text('u195091 ... 190591'), findsOneWidget);
+  });
+
+  testWidgets('a long message expands in place and collapses again', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestLongValuesUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Collapse'), findsNothing);
+
+    await _tapRow(tester, 'payment_request_memo');
+    expect(find.text('Collapse'), findsOneWidget);
+
+    await _tapRow(tester, 'payment_request_memo');
+    expect(find.text('Collapse'), findsNothing);
+  });
+
+  testWidgets('the amount stays pinned above the scrolling details', (
+    tester,
+  ) async {
+    await _pumpUseCase(
+      tester,
+      buildMobilePaymentRequestLongValuesExpandedUseCase,
+      size: _mobileSize,
+    );
+
+    final amount = _key('payment_request_amount');
+    expect(amount, findsOneWidget);
+    final before = tester.getRect(amount);
+
+    await tester.drag(
+      find.byKey(kPaymentRequestScrollViewKey),
+      const Offset(0, -2000),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    // Scrolled to the very end, and the amount has not moved a pixel.
+    expect(_scrollOffset(tester), greaterThan(0));
+    expect(amount, findsOneWidget);
+    expect(tester.getRect(amount), before);
+    // The pinned amount takes the serif step above the review screens'.
+    expect(
+      tester.widget<Text>(amount).style!.fontSize,
+      AppTypography.displayLarge.fontSize,
+    );
+  });
+
+  // ─── The scroll region ─────────────────────────────────────────────
+
+  testWidgets('an expanded message survives scrolling the region', (
+    tester,
+  ) async {
+    await _pumpUseCase(
+      tester,
+      buildMobilePaymentRequestLongValuesUseCase,
+      size: _mobileSize,
+    );
+
+    await _tapRow(tester, 'payment_request_memo');
+    expect(find.text('Collapse'), findsOneWidget);
+
+    // The scroll used to reparent the region's subtree, which discarded the
+    // expansion state along with every other `State` under it.
+    await tester.drag(
+      find.byKey(kPaymentRequestScrollViewKey),
+      const Offset(0, -200),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Collapse'), findsOneWidget);
+    // The scroll actually moved, and stayed moved.
+    expect(_scrollOffset(tester), greaterThan(0));
+  });
+
+  testWidgets('an expanded full address survives scrolling the region', (
+    tester,
+  ) async {
+    await _pumpUseCase(
+      tester,
+      buildMobilePaymentRequestLongValuesUseCase,
+      size: _mobileSize,
+    );
+
+    await tester.tap(find.text('Show full address'));
+    await tester.pumpAndSettle();
+    expect(find.text('Hide full address'), findsOneWidget);
+
+    await tester.drag(
+      find.byKey(kPaymentRequestScrollViewKey),
+      const Offset(0, -150),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Hide full address'), findsOneWidget);
+  });
+
+  testWidgets('the scrollbar tracks the region it lives in', (tester) async {
+    await _pumpUseCase(
+      tester,
+      buildMobilePaymentRequestLongValuesUseCase,
+      size: _mobileSize,
+    );
+
+    final scrollbar = tester.widget<RawScrollbar>(
+      find.byKey(kPaymentRequestScrollbarKey),
+    );
+    final scrollView = tester.widget<SingleChildScrollView>(
+      find.byKey(kPaymentRequestScrollViewKey),
+    );
+
+    expect(tester.takeException(), isNull);
+    // One controller, shared: a scrollbar attached to anything else would
+    // track a scroll the user is not performing.
+    expect(scrollbar.controller, isNotNull);
+    expect(identical(scrollbar.controller, scrollView.controller), isTrue);
+    // It rides inside the details card, not outside it.
+    final region = tester.getRect(find.byKey(kPaymentRequestScrollbarKey));
+    final view = tester.getRect(find.byKey(kPaymentRequestScrollViewKey));
+    final card = tester.getRect(_transactionDetailsCard());
+    expect(region.right, lessThanOrEqualTo(view.right + 0.5));
+    expect(region.left, greaterThanOrEqualTo(card.left - 0.5));
+    expect(region.right, lessThanOrEqualTo(card.right + 0.5));
+    expect(region.top, greaterThanOrEqualTo(card.top - 0.5));
+    expect(region.bottom, lessThanOrEqualTo(card.bottom + 0.5));
+  });
+
+  testWidgets('the details card is a fixed frame its content scrolls inside', (
+    tester,
+  ) async {
+    await _pumpUseCase(
+      tester,
+      buildMobilePaymentRequestLongValuesExpandedUseCase,
+      size: _mobileSize,
+    );
+
+    final card = _transactionDetailsCard();
+    final before = tester.getRect(card);
+    expect(_maxScrollExtent(tester), greaterThan(0));
+
+    await tester.drag(
+      find.byKey(kPaymentRequestScrollViewKey),
+      const Offset(0, -200),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    // The content moved; the frame around it did not.
+    expect(_scrollOffset(tester), greaterThan(0));
+    expect(tester.getRect(card), before);
+  });
+
+  testWidgets('short content leaves the frame unscrollable and hugged', (
+    tester,
+  ) async {
+    await _pumpUseCase(
+      tester,
+      buildMobilePaymentRequestMinimalUseCase,
+      size: _mobileSize,
+    );
+
+    expect(tester.takeException(), isNull);
+    // Nothing to scroll, and the card takes only the height it needs rather
+    // than stretching to the space the sheet could give it.
+    expect(_maxScrollExtent(tester), 0);
+    final card = tester.getRect(_transactionDetailsCard());
+    final status = tester.getRect(_key('payment_request_continue'));
+    expect(card.height, lessThan(status.top - card.top));
+  });
+
+  // ─── Status ────────────────────────────────────────────────────────
+
+  testWidgets('blocking statuses disable the primary action and say why', (
+    tester,
+  ) async {
+    for (final (builder, message) in <(WidgetBuilder, String)>[
+      (
+        buildPaymentRequestInvalidAddressUseCase,
+        "Recipient address doesn't look right",
+      ),
+      (
+        buildPaymentRequestInsufficientUseCase,
+        'Not enough ZEC for this amount and the network fee (0.21 available)',
+      ),
+      (
+        buildPaymentRequestSyncingUseCase,
+        'Wallet is still syncing — this will update when it finishes',
+      ),
+      (
+        buildPaymentRequestFailedUseCase,
+        "Couldn't check this request — open Edit to review the details",
+      ),
+    ]) {
+      await _pumpUseCase(tester, builder);
+
+      expect(tester.takeException(), isNull, reason: message);
+      // Exactly one status line, attached to the details card.
+      expect(find.text(message), findsOneWidget, reason: message);
+      expect(
+        find.byKey(const ValueKey('payment_request_status')),
+        findsOneWidget,
+        reason: message,
+      );
+      expect(
+        _button(tester, 'payment_request_continue').onPressed,
+        isNull,
+        reason: message,
+      );
+    }
+  });
+
+  testWidgets('the status line sits below the card, away from the actions', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestInvalidAddressUseCase);
+
+    final status = tester.getRect(
+      find.byKey(const ValueKey('payment_request_status')),
+    );
+    final card = tester.getRect(_transactionDetailsCard());
+    final review = tester.getRect(_key('payment_request_continue'));
+
+    expect(tester.takeException(), isNull);
+    expect(status.top, greaterThanOrEqualTo(card.bottom - 0.5));
+    expect(status.bottom, lessThanOrEqualTo(review.top + 0.5));
+    expect(status.top - card.bottom, lessThan(review.top - status.bottom));
+  });
+
+  testWidgets('checking is a button state, not a status line', (tester) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildPaymentRequestCheckingUseCase, _desktopSize),
+      (buildMobilePaymentRequestCheckingUseCase, _mobileSize),
+    ]) {
+      await _pumpUseCase(tester, builder, size: size);
+
+      expect(tester.takeException(), isNull);
+      // No status line at all while checks run.
+      expect(
+        find.byKey(const ValueKey('payment_request_status')),
+        findsNothing,
+      );
+      // The primary says it instead, disabled, with the spinner beside it.
+      expect(find.text('Checking…'), findsOneWidget);
+      expect(find.text('Review'), findsNothing);
+      final primary = _button(tester, 'payment_request_continue');
+      expect(primary.onPressed, isNull);
+      expect(primary.leading, isNotNull);
+      // Edit stays reachable while the request is being checked.
+      expect(_button(tester, 'payment_request_edit').onPressed, isNotNull);
+    }
+
+    expect(
+      defaultPaymentRequestStatusMessage(PaymentRequestStatus.checking),
+      isNull,
+    );
+  });
+
+  testWidgets('errors take the destructive tone', (tester) async {
+    final colors = AppThemeData.light.colors;
+
+    for (final (builder, message) in <(WidgetBuilder, String)>[
+      (
+        buildPaymentRequestInvalidAddressUseCase,
+        "Recipient address doesn't look right",
+      ),
+      (
+        buildPaymentRequestInsufficientUseCase,
+        'Not enough ZEC for this amount and the network fee (0.21 available)',
+      ),
+      (
+        buildPaymentRequestFailedUseCase,
+        "Couldn't check this request — open Edit to review the details",
+      ),
+    ]) {
+      await _pumpUseCase(tester, builder);
+      expect(
+        _statusColor(tester, message),
+        colors.text.destructive,
+        reason: message,
+      );
+      expect(
+        _statusIcons(tester),
+        findsOneWidget,
+        reason: 'an error carries the warning glyph: $message',
+      );
+    }
+  });
+
+  testWidgets('syncing is a pending line, not an error', (tester) async {
+    final colors = AppThemeData.light.colors;
+    const message =
+        'Wallet is still syncing — this will update when it '
+        'finishes';
+
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildPaymentRequestSyncingUseCase, _desktopSize),
+      (buildMobilePaymentRequestSyncingUseCase, _mobileSize),
+    ]) {
+      await _pumpUseCase(tester, builder, size: size);
+
+      expect(tester.takeException(), isNull);
+      // The copy promises the card will update itself, so the line stays
+      // quiet: secondary text and no warning glyph to act on.
+      expect(_statusColor(tester, message), colors.text.secondary);
+      expect(_statusIcons(tester), findsNothing);
+      // Review still cannot be pressed — that is `blocksContinue`'s job, not
+      // the tone's.
+      expect(_button(tester, 'payment_request_continue').onPressed, isNull);
+    }
+
+    expect(PaymentRequestStatus.syncing.blocksContinue, isTrue);
+    expect(PaymentRequestStatus.syncing.isError, isFalse);
+  });
+
+  testWidgets('a stalled sync keeps the quiet tone but a live button', (
+    tester,
+  ) async {
+    final colors = AppThemeData.light.colors;
+    const message = 'Still syncing — check again when the wallet is up to date';
+
+    await _pumpUseCase(tester, buildPaymentRequestSyncStalledUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(message), findsOneWidget);
+    // Still not the user's fault, so still no warning glyph — but the card
+    // has stopped promising to update itself, so the next move is a button
+    // rather than a wait.
+    expect(_statusColor(tester, message), colors.text.secondary);
+    expect(_statusIcons(tester), findsNothing);
+    expect(find.text('Check again'), findsOneWidget);
+    expect(find.text('Review'), findsNothing);
+    expect(
+      _button(tester, 'payment_request_continue').onPressed,
+      isNotNull,
+      reason:
+          'the only status that blocks Review and still offers a live '
+          'primary: re-asking is the one thing that can change the answer',
+    );
+
+    expect(PaymentRequestStatus.syncStalled.blocksContinue, isTrue);
+    expect(PaymentRequestStatus.syncStalled.isError, isFalse);
+    expect(PaymentRequestStatus.syncStalled.offersRecheck, isTrue);
+    expect(PaymentRequestStatus.syncing.offersRecheck, isFalse);
+  });
+
+  testWidgets('a failed check is its own status, not a bad address', (
+    tester,
+  ) async {
+    expect(
+      defaultPaymentRequestStatusMessage(PaymentRequestStatus.failed),
+      "Couldn't check this request",
+      reason: 'the floor under a reason the pre-check always supplies',
+    );
+    expect(PaymentRequestStatus.failed.blocksContinue, isTrue);
+    expect(PaymentRequestStatus.failed.isError, isTrue);
+  });
+
+  testWidgets('an insufficient-funds message without a balance stays short', (
+    tester,
+  ) async {
+    expect(
+      defaultPaymentRequestStatusMessage(
+        PaymentRequestStatus.insufficientFunds,
+      ),
+      'Not enough ZEC for this amount and the network fee',
+    );
+  });
+
+  testWidgets('a ready request renders no status line at all', (tester) async {
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(const ValueKey('payment_request_status')), findsNothing);
+  });
+
+  testWidgets('replaced notice renders above the content', (tester) async {
+    await _pumpUseCase(tester, buildPaymentRequestReplacedUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Replaced an earlier link'), findsOneWidget);
+  });
+
+  testWidgets('a transparent recipient is badged as transparent', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestTransparentUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Transparent'), findsOneWidget);
+    expect(find.text('Shielded'), findsNothing);
+  });
+
+  testWidgets('a requester note without a name stays collapsed', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestNoteOnlyUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Requester'), findsOneWidget);
+    expect(find.text('Note from requester'), findsOneWidget);
+    expect(_key('payment_request_requester_note'), findsNothing);
+    expect(find.text('Transaction memo'), findsNothing);
+
+    await tester.tap(_key('payment_request_requester_toggle'));
+    await tester.pumpAndSettle();
+
+    expect(_key('payment_request_requester_note'), findsOneWidget);
+    expect(
+      tester.widget<Text>(_key('payment_request_requester_note')).data,
+      'Saved from the invoice link you opened.',
+    );
+  });
+
+  testWidgets('a blocked primary action still announces why', (tester) async {
+    final handle = tester.ensureSemantics();
+    await _pumpUseCase(tester, buildPaymentRequestInsufficientUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.bySemanticsLabel(
+        'Review, unavailable. Not enough ZEC for this amount and the '
+        'network fee (0.21 available)',
+      ),
+      findsOneWidget,
+    );
+    handle.dispose();
+  });
+
+  testWidgets('large text and RTL render without overflow', (tester) async {
+    for (final builder in <WidgetBuilder>[
+      buildPaymentRequestLargeTextUseCase,
+      buildPaymentRequestRtlUseCase,
+      buildMobilePaymentRequestLargeTextUseCase,
+      buildMobilePaymentRequestRtlUseCase,
+    ]) {
+      await _pumpUseCase(tester, builder, size: const Size(1080, 900));
+      expect(tester.takeException(), isNull);
+    }
+  });
+
+  testWidgets('every registered use case renders in its own lane', (
+    tester,
+  ) async {
+    for (final builder in <WidgetBuilder>[
+      buildPaymentRequestFullUseCase,
+      buildPaymentRequestMinimalUseCase,
+      buildPaymentRequestLongValuesUseCase,
+      buildPaymentRequestLongValuesExpandedUseCase,
+      buildPaymentRequestAddressExpandedUseCase,
+      buildPaymentRequestCheckingUseCase,
+      buildPaymentRequestInvalidAddressUseCase,
+      buildPaymentRequestInsufficientUseCase,
+      buildPaymentRequestSyncingUseCase,
+      buildPaymentRequestSyncStalledUseCase,
+      buildPaymentRequestFailedUseCase,
+      buildPaymentRequestReplacedUseCase,
+      buildPaymentRequestTransparentUseCase,
+      buildPaymentRequestContactUseCase,
+      buildPaymentRequestOwnAccountUseCase,
+      buildPaymentRequestOwnAccountExpandedUseCase,
+      buildPaymentRequestNoteOnlyUseCase,
+      buildPaymentRequestNoAmountUseCase,
+    ]) {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await _pumpUseCase(tester, builder);
+      expect(tester.takeException(), isNull);
+    }
+
+    for (final builder in <WidgetBuilder>[
+      buildMobilePaymentRequestFullUseCase,
+      buildMobilePaymentRequestMinimalUseCase,
+      buildMobilePaymentRequestLongValuesUseCase,
+      buildMobilePaymentRequestLongValuesExpandedUseCase,
+      buildMobilePaymentRequestAddressExpandedUseCase,
+      buildMobilePaymentRequestCheckingUseCase,
+      buildMobilePaymentRequestInvalidAddressUseCase,
+      buildMobilePaymentRequestInsufficientUseCase,
+      buildMobilePaymentRequestSyncingUseCase,
+      buildMobilePaymentRequestFailedUseCase,
+      buildMobilePaymentRequestReplacedUseCase,
+      buildMobilePaymentRequestTransparentUseCase,
+      buildMobilePaymentRequestContactUseCase,
+      buildMobilePaymentRequestOwnAccountUseCase,
+      buildMobilePaymentRequestOwnAccountExpandedUseCase,
+      buildMobilePaymentRequestNoteOnlyUseCase,
+      buildMobilePaymentRequestNoAmountUseCase,
+    ]) {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await _pumpUseCase(tester, builder, size: _mobileSize);
+      expect(tester.takeException(), isNull);
+    }
+  });
+
+  testWidgets('mobile use cases render the stacked action layout', (
+    tester,
+  ) async {
+    await _pumpUseCase(
+      tester,
+      buildMobilePaymentRequestFullUseCase,
+      size: _mobileSize,
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(
+      tester
+          .widget<PaymentRequestCard>(find.byType(PaymentRequestCard))
+          .isMobileLayout,
+      isTrue,
+    );
+    // The desktop close affordance belongs to the modal card only.
+    expect(find.byKey(const ValueKey('payment_request_close')), findsNothing);
+    expect(find.text('Review'), findsOneWidget);
+    // Refusal is the sheet's own pinned ⨯ (`MobileModalScaffold`), so the
+    // action stack carries no ghost Cancel link.
+    expect(find.text('Cancel'), findsNothing);
+    expect(find.byKey(const ValueKey('payment_request_cancel')), findsNothing);
+  });
+
+  testWidgets('the mobile sheet is hosted in the shared modal scaffold', (
+    tester,
+  ) async {
+    await _pumpUseCase(
+      tester,
+      buildMobilePaymentRequestFullUseCase,
+      size: _mobileSize,
+    );
+
+    expect(tester.takeException(), isNull);
+    // The app's common bottom-sheet chrome, which owns the pinned close.
+    expect(find.byType(MobileModalScaffold), findsOneWidget);
+    expect(find.bySemanticsLabel('Close'), findsOneWidget);
+    // The scaffold sits inside the floating card, which still owns the
+    // bottom safe area — the card must not take it a second time.
+    expect(find.byType(MobileModalCard), findsOneWidget);
+    expect(find.byType(MobileBottomSafeArea), findsNothing);
+    // The pinned action stack stays clear of the sheet's bottom edge.
+    final actions = tester.getRect(_key('payment_request_edit'));
+    final sheet = tester.getRect(find.byType(MobileModalScaffold));
+    expect(actions.bottom, lessThanOrEqualTo(sheet.bottom - 8));
+  });
+
+  testWidgets('the transaction group spans the mobile action width', (
+    tester,
+  ) async {
+    await _pumpUseCase(
+      tester,
+      buildMobilePaymentRequestLongValuesUseCase,
+      size: _mobileSize,
+    );
+
+    expect(tester.takeException(), isNull);
+    final transaction = tester.getRect(
+      _key('payment_request_transaction_content'),
+    );
+    final actions = tester.getRect(_key('payment_request_continue'));
+    expect(
+      transaction.left - actions.left,
+      moreOrLessEquals(actions.right - transaction.right, epsilon: 0.5),
+    );
+    expect(transaction.width, moreOrLessEquals(actions.width, epsilon: 0.5));
+  });
+
+  // ─── A recipient the wallet can name ───────────────────────────────
+
+  testWidgets('a saved contact takes the To headline, the address drops', (
+    tester,
+  ) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildPaymentRequestContactUseCase, _desktopSize),
+      (buildMobilePaymentRequestContactUseCase, _mobileSize),
+    ]) {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await _pumpUseCase(tester, builder, size: size);
+
+      expect(tester.takeException(), isNull);
+      // The name is the headline, in the accent colour the address used to
+      // take; the address is still on screen underneath it.
+      final name = tester.widget<Text>(_key('payment_request_recipient_name'));
+      expect(name.data, 'Blue Door Coffee');
+      expect(name.style!.fontSize, AppTypography.headlineSmall.fontSize);
+      expect(name.style!.color, AppThemeData.light.colors.text.accent);
+      expect(find.text('u195091 ... 190591'), findsOneWidget);
+      // The avatar is the contact's, not a generic wallet glyph.
+      expect(
+        tester
+            .widget<AppProfilePicture>(_key('payment_request_recipient_avatar'))
+            .profilePictureId,
+        'pfp-03',
+      );
+      // A contact is not the user's own account, so nothing claims it is.
+      expect(_key('payment_request_own_account_label'), findsNothing);
+      expect(find.text('Your account'), findsNothing);
+      // Everything the unmapped row carried is still there.
+      expect(_key('payment_request_to_row'), findsOneWidget);
+      expect(_key('payment_request_pool_badge'), findsOneWidget);
+      expect(find.text('Shielded'), findsOneWidget);
+      expect(find.text('Show full address'), findsOneWidget);
+    }
+  });
+
+  testWidgets('an own-account recipient says whose account it is', (
+    tester,
+  ) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildPaymentRequestOwnAccountUseCase, _desktopSize),
+      (buildMobilePaymentRequestOwnAccountUseCase, _mobileSize),
+    ]) {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await _pumpUseCase(tester, builder, size: size);
+
+      expect(tester.takeException(), isNull);
+      expect(
+        tester.widget<Text>(_key('payment_request_recipient_name')).data,
+        'Savings',
+      );
+      expect(
+        tester
+            .widget<AppProfilePicture>(_key('payment_request_recipient_avatar'))
+            .profilePictureId,
+        'pfp-07',
+      );
+      // Sentence case, muted, one line — the card's own label treatment.
+      final label = tester.widget<Text>(
+        _key('payment_request_own_account_label'),
+      );
+      expect(label.data, 'Your account');
+      expect(label.style!.color, AppThemeData.light.colors.text.secondary);
+      expect(find.text('u195091 ... 190591'), findsOneWidget);
+      expect(_key('payment_request_pool_badge'), findsOneWidget);
+    }
+  });
+
+  testWidgets('a named recipient still expands to the full address', (
+    tester,
+  ) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildPaymentRequestOwnAccountUseCase, _desktopSize),
+      (buildMobilePaymentRequestOwnAccountUseCase, _mobileSize),
+    ]) {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await _pumpUseCase(tester, builder, size: size);
+
+      await tester.tap(find.text('Show full address'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(_key('payment_request_address_chunks'), findsOneWidget);
+      expect(find.text('u1950'), findsOneWidget);
+      // The name and its sub-label stay; the truncated sub-line does not
+      // repeat the address the grid is already showing.
+      expect(_key('payment_request_recipient_name'), findsOneWidget);
+      expect(_key('payment_request_own_account_label'), findsOneWidget);
+      expect(_key('payment_request_recipient_address'), findsNothing);
+      // Nothing left the card.
+      expect(find.text('Review'), findsOneWidget);
+
+      await tester.tap(find.text('Hide full address'));
+      await tester.pumpAndSettle();
+      expect(_key('payment_request_recipient_address'), findsOneWidget);
+    }
+  });
+
+  testWidgets('the expanded own-account use cases render both lanes', (
+    tester,
+  ) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildPaymentRequestOwnAccountExpandedUseCase, _desktopSize),
+      (buildMobilePaymentRequestOwnAccountExpandedUseCase, _mobileSize),
+    ]) {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await _pumpUseCase(tester, builder, size: size);
+      expect(tester.takeException(), isNull);
+      expect(find.text('Hide full address'), findsOneWidget);
+      expect(find.text('u1950'), findsOneWidget);
+      expect(find.text('Your account'), findsOneWidget);
+    }
+  });
+
+  testWidgets('an unmapped recipient keeps the plain address layout', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildPaymentRequestFullUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(_key('payment_request_recipient_name'), findsNothing);
+    expect(_key('payment_request_recipient_avatar'), findsNothing);
+    expect(find.byType(AppProfilePicture), findsNothing);
+    // The address itself is the value, in the accent colour.
+    final address = tester.widget<Text>(find.text('u195091 ... 190591'));
+    expect(address.style!.color, AppThemeData.light.colors.text.accent);
+  });
+
+  // ─── No amount ─────────────────────────────────────────────────────
+
+  testWidgets('an amount-less request renders no hero and edits instead', (
+    tester,
+  ) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildPaymentRequestNoAmountUseCase, _desktopSize),
+      (buildMobilePaymentRequestNoAmountUseCase, _mobileSize),
+    ]) {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await _pumpUseCase(tester, builder, size: size);
+
+      expect(tester.takeException(), isNull);
+      // No hero, and no placeholder standing in for one.
+      expect(_key('payment_request_amount'), findsNothing);
+      expect(_key('payment_request_fiat'), findsNothing);
+      expect(find.text('Amount not set'), findsNothing);
+      // The primary is the edit action; there is no second Edit under it.
+      expect(find.text('Enter amount'), findsOneWidget);
+      expect(find.text('Review'), findsNothing);
+      expect(find.text('Edit'), findsNothing);
+      expect(_key('payment_request_edit'), findsNothing);
+      expect(_button(tester, 'payment_request_continue').onPressed, isNotNull);
+      // The amount slot is omitted inside the transaction group.
+      expect(_titleText(tester), 'Payment request');
+      expect(_key('payment_request_transaction_content'), findsOneWidget);
+    }
+  });
+
+  testWidgets('an amount-less request that is blocked still has one live '
+      'control', (tester) async {
+    await _pumpUseCase(tester, (context) => _noAmountFrame(context));
+
+    expect(tester.takeException(), isNull);
+    expect(find.text("Recipient address doesn't look right"), findsOneWidget);
+    // The card renders no secondary without an amount, so blocking the
+    // primary too would leave the ⨯ as the only exit. The primary is the
+    // edit action here, and it is named after what it does.
+    expect(_key('payment_request_edit'), findsNothing);
+    expect(find.text('Enter amount'), findsNothing);
+    expect(find.text('Edit'), findsOneWidget);
+    expect(_button(tester, 'payment_request_continue').onPressed, isNotNull);
+  });
+
+  testWidgets('an amount-less request keeps waiting while it is checked', (
+    tester,
+  ) async {
+    await _pumpUseCase(
+      tester,
+      (context) => _noAmountFrame(context, PaymentRequestStatus.checking),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Checking…'), findsOneWidget);
+    expect(_button(tester, 'payment_request_continue').onPressed, isNull);
+  });
+
+  // ─── Actions ───────────────────────────────────────────────────────
+
+  testWidgets('the actions are full-width primary and ghost buttons', (
+    tester,
+  ) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildPaymentRequestFullUseCase, _desktopSize),
+      (buildMobilePaymentRequestFullUseCase, _mobileSize),
+    ]) {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await _pumpUseCase(tester, builder, size: size);
+      expect(tester.takeException(), isNull);
+
+      expect(find.text('Review'), findsOneWidget);
+      expect(find.text('Edit'), findsOneWidget);
+
+      final review = _button(tester, 'payment_request_continue');
+      final edit = _button(tester, 'payment_request_edit');
+      expect(review.variant, AppButtonVariant.primary);
+      expect(edit.variant, AppButtonVariant.ghost);
+      expect(review.expand, isTrue);
+      expect(edit.expand, isTrue);
+
+      final reviewRect = tester.getRect(_key('payment_request_continue'));
+      final editRect = tester.getRect(_key('payment_request_edit'));
+      expect(editRect.width, moreOrLessEquals(reviewRect.width));
+      expect(editRect.height, moreOrLessEquals(reviewRect.height));
+      expect(editRect.top, greaterThan(reviewRect.bottom));
+
+      // Nothing edits in place any more.
+      expect(
+        find.byKey(const ValueKey('payment_request_edit_amount')),
+        findsNothing,
+      );
+    }
+  });
+
+  testWidgets('the address-expanded state keeps the actions visible', (
+    tester,
+  ) async {
+    for (final builder in <WidgetBuilder>[
+      buildPaymentRequestFullUseCase,
+      buildPaymentRequestLongValuesUseCase,
+    ]) {
+      // A fresh tree per style: the address row's expanded state would
+      // otherwise survive into the next iteration.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await _pumpUseCase(tester, builder);
+      await tester.tap(find.text('Show full address'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Hide full address'), findsOneWidget);
+      expect(find.text('Review'), findsOneWidget);
+    }
+  });
+}
+
+/// The amount-less card with a failing pre-check — the one combination no
+/// registered use case covers, because the gallery shows the two states
+/// separately.
+Widget _noAmountFrame(
+  BuildContext context, [
+  PaymentRequestStatus status = PaymentRequestStatus.invalidAddress,
+]) => PaymentRequestSurface(
+  layout: PaymentRequestLayout.desktop,
+  request: PaymentRequestView(
+    source: PaymentRequestSource.link,
+    address: 't1PZ4vMuLdt2wRfDGGKS1qXfBpJt5CJHhNz',
+    status: status,
+  ),
+  onContinue: () {},
+  onEdit: () {},
+  onCancel: () {},
+);
+
+const _desktopSize = Size(1080, 720);
+const _mobileSize = Size(393, 852);
+
+Finder _key(String value) => find.byKey(ValueKey(value));
+
+Finder _transactionDetailsCard() => find.descendant(
+  of: _key('payment_request_transaction_content'),
+  matching: find.byType(ReviewWrapCard),
+);
+
+/// Taps the value pill of a `ReviewListRow`-shaped row. The label itself is
+/// not the tap target — the review's rows put the gesture on the pill.
+Future<void> _tapRow(WidgetTester tester, String rowKey) async {
+  await tester.tap(
+    find
+        .descendant(
+          of: find.byKey(ValueKey(rowKey)),
+          matching: find.byType(GestureDetector),
+        )
+        .last,
+  );
+  await tester.pumpAndSettle();
+}
+
+AppButton _button(WidgetTester tester, String key) =>
+    tester.widget<AppButton>(_key(key));
+
+String _titleText(WidgetTester tester) => tester
+    .widget<Text>(find.byKey(const ValueKey('payment_request_title')))
+    .data!;
+
+Color? _statusColor(WidgetTester tester, String message) =>
+    tester.widget<Text>(find.text(message)).style?.color;
+
+/// Glyphs inside the one status slot — the warning badge, when there is one.
+Finder _statusIcons(WidgetTester tester) => find.descendant(
+  of: find.byKey(const ValueKey('payment_request_status')),
+  matching: find.byType(AppIcon),
+);
+
+double _scrollOffset(WidgetTester tester) => tester
+    .widget<SingleChildScrollView>(find.byKey(kPaymentRequestScrollViewKey))
+    .controller!
+    .offset;
+
+double _maxScrollExtent(WidgetTester tester) => tester
+    .widget<SingleChildScrollView>(find.byKey(kPaymentRequestScrollViewKey))
+    .controller!
+    .position
+    .maxScrollExtent;
+
+double _requesterNoteScrollOffset(WidgetTester tester) => tester
+    .widget<SingleChildScrollView>(
+      find.byKey(kPaymentRequestRequesterNoteScrollViewKey),
+    )
+    .controller!
+    .offset;
+
+double _requesterNoteMaxScrollExtent(WidgetTester tester) => tester
+    .widget<SingleChildScrollView>(
+      find.byKey(kPaymentRequestRequesterNoteScrollViewKey),
+    )
+    .controller!
+    .position
+    .maxScrollExtent;
+
+Future<void> _pumpUseCase(
+  WidgetTester tester,
+  WidgetBuilder builder, {
+  Size size = _desktopSize,
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: Center(
+          child: SizedBox(
+            width: size.width,
+            height: size.height,
+            child: Builder(builder: builder),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <desktop_window_bootstrap/desktop_window_bootstrap_plugin_c_api.h>
+#include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <mobile_scanner/mobile_scanner_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
@@ -17,6 +18,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   DesktopWindowBootstrapPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DesktopWindowBootstrapPluginCApi"));
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   MobileScannerPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   desktop_window_bootstrap
+  file_selector_windows
   flutter_secure_storage_windows
   mobile_scanner
   screen_retriever_windows


### PR DESCRIPTION
## Summary

The desktop half of the ZIP-321 lane: the surface that presents an incoming payment request, and the surface that creates one. Incoming, a `zcash:` link now becomes a card above the content pane that leads into send review; outgoing, "Request an amount" in Receive builds a ZIP-321 URI and its QR. It is a separate layer from #609 because everything here is presentation — the parser, policy and pre-check it drives are already merged below — and because mounting the host is what finally makes a delivered request presentable.

## Changes

**UI (desktop) — incoming request**
- `send/widgets/payment_request_surface.dart` (234) mounts the card from #609; `send/screens/send_screen.dart` (+172) consumes the prefill; `send_review_screen.dart` (+112), `send_review_layout.dart`, `send_review_content_view.dart`, `send_status_screen.dart` — requested amount, requester tooltip, request framing through review and status.
- `send/widgets/send_recipient_resolver.dart` — contact / own-account resolution for the requester line.

**UI (desktop) — Receive request**
- `receive/screens/receive_screen.dart` (+324) and `receive_desktop_preview.dart`; new `receive/widgets/request/`: `request_amount_card.dart` (771), `request_amount_sheet.dart` (585), `request_qr_surface.dart` (341), `request_amount_model.dart`, `request_amount_formatters.dart`.
- `receive/services/zec_request_draft.dart` (282) and `request_qr_export.dart` (116); `core/storage/png_save_location.dart`.

**Layout / shared widgets**
- `core/layout/content_overlay_inset.dart` (+69) — window-level overlays now align to the content pane rather than the whole window; `app_desktop_shell.dart`, `app_pane_floating_bar.dart` publish their insets.
- `core/widgets/amount_price_loading_bar.dart` (174), `review_list_row.dart`, `review_wrap_card.dart`.
- Busy-surface holds adopted by the Keystone scan/sign, Ironwood signing, voting-status and wallet-link screens.
- Both unlock screens claim the parked prefill again (see below).

**Dependencies**
- `file_selector: ^1.1.0` for the desktop "Save QR image" dialog — the macOS app is sandboxed, so only an `NSSavePanel` result is a folder the user can reach. Plugin registrants for macOS/Windows/Linux, `pubspec.lock`.

**Fixtures (widgetbook / figma-compare)**
- `widgetbook/payment_request_use_cases.dart` (401), `request_amount_use_cases.dart` (233), `send_review_status_use_cases.dart`, `receive_use_cases.dart`; `figma_compare/zip321_prefill_use_cases.dart` (332) and 320 lines of new scenarios.

**Tests** (~5.5k lines)
- `widgetbook/payment_request_use_cases_test.dart` (1302), `receive/request_amount_widgets_test.dart` (938), `receive_screen_test.dart` (616), `app_payment_uri_wallet_reset_test.dart` (554), `zec_request_draft_test.dart` (337), `receive_request_modal_layout_test.dart` (311), `send_screen_test.dart` (+278), `send_review_screen_test.dart` (+301), plus rejection / unlock-claim / first-frame and per-screen busy-surface suites.

## Behaviour at this point of the stack

This is where the stack's ZIP-321 story closes on desktop. The drain's `deliver` outcome, parked since #609, now presents: the card is mounted, so the pre-check may build its proposal, and the unlock screens claim a parked link again. `preserveMemoText` (added in #609) gets its first reader here, in `send_screen.dart`. Mobile still has no card — `/send` on mobile does not yet unpack a `SendPrefillArgs` — which is #612.

## Verification

- `fvm flutter analyze` clean.
- Desktop lane (`fvm flutter test`) green.
- Mobile lane (`--tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`): 20 failures, all pre-existing — the identical set fails at the base of this stack. Files: `ironwood_migration_coordinator_provider_test.dart` (15), `mobile_import_birthday_screen_test.dart` (2), `mobile_onboarding_progress_test.dart`, `mobile_keystone_use_cases_test.dart`, `mobile_receive_use_cases_test.dart`.

## Stack

Part 3/9 · base: `rowan/zip321-02-core` (#609) · next: #612 — [stack #618](https://github.com/chainapsis/vizor-wallet/pull/608)

https://claude.ai/code/session_01Uybjg6JVS5RFEG8B9GHi3s
