### PR TITLE
[5/10] Gift Cards: link model, claim service, stores, and coordinator

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -66,6 +66,10 @@ import 'src/features/onboarding/mobile/mobile_unlock_screen.dart';
 import 'src/features/onboarding/unlock_screen.dart';
 import 'src/features/onboarding/welcome.dart';
 import 'src/features/pay/screens/pay_screen.dart';
+import 'src/features/payment_links/models/vizor_payment_link.dart';
+import 'src/features/payment_links/providers/payment_link_claim_coordinator_provider.dart';
+import 'src/features/payment_links/providers/payment_link_intake_provider.dart';
+import 'src/features/payment_links/services/payment_link_entry_policy.dart';
 import 'src/features/receive/screens/receive_screen.dart';
 import 'src/features/send/screens/keystone_send_scan_screen.dart';
 import 'src/features/send/models/send_prefill_args.dart';
@@ -256,9 +260,10 @@ final _routerProvider = Provider<_AppRouter>((ref) {
     canPop: () => router.canPop(),
     currentLocation: () =>
         router.routerDelegate.currentConfiguration.uri.toString(),
-    // The payment request card is presented over the `Router`, where a
-    // `PopScope` finds no `ModalRoute` to register with. Back must reach the
-    // card first or it would navigate underneath a modal the user is looking at.
+    // `PaymentRequestHost` is mounted above the `Router`, where a `PopScope`
+    // finds no `ModalRoute` to register with and is therefore inert. Back has
+    // to reach the card here or it would navigate — and on the second press
+    // exit the app — underneath a modal the user is still looking at.
     handleBackAboveRouter: () {
       if (ref.read(paymentRequestFlowProvider) == null) return false;
       ref.read(paymentRequestFlowProvider.notifier).dismiss();
@@ -1186,6 +1191,7 @@ class ZcashWalletApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.watch(votingShareTrackingRestorerProvider);
+    ref.watch(paymentLinkClaimCoordinatorProvider);
     final appRouter = ref.watch(_routerProvider);
     final router = appRouter.router;
     final themeMode = ref.watch(themeModeProvider);
@@ -1317,16 +1323,25 @@ Widget buildIncomingLinkHostForTest({
 
 /// The single subscriber to the native incoming-link stream.
 ///
-/// Incoming URIs are dispatched here. `classifyIncomingLink` picks the lane:
+/// Both products that arrive on `com.zcash.wallet/payment_uri` are dispatched
+/// from here, because there is only one method-call handler to go around and
+/// because two independent listeners would each hand every link to their own
+/// parser — which is how a Gift Card link's mnemonic-bearing fragment ends up
+/// in the ZIP-321 rejection snackbar. `classifyIncomingLink` picks the lane;
+/// everything below is per-lane and unchanged from the two hosts this replaced:
 ///
 /// * **payment request** (`zcash:`) — parks in `paymentUriPrefillProvider` and
 ///   drains through `decidePaymentUriDrain` into a card over the current
 ///   screen. Route-agnostic: it never navigates on delivery.
-/// * **gift card** (`https://` on the Vizor origin) — no-op in this prefix;
-///   the gift card lane is wired in a later PR.
+/// * **gift card** (`https://` on the Vizor origin) — queues in
+///   `paymentLinkIntakeProvider` and navigates to `/payment-links`.
 /// * **vizor home** — brings an unlocked wallet to `/home`, unless the user is
 ///   part-way through onboarding, import, or add-account, where the link is
 ///   dropped rather than allowed to discard widget-only state.
+///
+/// The two intakes defer to each other: a Gift Card waits while a request card
+/// is up (`paymentLinkEntryDeferredMessageAtLocation`), and a request waits
+/// while a Gift Card signing round holds the busy-surface latch.
 class _IncomingLinkHost extends ConsumerStatefulWidget {
   const _IncomingLinkHost({required this.router, required this.child});
 
@@ -1345,7 +1360,11 @@ const _kIncomingLinkNoticeDuration = Duration(seconds: 4);
 
 class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   StreamSubscription<String>? _subscription;
+  ProviderSubscription<VizorPaymentLink?>? _intakeSubscription;
 
+  // --- gift card lane ---
+  VizorPaymentLink? _lastDeferredLink;
+  bool _navigationScheduled = false;
 
   // --- payment request lane ---
   var _paymentSequence = 0;
@@ -1369,6 +1388,13 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
     _lastKnownHasWallet =
         ref.read(walletProvider).value?.hasWallet ??
         ref.read(appBootstrapProvider).hasWallet;
+    widget.router.routerDelegate.addListener(_handleRouteChanged);
+    _intakeSubscription = ref.listenManual(
+      paymentLinkIntakeProvider.select((state) => state.pendingLink),
+      (_, link) {
+        if (link != null) _openPendingPaymentLink();
+      },
+    );
     final service = ref.read(incomingUriServiceProvider);
     _subscription = service.uriStream.listen(_handleIncomingUri);
     unawaited(service.initialize());
@@ -1378,12 +1404,15 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   void didUpdateWidget(covariant _IncomingLinkHost oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.router == widget.router) return;
-
+    oldWidget.router.routerDelegate.removeListener(_handleRouteChanged);
+    widget.router.routerDelegate.addListener(_handleRouteChanged);
   }
 
   @override
   void dispose() {
+    widget.router.routerDelegate.removeListener(_handleRouteChanged);
     unawaited(_subscription?.cancel());
+    _intakeSubscription?.close();
     super.dispose();
   }
 
@@ -1401,6 +1430,10 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
           // Wallet reset (uninstall, lost-password reset). Drop the parked
           // ZIP-321 link quietly: draining it here would follow the wipe with
           // a "Set up or import a wallet" notice and a jump to /welcome.
+          //
+          // Only the ZIP-321 park and its card. A Gift Card is a bearer claim
+          // on funds that do not belong to this wallet, so it survives a reset
+          // by design — see `paymentLinkIntakeProvider`.
           ref.read(paymentUriPrefillProvider.notifier).clear();
           ref.read(paymentRequestFlowProvider.notifier).clear();
           return;
@@ -1418,6 +1451,14 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
     ref.listen<bool>(sendStatusTerminalProvider, (previous, next) {
       if (next && !(previous ?? false)) _schedulePendingDrain();
     });
+    // The reciprocal of the busy-surface hold: a Gift Card waits while a
+    // request card is up, so answering the card releases it.
+    ref.listen<PaymentRequestFlowState?>(paymentRequestFlowProvider, (
+      previous,
+      next,
+    ) {
+      if (next == null && previous != null) _openPendingPaymentLink();
+    });
     // No appSecurityProvider listener: the unlock screens own the post-unlock
     // navigation for a parked prefill (claim + present the card). Draining
     // here on unlock too would race and clobber that navigation. The wallet
@@ -1433,8 +1474,7 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
       case IncomingPaymentRequestLink(:final raw):
         _handlePaymentRequestLink(raw);
       case IncomingGiftCardLink():
-        // gift card lane not yet active in this prefix
-        return;
+        _handleGiftCardLink(rawUri);
       case IncomingVizorHomeLink():
         if (ref.read(appSecurityProvider).requiresUnlock) return;
         // Onboarding, import, and add-account keep their state only in the
@@ -1450,6 +1490,95 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
         // Silent by contract — see `classifyIncomingLink`.
         return;
     }
+  }
+
+  // ---------------------------------------------------------------------
+  // Gift card lane
+  // ---------------------------------------------------------------------
+
+  void _handleGiftCardLink(String rawUri) {
+    final result = ref.read(paymentLinkIntakeProvider.notifier).receive(rawUri);
+    if (result == PaymentLinkIntakeResult.rejected) {
+      _showRejectedPaymentLinkMessage();
+    }
+  }
+
+  void _handleRouteChanged() {
+    _openPendingPaymentLink();
+  }
+
+  void _showRejectedPaymentLinkMessage() {
+    final message = ref.read(paymentLinkIntakeProvider).errorMessage;
+    if (message == null) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      showAppToast(
+        context,
+        message,
+        iconName: AppIcons.warning,
+        tone: AppToastTone.destructive,
+      );
+      ref.read(paymentLinkIntakeProvider.notifier).clearError();
+    });
+  }
+
+  void _openPendingPaymentLink() {
+    final pendingLink = ref.read(paymentLinkIntakeProvider).pendingLink;
+    if (_navigationScheduled ||
+        ref.read(appSecurityProvider).requiresUnlock ||
+        pendingLink == null) {
+      return;
+    }
+    final location = widget.router.state.matchedLocation;
+    // Unlock owns post-authentication navigation. The Payment Links screen
+    // owns intake while it is already visible, including its local wizard.
+    if (location == '/' ||
+        location == '/unlock' ||
+        location == '/payment-links') {
+      return;
+    }
+    final deferredMessage = paymentLinkEntryDeferredMessageAtLocation(
+      location,
+      paymentRequestCardPresented: _paymentRequestCardPresented,
+    );
+    if (deferredMessage != null) {
+      _showDeferredPaymentLinkMessage(pendingLink, deferredMessage);
+      return;
+    }
+    _lastDeferredLink = null;
+    _navigationScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _navigationScheduled = false;
+      if (!mounted ||
+          ref.read(appSecurityProvider).requiresUnlock ||
+          ref.read(paymentLinkIntakeProvider).pendingLink == null) {
+        return;
+      }
+      final currentLocation = widget.router.state.matchedLocation;
+      if (currentLocation == '/' ||
+          currentLocation == '/unlock' ||
+          currentLocation == '/payment-links' ||
+          paymentLinkEntryBlockedAtLocation(
+            currentLocation,
+            paymentRequestCardPresented: _paymentRequestCardPresented,
+          )) {
+        _openPendingPaymentLink();
+        return;
+      }
+      widget.router.go('/payment-links');
+    });
+  }
+
+  bool get _paymentRequestCardPresented =>
+      ref.read(paymentRequestFlowProvider) != null;
+
+  void _showDeferredPaymentLinkMessage(VizorPaymentLink link, String message) {
+    if (identical(_lastDeferredLink, link)) return;
+    _lastDeferredLink = link;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      showAppToast(context, message, iconName: AppIcons.warning);
+    });
   }
 
   // ---------------------------------------------------------------------
@@ -1681,7 +1810,8 @@ class _WindowsUpdatePromptHostState
   void didUpdateWidget(covariant _WindowsUpdatePromptHost oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.router == widget.router) return;
-
+    oldWidget.router.routerDelegate.removeListener(_handleRouteChanged);
+    widget.router.routerDelegate.addListener(_handleRouteChanged);
   }
 
   @override

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1546,6 +1546,10 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
       return;
     }
     _lastDeferredLink = null;
+    // The `/payment-links` surface is registered by the next PR in this
+    // stack; until then a valid link stays pending rather than opening the
+    // router's error page.
+    if (!_paymentLinksSurfaceRegistered) return;
     _navigationScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _navigationScheduled = false;
@@ -1571,6 +1575,10 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
 
   bool get _paymentRequestCardPresented =>
       ref.read(paymentRequestFlowProvider) != null;
+
+  bool get _paymentLinksSurfaceRegistered => widget.router.configuration.routes
+      .whereType<GoRoute>()
+      .any((route) => route.path == '/payment-links');
 
   void _showDeferredPaymentLinkMessage(VizorPaymentLink link, String message) {
     if (identical(_lastDeferredLink, link)) return;

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -70,6 +70,7 @@ import 'src/features/payment_links/models/vizor_payment_link.dart';
 import 'src/features/payment_links/providers/payment_link_claim_coordinator_provider.dart';
 import 'src/features/payment_links/providers/payment_link_intake_provider.dart';
 import 'src/features/payment_links/services/payment_link_entry_policy.dart';
+import 'src/features/payment_links/services/payment_link_surface.dart';
 import 'src/features/receive/screens/receive_screen.dart';
 import 'src/features/send/screens/keystone_send_scan_screen.dart';
 import 'src/features/send/models/send_prefill_args.dart';
@@ -1576,9 +1577,8 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   bool get _paymentRequestCardPresented =>
       ref.read(paymentRequestFlowProvider) != null;
 
-  bool get _paymentLinksSurfaceRegistered => widget.router.configuration.routes
-      .whereType<GoRoute>()
-      .any((route) => route.path == '/payment-links');
+  bool get _paymentLinksSurfaceRegistered =>
+      paymentLinkSurfaceRegistered(widget.router);
 
   void _showDeferredPaymentLinkMessage(VizorPaymentLink link, String message) {
     if (identical(_lastDeferredLink, link)) return;

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -28,6 +28,10 @@ const kRpcEndpointUrlKey = 'zcash_rpc_endpoint_url';
 const kRpcEndpointPresetKey = 'zcash_rpc_endpoint_preset';
 const kPaymentLinkRecoveryStorageKey = 'zcash_gift_card_recovery_v1';
 const kPaymentLinkReceivedStorageKey = 'zcash_gift_card_received_v1';
+
+/// Plain (locked-readable) count of Gift Card claims still in flight.
+const kPaymentLinkClaimsInFlightCountKey =
+    'zcash_gift_card_claims_in_flight_v1';
 const kZcashExplorerUrlKey = 'zcash_explorer_url';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';
 const _passwordVerifierKey = 'zcash_password_verifier';

--- a/lib/src/core/storage/wallet_paths.dart
+++ b/lib/src/core/storage/wallet_paths.dart
@@ -4,6 +4,11 @@ import 'package:path_provider/path_provider.dart';
 
 import 'app_secure_store.dart';
 
+const kPaymentLinkClaimWalletDirectoryPrefix = 'payment_link_claim_';
+final _paymentLinkClaimWalletDirectoryPattern = RegExp(
+  r'^payment_link_claim_[0-9a-f]{64}$',
+);
+
 Future<Directory> getWalletSupportDirectory() async {
   final dir = await getApplicationSupportDirectory();
   await dir.create(recursive: true);
@@ -23,4 +28,36 @@ Future<String> getWalletDbPath() async {
 Future<String> getTorDataDirectoryPath() async {
   final dir = await getWalletSupportDirectory();
   return '${dir.path}${Platform.pathSeparator}tor';
+}
+
+Future<void> deletePaymentLinkClaimWalletDirectories({
+  Future<Directory> Function() resolveSupportDirectory =
+      getWalletSupportDirectory,
+  Future<void> Function(Directory directory)? deleteDirectory,
+}) async {
+  final supportDirectory = await resolveSupportDirectory();
+  if (!await supportDirectory.exists()) return;
+
+  Object? firstError;
+  StackTrace? firstStackTrace;
+  await for (final entity in supportDirectory.list(followLinks: false)) {
+    if (entity is! Directory) continue;
+    final directoryName = entity.path.split(Platform.pathSeparator).last;
+    if (!_paymentLinkClaimWalletDirectoryPattern.hasMatch(directoryName)) {
+      continue;
+    }
+    try {
+      if (deleteDirectory == null) {
+        await entity.delete(recursive: true);
+      } else {
+        await deleteDirectory(entity);
+      }
+    } catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
+  }
+  if (firstError != null) {
+    Error.throwWithStackTrace(firstError, firstStackTrace!);
+  }
 }

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -279,10 +279,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             _activeModal == _AccountModalType.removeAccount
         ? ref.watch(paymentLinkUnsharedFundedCountProvider(modalAccount.uuid))
         : const AsyncValue<int>.data(0);
+    // Kept for the last account too: its removal is a full reset, which
+    // `resetWallet` refuses over an in-flight claim while unlocked.
     final modalReceivingGiftCardCount =
-        modalAccount != null &&
-            !isLastModalAccount &&
-            _activeModal == _AccountModalType.removeAccount
+        modalAccount != null && _activeModal == _AccountModalType.removeAccount
         ? ref.watch(paymentLinkReceivingCountProvider(modalAccount.uuid))
         : const AsyncValue<int>.data(0);
 

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -27,6 +27,8 @@ import '../../../providers/sync_provider.dart';
 import '../../../providers/voting/voting_submission_guard_provider.dart';
 import '../../../providers/wallet_mutation_guard.dart';
 import '../../send/models/send_prefill_args.dart';
+import '../../payment_links/services/payment_link_received_store.dart';
+import '../../payment_links/services/payment_link_recovery_reconciler.dart';
 import '../../swap/providers/swap_activity_store.dart';
 import '../widgets/account_edit_modal.dart';
 import '../widgets/account_profile_picture_modal.dart';
@@ -271,6 +273,18 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         modalAccount != null && _activeModal == _AccountModalType.removeAccount
         ? ref.watch(swapPendingIntentCountProvider(modalAccount.uuid))
         : const AsyncValue<int>.data(0);
+    final modalUnsharedGiftCardCount =
+        modalAccount != null &&
+            !isLastModalAccount &&
+            _activeModal == _AccountModalType.removeAccount
+        ? ref.watch(paymentLinkUnsharedFundedCountProvider(modalAccount.uuid))
+        : const AsyncValue<int>.data(0);
+    final modalReceivingGiftCardCount =
+        modalAccount != null &&
+            !isLastModalAccount &&
+            _activeModal == _AccountModalType.removeAccount
+        ? ref.watch(paymentLinkReceivingCountProvider(modalAccount.uuid))
+        : const AsyncValue<int>.data(0);
 
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
@@ -355,6 +369,18 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                     pendingSwapCount: modalPendingSwapCount.value ?? 0,
                     checkingPendingSwaps: modalPendingSwapCount.isLoading,
                     pendingSwapCheckFailed: modalPendingSwapCount.hasError,
+                    receivingGiftCardCount:
+                        modalReceivingGiftCardCount.value ?? 0,
+                    checkingReceivingGiftCards:
+                        modalReceivingGiftCardCount.isLoading,
+                    receivingGiftCardCheckFailed:
+                        modalReceivingGiftCardCount.hasError,
+                    unsharedGiftCardCount:
+                        modalUnsharedGiftCardCount.value ?? 0,
+                    checkingUnsharedGiftCards:
+                        modalUnsharedGiftCardCount.isLoading,
+                    unsharedGiftCardCheckFailed:
+                        modalUnsharedGiftCardCount.hasError,
                     onCancel: _closeModal,
                     onConfirmPassword: (password) => ref
                         .read(appSecurityProvider.notifier)

--- a/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
+++ b/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
@@ -497,6 +497,7 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
       if (mounted) {
         showAppToast(context, switch (e) {
           PaymentLinkInFlightClaimsException() => e.toString(),
+          WalletResetInFlightGiftCardClaimsException() => e.toString(),
           PaymentLinkUnsharedGiftCardsException() => e.toString(),
           _ when isLastAccount => "Couldn't reset Vizor",
           _ => "Couldn't remove the account",

--- a/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
+++ b/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
@@ -27,6 +27,8 @@ import '../../../../providers/sync_provider.dart';
 import '../../../../providers/wallet_mutation_guard.dart';
 import '../../../migration/models/ironwood_migration_phases.dart';
 import '../../../migration/providers/ironwood_migration_coordinator_provider.dart';
+import '../../../payment_links/services/payment_link_received_store.dart';
+import '../../../payment_links/services/payment_link_recovery_store.dart';
 import '../../widgets/mobile/account_edit_sheets.dart';
 
 /// Mobile account management — Figma `Accounts` / `Accounts Edits` /
@@ -493,13 +495,12 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
     } catch (e, st) {
       log('MobileAccounts: remove failed: $e\n$st');
       if (mounted) {
-        showAppToast(
-          context,
-          isLastAccount
-              ? "Couldn't reset Vizor"
-              : "Couldn't remove the account",
-          iconName: AppIcons.cross,
-        );
+        showAppToast(context, switch (e) {
+          PaymentLinkInFlightClaimsException() => e.toString(),
+          PaymentLinkUnsharedGiftCardsException() => e.toString(),
+          _ when isLastAccount => "Couldn't reset Vizor",
+          _ => "Couldn't remove the account",
+        }, iconName: AppIcons.cross);
       }
     } finally {
       if (mounted) setState(() => _busy = false);

--- a/lib/src/features/accounts/widgets/account_remove_modal.dart
+++ b/lib/src/features/accounts/widgets/account_remove_modal.dart
@@ -22,6 +22,12 @@ class AccountRemoveModal extends StatefulWidget {
     required this.pendingSwapCount,
     required this.checkingPendingSwaps,
     required this.pendingSwapCheckFailed,
+    this.receivingGiftCardCount = 0,
+    this.checkingReceivingGiftCards = false,
+    this.receivingGiftCardCheckFailed = false,
+    this.unsharedGiftCardCount = 0,
+    this.checkingUnsharedGiftCards = false,
+    this.unsharedGiftCardCheckFailed = false,
     required this.onCancel,
     required this.onConfirmPassword,
     required this.onRemove,
@@ -34,6 +40,12 @@ class AccountRemoveModal extends StatefulWidget {
   final int pendingSwapCount;
   final bool checkingPendingSwaps;
   final bool pendingSwapCheckFailed;
+  final int receivingGiftCardCount;
+  final bool checkingReceivingGiftCards;
+  final bool receivingGiftCardCheckFailed;
+  final int unsharedGiftCardCount;
+  final bool checkingUnsharedGiftCards;
+  final bool unsharedGiftCardCheckFailed;
   final VoidCallback onCancel;
   final Future<bool> Function(String password) onConfirmPassword;
   final Future<void> Function(AccountRemoveProgressCallback onProgress)
@@ -54,7 +66,7 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
 
   bool get _canSubmit =>
       !_isSubmitting &&
-      _swapRemovalBlockMessage == null &&
+      _removalBlockMessage == null &&
       isWalletPasswordValid(_passwordController.text);
 
   String? get _passwordMessage {
@@ -62,17 +74,45 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
     return validateWalletPassword(_passwordController.text);
   }
 
-  String? get _swapRemovalBlockMessage {
+  String? get _removalBlockMessage {
     if (widget.checkingPendingSwaps) {
       return 'Checking this account for active swaps before removal.';
     }
     if (widget.pendingSwapCheckFailed) {
       return "Couldn't check this account for active swaps. Try again before removing it.";
     }
-    if (widget.pendingSwapCount <= 0) return null;
-    final plural = widget.pendingSwapCount == 1 ? 'swap' : 'swaps';
-    return 'This account has ${widget.pendingSwapCount} active $plural. '
-        'Complete or remove them from swap activity before removing this account.';
+    if (widget.pendingSwapCount > 0) {
+      final plural = widget.pendingSwapCount == 1 ? 'swap' : 'swaps';
+      return 'This account has ${widget.pendingSwapCount} active $plural. '
+          'Complete or remove them from swap activity before removing this account.';
+    }
+    if (widget.checkingReceivingGiftCards) {
+      return 'Checking this account for incoming Gift Cards before removal.';
+    }
+    if (widget.receivingGiftCardCheckFailed) {
+      return "Couldn't check this account for incoming Gift Cards. Try again before removing it.";
+    }
+    if (widget.receivingGiftCardCount > 0) {
+      if (widget.receivingGiftCardCount == 1) {
+        return 'This account is receiving a Gift Card. '
+            'Wait for it to finish before removing this account.';
+      }
+      return 'This account is receiving ${widget.receivingGiftCardCount} Gift Cards. '
+          'Wait for them to finish before removing this account.';
+    }
+    if (widget.checkingUnsharedGiftCards) {
+      return 'Checking this account for unshared Gift Cards before removal.';
+    }
+    if (widget.unsharedGiftCardCheckFailed) {
+      return "Couldn't check this account for unshared Gift Cards. Try again before removing it.";
+    }
+    if (widget.unsharedGiftCardCount <= 0) return null;
+    final plural = widget.unsharedGiftCardCount == 1 ? 'link' : 'links';
+    final action = widget.unsharedGiftCardCount == 1
+        ? 'Copy it before removing this account.'
+        : 'Copy them before removing this account.';
+    return 'This account has ${widget.unsharedGiftCardCount} unshared Gift Card $plural. '
+        '$action';
   }
 
   @override
@@ -84,7 +124,7 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
 
   Future<void> _submit() async {
     if (_isSubmitting) return;
-    if (_swapRemovalBlockMessage != null) return;
+    if (_removalBlockMessage != null) return;
     final passwordError = validateRequiredWalletPassword(
       _passwordController.text,
     );
@@ -176,7 +216,7 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
   @override
   Widget build(BuildContext context) {
     final passwordMessage = _passwordMessage;
-    final swapRemovalBlockMessage = _swapRemovalBlockMessage;
+    final removalBlockMessage = _removalBlockMessage;
 
     return AccountModalCard(
       child: Column(
@@ -195,9 +235,9 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
               color: context.colors.text.accent,
             ),
           ),
-          if (swapRemovalBlockMessage != null) ...[
+          if (removalBlockMessage != null) ...[
             const SizedBox(height: AppSpacing.sm),
-            _AccountRemoveWarningPanel(message: swapRemovalBlockMessage),
+            _AccountRemoveWarningPanel(message: removalBlockMessage),
           ],
           const SizedBox(height: AppSpacing.sm),
           SizedBox(
@@ -210,7 +250,7 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
               inputHorizontalPadding: AppSpacing.s,
               controller: _passwordController,
               autofocus: true,
-              enabled: !_isSubmitting && swapRemovalBlockMessage == null,
+              enabled: !_isSubmitting && removalBlockMessage == null,
               tone: passwordMessage == null
                   ? AppTextFieldTone.neutral
                   : AppTextFieldTone.destructive,
@@ -257,6 +297,7 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
       return 'Removing this account will completely reset the Vizor app. '
           'This means deleting all accounts and requiring you to import '
           'accounts again.\n'
+          'Unshared Gift Card links will also be permanently lost.\n'
           'This cannot be undone.';
     }
     return "Are you sure you want to remove this account? "

--- a/lib/src/features/onboarding/lost_password_screen.dart
+++ b/lib/src/features/onboarding/lost_password_screen.dart
@@ -10,6 +10,7 @@ import '../../core/theme/app_theme.dart';
 import '../../core/widgets/app_button.dart';
 import '../../core/widgets/app_icon.dart';
 import '../../providers/account_provider.dart';
+import '../payment_links/services/payment_link_received_store.dart';
 import '../../providers/device_owner_auth_provider.dart';
 import '../../providers/sync_provider.dart';
 import '../../providers/wallet_mutation_guard.dart';
@@ -117,6 +118,14 @@ class _LostPasswordScreenState extends ConsumerState<LostPasswordScreen> {
             ? kWalletResetDeviceAuthRequiredMessage
             : kWalletResetDeviceAuthFailedMessage;
       });
+    } on WalletResetInFlightGiftCardClaimsException catch (e, st) {
+      // Not a failed wipe: nothing was deleted, and the user only has to wait.
+      log('LostPasswordScreen._handleReset held for claim: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _isResetting = false;
+        _error = kWalletResetInFlightGiftCardClaimsMessage;
+      });
     } catch (e, st) {
       log('LostPasswordScreen._handleReset: ERROR: $e\n$st');
       if (!mounted) return;
@@ -184,6 +193,13 @@ class _LostPasswordScreenState extends ConsumerState<LostPasswordScreen> {
               remainingSeconds: _remainingSeconds,
               canReset: _canReset,
               error: _error,
+              // Warned, not blocked: reset is the only way back into a wallet
+              // whose password is lost, and a claim cannot finish while the
+              // wallet is locked, so refusing here would never lift.
+              warning:
+                  (ref.watch(paymentLinkClaimsInFlightProvider).value ?? 0) > 0
+                  ? kWalletResetInFlightGiftCardWarningMessage
+                  : null,
               onBack: _handleBack,
               onReset: _handleReset,
             ),
@@ -199,6 +215,7 @@ class _LostPasswordContent extends StatelessWidget {
     required this.remainingSeconds,
     required this.canReset,
     required this.error,
+    required this.warning,
     required this.onBack,
     required this.onReset,
   });
@@ -206,6 +223,7 @@ class _LostPasswordContent extends StatelessWidget {
   final int remainingSeconds;
   final bool canReset;
   final String? error;
+  final String? warning;
   final VoidCallback onBack;
   final VoidCallback onReset;
 
@@ -226,7 +244,7 @@ class _LostPasswordContent extends StatelessWidget {
     final buttonLabel = remainingSeconds > 0
         ? 'Reset after ${remainingSeconds}s...'
         : 'Reset Vizor';
-    final statusText = error ?? 'This cannot be undone.';
+    final statusText = error ?? warning ?? 'This cannot be undone.';
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -269,7 +287,7 @@ class _LostPasswordContent extends StatelessWidget {
                   ),
                   const TextSpan(
                     text:
-                        ', which\nmeans deleting all accounts and requiring you to\n',
+                        '.\nThis deletes all accounts and unshared Gift Card links.\nYou will need to ',
                   ),
                   TextSpan(text: 'import accounts again', style: strongStyle),
                   const TextSpan(text: '.'),

--- a/lib/src/features/onboarding/mobile/forgot_passcode_sheet.dart
+++ b/lib/src/features/onboarding/mobile/forgot_passcode_sheet.dart
@@ -8,6 +8,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
+import '../../payment_links/services/payment_link_received_store.dart';
 import '../../../providers/biometric_unlock_provider.dart';
 import '../../../providers/device_owner_auth_provider.dart';
 import '../../../providers/sync_provider.dart';
@@ -22,12 +23,18 @@ const double _kForgotPasscodeButtonMinWidth = 196;
 /// shows [ForgotPasscodeLastWarningSheet] as a second, irreversible-action
 /// gate before actually wiping the wallet. Shown from the app-entry unlock
 /// screen and the settings passcode verification step.
-class ForgotPasscodeSheet extends StatelessWidget {
+class ForgotPasscodeSheet extends ConsumerWidget {
   const ForgotPasscodeSheet({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.colors;
+    // Warned, not blocked: this is the only way back into a wallet whose
+    // passcode is lost, and a claim cannot finish while the wallet is locked,
+    // so refusing here would never lift. `resetWallet` skips its refusal on
+    // the locked path for the same reason.
+    final claimsInFlight =
+        ref.watch(paymentLinkClaimsInFlightProvider).value ?? 0;
     return MobileModalScaffold(
       title: 'Forgot Passcode?',
       onClose: () => Navigator.of(context).pop(false),
@@ -41,9 +48,19 @@ class ForgotPasscodeSheet extends StatelessWidget {
             "If you can't remember your passcode, the only way to "
             'recover your account is to completely reset the Vizor app, '
             'which means deleting all accounts and requiring you to '
-            'import accounts again.',
+            'import accounts again. Unshared Gift Card links will be '
+            'permanently lost.',
             style: AppTypography.bodyMedium.copyWith(color: colors.text.accent),
           ),
+          if (claimsInFlight > 0) ...[
+            const SizedBox(height: AppSpacing.s),
+            Text(
+              kWalletResetInFlightGiftCardWarningMessage,
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: colors.text.destructive,
+              ),
+            ),
+          ],
           const SizedBox(height: AppSpacing.md),
           AppButton(
             key: const ValueKey('mobile_forgot_passcode_reset'),

--- a/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
@@ -23,6 +23,7 @@ import '../../../providers/router_refresh_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../services/biometric_unlock.dart';
 import '../../../services/device_owner_auth.dart';
+import '../../payment_links/services/payment_link_surface.dart';
 import 'forgot_passcode_sheet.dart';
 import 'mobile_passcode_screen.dart' show kMobilePasscodeLength;
 import 'passcode_widgets.dart';
@@ -229,7 +230,8 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
         // lands on top of whichever destination that picks.
         final claimed = claimParkedPaymentUriAfterUnlock(ref);
         final hasPendingPaymentLink =
-            ref.read(paymentLinkIntakeProvider).pendingLink != null;
+            ref.read(paymentLinkIntakeProvider).pendingLink != null &&
+            paymentLinkSurfaceRegistered(GoRouter.of(context));
         context.go(hasPendingPaymentLink ? '/payment-links' : '/home');
         final pendingPrefill = claimed.prefill;
         final notice = claimed.notice;

--- a/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
@@ -13,6 +13,7 @@ import '../../../core/feedback/app_haptics.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_toast.dart';
+import '../../payment_links/providers/payment_link_intake_provider.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
 import '../../../providers/biometric_unlock_provider.dart';
@@ -222,8 +223,14 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
         // the prefill would already be cleared with no way to recover it —
         // and the drain policy inside the claim reads state those awaits
         // settle.
+        // Claim first, then pick the destination, then present. Both link
+        // kinds can be waiting at once, and they do not compete: the Gift Card
+        // owns the route, the ZIP-321 card is a route-agnostic overlay that
+        // lands on top of whichever destination that picks.
         final claimed = claimParkedPaymentUriAfterUnlock(ref);
-        context.go('/home');
+        final hasPendingPaymentLink =
+            ref.read(paymentLinkIntakeProvider).pendingLink != null;
+        context.go(hasPendingPaymentLink ? '/payment-links' : '/home');
         final pendingPrefill = claimed.prefill;
         final notice = claimed.notice;
         if (pendingPrefill != null) {
@@ -309,6 +316,15 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
         _error = e.kind == DeviceOwnerAuthErrorKind.unavailable
             ? kWalletResetDeviceAuthRequiredMessage
             : kWalletResetDeviceAuthFailedMessage;
+      });
+      return;
+    } on WalletResetInFlightGiftCardClaimsException catch (e, st) {
+      // Not a failed wipe: nothing was deleted, and the user only has to wait.
+      log('MobileUnlockScreen._resetWallet held for claim: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _submitting = false;
+        _error = kWalletResetInFlightGiftCardClaimsMessage;
       });
       return;
     } catch (e, st) {

--- a/lib/src/features/payment_links/models/vizor_payment_link.dart
+++ b/lib/src/features/payment_links/models/vizor_payment_link.dart
@@ -1,0 +1,271 @@
+import 'dart:convert';
+
+import 'package:characters/characters.dart';
+
+import '../../../core/navigation/vizor_deep_link.dart';
+
+const kPaymentLinkRegtestEnabledEnvKey = 'VIZOR_PAYMENT_LINK_REGTEST_ENABLED';
+const kPaymentLinkRegtestEnabled = bool.fromEnvironment(
+  kPaymentLinkRegtestEnabledEnvKey,
+  defaultValue: false,
+);
+
+class PaymentLinkPresentation {
+  const PaymentLinkPresentation({this.artworkId, this.message});
+
+  static const maxArtworkIdLength = 64;
+  static const maxMessageCharacters = 128;
+  static const maxMessageUtf8Bytes = 512;
+
+  final String? artworkId;
+  final String? message;
+
+  static bool isMessageWithinUtf8ByteLimit(String? message) {
+    final normalizedMessage = _normalizeOptionalString(message);
+    return normalizedMessage == null ||
+        utf8.encode(normalizedMessage).length <= maxMessageUtf8Bytes;
+  }
+
+  Map<String, Object?>? toPayload() {
+    final normalizedArtworkId = _normalizeOptionalString(artworkId);
+    final normalizedMessage = _normalizeOptionalString(message);
+    _validate(artworkId: normalizedArtworkId, message: normalizedMessage);
+    if (normalizedArtworkId == null && normalizedMessage == null) {
+      return null;
+    }
+    return <String, Object?>{
+      'artworkId': ?normalizedArtworkId,
+      'message': ?normalizedMessage,
+    };
+  }
+
+  static PaymentLinkPresentation? fromPayload(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, Object?>) {
+      throw const FormatException('Payment link presentation is invalid.');
+    }
+    final artworkId = _readOptionalString(value, 'artworkId');
+    final message = _readOptionalString(value, 'message');
+    _validate(artworkId: artworkId, message: message);
+    if (artworkId == null && message == null) return null;
+    return PaymentLinkPresentation(artworkId: artworkId, message: message);
+  }
+
+  static void _validate({String? artworkId, String? message}) {
+    if (artworkId != null &&
+        !RegExp(
+          '^[a-zA-Z0-9_-]{1,$maxArtworkIdLength}\$',
+        ).hasMatch(artworkId)) {
+      throw const FormatException('Payment link artwork is invalid.');
+    }
+    if (message != null) {
+      if (message.characters.length > maxMessageCharacters) {
+        throw const FormatException('Payment link message is too long.');
+      }
+      if (!isMessageWithinUtf8ByteLimit(message)) {
+        throw const FormatException('Payment link message is too large.');
+      }
+    }
+  }
+
+  static String? _readOptionalString(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value == null) return null;
+    if (value is! String) {
+      throw FormatException('Payment link presentation "$key" is invalid.');
+    }
+    return _normalizeOptionalString(value);
+  }
+
+  static String? _normalizeOptionalString(String? value) {
+    final trimmed = value?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+}
+
+class VizorPaymentLink {
+  const VizorPaymentLink({
+    required this.network,
+    required this.address,
+    required this.amountZatoshi,
+    required this.mnemonic,
+    required this.birthdayHeight,
+    required this.label,
+    required this.createdAt,
+    this.presentation,
+  });
+
+  static const maxEncodedLength = 16 * 1024;
+  static const _version = 1;
+  static const _fragmentPrefix = 'v1=';
+
+  final String network;
+  final String address;
+  final BigInt amountZatoshi;
+  final String mnemonic;
+  final int birthdayHeight;
+  final String label;
+  final DateTime createdAt;
+  final PaymentLinkPresentation? presentation;
+
+  static bool supportsNetwork(String network) {
+    final normalizedNetwork = network.trim();
+    return normalizedNetwork == 'main' ||
+        (kPaymentLinkRegtestEnabled && normalizedNetwork == 'regtest');
+  }
+
+  /// Compares every field carried by the versioned payment-link payload after
+  /// applying the same normalization as [toUri]. This is intentionally stricter
+  /// than claim-wallet cache identity: a corrected amount or changed
+  /// presentation must remain a distinct intake item.
+  bool hasSameCanonicalPayload(VizorPaymentLink other) {
+    return _encodedPayload() == other._encodedPayload();
+  }
+
+  Uri toUri() {
+    return Uri(
+      scheme: VizorDeepLink.scheme,
+      host: VizorDeepLink.host,
+      path: VizorDeepLink.paymentLinkPath,
+      fragment: '$_fragmentPrefix${_encodedPayload()}',
+    );
+  }
+
+  String _encodedPayload() {
+    final normalizedNetwork = network.trim();
+    if (!supportsNetwork(normalizedNetwork)) {
+      throw const FormatException(
+        'Payment links are only available on mainnet.',
+      );
+    }
+    final payload = <String, Object?>{
+      'v': _version,
+      'network': normalizedNetwork,
+      'address': address.trim(),
+      'amountZatoshi': amountZatoshi.toString(),
+      'mnemonic': mnemonic.trim(),
+      'birthdayHeight': birthdayHeight,
+      'label': label.trim(),
+      'createdAt': createdAt.toUtc().toIso8601String(),
+    };
+    final presentationPayload = presentation?.toPayload();
+    if (presentationPayload != null) {
+      payload['presentation'] = presentationPayload;
+    }
+    return base64UrlEncode(utf8.encode(jsonEncode(payload)));
+  }
+
+  static bool matchesEndpoint(Uri uri) {
+    return VizorDeepLink.routeFor(uri) == VizorDeepLinkRoute.paymentLink;
+  }
+
+  static VizorPaymentLink parse(String rawLink) {
+    final trimmed = rawLink.trim();
+    if (trimmed.length > maxEncodedLength) {
+      throw const FormatException('Payment link is too large.');
+    }
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null || !matchesEndpoint(uri)) {
+      throw const FormatException('This is not a Vizor payment link.');
+    }
+    if (uri.userInfo.isNotEmpty || uri.hasPort || uri.hasQuery) {
+      throw const FormatException('Payment link URL is invalid.');
+    }
+
+    final fragment = uri.fragment;
+    if (!fragment.startsWith(_fragmentPrefix)) {
+      throw const FormatException('Payment link is missing its payload.');
+    }
+    final encoded = fragment.substring(_fragmentPrefix.length);
+    if (encoded.isEmpty || encoded.contains('&')) {
+      throw const FormatException('Payment link payload is invalid.');
+    }
+
+    late final Object? decodedJson;
+    try {
+      decodedJson = jsonDecode(
+        utf8.decode(base64Url.decode(base64Url.normalize(encoded))),
+      );
+    } catch (_) {
+      throw const FormatException('Payment link payload could not be read.');
+    }
+
+    if (decodedJson is! Map<String, Object?>) {
+      throw const FormatException('Payment link payload is invalid.');
+    }
+    final payload = decodedJson;
+    if (payload['v'] != _version) {
+      throw const FormatException('Payment link version is not supported.');
+    }
+
+    final network = _readString(payload, 'network');
+    final address = _readString(payload, 'address');
+    final amountZatoshi = _readBigInt(payload, 'amountZatoshi');
+    final mnemonic = _readString(payload, 'mnemonic');
+    final birthdayHeight = _readInt(payload, 'birthdayHeight');
+    final label = _readString(payload, 'label');
+    final createdAtRaw = _readString(payload, 'createdAt');
+    final createdAt = DateTime.tryParse(createdAtRaw);
+    final presentation = PaymentLinkPresentation.fromPayload(
+      payload['presentation'],
+    );
+
+    if (!supportsNetwork(network)) {
+      throw const FormatException('Payment link network is not supported.');
+    }
+    if (address.isEmpty) {
+      throw const FormatException('Payment link address is missing.');
+    }
+    if (amountZatoshi <= BigInt.zero) {
+      throw const FormatException('Payment link amount is invalid.');
+    }
+    if (mnemonic.split(RegExp(r'\s+')).length < 12) {
+      throw const FormatException('Payment link recovery phrase is invalid.');
+    }
+    if (birthdayHeight <= 0) {
+      throw const FormatException('Payment link birthday height is invalid.');
+    }
+    if (createdAt == null) {
+      throw const FormatException('Payment link timestamp is invalid.');
+    }
+
+    return VizorPaymentLink(
+      network: network,
+      address: address,
+      amountZatoshi: amountZatoshi,
+      mnemonic: mnemonic,
+      birthdayHeight: birthdayHeight,
+      label: label,
+      createdAt: createdAt,
+      presentation: presentation,
+    );
+  }
+
+  static String _readString(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value is! String) {
+      throw FormatException('Payment link is missing "$key".');
+    }
+    return value.trim();
+  }
+
+  static int _readInt(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value is int) return value;
+    if (value is String) {
+      final parsed = int.tryParse(value.trim());
+      if (parsed != null) return parsed;
+    }
+    throw FormatException('Payment link "$key" is invalid.');
+  }
+
+  static BigInt _readBigInt(Map<String, Object?> payload, String key) {
+    final value = payload[key];
+    if (value is int) return BigInt.from(value);
+    if (value is String) {
+      final parsed = BigInt.tryParse(value.trim());
+      if (parsed != null) return parsed;
+    }
+    throw FormatException('Payment link "$key" is invalid.');
+  }
+}

--- a/lib/src/features/payment_links/providers/payment_link_cards_provider.dart
+++ b/lib/src/features/payment_links/providers/payment_link_cards_provider.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/payment_link_received_store.dart';
+import '../services/payment_link_recovery_store.dart';
+import '../services/payment_link_service.dart';
+
+@immutable
+class PaymentLinkCardsSnapshot {
+  const PaymentLinkCardsSnapshot({
+    required this.created,
+    required this.received,
+  });
+
+  final List<PaymentLinkRecoveryRecord> created;
+  final List<PaymentLinkReceivedRecord> received;
+}
+
+typedef PaymentLinkCardsLoader = Future<PaymentLinkCardsSnapshot> Function();
+
+final paymentLinkCardsLoaderProvider = Provider<PaymentLinkCardsLoader>((ref) {
+  final operations = ref.watch(paymentLinkOperationsProvider);
+  return () => loadPaymentLinkCardsSnapshot(operations);
+});
+
+Future<PaymentLinkCardsSnapshot> loadPaymentLinkCardsSnapshot(
+  PaymentLinkOperations operations,
+) async {
+  final results = await Future.wait<Object>([
+    operations.loadCreatedLinkRecoveries(),
+    operations.loadReceivedLinkRecoveries(),
+  ]);
+  final created = List<PaymentLinkRecoveryRecord>.of(
+    results[0] as List<PaymentLinkRecoveryRecord>,
+  );
+  final received = List<PaymentLinkReceivedRecord>.of(
+    results[1] as List<PaymentLinkReceivedRecord>,
+  );
+  created.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+  received.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+  return PaymentLinkCardsSnapshot(created: created, received: received);
+}

--- a/lib/src/features/payment_links/providers/payment_link_claim_coordinator_provider.dart
+++ b/lib/src/features/payment_links/providers/payment_link_claim_coordinator_provider.dart
@@ -1,0 +1,217 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../providers/app_security_provider.dart';
+import 'payment_link_claim_lifecycle_registry_provider.dart';
+import '../services/payment_link_received_store.dart';
+import '../services/payment_link_service.dart';
+
+typedef PaymentLinkClaimSubmitter =
+    Future<PaymentLinkClaimResult> Function(PaymentLinkClaimSession session);
+
+typedef PaymentLinkClaimRecoveryRunner =
+    Future<List<PaymentLinkReceivedRecord>> Function();
+
+@visibleForTesting
+final paymentLinkClaimSubmitterProvider = Provider<PaymentLinkClaimSubmitter>((
+  ref,
+) {
+  final operations = ref.watch(paymentLinkOperationsProvider);
+  return operations.claimPreparedLink;
+});
+
+@visibleForTesting
+final paymentLinkClaimRecoveryRunnerProvider =
+    Provider<PaymentLinkClaimRecoveryRunner>((ref) {
+      final operations = ref.watch(paymentLinkOperationsProvider);
+      return () async {
+        final records = await operations.loadReceivedLinkRecoveries();
+        if (!records.any((record) => record.isClaimInFlight)) {
+          return records;
+        }
+        return operations.inspectReceivedLinkClaims(records);
+      };
+    });
+
+@visibleForTesting
+final paymentLinkClaimRecoveryRetryDelayProvider = Provider<Duration>((ref) {
+  return const Duration(seconds: 10);
+});
+
+/// Owns claim work whose lifetime must not depend on a Gift Card screen.
+///
+/// Different addresses submit independently. Repeated submission of the same
+/// address joins the existing future, while retained receiving claims are
+/// reconciled on app start, unlock, resume, and a bounded foreground timer.
+class PaymentLinkClaimCoordinator {
+  PaymentLinkClaimCoordinator(this._ref);
+
+  final Ref _ref;
+  final Map<String, Future<PaymentLinkClaimResult>> _submissions = {};
+  Future<List<PaymentLinkReceivedRecord>>? _recoveryInFlight;
+  Timer? _retryTimer;
+  bool _enabled = false;
+  bool _resetQuiesced = false;
+  bool _disposed = false;
+
+  @visibleForTesting
+  int get activeSubmissionCount => _submissions.length;
+
+  bool isSubmitting(String address) => _submissions.containsKey(address);
+
+  Future<PaymentLinkClaimResult> submit(PaymentLinkClaimSession session) {
+    if (_resetQuiesced) {
+      return Future.error(
+        StateError(
+          'Gift Card claims are paused while the wallet is being changed.',
+        ),
+      );
+    }
+    final claimId = session.link.address;
+    final existing = _submissions[claimId];
+    if (existing != null) return existing;
+
+    late final Future<PaymentLinkClaimResult> tracked;
+    tracked =
+        Future<PaymentLinkClaimResult>.sync(
+          () => _ref.read(paymentLinkClaimSubmitterProvider)(session),
+        ).whenComplete(() {
+          if (identical(_submissions[claimId], tracked)) {
+            _submissions.remove(claimId);
+          }
+          if (_enabled && !_disposed) _refreshInBackground();
+        });
+    _submissions[claimId] = tracked;
+    return tracked;
+  }
+
+  Future<List<PaymentLinkReceivedRecord>> refresh() {
+    if (_resetQuiesced) return Future.value(const []);
+    final existing = _recoveryInFlight;
+    if (existing != null) return existing;
+
+    late final Future<List<PaymentLinkReceivedRecord>> tracked;
+    tracked = _refreshOnce().whenComplete(() {
+      if (identical(_recoveryInFlight, tracked)) {
+        _recoveryInFlight = null;
+      }
+    });
+    _recoveryInFlight = tracked;
+    return tracked;
+  }
+
+  void resume() {
+    if (_disposed || _resetQuiesced) return;
+    _enabled = true;
+    _refreshInBackground();
+  }
+
+  void pause() {
+    _enabled = false;
+    _retryTimer?.cancel();
+    _retryTimer = null;
+  }
+
+  void dispose() {
+    _disposed = true;
+    _resetQuiesced = true;
+    pause();
+  }
+
+  Future<void> quiesceAndDrain() async {
+    _resetQuiesced = true;
+    pause();
+    while (_submissions.isNotEmpty || _recoveryInFlight != null) {
+      final pending = <Future<Object?>>[
+        ..._submissions.values,
+        ?_recoveryInFlight,
+      ];
+      await Future.wait(pending.map(_ignoreOutcome));
+    }
+  }
+
+  void resumeAfterReset() {
+    if (_disposed) return;
+    _resetQuiesced = false;
+    if (!_ref.read(appSecurityProvider).requiresUnlock) resume();
+  }
+
+  Future<void> _ignoreOutcome(Future<Object?> operation) async {
+    try {
+      await operation;
+    } catch (_) {
+      // A failed operation is settled and no longer blocks destructive reset.
+    }
+  }
+
+  Future<List<PaymentLinkReceivedRecord>> _refreshOnce() async {
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    if (!_enabled || _ref.read(appSecurityProvider).requiresUnlock) {
+      return const [];
+    }
+
+    var retry = true;
+    try {
+      final records = await _ref.read(paymentLinkClaimRecoveryRunnerProvider)();
+      retry = records.any((record) => record.isClaimInFlight);
+      return records;
+    } finally {
+      if (retry && _enabled && !_disposed) _scheduleRetry();
+    }
+  }
+
+  void _scheduleRetry() {
+    if (_retryTimer?.isActive ?? false) return;
+    final configured = _ref.read(paymentLinkClaimRecoveryRetryDelayProvider);
+    final delay = configured.isNegative ? Duration.zero : configured;
+    _retryTimer = Timer(delay, () {
+      _retryTimer = null;
+      if (_enabled && !_disposed) _refreshInBackground();
+    });
+  }
+
+  void _refreshInBackground() {
+    unawaited(
+      refresh().catchError((Object error, StackTrace stackTrace) {
+        debugPrint(
+          '[zcash] PaymentLinkClaim: background recovery failed: '
+          '$error\n$stackTrace',
+        );
+        return <PaymentLinkReceivedRecord>[];
+      }),
+    );
+  }
+}
+
+final paymentLinkClaimCoordinatorProvider = Provider((ref) {
+  final coordinator = PaymentLinkClaimCoordinator(ref);
+  final lifecycleRegistry = ref.read(paymentLinkClaimLifecycleRegistryProvider);
+  lifecycleRegistry.register(
+    owner: coordinator,
+    quiesceAndDrain: coordinator.quiesceAndDrain,
+    resume: coordinator.resumeAfterReset,
+  );
+  ref.listen<AppSecurityState>(appSecurityProvider, (previous, next) {
+    if (next.requiresUnlock) {
+      coordinator.pause();
+    } else if (previous?.requiresUnlock == true) {
+      coordinator.resume();
+    }
+  });
+  if (!ref.read(appSecurityProvider).requiresUnlock) coordinator.resume();
+
+  final lifecycleListener = AppLifecycleListener(
+    onHide: coordinator.pause,
+    onPause: coordinator.pause,
+    onResume: coordinator.resume,
+  );
+  ref.onDispose(() {
+    lifecycleRegistry.unregister(coordinator);
+    lifecycleListener.dispose();
+    coordinator.dispose();
+  });
+  return coordinator;
+});

--- a/lib/src/features/payment_links/providers/payment_link_claim_lifecycle_registry_provider.dart
+++ b/lib/src/features/payment_links/providers/payment_link_claim_lifecycle_registry_provider.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final paymentLinkClaimLifecycleRegistryProvider = Provider(
+  (ref) => PaymentLinkClaimLifecycleRegistry(),
+);
+
+class PaymentLinkClaimLifecycleRegistry {
+  Object? _owner;
+  Future<void> Function()? _quiesceAndDrain;
+  void Function()? _resume;
+
+  void register({
+    required Object owner,
+    required Future<void> Function() quiesceAndDrain,
+    required void Function() resume,
+  }) {
+    final currentOwner = _owner;
+    if (currentOwner != null && !identical(currentOwner, owner)) {
+      throw StateError('A Gift Card claim lifecycle owner is already active.');
+    }
+    _owner = owner;
+    _quiesceAndDrain = quiesceAndDrain;
+    _resume = resume;
+  }
+
+  void unregister(Object owner) {
+    if (!identical(_owner, owner)) return;
+    _owner = null;
+    _quiesceAndDrain = null;
+    _resume = null;
+  }
+
+  Future<void> quiesceAndDrain() async {
+    await _quiesceAndDrain?.call();
+  }
+
+  void resume() {
+    _resume?.call();
+  }
+}

--- a/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
+++ b/lib/src/features/payment_links/providers/payment_link_intake_provider.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/vizor_payment_link.dart';
+
+enum PaymentLinkIntakeResult { accepted, ignored, rejected }
+
+/// The queue of Gift Card links that arrived but have not been opened yet.
+///
+/// **Deliberately not the same store as `paymentUriPrefillProvider`**, even
+/// though both hold links delivered by the same native channel. A Gift Card is
+/// a bearer claim on funds that are *not* in this wallet: losing one loses the
+/// money, so up to [kPaymentLinkIntakeQueueCapacity] of them queue instead of
+/// displacing each other, they never expire, and they survive a wallet reset —
+/// the claim is still good on whatever wallet the user sets up next. A ZIP-321
+/// request is the opposite on all three counts (one at a time, a 10-minute
+/// TTL, dropped on reset) because it spends *this* wallet's money.
+
+const kPaymentLinkIntakeQueueCapacity = 16;
+
+class PaymentLinkIntakeState {
+  const PaymentLinkIntakeState({
+    this.pendingLinks = const [],
+    this.errorMessage,
+  });
+
+  final List<VizorPaymentLink> pendingLinks;
+  final String? errorMessage;
+
+  VizorPaymentLink? get pendingLink =>
+      pendingLinks.isEmpty ? null : pendingLinks.first;
+}
+
+class PaymentLinkIntakeNotifier extends Notifier<PaymentLinkIntakeState> {
+  @override
+  PaymentLinkIntakeState build() => const PaymentLinkIntakeState();
+
+  PaymentLinkIntakeResult receive(String rawUri) {
+    final uri = Uri.tryParse(rawUri.trim());
+    if (uri == null || !VizorPaymentLink.matchesEndpoint(uri)) {
+      return PaymentLinkIntakeResult.ignored;
+    }
+
+    try {
+      final link = VizorPaymentLink.parse(rawUri);
+      final pendingLinks = state.pendingLinks;
+      // Account and birthday identify a reusable claim wallet, not a duplicate
+      // user intent. Only an identical versioned payload can be coalesced.
+      final duplicate = pendingLinks.any(
+        (pending) => pending.hasSameCanonicalPayload(link),
+      );
+      if (duplicate) {
+        state = PaymentLinkIntakeState(pendingLinks: pendingLinks);
+        return PaymentLinkIntakeResult.accepted;
+      }
+      if (pendingLinks.length >= kPaymentLinkIntakeQueueCapacity) {
+        state = PaymentLinkIntakeState(
+          pendingLinks: pendingLinks,
+          errorMessage: 'Too many payment links are waiting to open.',
+        );
+        return PaymentLinkIntakeResult.rejected;
+      }
+      state = PaymentLinkIntakeState(pendingLinks: [...pendingLinks, link]);
+      return PaymentLinkIntakeResult.accepted;
+    } on FormatException {
+      state = PaymentLinkIntakeState(
+        pendingLinks: state.pendingLinks,
+        errorMessage: 'Payment link could not be opened.',
+      );
+      return PaymentLinkIntakeResult.rejected;
+    }
+  }
+
+  VizorPaymentLink? takePending() {
+    final link = state.pendingLink;
+    if (link == null) return null;
+    state = PaymentLinkIntakeState(
+      pendingLinks: state.pendingLinks.sublist(1),
+      errorMessage: state.errorMessage,
+    );
+    return link;
+  }
+
+  void clearError() {
+    state = PaymentLinkIntakeState(pendingLinks: state.pendingLinks);
+  }
+}
+
+final paymentLinkIntakeProvider =
+    NotifierProvider<PaymentLinkIntakeNotifier, PaymentLinkIntakeState>(
+      PaymentLinkIntakeNotifier.new,
+    );

--- a/lib/src/features/payment_links/services/payment_link_claim_math.dart
+++ b/lib/src/features/payment_links/services/payment_link_claim_math.dart
@@ -1,0 +1,279 @@
+/// Part of `payment_link_service.dart`: pure Gift Card claim and funding
+/// arithmetic.
+///
+/// Confirmation counting, expiry, funding amounts, and received-status
+/// derivation are decisions about numbers and wire strings only: they touch no
+/// widget, no wallet DB, and no Rust call. They stay a `part` rather than their
+/// own library so the `@visibleForTesting` contract on them keeps its meaning —
+/// the annotation is library-scoped, and the service is their only production
+/// caller.
+part of 'payment_link_service.dart';
+
+const kPaymentLinkClaimConfirmationTarget = 6;
+
+/// The ZIP-317 fee for the payment link's expected one-input, one-output
+/// shielded claim transaction.
+const kPaymentLinkClaimFeeReserveZatoshi = 10000;
+
+@visibleForTesting
+Future<T> runPaymentLinkFundingSubmission<T>(
+  Future<T> Function(void Function() markSubmissionStarted) operation,
+) async {
+  var submissionStarted = false;
+  try {
+    return await operation(() => submissionStarted = true);
+  } catch (error, stackTrace) {
+    if (!submissionStarted) {
+      throw PaymentLinkFundingNotSubmittedException(error, stackTrace);
+    }
+    rethrow;
+  }
+}
+
+BigInt paymentLinkFundingAmountZatoshi(BigInt recipientAmountZatoshi) {
+  if (recipientAmountZatoshi <= BigInt.zero) {
+    throw ArgumentError.value(
+      recipientAmountZatoshi,
+      'recipientAmountZatoshi',
+      'Payment link amount must be positive.',
+    );
+  }
+  return recipientAmountZatoshi +
+      BigInt.from(kPaymentLinkClaimFeeReserveZatoshi);
+}
+
+@visibleForTesting
+int paymentLinkConfirmationCount({
+  required BigInt minedHeight,
+  required BigInt chainTipHeight,
+}) {
+  if (minedHeight <= BigInt.zero || chainTipHeight < minedHeight) return 0;
+  return (chainTipHeight - minedHeight + BigInt.one).toInt();
+}
+
+@visibleForTesting
+BigInt paymentLinkVerifiedChainHeight({
+  required int scannedHeight,
+  required int chainTipHeight,
+}) {
+  if (scannedHeight <= 0 || chainTipHeight <= 0) return BigInt.zero;
+  return BigInt.from(min(scannedHeight, chainTipHeight));
+}
+
+@visibleForTesting
+int paymentLinkFundingConfirmationCountForClaim({
+  required BigInt recipientAmountZatoshi,
+  required List<rust_sync.TransactionInfo> transactions,
+  required BigInt chainTipHeight,
+}) {
+  final expectedFunding = paymentLinkFundingAmountZatoshi(
+    recipientAmountZatoshi,
+  );
+  var confirmationCount = 0;
+  for (final transaction in transactions) {
+    if (transaction.expiredUnmined ||
+        transaction.txKind != 'received' ||
+        BigInt.from(transaction.accountBalanceDelta) != expectedFunding) {
+      continue;
+    }
+    confirmationCount = max(
+      confirmationCount,
+      paymentLinkConfirmationCount(
+        minedHeight: transaction.minedHeight,
+        chainTipHeight: chainTipHeight,
+      ),
+    );
+  }
+  return min(confirmationCount, kPaymentLinkClaimConfirmationTarget);
+}
+
+@visibleForTesting
+bool paymentLinkShouldWaitForFunding({
+  required BigInt recipientAmountZatoshi,
+  required BigInt totalZatoshi,
+  required int fundingConfirmationCount,
+  required int birthdayHeight,
+  required int currentTipHeight,
+}) {
+  if (fundingConfirmationCount >= kPaymentLinkClaimConfirmationTarget) {
+    return false;
+  }
+  final expectedFunding = paymentLinkFundingAmountZatoshi(
+    recipientAmountZatoshi,
+  );
+  if (totalZatoshi >= expectedFunding) return true;
+  return currentTipHeight - birthdayHeight <
+      kPaymentLinkClaimConfirmationTarget;
+}
+
+@visibleForTesting
+PaymentLinkReceivedStatus paymentLinkReceivedStatusForTransactions({
+  required String claimTxids,
+  required List<rust_sync.TransactionInfo> transactions,
+  required BigInt chainTipHeight,
+}) {
+  final expectedTxids = claimTxids
+      .split(',')
+      .map(normalizePaymentLinkTxid)
+      .where((txid) => txid.isNotEmpty)
+      .toSet();
+  if (expectedTxids.isEmpty) return PaymentLinkReceivedStatus.receiving;
+
+  bool everyTxidMatches(
+    bool Function(rust_sync.TransactionInfo transaction) predicate,
+  ) {
+    return expectedTxids.every(
+      (expectedTxid) => transactions.any(
+        (transaction) =>
+            paymentLinkTxidsMatch(expectedTxid, transaction.txidHex) &&
+            predicate(transaction),
+      ),
+    );
+  }
+
+  final allConfirmed = everyTxidMatches(
+    (transaction) =>
+        transaction.txKind == 'received' &&
+        paymentLinkConfirmationCount(
+              minedHeight: transaction.minedHeight,
+              chainTipHeight: chainTipHeight,
+            ) >=
+            kPaymentLinkClaimConfirmationTarget,
+  );
+  if (allConfirmed) return PaymentLinkReceivedStatus.received;
+
+  final allExpired = paymentLinkClaimTransactionsExpired(
+    claimTxids: claimTxids,
+    transactions: transactions,
+  );
+  return allExpired
+      ? PaymentLinkReceivedStatus.readyToClaim
+      : PaymentLinkReceivedStatus.receiving;
+}
+
+@visibleForTesting
+bool paymentLinkClaimTransactionsExpired({
+  required String claimTxids,
+  required List<rust_sync.TransactionInfo> transactions,
+}) {
+  final expectedTxids = claimTxids
+      .split(',')
+      .map(normalizePaymentLinkTxid)
+      .where((txid) => txid.isNotEmpty)
+      .toSet();
+  if (expectedTxids.isEmpty) return false;
+  return expectedTxids.every(
+    (expectedTxid) => transactions.any(
+      (transaction) =>
+          paymentLinkTxidsMatch(expectedTxid, transaction.txidHex) &&
+          transaction.expiredUnmined,
+    ),
+  );
+}
+
+@visibleForTesting
+List<String> paymentLinkActiveClaimTxids(
+  Iterable<rust_sync.TransactionInfo> transactions,
+) {
+  return transactions
+      .where(
+        (transaction) =>
+            transaction.txKind == 'sent' &&
+            !transaction.expiredUnmined &&
+            transaction.txidHex.trim().isNotEmpty,
+      )
+      .map((transaction) => transaction.txidHex.trim())
+      .toSet()
+      .toList();
+}
+
+const _submittedPaymentLinkFundingStatuses = {
+  'broadcasted',
+  'pending_broadcast',
+  'partial_broadcast',
+  'broadcast_unknown',
+  'broadcasted_storage_failed',
+};
+
+bool isPaymentLinkFundingSubmitted({
+  required String status,
+  required String txids,
+}) {
+  return txids.trim().isNotEmpty &&
+      _submittedPaymentLinkFundingStatuses.contains(status);
+}
+
+bool isPaymentLinkFundingBroadcastAccepted(String status) {
+  return status == 'broadcasted' || status == 'broadcasted_storage_failed';
+}
+
+@visibleForTesting
+BigInt paymentLinkClaimableAmountZatoshi({
+  required BigInt recipientAmountZatoshi,
+  required BigInt maxSpendableZatoshi,
+}) {
+  return maxSpendableZatoshi >= recipientAmountZatoshi
+      ? recipientAmountZatoshi
+      : BigInt.zero;
+}
+
+@visibleForTesting
+Future<bool> finalizeConfirmedPaymentLinkClaim({
+  required PaymentLinkReceivedRecord record,
+  required Future<bool> Function(PaymentLinkReceivedRecord record)
+  deleteRetainedWallet,
+  required Future<void> Function(String address) markReceived,
+}) async {
+  if (!await deleteRetainedWallet(record)) return false;
+  await markReceived(record.address);
+  return true;
+}
+
+@visibleForTesting
+bool shouldRecreatePaymentLinkClaimWallet({
+  required List<String> accountAddresses,
+  required String expectedAddress,
+}) {
+  return accountAddresses.length != 1 ||
+      accountAddresses.single != expectedAddress;
+}
+
+@visibleForTesting
+void requireUnlockedPaymentLinkWallet({required bool requiresUnlock}) {
+  if (requiresUnlock) {
+    throw StateError('Wallet is locked.');
+  }
+}
+
+@visibleForTesting
+int validatePaymentLinkClaimBirthday({
+  required int advertisedBirthdayHeight,
+  required int currentTipHeight,
+}) {
+  if (currentTipHeight <= 0) {
+    throw StateError('Current chain tip is unavailable.');
+  }
+  if (advertisedBirthdayHeight <= 0) {
+    throw const FormatException('Payment link birthday must be positive.');
+  }
+  if (advertisedBirthdayHeight > currentTipHeight) {
+    throw const FormatException(
+      'Payment link birthday is ahead of the current chain tip.',
+    );
+  }
+  return advertisedBirthdayHeight;
+}
+
+const kPaymentLinkLongSyncLookbackBlocks = 100000;
+
+@visibleForTesting
+bool isLongPaymentLinkSync({
+  required int birthdayHeight,
+  required int currentTipHeight,
+}) {
+  validatePaymentLinkClaimBirthday(
+    advertisedBirthdayHeight: birthdayHeight,
+    currentTipHeight: currentTipHeight,
+  );
+  return currentTipHeight - birthdayHeight > kPaymentLinkLongSyncLookbackBlocks;
+}

--- a/lib/src/features/payment_links/services/payment_link_claim_wallet.dart
+++ b/lib/src/features/payment_links/services/payment_link_claim_wallet.dart
@@ -132,35 +132,46 @@ class PaymentLinkClaimWallet {
     VizorPaymentLink link,
   ) async {
     final tempWallet = await createOrOpen(link);
-    if (!tempWallet.existed) {
-      await importClaimAccount(
+    String? accountUuid;
+    if (tempWallet.existed) {
+      List<rust_wallet.AccountInfo>? accounts;
+      try {
+        accounts = await rust_wallet.listAccounts(
+          dbPath: tempWallet.dbPath,
+          network: link.network,
+        );
+      } catch (e) {
+        log('PaymentLinkClaimWallet: reopening the claim wallet failed: $e');
+      }
+      if (accounts != null &&
+          !shouldRecreatePaymentLinkClaimWallet(
+            accountAddresses: [
+              for (final account in accounts) account.unifiedAddress,
+            ],
+            expectedAddress: link.address,
+          )) {
+        accountUuid = accounts.single.uuid;
+      } else {
+        // An import that died between creating the file and the account, or a
+        // wallet for another identity: recreate, as the claim path does.
+        await resetDb(tempWallet.directory);
+        await tempWallet.directory.create(recursive: true);
+      }
+    }
+    if (accountUuid == null) {
+      final imported = await importClaimAccount(
         link: link,
         birthdayHeight: link.birthdayHeight,
         dbPath: tempWallet.dbPath,
         network: link.network,
       );
+      accountUuid = imported.accountUuid;
     }
     await runClaimSync(link: link, dbPath: tempWallet.dbPath);
-    final accounts = await rust_wallet.listAccounts(
-      dbPath: tempWallet.dbPath,
-      network: link.network,
-    );
-    if (shouldRecreatePaymentLinkClaimWallet(
-      accountAddresses: [
-        for (final account in accounts) account.unifiedAddress,
-      ],
-      expectedAddress: link.address,
-    )) {
-      log(
-        'PaymentLinkClaimWallet: funding history skipped because the claim '
-        'wallet no longer matches its Gift Card identity',
-      );
-      return const [];
-    }
     return rust_sync.getTransactionHistory(
       dbPath: tempWallet.dbPath,
       network: link.network,
-      accountUuid: accounts.single.uuid,
+      accountUuid: accountUuid,
       limit: null,
     );
   }

--- a/lib/src/features/payment_links/services/payment_link_claim_wallet.dart
+++ b/lib/src/features/payment_links/services/payment_link_claim_wallet.dart
@@ -120,6 +120,51 @@ class PaymentLinkClaimWallet {
     );
   }
 
+  /// Reads the link's own wallet history so a funding broadcast whose result
+  /// was lost can be matched against the chain.
+  ///
+  /// The funding transaction is invisible from the source account's history —
+  /// nothing there records which address it paid — but it is a plain receive
+  /// in the Gift Card's own wallet. That wallet normally exists only once
+  /// somebody claims the Card, so this creates and imports it if needed, and
+  /// leaves it in place for the claim that may still follow.
+  Future<List<rust_sync.TransactionInfo>> loadFundingHistory(
+    VizorPaymentLink link,
+  ) async {
+    final tempWallet = await createOrOpen(link);
+    if (!tempWallet.existed) {
+      await importClaimAccount(
+        link: link,
+        birthdayHeight: link.birthdayHeight,
+        dbPath: tempWallet.dbPath,
+        network: link.network,
+      );
+    }
+    await runClaimSync(link: link, dbPath: tempWallet.dbPath);
+    final accounts = await rust_wallet.listAccounts(
+      dbPath: tempWallet.dbPath,
+      network: link.network,
+    );
+    if (shouldRecreatePaymentLinkClaimWallet(
+      accountAddresses: [
+        for (final account in accounts) account.unifiedAddress,
+      ],
+      expectedAddress: link.address,
+    )) {
+      log(
+        'PaymentLinkClaimWallet: funding history skipped because the claim '
+        'wallet no longer matches its Gift Card identity',
+      );
+      return const [];
+    }
+    return rust_sync.getTransactionHistory(
+      dbPath: tempWallet.dbPath,
+      network: link.network,
+      accountUuid: accounts.single.uuid,
+      limit: null,
+    );
+  }
+
   Future<bool> deleteRetained(PaymentLinkReceivedRecord record) async {
     final link = record.claimLink;
     if (link == null) return true;

--- a/lib/src/features/payment_links/services/payment_link_claim_wallet.dart
+++ b/lib/src/features/payment_links/services/payment_link_claim_wallet.dart
@@ -1,0 +1,223 @@
+/// Part of `payment_link_service.dart`: the temporary wallet a Gift Card claim
+/// is scanned in.
+///
+/// A claim imports the link's mnemonic into a throwaway wallet DB under its own
+/// directory, scans it, and deletes it again. That directory lifecycle plus the
+/// per-claim scan de-duplication is the whole concern here, so it is kept out of
+/// the service file, which only orchestrates funding and claiming over this
+/// small surface. It stays a `part` rather than its own library because it needs
+/// the `@visibleForTesting` claim math and the service's own claim types.
+part of 'payment_link_service.dart';
+
+/// Claim databases are cached by the fields that determine the recovered
+/// account and its scan range. Share-payload fields such as amount, label,
+/// timestamp, and presentation deliberately do not participate, so a corrected
+/// payload can reuse already-scanned state.
+String paymentLinkClaimWalletDirectoryName(VizorPaymentLink link) {
+  final identity = sha256
+      .convert(
+        utf8.encode(
+          '${link.network}:${link.address}:${link.mnemonic}:'
+          '${link.birthdayHeight}',
+        ),
+      )
+      .toString();
+  return '$kPaymentLinkClaimWalletDirectoryPrefix$identity';
+}
+
+/// Owns every filesystem and scan operation on a claim's temporary wallet.
+class PaymentLinkClaimWallet {
+  PaymentLinkClaimWallet(this._ref);
+
+  final Ref _ref;
+  final Map<String, Future<void>> _claimSyncs = {};
+
+  Future<void> runClaimSync({
+    required VizorPaymentLink link,
+    required String dbPath,
+  }) {
+    final claimId = paymentLinkClaimWalletDirectoryName(link);
+    final existing = _claimSyncs[claimId];
+    if (existing != null) return existing;
+    final future = _runClaimSyncOnce(
+      claimId: claimId,
+      dbPath: dbPath,
+      network: link.network,
+    );
+    _claimSyncs[claimId] = future;
+    return future.whenComplete(() {
+      if (identical(_claimSyncs[claimId], future)) {
+        _claimSyncs.remove(claimId);
+      }
+    });
+  }
+
+  Future<void> _runClaimSyncOnce({
+    required String claimId,
+    required String dbPath,
+    required String network,
+  }) {
+    return _ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .runWithEndpointFallback<void>(
+          operation: 'Gift Card claim sync',
+          action: (endpoint) {
+            if (endpoint.networkName != network) {
+              throw StateError(
+                'Payment link is for $network, but this wallet is using '
+                '${endpoint.networkName}.',
+              );
+            }
+            return rust_sync.runPaymentLinkClaimSync(
+              claimId: claimId,
+              dbPath: dbPath,
+              lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+              network: network,
+            );
+          },
+        );
+  }
+
+  Future<bool> syncRetained({
+    required PaymentLinkReceivedRecord record,
+    required String network,
+  }) async {
+    final link = record.claimLink;
+    final claimTxids = record.claimTxids;
+    if (link == null || claimTxids == null || claimTxids.trim().isEmpty) {
+      return false;
+    }
+
+    final tempWallet = await locate(link);
+    if (!await File(tempWallet.dbPath).exists()) return false;
+
+    await runClaimSync(link: link, dbPath: tempWallet.dbPath);
+    final accounts = await rust_wallet.listAccounts(
+      dbPath: tempWallet.dbPath,
+      network: network,
+    );
+    if (shouldRecreatePaymentLinkClaimWallet(
+      accountAddresses: [
+        for (final account in accounts) account.unifiedAddress,
+      ],
+      expectedAddress: link.address,
+    )) {
+      log(
+        'PaymentLinkService: retained claim wallet no longer matches its '
+        'Gift Card identity; leaving it recoverable from the stored link',
+      );
+      return false;
+    }
+    final transactions = await rust_sync.getTransactionHistory(
+      dbPath: tempWallet.dbPath,
+      network: network,
+      accountUuid: accounts.single.uuid,
+      limit: null,
+    );
+    return paymentLinkClaimTransactionsExpired(
+      claimTxids: claimTxids,
+      transactions: transactions,
+    );
+  }
+
+  Future<bool> deleteRetained(PaymentLinkReceivedRecord record) async {
+    final link = record.claimLink;
+    if (link == null) return true;
+
+    final tempWallet = await locate(link);
+    if (!await tempWallet.directory.exists()) return true;
+    try {
+      await tempWallet.directory.delete(recursive: true);
+      return true;
+    } catch (error, stackTrace) {
+      log(
+        'PaymentLinkService: failed to delete confirmed claim wallet: '
+        '$error\n$stackTrace',
+      );
+      return false;
+    }
+  }
+
+  Future<({Directory directory, String dbPath})> locate(
+    VizorPaymentLink link,
+  ) async {
+    final supportDir = await getWalletSupportDirectory();
+    final separator = Platform.pathSeparator;
+    final directory = Directory(
+      '${supportDir.path}$separator${paymentLinkClaimWalletDirectoryName(link)}',
+    );
+    return (
+      directory: directory,
+      dbPath: '${directory.path}${separator}zcash_wallet.db',
+    );
+  }
+
+  Future<({Directory directory, String dbPath, bool existed})> createOrOpen(
+    VizorPaymentLink link,
+  ) async {
+    final location = await locate(link);
+    final existed = await File(location.dbPath).exists();
+    await location.directory.create(recursive: true);
+    return (
+      directory: location.directory,
+      dbPath: location.dbPath,
+      existed: existed,
+    );
+  }
+
+  Future<({String address, String accountUuid})> importClaimAccount({
+    required VizorPaymentLink link,
+    required int birthdayHeight,
+    required String dbPath,
+    required String network,
+  }) async {
+    final imported = await rust_wallet.importWallet(
+      mnemonic: link.mnemonic,
+      bip39Passphrase: '',
+      birthdayHeight: BigInt.from(birthdayHeight),
+      network: network,
+      dbPath: dbPath,
+      accountName: 'Payment link claim',
+    );
+    return (
+      address: imported.unifiedAddress,
+      accountUuid: imported.accountUuid,
+    );
+  }
+
+  Future<void> resetDb(Directory directory) async {
+    if (await directory.exists()) {
+      await directory.delete(recursive: true);
+    }
+    await directory.create(recursive: true);
+  }
+
+  Future<void> deleteDb(Directory directory) async {
+    try {
+      if (await directory.exists()) {
+        await directory.delete(recursive: true);
+      }
+    } catch (e, st) {
+      log(
+        'PaymentLinkService: failed to delete temporary payment-link DB '
+        '${directory.path}: $e\n$st',
+      );
+    }
+  }
+
+  /// Stops a running claim scan for [link] and waits for it to unwind, so a
+  /// caller can delete the wallet directory underneath it.
+  Future<void> cancelClaimSync(VizorPaymentLink link) async {
+    final claimId = paymentLinkClaimWalletDirectoryName(link);
+    rust_sync.cancelPaymentLinkClaimSync(claimId: claimId);
+    try {
+      await _claimSyncs[claimId];
+    } catch (_) {
+      // A failed scan does not prevent the user-requested preview cleanup.
+    }
+  }
+}
+
+void _zeroize(Uint8List bytes) {
+  bytes.fillRange(0, bytes.length, 0);
+}

--- a/lib/src/features/payment_links/services/payment_link_clipboard.dart
+++ b/lib/src/features/payment_links/services/payment_link_clipboard.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/clipboard/sensitive_clipboard.dart';
+
+abstract interface class PaymentLinkClipboard {
+  Future<String?> readText();
+
+  Future<void> copySecret(String text);
+
+  Future<void> clear();
+}
+
+final paymentLinkClipboardProvider = Provider<PaymentLinkClipboard>((ref) {
+  return const SystemPaymentLinkClipboard();
+});
+
+class SystemPaymentLinkClipboard implements PaymentLinkClipboard {
+  const SystemPaymentLinkClipboard();
+
+  @override
+  Future<String?> readText() async {
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    return data?.text;
+  }
+
+  @override
+  Future<void> copySecret(String text) {
+    return SensitiveClipboard.copyText(text);
+  }
+
+  @override
+  Future<void> clear() {
+    return Clipboard.setData(const ClipboardData(text: ''));
+  }
+}

--- a/lib/src/features/payment_links/services/payment_link_entry_policy.dart
+++ b/lib/src/features/payment_links/services/payment_link_entry_policy.dart
@@ -1,0 +1,64 @@
+/// Where an incoming Gift Card link may open itself, and where it has to wait.
+///
+/// The mirror image of `payment_uri_drain_policy.dart`: that policy keeps a
+/// ZIP-321 request from covering a Gift Card signing round, this one keeps a
+/// Gift Card from navigating out from under a ZIP-321 request card. The two
+/// products share one native pipe, so each has to yield to the other or
+/// whichever link happens to arrive second wins by accident.
+library;
+
+import '../../../core/navigation/app_route_predicates.dart';
+
+const kPaymentLinkDeferredByActiveFlowMessage =
+    'Finish or cancel your current task to open this Gift Card.';
+const kPaymentLinkDeferredByAccountSetupMessage =
+    'Finish account setup to open this Gift Card.';
+
+/// Routes whose in-progress user input or signing state must not be replaced
+/// by an incoming Gift Card.
+///
+/// [paymentRequestCardPresented] is `paymentRequestFlowProvider` holding a
+/// live ZIP-321 card. The card is a route-agnostic overlay, so no location
+/// test can see it, and navigating to `/payment-links` underneath it would
+/// tear down a payment the user was part-way through answering.
+bool paymentLinkEntryBlockedAtLocation(
+  String matchedLocation, {
+  bool paymentRequestCardPresented = false,
+}) {
+  return paymentLinkEntryDeferredMessageAtLocation(
+        matchedLocation,
+        paymentRequestCardPresented: paymentRequestCardPresented,
+      ) !=
+      null;
+}
+
+String? paymentLinkEntryDeferredMessageAtLocation(
+  String matchedLocation, {
+  bool paymentRequestCardPresented = false,
+}) {
+  // The onboarding/import/add-account set is the same one the payment-URI
+  // drain drops on; `/import` covers `/import-keystone` and its children.
+  if (isOnboardingLocation(matchedLocation)) {
+    return kPaymentLinkDeferredByAccountSetupMessage;
+  }
+  // A live payment-request card is a task in progress even though it owns no
+  // route, so it reads as one.
+  if (paymentRequestCardPresented) {
+    return kPaymentLinkDeferredByActiveFlowMessage;
+  }
+  if (matchedLocation == '/lost-password' ||
+      isRouteOrChild(matchedLocation, '/send') ||
+      isRouteOrChild(matchedLocation, '/swap') ||
+      isRouteOrChild(matchedLocation, '/pay') ||
+      isRouteOrChild(matchedLocation, '/migration') ||
+      isRouteOrChild(matchedLocation, '/home/keystone-shield') ||
+      isRouteOrChild(matchedLocation, '/voting/poll') ||
+      isRouteOrChild(matchedLocation, '/voting/keystone/scan') ||
+      isRouteOrChild(matchedLocation, '/settings/change-password') ||
+      isRouteOrChild(matchedLocation, '/settings/secret-passphrase') ||
+      isRouteOrChild(matchedLocation, '/settings/viewing-key') ||
+      isRouteOrChild(matchedLocation, '/settings/uninstall')) {
+    return kPaymentLinkDeferredByActiveFlowMessage;
+  }
+  return null;
+}

--- a/lib/src/features/payment_links/services/payment_link_hardware_signing_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_hardware_signing_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -59,7 +60,7 @@ abstract interface class PaymentLinkHardwareSigningService {
     required List<int> pcztWithSignaturesBytes,
     String? spendParamsPath,
     String? outputParamsPath,
-    void Function()? onSubmissionStarted,
+    FutureOr<void> Function()? onSubmissionStarted,
   });
 }
 
@@ -294,13 +295,13 @@ class RustPaymentLinkHardwareSigningService
     required List<int> pcztWithSignaturesBytes,
     String? spendParamsPath,
     String? outputParamsPath,
-    void Function()? onSubmissionStarted,
+    FutureOr<void> Function()? onSubmissionStarted,
   }) async {
     final dbPath = await getWalletDbPath();
     final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
     // Rust broadcasts before it stores, so from here on a throw can no longer
     // prove the network did not accept the transaction.
-    onSubmissionStarted?.call();
+    await onSubmissionStarted?.call();
     final stored = await rust_sync
         .storeAndBroadcastPcztsWithKeystoneSignaturesForProposal(
           dbPath: dbPath,

--- a/lib/src/features/payment_links/services/payment_link_hardware_signing_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_hardware_signing_service.dart
@@ -1,0 +1,362 @@
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/storage/wallet_paths.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../providers/sync_provider.dart';
+import '../../../rust/api/sync.dart' as rust_sync;
+import '../../keystone/services/keystone_batch_signing.dart';
+import '../models/vizor_payment_link.dart';
+import 'payment_link_recovery_store.dart';
+import 'payment_link_service.dart';
+
+final paymentLinkHardwareSigningServiceProvider =
+    Provider<PaymentLinkHardwareSigningService>((ref) {
+      return RustPaymentLinkHardwareSigningService(
+        ref,
+        ref.read(paymentLinkServiceProvider),
+        ref.read(paymentLinkRecoveryStoreProvider),
+      );
+    });
+
+abstract interface class PaymentLinkHardwareSigningService {
+  Future<PaymentLinkHardwarePcztDraft> createFundingPczt({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+    PaymentLinkPresentation? presentation,
+  });
+
+  Future<List<String>> encodeSigningUrParts({
+    required PaymentLinkHardwarePcztDraft draft,
+  });
+
+  Future<List<int>> decodeSigningResponse({
+    required PaymentLinkHardwarePcztDraft draft,
+    required List<int> responseCbor,
+  });
+
+  Future<List<int>> addProofsForSigning({
+    required PaymentLinkHardwarePcztDraft draft,
+    String? spendParamsPath,
+    String? outputParamsPath,
+  });
+
+  Future<void> discardPcztDraft({required PaymentLinkHardwarePcztDraft draft});
+
+  /// Applies [pcztWithSignaturesBytes] and broadcasts the funding transaction.
+  ///
+  /// [onSubmissionStarted] fires immediately before the transaction is handed
+  /// to the network, mirroring the software path's
+  /// `runPaymentLinkFundingSubmission` marker. Once it has fired the caller
+  /// must keep the recovery draft on failure: the network may already hold
+  /// the transaction, and the draft carries the `markPrepared` txid the
+  /// reconciler needs to settle it.
+  Future<PaymentLinkHardwareFundingResult> broadcastSignedPczt({
+    required PaymentLinkHardwarePcztDraft draft,
+    required List<int> pcztWithProofsBytes,
+    required List<int> pcztWithSignaturesBytes,
+    String? spendParamsPath,
+    String? outputParamsPath,
+    void Function()? onSubmissionStarted,
+  });
+}
+
+class PaymentLinkHardwarePcztDraft {
+  const PaymentLinkHardwarePcztDraft({
+    required this.link,
+    required this.pcztBytes,
+    required this.needsSaplingParams,
+    required this.feeZatoshi,
+    required this.proposalId,
+    required this.sendFlowId,
+  });
+
+  final VizorPaymentLink link;
+  final List<int> pcztBytes;
+  final bool needsSaplingParams;
+  final BigInt feeZatoshi;
+  final BigInt proposalId;
+  final String sendFlowId;
+}
+
+class PaymentLinkHardwareFundingResult {
+  const PaymentLinkHardwareFundingResult({
+    required this.txids,
+    required this.status,
+    required this.fundingMetadataSaved,
+    this.message,
+  });
+
+  final String txids;
+  final String status;
+  final String? message;
+  final bool fundingMetadataSaved;
+}
+
+class RustPaymentLinkHardwareSigningService
+    implements PaymentLinkHardwareSigningService {
+  RustPaymentLinkHardwareSigningService(
+    this._ref,
+    this._paymentLinkService,
+    this._recoveryStore,
+  );
+
+  final Ref _ref;
+  final PaymentLinkService _paymentLinkService;
+  final PaymentLinkRecoveryStore _recoveryStore;
+
+  @override
+  Future<PaymentLinkHardwarePcztDraft> createFundingPczt({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+    PaymentLinkPresentation? presentation,
+  }) async {
+    final link = await _paymentLinkService.createFundingDraft(
+      amountZatoshi: amountZatoshi,
+      sourceAccountUuid: sourceAccountUuid,
+      presentation: presentation,
+    );
+    final sendFlowId =
+        'payment-link-hw-${DateTime.now().microsecondsSinceEpoch}';
+
+    try {
+      return await _ref
+          .read(syncProvider.notifier)
+          .runWithAuthoritativeSpendable(
+            accountUuid: sourceAccountUuid,
+            operation: () async {
+              final dbPath = await getWalletDbPath();
+              final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+              BigInt? proposalId;
+              var proposalConsumed = false;
+
+              try {
+                final proposal = await rust_sync.proposeSend(
+                  dbPath: dbPath,
+                  network: endpoint.networkName,
+                  accountUuid: sourceAccountUuid,
+                  sendFlowId: sendFlowId,
+                  toAddress: link.address,
+                  amountZatoshi: paymentLinkFundingAmountZatoshi(amountZatoshi),
+                );
+                proposalId = proposal.proposalId;
+                final pcztBytes = await rust_sync.createPcztFromProposal(
+                  dbPath: dbPath,
+                  lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+                  network: endpoint.networkName,
+                  proposalId: proposal.proposalId,
+                  sendFlowId: sendFlowId,
+                );
+                proposalConsumed = true;
+                return PaymentLinkHardwarePcztDraft(
+                  link: link,
+                  pcztBytes: pcztBytes,
+                  needsSaplingParams: proposal.needsSaplingParams,
+                  feeZatoshi: proposal.feeZatoshi,
+                  proposalId: proposal.proposalId,
+                  sendFlowId: sendFlowId,
+                );
+              } finally {
+                if (proposalId != null && !proposalConsumed) {
+                  try {
+                    await rust_sync.discardProposal(
+                      proposalId: proposalId,
+                      sendFlowId: sendFlowId,
+                    );
+                  } catch (error) {
+                    log(
+                      'PaymentLinkHardwareSigning: proposal cleanup failed '
+                      'flow=$sendFlowId proposal=$proposalId error=$error',
+                    );
+                  }
+                }
+              }
+            },
+          );
+    } catch (error, stackTrace) {
+      try {
+        await _recoveryStore.removeUnsubmittedDraft(address: link.address);
+      } catch (cleanupError) {
+        log(
+          'PaymentLinkHardwareSigning: failed PCZT draft cleanup '
+          'address=${link.address} error=$cleanupError',
+        );
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+  }
+
+  @override
+  Future<List<String>> encodeSigningUrParts({
+    required PaymentLinkHardwarePcztDraft draft,
+  }) async {
+    final request = await buildKeystoneBatchSigningRequest(
+      requestId: _paymentLinkKeystoneRequestId(draft),
+      pczts: [
+        KeystoneBatchPcztSource(
+          id: _paymentLinkKeystoneMessageId,
+          pcztBytes: draft.pcztBytes,
+        ),
+      ],
+    );
+    return request.urParts;
+  }
+
+  @override
+  Future<List<int>> decodeSigningResponse({
+    required PaymentLinkHardwarePcztDraft draft,
+    required List<int> responseCbor,
+  }) async {
+    final prepared = await rust_sync.preparePcztForKeystoneBatch(
+      pcztBytes: draft.pcztBytes,
+    );
+    final request = KeystoneBatchSigningRequest(
+      requestId: _paymentLinkKeystoneRequestId(draft),
+      messageIds: const [_paymentLinkKeystoneMessageId],
+      expectedSignatureCounts: [prepared.expectedSignatureCount],
+      urParts: const [],
+    );
+    final signatureBlobs = await request.decodeResponse(responseCbor);
+    if (signatureBlobs.length != 1) {
+      throw StateError(
+        'Keystone returned an invalid Gift Card signature count.',
+      );
+    }
+    return signatureBlobs.single;
+  }
+
+  @override
+  Future<List<int>> addProofsForSigning({
+    required PaymentLinkHardwarePcztDraft draft,
+    String? spendParamsPath,
+    String? outputParamsPath,
+  }) async {
+    final pcztWithProofs = await rust_sync.addProofsToPczt(
+      pcztBytes: draft.pcztBytes,
+      spendParamsPath: draft.needsSaplingParams ? spendParamsPath : null,
+      outputParamsPath: draft.needsSaplingParams ? outputParamsPath : null,
+    );
+    final preparedTxid = rust_sync.getPcztTxid(pcztBytes: pcztWithProofs);
+    final preparedExpiryHeight = rust_sync.getPcztExpiryHeight(
+      pcztBytes: pcztWithProofs,
+    );
+    await _recoveryStore.markPrepared(
+      address: draft.link.address,
+      fundingTxid: preparedTxid,
+      expiryHeight: preparedExpiryHeight,
+    );
+    return pcztWithProofs;
+  }
+
+  @override
+  Future<void> discardPcztDraft({
+    required PaymentLinkHardwarePcztDraft draft,
+  }) async {
+    await _discardProposal(draft);
+    try {
+      await _recoveryStore.removeUnbroadcastDraft(address: draft.link.address);
+    } catch (error) {
+      log(
+        'PaymentLinkHardwareSigning: canceled funding cleanup failed '
+        'address=${draft.link.address} error=$error',
+      );
+    }
+  }
+
+  Future<void> _discardProposal(PaymentLinkHardwarePcztDraft draft) async {
+    Object? lastError;
+    for (var attempt = 1; attempt <= 3; attempt++) {
+      try {
+        await rust_sync.discardProposal(
+          proposalId: draft.proposalId,
+          sendFlowId: draft.sendFlowId,
+        );
+        return;
+      } catch (error) {
+        lastError = error;
+        if (attempt < 3) {
+          await Future<void>.delayed(Duration(milliseconds: attempt * 100));
+        }
+      }
+    }
+    log(
+      'PaymentLinkHardwareSigning: proposal cleanup remains pending '
+      'flow=${draft.sendFlowId} proposal=${draft.proposalId} error=$lastError',
+    );
+  }
+
+  @override
+  Future<PaymentLinkHardwareFundingResult> broadcastSignedPczt({
+    required PaymentLinkHardwarePcztDraft draft,
+    required List<int> pcztWithProofsBytes,
+    required List<int> pcztWithSignaturesBytes,
+    String? spendParamsPath,
+    String? outputParamsPath,
+    void Function()? onSubmissionStarted,
+  }) async {
+    final dbPath = await getWalletDbPath();
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    // Rust broadcasts before it stores, so from here on a throw can no longer
+    // prove the network did not accept the transaction.
+    onSubmissionStarted?.call();
+    final stored = await rust_sync
+        .storeAndBroadcastPcztsWithKeystoneSignaturesForProposal(
+          dbPath: dbPath,
+          lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+          network: endpoint.networkName,
+          proposalId: draft.proposalId,
+          sendFlowId: draft.sendFlowId,
+          pcztWithProofs: [Uint8List.fromList(pcztWithProofsBytes)],
+          signatureBlobs: [Uint8List.fromList(pcztWithSignaturesBytes)],
+          spendParamsPath: spendParamsPath,
+          outputParamsPath: outputParamsPath,
+        );
+    final result = rust_sync.ExtractAndBroadcastPcztResult(
+      txid: stored.txids
+          .split(',')
+          .map((txid) => txid.trim())
+          .firstWhere((txid) => txid.isNotEmpty, orElse: () => ''),
+      status: stored.status,
+      message: stored.message,
+    );
+
+    final fundingAccepted = isPaymentLinkFundingSubmitted(
+      status: result.status,
+      txids: result.txid,
+    );
+    var fundingMetadataSaved = false;
+    if (fundingAccepted) {
+      final funding = await PaymentLinkFundingRecovery(_recoveryStore).complete(
+        transaction: result,
+        address: draft.link.address,
+        fundingTxids: (broadcast) => broadcast.txid,
+      );
+      if (!funding.fundingMetadataSaved) {
+        log(
+          'PaymentLinkHardwareSigning: funding was submitted but recovery '
+          'metadata could not be saved after retry: '
+          '${funding.recoveryError}\n${funding.recoveryStackTrace}',
+        );
+      }
+      fundingMetadataSaved = funding.fundingMetadataSaved;
+    }
+    try {
+      await _ref.read(syncProvider.notifier).refreshAfterSend();
+    } catch (error) {
+      log('PaymentLinkHardwareSigning: refreshAfterSend failed: $error');
+    }
+    return PaymentLinkHardwareFundingResult(
+      txids: result.txid,
+      status: result.status,
+      message: result.message,
+      fundingMetadataSaved: fundingMetadataSaved,
+    );
+  }
+}
+
+const _paymentLinkKeystoneMessageId = 'gift-card-funding';
+
+String _paymentLinkKeystoneRequestId(PaymentLinkHardwarePcztDraft draft) =>
+    'vizor-${draft.sendFlowId}';

--- a/lib/src/features/payment_links/services/payment_link_lifecycle_revision.dart
+++ b/lib/src/features/payment_links/services/payment_link_lifecycle_revision.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class PaymentLinkLifecycleRevisionNotifier extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void bump() {
+    state++;
+  }
+}
+
+final paymentLinkLifecycleRevisionProvider =
+    NotifierProvider<PaymentLinkLifecycleRevisionNotifier, int>(
+      PaymentLinkLifecycleRevisionNotifier.new,
+    );

--- a/lib/src/features/payment_links/services/payment_link_received_store.dart
+++ b/lib/src/features/payment_links/services/payment_link_received_store.dart
@@ -1,0 +1,615 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/storage/app_secure_store.dart';
+import '../models/vizor_payment_link.dart';
+import 'payment_link_lifecycle_revision.dart';
+
+const _storageVersion = 1;
+const _fieldNotProvided = Object();
+
+final paymentLinkReceivedStoreProvider = Provider<PaymentLinkReceivedStore>((
+  ref,
+) {
+  return PaymentLinkReceivedStore(
+    AppSecureStorePaymentLinkReceivedStorage(AppSecureStore.instance),
+    onRecordsChanged: () {
+      ref.read(paymentLinkLifecycleRevisionProvider.notifier).bump();
+    },
+  );
+});
+
+final paymentLinkReceivingCountProvider = FutureProvider.family<int, String>((
+  ref,
+  destinationAccountUuid,
+) {
+  ref.watch(paymentLinkLifecycleRevisionProvider);
+  return ref
+      .watch(paymentLinkReceivedStoreProvider)
+      .countReceivingForAccount(destinationAccountUuid);
+});
+
+/// Gift Card claims that are mid-flight across every account.
+///
+/// A wallet reset drains claims instead of refusing them, so a claim that
+/// finishes during the drain settles into a wallet that is about to be wiped.
+/// The reset and uninstall confirmations read this to warn about that window
+/// before the user commits; a non-zero count means funds are still moving.
+final paymentLinkClaimsInFlightProvider = FutureProvider<int>((ref) {
+  ref.watch(paymentLinkLifecycleRevisionProvider);
+  return ref.watch(paymentLinkReceivedStoreProvider).countClaimsInFlight();
+});
+
+enum PaymentLinkReceivedStatus { readyToClaim, submitting, receiving, received }
+
+class PaymentLinkInFlightClaimsException implements Exception {
+  const PaymentLinkInFlightClaimsException({
+    required this.destinationAccountUuid,
+    required this.count,
+  });
+
+  final String destinationAccountUuid;
+  final int count;
+
+  @override
+  String toString() =>
+      'Wait for incoming Gift Cards to finish before deleting this account.';
+}
+
+class PaymentLinkReceivedRecord {
+  const PaymentLinkReceivedRecord({
+    required this.network,
+    required this.address,
+    required this.amountZatoshi,
+    required this.createdAt,
+    required this.artworkId,
+    required this.status,
+    required this.claimLink,
+    required this.destinationAccountUuid,
+    required this.claimTxids,
+    required this.updatedAt,
+    this.message,
+  });
+
+  factory PaymentLinkReceivedRecord.fromLink(
+    VizorPaymentLink link, {
+    DateTime? updatedAt,
+  }) {
+    return PaymentLinkReceivedRecord(
+      network: link.network,
+      address: link.address,
+      amountZatoshi: link.amountZatoshi,
+      createdAt: link.createdAt.toUtc(),
+      artworkId: link.presentation?.artworkId,
+      message: link.presentation?.message,
+      status: PaymentLinkReceivedStatus.readyToClaim,
+      claimLink: link,
+      destinationAccountUuid: null,
+      claimTxids: null,
+      updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+    );
+  }
+
+  final String network;
+  final String address;
+  final BigInt amountZatoshi;
+  final DateTime createdAt;
+  final String? artworkId;
+  final String? message;
+  final PaymentLinkReceivedStatus status;
+
+  /// The bearer secret is retained only while the Card can still require a
+  /// retry. It is removed only after the receiver's history proves the claim
+  /// reached the required confirmation target.
+  final VizorPaymentLink? claimLink;
+  final String? destinationAccountUuid;
+  final String? claimTxids;
+  final DateTime updatedAt;
+
+  bool get isClaimInFlight =>
+      status == PaymentLinkReceivedStatus.submitting ||
+      status == PaymentLinkReceivedStatus.receiving;
+
+  bool get needsClaimMetadataRecovery =>
+      status == PaymentLinkReceivedStatus.submitting;
+
+  PaymentLinkReceivedRecord copyWith({
+    PaymentLinkReceivedStatus? status,
+    Object? claimLink = _fieldNotProvided,
+    Object? destinationAccountUuid = _fieldNotProvided,
+    Object? claimTxids = _fieldNotProvided,
+    DateTime? updatedAt,
+  }) {
+    return PaymentLinkReceivedRecord(
+      network: network,
+      address: address,
+      amountZatoshi: amountZatoshi,
+      createdAt: createdAt,
+      artworkId: artworkId,
+      message: message,
+      status: status ?? this.status,
+      claimLink: identical(claimLink, _fieldNotProvided)
+          ? this.claimLink
+          : claimLink as VizorPaymentLink?,
+      destinationAccountUuid:
+          identical(destinationAccountUuid, _fieldNotProvided)
+          ? this.destinationAccountUuid
+          : destinationAccountUuid as String?,
+      claimTxids: identical(claimTxids, _fieldNotProvided)
+          ? this.claimTxids
+          : claimTxids as String?,
+      updatedAt: (updatedAt ?? this.updatedAt).toUtc(),
+    );
+  }
+}
+
+class PaymentLinkReceivedStoreFormatException implements Exception {
+  const PaymentLinkReceivedStoreFormatException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'PaymentLinkReceivedStoreFormatException: $message';
+}
+
+abstract interface class PaymentLinkReceivedStorage {
+  Future<String?> read();
+
+  Future<void> write(String value);
+
+  Future<void> delete();
+}
+
+class AppSecureStorePaymentLinkReceivedStorage
+    implements PaymentLinkReceivedStorage {
+  const AppSecureStorePaymentLinkReceivedStorage(this._store);
+
+  final AppSecureStore _store;
+
+  @override
+  Future<String?> read() {
+    return _store.readSecretStringWithOptions(
+      kPaymentLinkReceivedStorageKey,
+      requireUnlockedSession: true,
+    );
+  }
+
+  @override
+  Future<void> write(String value) {
+    return _store.writeSecretString(kPaymentLinkReceivedStorageKey, value);
+  }
+
+  @override
+  Future<void> delete() {
+    return _store.delete(kPaymentLinkReceivedStorageKey);
+  }
+}
+
+class PaymentLinkReceivedStore {
+  PaymentLinkReceivedStore(this._storage, {void Function()? onRecordsChanged})
+    : _onRecordsChanged = onRecordsChanged;
+
+  final PaymentLinkReceivedStorage _storage;
+  final void Function()? _onRecordsChanged;
+  Future<void> _operationTail = Future<void>.value();
+
+  Future<List<PaymentLinkReceivedRecord>> load() {
+    return _runExclusive(_loadUnlocked);
+  }
+
+  Future<PaymentLinkReceivedRecord?> find(String address) {
+    return _runExclusive(() async {
+      return _findByAddress(await _loadUnlocked(), address);
+    });
+  }
+
+  /// Claims that have been submitted but not yet observed as received, across
+  /// every destination account — including records whose destination account
+  /// is not yet written, which [countReceivingForAccount] cannot see.
+  Future<int> countClaimsInFlight() async {
+    final records = await load();
+    return records.where((record) => record.isClaimInFlight).length;
+  }
+
+  Future<int> countReceivingForAccount(String destinationAccountUuid) async {
+    if (destinationAccountUuid.isEmpty) return 0;
+    final records = await load();
+    return records
+        .where(
+          (record) =>
+              record.isClaimInFlight &&
+              record.destinationAccountUuid == destinationAccountUuid,
+        )
+        .length;
+  }
+
+  Future<PaymentLinkReceivedRecord> saveReady(
+    VizorPaymentLink link, {
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      final records = await _loadUnlocked();
+      final existing = _findByAddress(records, link.address);
+      if (existing?.status == PaymentLinkReceivedStatus.received) {
+        return existing!;
+      }
+      final record = PaymentLinkReceivedRecord(
+        network: link.network,
+        address: link.address,
+        amountZatoshi: link.amountZatoshi,
+        createdAt: link.createdAt.toUtc(),
+        artworkId: link.presentation?.artworkId,
+        message: link.presentation?.message,
+        status: existing?.status ?? PaymentLinkReceivedStatus.readyToClaim,
+        claimLink: link,
+        destinationAccountUuid: existing?.destinationAccountUuid,
+        claimTxids: existing?.claimTxids,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+      );
+      await _writeRecords(_replaceByAddress(records, record));
+      return record;
+    });
+  }
+
+  Future<PaymentLinkReceivedRecord> markReceiving({
+    required String address,
+    required String destinationAccountUuid,
+    required String claimTxids,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      if (destinationAccountUuid.trim().isEmpty) {
+        throw ArgumentError.value(
+          destinationAccountUuid,
+          'destinationAccountUuid',
+          'A receiving payment link requires a destination account.',
+        );
+      }
+      if (claimTxids.trim().isEmpty) {
+        throw ArgumentError.value(
+          claimTxids,
+          'claimTxids',
+          'A receiving payment link requires a claim transaction id.',
+        );
+      }
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      if (existing.status == PaymentLinkReceivedStatus.received) {
+        return existing;
+      }
+      final updated = PaymentLinkReceivedRecord(
+        network: existing.network,
+        address: existing.address,
+        amountZatoshi: existing.amountZatoshi,
+        createdAt: existing.createdAt,
+        artworkId: existing.artworkId,
+        message: existing.message,
+        status: PaymentLinkReceivedStatus.receiving,
+        claimLink: existing.claimLink,
+        destinationAccountUuid: destinationAccountUuid.trim(),
+        claimTxids: claimTxids.trim(),
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<PaymentLinkReceivedRecord> markClaimStarted({
+    required String address,
+    required String destinationAccountUuid,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      final normalizedAccountUuid = destinationAccountUuid.trim();
+      if (normalizedAccountUuid.isEmpty) {
+        throw ArgumentError.value(
+          destinationAccountUuid,
+          'destinationAccountUuid',
+          'A started payment link claim requires a destination account.',
+        );
+      }
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      if (existing.status == PaymentLinkReceivedStatus.received) {
+        return existing;
+      }
+      if (existing.status != PaymentLinkReceivedStatus.readyToClaim ||
+          existing.claimLink == null) {
+        throw StateError('Only a ready Gift Card claim can be started.');
+      }
+      final updated = existing.copyWith(
+        status: PaymentLinkReceivedStatus.submitting,
+        destinationAccountUuid: normalizedAccountUuid,
+        claimTxids: null,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<PaymentLinkReceivedRecord> markReceived({
+    required String address,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      final updated = PaymentLinkReceivedRecord(
+        network: existing.network,
+        address: existing.address,
+        amountZatoshi: existing.amountZatoshi,
+        createdAt: existing.createdAt,
+        artworkId: existing.artworkId,
+        message: existing.message,
+        status: PaymentLinkReceivedStatus.received,
+        claimLink: null,
+        destinationAccountUuid: existing.destinationAccountUuid,
+        claimTxids: existing.claimTxids,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<PaymentLinkReceivedRecord> markReadyToClaim({
+    required String address,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      if (existing.claimLink == null) {
+        throw StateError(
+          'A received payment link without its secret cannot be retried.',
+        );
+      }
+      final updated = PaymentLinkReceivedRecord(
+        network: existing.network,
+        address: existing.address,
+        amountZatoshi: existing.amountZatoshi,
+        createdAt: existing.createdAt,
+        artworkId: existing.artworkId,
+        message: existing.message,
+        status: PaymentLinkReceivedStatus.readyToClaim,
+        claimLink: existing.claimLink,
+        destinationAccountUuid: null,
+        claimTxids: null,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<List<PaymentLinkReceivedRecord>> _loadUnlocked() async {
+    final raw = await _storage.read();
+    if (raw == null || raw.trim().isEmpty) return const [];
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        throw const PaymentLinkReceivedStoreFormatException(
+          'Received-card payload must be a JSON object.',
+        );
+      }
+      if (decoded['version'] != _storageVersion) {
+        throw const PaymentLinkReceivedStoreFormatException(
+          'Received-card payload version is not supported.',
+        );
+      }
+      final items = decoded['records'];
+      if (items is! List) {
+        throw const PaymentLinkReceivedStoreFormatException(
+          'Received-card records are missing.',
+        );
+      }
+      return [for (final item in items) _recordFromJson(item)];
+    } on PaymentLinkReceivedStoreFormatException {
+      rethrow;
+    } catch (error) {
+      throw PaymentLinkReceivedStoreFormatException(
+        'Received-card payload could not be decoded: $error',
+      );
+    }
+  }
+
+  Future<void> _writeRecords(List<PaymentLinkReceivedRecord> records) async {
+    if (records.isEmpty) {
+      await _storage.delete();
+      _onRecordsChanged?.call();
+      return;
+    }
+    await _storage.write(
+      jsonEncode({
+        'version': _storageVersion,
+        'records': [for (final record in records) _recordToJson(record)],
+      }),
+    );
+    _onRecordsChanged?.call();
+  }
+
+  Future<T> _runExclusive<T>(Future<T> Function() operation) {
+    final result = _operationTail.then((_) => operation());
+    _operationTail = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+}
+
+PaymentLinkReceivedRecord? _findByAddress(
+  List<PaymentLinkReceivedRecord> records,
+  String address,
+) {
+  for (final record in records) {
+    if (record.address == address) return record;
+  }
+  return null;
+}
+
+PaymentLinkReceivedRecord _findRequired(
+  List<PaymentLinkReceivedRecord> records,
+  String address,
+) {
+  final record = _findByAddress(records, address);
+  if (record == null) {
+    throw StateError('Received payment link record was not found.');
+  }
+  return record;
+}
+
+List<PaymentLinkReceivedRecord> _replaceByAddress(
+  List<PaymentLinkReceivedRecord> records,
+  PaymentLinkReceivedRecord replacement,
+) {
+  final replaced = <PaymentLinkReceivedRecord>[];
+  var didReplace = false;
+  for (final record in records) {
+    if (record.address == replacement.address) {
+      replaced.add(replacement);
+      didReplace = true;
+    } else {
+      replaced.add(record);
+    }
+  }
+  if (!didReplace) replaced.add(replacement);
+  return replaced;
+}
+
+Map<String, Object?> _recordToJson(PaymentLinkReceivedRecord record) {
+  return {
+    'network': record.network,
+    'address': record.address,
+    'amountZatoshi': record.amountZatoshi.toString(),
+    'createdAt': record.createdAt.toUtc().toIso8601String(),
+    'artworkId': record.artworkId,
+    'message': record.message,
+    'status': record.status.name,
+    'claimLink': record.claimLink?.toUri().toString(),
+    'destinationAccountUuid': record.destinationAccountUuid,
+    'claimTxids': record.claimTxids,
+    'updatedAt': record.updatedAt.toUtc().toIso8601String(),
+  };
+}
+
+PaymentLinkReceivedRecord _recordFromJson(Object? value) {
+  if (value is! Map<String, dynamic>) {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'Received-card record must be a JSON object.',
+    );
+  }
+  final network = value['network'];
+  final address = value['address'];
+  final amountRaw = value['amountZatoshi'];
+  final createdAtRaw = value['createdAt'];
+  final artworkId = value['artworkId'];
+  final message = value['message'];
+  final statusRaw = value['status'];
+  final claimLinkRaw = value['claimLink'];
+  final destinationAccountUuid = value['destinationAccountUuid'];
+  final claimTxids = value['claimTxids'];
+  final updatedAtRaw = value['updatedAt'];
+  if (network is! String ||
+      network.isEmpty ||
+      address is! String ||
+      address.isEmpty ||
+      amountRaw is! String ||
+      createdAtRaw is! String ||
+      (artworkId != null && artworkId is! String) ||
+      (message != null && message is! String) ||
+      statusRaw is! String ||
+      (claimLinkRaw != null && claimLinkRaw is! String) ||
+      (destinationAccountUuid != null && destinationAccountUuid is! String) ||
+      (claimTxids != null && claimTxids is! String) ||
+      updatedAtRaw is! String) {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'Received-card record fields are invalid.',
+    );
+  }
+  final amountZatoshi = BigInt.tryParse(amountRaw);
+  final createdAt = DateTime.tryParse(createdAtRaw);
+  final updatedAt = DateTime.tryParse(updatedAtRaw);
+  if (amountZatoshi == null ||
+      amountZatoshi <= BigInt.zero ||
+      createdAt == null ||
+      updatedAt == null) {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'Received-card amount or timestamp is invalid.',
+    );
+  }
+  late final PaymentLinkReceivedStatus status;
+  try {
+    status = PaymentLinkReceivedStatus.values.byName(statusRaw);
+  } on ArgumentError {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'Received-card status is invalid.',
+    );
+  }
+  final claimLink = claimLinkRaw == null
+      ? null
+      : VizorPaymentLink.parse(claimLinkRaw);
+  if (claimLink != null &&
+      (claimLink.network != network ||
+          claimLink.address != address ||
+          claimLink.amountZatoshi != amountZatoshi)) {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'Received-card link metadata does not match its record.',
+    );
+  }
+  if (status != PaymentLinkReceivedStatus.received && claimLink == null) {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'An unfinished received Card must retain its claim link.',
+    );
+  }
+  if (status == PaymentLinkReceivedStatus.received && claimLink != null) {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'A received Card must not retain its claim link.',
+    );
+  }
+  if (status == PaymentLinkReceivedStatus.receiving &&
+      ((destinationAccountUuid as String?)?.trim().isEmpty ?? true)) {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'A receiving Card must retain its destination account.',
+    );
+  }
+  if (status == PaymentLinkReceivedStatus.receiving &&
+      ((claimTxids as String?)?.trim().isEmpty ?? true)) {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'A receiving Card must retain its claim transaction id.',
+    );
+  }
+  if (status == PaymentLinkReceivedStatus.submitting &&
+      ((destinationAccountUuid as String?)?.trim().isEmpty ?? true)) {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'A submitting Card must retain its destination account.',
+    );
+  }
+  if (status == PaymentLinkReceivedStatus.submitting && claimTxids != null) {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'A submitting Card cannot retain claim transaction ids.',
+    );
+  }
+  if (status == PaymentLinkReceivedStatus.readyToClaim &&
+      (destinationAccountUuid != null || claimTxids != null)) {
+    throw const PaymentLinkReceivedStoreFormatException(
+      'A ready Card cannot retain in-flight claim metadata.',
+    );
+  }
+
+  return PaymentLinkReceivedRecord(
+    network: network,
+    address: address,
+    amountZatoshi: amountZatoshi,
+    createdAt: createdAt.toUtc(),
+    artworkId: artworkId as String?,
+    message: message as String?,
+    status: status,
+    claimLink: claimLink,
+    destinationAccountUuid: destinationAccountUuid as String?,
+    claimTxids: claimTxids as String?,
+    updatedAt: updatedAt.toUtc(),
+  );
+}

--- a/lib/src/features/payment_links/services/payment_link_received_store.dart
+++ b/lib/src/features/payment_links/services/payment_link_received_store.dart
@@ -15,6 +15,9 @@ final paymentLinkReceivedStoreProvider = Provider<PaymentLinkReceivedStore>((
 ) {
   return PaymentLinkReceivedStore(
     AppSecureStorePaymentLinkReceivedStorage(AppSecureStore.instance),
+    countMirror: AppSecureStorePaymentLinkClaimCountMirror(
+      AppSecureStore.instance,
+    ),
     onRecordsChanged: () {
       ref.read(paymentLinkLifecycleRevisionProvider.notifier).bump();
     },
@@ -162,6 +165,33 @@ abstract interface class PaymentLinkReceivedStorage {
   Future<void> delete();
 }
 
+/// Locked-readable copy of the in-flight claim count. The records are a
+/// secret the locked app cannot read, but the reset screens exist only while
+/// locked and need this one number.
+abstract interface class PaymentLinkClaimCountMirror {
+  Future<int?> read();
+
+  Future<void> write(int count);
+}
+
+class AppSecureStorePaymentLinkClaimCountMirror
+    implements PaymentLinkClaimCountMirror {
+  const AppSecureStorePaymentLinkClaimCountMirror(this._store);
+
+  final AppSecureStore _store;
+
+  @override
+  Future<int?> read() async {
+    final raw = await _store.readPlain(kPaymentLinkClaimsInFlightCountKey);
+    return raw == null ? null : int.tryParse(raw);
+  }
+
+  @override
+  Future<void> write(int count) {
+    return _store.writePlain(kPaymentLinkClaimsInFlightCountKey, '$count');
+  }
+}
+
 class AppSecureStorePaymentLinkReceivedStorage
     implements PaymentLinkReceivedStorage {
   const AppSecureStorePaymentLinkReceivedStorage(this._store);
@@ -188,8 +218,14 @@ class AppSecureStorePaymentLinkReceivedStorage
 }
 
 class PaymentLinkReceivedStore {
-  PaymentLinkReceivedStore(this._storage, {void Function()? onRecordsChanged})
-    : _onRecordsChanged = onRecordsChanged;
+  PaymentLinkReceivedStore(
+    this._storage, {
+    PaymentLinkClaimCountMirror? countMirror,
+    void Function()? onRecordsChanged,
+  }) : _countMirror = countMirror,
+       _onRecordsChanged = onRecordsChanged;
+
+  final PaymentLinkClaimCountMirror? _countMirror;
 
   final PaymentLinkReceivedStorage _storage;
   final void Function()? _onRecordsChanged;
@@ -208,9 +244,13 @@ class PaymentLinkReceivedStore {
   /// Claims that have been submitted but not yet observed as received, across
   /// every destination account — including records whose destination account
   /// is not yet written, which [countReceivingForAccount] cannot see.
-  Future<int> countClaimsInFlight() async {
-    final records = await load();
-    return records.where((record) => record.isClaimInFlight).length;
+  Future<int> countClaimsInFlight() {
+    return _runExclusive(() async {
+      final raw = await _storage.read();
+      // Locked: the secret payload reads as null; the plain mirror answers.
+      if (raw == null) return await _countMirror?.read() ?? 0;
+      return _decodeRecords(raw).where((r) => r.isClaimInFlight).length;
+    });
   }
 
   Future<int> countReceivingForAccount(String destinationAccountUuid) async {
@@ -387,7 +427,10 @@ class PaymentLinkReceivedStore {
   }
 
   Future<List<PaymentLinkReceivedRecord>> _loadUnlocked() async {
-    final raw = await _storage.read();
+    return _decodeRecords(await _storage.read());
+  }
+
+  List<PaymentLinkReceivedRecord> _decodeRecords(String? raw) {
     if (raw == null || raw.trim().isEmpty) return const [];
 
     try {
@@ -421,14 +464,16 @@ class PaymentLinkReceivedStore {
   Future<void> _writeRecords(List<PaymentLinkReceivedRecord> records) async {
     if (records.isEmpty) {
       await _storage.delete();
-      _onRecordsChanged?.call();
-      return;
+    } else {
+      await _storage.write(
+        jsonEncode({
+          'version': _storageVersion,
+          'records': [for (final record in records) _recordToJson(record)],
+        }),
+      );
     }
-    await _storage.write(
-      jsonEncode({
-        'version': _storageVersion,
-        'records': [for (final record in records) _recordToJson(record)],
-      }),
+    await _countMirror?.write(
+      records.where((record) => record.isClaimInFlight).length,
     );
     _onRecordsChanged?.call();
   }

--- a/lib/src/features/payment_links/services/payment_link_recovery_reconciler.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_reconciler.dart
@@ -4,8 +4,10 @@ import '../../../../main.dart' show log;
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
+import '../models/vizor_payment_link.dart';
 import 'payment_link_lifecycle_revision.dart';
 import 'payment_link_recovery_store.dart';
+import 'payment_link_service.dart';
 import 'payment_link_transaction_matching.dart';
 
 typedef PaymentLinkFundingHistoryLoader =
@@ -13,8 +15,23 @@ typedef PaymentLinkFundingHistoryLoader =
       Set<String> accountUuids,
     );
 
+typedef PaymentLinkOwnFundingHistoryLoader =
+    Future<List<rust_sync.TransactionInfo>> Function(VizorPaymentLink link);
+
+/// How far past its submission height an ambiguous funding broadcast is
+/// treated as never having reached the chain.
+///
+/// A Zcash transaction expires 40 blocks after the height it was built at
+/// (ZIP-203), and the wallet's own scan trails the tip; 20 blocks of margin
+/// keeps a slow scan from discarding a Gift Card that really was funded.
+const kPaymentLinkAmbiguousFundingExpiryDelta = 60;
+
+/// How long an ambiguous funding is kept when no submission height was known.
+const kPaymentLinkAmbiguousFundingUndatedRetention = Duration(hours: 24);
+
 final paymentLinkRecoveryReconcilerProvider =
     Provider<PaymentLinkRecoveryReconciler>((ref) {
+      final claimWallet = PaymentLinkClaimWallet(ref);
       return PaymentLinkRecoveryReconciler(
         ref.watch(paymentLinkRecoveryStoreProvider),
         loadCurrentHeight: () => ref
@@ -44,6 +61,7 @@ final paymentLinkRecoveryReconcilerProvider =
           );
           return Map.fromEntries(entries);
         },
+        loadLinkFundingHistory: claimWallet.loadFundingHistory,
       );
     });
 
@@ -89,20 +107,60 @@ PaymentLinkPreparedFundingDisposition _paymentLinkPreparedFundingDisposition({
   return PaymentLinkPreparedFundingDisposition.pending;
 }
 
+/// The transaction ids by which a Gift Card's own wallet holds funds.
+///
+/// Only inbound transactions count: `sent` rows are the Card being claimed,
+/// and Rust labels an inbound transaction `receiving` until it is mined
+/// ([`receiving_tx_kind`] in `rust/src/wallet/sync/transactions.rs`), so a
+/// funding still in the mempool has to count too — treating it as unseen
+/// would discard a Card that does hold funds.
+List<String> _paymentLinkOwnFundingTxids(
+  Iterable<rust_sync.TransactionInfo> transactions,
+) {
+  return transactions
+      .where(
+        (transaction) =>
+            (transaction.txKind == 'received' ||
+                transaction.txKind == 'receiving') &&
+            !transaction.expiredUnmined &&
+            transaction.txidHex.trim().isNotEmpty,
+      )
+      .map((transaction) => transaction.txidHex.trim())
+      .toSet()
+      .toList();
+}
+
+bool _paymentLinkAmbiguousFundingExpired({
+  required PaymentLinkRecoveryRecord record,
+  required BigInt scannedHeight,
+}) {
+  final submittedAtHeight = record.submittedAtHeight ?? 0;
+  if (submittedAtHeight <= 0) {
+    // No height was known at submission, so age is the only measure left.
+    return DateTime.now().toUtc().difference(record.updatedAt) >
+        kPaymentLinkAmbiguousFundingUndatedRetention;
+  }
+  return scannedHeight >=
+      BigInt.from(submittedAtHeight + kPaymentLinkAmbiguousFundingExpiryDelta);
+}
+
 class PaymentLinkRecoveryReconciler {
   const PaymentLinkRecoveryReconciler(
     this._store, {
     required Future<BigInt> Function() loadCurrentHeight,
     required Future<BigInt> Function() loadScannedHeight,
     required PaymentLinkFundingHistoryLoader loadTransactionsByAccount,
+    required PaymentLinkOwnFundingHistoryLoader loadLinkFundingHistory,
   }) : _loadCurrentHeight = loadCurrentHeight,
        _loadScannedHeight = loadScannedHeight,
-       _loadTransactionsByAccount = loadTransactionsByAccount;
+       _loadTransactionsByAccount = loadTransactionsByAccount,
+       _loadLinkFundingHistory = loadLinkFundingHistory;
 
   final PaymentLinkRecoveryStore _store;
   final Future<BigInt> Function() _loadCurrentHeight;
   final Future<BigInt> Function() _loadScannedHeight;
   final PaymentLinkFundingHistoryLoader _loadTransactionsByAccount;
+  final PaymentLinkOwnFundingHistoryLoader _loadLinkFundingHistory;
 
   Future<int> countUnsharedFundedForAccount(String sourceAccountUuid) async {
     if (sourceAccountUuid.isEmpty) return 0;
@@ -121,6 +179,12 @@ class PaymentLinkRecoveryReconciler {
               (record.fundingTxids?.trim().isNotEmpty ?? false),
         )
         .toList();
+    // A broadcast the wallet started but never got a result for. It has no
+    // transaction id to match, so it is settled against the Gift Card's own
+    // wallet rather than the source account's history.
+    final ambiguousDrafts = records
+        .where((record) => record.isAmbiguousSubmission)
+        .toList();
     final unsharedFundings = records
         .where(
           (record) =>
@@ -128,7 +192,11 @@ class PaymentLinkRecoveryReconciler {
               (record.fundingTxids?.trim().isNotEmpty ?? false),
         )
         .toList();
-    if (preparedDrafts.isEmpty && unsharedFundings.isEmpty) return records;
+    if (preparedDrafts.isEmpty &&
+        ambiguousDrafts.isEmpty &&
+        unsharedFundings.isEmpty) {
+      return records;
+    }
 
     try {
       final accountUuids = {
@@ -139,7 +207,7 @@ class PaymentLinkRecoveryReconciler {
       late final BigInt scannedHeight;
       late final Map<String, List<rust_sync.TransactionInfo>>
       transactionsByAccount;
-      if (preparedDrafts.isEmpty) {
+      if (preparedDrafts.isEmpty && ambiguousDrafts.isEmpty) {
         transactionsByAccount = await _loadTransactionsByAccount(accountUuids);
       } else {
         final lookupResults = await Future.wait<Object>([
@@ -183,6 +251,44 @@ class PaymentLinkRecoveryReconciler {
         } catch (error) {
           log(
             'PaymentLinkRecoveryReconciler: prepared funding update failed '
+            'address=${record.link.address} error=$error',
+          );
+        }
+      }
+      for (final record in ambiguousDrafts) {
+        try {
+          final fundingTxids = _paymentLinkOwnFundingTxids(
+            await _loadLinkFundingHistory(record.link),
+          );
+          if (fundingTxids.isNotEmpty) {
+            final txids = fundingTxids.join(',');
+            // Record the recovered id before promoting, so a failure between
+            // the two still leaves a draft the prepared path can settle.
+            await _store.markSubmitted(
+              address: record.link.address,
+              fundingTxids: txids,
+            );
+            await _store.markFunded(
+              address: record.link.address,
+              fundingTxids: txids,
+            );
+            changed = true;
+            continue;
+          }
+          if (!_paymentLinkAmbiguousFundingExpired(
+            record: record,
+            scannedHeight: scannedHeight,
+          )) {
+            continue;
+          }
+          // The wallet scanned well past any height this broadcast could have
+          // been mined at and the Gift Card holds nothing: the transaction
+          // never reached the chain.
+          await _store.removeUnbroadcastDraft(address: record.link.address);
+          changed = true;
+        } catch (error) {
+          log(
+            'PaymentLinkRecoveryReconciler: ambiguous funding update failed '
             'address=${record.link.address} error=$error',
           );
         }

--- a/lib/src/features/payment_links/services/payment_link_recovery_reconciler.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_reconciler.dart
@@ -29,6 +29,10 @@ const kPaymentLinkAmbiguousFundingExpiryDelta = 60;
 /// How long an ambiguous funding is kept when no submission height was known.
 const kPaymentLinkAmbiguousFundingUndatedRetention = Duration(hours: 24);
 
+/// How long a draft that never started its broadcast is kept before recovery
+/// drops it — long enough for a creation still proposing in this process.
+const kPaymentLinkInertDraftRetention = Duration(minutes: 10);
+
 final paymentLinkRecoveryReconcilerProvider =
     Provider<PaymentLinkRecoveryReconciler>((ref) {
       final claimWallet = PaymentLinkClaimWallet(ref);
@@ -163,6 +167,33 @@ class PaymentLinkRecoveryReconciler {
   final PaymentLinkFundingHistoryLoader _loadTransactionsByAccount;
   final PaymentLinkOwnFundingHistoryLoader _loadLinkFundingHistory;
 
+  /// Removes drafts that were saved but never reached the broadcast boundary
+  /// (app killed mid-propose): they hold nothing and would otherwise sit in
+  /// the list forever.
+  Future<List<PaymentLinkRecoveryRecord>> _dropInertDrafts(
+    List<PaymentLinkRecoveryRecord> records,
+  ) async {
+    final now = DateTime.now().toUtc();
+    final inert = records.where(
+      (record) =>
+          record.isInertDraft &&
+          now.difference(record.updatedAt) > kPaymentLinkInertDraftRetention,
+    );
+    var changed = false;
+    for (final record in inert) {
+      try {
+        await _store.removeUnsubmittedDraft(address: record.link.address);
+        changed = true;
+      } catch (error) {
+        log(
+          'PaymentLinkRecoveryReconciler: inert draft cleanup failed '
+          'address=${record.link.address} error=$error',
+        );
+      }
+    }
+    return changed ? _store.load() : records;
+  }
+
   Future<int> countUnsharedFundedForAccount(String sourceAccountUuid) async {
     if (sourceAccountUuid.isEmpty) return 0;
     return countUnsharedFundedPaymentLinks(
@@ -172,7 +203,8 @@ class PaymentLinkRecoveryReconciler {
   }
 
   Future<List<PaymentLinkRecoveryRecord>> load() async {
-    final records = await _store.load();
+    var records = await _store.load();
+    records = await _dropInertDrafts(records);
     final preparedDrafts = records
         .where(
           (record) =>

--- a/lib/src/features/payment_links/services/payment_link_recovery_reconciler.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_reconciler.dart
@@ -120,14 +120,18 @@ PaymentLinkPreparedFundingDisposition _paymentLinkPreparedFundingDisposition({
 /// funding still in the mempool has to count too — treating it as unseen
 /// would discard a Card that does hold funds.
 List<String> _paymentLinkOwnFundingTxids(
-  Iterable<rust_sync.TransactionInfo> transactions,
-) {
+  Iterable<rust_sync.TransactionInfo> transactions, {
+  required BigInt expectedZatoshi,
+}) {
   return transactions
       .where(
         (transaction) =>
             (transaction.txKind == 'received' ||
                 transaction.txKind == 'receiving') &&
             !transaction.expiredUnmined &&
+            // Only the promised funding counts; unrelated dust must not
+            // promote the draft.
+            BigInt.from(transaction.accountBalanceDelta) >= expectedZatoshi &&
             transaction.txidHex.trim().isNotEmpty,
       )
       .map((transaction) => transaction.txidHex.trim())
@@ -292,6 +296,9 @@ class PaymentLinkRecoveryReconciler {
         try {
           final fundingTxids = _paymentLinkOwnFundingTxids(
             await _loadLinkFundingHistory(record.link),
+            expectedZatoshi: paymentLinkFundingAmountZatoshi(
+              record.link.amountZatoshi,
+            ),
           );
           if (fundingTxids.isNotEmpty) {
             final txids = fundingTxids.join(',');

--- a/lib/src/features/payment_links/services/payment_link_recovery_reconciler.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_reconciler.dart
@@ -82,8 +82,9 @@ PaymentLinkPreparedFundingDisposition _paymentLinkPreparedFundingDisposition({
   required BigInt scannedHeight,
   required List<rust_sync.TransactionInfo> transactions,
 }) {
-  if (paymentLinkFundingTransactionExists(
-    fundingTxid: fundingTxid,
+  // A software proposal can carry several ids; every one has to be mined.
+  if (paymentLinkFundingTransactionsExist(
+    fundingTxids: fundingTxid,
     transactions: transactions,
   )) {
     return PaymentLinkPreparedFundingDisposition.funded;

--- a/lib/src/features/payment_links/services/payment_link_recovery_reconciler.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_reconciler.dart
@@ -1,0 +1,222 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/storage/wallet_paths.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../rust/api/sync.dart' as rust_sync;
+import 'payment_link_lifecycle_revision.dart';
+import 'payment_link_recovery_store.dart';
+import 'payment_link_transaction_matching.dart';
+
+typedef PaymentLinkFundingHistoryLoader =
+    Future<Map<String, List<rust_sync.TransactionInfo>>> Function(
+      Set<String> accountUuids,
+    );
+
+final paymentLinkRecoveryReconcilerProvider =
+    Provider<PaymentLinkRecoveryReconciler>((ref) {
+      return PaymentLinkRecoveryReconciler(
+        ref.watch(paymentLinkRecoveryStoreProvider),
+        loadCurrentHeight: () => ref
+            .read(rpcEndpointFailoverProvider.notifier)
+            .getLatestBlockHeight(),
+        loadScannedHeight: () async {
+          final endpoint = ref.read(rpcEndpointFailoverProvider).current;
+          final status = await rust_sync.getSyncStatus(
+            dbPath: await getWalletDbPath(),
+            network: endpoint.networkName,
+          );
+          return status.scannedHeight;
+        },
+        loadTransactionsByAccount: (accountUuids) async {
+          final endpoint = ref.read(rpcEndpointFailoverProvider).current;
+          final dbPath = await getWalletDbPath();
+          final entries = await Future.wait(
+            accountUuids.map((accountUuid) async {
+              final transactions = await rust_sync.getTransactionHistory(
+                dbPath: dbPath,
+                network: endpoint.networkName,
+                accountUuid: accountUuid,
+                limit: null,
+              );
+              return MapEntry(accountUuid, transactions);
+            }),
+          );
+          return Map.fromEntries(entries);
+        },
+      );
+    });
+
+final paymentLinkUnsharedFundedCountProvider =
+    FutureProvider.family<int, String>((ref, sourceAccountUuid) async {
+      ref.watch(paymentLinkLifecycleRevisionProvider);
+      return ref
+          .watch(paymentLinkRecoveryReconcilerProvider)
+          .countUnsharedFundedForAccount(sourceAccountUuid);
+    });
+
+enum PaymentLinkPreparedFundingDisposition { pending, funded, expired }
+
+PaymentLinkPreparedFundingDisposition _paymentLinkPreparedFundingDisposition({
+  required String fundingTxid,
+  required int? expiryHeight,
+  required BigInt currentHeight,
+  required BigInt scannedHeight,
+  required List<rust_sync.TransactionInfo> transactions,
+}) {
+  if (paymentLinkFundingTransactionExists(
+    fundingTxid: fundingTxid,
+    transactions: transactions,
+  )) {
+    return PaymentLinkPreparedFundingDisposition.funded;
+  }
+  // The wallet watched this transaction expire unmined, which is definitive
+  // whatever the record knows about expiry heights.
+  if (paymentLinkFundingExpired(
+    fundingTxids: fundingTxid,
+    transactions: transactions,
+  )) {
+    return PaymentLinkPreparedFundingDisposition.expired;
+  }
+  // A software draft carries its broadcast transaction but no expiry height,
+  // so it can only be promoted once mined; without a height there is nothing
+  // to discard it on.
+  if (expiryHeight != null &&
+      currentHeight >= BigInt.from(expiryHeight) &&
+      scannedHeight >= BigInt.from(expiryHeight)) {
+    return PaymentLinkPreparedFundingDisposition.expired;
+  }
+  return PaymentLinkPreparedFundingDisposition.pending;
+}
+
+class PaymentLinkRecoveryReconciler {
+  const PaymentLinkRecoveryReconciler(
+    this._store, {
+    required Future<BigInt> Function() loadCurrentHeight,
+    required Future<BigInt> Function() loadScannedHeight,
+    required PaymentLinkFundingHistoryLoader loadTransactionsByAccount,
+  }) : _loadCurrentHeight = loadCurrentHeight,
+       _loadScannedHeight = loadScannedHeight,
+       _loadTransactionsByAccount = loadTransactionsByAccount;
+
+  final PaymentLinkRecoveryStore _store;
+  final Future<BigInt> Function() _loadCurrentHeight;
+  final Future<BigInt> Function() _loadScannedHeight;
+  final PaymentLinkFundingHistoryLoader _loadTransactionsByAccount;
+
+  Future<int> countUnsharedFundedForAccount(String sourceAccountUuid) async {
+    if (sourceAccountUuid.isEmpty) return 0;
+    return countUnsharedFundedPaymentLinks(
+      await load(),
+      sourceAccountUuid: sourceAccountUuid,
+    );
+  }
+
+  Future<List<PaymentLinkRecoveryRecord>> load() async {
+    final records = await _store.load();
+    final preparedDrafts = records
+        .where(
+          (record) =>
+              record.state == PaymentLinkRecoveryState.draft &&
+              (record.fundingTxids?.trim().isNotEmpty ?? false),
+        )
+        .toList();
+    final unsharedFundings = records
+        .where(
+          (record) =>
+              record.state == PaymentLinkRecoveryState.funded &&
+              (record.fundingTxids?.trim().isNotEmpty ?? false),
+        )
+        .toList();
+    if (preparedDrafts.isEmpty && unsharedFundings.isEmpty) return records;
+
+    try {
+      final accountUuids = {
+        for (final record in [...preparedDrafts, ...unsharedFundings])
+          record.sourceAccountUuid,
+      };
+      late final BigInt currentHeight;
+      late final BigInt scannedHeight;
+      late final Map<String, List<rust_sync.TransactionInfo>>
+      transactionsByAccount;
+      if (preparedDrafts.isEmpty) {
+        transactionsByAccount = await _loadTransactionsByAccount(accountUuids);
+      } else {
+        final lookupResults = await Future.wait<Object>([
+          _loadCurrentHeight(),
+          _loadScannedHeight(),
+          _loadTransactionsByAccount(accountUuids),
+        ]);
+        currentHeight = lookupResults[0] as BigInt;
+        scannedHeight = lookupResults[1] as BigInt;
+        transactionsByAccount =
+            lookupResults[2] as Map<String, List<rust_sync.TransactionInfo>>;
+      }
+
+      var changed = false;
+      for (final record in preparedDrafts) {
+        final fundingTxid = record.fundingTxids!.trim();
+        final disposition = _paymentLinkPreparedFundingDisposition(
+          fundingTxid: fundingTxid,
+          expiryHeight: record.preparedExpiryHeight,
+          currentHeight: currentHeight,
+          scannedHeight: scannedHeight,
+          transactions:
+              transactionsByAccount[record.sourceAccountUuid] ?? const [],
+        );
+        try {
+          switch (disposition) {
+            case PaymentLinkPreparedFundingDisposition.pending:
+              continue;
+            case PaymentLinkPreparedFundingDisposition.funded:
+              await _store.markFunded(
+                address: record.link.address,
+                fundingTxids: fundingTxid,
+              );
+              changed = true;
+              break;
+            case PaymentLinkPreparedFundingDisposition.expired:
+              await _store.removeUnbroadcastDraft(address: record.link.address);
+              changed = true;
+              break;
+          }
+        } catch (error) {
+          log(
+            'PaymentLinkRecoveryReconciler: prepared funding update failed '
+            'address=${record.link.address} error=$error',
+          );
+        }
+      }
+      for (final record in unsharedFundings) {
+        final fundingTxids = record.fundingTxids!.trim();
+        if (!paymentLinkFundingExpired(
+          fundingTxids: fundingTxids,
+          transactions:
+              transactionsByAccount[record.sourceAccountUuid] ?? const [],
+        )) {
+          continue;
+        }
+        try {
+          await _store.removeUnsharedExpiredFunding(
+            address: record.link.address,
+            fundingTxids: fundingTxids,
+          );
+          changed = true;
+        } catch (error) {
+          log(
+            'PaymentLinkRecoveryReconciler: expired funding cleanup failed '
+            'address=${record.link.address} error=$error',
+          );
+        }
+      }
+      return changed ? _store.load() : records;
+    } catch (error) {
+      // Retain the bearer secret and retry on the next foreground refresh when
+      // chain height or wallet history is temporarily unavailable.
+      log(
+        'PaymentLinkRecoveryReconciler: prepared funding lookup failed: $error',
+      );
+      return records;
+    }
+  }
+}

--- a/lib/src/features/payment_links/services/payment_link_recovery_store.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_store.dart
@@ -47,6 +47,7 @@ class PaymentLinkRecoveryRecord {
     required this.updatedAt,
     this.fundingTxids,
     this.preparedExpiryHeight,
+    this.submittedAtHeight,
   });
 
   final VizorPaymentLink link;
@@ -56,11 +57,32 @@ class PaymentLinkRecoveryRecord {
   final String? fundingTxids;
   final int? preparedExpiryHeight;
 
+  /// The chain height the wallet knew when a software funding broadcast
+  /// started.
+  ///
+  /// It is written before the broadcast boundary is crossed, so a broadcast
+  /// whose result never came back — an FFI or channel failure after the
+  /// transaction reached the network — still leaves a durable trace to
+  /// reconcile. `0` means the height was unknown at submission time.
+  final int? submittedAtHeight;
+
+  /// True while the wallet knows a funding broadcast started but never learned
+  /// its transaction id.
+  ///
+  /// Such a draft may hold funds, so it is neither removable as inert nor
+  /// matchable by transaction id; the reconciler settles it by scanning the
+  /// link's own wallet.
+  bool get isAmbiguousSubmission =>
+      state == PaymentLinkRecoveryState.draft &&
+      (fundingTxids?.trim().isEmpty ?? true) &&
+      submittedAtHeight != null;
+
   PaymentLinkRecoveryRecord copyWith({
     required PaymentLinkRecoveryState state,
     required DateTime updatedAt,
     Object? fundingTxids = _fieldNotProvided,
     Object? preparedExpiryHeight = _fieldNotProvided,
+    Object? submittedAtHeight = _fieldNotProvided,
   }) {
     return PaymentLinkRecoveryRecord(
       link: link,
@@ -73,6 +95,9 @@ class PaymentLinkRecoveryRecord {
       preparedExpiryHeight: identical(preparedExpiryHeight, _fieldNotProvided)
           ? this.preparedExpiryHeight
           : preparedExpiryHeight as int?,
+      submittedAtHeight: identical(submittedAtHeight, _fieldNotProvided)
+          ? this.submittedAtHeight
+          : submittedAtHeight as int?,
     );
   }
 }
@@ -205,6 +230,46 @@ class PaymentLinkRecoveryStore {
         updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
         fundingTxids: submittedTxid,
         preparedExpiryHeight: null,
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  /// Records that a software funding broadcast is about to be handed to the
+  /// network, before its transaction id can be known.
+  ///
+  /// The software path only learns its transaction id from the broadcast
+  /// result, so a failure that loses that result would otherwise leave an inert
+  /// draft that recovery cannot tell apart from one that never funded. Writing
+  /// the submission height first turns that case into an ambiguous submission
+  /// the reconciler can settle against the link's own wallet.
+  ///
+  /// Idempotent: an already-recorded height is the earlier, safer one and is
+  /// kept. A draft that already carries a transaction id, or a record past
+  /// `draft`, needs no marker and is returned unchanged.
+  Future<PaymentLinkRecoveryRecord> markSubmissionStarted({
+    required String address,
+    required int chainHeight,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      if (chainHeight < 0) {
+        throw ArgumentError.value(
+          chainHeight,
+          'chainHeight',
+          'A submitted payment link requires a non-negative chain height.',
+        );
+      }
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      if (existing.state != PaymentLinkRecoveryState.draft) return existing;
+      if (existing.fundingTxids?.trim().isNotEmpty ?? false) return existing;
+      if (existing.submittedAtHeight != null) return existing;
+      final updated = existing.copyWith(
+        state: PaymentLinkRecoveryState.draft,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+        submittedAtHeight: chainHeight,
       );
       await _writeRecords(_replaceByAddress(records, updated));
       return updated;
@@ -344,7 +409,10 @@ class PaymentLinkRecoveryStore {
       if (existing == null) return;
       if (existing.state != PaymentLinkRecoveryState.draft ||
           (existing.fundingTxids?.trim().isNotEmpty ?? false) ||
-          existing.preparedExpiryHeight != null) {
+          existing.preparedExpiryHeight != null ||
+          // A broadcast started for this draft and its result was never seen,
+          // so it may hold funds even without a transaction id.
+          existing.submittedAtHeight != null) {
         throw StateError(
           'Only an unsubmitted payment link draft can be removed.',
         );
@@ -465,16 +533,41 @@ class PaymentLinkFundingRecovery {
 
   final PaymentLinkRecoveryStore _store;
 
+  /// Persists the bearer secret, then runs [createTransaction] to fund it.
+  ///
+  /// [createTransaction] receives a `markSubmissionStarted` callback it must
+  /// await immediately before the broadcast boundary. The ordering is what
+  /// makes recovery possible:
+  ///
+  /// 1. `saveDraft` — the bearer secret exists before anything can be spent to
+  ///    it.
+  /// 2. `markSubmissionStarted` — a durable trace of a broadcast that is about
+  ///    to happen, written while the transaction id is still unknown.
+  /// 3. the broadcast, then `complete` — the transaction id, then the
+  ///    promotion to funded.
+  ///
+  /// A failure before step 2 is definitive: nothing was sent, so the draft is
+  /// removed as inert. A failure after it — including one that loses the
+  /// broadcast result itself — still propagates to the caller, but leaves an
+  /// ambiguous submission the reconciler can settle against the link's own
+  /// wallet instead of an inert draft it would ignore.
   Future<PaymentLinkFundingRecoveryResult<T>> fund<T>({
     required VizorPaymentLink link,
     required String sourceAccountUuid,
-    required Future<T> Function() createTransaction,
+    required Future<T> Function(Future<void> Function() markSubmissionStarted)
+    createTransaction,
+    required Future<int> Function() currentChainHeight,
     required String Function(T result) fundingTxids,
   }) async {
     await _store.saveDraft(link: link, sourceAccountUuid: sourceAccountUuid);
     late final T result;
     try {
-      result = await createTransaction();
+      result = await createTransaction(() async {
+        await _store.markSubmissionStarted(
+          address: link.address,
+          chainHeight: await currentChainHeight(),
+        );
+      });
     } on PaymentLinkFundingNotSubmittedException catch (failure) {
       await _store.removeUnsubmittedDraft(address: link.address);
       Error.throwWithStackTrace(failure.error, failure.stackTrace);
@@ -574,6 +667,7 @@ Map<String, Object?> _recordToJson(PaymentLinkRecoveryRecord record) {
     'state': record.state.name,
     'fundingTxids': record.fundingTxids,
     'preparedExpiryHeight': record.preparedExpiryHeight,
+    'submittedAtHeight': record.submittedAtHeight,
     'updatedAt': record.updatedAt.toUtc().toIso8601String(),
   };
 }
@@ -589,6 +683,7 @@ PaymentLinkRecoveryRecord _recordFromJson(Object? value) {
   final stateRaw = value['state'];
   final fundingTxids = value['fundingTxids'];
   final preparedExpiryHeight = value['preparedExpiryHeight'];
+  final submittedAtHeight = value['submittedAtHeight'];
   final updatedAtRaw = value['updatedAt'];
   if (linkRaw is! String ||
       sourceAccountUuid is! String ||
@@ -597,6 +692,8 @@ PaymentLinkRecoveryRecord _recordFromJson(Object? value) {
       (fundingTxids != null && fundingTxids is! String) ||
       (preparedExpiryHeight != null &&
           (preparedExpiryHeight is! int || preparedExpiryHeight <= 0)) ||
+      (submittedAtHeight != null &&
+          (submittedAtHeight is! int || submittedAtHeight < 0)) ||
       updatedAtRaw is! String) {
     throw const PaymentLinkRecoveryStoreFormatException(
       'Recovery record fields are invalid.',
@@ -637,6 +734,7 @@ PaymentLinkRecoveryRecord _recordFromJson(Object? value) {
     state: state,
     fundingTxids: fundingTxids,
     preparedExpiryHeight: preparedExpiryHeight as int?,
+    submittedAtHeight: submittedAtHeight as int?,
     updatedAt: updatedAt.toUtc(),
   );
 }
@@ -652,7 +750,11 @@ int countUnsharedFundedPaymentLinks(
             record.sourceAccountUuid == sourceAccountUuid &&
             (record.state == PaymentLinkRecoveryState.funded ||
                 (record.state == PaymentLinkRecoveryState.draft &&
-                    (record.fundingTxids?.trim().isNotEmpty ?? false))),
+                    (record.fundingTxids?.trim().isNotEmpty ?? false)) ||
+                // An ambiguous submission has no transaction id to check, and
+                // its broadcast may well have landed. Blocking the delete is
+                // the conservative answer.
+                record.isAmbiguousSubmission),
       )
       .length;
 }

--- a/lib/src/features/payment_links/services/payment_link_recovery_store.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_store.dart
@@ -77,6 +77,15 @@ class PaymentLinkRecoveryRecord {
       (fundingTxids?.trim().isEmpty ?? true) &&
       submittedAtHeight != null;
 
+  /// A draft that never reached the broadcast boundary: no transaction, no
+  /// submission marker. Provably unfunded, so recovery may drop it once it is
+  /// old enough not to be a creation still in progress.
+  bool get isInertDraft =>
+      state == PaymentLinkRecoveryState.draft &&
+      (fundingTxids?.trim().isEmpty ?? true) &&
+      preparedExpiryHeight == null &&
+      submittedAtHeight == null;
+
   PaymentLinkRecoveryRecord copyWith({
     required PaymentLinkRecoveryState state,
     required DateTime updatedAt,

--- a/lib/src/features/payment_links/services/payment_link_recovery_store.dart
+++ b/lib/src/features/payment_links/services/payment_link_recovery_store.dart
@@ -1,0 +1,658 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/storage/app_secure_store.dart';
+import '../models/vizor_payment_link.dart';
+import 'payment_link_lifecycle_revision.dart';
+
+const _storageVersion = 1;
+const _fundingMetadataWriteAttempts = 2;
+
+final paymentLinkRecoveryStoreProvider = Provider<PaymentLinkRecoveryStore>((
+  ref,
+) {
+  return PaymentLinkRecoveryStore(
+    AppSecureStorePaymentLinkRecoveryStorage(AppSecureStore.instance),
+    onRecordsChanged: () {
+      ref.read(paymentLinkLifecycleRevisionProvider.notifier).bump();
+    },
+  );
+});
+
+enum PaymentLinkRecoveryState { draft, funded, shared }
+
+class PaymentLinkUnsharedGiftCardsException implements Exception {
+  const PaymentLinkUnsharedGiftCardsException({
+    required this.sourceAccountUuid,
+    required this.count,
+  });
+
+  final String sourceAccountUuid;
+  final int count;
+
+  @override
+  String toString() =>
+      'Copy your unshared Gift Card links before deleting this account.';
+}
+
+const _fieldNotProvided = Object();
+
+class PaymentLinkRecoveryRecord {
+  const PaymentLinkRecoveryRecord({
+    required this.link,
+    required this.sourceAccountUuid,
+    required this.state,
+    required this.updatedAt,
+    this.fundingTxids,
+    this.preparedExpiryHeight,
+  });
+
+  final VizorPaymentLink link;
+  final String sourceAccountUuid;
+  final PaymentLinkRecoveryState state;
+  final DateTime updatedAt;
+  final String? fundingTxids;
+  final int? preparedExpiryHeight;
+
+  PaymentLinkRecoveryRecord copyWith({
+    required PaymentLinkRecoveryState state,
+    required DateTime updatedAt,
+    Object? fundingTxids = _fieldNotProvided,
+    Object? preparedExpiryHeight = _fieldNotProvided,
+  }) {
+    return PaymentLinkRecoveryRecord(
+      link: link,
+      sourceAccountUuid: sourceAccountUuid,
+      state: state,
+      updatedAt: updatedAt,
+      fundingTxids: identical(fundingTxids, _fieldNotProvided)
+          ? this.fundingTxids
+          : fundingTxids as String?,
+      preparedExpiryHeight: identical(preparedExpiryHeight, _fieldNotProvided)
+          ? this.preparedExpiryHeight
+          : preparedExpiryHeight as int?,
+    );
+  }
+}
+
+class PaymentLinkRecoveryStoreFormatException implements Exception {
+  const PaymentLinkRecoveryStoreFormatException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'PaymentLinkRecoveryStoreFormatException: $message';
+}
+
+abstract interface class PaymentLinkRecoveryStorage {
+  Future<String?> read();
+
+  Future<void> write(String value);
+
+  Future<void> delete();
+}
+
+class AppSecureStorePaymentLinkRecoveryStorage
+    implements PaymentLinkRecoveryStorage {
+  const AppSecureStorePaymentLinkRecoveryStorage(this._store);
+
+  final AppSecureStore _store;
+
+  @override
+  Future<String?> read() {
+    return _store.readSecretStringWithOptions(
+      kPaymentLinkRecoveryStorageKey,
+      requireUnlockedSession: true,
+    );
+  }
+
+  @override
+  Future<void> write(String value) {
+    return _store.writeSecretString(kPaymentLinkRecoveryStorageKey, value);
+  }
+
+  @override
+  Future<void> delete() {
+    return _store.delete(kPaymentLinkRecoveryStorageKey);
+  }
+}
+
+class PaymentLinkRecoveryStore {
+  PaymentLinkRecoveryStore(this._storage, {void Function()? onRecordsChanged})
+    : _onRecordsChanged = onRecordsChanged;
+
+  final PaymentLinkRecoveryStorage _storage;
+  final void Function()? _onRecordsChanged;
+  Future<void> _operationTail = Future<void>.value();
+
+  Future<List<PaymentLinkRecoveryRecord>> load() {
+    return _runExclusive(_loadUnlocked);
+  }
+
+  Future<int> countUnsharedFundedForAccount(String sourceAccountUuid) async {
+    if (sourceAccountUuid.isEmpty) return 0;
+    return countUnsharedFundedPaymentLinks(
+      await load(),
+      sourceAccountUuid: sourceAccountUuid,
+    );
+  }
+
+  Future<PaymentLinkRecoveryRecord> saveDraft({
+    required VizorPaymentLink link,
+    required String sourceAccountUuid,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      if (sourceAccountUuid.isEmpty) {
+        throw ArgumentError.value(
+          sourceAccountUuid,
+          'sourceAccountUuid',
+          'Payment link source account is required.',
+        );
+      }
+      final records = await _loadUnlocked();
+      final existing = _findByAddress(records, link.address);
+      if (existing != null &&
+          existing.state != PaymentLinkRecoveryState.draft) {
+        throw StateError(
+          'Payment link recovery cannot replace a funded record with a draft.',
+        );
+      }
+      final record = PaymentLinkRecoveryRecord(
+        link: link,
+        sourceAccountUuid: sourceAccountUuid,
+        state: PaymentLinkRecoveryState.draft,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+      );
+      await _writeRecords(_replaceByAddress(records, record));
+      return record;
+    });
+  }
+
+  Future<PaymentLinkRecoveryRecord> markFunded({
+    required String address,
+    required String fundingTxids,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      if (fundingTxids.trim().isEmpty) {
+        throw ArgumentError.value(
+          fundingTxids,
+          'fundingTxids',
+          'A funded payment link requires a transaction id.',
+        );
+      }
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      if (existing.state != PaymentLinkRecoveryState.draft &&
+          existing.state != PaymentLinkRecoveryState.funded) {
+        throw StateError('Payment link funding state cannot move backwards.');
+      }
+      final preparedTxid = existing.fundingTxids?.trim();
+      final submittedTxid = fundingTxids.trim();
+      if (existing.state == PaymentLinkRecoveryState.draft &&
+          preparedTxid != null &&
+          preparedTxid.isNotEmpty &&
+          preparedTxid.toLowerCase() != submittedTxid.toLowerCase()) {
+        throw StateError(
+          'Payment link funding result does not match the prepared transaction.',
+        );
+      }
+      final updated = existing.copyWith(
+        state: PaymentLinkRecoveryState.funded,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+        fundingTxids: submittedTxid,
+        preparedExpiryHeight: null,
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  /// Records the broadcast transaction id on a draft without promoting it to
+  /// [PaymentLinkRecoveryState.funded].
+  ///
+  /// The software funding path only learns its transaction id when the
+  /// broadcast returns, so unlike the hardware path it has nothing to write
+  /// through [markPrepared] beforehand. Writing the id separately from the
+  /// promotion means a [markFunded] that fails still leaves the reconciler a
+  /// transaction to match against the chain, and leaves
+  /// [countUnsharedFundedPaymentLinks] counting the row — otherwise a draft
+  /// whose funding really was broadcast reads as inert and its Card link
+  /// becomes unreachable.
+  ///
+  /// No expiry height is recorded, because the software path never sees one.
+  /// The reconciler therefore promotes such a draft when its transaction is
+  /// mined but never expires it.
+  Future<PaymentLinkRecoveryRecord> markSubmitted({
+    required String address,
+    required String fundingTxids,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      final submittedTxids = fundingTxids.trim();
+      if (submittedTxids.isEmpty) {
+        throw ArgumentError.value(
+          fundingTxids,
+          'fundingTxids',
+          'A submitted payment link requires a transaction id.',
+        );
+      }
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      // Nothing to add once the record has moved past `draft`; the promotion
+      // that follows owns those states.
+      if (existing.state != PaymentLinkRecoveryState.draft) return existing;
+      final existingTxids = existing.fundingTxids?.trim();
+      if (existingTxids != null && existingTxids.isNotEmpty) {
+        if (existingTxids.toLowerCase() != submittedTxids.toLowerCase()) {
+          throw StateError(
+            'Payment link funding was prepared with a different transaction.',
+          );
+        }
+        return existing;
+      }
+      final updated = existing.copyWith(
+        state: PaymentLinkRecoveryState.draft,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+        fundingTxids: submittedTxids,
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<PaymentLinkRecoveryRecord> markPrepared({
+    required String address,
+    required String fundingTxid,
+    required int expiryHeight,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      final normalizedTxid = fundingTxid.trim();
+      if (normalizedTxid.isEmpty) {
+        throw ArgumentError.value(
+          fundingTxid,
+          'fundingTxid',
+          'A prepared payment link requires a transaction id.',
+        );
+      }
+      if (expiryHeight <= 0) {
+        throw ArgumentError.value(
+          expiryHeight,
+          'expiryHeight',
+          'A prepared payment link requires a positive expiry height.',
+        );
+      }
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      if (existing.state != PaymentLinkRecoveryState.draft) {
+        throw StateError('Only a draft payment link can be prepared.');
+      }
+      final existingTxid = existing.fundingTxids?.trim();
+      if (existingTxid != null &&
+          existingTxid.isNotEmpty &&
+          existingTxid.toLowerCase() != normalizedTxid.toLowerCase()) {
+        throw StateError(
+          'Payment link funding was prepared with a different transaction.',
+        );
+      }
+      final existingExpiryHeight = existing.preparedExpiryHeight;
+      if (existingExpiryHeight != null &&
+          existingExpiryHeight != expiryHeight) {
+        throw StateError(
+          'Payment link funding was prepared with a different expiry height.',
+        );
+      }
+      final updated = existing.copyWith(
+        state: PaymentLinkRecoveryState.draft,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+        fundingTxids: normalizedTxid,
+        preparedExpiryHeight: expiryHeight,
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<PaymentLinkRecoveryRecord> markShared({
+    required String address,
+    DateTime? updatedAt,
+  }) {
+    return _runExclusive(() async {
+      final records = await _loadUnlocked();
+      final existing = _findRequired(records, address);
+      if (existing.state != PaymentLinkRecoveryState.funded &&
+          existing.state != PaymentLinkRecoveryState.shared) {
+        throw StateError('Only a funded payment link can be marked shared.');
+      }
+      final updated = existing.copyWith(
+        state: PaymentLinkRecoveryState.shared,
+        updatedAt: (updatedAt ?? DateTime.now()).toUtc(),
+      );
+      await _writeRecords(_replaceByAddress(records, updated));
+      return updated;
+    });
+  }
+
+  Future<void> removeUnsubmittedDraft({required String address}) {
+    return _runExclusive(() async {
+      final records = await _loadUnlocked();
+      final existing = _findByAddress(records, address);
+      if (existing == null) return;
+      if (existing.state != PaymentLinkRecoveryState.draft ||
+          (existing.fundingTxids?.trim().isNotEmpty ?? false) ||
+          existing.preparedExpiryHeight != null) {
+        throw StateError(
+          'Only an unsubmitted payment link draft can be removed.',
+        );
+      }
+      await _writeRecords(
+        records.where((record) => record.link.address != address).toList(),
+      );
+    });
+  }
+
+  Future<void> removeUnbroadcastDraft({required String address}) {
+    return _runExclusive(() async {
+      final records = await _loadUnlocked();
+      final existing = _findByAddress(records, address);
+      if (existing == null) return;
+      if (existing.state != PaymentLinkRecoveryState.draft) {
+        throw StateError(
+          'Only an unbroadcast payment link draft can be removed.',
+        );
+      }
+      await _writeRecords(
+        records.where((record) => record.link.address != address).toList(),
+      );
+    });
+  }
+
+  Future<void> removeUnsharedExpiredFunding({
+    required String address,
+    required String fundingTxids,
+  }) {
+    return _runExclusive(() async {
+      final records = await _loadUnlocked();
+      final existing = _findByAddress(records, address);
+      if (existing == null) return;
+      if (existing.state != PaymentLinkRecoveryState.funded ||
+          existing.fundingTxids?.trim().toLowerCase() !=
+              fundingTxids.trim().toLowerCase()) {
+        throw StateError(
+          'Only the matching unshared expired funding can be removed.',
+        );
+      }
+      await _writeRecords(
+        records.where((record) => record.link.address != address).toList(),
+      );
+    });
+  }
+
+  Future<List<PaymentLinkRecoveryRecord>> _loadUnlocked() async {
+    final raw = await _storage.read();
+    if (raw == null || raw.trim().isEmpty) return const [];
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        throw const PaymentLinkRecoveryStoreFormatException(
+          'Recovery payload must be a JSON object.',
+        );
+      }
+      if (decoded['version'] != _storageVersion) {
+        throw const PaymentLinkRecoveryStoreFormatException(
+          'Recovery payload version is not supported.',
+        );
+      }
+      final items = decoded['records'];
+      if (items is! List) {
+        throw const PaymentLinkRecoveryStoreFormatException(
+          'Recovery payload records are missing.',
+        );
+      }
+      return [for (final item in items) _recordFromJson(item)];
+    } on PaymentLinkRecoveryStoreFormatException {
+      rethrow;
+    } catch (error) {
+      throw PaymentLinkRecoveryStoreFormatException(
+        'Recovery payload could not be decoded: $error',
+      );
+    }
+  }
+
+  Future<void> _writeRecords(List<PaymentLinkRecoveryRecord> records) async {
+    if (records.isEmpty) {
+      await _storage.delete();
+      _onRecordsChanged?.call();
+      return;
+    }
+    await _storage.write(
+      jsonEncode({
+        'version': _storageVersion,
+        'records': [for (final record in records) _recordToJson(record)],
+      }),
+    );
+    _onRecordsChanged?.call();
+  }
+
+  Future<T> _runExclusive<T>(Future<T> Function() operation) {
+    final result = _operationTail.then((_) => operation());
+    _operationTail = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+}
+
+class PaymentLinkFundingRecoveryResult<T> {
+  const PaymentLinkFundingRecoveryResult({
+    required this.transaction,
+    this.recoveryError,
+    this.recoveryStackTrace,
+  });
+
+  final T transaction;
+  final Object? recoveryError;
+  final StackTrace? recoveryStackTrace;
+
+  bool get fundingMetadataSaved => recoveryError == null;
+}
+
+class PaymentLinkFundingRecovery {
+  const PaymentLinkFundingRecovery(this._store);
+
+  final PaymentLinkRecoveryStore _store;
+
+  Future<PaymentLinkFundingRecoveryResult<T>> fund<T>({
+    required VizorPaymentLink link,
+    required String sourceAccountUuid,
+    required Future<T> Function() createTransaction,
+    required String Function(T result) fundingTxids,
+  }) async {
+    await _store.saveDraft(link: link, sourceAccountUuid: sourceAccountUuid);
+    late final T result;
+    try {
+      result = await createTransaction();
+    } on PaymentLinkFundingNotSubmittedException catch (failure) {
+      await _store.removeUnsubmittedDraft(address: link.address);
+      Error.throwWithStackTrace(failure.error, failure.stackTrace);
+    }
+    return complete(
+      transaction: result,
+      address: link.address,
+      fundingTxids: fundingTxids,
+    );
+  }
+
+  Future<PaymentLinkFundingRecoveryResult<T>> complete<T>({
+    required T transaction,
+    required String address,
+    required String Function(T result) fundingTxids,
+  }) async {
+    final txids = fundingTxids(transaction);
+    // Earliest durable trace of a broadcast the software path can produce. If
+    // the promotion below never lands and the in-app retry never runs, the
+    // draft still carries its funding transaction, so recovery can finish the
+    // job on a later launch instead of leaving funded ZEC behind an
+    // unreachable link.
+    try {
+      await _store.markSubmitted(address: address, fundingTxids: txids);
+    } catch (_) {
+      // The promotion below reports the durable-write failure to the caller.
+    }
+    Object? recoveryError;
+    StackTrace? recoveryStackTrace;
+    for (var attempt = 0; attempt < _fundingMetadataWriteAttempts; attempt++) {
+      try {
+        await _store.markFunded(address: address, fundingTxids: txids);
+        return PaymentLinkFundingRecoveryResult(transaction: transaction);
+      } catch (error, stackTrace) {
+        recoveryError = error;
+        recoveryStackTrace = stackTrace;
+      }
+    }
+    return PaymentLinkFundingRecoveryResult(
+      transaction: transaction,
+      recoveryError: recoveryError,
+      recoveryStackTrace: recoveryStackTrace,
+    );
+  }
+}
+
+class PaymentLinkFundingNotSubmittedException implements Exception {
+  const PaymentLinkFundingNotSubmittedException(this.error, this.stackTrace);
+
+  final Object error;
+  final StackTrace stackTrace;
+}
+
+PaymentLinkRecoveryRecord? _findByAddress(
+  List<PaymentLinkRecoveryRecord> records,
+  String address,
+) {
+  for (final record in records) {
+    if (record.link.address == address) return record;
+  }
+  return null;
+}
+
+PaymentLinkRecoveryRecord _findRequired(
+  List<PaymentLinkRecoveryRecord> records,
+  String address,
+) {
+  final record = _findByAddress(records, address);
+  if (record == null) {
+    throw StateError('Payment link recovery record was not found.');
+  }
+  return record;
+}
+
+List<PaymentLinkRecoveryRecord> _replaceByAddress(
+  List<PaymentLinkRecoveryRecord> records,
+  PaymentLinkRecoveryRecord replacement,
+) {
+  final replaced = <PaymentLinkRecoveryRecord>[];
+  var didReplace = false;
+  for (final record in records) {
+    if (record.link.address == replacement.link.address) {
+      replaced.add(replacement);
+      didReplace = true;
+    } else {
+      replaced.add(record);
+    }
+  }
+  if (!didReplace) replaced.add(replacement);
+  return replaced;
+}
+
+Map<String, Object?> _recordToJson(PaymentLinkRecoveryRecord record) {
+  return {
+    'link': record.link.toUri().toString(),
+    'sourceAccountUuid': record.sourceAccountUuid,
+    'state': record.state.name,
+    'fundingTxids': record.fundingTxids,
+    'preparedExpiryHeight': record.preparedExpiryHeight,
+    'updatedAt': record.updatedAt.toUtc().toIso8601String(),
+  };
+}
+
+PaymentLinkRecoveryRecord _recordFromJson(Object? value) {
+  if (value is! Map<String, dynamic>) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record must be a JSON object.',
+    );
+  }
+  final linkRaw = value['link'];
+  final sourceAccountUuid = value['sourceAccountUuid'];
+  final stateRaw = value['state'];
+  final fundingTxids = value['fundingTxids'];
+  final preparedExpiryHeight = value['preparedExpiryHeight'];
+  final updatedAtRaw = value['updatedAt'];
+  if (linkRaw is! String ||
+      sourceAccountUuid is! String ||
+      sourceAccountUuid.isEmpty ||
+      stateRaw is! String ||
+      (fundingTxids != null && fundingTxids is! String) ||
+      (preparedExpiryHeight != null &&
+          (preparedExpiryHeight is! int || preparedExpiryHeight <= 0)) ||
+      updatedAtRaw is! String) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record fields are invalid.',
+    );
+  }
+  final updatedAt = DateTime.tryParse(updatedAtRaw);
+  if (updatedAt == null) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record timestamp is invalid.',
+    );
+  }
+  late final PaymentLinkRecoveryState state;
+  try {
+    state = PaymentLinkRecoveryState.values.byName(stateRaw);
+  } on ArgumentError {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Recovery record state is invalid.',
+    );
+  }
+
+  // A draft may carry a funding transaction without an expiry height: the
+  // hardware path records both through `markPrepared`, while the software path
+  // learns its transaction id only when the broadcast returns and never sees an
+  // expiry height. An expiry height without a transaction is still incomplete —
+  // there would be nothing to reconcile it against.
+  final hasPreparedTxid =
+      state == PaymentLinkRecoveryState.draft &&
+      (fundingTxids as String?)?.trim().isNotEmpty == true;
+  if (preparedExpiryHeight != null && !hasPreparedTxid) {
+    throw const PaymentLinkRecoveryStoreFormatException(
+      'Prepared recovery metadata is incomplete.',
+    );
+  }
+
+  return PaymentLinkRecoveryRecord(
+    link: VizorPaymentLink.parse(linkRaw),
+    sourceAccountUuid: sourceAccountUuid,
+    state: state,
+    fundingTxids: fundingTxids,
+    preparedExpiryHeight: preparedExpiryHeight as int?,
+    updatedAt: updatedAt.toUtc(),
+  );
+}
+
+int countUnsharedFundedPaymentLinks(
+  Iterable<PaymentLinkRecoveryRecord> records, {
+  required String sourceAccountUuid,
+}) {
+  if (sourceAccountUuid.isEmpty) return 0;
+  return records
+      .where(
+        (record) =>
+            record.sourceAccountUuid == sourceAccountUuid &&
+            (record.state == PaymentLinkRecoveryState.funded ||
+                (record.state == PaymentLinkRecoveryState.draft &&
+                    (record.fundingTxids?.trim().isNotEmpty ?? false))),
+      )
+      .length;
+}

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -1,0 +1,1314 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/config/network_config.dart';
+import '../../../core/storage/wallet_paths.dart';
+import '../../../providers/account_provider.dart';
+import '../../../providers/app_security_provider.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../providers/sync_provider.dart';
+import '../../../rust/api/sync.dart' as rust_sync;
+import '../../../rust/api/wallet.dart' as rust_wallet;
+import '../../send/services/sapling_params.dart';
+import '../models/vizor_payment_link.dart';
+import 'payment_link_received_store.dart';
+import 'payment_link_recovery_reconciler.dart';
+import 'payment_link_recovery_store.dart';
+import 'payment_link_transaction_matching.dart';
+
+part 'payment_link_claim_math.dart';
+part 'payment_link_claim_wallet.dart';
+
+final paymentLinkServiceProvider = Provider<PaymentLinkService>((ref) {
+  return PaymentLinkService(
+    ref,
+    ref.read(paymentLinkRecoveryStoreProvider),
+    ref.read(paymentLinkReceivedStoreProvider),
+    ref.read(paymentLinkRecoveryReconcilerProvider),
+  );
+});
+
+const kPaymentLinkShareConfirmationTarget = 1;
+const _paymentLinkClaimMetadataWriteAttempts = 2;
+
+class PaymentLinkFundingQuote {
+  const PaymentLinkFundingQuote({
+    required this.sourceAccountUuid,
+    required this.recipientAmountZatoshi,
+    required this.fundingFeeZatoshi,
+    required this.claimFeeReserveZatoshi,
+  });
+
+  final String sourceAccountUuid;
+  final BigInt recipientAmountZatoshi;
+  final BigInt fundingFeeZatoshi;
+  final BigInt claimFeeReserveZatoshi;
+
+  BigInt get cardFeeZatoshi => fundingFeeZatoshi + claimFeeReserveZatoshi;
+
+  BigInt get totalDeductedZatoshi => recipientAmountZatoshi + cardFeeZatoshi;
+}
+
+@visibleForTesting
+PaymentLinkFundingQuote paymentLinkMaxFundingQuote({
+  required String sourceAccountUuid,
+  required BigInt maxSpendAmountZatoshi,
+  required BigInt fundingFeeZatoshi,
+}) {
+  final claimFeeReserve = BigInt.from(kPaymentLinkClaimFeeReserveZatoshi);
+  if (maxSpendAmountZatoshi <= claimFeeReserve) {
+    throw StateError(
+      'Insufficient balance to fund a Gift Card and its claim fee.',
+    );
+  }
+  return PaymentLinkFundingQuote(
+    sourceAccountUuid: sourceAccountUuid,
+    recipientAmountZatoshi: maxSpendAmountZatoshi - claimFeeReserve,
+    fundingFeeZatoshi: fundingFeeZatoshi,
+    claimFeeReserveZatoshi: claimFeeReserve,
+  );
+}
+
+class PaymentLinkFundingProgress {
+  const PaymentLinkFundingProgress({
+    required this.confirmationCount,
+    this.confirmationTarget = kPaymentLinkShareConfirmationTarget,
+    this.broadcastAccepted = false,
+  });
+
+  final int confirmationCount;
+  final int confirmationTarget;
+  final bool broadcastAccepted;
+
+  bool get isReady =>
+      broadcastAccepted || confirmationCount >= confirmationTarget;
+
+  PaymentLinkFundingProgress copyWith({bool? broadcastAccepted}) {
+    return PaymentLinkFundingProgress(
+      confirmationCount: confirmationCount,
+      confirmationTarget: confirmationTarget,
+      broadcastAccepted: broadcastAccepted ?? this.broadcastAccepted,
+    );
+  }
+}
+
+/// UI-facing boundary for the persisted Payment Link lifecycle.
+///
+/// Keeping the screen on this small surface makes transaction behavior
+/// replaceable in widget tests without weakening the production service.
+abstract interface class PaymentLinkOperations {
+  Future<PaymentLinkFundingQuote> quoteMaxFunding({
+    required String sourceAccountUuid,
+  });
+
+  Future<PaymentLinkFundingQuote> quoteFunding({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+  });
+
+  Future<PaymentLinkFundingResult> createFundedLink({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+    PaymentLinkPresentation? presentation,
+  });
+
+  Future<void> retryFundingMetadata({
+    required String address,
+    required String fundingTxids,
+  });
+
+  Future<List<PaymentLinkRecoveryRecord>> loadCreatedLinkRecoveries();
+
+  Future<PaymentLinkRecoveryRecord> markCreatedLinkShared(
+    VizorPaymentLink link,
+  );
+
+  Future<Map<String, PaymentLinkFundingProgress>> inspectCreatedLinkFundings(
+    List<PaymentLinkRecoveryRecord> records,
+  );
+
+  Future<List<PaymentLinkReceivedRecord>> loadReceivedLinkRecoveries();
+
+  Future<List<PaymentLinkReceivedRecord>> inspectReceivedLinkClaims(
+    List<PaymentLinkReceivedRecord> records,
+  );
+
+  Future<PaymentLinkClaimSession> prepareClaim(
+    VizorPaymentLink link, {
+    bool allowLongSync = false,
+  });
+
+  Future<PaymentLinkClaimResult> claimPreparedLink(
+    PaymentLinkClaimSession session,
+  );
+
+  Future<void> discardClaimSession(PaymentLinkClaimSession session);
+}
+
+final paymentLinkOperationsProvider = Provider<PaymentLinkOperations>((ref) {
+  return ref.watch(paymentLinkServiceProvider);
+});
+
+class PaymentLinkClaimSession {
+  const PaymentLinkClaimSession({
+    required this.link,
+    required this.destinationAddress,
+    required this.destinationAccountUuid,
+    required this.directory,
+    required this.dbPath,
+    required this.accountUuid,
+    required this.totalZatoshi,
+    required this.claimableZatoshi,
+    required this.feeZatoshi,
+    this.fundingConfirmationCount = 0,
+    this.waitingForFundingConfirmations = false,
+  });
+
+  final VizorPaymentLink link;
+  final String destinationAddress;
+  final String destinationAccountUuid;
+  final Directory directory;
+  final String dbPath;
+  final String accountUuid;
+  final BigInt totalZatoshi;
+  final BigInt claimableZatoshi;
+  final BigInt feeZatoshi;
+  final int fundingConfirmationCount;
+  final bool waitingForFundingConfirmations;
+
+  bool get canClaim =>
+      claimableZatoshi > BigInt.zero && !waitingForFundingConfirmations;
+}
+
+enum PaymentLinkClaimBroadcastStatus {
+  broadcasted,
+  pendingBroadcast,
+  partialBroadcast,
+}
+
+@visibleForTesting
+PaymentLinkClaimBroadcastStatus paymentLinkClaimBroadcastStatusFromWire(
+  String status,
+) {
+  return switch (status) {
+    'broadcasted' => PaymentLinkClaimBroadcastStatus.broadcasted,
+    'pending_broadcast' => PaymentLinkClaimBroadcastStatus.pendingBroadcast,
+    'partial_broadcast' => PaymentLinkClaimBroadcastStatus.partialBroadcast,
+    _ => throw StateError('Unknown payment link broadcast status: $status'),
+  };
+}
+
+class PaymentLinkLongSyncConfirmationRequired implements Exception {
+  const PaymentLinkLongSyncConfirmationRequired();
+}
+
+class PaymentLinkClaimDestinationChangedException implements Exception {
+  const PaymentLinkClaimDestinationChangedException();
+
+  @override
+  String toString() =>
+      'The Gift Card receiving account or address changed before claim.';
+}
+
+class PaymentLinkClaimInFlightException implements Exception {
+  const PaymentLinkClaimInFlightException();
+
+  @override
+  String toString() => 'This Gift Card is already being received.';
+}
+
+/// A pasted Gift Card belongs to a different Zcash network than the wallet.
+///
+/// This is a permanent property of the link, not a transient lookup failure,
+/// so the redeem screen says so instead of offering a retry.
+class PaymentLinkNetworkMismatchException implements Exception {
+  const PaymentLinkNetworkMismatchException({
+    required this.linkNetwork,
+    required this.walletNetwork,
+  });
+
+  final String linkNetwork;
+  final String walletNetwork;
+
+  @override
+  String toString() => 'This Gift Card is for a different Zcash network.';
+}
+
+@visibleForTesting
+void requireMatchingPaymentLinkClaimDestination({
+  required String preparedAddress,
+  required String currentAddress,
+}) {
+  if (preparedAddress != currentAddress) {
+    throw const PaymentLinkClaimDestinationChangedException();
+  }
+}
+
+class PaymentLinkClaimResult {
+  const PaymentLinkClaimResult({required this.txids, required this.status});
+
+  final String txids;
+  final PaymentLinkClaimBroadcastStatus status;
+}
+
+/// A fully broadcast payment-link funding result.
+///
+/// When [fundingMetadataSaved] is false, the durable draft still preserves the
+/// bearer secret, but callers must not offer another funding attempt as the
+/// transaction already reached the network.
+class PaymentLinkFundingResult {
+  const PaymentLinkFundingResult({
+    required this.link,
+    required this.txids,
+    required this.fundingMetadataSaved,
+    required this.broadcastAccepted,
+  });
+
+  final VizorPaymentLink link;
+  final String txids;
+
+  /// Whether the durable recovery record advanced from draft to funded.
+  /// The link remains recoverable from its draft when this is false.
+  final bool fundingMetadataSaved;
+
+  /// Whether the network explicitly accepted the funding broadcast. An
+  /// uncertain hardware response falls back to one mined confirmation.
+  final bool broadcastAccepted;
+}
+
+class PaymentLinkService implements PaymentLinkOperations {
+  PaymentLinkService(
+    this._ref,
+    this._recoveryStore,
+    this._receivedStore,
+    this._recoveryReconciler,
+  );
+
+  final Ref _ref;
+  final PaymentLinkRecoveryStore _recoveryStore;
+  final PaymentLinkReceivedStore _receivedStore;
+  final PaymentLinkRecoveryReconciler _recoveryReconciler;
+  late final PaymentLinkClaimWallet _claimWallet = PaymentLinkClaimWallet(_ref);
+
+  @override
+  Future<PaymentLinkFundingQuote> quoteMaxFunding({
+    required String sourceAccountUuid,
+  }) async {
+    if (sourceAccountUuid.isEmpty) {
+      throw StateError('No active account.');
+    }
+    return _ref
+        .read(syncProvider.notifier)
+        .runWithAuthoritativeSpendable(
+          accountUuid: sourceAccountUuid,
+          operation: () async {
+            final dbPath = await getWalletDbPath();
+            final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+            final estimateAddress = await rust_wallet.getUnifiedAddress(
+              dbPath: dbPath,
+              network: endpoint.networkName,
+              accountUuid: sourceAccountUuid,
+            );
+            final estimate = await rust_sync.estimateSendMax(
+              dbPath: dbPath,
+              network: endpoint.networkName,
+              accountUuid: sourceAccountUuid,
+              toAddress: estimateAddress,
+            );
+            return paymentLinkMaxFundingQuote(
+              sourceAccountUuid: sourceAccountUuid,
+              maxSpendAmountZatoshi: estimate.amountZatoshi,
+              fundingFeeZatoshi: estimate.feeZatoshi,
+            );
+          },
+        );
+  }
+
+  @override
+  Future<PaymentLinkFundingQuote> quoteFunding({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+  }) async {
+    if (sourceAccountUuid.isEmpty) {
+      throw StateError('No active account.');
+    }
+    final fundingAmount = paymentLinkFundingAmountZatoshi(amountZatoshi);
+    return _ref
+        .read(syncProvider.notifier)
+        .runWithAuthoritativeSpendable(
+          accountUuid: sourceAccountUuid,
+          operation: () async {
+            final dbPath = await getWalletDbPath();
+            final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+            final estimateAddress = await rust_wallet.getUnifiedAddress(
+              dbPath: dbPath,
+              network: endpoint.networkName,
+              accountUuid: sourceAccountUuid,
+            );
+            final fundingFee = await rust_sync.estimateFee(
+              dbPath: dbPath,
+              network: endpoint.networkName,
+              accountUuid: sourceAccountUuid,
+              toAddress: estimateAddress,
+              amountZatoshi: fundingAmount,
+              memo: null,
+            );
+            return PaymentLinkFundingQuote(
+              sourceAccountUuid: sourceAccountUuid,
+              recipientAmountZatoshi: amountZatoshi,
+              fundingFeeZatoshi: fundingFee,
+              claimFeeReserveZatoshi: BigInt.from(
+                kPaymentLinkClaimFeeReserveZatoshi,
+              ),
+            );
+          },
+        );
+  }
+
+  @override
+  Future<PaymentLinkFundingResult> createFundedLink({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+    PaymentLinkPresentation? presentation,
+  }) async {
+    if (_ref
+        .read(accountProvider.notifier)
+        .isHardwareAccount(sourceAccountUuid)) {
+      throw StateError(
+        'Keystone payment links require the hardware signing flow.',
+      );
+    }
+    final link = await _createFundingLink(
+      amountZatoshi: amountZatoshi,
+      sourceAccountUuid: sourceAccountUuid,
+      presentation: presentation,
+    );
+    final funding = await PaymentLinkFundingRecovery(_recoveryStore)
+        .fund<rust_sync.ExecuteProposalResult>(
+          link: link,
+          sourceAccountUuid: sourceAccountUuid,
+          createTransaction: () => runPaymentLinkFundingSubmission(
+            (markSubmissionStarted) => _sendShielded(
+              fromAccountUuid: sourceAccountUuid,
+              toAddress: link.address,
+              amountZatoshi: paymentLinkFundingAmountZatoshi(amountZatoshi),
+              memo: null,
+              onSubmissionStarted: markSubmissionStarted,
+            ),
+          ),
+          fundingTxids: (result) => result.txids,
+        );
+    final fundingResult = funding.transaction;
+    if (!funding.fundingMetadataSaved) {
+      log(
+        'PaymentLinkService: funding was submitted but recovery metadata '
+        'could not be saved after retry: ${funding.recoveryError}\n'
+        '${funding.recoveryStackTrace}',
+      );
+    }
+
+    unawaited(_refreshMainWalletAfterSend());
+    return PaymentLinkFundingResult(
+      link: link,
+      txids: fundingResult.txids,
+      fundingMetadataSaved: funding.fundingMetadataSaved,
+      broadcastAccepted: isPaymentLinkFundingBroadcastAccepted(
+        fundingResult.status,
+      ),
+    );
+  }
+
+  @override
+  Future<void> retryFundingMetadata({
+    required String address,
+    required String fundingTxids,
+  }) async {
+    final recovery = await PaymentLinkFundingRecovery(_recoveryStore)
+        .complete<String>(
+          transaction: fundingTxids,
+          address: address,
+          fundingTxids: (txids) => txids,
+        );
+    if (recovery.fundingMetadataSaved) return;
+    Error.throwWithStackTrace(
+      recovery.recoveryError!,
+      recovery.recoveryStackTrace!,
+    );
+  }
+
+  /// Creates the bearer-secret account and persists its recovery record before
+  /// any funding proposal can be signed or broadcast.
+  Future<VizorPaymentLink> createFundingDraft({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+    PaymentLinkPresentation? presentation,
+  }) async {
+    final link = await _createFundingLink(
+      amountZatoshi: amountZatoshi,
+      sourceAccountUuid: sourceAccountUuid,
+      presentation: presentation,
+    );
+    await _recoveryStore.saveDraft(
+      link: link,
+      sourceAccountUuid: sourceAccountUuid,
+    );
+    return link;
+  }
+
+  Future<VizorPaymentLink> _createFundingLink({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+    PaymentLinkPresentation? presentation,
+  }) async {
+    if (sourceAccountUuid.isEmpty) {
+      throw StateError('No active account.');
+    }
+    if (amountZatoshi <= BigInt.zero) {
+      throw ArgumentError.value(
+        amountZatoshi,
+        'amountZatoshi',
+        'Payment link amount must be positive.',
+      );
+    }
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    if (!VizorPaymentLink.supportsNetwork(endpoint.networkName)) {
+      throw StateError('Payment links are only available on mainnet.');
+    }
+    final paymentAccount = await rust_wallet.generateSoftwareAccount(
+      network: endpoint.networkName,
+    );
+    final ephemeralAddress = paymentAccount.unifiedAddress;
+    if (ephemeralAddress.isEmpty) {
+      throw StateError('Payment link account was created without an address.');
+    }
+
+    final birthdayHeight = await _ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .getLatestBlockHeight();
+    final link = VizorPaymentLink(
+      network: endpoint.networkName,
+      address: ephemeralAddress,
+      amountZatoshi: amountZatoshi,
+      mnemonic: paymentAccount.mnemonic,
+      birthdayHeight: birthdayHeight.toInt(),
+      label: 'Payment link',
+      createdAt: DateTime.now(),
+      presentation: presentation,
+    );
+    return link;
+  }
+
+  @override
+  Future<List<PaymentLinkRecoveryRecord>> loadCreatedLinkRecoveries() =>
+      _recoveryReconciler.load();
+
+  @override
+  Future<PaymentLinkRecoveryRecord> markCreatedLinkShared(
+    VizorPaymentLink link,
+  ) {
+    return _recoveryStore.markShared(address: link.address);
+  }
+
+  @override
+  Future<Map<String, PaymentLinkFundingProgress>> inspectCreatedLinkFundings(
+    List<PaymentLinkRecoveryRecord> records,
+  ) async {
+    final needsHistory = records
+        .where((record) => record.state == PaymentLinkRecoveryState.funded)
+        .toList();
+    if (needsHistory.isEmpty) {
+      return {
+        for (final record in records)
+          record.link.address: PaymentLinkFundingProgress(
+            confirmationCount: record.state == PaymentLinkRecoveryState.shared
+                ? kPaymentLinkShareConfirmationTarget
+                : 0,
+          ),
+      };
+    }
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    final dbPath = await getWalletDbPath();
+    final transactionsByAccount = <String, List<rust_sync.TransactionInfo>>{};
+    for (final accountUuid
+        in needsHistory.map((record) => record.sourceAccountUuid).toSet()) {
+      transactionsByAccount[accountUuid] = await rust_sync
+          .getTransactionHistory(
+            dbPath: dbPath,
+            network: endpoint.networkName,
+            accountUuid: accountUuid,
+            limit: null,
+          );
+    }
+    final cachedTip = _ref.read(syncProvider).value?.chainTipHeight ?? 0;
+    final chainTipHeight = cachedTip > 0
+        ? BigInt.from(cachedTip)
+        : await _ref
+              .read(rpcEndpointFailoverProvider.notifier)
+              .getLatestBlockHeight();
+    final expiredAddresses = <String>{};
+    for (final record in needsHistory) {
+      final fundingTxids = record.fundingTxids;
+      if (fundingTxids == null ||
+          !paymentLinkFundingExpired(
+            fundingTxids: fundingTxids,
+            transactions:
+                transactionsByAccount[record.sourceAccountUuid] ?? const [],
+          )) {
+        continue;
+      }
+      await _recoveryStore.removeUnsharedExpiredFunding(
+        address: record.link.address,
+        fundingTxids: fundingTxids,
+      );
+      expiredAddresses.add(record.link.address);
+    }
+    return {
+      for (final record in records)
+        if (!expiredAddresses.contains(record.link.address))
+          record.link.address: record.state == PaymentLinkRecoveryState.shared
+              ? const PaymentLinkFundingProgress(
+                  confirmationCount: kPaymentLinkShareConfirmationTarget,
+                )
+              : _fundingProgressForRecord(
+                  record: record,
+                  transactions:
+                      transactionsByAccount[record.sourceAccountUuid] ??
+                      const [],
+                  chainTipHeight: chainTipHeight,
+                ),
+    };
+  }
+
+  @override
+  Future<List<PaymentLinkReceivedRecord>> loadReceivedLinkRecoveries() {
+    return _receivedStore.load();
+  }
+
+  @override
+  Future<List<PaymentLinkReceivedRecord>> inspectReceivedLinkClaims(
+    List<PaymentLinkReceivedRecord> _,
+  ) async {
+    // The screen can optimistically render Receiving before the broadcast
+    // result returns. Always reconcile from the persisted copy, which owns
+    // the destination account UUID and claim txids needed for history lookup.
+    var persistedRecords = await _receivedStore.load();
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    final submitting = persistedRecords
+        .where(
+          (record) =>
+              record.needsClaimMetadataRecovery &&
+              record.network == endpoint.networkName,
+        )
+        .toList();
+    await Future.wait(
+      submitting.map((record) async {
+        try {
+          await _recoverClaimMetadata(
+            record: record,
+            network: endpoint.networkName,
+          );
+        } catch (error, stackTrace) {
+          log(
+            'PaymentLinkService: retained claim metadata recovery failed for '
+            '${record.address}: $error\n$stackTrace',
+          );
+        }
+      }),
+    );
+    if (submitting.isNotEmpty) {
+      persistedRecords = await _receivedStore.load();
+    }
+    final receiving = persistedRecords
+        .where(
+          (record) =>
+              record.status == PaymentLinkReceivedStatus.receiving &&
+              record.destinationAccountUuid != null &&
+              record.claimTxids != null &&
+              record.claimTxids!.trim().isNotEmpty,
+        )
+        .toList();
+    if (receiving.isEmpty) return persistedRecords;
+
+    final currentNetworkRecords = receiving
+        .where((record) => record.network == endpoint.networkName)
+        .toList();
+    if (currentNetworkRecords.isEmpty) return persistedRecords;
+
+    final retryableAddresses = <String>{};
+    await Future.wait(
+      currentNetworkRecords.map((record) async {
+        try {
+          if (await _claimWallet.syncRetained(
+            record: record,
+            network: endpoint.networkName,
+          )) {
+            await _receivedStore.markReadyToClaim(address: record.address);
+            retryableAddresses.add(record.address);
+          }
+        } catch (error, stackTrace) {
+          log(
+            'PaymentLinkService: retained claim wallet sync failed for '
+            '${record.address}: $error\n$stackTrace',
+          );
+        }
+      }),
+    );
+    final awaitingReceipt = currentNetworkRecords
+        .where((record) => !retryableAddresses.contains(record.address))
+        .toList();
+    if (awaitingReceipt.isEmpty) return _receivedStore.load();
+
+    final dbPath = await getWalletDbPath();
+    final transactionsByAccount = <String, List<rust_sync.TransactionInfo>>{};
+    for (final accountUuid
+        in awaitingReceipt
+            .map((record) => record.destinationAccountUuid!)
+            .toSet()) {
+      transactionsByAccount[accountUuid] = await rust_sync
+          .getTransactionHistory(
+            dbPath: dbPath,
+            network: endpoint.networkName,
+            accountUuid: accountUuid,
+            limit: null,
+          );
+    }
+    final syncState = _ref.read(syncProvider).value;
+    // A polled tip can advance before the main wallet DB has scanned it. In
+    // particular, after a reorg the DB can still expose a transaction's old
+    // mined height while chainTipHeight already describes the replacement
+    // branch. Only confirmations covered by both heights are safe for the
+    // destructive retained-wallet cleanup boundary.
+    final chainTipHeight = paymentLinkVerifiedChainHeight(
+      scannedHeight: syncState?.scannedHeight ?? 0,
+      chainTipHeight: syncState?.chainTipHeight ?? 0,
+    );
+
+    for (final record in awaitingReceipt) {
+      final status = paymentLinkReceivedStatusForTransactions(
+        claimTxids: record.claimTxids!,
+        transactions:
+            transactionsByAccount[record.destinationAccountUuid!] ?? const [],
+        chainTipHeight: chainTipHeight,
+      );
+      switch (status) {
+        case PaymentLinkReceivedStatus.readyToClaim:
+          await _receivedStore.markReadyToClaim(address: record.address);
+        case PaymentLinkReceivedStatus.submitting:
+          throw StateError(
+            'Transaction reconciliation cannot produce submitting state.',
+          );
+        case PaymentLinkReceivedStatus.receiving:
+          break;
+        case PaymentLinkReceivedStatus.received:
+          await finalizeConfirmedPaymentLinkClaim(
+            record: record,
+            deleteRetainedWallet: _claimWallet.deleteRetained,
+            markReceived: (address) =>
+                _receivedStore.markReceived(address: address),
+          );
+      }
+    }
+    return _receivedStore.load();
+  }
+
+  PaymentLinkFundingProgress _fundingProgressForRecord({
+    required PaymentLinkRecoveryRecord record,
+    required List<rust_sync.TransactionInfo> transactions,
+    required BigInt chainTipHeight,
+  }) {
+    final rawTxids = record.fundingTxids;
+    if (record.state == PaymentLinkRecoveryState.draft ||
+        rawTxids == null ||
+        rawTxids.trim().isEmpty) {
+      return const PaymentLinkFundingProgress(confirmationCount: 0);
+    }
+    final fundingTxids = rawTxids
+        .split(',')
+        .map(normalizePaymentLinkTxid)
+        .where((txid) => txid.isNotEmpty)
+        .toSet();
+    if (fundingTxids.isEmpty) {
+      return const PaymentLinkFundingProgress(confirmationCount: 0);
+    }
+    final minedHeights = <String, BigInt>{};
+    for (final transaction in transactions) {
+      final txid = normalizePaymentLinkTxid(transaction.txidHex);
+      if (transaction.minedHeight <= BigInt.zero) continue;
+      for (final fundingTxid in fundingTxids) {
+        if (paymentLinkTxidsMatch(fundingTxid, txid)) {
+          minedHeights[fundingTxid] = transaction.minedHeight;
+        }
+      }
+    }
+    final allFundingTransactionsMined = minedHeights.keys.toSet().containsAll(
+      fundingTxids,
+    );
+    final minedHeight = allFundingTransactionsMined
+        ? minedHeights.values.reduce(
+            (latest, height) => height > latest ? height : latest,
+          )
+        : BigInt.zero;
+    return PaymentLinkFundingProgress(
+      confirmationCount: paymentLinkConfirmationCount(
+        minedHeight: minedHeight,
+        chainTipHeight: chainTipHeight,
+      ),
+    );
+  }
+
+  @override
+  Future<PaymentLinkClaimSession> prepareClaim(
+    VizorPaymentLink link, {
+    bool allowLongSync = false,
+  }) async {
+    final receiverState = _ref.read(accountProvider).value;
+    final receiverAccountUuid = receiverState?.activeAccountUuid;
+    final receiverAddress = receiverState?.activeAddress;
+    if (receiverAccountUuid == null ||
+        receiverAddress == null ||
+        receiverAddress.isEmpty) {
+      throw StateError('No active receive account.');
+    }
+    return _prepareSpend(
+      link: link,
+      destinationAddress: receiverAddress,
+      destinationAccountUuid: receiverAccountUuid,
+      allowLongSync: allowLongSync,
+    );
+  }
+
+  Future<PaymentLinkClaimSession> _prepareSpend({
+    required VizorPaymentLink link,
+    required String destinationAddress,
+    required String destinationAccountUuid,
+    required bool allowLongSync,
+  }) async {
+    log('PaymentLinkClaim: preparation started');
+    final existingRecord = await _receivedStore.find(link.address);
+    if (existingRecord?.isClaimInFlight ?? false) {
+      throw const PaymentLinkClaimInFlightException();
+    }
+    await _requireShieldedAddress(destinationAddress);
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    if (link.network != endpoint.networkName) {
+      throw PaymentLinkNetworkMismatchException(
+        linkNetwork: link.network,
+        walletNetwork: endpoint.networkName,
+      );
+    }
+    log('PaymentLinkClaim: endpoint validated');
+
+    final currentTipHeight = await _ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .getLatestBlockHeight();
+    final claimBirthdayHeight = validatePaymentLinkClaimBirthday(
+      advertisedBirthdayHeight: link.birthdayHeight,
+      currentTipHeight: currentTipHeight.toInt(),
+    );
+    log('PaymentLinkClaim: birthday validated');
+    if (!allowLongSync &&
+        isLongPaymentLinkSync(
+          birthdayHeight: claimBirthdayHeight,
+          currentTipHeight: currentTipHeight.toInt(),
+        )) {
+      log('PaymentLinkClaim: long sync confirmation required');
+      throw const PaymentLinkLongSyncConfirmationRequired();
+    }
+
+    final tempWallet = await _claimWallet.createOrOpen(link);
+    log('PaymentLinkClaim: temporary wallet opened');
+    var deleteOnError = !tempWallet.existed;
+    try {
+      final String importedAddress;
+      final String importedAccountUuid;
+      if (tempWallet.existed) {
+        List<rust_wallet.AccountInfo>? accounts;
+        try {
+          accounts = await rust_wallet.listAccounts(
+            dbPath: tempWallet.dbPath,
+            network: endpoint.networkName,
+          );
+        } catch (e, st) {
+          log(
+            'PaymentLinkService: reopening payment-link claim wallet failed; '
+            'recreating it: $e\n$st',
+          );
+        }
+        if (accounts == null ||
+            shouldRecreatePaymentLinkClaimWallet(
+              accountAddresses: [
+                for (final account in accounts) account.unifiedAddress,
+              ],
+              expectedAddress: link.address,
+            )) {
+          if (accounts != null) {
+            log(
+              'PaymentLinkService: recreating incomplete payment-link claim '
+              'wallet with ${accounts.length} account(s)',
+            );
+          }
+          deleteOnError = true;
+          await _claimWallet.resetDb(tempWallet.directory);
+          final imported = await _claimWallet.importClaimAccount(
+            link: link,
+            birthdayHeight: claimBirthdayHeight,
+            dbPath: tempWallet.dbPath,
+            network: endpoint.networkName,
+          );
+          importedAddress = imported.address;
+          importedAccountUuid = imported.accountUuid;
+        } else {
+          importedAddress = accounts.single.unifiedAddress;
+          importedAccountUuid = accounts.single.uuid;
+        }
+      } else {
+        final imported = await _claimWallet.importClaimAccount(
+          link: link,
+          birthdayHeight: claimBirthdayHeight,
+          dbPath: tempWallet.dbPath,
+          network: endpoint.networkName,
+        );
+        importedAddress = imported.address;
+        importedAccountUuid = imported.accountUuid;
+      }
+      if (importedAddress != link.address) {
+        throw const FormatException(
+          'Payment link address does not match its recovery phrase.',
+        );
+      }
+      log('PaymentLinkClaim: recovery address validated');
+
+      await _claimWallet.runClaimSync(link: link, dbPath: tempWallet.dbPath);
+      log('PaymentLinkClaim: temporary wallet sync completed');
+      final balance = await rust_sync.getBalance(
+        dbPath: tempWallet.dbPath,
+        network: endpoint.networkName,
+        accountUuid: importedAccountUuid,
+      );
+      var claimableZatoshi = BigInt.zero;
+      var feeZatoshi = BigInt.zero;
+      try {
+        final estimate = await rust_sync.estimateSendMax(
+          dbPath: tempWallet.dbPath,
+          network: endpoint.networkName,
+          accountUuid: importedAccountUuid,
+          toAddress: destinationAddress,
+        );
+        claimableZatoshi = paymentLinkClaimableAmountZatoshi(
+          recipientAmountZatoshi: link.amountZatoshi,
+          maxSpendableZatoshi: estimate.amountZatoshi,
+        );
+        feeZatoshi = estimate.feeZatoshi;
+      } catch (e) {
+        final message = e.toString().toLowerCase();
+        if (!message.contains('insufficient balance')) {
+          rethrow;
+        }
+      }
+
+      final transactions = await rust_sync.getTransactionHistory(
+        dbPath: tempWallet.dbPath,
+        network: endpoint.networkName,
+        accountUuid: importedAccountUuid,
+        limit: null,
+      );
+      final fundingConfirmationCount =
+          paymentLinkFundingConfirmationCountForClaim(
+            recipientAmountZatoshi: link.amountZatoshi,
+            transactions: transactions,
+            chainTipHeight: currentTipHeight,
+          );
+      final waitingForFundingConfirmations = paymentLinkShouldWaitForFunding(
+        recipientAmountZatoshi: link.amountZatoshi,
+        totalZatoshi: balance.total,
+        fundingConfirmationCount: fundingConfirmationCount,
+        birthdayHeight: claimBirthdayHeight,
+        currentTipHeight: currentTipHeight.toInt(),
+      );
+
+      log(
+        'PaymentLinkClaim: balance checked '
+        'claimable=${claimableZatoshi > BigInt.zero} '
+        'confirmations=$fundingConfirmationCount',
+      );
+
+      return PaymentLinkClaimSession(
+        link: link,
+        destinationAddress: destinationAddress,
+        destinationAccountUuid: destinationAccountUuid,
+        directory: tempWallet.directory,
+        dbPath: tempWallet.dbPath,
+        accountUuid: importedAccountUuid,
+        totalZatoshi: balance.total,
+        claimableZatoshi: claimableZatoshi,
+        feeZatoshi: feeZatoshi,
+        fundingConfirmationCount: fundingConfirmationCount,
+        waitingForFundingConfirmations: waitingForFundingConfirmations,
+      );
+    } catch (_) {
+      if (deleteOnError) {
+        await _claimWallet.deleteDb(tempWallet.directory);
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<PaymentLinkClaimResult> claimPreparedLink(
+    PaymentLinkClaimSession session,
+  ) async {
+    // Checking a Gift Card is a read-only preview. Persist it only after the
+    // user explicitly starts a claim, before any broadcast can occur, so an
+    // interrupted submission remains recoverable without making previews look
+    // received.
+    await _receivedStore.saveReady(session.link);
+    await _receivedStore.markClaimStarted(
+      address: session.link.address,
+      destinationAccountUuid: session.destinationAccountUuid,
+    );
+    var submissionStarted = false;
+    try {
+      final result = await _broadcastPreparedSpend(
+        session,
+        onSubmissionStarted: () => submissionStarted = true,
+      );
+      final metadataSaved = await _saveClaimMetadata(
+        session: session,
+        claimTxids: result.txids,
+      );
+      if (!metadataSaved) {
+        log(
+          'PaymentLinkService: claim was submitted but receiving metadata '
+          'could not be saved after retry; retaining the claim wallet',
+        );
+      }
+      // Keep the claim database for rebroadcast/reorg recovery. Reconciliation
+      // deletes it only after every claim transaction reaches six confirmations.
+      return result;
+    } catch (_) {
+      if (!submissionStarted) {
+        await _receivedStore.markReadyToClaim(address: session.link.address);
+      }
+      rethrow;
+    }
+  }
+
+  Future<PaymentLinkClaimResult> _broadcastPreparedSpend(
+    PaymentLinkClaimSession session, {
+    void Function()? onSubmissionStarted,
+  }) async {
+    if (!session.canClaim) {
+      throw StateError('Payment link has no spendable shielded balance yet.');
+    }
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    if (session.link.network != endpoint.networkName) {
+      throw StateError(
+        'Payment link is for ${session.link.network}, but this wallet is '
+        'using ${endpoint.networkName}.',
+      );
+    }
+    final estimate = await rust_sync.estimateSendMax(
+      dbPath: session.dbPath,
+      network: endpoint.networkName,
+      accountUuid: session.accountUuid,
+      toAddress: session.destinationAddress,
+    );
+    if (estimate.amountZatoshi < session.link.amountZatoshi) {
+      throw StateError(
+        'Payment link does not yet have enough spendable shielded balance.',
+      );
+    }
+
+    // A Vizor-created Gift Card funds exactly the advertised amount plus its
+    // claim fee. Keep that advertised amount as the Card contract instead of
+    // sweeping unrelated top-ups; the bearer link can recover this wallet.
+    _requireWalletUnlocked();
+    final sendResult = await _sendShielded(
+      dbPath: session.dbPath,
+      fromAccountUuid: session.accountUuid,
+      toAddress: session.destinationAddress,
+      amountZatoshi: session.link.amountZatoshi,
+      memo: null,
+      mnemonic: session.link.mnemonic,
+      beforeExecute: () => _revalidateClaimDestination(session),
+      onSubmissionStarted: onSubmissionStarted,
+    );
+    final claimResult = PaymentLinkClaimResult(
+      txids: sendResult.txids,
+      status: paymentLinkClaimBroadcastStatusFromWire(sendResult.status),
+    );
+    unawaited(_refreshMainWalletAfterSend());
+    return claimResult;
+  }
+
+  Future<bool> _saveClaimMetadata({
+    required PaymentLinkClaimSession session,
+    required String claimTxids,
+  }) async {
+    for (
+      var attempt = 0;
+      attempt < _paymentLinkClaimMetadataWriteAttempts;
+      attempt++
+    ) {
+      try {
+        await _receivedStore.markReceiving(
+          address: session.link.address,
+          destinationAccountUuid: session.destinationAccountUuid,
+          claimTxids: claimTxids,
+        );
+        return true;
+      } catch (_) {
+        if (attempt + 1 == _paymentLinkClaimMetadataWriteAttempts) {
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
+  Future<void> _revalidateClaimDestination(
+    PaymentLinkClaimSession session,
+  ) async {
+    try {
+      final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+      final currentAddress = await rust_wallet.getUnifiedAddress(
+        dbPath: await getWalletDbPath(),
+        network: endpoint.networkName,
+        accountUuid: session.destinationAccountUuid,
+      );
+      requireMatchingPaymentLinkClaimDestination(
+        preparedAddress: session.destinationAddress,
+        currentAddress: currentAddress,
+      );
+    } on PaymentLinkClaimDestinationChangedException {
+      rethrow;
+    } catch (_) {
+      throw const PaymentLinkClaimDestinationChangedException();
+    }
+  }
+
+  @override
+  Future<void> discardClaimSession(PaymentLinkClaimSession session) async {
+    await _claimWallet.cancelClaimSync(session.link);
+    await _claimWallet.deleteDb(session.directory);
+  }
+
+  Future<void> _refreshMainWalletAfterSend() async {
+    try {
+      await _ref.read(syncProvider.notifier).refreshAfterSend();
+    } catch (e, stackTrace) {
+      log(
+        'PaymentLinkService: refreshAfterSend failed (non-critical): $e\n'
+        '$stackTrace',
+      );
+    }
+  }
+
+  Future<rust_sync.ExecuteProposalResult> _sendShielded({
+    String? dbPath,
+    required String fromAccountUuid,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+    String? mnemonic,
+    Future<void> Function()? beforeExecute,
+    void Function()? onSubmissionStarted,
+  }) async {
+    await _requireShieldedAddress(toAddress);
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
+    final sendFlowId = _newSendFlowId();
+    Future<({String dbPath, rust_sync.ProposalResult proposal})> createProposal(
+      String proposalDbPath,
+    ) async {
+      final proposal = await rust_sync.proposeSend(
+        dbPath: proposalDbPath,
+        network: endpoint.networkName,
+        accountUuid: fromAccountUuid,
+        sendFlowId: sendFlowId,
+        toAddress: toAddress,
+        amountZatoshi: amountZatoshi,
+        memo: memo,
+      );
+      return (dbPath: proposalDbPath, proposal: proposal);
+    }
+
+    // The primary wallet shares the ordinary send flow's authoritative
+    // spendable lease. Claim wallets are fully synchronized before this path.
+    final proposalContext = dbPath == null
+        ? await _ref
+              .read(syncProvider.notifier)
+              .runWithAuthoritativeSpendable(
+                accountUuid: fromAccountUuid,
+                operation: () async => createProposal(await getWalletDbPath()),
+              )
+        : await createProposal(dbPath);
+    final walletDbPath = proposalContext.dbPath;
+    final proposal = proposalContext.proposal;
+
+    try {
+      final result = await _executeProposal(
+        dbPath: walletDbPath,
+        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        accountUuid: fromAccountUuid,
+        proposalId: proposal.proposalId,
+        sendFlowId: sendFlowId,
+        needsSaplingParams: proposal.needsSaplingParams,
+        mnemonic: mnemonic,
+        beforeExecute: beforeExecute,
+        onSubmissionStarted: onSubmissionStarted,
+      );
+      paymentLinkClaimBroadcastStatusFromWire(result.status);
+      return result;
+    } catch (e) {
+      try {
+        await rust_sync.discardProposal(
+          proposalId: proposal.proposalId,
+          sendFlowId: sendFlowId,
+        );
+      } catch (discardError) {
+        log('PaymentLinkService: discardProposal failed: $discardError');
+      }
+      rethrow;
+    }
+  }
+
+  Future<rust_sync.ExecuteProposalResult> _executeProposal({
+    required String dbPath,
+    required String lightwalletdUrl,
+    required String accountUuid,
+    required BigInt proposalId,
+    required String sendFlowId,
+    required bool needsSaplingParams,
+    String? mnemonic,
+    Future<void> Function()? beforeExecute,
+    void Function()? onSubmissionStarted,
+  }) async {
+    var saplingParams = await loadSaplingParamsStatus();
+    if (needsSaplingParams && !saplingParams.complete) {
+      await downloadMissingSaplingParams(
+        saplingParams,
+        log: (message) => log('PaymentLinkService: $message'),
+      );
+      saplingParams = await loadSaplingParamsStatus();
+    }
+
+    await beforeExecute?.call();
+    _requireWalletUnlocked();
+
+    if (Platform.isMacOS && mnemonic == null) {
+      final password = _ref
+          .read(appSecurityProvider.notifier)
+          .requireSessionPasswordForNativeSecretUse();
+      onSubmissionStarted?.call();
+      return rust_sync.executeProposalWithMacosStoredMnemonic(
+        dbPath: dbPath,
+        lightwalletdUrl: lightwalletdUrl,
+        proposalId: proposalId,
+        sendFlowId: sendFlowId,
+        password: password,
+        spendParamsPath: needsSaplingParams ? saplingParams.spendPath : null,
+        outputParamsPath: needsSaplingParams ? saplingParams.outputPath : null,
+      );
+    }
+
+    final mnemonicBytes = mnemonic == null
+        ? await _ref
+              .read(accountProvider.notifier)
+              .getMnemonicBytesForAccount(accountUuid)
+        : Uint8List.fromList(utf8.encode(mnemonic));
+    if (mnemonicBytes == null || mnemonicBytes.isEmpty) {
+      throw StateError('Mnemonic not found for payment link account.');
+    }
+    late final Future<rust_sync.ExecuteProposalResult> result;
+    try {
+      onSubmissionStarted?.call();
+      result = rust_sync.executeProposal(
+        dbPath: dbPath,
+        lightwalletdUrl: lightwalletdUrl,
+        proposalId: proposalId,
+        sendFlowId: sendFlowId,
+        mnemonicBytes: mnemonicBytes,
+        spendParamsPath: needsSaplingParams ? saplingParams.spendPath : null,
+        outputParamsPath: needsSaplingParams ? saplingParams.outputPath : null,
+      );
+    } finally {
+      _zeroize(mnemonicBytes);
+    }
+    return result;
+  }
+
+  Future<void> _recoverClaimMetadata({
+    required PaymentLinkReceivedRecord record,
+    required String network,
+  }) async {
+    final link = record.claimLink;
+    final destinationAccountUuid = record.destinationAccountUuid;
+    if (link == null || destinationAccountUuid == null) return;
+
+    final tempWallet = await _claimWallet.locate(link);
+    if (!await File(tempWallet.dbPath).exists()) return;
+
+    await _claimWallet.runClaimSync(link: link, dbPath: tempWallet.dbPath);
+    final accounts = await rust_wallet.listAccounts(
+      dbPath: tempWallet.dbPath,
+      network: network,
+    );
+    if (shouldRecreatePaymentLinkClaimWallet(
+      accountAddresses: [
+        for (final account in accounts) account.unifiedAddress,
+      ],
+      expectedAddress: link.address,
+    )) {
+      return;
+    }
+    final transactions = await rust_sync.getTransactionHistory(
+      dbPath: tempWallet.dbPath,
+      network: network,
+      accountUuid: accounts.single.uuid,
+      limit: null,
+    );
+    final activeTxids = paymentLinkActiveClaimTxids(transactions);
+    if (activeTxids.isEmpty) {
+      await _receivedStore.markReadyToClaim(address: record.address);
+      return;
+    }
+    await _receivedStore.markReceiving(
+      address: record.address,
+      destinationAccountUuid: destinationAccountUuid,
+      claimTxids: activeTxids.join(','),
+    );
+  }
+
+  Future<void> _requireShieldedAddress(String address) async {
+    final validation = await rust_sync.validateAddress(
+      address: address,
+      network: kZcashDefaultNetworkName,
+    );
+    if (!validation.isValid ||
+        (validation.addressType != 'unified' &&
+            validation.addressType != 'sapling')) {
+      throw StateError('Payment links only support shielded addresses.');
+    }
+  }
+
+  void _requireWalletUnlocked() {
+    requireUnlockedPaymentLinkWallet(
+      requiresUnlock: _ref.read(appSecurityProvider).requiresUnlock,
+    );
+  }
+
+  String _newSendFlowId() {
+    final random = Random.secure();
+    return List<int>.generate(
+      16,
+      (_) => random.nextInt(256),
+    ).map((byte) => byte.toRadixString(16).padLeft(2, '0')).join();
+  }
+}

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -8,7 +8,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
-import '../../../core/config/network_config.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
@@ -1289,7 +1288,9 @@ class PaymentLinkService implements PaymentLinkOperations {
   Future<void> _requireShieldedAddress(String address) async {
     final validation = await rust_sync.validateAddress(
       address: address,
-      network: kZcashDefaultNetworkName,
+      // The wallet's network, not the build default: a wallet moved off it
+      // would otherwise refuse every address it can actually pay.
+      network: _ref.read(rpcEndpointFailoverProvider).current.networkName,
     );
     if (!validation.isValid ||
         (validation.addressType != 'unified' &&

--- a/lib/src/features/payment_links/services/payment_link_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_service.dart
@@ -393,15 +393,28 @@ class PaymentLinkService implements PaymentLinkOperations {
         .fund<rust_sync.ExecuteProposalResult>(
           link: link,
           sourceAccountUuid: sourceAccountUuid,
-          createTransaction: () => runPaymentLinkFundingSubmission(
-            (markSubmissionStarted) => _sendShielded(
-              fromAccountUuid: sourceAccountUuid,
-              toAddress: link.address,
-              amountZatoshi: paymentLinkFundingAmountZatoshi(amountZatoshi),
-              memo: null,
-              onSubmissionStarted: markSubmissionStarted,
-            ),
-          ),
+          createTransaction: (markSubmissionStarted) =>
+              runPaymentLinkFundingSubmission(
+                (markLocalSubmission) => _sendShielded(
+                  fromAccountUuid: sourceAccountUuid,
+                  toAddress: link.address,
+                  amountZatoshi: paymentLinkFundingAmountZatoshi(amountZatoshi),
+                  memo: null,
+                  onSubmissionStarted: () async {
+                    // The durable trace has to land before the broadcast, and
+                    // the local marker only after it: a failed write leaves
+                    // the submission unmarked, which classifies the failure as
+                    // definitely-not-submitted and discards the inert draft.
+                    await markSubmissionStarted();
+                    markLocalSubmission();
+                  },
+                ),
+              ),
+          // The in-memory sync tip, not a network round trip: this runs on the
+          // broadcast path, and a height the wallet already knows is enough to
+          // date the submission.
+          currentChainHeight: () async =>
+              _ref.read(syncProvider).value?.chainTipHeight ?? 0,
           fundingTxids: (result) => result.txids,
         );
     final fundingResult = funding.transaction;
@@ -1001,7 +1014,7 @@ class PaymentLinkService implements PaymentLinkOperations {
 
   Future<PaymentLinkClaimResult> _broadcastPreparedSpend(
     PaymentLinkClaimSession session, {
-    void Function()? onSubmissionStarted,
+    FutureOr<void> Function()? onSubmissionStarted,
   }) async {
     if (!session.canClaim) {
       throw StateError('Payment link has no spendable shielded balance yet.');
@@ -1118,7 +1131,7 @@ class PaymentLinkService implements PaymentLinkOperations {
     String? memo,
     String? mnemonic,
     Future<void> Function()? beforeExecute,
-    void Function()? onSubmissionStarted,
+    FutureOr<void> Function()? onSubmissionStarted,
   }) async {
     await _requireShieldedAddress(toAddress);
     final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
@@ -1187,7 +1200,7 @@ class PaymentLinkService implements PaymentLinkOperations {
     required bool needsSaplingParams,
     String? mnemonic,
     Future<void> Function()? beforeExecute,
-    void Function()? onSubmissionStarted,
+    FutureOr<void> Function()? onSubmissionStarted,
   }) async {
     var saplingParams = await loadSaplingParamsStatus();
     if (needsSaplingParams && !saplingParams.complete) {
@@ -1205,7 +1218,9 @@ class PaymentLinkService implements PaymentLinkOperations {
       final password = _ref
           .read(appSecurityProvider.notifier)
           .requireSessionPasswordForNativeSecretUse();
-      onSubmissionStarted?.call();
+      // Awaited, not fired: the caller's durable write must be on disk
+      // before the transaction can reach the network.
+      await onSubmissionStarted?.call();
       return rust_sync.executeProposalWithMacosStoredMnemonic(
         dbPath: dbPath,
         lightwalletdUrl: lightwalletdUrl,
@@ -1227,7 +1242,7 @@ class PaymentLinkService implements PaymentLinkOperations {
     }
     late final Future<rust_sync.ExecuteProposalResult> result;
     try {
-      onSubmissionStarted?.call();
+      await onSubmissionStarted?.call();
       result = rust_sync.executeProposal(
         dbPath: dbPath,
         lightwalletdUrl: lightwalletdUrl,

--- a/lib/src/features/payment_links/services/payment_link_surface.dart
+++ b/lib/src/features/payment_links/services/payment_link_surface.dart
@@ -1,0 +1,10 @@
+import 'package:go_router/go_router.dart';
+
+/// Whether [router] knows the Gift Card surface. The surface is registered by
+/// the next PR in this stack; until then a pending link stays parked instead
+/// of navigating into the router's error page.
+bool paymentLinkSurfaceRegistered(GoRouter router) => router
+    .configuration
+    .routes
+    .whereType<GoRoute>()
+    .any((route) => route.path == '/payment-links');

--- a/lib/src/features/payment_links/services/payment_link_transaction_matching.dart
+++ b/lib/src/features/payment_links/services/payment_link_transaction_matching.dart
@@ -25,6 +25,26 @@ bool paymentLinkFundingTransactionExists({
   );
 }
 
+/// True when every transaction in a comma-separated funding proposal is in
+/// [transactions] and not expired.
+bool paymentLinkFundingTransactionsExist({
+  required String fundingTxids,
+  required List<rust_sync.TransactionInfo> transactions,
+}) {
+  final expectedTxids = fundingTxids
+      .split(',')
+      .map(normalizePaymentLinkTxid)
+      .where((txid) => txid.isNotEmpty)
+      .toList();
+  if (expectedTxids.isEmpty) return false;
+  return expectedTxids.every(
+    (txid) => paymentLinkFundingTransactionExists(
+      fundingTxid: txid,
+      transactions: transactions,
+    ),
+  );
+}
+
 /// Returns true only when every transaction in a funding proposal is known to
 /// have expired without being mined.
 bool paymentLinkFundingExpired({

--- a/lib/src/features/payment_links/services/payment_link_transaction_matching.dart
+++ b/lib/src/features/payment_links/services/payment_link_transaction_matching.dart
@@ -1,0 +1,71 @@
+import '../../../rust/api/sync.dart' as rust_sync;
+
+/// Rust's broadcast result formats a transaction ID for display, while the
+/// transaction-history API currently exposes the same SQLite txid bytes in
+/// storage order. Accept both byte orders at this boundary.
+bool paymentLinkTxidsMatch(String first, String second) {
+  final normalizedFirst = normalizePaymentLinkTxid(first);
+  final normalizedSecond = normalizePaymentLinkTxid(second);
+  if (normalizedFirst == normalizedSecond) return true;
+  if (!_isTransactionIdHex(normalizedFirst) ||
+      !_isTransactionIdHex(normalizedSecond)) {
+    return false;
+  }
+  return _reverseHexBytes(normalizedFirst) == normalizedSecond;
+}
+
+bool paymentLinkFundingTransactionExists({
+  required String fundingTxid,
+  required List<rust_sync.TransactionInfo> transactions,
+}) {
+  return transactions.any(
+    (transaction) =>
+        !transaction.expiredUnmined &&
+        paymentLinkTxidsMatch(fundingTxid, transaction.txidHex),
+  );
+}
+
+/// Returns true only when every transaction in a funding proposal is known to
+/// have expired without being mined.
+bool paymentLinkFundingExpired({
+  required String fundingTxids,
+  required List<rust_sync.TransactionInfo> transactions,
+}) {
+  final expectedTxids = fundingTxids
+      .split(',')
+      .map(normalizePaymentLinkTxid)
+      .where((txid) => txid.isNotEmpty)
+      .toSet();
+  if (expectedTxids.isEmpty) return false;
+
+  for (final expectedTxid in expectedTxids) {
+    final matching = transactions
+        .where(
+          (transaction) =>
+              paymentLinkTxidsMatch(expectedTxid, transaction.txidHex),
+        )
+        .toList();
+    if (matching.isEmpty ||
+        matching.any((transaction) => !transaction.expiredUnmined)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+String normalizePaymentLinkTxid(String txid) {
+  final normalized = txid.trim().toLowerCase();
+  return normalized.startsWith('0x') ? normalized.substring(2) : normalized;
+}
+
+bool _isTransactionIdHex(String value) {
+  return value.length == 64 && RegExp(r'^[0-9a-f]+$').hasMatch(value);
+}
+
+String _reverseHexBytes(String value) {
+  final reversed = StringBuffer();
+  for (var index = value.length; index > 0; index -= 2) {
+    reversed.write(value.substring(index - 2, index));
+  }
+  return reversed.toString();
+}

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -18,6 +18,10 @@ import '../core/storage/wallet_paths.dart';
 import '../features/swap/providers/swap_activity_store.dart';
 import '../features/migration/services/ironwood_migration_background_credential_store.dart';
 import '../features/migration/services/ironwood_migration_operation_registry.dart';
+import '../features/payment_links/providers/payment_link_claim_lifecycle_registry_provider.dart';
+import '../features/payment_links/services/payment_link_received_store.dart';
+import '../features/payment_links/services/payment_link_recovery_reconciler.dart';
+import '../features/payment_links/services/payment_link_recovery_store.dart';
 import '../features/voting/voting_flow_models.dart';
 import '../rust/api/sync.dart' as rust_sync;
 import '../rust/api/voting.dart' as rust_voting;
@@ -57,6 +61,34 @@ class WalletCreationCurrentBlockHeightException implements Exception {
 
   @override
   String toString() => kWalletCreationCurrentBlockHeightErrorMessage;
+}
+
+/// Kept to one rendered line: the desktop lost-password card is a fixed 520px
+/// box whose status line is 348px wide and single-line, and a second line
+/// overflows the card by 20px. `Wait for it to finish.` carries the remedy
+/// without naming the reset, which every surface that shows this already does.
+const kWalletResetInFlightGiftCardClaimsMessage =
+    'A Gift Card is still being received. Wait for it to finish.';
+
+/// Shown where the reset is not refused — the locked recovery surfaces,
+/// whose CTA stays enabled because reset is the user's only way back in.
+/// It states the cost instead of asking the user to wait, because waiting is
+/// exactly what cannot help there. Fits the same 348px line.
+const kWalletResetInFlightGiftCardWarningMessage =
+    'A Gift Card is still being received. Resetting loses it.';
+
+/// A full wallet reset was refused because a Gift Card claim is still in
+/// flight.
+///
+/// The per-account refusal is [PaymentLinkInFlightClaimsException]; a reset
+/// destroys every account, so this one names no destination.
+class WalletResetInFlightGiftCardClaimsException implements Exception {
+  const WalletResetInFlightGiftCardClaimsException({required this.count});
+
+  final int count;
+
+  @override
+  String toString() => kWalletResetInFlightGiftCardClaimsMessage;
 }
 
 class WalletResetException implements Exception {
@@ -545,11 +577,22 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       throw ArgumentError.value(uuid, 'uuid', 'Unknown account UUID');
     }
 
+    final claimLifecycle = ref.read(paymentLinkClaimLifecycleRegistryProvider);
     final shareTracking = ref.read(votingShareTrackingRegistryProvider);
     try {
+      // Gift Card claims first, and before the in-flight count below: that
+      // count is a one-shot read, and a claim that enters `submitting` right
+      // after it returned zero would revalidate its destination against an
+      // account this method is still several awaits away from deleting — and
+      // then broadcast to an address the wallet can no longer recover. Pausing
+      // new claims and draining the running ones here means a claim already
+      // under way finishes first, and the count then sees it and refuses the
+      // deletion. The pause holds until the wallet rows are gone.
+      await claimLifecycle.quiesceAndDrain();
       await shareTracking.quiesceAndDrain(accountUuid: uuid);
       await _removeAccountWithShareTrackingStopped(uuid);
     } finally {
+      claimLifecycle.resume();
       shareTracking.resume(accountUuid: uuid);
       shareTracking.requestRestore();
     }
@@ -563,6 +606,24 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     }
 
     final target = prev.accounts[targetIndex];
+    final receivingGiftCardCount = await ref
+        .read(paymentLinkReceivedStoreProvider)
+        .countReceivingForAccount(uuid);
+    if (receivingGiftCardCount > 0) {
+      throw PaymentLinkInFlightClaimsException(
+        destinationAccountUuid: uuid,
+        count: receivingGiftCardCount,
+      );
+    }
+    final unsharedGiftCardCount = await ref
+        .read(paymentLinkRecoveryReconcilerProvider)
+        .countUnsharedFundedForAccount(uuid);
+    if (unsharedGiftCardCount > 0) {
+      throw PaymentLinkUnsharedGiftCardsException(
+        sourceAccountUuid: uuid,
+        count: unsharedGiftCardCount,
+      );
+    }
     final remaining = [
       for (final account in prev.accounts)
         if (account.uuid != uuid) account,
@@ -683,10 +744,15 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
 
   /// Delete all wallet data (DB + keychain). Caller must stop sync first.
   ///
-  /// In-flight voting background work is quiesced and drained first so it
-  /// cannot keep reading or writing voting records or secure storage during
-  /// the wipe. This also clears voting state held in this process for every
-  /// account before the wallet DB and voting sidecar DB are deleted.
+  /// In-flight Gift Card claims and voting background work are quiesced and
+  /// drained first so they cannot keep reading or writing wallet records or
+  /// secure storage during the wipe. This also clears voting state held in
+  /// this process for every account before the wallet DB and voting sidecar DB
+  /// are deleted. While the wallet is unlocked, a claim still in flight after
+  /// that drain refuses the reset outright with
+  /// [WalletResetInFlightGiftCardClaimsException], the way [removeAccount]
+  /// refuses a deletion, rather than wiping the wallet the claim just paid
+  /// into. A locked wallet does not refuse — see the comment on that check.
   ///
   /// Migration work must first stop without deleting its credential. After
   /// that fail-closed preflight, the wipe is best-effort: deletion steps remain
@@ -697,21 +763,53 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   Future<void> resetWallet() async {
     ref.read(votingSubmissionGuardProvider.notifier).throwIfActive();
 
+    final claimLifecycle = ref.read(paymentLinkClaimLifecycleRegistryProvider);
     final shareTracking = ref.read(votingShareTrackingRegistryProvider);
     var restoreAfterFailure = false;
+    var resumeClaimLifecycle = false;
     try {
+      await claimLifecycle.quiesceAndDrain();
       await shareTracking.quiesceAndDrain();
       await _resetWalletWithShareTrackingStopped();
+      resumeClaimLifecycle = true;
     } catch (error) {
       restoreAfterFailure = error is! WalletResetException || !error.dbDeleted;
+      resumeClaimLifecycle = restoreAfterFailure;
       rethrow;
     } finally {
+      if (resumeClaimLifecycle) claimLifecycle.resume();
       shareTracking.resume();
       if (restoreAfterFailure) shareTracking.requestRestore();
     }
   }
 
   Future<void> _resetWalletWithShareTrackingStopped() async {
+    // Only an unlocked wallet refuses. A claim advances only while unlocked --
+    // PaymentLinkClaimCoordinator pauses on `requiresUnlock` -- so on the
+    // locked recovery path (`/lost-password`, the forgot-passcode sheet) a
+    // record frozen in `receiving` would never clear and the refusal would
+    // never lift, trapping a user whose only remaining way into the wallet is
+    // this reset. Those surfaces show
+    // [kWalletResetInFlightGiftCardWarningMessage] and let the reset through:
+    // one in-flight claim is worth less than the whole wallet.
+    if (!ref.read(appSecurityProvider).requiresUnlock) {
+      // Read after the drain, not before, for the reason spelled out in
+      // [removeAccount]: a one-shot count taken first can read zero and then
+      // be overtaken by a claim entering `submitting`. Draining first settles
+      // the running submissions, and a settled claim sits in `receiving` until
+      // it confirms -- which `isClaimInFlight` still counts -- so the refusal
+      // sees it. Every account is about to go, so any in-flight claim counts,
+      // including one whose destination account is not yet written.
+      final inFlightClaimCount = await ref
+          .read(paymentLinkReceivedStoreProvider)
+          .countClaimsInFlight();
+      if (inFlightClaimCount > 0) {
+        throw WalletResetInFlightGiftCardClaimsException(
+          count: inFlightClaimCount,
+        );
+      }
+    }
+
     Object? firstError;
     StackTrace? firstStackTrace;
     void recordError(String step, Object e, StackTrace st) {
@@ -815,6 +913,13 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         // The durable reset already succeeded. Cache cleanup is best-effort
         // and must not prevent the secure-storage wipe from completing.
         log('resetWallet: failed to evict wallet summary cache: $e\n$st');
+      }
+      try {
+        await clearPaymentLinkClaimWalletsForReset();
+      } catch (e, st) {
+        // Finish the remaining safe cleanup, but do not report a complete
+        // reset while a privacy-sensitive claim database remains.
+        recordError('payment-link claim db cleanup', e, st);
       }
       try {
         await _storage.deleteAll();
@@ -1405,6 +1510,14 @@ String _normalizedExceptionMessage(Object error) {
 final accountProvider = AsyncNotifierProvider<AccountNotifier, AccountState>(
   AccountNotifier.new,
 );
+
+/// Removes every isolated payment-link claim database or reports the failure
+/// to the reset coordinator.
+@visibleForTesting
+Future<void> clearPaymentLinkClaimWalletsForReset({
+  Future<void> Function() deleteDirectories =
+      deletePaymentLinkClaimWalletDirectories,
+}) => deleteDirectories();
 
 @visibleForTesting
 String? resolveNextActiveAccountUuidAfterRemoval({

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -180,9 +180,15 @@ class SyncState {
   bool get isUsingCompletedSpendableSnapshot =>
       displaySpendableFreshness == SpendableBalanceFreshness.lastCompletedSync;
 
-  /// True when the spendable balance is authoritative (scanned to tip, has
-  /// balance data, not using a completed-sync snapshot). The single predicate
-  /// for "is a shortfall real?".
+  /// Whether this state's spendable balance may end a check as "not enough".
+  ///
+  /// Read on an *account-scoped* state ([scopedToAccount]): the wallet-wide
+  /// sync fields survive [withoutAccountScopedData], so a state carrying no
+  /// balance for the account still reports `isSyncedToTip` with a zero
+  /// spendable. [hasBalanceData] is what separates "scanned to the tip and
+  /// this is the balance" from "scanned to the tip and this account's balance
+  /// was never fetched" — without it the predicate fails open on a zero, which
+  /// is the VZR-42 shape (a shortfall announced against a balance nobody read).
   bool get hasSettledSpendableBalance =>
       hasBalanceData && isSyncedToTip && !isUsingCompletedSpendableSnapshot;
 
@@ -1647,8 +1653,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   void resumeAfterWalletMutation(WalletMutationSyncPause pause) {
     if (_requiresUnlock) return;
 
-    if (pause.hadActiveSync) {
-      log('SyncNotifier: resuming sync after wallet DB mutation');
+    if (pause.hadActiveSync || pause.hadMempoolObserver) {
+      log('SyncNotifier: resuming sync and mempool observation after pause');
       startSync();
     }
     if (pause.hadPolling || pause.hadActiveSync) {
@@ -2962,8 +2968,12 @@ final syncProvider = AsyncNotifierProvider<SyncNotifier, SyncState>(
 );
 
 /// [SyncState.hasSettledSpendableBalance] for [accountUuid], from an unscoped
-/// state. Scoping first is mandatory: an unscoped read answers with another
-/// account's balance, or with wallet-wide fields of a state with no balance.
+/// state.
+///
+/// The single spelling of "this balance is an answer" for everything that has
+/// to decide whether a shortfall is real. Scoping first is not optional: an
+/// unscoped read answers with another account's balance, or with the
+/// wallet-wide sync fields of a state that has no balance at all.
 bool spendableIsSettledForAccount(SyncState? sync, String? accountUuid) =>
     sync != null &&
     sync.scopedToAccount(accountUuid).hasSettledSpendableBalance;

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -63,6 +63,29 @@ bool isSyncCancelRequested() =>
 /// Check if a sync is currently running.
 bool isSyncRunning() => RustLib.instance.api.crateApiSyncIsSyncRunning();
 
+/// Runs an isolated scan for one short-lived payment-link claim database.
+///
+/// Claim syncs do not use the main wallet's process-global running guard or
+/// desired mode. Different claim IDs can therefore scan independent databases
+/// concurrently with each other and with the main wallet.
+Future<void> runPaymentLinkClaimSync({
+  required String claimId,
+  required String dbPath,
+  required String lightwalletdUrl,
+  required String network,
+}) => RustLib.instance.api.crateApiSyncRunPaymentLinkClaimSync(
+  claimId: claimId,
+  dbPath: dbPath,
+  lightwalletdUrl: lightwalletdUrl,
+  network: network,
+);
+
+/// Cancels only the isolated scan associated with `claim_id`.
+void cancelPaymentLinkClaimSync({required String claimId}) => RustLib
+    .instance
+    .api
+    .crateApiSyncCancelPaymentLinkClaimSync(claimId: claimId);
+
 /// Start the background mempool observer.
 ///
 /// Blocks until [`stop_mempool_observer`] is called or the
@@ -1045,6 +1068,15 @@ storeAndBroadcastPcztsWithKeystoneSignaturesForProposal({
       spendParamsPath: spendParamsPath,
       outputParamsPath: outputParamsPath,
     );
+
+/// Computes the stable transaction ID before a finalized PCZT crosses the
+/// irreversible broadcast boundary.
+String getPcztTxid({required List<int> pcztBytes}) =>
+    RustLib.instance.api.crateApiSyncGetPcztTxid(pcztBytes: pcztBytes);
+
+/// Returns the expiry height committed to by an IO-finalized PCZT.
+int getPcztExpiryHeight({required List<int> pcztBytes}) =>
+    RustLib.instance.api.crateApiSyncGetPcztExpiryHeight(pcztBytes: pcztBytes);
 
 /// Combine a PCZT-with-proofs and a PCZT-with-signatures, extract the final
 /// transaction, store it in the wallet DB, and broadcast it to lightwalletd.

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -86,6 +86,15 @@ Future<AccountCreationResult> addAccount({
   birthdayHeight: birthdayHeight,
 );
 
+/// Generate a software account mnemonic and shielded address without touching
+/// the wallet DB. Used for an external one-time recipient controlled by a
+/// fresh seed, such as payment-link funding.
+Future<GeneratedSoftwareAccount> generateSoftwareAccount({
+  required String network,
+}) => RustLib.instance.api.crateApiWalletGenerateSoftwareAccount(
+  network: network,
+);
+
 /// Discover higher ZIP32 software accounts with transparent history that are
 /// not already present in the wallet DB for this mnemonic.
 Future<SoftwareWalletImportDiscoveryResult>
@@ -498,6 +507,28 @@ class ChainUpgradeStatus {
           nu63ActivationHeight == other.nu63ActivationHeight &&
           ironwoodActiveAtTip == other.ironwoodActiveAtTip &&
           endpointMatchesNetwork == other.endpointMatchesNetwork;
+}
+
+/// A generated software account that has not been imported into the wallet DB.
+class GeneratedSoftwareAccount {
+  final String mnemonic;
+  final String unifiedAddress;
+
+  const GeneratedSoftwareAccount({
+    required this.mnemonic,
+    required this.unifiedAddress,
+  });
+
+  @override
+  int get hashCode => mnemonic.hashCode ^ unifiedAddress.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GeneratedSoftwareAccount &&
+          runtimeType == other.runtimeType &&
+          mnemonic == other.mnemonic &&
+          unifiedAddress == other.unifiedAddress;
 }
 
 /// A higher ZIP32 software account that can be imported by user choice.

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 533571650;
+  int get rustContentHash => 482807914;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -183,6 +183,8 @@ abstract class RustLibApi extends BaseApi {
   });
 
   void crateApiSyncCancelFullSync();
+
+  void crateApiSyncCancelPaymentLinkClaimSync({required String claimId});
 
   Future<ApiVotingEligibility> crateApiVotingCheckVotingEligibility({
     required ApiVotingRoundContext ctx,
@@ -513,6 +515,10 @@ abstract class RustLibApi extends BaseApi {
 
   String crateApiWalletGenerateMnemonic();
 
+  Future<GeneratedSoftwareAccount> crateApiWalletGenerateSoftwareAccount({
+    required String network,
+  });
+
   Future<VanWitness> crateApiVotingGenerateVanWitness({
     required String dbPath,
     required String accountUuid,
@@ -627,6 +633,10 @@ abstract class RustLibApi extends BaseApi {
     required String network,
     required List<String> accountUuids,
   });
+
+  int crateApiSyncGetPcztExpiryHeight({required List<int> pcztBytes});
+
+  String crateApiSyncGetPcztTxid({required List<int> pcztBytes});
 
   Future<int> crateApiSyncGetPreviousTransactionCountForAddress({
     required String dbPath,
@@ -1045,6 +1055,13 @@ abstract class RustLibApi extends BaseApi {
     required String lightwalletdUrl,
     required String network,
     required int mode,
+  });
+
+  Future<void> crateApiSyncRunPaymentLinkClaimSync({
+    required String claimId,
+    required String dbPath,
+    required String lightwalletdUrl,
+    required String network,
   });
 
   Future<ScanResult> crateApiSyncScanBlocks({
@@ -1941,6 +1958,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "cancel_full_sync", argNames: []);
 
   @override
+  void crateApiSyncCancelPaymentLinkClaimSync({required String claimId}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(claimId, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiSyncCancelPaymentLinkClaimSyncConstMeta,
+        argValues: [claimId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncCancelPaymentLinkClaimSyncConstMeta =>
+      const TaskConstMeta(
+        debugName: "cancel_payment_link_claim_sync",
+        argNames: ["claimId"],
+      );
+
+  @override
   Future<ApiVotingEligibility> crateApiVotingCheckVotingEligibility({
     required ApiVotingRoundContext ctx,
   }) {
@@ -1952,7 +1995,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -2001,7 +2044,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -2073,7 +2116,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -2142,7 +2185,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -2208,7 +2251,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -2260,7 +2303,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 20,
             port: port_,
           );
         },
@@ -2295,7 +2338,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 21,
             port: port_,
           );
         },
@@ -2328,7 +2371,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 22,
             port: port_,
           );
         },
@@ -2373,7 +2416,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 23,
             port: port_,
           );
         },
@@ -2433,7 +2476,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 24,
             port: port_,
           );
         },
@@ -2492,7 +2535,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -2552,7 +2595,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -2605,7 +2648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -2650,7 +2693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 28,
             port: port_,
           );
         },
@@ -2691,7 +2734,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 29,
             port: port_,
           );
         },
@@ -2731,7 +2774,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(dbPath, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(roundId, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2769,7 +2812,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -2801,7 +2844,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -2834,7 +2877,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -2867,7 +2910,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -2902,7 +2945,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -2933,7 +2976,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -2970,7 +3013,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -3003,7 +3046,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -3037,7 +3080,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 39,
             port: port_,
           );
         },
@@ -3078,7 +3121,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -3115,7 +3158,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -3151,7 +3194,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -3188,7 +3231,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -3227,7 +3270,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -3262,7 +3305,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -3297,7 +3340,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -3327,7 +3370,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -3360,7 +3403,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -3395,7 +3438,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -3441,7 +3484,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -3491,7 +3534,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -3524,7 +3567,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -3559,7 +3602,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -3596,7 +3639,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -3633,7 +3676,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -3668,7 +3711,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -3711,7 +3754,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 57,
             port: port_,
           );
         },
@@ -3765,7 +3808,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -3819,7 +3862,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -3850,7 +3893,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -3895,7 +3938,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 61,
             port: port_,
           );
         },
@@ -3957,7 +4000,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 62,
             port: port_,
           );
         },
@@ -4015,7 +4058,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 63,
             port: port_,
           );
         },
@@ -4066,7 +4109,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 64,
             port: port_,
           );
         },
@@ -4109,7 +4152,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4134,7 +4177,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4149,6 +4192,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiWalletGenerateMnemonicConstMeta =>
       const TaskConstMeta(debugName: "generate_mnemonic", argNames: []);
+
+  @override
+  Future<GeneratedSoftwareAccount> crateApiWalletGenerateSoftwareAccount({
+    required String network,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(network, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 67,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_generated_software_account,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletGenerateSoftwareAccountConstMeta,
+        argValues: [network],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletGenerateSoftwareAccountConstMeta =>
+      const TaskConstMeta(
+        debugName: "generate_software_account",
+        argNames: ["network"],
+      );
 
   @override
   Future<VanWitness> crateApiVotingGenerateVanWitness({
@@ -4170,7 +4246,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 68,
             port: port_,
           );
         },
@@ -4209,7 +4285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 69,
             port: port_,
           );
         },
@@ -4246,7 +4322,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 70,
             port: port_,
           );
         },
@@ -4283,7 +4359,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 71,
             port: port_,
           );
         },
@@ -4320,7 +4396,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 72,
             port: port_,
           );
         },
@@ -4354,7 +4430,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 73,
             port: port_,
           );
         },
@@ -4381,7 +4457,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4411,7 +4487,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 75,
             port: port_,
           );
         },
@@ -4447,7 +4523,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 76,
             port: port_,
           );
         },
@@ -4484,7 +4560,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 77,
             port: port_,
           );
         },
@@ -4520,7 +4596,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 78,
             port: port_,
           );
         },
@@ -4557,7 +4633,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 79,
             port: port_,
           );
         },
@@ -4590,7 +4666,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 80,
             port: port_,
           );
         },
@@ -4623,7 +4699,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 81,
             port: port_,
           );
         },
@@ -4650,7 +4726,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_network_privacy_status,
@@ -4687,7 +4763,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 83,
             port: port_,
           );
         },
@@ -4722,7 +4798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 84,
             port: port_,
           );
         },
@@ -4760,7 +4836,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4801,7 +4877,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 86,
             port: port_,
           );
         },
@@ -4844,7 +4920,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 87,
             port: port_,
           );
         },
@@ -4881,7 +4957,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4903,6 +4979,55 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  int crateApiSyncGetPcztExpiryHeight({required List<int> pcztBytes}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_list_prim_u_8_loose(pcztBytes, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_u_32,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncGetPcztExpiryHeightConstMeta,
+        argValues: [pcztBytes],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncGetPcztExpiryHeightConstMeta =>
+      const TaskConstMeta(
+        debugName: "get_pczt_expiry_height",
+        argNames: ["pcztBytes"],
+      );
+
+  @override
+  String crateApiSyncGetPcztTxid({required List<int> pcztBytes}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_list_prim_u_8_loose(pcztBytes, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_String,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncGetPcztTxidConstMeta,
+        argValues: [pcztBytes],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncGetPcztTxidConstMeta =>
+      const TaskConstMeta(debugName: "get_pczt_txid", argNames: ["pcztBytes"]);
+
+  @override
   Future<int> crateApiSyncGetPreviousTransactionCountForAddress({
     required String dbPath,
     required String network,
@@ -4920,7 +5045,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4960,7 +5085,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 92,
             port: port_,
           );
         },
@@ -5000,7 +5125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 93,
             port: port_,
           );
         },
@@ -5036,7 +5161,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 94,
             port: port_,
           );
         },
@@ -5073,7 +5198,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 95,
             port: port_,
           );
         },
@@ -5100,7 +5225,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 96)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -5130,7 +5255,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 97,
             port: port_,
           );
         },
@@ -5164,7 +5289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 98,
             port: port_,
           );
         },
@@ -5205,7 +5330,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 99,
             port: port_,
           );
         },
@@ -5244,7 +5369,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 100,
             port: port_,
           );
         },
@@ -5281,7 +5406,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 101,
             port: port_,
           );
         },
@@ -5318,7 +5443,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 102,
             port: port_,
           );
         },
@@ -5346,7 +5471,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 103,
+          )!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -5386,7 +5515,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 104,
             port: port_,
           );
         },
@@ -5450,7 +5579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 105,
             port: port_,
           );
         },
@@ -5518,7 +5647,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 106,
             port: port_,
           );
         },
@@ -5584,7 +5713,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 107,
             port: port_,
           );
         },
@@ -5627,7 +5756,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 108,
             port: port_,
           );
         },
@@ -5661,7 +5790,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 109,
           )!;
         },
         codec: SseCodec(
@@ -5689,7 +5818,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 110,
           )!;
         },
         codec: SseCodec(
@@ -5729,7 +5858,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5772,7 +5901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 112,
           )!;
         },
         codec: SseCodec(
@@ -5798,7 +5927,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 113,
           )!;
         },
         codec: SseCodec(
@@ -5824,7 +5953,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 114,
           )!;
         },
         codec: SseCodec(
@@ -5852,7 +5981,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 115,
             port: port_,
           );
         },
@@ -5887,7 +6016,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 116,
           )!;
         },
         codec: SseCodec(
@@ -5921,7 +6050,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 117,
             port: port_,
           );
         },
@@ -5955,7 +6084,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 118,
             port: port_,
           );
         },
@@ -5996,7 +6125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 119,
             port: port_,
           );
         },
@@ -6039,7 +6168,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 120,
             port: port_,
           );
         },
@@ -6105,7 +6234,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 121,
             port: port_,
           );
         },
@@ -6175,7 +6304,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 122,
             port: port_,
           );
         },
@@ -6246,7 +6375,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 123,
             port: port_,
           );
         },
@@ -6296,7 +6425,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 124,
           )!;
         },
         codec: SseCodec(
@@ -6327,7 +6456,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 125,
             port: port_,
           );
         },
@@ -6360,7 +6489,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6400,7 +6529,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6439,7 +6568,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6475,7 +6604,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6513,7 +6642,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6566,7 +6695,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6622,7 +6751,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6667,7 +6796,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6727,7 +6856,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 134,
             port: port_,
           );
         },
@@ -6787,7 +6916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 135,
             port: port_,
           );
         },
@@ -6846,7 +6975,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 136,
             port: port_,
           );
         },
@@ -6891,7 +7020,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 137,
             port: port_,
           );
         },
@@ -6932,7 +7061,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 138,
             port: port_,
           );
         },
@@ -6991,7 +7120,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7053,7 +7182,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7101,7 +7230,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7160,7 +7289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7224,7 +7353,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7263,7 +7392,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 144,
             port: port_,
           );
         },
@@ -7293,7 +7422,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 145,
           )!;
         },
         codec: SseCodec(
@@ -7326,7 +7455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 146,
             port: port_,
           );
         },
@@ -7363,7 +7492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7398,7 +7527,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 148,
             port: port_,
           );
         },
@@ -7440,7 +7569,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7475,7 +7604,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7516,7 +7645,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 151,
             port: port_,
           );
         },
@@ -7565,7 +7694,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7603,7 +7732,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7622,6 +7751,45 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(
         debugName: "run_full_sync_blocking",
         argNames: ["dbPath", "lightwalletdUrl", "network", "mode"],
+      );
+
+  @override
+  Future<void> crateApiSyncRunPaymentLinkClaimSync({
+    required String claimId,
+    required String dbPath,
+    required String lightwalletdUrl,
+    required String network,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(claimId, serializer);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_String(network, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 154,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncRunPaymentLinkClaimSyncConstMeta,
+        argValues: [claimId, dbPath, lightwalletdUrl, network],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncRunPaymentLinkClaimSyncConstMeta =>
+      const TaskConstMeta(
+        debugName: "run_payment_link_claim_sync",
+        argNames: ["claimId", "dbPath", "lightwalletdUrl", "network"],
       );
 
   @override
@@ -7658,7 +7826,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 155,
             port: port_,
           );
         },
@@ -7723,7 +7891,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 156,
           )!;
         },
         codec: SseCodec(
@@ -7753,7 +7921,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 157,
           )!;
         },
         codec: SseCodec(
@@ -7797,7 +7965,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7844,7 +8012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 159,
           )!;
         },
         codec: SseCodec(
@@ -7874,7 +8042,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 160,
           )!;
         },
         codec: SseCodec(
@@ -7909,7 +8077,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 161,
             port: port_,
           );
         },
@@ -7942,7 +8110,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 162,
             port: port_,
           );
         },
@@ -7983,7 +8151,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8037,7 +8205,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8087,7 +8255,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 160,
+              funcId: 165,
               port: port_,
             );
           },
@@ -8128,7 +8296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 161,
+              funcId: 166,
               port: port_,
             );
           },
@@ -8160,7 +8328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8187,7 +8355,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 168,
           )!;
         },
         codec: SseCodec(
@@ -8213,7 +8381,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8260,7 +8428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8333,7 +8501,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 171,
             port: port_,
           );
         },
@@ -8400,7 +8568,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8456,7 +8624,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 173,
             port: port_,
           );
         },
@@ -8501,7 +8669,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 174,
             port: port_,
           );
         },
@@ -8548,7 +8716,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 175,
             port: port_,
           );
         },
@@ -8587,7 +8755,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 176,
             port: port_,
           );
         },
@@ -8616,7 +8784,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 177,
           )!;
         },
         codec: SseCodec(
@@ -8643,7 +8811,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 178,
           )!;
         },
         codec: SseCodec(
@@ -8679,7 +8847,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 179,
             port: port_,
           );
         },
@@ -8718,7 +8886,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 180,
             port: port_,
           );
         },
@@ -8759,7 +8927,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 181,
             port: port_,
           );
         },
@@ -8807,7 +8975,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 182,
             port: port_,
           );
         },
@@ -8861,7 +9029,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 178,
+            funcId: 183,
             port: port_,
           );
         },
@@ -8911,7 +9079,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 179,
+            funcId: 184,
             port: port_,
           );
         },
@@ -8945,7 +9113,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 180,
+            funcId: 185,
             port: port_,
           );
         },
@@ -8976,7 +9144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 181,
+            funcId: 186,
           )!;
         },
         codec: SseCodec(
@@ -9008,7 +9176,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 182,
+            funcId: 187,
             port: port_,
           );
         },
@@ -9039,7 +9207,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 183,
+            funcId: 188,
           )!;
         },
         codec: SseCodec(
@@ -9065,7 +9233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 184,
+            funcId: 189,
           )!;
         },
         codec: SseCodec(
@@ -9111,7 +9279,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 185,
+            funcId: 190,
             port: port_,
           );
         },
@@ -9159,7 +9327,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 186,
+            funcId: 191,
           )!;
         },
         codec: SseCodec(
@@ -9193,7 +9361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 187,
+            funcId: 192,
             port: port_,
           );
         },
@@ -9230,7 +9398,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 188,
+            funcId: 193,
             port: port_,
           );
         },
@@ -10162,6 +10330,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   double dco_decode_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as double;
+  }
+
+  @protected
+  GeneratedSoftwareAccount dco_decode_generated_software_account(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return GeneratedSoftwareAccount(
+      mnemonic: dco_decode_String(arr[0]),
+      unifiedAddress: dco_decode_String(arr[1]),
+    );
   }
 
   @protected
@@ -13083,6 +13263,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   double sse_decode_f_64(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getFloat64();
+  }
+
+  @protected
+  GeneratedSoftwareAccount sse_decode_generated_software_account(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_mnemonic = sse_decode_String(deserializer);
+    var var_unifiedAddress = sse_decode_String(deserializer);
+    return GeneratedSoftwareAccount(
+      mnemonic: var_mnemonic,
+      unifiedAddress: var_unifiedAddress,
+    );
   }
 
   @protected
@@ -16553,6 +16746,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_f_64(double self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putFloat64(self);
+  }
+
+  @protected
+  void sse_encode_generated_software_account(
+    GeneratedSoftwareAccount self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.mnemonic, serializer);
+    sse_encode_String(self.unifiedAddress, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -334,6 +334,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double dco_decode_f_64(dynamic raw);
 
   @protected
+  GeneratedSoftwareAccount dco_decode_generated_software_account(dynamic raw);
+
+  @protected
   int dco_decode_i_32(dynamic raw);
 
   @protected
@@ -1295,6 +1298,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double sse_decode_f_64(SseDeserializer deserializer);
+
+  @protected
+  GeneratedSoftwareAccount sse_decode_generated_software_account(
+    SseDeserializer deserializer,
+  );
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
@@ -2478,6 +2486,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_generated_software_account(
+    GeneratedSoftwareAccount self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -336,6 +336,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double dco_decode_f_64(dynamic raw);
 
   @protected
+  GeneratedSoftwareAccount dco_decode_generated_software_account(dynamic raw);
+
+  @protected
   int dco_decode_i_32(dynamic raw);
 
   @protected
@@ -1297,6 +1300,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double sse_decode_f_64(SseDeserializer deserializer);
+
+  @protected
+  GeneratedSoftwareAccount sse_decode_generated_software_account(
+    SseDeserializer deserializer,
+  );
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
@@ -2480,6 +2488,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_generated_software_account(
+    GeneratedSoftwareAccount self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::panic;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use flutter_rust_bridge::frb;
 use zeroize::Zeroizing;
@@ -13,6 +14,9 @@ use crate::wallet::{keys, network::WalletNetwork, secret_store, sync as wallet_s
 pub(crate) static DESIRED_SYNC_MODE: AtomicU8 = AtomicU8::new(0);
 static ACTIVE_SYNC_ACCOUNT: std::sync::LazyLock<sync_engine::ActiveSyncAccountTarget> =
     std::sync::LazyLock::new(|| Arc::new(RwLock::new(None)));
+static PAYMENT_LINK_CLAIM_SYNCS: std::sync::LazyLock<Mutex<HashMap<String, Arc<AtomicBool>>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+
 /// Set the desired sync mode. 0=none, 1=foreground, 2=background.
 /// The running sync loop checks this each batch and exits if mismatched.
 #[frb(sync)]
@@ -186,6 +190,65 @@ pub fn is_sync_cancel_requested() -> bool {
 #[frb(sync)]
 pub fn is_sync_running() -> bool {
     SYNC_RUNNING.load(Ordering::SeqCst)
+}
+
+/// Runs an isolated scan for one short-lived payment-link claim database.
+///
+/// Claim syncs do not use the main wallet's process-global running guard or
+/// desired mode. Different claim IDs can therefore scan independent databases
+/// concurrently with each other and with the main wallet.
+pub fn run_payment_link_claim_sync(
+    claim_id: String,
+    db_path: String,
+    lightwalletd_url: String,
+    network: String,
+) -> Result<(), String> {
+    if claim_id.trim().is_empty() {
+        return Err("Payment-link claim ID must not be empty".into());
+    }
+
+    let cancel = Arc::new(AtomicBool::new(false));
+    {
+        let mut active = PAYMENT_LINK_CLAIM_SYNCS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if active.contains_key(&claim_id) {
+            return Err(format!(
+                "Payment-link claim sync already running: {claim_id}"
+            ));
+        }
+        active.insert(claim_id.clone(), cancel.clone());
+    }
+
+    let result = catch(panic::AssertUnwindSafe(|| {
+        let network = parse_network_and_migrate(&db_path, &network)?;
+        let runtime = tokio::runtime::Runtime::new().map_err(|error| format!("tokio: {error}"))?;
+        runtime.block_on(sync_engine::run_payment_link_claim_sync(
+            &db_path,
+            &lightwalletd_url,
+            network,
+            cancel,
+        ))
+    }));
+
+    PAYMENT_LINK_CLAIM_SYNCS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&claim_id);
+
+    result
+}
+
+/// Cancels only the isolated scan associated with `claim_id`.
+#[frb(sync)]
+pub fn cancel_payment_link_claim_sync(claim_id: String) {
+    if let Some(cancel) = PAYMENT_LINK_CLAIM_SYNCS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&claim_id)
+    {
+        cancel.store(true, Ordering::Relaxed);
+    }
 }
 
 pub(crate) static SYNC_CANCEL: std::sync::LazyLock<Arc<AtomicBool>> =
@@ -2748,6 +2811,19 @@ pub async fn store_and_broadcast_pczts_with_keystone_signatures_for_proposal(
         total_count: result.total_count,
         message: result.message,
     })
+}
+
+/// Computes the stable transaction ID before a finalized PCZT crosses the
+/// irreversible broadcast boundary.
+#[flutter_rust_bridge::frb(sync)]
+pub fn get_pczt_txid(pczt_bytes: Vec<u8>) -> Result<String, String> {
+    catch(|| wallet_sync::txid_from_io_finalized_pczt(&pczt_bytes).map(|txid| txid.to_string()))
+}
+
+/// Returns the expiry height committed to by an IO-finalized PCZT.
+#[flutter_rust_bridge::frb(sync)]
+pub fn get_pczt_expiry_height(pczt_bytes: Vec<u8>) -> Result<u32, String> {
+    catch(|| wallet_sync::expiry_height_from_io_finalized_pczt(&pczt_bytes))
 }
 
 /// Combine a PCZT-with-proofs and a PCZT-with-signatures, extract the final

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -30,6 +30,12 @@ pub struct AccountCreationResult {
     pub unified_address: String,
 }
 
+/// A generated software account that has not been imported into the wallet DB.
+pub struct GeneratedSoftwareAccount {
+    pub mnemonic: String,
+    pub unified_address: String,
+}
+
 /// Result of software mnemonic import with ZIP32 account discovery.
 pub struct SoftwareWalletImportWithDiscoveryResult {
     pub accounts: Vec<SoftwareWalletImportAccount>,
@@ -313,6 +319,23 @@ pub fn add_account(
 
         Ok(AccountCreationResult {
             account_uuid,
+            unified_address,
+        })
+    })
+}
+
+/// Generate a software account mnemonic and shielded address without touching
+/// the wallet DB. Used for an external one-time recipient controlled by a
+/// fresh seed, such as payment-link funding.
+pub fn generate_software_account(network: String) -> Result<GeneratedSoftwareAccount, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        let mnemonic = keys::generate_mnemonic();
+        let seed = keys::mnemonic_to_seed(&mnemonic)?;
+        let unified_address = keys::derive_software_address(network, &seed, 0)?;
+
+        Ok(GeneratedSoftwareAccount {
+            mnemonic,
             unified_address,
         })
     })
@@ -1095,6 +1118,15 @@ mod tests {
     const BIP39_VECTOR_MAINNET_UA: &str =
         "u1flce76a85e0zvdtrqaqj59mdk2mv35d074lafaeej5s09qjm4vflc9gndayyxt37v6tekfgram4p9209ygugkz7es438hc9gsujwmcm0trr7zt5lcz8xmpfg9rqyfyznc83ax697lc5ur3nem8wwyen732wemtxcg6lxr4n2agm437m2";
     const BIP39_VECTOR_MAINNET_TADDR: &str = "t1eB9Q9aDobjEnazefA9hdGyx3ku7dHshw5";
+
+    #[test]
+    fn generates_valid_software_account_without_creating_a_database() {
+        let account = generate_software_account("main".to_string()).unwrap();
+
+        assert_eq!(account.mnemonic.split_whitespace().count(), 24);
+        assert!(validate_mnemonic(account.mnemonic.clone()));
+        assert!(account.unified_address.starts_with("u1"));
+    }
 
     #[test]
     fn bip39_passphrase_import_matches_independent_mainnet_address_vectors() {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 533571650;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 482807914;
 
 // Section: executor
 
@@ -570,6 +570,38 @@ fn wire__crate__api__sync__cancel_full_sync_impl(
             transform_result_sse::<_, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok({
                     crate::api::sync::cancel_full_sync();
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__sync__cancel_payment_link_claim_sync_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "cancel_payment_link_claim_sync",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_claim_id = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::sync::cancel_payment_link_claim_sync(api_claim_id);
                 })?;
                 Ok(output_ok)
             })())
@@ -2690,6 +2722,39 @@ fn wire__crate__api__wallet__generate_mnemonic_impl(
         },
     )
 }
+fn wire__crate__api__wallet__generate_software_account_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "generate_software_account",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::wallet::generate_software_account(api_network)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__voting__generate_van_witness_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -3468,6 +3533,66 @@ fn wire__crate__api__sync__get_orchard_migration_statuses_impl(
                     Ok(output_ok)
                 })())
             }
+        },
+    )
+}
+fn wire__crate__api__sync__get_pczt_expiry_height_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_pczt_expiry_height",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_pczt_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, String>((move || {
+                let output_ok = crate::api::sync::get_pczt_expiry_height(api_pczt_bytes)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__sync__get_pczt_txid_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_pczt_txid",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_pczt_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, String>((move || {
+                let output_ok = crate::api::sync::get_pczt_txid(api_pczt_bytes)?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -6039,6 +6164,47 @@ fn wire__crate__api__sync__run_full_sync_blocking_impl(
                         api_lightwalletd_url,
                         api_network,
                         api_mode,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__sync__run_payment_link_claim_sync_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "run_payment_link_claim_sync",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_claim_id = <String>::sse_decode(&mut deserializer);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::sync::run_payment_link_claim_sync(
+                        api_claim_id,
+                        api_db_path,
+                        api_lightwalletd_url,
+                        api_network,
                     )?;
                     Ok(output_ok)
                 })())
@@ -8828,6 +8994,18 @@ impl SseDecode for f64 {
     }
 }
 
+impl SseDecode for crate::api::wallet::GeneratedSoftwareAccount {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_mnemonic = <String>::sse_decode(deserializer);
+        let mut var_unifiedAddress = <String>::sse_decode(deserializer);
+        return crate::api::wallet::GeneratedSoftwareAccount {
+            mnemonic: var_mnemonic,
+            unified_address: var_unifiedAddress,
+        };
+    }
+}
+
 impl SseDecode for i32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -11373,155 +11551,157 @@ fn pde_ffi_dispatcher_primary_impl(
 10 => wire__crate__api__voting__build_prove_and_sign_delegation_payload_with_progress_impl(port, ptr, rust_vec_len, data_len),
 11 => wire__crate__api__voting__build_prove_delegation_payload_with_keystone_signature_with_progress_impl(port, ptr, rust_vec_len, data_len),
 12 => wire__crate__api__voting__build_vote_commitments_with_progress_impl(port, ptr, rust_vec_len, data_len),
-14 => wire__crate__api__voting__check_voting_eligibility_impl(port, ptr, rust_vec_len, data_len),
-15 => wire__crate__api__sync__complete_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-16 => wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-17 => wire__crate__api__sync__complete_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-18 => wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-19 => wire__crate__api__simple__configure_fast_testnet_migration_impl(port, ptr, rust_vec_len, data_len),
-20 => wire__crate__api__network_privacy__configure_network_privacy_impl(port, ptr, rust_vec_len, data_len),
-21 => wire__crate__api__simple__configure_regtest_ironwood_activation_height_impl(port, ptr, rust_vec_len, data_len),
-22 => wire__crate__api__voting__confirm_delegation_submission_impl(port, ptr, rust_vec_len, data_len),
-23 => wire__crate__api__voting__confirm_share_with_helpers_impl(port, ptr, rust_vec_len, data_len),
-24 => wire__crate__api__voting__confirm_vote_submission_impl(port, ptr, rust_vec_len, data_len),
-25 => wire__crate__api__sync__create_or_resume_private_migration_draft_impl(port, ptr, rust_vec_len, data_len),
-26 => wire__crate__api__sync__create_pczt_from_proposal_impl(port, ptr, rust_vec_len, data_len),
-27 => wire__crate__api__sync__create_shield_transparent_pczt_impl(port, ptr, rust_vec_len, data_len),
-28 => wire__crate__api__sync__create_tex_pczts_from_proposal_impl(port, ptr, rust_vec_len, data_len),
-30 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
-31 => wire__crate__api__keystone__decode_accounts_from_cbor_impl(port, ptr, rust_vec_len, data_len),
-32 => wire__crate__api__keystone__decode_accounts_ur_impl(port, ptr, rust_vec_len, data_len),
-33 => wire__crate__api__keystone__decode_pczt_from_cbor_impl(port, ptr, rust_vec_len, data_len),
-34 => wire__crate__api__keystone__decode_ur_part_impl(port, ptr, rust_vec_len, data_len),
-35 => wire__crate__api__keystone__decode_ur_to_pczt_impl(port, ptr, rust_vec_len, data_len),
-36 => wire__crate__api__keystone__decode_zcash_batch_sign_response_impl(port, ptr, rust_vec_len, data_len),
-37 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_impl(port, ptr, rust_vec_len, data_len),
-38 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_as_sig_result_impl(port, ptr, rust_vec_len, data_len),
-39 => wire__crate__api__sync__decrypt_and_store_transaction_impl(port, ptr, rust_vec_len, data_len),
-40 => wire__crate__api__secret__decrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
-41 => wire__crate__api__voting__delegation_submission_wire_json_impl(port, ptr, rust_vec_len, data_len),
-42 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
-43 => wire__crate__api__voting__delete_skipped_bundles_impl(port, ptr, rust_vec_len, data_len),
-44 => wire__crate__api__voting__delete_voting_account_state_impl(port, ptr, rust_vec_len, data_len),
-45 => wire__crate__api__secret__derive_secret_password_verifier_impl(port, ptr, rust_vec_len, data_len),
-46 => wire__crate__api__sync__discard_all_keystone_migration_requests_impl(port, ptr, rust_vec_len, data_len),
-47 => wire__crate__api__sync__discard_keystone_migration_request_impl(port, ptr, rust_vec_len, data_len),
-48 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
-49 => wire__crate__api__wallet__discover_software_wallet_import_accounts_impl(port, ptr, rust_vec_len, data_len),
-50 => wire__crate__api__keystone__encode_keystone_action_sigs_impl(port, ptr, rust_vec_len, data_len),
-51 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
-52 => wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len),
-53 => wire__crate__api__keystone__encode_zcash_sign_batch_ur_parts_impl(port, ptr, rust_vec_len, data_len),
-54 => wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
-55 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(port, ptr, rust_vec_len, data_len),
-56 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
-57 => wire__crate__api__network_privacy__estimate_import_birthday_height_impl(port, ptr, rust_vec_len, data_len),
-58 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
-59 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
-60 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-61 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-62 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-63 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
-66 => wire__crate__api__voting__generate_van_witness_impl(port, ptr, rust_vec_len, data_len),
-67 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
-68 => wire__crate__api__wallet__get_account_export_metadata_impl(port, ptr, rust_vec_len, data_len),
-69 => wire__crate__api__wallet__get_account_ufvk_impl(port, ptr, rust_vec_len, data_len),
-70 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-71 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
-73 => wire__crate__api__wallet__get_chain_upgrade_status_impl(port, ptr, rust_vec_len, data_len),
-74 => wire__crate__api__wallet__get_chain_upgrade_status_at_height_impl(port, ptr, rust_vec_len, data_len),
-75 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
-76 => wire__crate__api__network_privacy__get_import_birthday_metadata_impl(port, ptr, rust_vec_len, data_len),
-77 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
-78 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
-79 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
-82 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__sync__get_orchard_migration_immediate_plan_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__sync__get_orchard_migration_private_plan_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__sync__get_orchard_migration_status_impl(port, ptr, rust_vec_len, data_len),
-86 => wire__crate__api__sync__get_orchard_migration_statuses_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__sync__get_previous_transaction_count_for_address_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__voting__get_round_recovery_state_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
-93 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-100 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__wallet__import_software_account_at_index_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
-103 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-107 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-116 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-117 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
-119 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__voting__precompute_delegation_proof_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__voting__precompute_snapshot_bundles_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__voting__preflight_voting_helpers_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__voting__prepare_committed_share_delivery_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__sync__prepare_pczt_for_keystone_batch_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-135 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-145 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__sync__store_and_broadcast_pczts_with_keystone_signatures_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__voting__submit_prepared_shares_to_helpers_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-174 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-175 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-176 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-177 => wire__crate__api__voting__track_pending_shares_impl(port, ptr, rust_vec_len, data_len),
-178 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-179 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-180 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-182 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-185 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
-187 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-188 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+15 => wire__crate__api__voting__check_voting_eligibility_impl(port, ptr, rust_vec_len, data_len),
+16 => wire__crate__api__sync__complete_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+17 => wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+18 => wire__crate__api__sync__complete_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+19 => wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+20 => wire__crate__api__simple__configure_fast_testnet_migration_impl(port, ptr, rust_vec_len, data_len),
+21 => wire__crate__api__network_privacy__configure_network_privacy_impl(port, ptr, rust_vec_len, data_len),
+22 => wire__crate__api__simple__configure_regtest_ironwood_activation_height_impl(port, ptr, rust_vec_len, data_len),
+23 => wire__crate__api__voting__confirm_delegation_submission_impl(port, ptr, rust_vec_len, data_len),
+24 => wire__crate__api__voting__confirm_share_with_helpers_impl(port, ptr, rust_vec_len, data_len),
+25 => wire__crate__api__voting__confirm_vote_submission_impl(port, ptr, rust_vec_len, data_len),
+26 => wire__crate__api__sync__create_or_resume_private_migration_draft_impl(port, ptr, rust_vec_len, data_len),
+27 => wire__crate__api__sync__create_pczt_from_proposal_impl(port, ptr, rust_vec_len, data_len),
+28 => wire__crate__api__sync__create_shield_transparent_pczt_impl(port, ptr, rust_vec_len, data_len),
+29 => wire__crate__api__sync__create_tex_pczts_from_proposal_impl(port, ptr, rust_vec_len, data_len),
+31 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
+32 => wire__crate__api__keystone__decode_accounts_from_cbor_impl(port, ptr, rust_vec_len, data_len),
+33 => wire__crate__api__keystone__decode_accounts_ur_impl(port, ptr, rust_vec_len, data_len),
+34 => wire__crate__api__keystone__decode_pczt_from_cbor_impl(port, ptr, rust_vec_len, data_len),
+35 => wire__crate__api__keystone__decode_ur_part_impl(port, ptr, rust_vec_len, data_len),
+36 => wire__crate__api__keystone__decode_ur_to_pczt_impl(port, ptr, rust_vec_len, data_len),
+37 => wire__crate__api__keystone__decode_zcash_batch_sign_response_impl(port, ptr, rust_vec_len, data_len),
+38 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_impl(port, ptr, rust_vec_len, data_len),
+39 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_as_sig_result_impl(port, ptr, rust_vec_len, data_len),
+40 => wire__crate__api__sync__decrypt_and_store_transaction_impl(port, ptr, rust_vec_len, data_len),
+41 => wire__crate__api__secret__decrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
+42 => wire__crate__api__voting__delegation_submission_wire_json_impl(port, ptr, rust_vec_len, data_len),
+43 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
+44 => wire__crate__api__voting__delete_skipped_bundles_impl(port, ptr, rust_vec_len, data_len),
+45 => wire__crate__api__voting__delete_voting_account_state_impl(port, ptr, rust_vec_len, data_len),
+46 => wire__crate__api__secret__derive_secret_password_verifier_impl(port, ptr, rust_vec_len, data_len),
+47 => wire__crate__api__sync__discard_all_keystone_migration_requests_impl(port, ptr, rust_vec_len, data_len),
+48 => wire__crate__api__sync__discard_keystone_migration_request_impl(port, ptr, rust_vec_len, data_len),
+49 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
+50 => wire__crate__api__wallet__discover_software_wallet_import_accounts_impl(port, ptr, rust_vec_len, data_len),
+51 => wire__crate__api__keystone__encode_keystone_action_sigs_impl(port, ptr, rust_vec_len, data_len),
+52 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
+53 => wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len),
+54 => wire__crate__api__keystone__encode_zcash_sign_batch_ur_parts_impl(port, ptr, rust_vec_len, data_len),
+55 => wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
+56 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(port, ptr, rust_vec_len, data_len),
+57 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crate__api__network_privacy__estimate_import_birthday_height_impl(port, ptr, rust_vec_len, data_len),
+59 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
+60 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
+61 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+63 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+64 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
+67 => wire__crate__api__wallet__generate_software_account_impl(port, ptr, rust_vec_len, data_len),
+68 => wire__crate__api__voting__generate_van_witness_impl(port, ptr, rust_vec_len, data_len),
+69 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
+70 => wire__crate__api__wallet__get_account_export_metadata_impl(port, ptr, rust_vec_len, data_len),
+71 => wire__crate__api__wallet__get_account_ufvk_impl(port, ptr, rust_vec_len, data_len),
+72 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+73 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
+75 => wire__crate__api__wallet__get_chain_upgrade_status_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__wallet__get_chain_upgrade_status_at_height_impl(port, ptr, rust_vec_len, data_len),
+77 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__network_privacy__get_import_birthday_metadata_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
+80 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__sync__get_orchard_migration_immediate_plan_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__sync__get_orchard_migration_private_plan_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__sync__get_orchard_migration_status_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__sync__get_orchard_migration_statuses_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__sync__get_previous_transaction_count_for_address_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__voting__get_round_recovery_state_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
+101 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
+105 => wire__crate__api__wallet__import_software_account_at_index_impl(port, ptr, rust_vec_len, data_len),
+106 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
+117 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+118 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__voting__precompute_delegation_proof_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__voting__precompute_snapshot_bundles_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__voting__preflight_voting_helpers_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__voting__prepare_committed_share_delivery_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+136 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__sync__prepare_pczt_for_keystone_batch_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+146 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+148 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__sync__run_payment_link_claim_sync_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__sync__store_and_broadcast_pczts_with_keystone_signatures_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+174 => wire__crate__api__voting__submit_prepared_shares_to_helpers_impl(port, ptr, rust_vec_len, data_len),
+175 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+176 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+179 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+180 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+181 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+182 => wire__crate__api__voting__track_pending_shares_impl(port, ptr, rust_vec_len, data_len),
+183 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+184 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+185 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+187 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+190 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
+192 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+193 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -11546,64 +11726,69 @@ fn pde_ffi_dispatcher_sync_impl(
         ),
         6 => wire__crate__api__voting__begin_share_tracking_pass_impl(ptr, rust_vec_len, data_len),
         13 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__voting__create_voting_helper_delivery_context_impl(
+        14 => {
+            wire__crate__api__sync__cancel_payment_link_claim_sync_impl(ptr, rust_vec_len, data_len)
+        }
+        30 => wire__crate__api__voting__create_voting_helper_delivery_context_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        64 => wire__crate__api__network_privacy__fail_network_privacy_enable_impl(
+        65 => wire__crate__api__network_privacy__fail_network_privacy_enable_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        65 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        72 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        80 => wire__crate__api__network_privacy__get_network_privacy_status_impl(
+        66 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        74 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__network_privacy__get_network_privacy_status_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        92 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        99 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        105 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
-        106 => {
+        89 => wire__crate__api__sync__get_pczt_expiry_height_impl(ptr, rust_vec_len, data_len),
+        90 => wire__crate__api__sync__get_pczt_txid_impl(ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        103 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        109 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
+        110 => {
             wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len)
         }
-        108 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        109 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        110 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
-        112 => {
+        112 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        113 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        114 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
+        116 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        120 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        141 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        151 => {
+        124 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        145 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        156 => {
             wire__crate__api__voting__select_pir_snapshot_endpoint_impl(ptr, rust_vec_len, data_len)
         }
-        152 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
-        154 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        157 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
+        159 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        155 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        163 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        172 => wire__crate__api__network_privacy__tor_http_begin_request_impl(
+        160 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        168 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        177 => wire__crate__api__network_privacy__tor_http_begin_request_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        173 => wire__crate__api__network_privacy__tor_http_cancel_request_impl(
+        178 => wire__crate__api__network_privacy__tor_http_cancel_request_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        181 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        183 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
-        184 => {
+        186 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        188 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        189 => {
             wire__crate__api__sync__warm_orchard_proving_key_cache_impl(ptr, rust_vec_len, data_len)
         }
-        186 => {
+        191 => {
             wire__crate__api__voting__warm_voting_proving_caches_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -12741,6 +12926,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ExtractAndBroadcastPczt
     for crate::api::sync::ExtractAndBroadcastPcztResult
 {
     fn into_into_dart(self) -> crate::api::sync::ExtractAndBroadcastPcztResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::wallet::GeneratedSoftwareAccount {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.mnemonic.into_into_dart().into_dart(),
+            self.unified_address.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::wallet::GeneratedSoftwareAccount
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::GeneratedSoftwareAccount>
+    for crate::api::wallet::GeneratedSoftwareAccount
+{
+    fn into_into_dart(self) -> crate::api::wallet::GeneratedSoftwareAccount {
         self
     }
 }
@@ -15351,6 +15557,14 @@ impl SseEncode for f64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_f64::<NativeEndian>(self).unwrap();
+    }
+}
+
+impl SseEncode for crate::api::wallet::GeneratedSoftwareAccount {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.mnemonic, serializer);
+        <String>::sse_encode(self.unified_address, serializer);
     }
 }
 

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -257,6 +257,20 @@ fn software_account_ufvk(
     )
 }
 
+/// Derive the default shielded Unified Address for a software account without
+/// importing it into the wallet database.
+pub fn derive_software_address(
+    network: WalletNetwork,
+    seed: &SecretVec<u8>,
+    account_index: u32,
+) -> Result<String, String> {
+    let ufvk = software_account_ufvk(network, seed, account_index)?;
+    let (ua, _di) = ufvk
+        .default_address(shielded_address_request())
+        .map_err(|e| format!("Failed to derive address: {e}"))?;
+    Ok(ua.encode(&network))
+}
+
 /// Return the transparent receiver at `m/44'/coin_type'/account'/0/0`.
 pub fn software_account_first_external_transparent_address(
     network: WalletNetwork,
@@ -1243,6 +1257,21 @@ mod tests {
         let phrase = generate_mnemonic();
         let seed = mnemonic_to_seed(&phrase).unwrap();
         assert_eq!(seed.expose_secret().len(), 64);
+    }
+
+    #[test]
+    fn software_address_derivation_is_deterministic_and_network_scoped() {
+        let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let seed = mnemonic_to_seed(phrase).unwrap();
+
+        let main = derive_software_address(WalletNetwork::Main, &seed, 0).unwrap();
+        let main_again = derive_software_address(WalletNetwork::Main, &seed, 0).unwrap();
+        let test = derive_software_address(WalletNetwork::Test, &seed, 0).unwrap();
+
+        assert_eq!(main, main_again);
+        assert!(main.starts_with("u1"));
+        assert!(test.starts_with("utest1"));
+        assert_ne!(main, test);
     }
 
     #[test]

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -55,7 +55,10 @@ pub use pczt::{
     store_and_broadcast_signed_pczts_for_proposal, ExtractAndBroadcastPcztResult,
     KeystoneBatchPczt, StoreAndBroadcastPcztsResult, TexPcztPair,
 };
-pub(crate) use pczt::extract_compact_sigs_from_pczt;
+pub(crate) use pczt::{
+    expiry_height_from_io_finalized_pczt, extract_compact_sigs_from_pczt,
+    txid_from_io_finalized_pczt,
+};
 pub(crate) use proposal_locks::recover_previous_process as recover_orphaned_send_locks;
 pub(crate) use send::estimate_send_max;
 pub(crate) use send::propose_send;

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -320,6 +320,22 @@ pub(crate) fn txid_from_io_finalized_pczt(pczt_bytes: &[u8]) -> Result<TxId, Str
     ))
 }
 
+/// Returns the expiry height committed to by an IO-finalized PCZT.
+pub(crate) fn expiry_height_from_io_finalized_pczt(pczt_bytes: &[u8]) -> Result<u32, String> {
+    let pczt = pczt::Pczt::parse(pczt_bytes).map_err(|e| format!("Parse PCZT: {e:?}"))?;
+    if pczt.global().inputs_modifiable()
+        || pczt.global().outputs_modifiable()
+        || pczt.global().shielded_modifiable()
+    {
+        return Err("PCZT IO is not finalized".to_string());
+    }
+
+    let effects = pczt
+        .into_effects()
+        .map_err(|e| format!("Extract PCZT effects: {e:?}"))?;
+    Ok(u32::from(effects.expiry_height()))
+}
+
 fn legacy_orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
     cached_orchard_proving_key(orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2)
 }
@@ -2575,9 +2591,10 @@ mod tests {
         // levels up from this nested test module.
         use super::super::{
             apply_sigs_and_extract, ensure_signed_pczt_matches_base, ensure_tex_pczt_dependency,
-            extract_compact_sigs_from_signed_pczt, extract_transaction_from_pczt,
-            ironwood_orchard_proving_key, preflight_orchard_spend_auth_signatures,
-            prepare_compact_signed_pczts, prepare_pczt_for_keystone_batch, redact_pczt_for_signer,
+            expiry_height_from_io_finalized_pczt, extract_compact_sigs_from_signed_pczt,
+            extract_transaction_from_pczt, ironwood_orchard_proving_key,
+            preflight_orchard_spend_auth_signatures, prepare_compact_signed_pczts,
+            prepare_pczt_for_keystone_batch, redact_pczt_for_signer,
             set_orchard_anchor_and_witnesses, txid_from_io_finalized_pczt,
         };
         use orchard::tree::MerkleHashOrchard;
@@ -2866,6 +2883,8 @@ mod tests {
             let (base_bytes, orchard_ask, spend_index, _, _, _) = build_migration_base_pczt();
             let pre_signature_txid = txid_from_io_finalized_pczt(&base_bytes)
                 .expect("IO-finalized PCZT effects should have a stable txid");
+            let pre_signature_expiry = expiry_height_from_io_finalized_pczt(&base_bytes)
+                .expect("IO-finalized PCZT effects should have a stable expiry height");
 
             let pk = ironwood_orchard_proving_key();
             let proofs = Prover::new(pczt::Pczt::parse(&base_bytes).unwrap())
@@ -2882,6 +2901,10 @@ mod tests {
             let extracted = extract_transaction_from_pczt(&proofs, &signed, None, None).unwrap();
 
             assert_eq!(pre_signature_txid, extracted.txid);
+            assert_eq!(
+                pre_signature_expiry,
+                u32::from(extracted.tx.expiry_height())
+            );
         }
 
         #[test]

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -2262,6 +2262,244 @@ pub async fn run_sync_inner(
     Err(last_err)
 }
 
+/// Runs the bounded shielded scan needed by one payment-link claim wallet.
+///
+/// Claim wallets are short-lived, single-account databases. They deliberately
+/// skip transparent refresh, transaction enhancement, migration preparation,
+/// and main-wallet completion metadata. Each caller owns its database, so this
+/// path does not take the main wallet's process-global sync guard or write lock.
+pub async fn run_payment_link_claim_sync(
+    db_data_path: &str,
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+    cancel: Arc<AtomicBool>,
+) -> Result<(), String> {
+    const MAX_RETRIES: u32 = 3;
+    let mut last_error = String::new();
+
+    for attempt in 0..=MAX_RETRIES {
+        if attempt > 0 {
+            let delay_secs = 1u64 << attempt;
+            for _ in 0..delay_secs {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                if cancel.load(Ordering::Relaxed) {
+                    return Ok(());
+                }
+            }
+        }
+
+        match run_payment_link_claim_sync_once(
+            db_data_path,
+            lightwalletd_url,
+            network,
+            cancel.clone(),
+        )
+        .await
+        {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                let strategy = error.recovery_strategy();
+                last_error = error.to_string();
+                if matches!(strategy, RecoveryStrategy::Fatal) {
+                    return Err(last_error);
+                }
+            }
+        }
+    }
+
+    Err(last_error)
+}
+
+async fn run_payment_link_claim_sync_once(
+    db_data_path: &str,
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+    cancel: Arc<AtomicBool>,
+) -> Result<(), SyncError> {
+    let should_exit = || cancel.load(Ordering::Relaxed);
+    let mut client = open_lwd_channel(lightwalletd_url).await?;
+    let mut db = open_db(db_data_path, network)?;
+    let initial_tip = get_latest_block(&mut client).await?;
+    let mut current_tip_height = initial_tip.height;
+    if let Some((_, db_tip_height)) = sync::wallet_scan_heights(&mut db).map_err(SyncError::db)? {
+        let stored_hash = stored_hash_for_refreshed_tip(&db, db_tip_height, initial_tip.height)?;
+        match classify_refreshed_tip_with_fallback(
+            &mut client,
+            db_tip_height,
+            stored_hash,
+            initial_tip.height,
+            &initial_tip.hash,
+        )
+        .await?
+        {
+            RefreshedTipRelation::ServerBehind => {
+                return Err(lagging_lightwalletd_tip(db_tip_height, initial_tip.height));
+            }
+            RefreshedTipRelation::Reorg => {
+                rewind_for_confirmed_tip_reorg(&mut db, initial_tip.height)?;
+            }
+            RefreshedTipRelation::Advanced
+            | RefreshedTipRelation::Unchanged
+            | RefreshedTipRelation::UnchangedUnverified => {}
+        }
+    }
+    let tip_height = block_height_from_u64(current_tip_height, "payment-link chain tip")?;
+    db.update_chain_tip(tip_height)
+        .map_err(|error| SyncError::db(format!("payment-link update_chain_tip: {error}")))?;
+    crate::wallet::sync::recover_orphaned_send_locks(db_data_path, network)
+        .map_err(|error| SyncError::db(format!("payment-link recover send locks: {error}")))?;
+
+    download_subtree_roots(&mut client, &mut db, db_data_path, network, tip_height).await?;
+
+    let mut rewind_attempts = 0u32;
+    loop {
+        if should_exit() {
+            return Ok(());
+        }
+
+        let ranges = db
+            .suggest_scan_ranges()
+            .map_err(|error| SyncError::db(format!("payment-link suggest_scan_ranges: {error}")))?;
+        let next_range = ranges
+            .iter()
+            .find(|range| is_pending_scan_range(range))
+            .cloned();
+
+        let Some(range) = next_range else {
+            let fresh_tip = get_latest_block(&mut client).await?;
+            let stored_hash =
+                stored_hash_for_refreshed_tip(&db, current_tip_height, fresh_tip.height)?;
+            match classify_refreshed_tip_with_fallback(
+                &mut client,
+                current_tip_height,
+                stored_hash,
+                fresh_tip.height,
+                &fresh_tip.hash,
+            )
+            .await?
+            {
+                RefreshedTipRelation::Advanced => {
+                    current_tip_height = fresh_tip.height;
+                    let height =
+                        block_height_from_u64(current_tip_height, "payment-link refreshed tip")?;
+                    db.update_chain_tip(height).map_err(|error| {
+                        SyncError::db(format!("payment-link update_chain_tip({height}): {error}"))
+                    })?;
+                    continue;
+                }
+                RefreshedTipRelation::Reorg => {
+                    if rewind_attempts >= MAX_REWINDS_PER_RUN {
+                        return Err(SyncError::continuity(
+                            fresh_tip.height,
+                            "payment-link tip reorg rewind budget exhausted",
+                        ));
+                    }
+                    rewind_attempts += 1;
+                    let fresh_height =
+                        block_height_from_u64(fresh_tip.height, "payment-link reorg tip")?;
+                    let requested = confirmed_reorg_rewind_target(fresh_height)?;
+                    truncate_wallet_with(requested, fresh_height, |height| {
+                        db.truncate_to_height(height)
+                    })?;
+                    db.update_chain_tip(fresh_height).map_err(|error| {
+                        SyncError::db(format!("payment-link update tip after reorg: {error}"))
+                    })?;
+                    current_tip_height = fresh_tip.height;
+                    continue;
+                }
+                RefreshedTipRelation::ServerBehind => {
+                    return Err(lagging_lightwalletd_tip(
+                        current_tip_height,
+                        fresh_tip.height,
+                    ));
+                }
+                RefreshedTipRelation::Unchanged | RefreshedTipRelation::UnchangedUnverified => {
+                    ensure_complete_scan_state(&mut db, current_tip_height)?;
+                    let _ = crate::wallet::sync::resubmit_pending_transactions(
+                        db_data_path,
+                        lightwalletd_url,
+                        &mut client,
+                        u32::try_from(current_tip_height).unwrap_or(u32::MAX),
+                        &std::collections::HashSet::new(),
+                        &should_exit,
+                    )
+                    .await;
+                    return Ok(());
+                }
+            }
+        };
+
+        let start = range.block_range().start;
+        let range_end = range.block_range().end;
+        let Some((_, end)) =
+            scannable_batch_end(BATCH_SIZE_FOREGROUND, start, range_end, current_tip_height)
+        else {
+            return Err(SyncError::continuity(
+                current_tip_height,
+                "payment-link pending scan range starts after the observed tip",
+            ));
+        };
+        let batch_blocks = u32::from(end).saturating_sub(u32::from(start)) as u64;
+
+        let (block_source, from_state) =
+            download_scan_batch(&mut client, start, end - 1, network).await?;
+        validate_scan_batch(&block_source, &from_state, start, end)?;
+        if should_exit() {
+            return Ok(());
+        }
+
+        let scan_result = scan_cached_blocks(
+            &network,
+            &block_source,
+            &mut db,
+            start,
+            &from_state,
+            batch_blocks as usize,
+        );
+        match scan_result {
+            Ok(_) => {}
+            Err(error) => {
+                let sync_error = match error {
+                    ChainError::Scan(scan_error) if scan_error.is_continuity_error() => {
+                        SyncError::continuity(
+                            u32::from(scan_error.at_height()) as u64,
+                            scan_error.to_string(),
+                        )
+                    }
+                    ChainError::Wallet(SqliteClientError::BlockConflict(at)) => {
+                        SyncError::continuity(u32::from(at) as u64, "payment-link block conflict")
+                    }
+                    ChainError::Wallet(wallet_error)
+                        if is_commitment_tree_root_conflict(&wallet_error) =>
+                    {
+                        SyncError::continuity(
+                            u32::from(start) as u64,
+                            format!("payment-link commitment tree root conflict: {wallet_error}"),
+                        )
+                    }
+                    ChainError::Wallet(wallet_error) => {
+                        SyncError::db(format!("payment-link scan wallet: {wallet_error}"))
+                    }
+                    other => SyncError::other(format!("payment-link scan: {other}")),
+                };
+                if !sync_error.is_continuity() || rewind_attempts >= MAX_REWINDS_PER_RUN {
+                    return Err(sync_error);
+                }
+                let attempt = rewind_attempts;
+                rewind_attempts += 1;
+                let requested_height = sync_error
+                    .rewind_target_for_attempt(attempt)
+                    .unwrap_or_else(|| u32::from(start).saturating_sub(10) as u64);
+                let requested =
+                    block_height_from_u64(requested_height, "payment-link scan rewind target")?;
+                let fresh_tip =
+                    block_height_from_u64(current_tip_height, "payment-link scan rewind tip")?;
+                truncate_wallet_with(requested, fresh_tip, |height| db.truncate_to_height(height))?;
+            }
+        }
+    }
+}
+
 /// Inner sync implementation. Called by run_sync_inner (with retry wrapper).
 async fn run_sync_impl(
     db_data_path: &str,

--- a/test/app_incoming_link_host_test.dart
+++ b/test/app_incoming_link_host_test.dart
@@ -1,0 +1,286 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_intake_provider.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_entry_policy.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_request_flow_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/services/incoming_uri_service.dart';
+
+import 'fakes/fake_sync_notifier.dart';
+
+// Both link products arrive on one native channel and are now dispatched by
+// one host. Two things have to hold at once:
+//
+//  1. each kind still reaches its own intake — the merge did not silently
+//     leave one of them handled by the other's parser;
+//  2. they defer to each other. A Gift Card navigates to `/payment-links`,
+//     which would tear a ZIP-321 request card off the screen mid-answer, so
+//     it waits for the card and opens when the card is gone.
+void main() {
+  const account = AccountInfo(
+    uuid: 'account-1',
+    name: 'Account 1',
+    order: 0,
+    isSeedAnchor: true,
+  );
+
+  const walletState = AccountState(
+    accounts: [account],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1active',
+  );
+
+  Future<(ProviderContainer, GoRouter, _FakeIncomingUriService)> pumpHost(
+    WidgetTester tester,
+  ) async {
+    final incomingUris = _FakeIncomingUriService();
+    addTearDown(incomingUris.dispose);
+
+    final router = GoRouter(
+      initialLocation: '/home',
+      routes: [
+        for (final path in [
+          '/home',
+          '/send',
+          '/welcome',
+          '/unlock',
+          '/payment-links',
+        ])
+          GoRoute(
+            path: path,
+            builder: (_, _) => Scaffold(body: Text('screen $path')),
+          ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    late ProviderContainer container;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(
+            _unlockedBootstrapWithWallet(walletState),
+          ),
+          accountProvider.overrideWith(
+            () => _ControllableAccountNotifier(walletState),
+          ),
+          syncProvider.overrideWith(FakeSyncNotifier.new),
+          paymentRequestPrecheckProvider.overrideWithValue(_readyPrecheck()),
+          incomingUriServiceProvider.overrideWithValue(incomingUris),
+        ],
+        child: Consumer(
+          builder: (context, ref, _) {
+            container = ProviderScope.containerOf(context, listen: false);
+            return MaterialApp.router(
+              routerConfig: router,
+              builder: (context, child) => AppTheme(
+                data: AppThemeData.dark,
+                child: buildIncomingLinkHostForTest(
+                  router: router,
+                  child: child!,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return (container, router, incomingUris);
+  }
+
+  testWidgets('one host routes each link kind to its own intake', (
+    tester,
+  ) async {
+    final (container, router, incomingUris) = await pumpHost(tester);
+
+    incomingUris.emit('zcash:u1recipient?amount=0.5');
+    await tester.pumpAndSettle();
+
+    expect(
+      container.read(paymentRequestFlowProvider),
+      isNotNull,
+      reason: 'the zcash: link became a request card',
+    );
+    expect(
+      container.read(paymentLinkIntakeProvider).pendingLink,
+      isNull,
+      reason: 'and it did not leak into the Gift Card queue',
+    );
+    expect(router.routerDelegate.currentConfiguration.uri.path, '/home');
+
+    // Answer the card so the Gift Card is not deferred by it.
+    container.read(paymentRequestFlowProvider.notifier).clear();
+    await tester.pumpAndSettle();
+
+    incomingUris.emit(_paymentLink.toUri().toString());
+    await tester.pumpAndSettle();
+
+    expect(
+      container.read(paymentLinkIntakeProvider).pendingLink,
+      isNotNull,
+      reason: 'the https link became a queued Gift Card',
+    );
+    expect(
+      container.read(paymentUriPrefillProvider),
+      isNull,
+      reason: 'and it never reached the ZIP-321 park',
+    );
+    expect(
+      router.routerDelegate.currentConfiguration.uri.path,
+      '/payment-links',
+    );
+  });
+
+  testWidgets('a Gift Card waits for a presented request card and opens once '
+      'it is answered', (tester) async {
+    final (container, router, incomingUris) = await pumpHost(tester);
+
+    incomingUris.emit('zcash:u1recipient?amount=0.5');
+    await tester.pumpAndSettle();
+    expect(container.read(paymentRequestFlowProvider), isNotNull);
+
+    incomingUris.emit(_paymentLink.toUri().toString());
+    await tester.pumpAndSettle();
+
+    expect(
+      router.routerDelegate.currentConfiguration.uri.path,
+      '/home',
+      reason: 'navigating now would unmount the card the user is answering',
+    );
+    expect(
+      container.read(paymentLinkIntakeProvider).pendingLink,
+      isNotNull,
+      reason: 'the Gift Card waits, it is not dropped',
+    );
+    expect(find.text(kPaymentLinkDeferredByActiveFlowMessage), findsOneWidget);
+
+    // The user answers the card. The Gift Card is released by the same
+    // listener that watches the card's own state.
+    container.read(paymentRequestFlowProvider.notifier).clear();
+    await tester.pumpAndSettle();
+
+    expect(
+      router.routerDelegate.currentConfiguration.uri.path,
+      '/payment-links',
+    );
+  });
+
+  testWidgets('an unknown link on the Vizor host is dropped without a word', (
+    tester,
+  ) async {
+    final (container, router, incomingUris) = await pumpHost(tester);
+
+    incomingUris.emit('https://link.vizor.cash/not-a-route#v1=secret');
+    await tester.pumpAndSettle();
+
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    expect(container.read(paymentLinkIntakeProvider).pendingLink, isNull);
+    expect(router.routerDelegate.currentConfiguration.uri.path, '/home');
+    // No ZIP-321 rejection sentence: the link never reached that parser.
+    expect(find.textContaining('payment link'), findsNothing);
+  });
+}
+
+class _FakeIncomingUriService extends IncomingUriService {
+  final StreamController<String> _uris = StreamController<String>.broadcast();
+
+  @override
+  Stream<String> get uriStream => _uris.stream;
+
+  @override
+  Future<void> initialize() async {}
+
+  void emit(String uri) => _uris.add(uri);
+
+  @override
+  Future<void> dispose() async {
+    await _uris.close();
+  }
+}
+
+final _paymentLink = VizorPaymentLink(
+  network: 'main',
+  address: 'u1giftcardaddress',
+  amountZatoshi: BigInt.from(100000000),
+  mnemonic: List.filled(24, 'abandon').join(' '),
+  birthdayHeight: 3000000,
+  label: 'Gift Card',
+  createdAt: DateTime.utc(2026, 8, 28),
+);
+
+PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  spendableIsAuthoritativeNow: () => true,
+  validateAddress: ({required String address, required String network}) async =>
+      rust_sync.AddressValidationResult(
+        isValid: true,
+        addressType: 'unified',
+        wrongNetwork: false,
+      ),
+  proposeTransfer:
+      ({
+        required String accountUuid,
+        required String sendFlowId,
+        required String address,
+        required String addressType,
+        required BigInt amountZatoshi,
+        String? memo,
+        bool isPaymentRequest = false,
+        String? requestedBy,
+        BigInt? requestedAmountZatoshi,
+      }) async => SendReviewArgs(
+        proposalId: BigInt.one,
+        sendFlowId: sendFlowId,
+        proposalAccountUuid: accountUuid,
+        address: address,
+        addressType: addressType,
+        amountZatoshi: amountZatoshi,
+        feeZatoshi: BigInt.from(10000),
+        needsSaplingParams: false,
+        isPaymentRequest: isPaymentRequest,
+      ),
+  discardProposal:
+      ({
+        required BigInt proposalId,
+        required String sendFlowId,
+        required String logContext,
+      }) async {},
+);
+
+AppBootstrapState _unlockedBootstrapWithWallet(AccountState accountState) =>
+    AppBootstrapState(
+      initialLocation: '/home',
+      initialAccountState: accountState,
+      initialSyncSnapshot: AppSyncSnapshot.empty,
+      network: 'main',
+      rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+      themeMode: ThemeMode.dark,
+      privacyModeEnabled: false,
+      isPasswordConfigured: true,
+      isUnlocked: true,
+      passwordRotationRecoveryFailed: false,
+    );
+
+class _ControllableAccountNotifier extends AccountNotifier {
+  _ControllableAccountNotifier(this._initial);
+
+  final AccountState _initial;
+
+  @override
+  FutureOr<AccountState> build() => _initial;
+}

--- a/test/app_incoming_link_host_test.dart
+++ b/test/app_incoming_link_host_test.dart
@@ -260,7 +260,7 @@ PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
-      }) async {},
+      }) async => true,
 );
 
 AppBootstrapState _unlockedBootstrapWithWallet(AccountState accountState) =>

--- a/test/app_incoming_link_host_test.dart
+++ b/test/app_incoming_link_host_test.dart
@@ -225,6 +225,7 @@ final _paymentLink = VizorPaymentLink(
 );
 
 PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
+  readNetworkName: () => kZcashDefaultNetworkName,
   spendableIsAuthoritativeNow: () => true,
   validateAddress: ({required String address, required String network}) async =>
       rust_sync.AddressValidationResult(

--- a/test/app_incoming_link_host_test.dart
+++ b/test/app_incoming_link_host_test.dart
@@ -45,8 +45,9 @@ void main() {
   );
 
   Future<(ProviderContainer, GoRouter, _FakeIncomingUriService)> pumpHost(
-    WidgetTester tester,
-  ) async {
+    WidgetTester tester, {
+    bool registerPaymentLinks = true,
+  }) async {
     final incomingUris = _FakeIncomingUriService();
     addTearDown(incomingUris.dispose);
 
@@ -58,7 +59,7 @@ void main() {
           '/send',
           '/welcome',
           '/unlock',
-          '/payment-links',
+          if (registerPaymentLinks) '/payment-links',
         ])
           GoRoute(
             path: path,
@@ -178,6 +179,22 @@ void main() {
       router.routerDelegate.currentConfiguration.uri.path,
       '/payment-links',
     );
+  });
+
+  testWidgets('a Gift Card stays pending while its surface is not registered', (
+    tester,
+  ) async {
+    final (container, router, incomingUris) = await pumpHost(
+      tester,
+      registerPaymentLinks: false,
+    );
+
+    incomingUris.emit(_paymentLink.toUri().toString());
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(router.routerDelegate.currentConfiguration.uri.path, '/home');
+    expect(container.read(paymentLinkIntakeProvider).pendingLink, isNotNull);
   });
 
   testWidgets('an unknown link on the Vizor host is dropped without a word', (

--- a/test/features/accounts/accounts_screen_test.dart
+++ b/test/features/accounts/accounts_screen_test.dart
@@ -1039,6 +1039,51 @@ void main() {
     expect(accountNotifier.removedUuid, isNull);
   });
 
+  testWidgets('resetting via the last account is blocked while it receives a '
+      'Gift Card', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    const singleAccountState = AccountState(
+      accounts: [
+        AccountInfo(
+          uuid: 'account-1',
+          name: 'Primary Vault',
+          order: 0,
+          isSeedAnchor: true,
+        ),
+      ],
+      activeAccountUuid: 'account-1',
+      activeAddress: 'u1accountsaddress',
+    );
+    final accountNotifier = _FakeAccountNotifier(singleAccountState);
+    await tester.pumpWidget(
+      _accountsHarness(
+        accountNotifier: () => accountNotifier,
+        receivingGiftCardCounts: const {'account-1': 1},
+      ),
+    );
+    await tester.pump();
+
+    await _openRemoveAccountModal(tester, 'account-1');
+
+    expect(
+      find.text(
+        'This account is receiving a Gift Card. Wait for it to finish before removing this account.',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.enterText(find.byType(EditableText), _validDeletePassword);
+    await tester.pump();
+    await tester.tap(find.text('Reset Vizor'));
+    await tester.pumpAndSettle();
+
+    expect(accountNotifier.resetWalletCalled, isFalse);
+  });
+
   testWidgets('remove account requires the current password before deleting', (
     tester,
   ) async {

--- a/test/features/accounts/accounts_screen_test.dart
+++ b/test/features/accounts/accounts_screen_test.dart
@@ -19,6 +19,8 @@ import 'package:zcash_wallet/src/core/widgets/app_context_menu.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_pane_modal_overlay.dart';
 import 'package:zcash_wallet/src/features/accounts/screens/accounts_screen.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_reconciler.dart';
 import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_activity_store.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
@@ -965,6 +967,78 @@ void main() {
     );
   });
 
+  testWidgets('remove account is blocked while it has an unshared Gift Card', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final accountNotifier = _FakeAccountNotifier(
+      _bootstrap.initialAccountState,
+    );
+    await tester.pumpWidget(
+      _accountsHarness(
+        accountNotifier: () => accountNotifier,
+        unsharedGiftCardCounts: const {'account-2': 1},
+      ),
+    );
+    await tester.pump();
+
+    await _openRemoveAccountModal(tester, 'account-2');
+
+    expect(
+      find.text(
+        'This account has 1 unshared Gift Card link. Copy it before removing this account.',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.enterText(find.byType(EditableText), _validDeletePassword);
+    await tester.pump();
+    await tester.tap(find.text('Remove'));
+    await tester.pumpAndSettle();
+
+    expect(accountNotifier.removedUuid, isNull);
+  });
+
+  testWidgets('remove account is blocked while it receives a Gift Card', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final accountNotifier = _FakeAccountNotifier(
+      _bootstrap.initialAccountState,
+    );
+    await tester.pumpWidget(
+      _accountsHarness(
+        accountNotifier: () => accountNotifier,
+        receivingGiftCardCounts: const {'account-2': 1},
+      ),
+    );
+    await tester.pump();
+
+    await _openRemoveAccountModal(tester, 'account-2');
+
+    expect(
+      find.text(
+        'This account is receiving a Gift Card. Wait for it to finish before removing this account.',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.enterText(find.byType(EditableText), _validDeletePassword);
+    await tester.pump();
+    await tester.tap(find.text('Remove'));
+    await tester.pumpAndSettle();
+
+    expect(accountNotifier.removedUuid, isNull);
+  });
+
   testWidgets('remove account requires the current password before deleting', (
     tester,
   ) async {
@@ -1197,6 +1271,12 @@ void main() {
       findsOneWidget,
     );
     expect(find.textContaining('This cannot be undone.'), findsOneWidget);
+    expect(
+      find.textContaining(
+        'Unshared Gift Card links will also be permanently lost.',
+      ),
+      findsOneWidget,
+    );
 
     await _submitRemovePassword(tester, buttonLabel: 'Reset Vizor');
     await tester.pumpAndSettle();
@@ -1299,6 +1379,8 @@ Widget _accountsHarness({
   AppSecurityNotifier Function()? securityNotifier,
   ReceiveAddressService Function(Ref ref)? receiveAddressService,
   Map<String, int> pendingSwapCounts = const {},
+  Map<String, int> receivingGiftCardCounts = const {},
+  Map<String, int> unsharedGiftCardCounts = const {},
 }) {
   final router = GoRouter(
     initialLocation: '/accounts',
@@ -1348,6 +1430,15 @@ Widget _accountsHarness({
         accountProvider.overrideWith(accountNotifier),
       swapPendingIntentCountProvider.overrideWith((ref, accountUuid) async {
         return pendingSwapCounts[accountUuid] ?? 0;
+      }),
+      paymentLinkReceivingCountProvider.overrideWith((ref, accountUuid) async {
+        return receivingGiftCardCounts[accountUuid] ?? 0;
+      }),
+      paymentLinkUnsharedFundedCountProvider.overrideWith((
+        ref,
+        accountUuid,
+      ) async {
+        return unsharedGiftCardCounts[accountUuid] ?? 0;
       }),
       appSecurityProvider.overrideWith(
         securityNotifier ?? _FakeAppSecurityNotifier.new,

--- a/test/features/accounts/mobile_accounts_screen_test.dart
+++ b/test/features/accounts/mobile_accounts_screen_test.dart
@@ -22,6 +22,8 @@ import 'package:zcash_wallet/src/core/widgets/mobile_text_field.dart';
 import 'package:zcash_wallet/src/features/accounts/screens/mobile/mobile_accounts_screen.dart';
 import 'package:zcash_wallet/src/features/accounts/widgets/mobile/account_edit_sheets.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/biometric_unlock_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
@@ -143,9 +145,10 @@ rust_sync.MigrationStatus _activeMigrationStatus() => rust_sync.MigrationStatus(
 );
 
 class _FakeAccountNotifier extends AccountNotifier {
-  _FakeAccountNotifier(this.initialState);
+  _FakeAccountNotifier(this.initialState, {this.removeError});
 
   final AccountState initialState;
+  final Object? removeError;
   var resetCount = 0;
   String? removedUuid;
 
@@ -154,6 +157,7 @@ class _FakeAccountNotifier extends AccountNotifier {
 
   @override
   Future<void> removeAccount(String uuid) async {
+    if (removeError case final error?) throw error;
     removedUuid = uuid;
     final previous = state.value ?? initialState;
     final remaining = [
@@ -558,6 +562,62 @@ void main() {
     expect(syncNotifier.accountSwitchRefreshes, 1);
     expect(syncNotifier.balanceRefreshes, 1);
   });
+
+  for (final testCase in [
+    (
+      name: 'unshared Gift Cards',
+      error: const PaymentLinkUnsharedGiftCardsException(
+        sourceAccountUuid: 'a',
+        count: 1,
+      ),
+      message:
+          'Copy your unshared Gift Card links before deleting this account.',
+    ),
+    (
+      name: 'incoming Gift Cards',
+      error: const PaymentLinkInFlightClaimsException(
+        destinationAccountUuid: 'a',
+        count: 1,
+      ),
+      message:
+          'Wait for incoming Gift Cards to finish before deleting this account.',
+    ),
+  ]) {
+    testWidgets('removal explains ${testCase.name} blockers', (tester) async {
+      final accountState = AccountState(
+        accounts: [_account('a', 'Active'), _account('b', 'Replacement')],
+        activeAccountUuid: 'a',
+      );
+      final accountNotifier = _FakeAccountNotifier(
+        accountState,
+        removeError: testCase.error,
+      );
+      final syncNotifier = _FakeWalletMutationSyncNotifier();
+
+      await tester.pumpWidget(
+        _app(
+          accountState,
+          accountNotifier: () => accountNotifier,
+          syncNotifier: () => syncNotifier,
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byKey(const ValueKey('mobile_accounts_menu_a')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('mobile_account_menu_remove')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('mobile_account_remove_confirm')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(testCase.message), findsOneWidget);
+      expect(find.text("Couldn't remove the account"), findsNothing);
+    });
+  }
 
   testWidgets('row menu stays above the floating tab bar clearance', (
     tester,

--- a/test/features/onboarding/lost_password_screen_test.dart
+++ b/test/features/onboarding/lost_password_screen_test.dart
@@ -1,12 +1,15 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart' show FontLoader, rootBundle;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/onboarding/lost_password_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/forgot_passcode_sheet.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/biometric_unlock_provider.dart';
 import 'package:zcash_wallet/src/providers/device_owner_auth_provider.dart';
@@ -129,6 +132,13 @@ void main() {
       ),
     );
     expect(tester.takeException(), isNull);
+    expect(
+      find.textContaining(
+        'This deletes all accounts and unshared Gift Card links.',
+        findRichText: true,
+      ),
+      findsOneWidget,
+    );
 
     await tester.tap(find.text('Reset Vizor'));
     await tester.pump();
@@ -244,6 +254,125 @@ void main() {
     expect(auth.calls, 1);
     expect(resetCalls, 1);
     expect(find.text(kWalletResetDeviceAuthRequiredMessage), findsNothing);
+  });
+
+  testWidgets('lost-password warns about an in-flight Gift Card, unblocked', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1080, 720);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          deviceOwnerAuthProvider.overrideWithValue(
+            _FakeDeviceOwnerAuth(result: true),
+          ),
+          paymentLinkClaimsInFlightProvider.overrideWith((ref) async => 1),
+        ],
+        child: const MaterialApp(
+          home: AppTheme(
+            data: AppThemeData.light,
+            child: LostPasswordScreen(
+              initialCountdownSeconds: 0,
+              countdownEnabled: false,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Warned, never blocked: reset is the only way back into this wallet, and
+    // the claim cannot finish while it stays locked.
+    expect(
+      find.text(kWalletResetInFlightGiftCardWarningMessage),
+      findsOneWidget,
+    );
+    expect(find.text('This cannot be undone.'), findsNothing);
+    final resetButton = tester.widget<AppButton>(
+      find.widgetWithText(AppButton, 'Reset Vizor'),
+    );
+    expect(resetButton.onPressed, isNotNull);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('lost-password says nothing when no Gift Card is arriving', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1080, 720);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          deviceOwnerAuthProvider.overrideWithValue(
+            _FakeDeviceOwnerAuth(result: true),
+          ),
+          paymentLinkClaimsInFlightProvider.overrideWith((ref) async => 0),
+        ],
+        child: const MaterialApp(
+          home: AppTheme(
+            data: AppThemeData.light,
+            child: LostPasswordScreen(
+              initialCountdownSeconds: 0,
+              countdownEnabled: false,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(kWalletResetInFlightGiftCardWarningMessage), findsNothing);
+    expect(find.text('This cannot be undone.'), findsOneWidget);
+  });
+
+  testWidgets('lost-password shows the in-flight Gift Card refusal in full', (
+    tester,
+  ) async {
+    final auth = _FakeDeviceOwnerAuth(result: true);
+
+    tester.view.physicalSize = const Size(1080, 720);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [deviceOwnerAuthProvider.overrideWithValue(auth)],
+        child: MaterialApp(
+          home: AppTheme(
+            data: AppThemeData.light,
+            child: LostPasswordScreen(
+              initialCountdownSeconds: 0,
+              countdownEnabled: false,
+              onReset: () async =>
+                  throw const WalletResetInFlightGiftCardClaimsException(
+                    count: 1,
+                  ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Reset Vizor'));
+    await tester.pumpAndSettle();
+
+    // Whole sentence, no ellipsis: this is the longest status the screen
+    // shows, and the half that would be cut is the one telling the user what
+    // to do. The card is a fixed 520px box, so a second line overflows it --
+    // the copy has to fit the 348px status line instead.
+    final status = tester.renderObject<RenderParagraph>(
+      find.text(kWalletResetInFlightGiftCardClaimsMessage),
+    );
+    expect(status.didExceedMaxLines, isFalse);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('forgot-passcode helper does not wipe when auth is cancelled', (

--- a/test/features/onboarding/mobile_unlock_screen_payment_uri_test.dart
+++ b/test/features/onboarding/mobile_unlock_screen_payment_uri_test.dart
@@ -108,7 +108,7 @@ PaymentRequestPrecheck _stubPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
-      }) async {},
+      }) async => true,
 );
 
 AppBootstrapState _bootstrap() => AppBootstrapState(

--- a/test/features/onboarding/mobile_unlock_screen_payment_uri_test.dart
+++ b/test/features/onboarding/mobile_unlock_screen_payment_uri_test.dart
@@ -1,0 +1,316 @@
+@Tags(['mobile'])
+library;
+
+// The mobile half of the locked -> unlock -> claim leg of a `zcash:` payment
+// link. See the desktop sibling (unlock_screen_payment_uri_test.dart) for why
+// password verification is faked here.
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_drain_policy.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_unlock_screen.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_intake_provider.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/biometric_unlock_provider.dart';
+import 'package:zcash_wallet/src/providers/migration_send_gate_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_request_flow_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import '../../fakes/fake_sync_notifier.dart';
+
+const _passcode = '123456';
+const _wrongPasscode = '999999';
+
+const _parkedRequest = SendPrefillArgs(
+  id: 'payment-uri-1',
+  source: kPaymentUriPrefillSource,
+  address:
+      'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+      '73d57f73c6dc05121591a83861cd190591',
+  amountText: '0.5',
+  label: 'Coffee shop',
+);
+
+class _FakeSecurityNotifier extends AppSecurityNotifier {
+  @override
+  Future<bool> unlock(String password) async {
+    if (password != _passcode) return false;
+    state = state.copyWith(isUnlocked: true);
+    return true;
+  }
+}
+
+class _FakeAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1unlockedaddress',
+  );
+
+  @override
+  Future<void> restoreAfterUnlock() async {}
+}
+
+class _FakeUnlockSyncNotifier extends FakeSyncNotifier {
+  _FakeUnlockSyncNotifier() : super(SyncState());
+
+  @override
+  Future<void> refreshAfterUnlock() async {}
+
+  @override
+  Future<void> startSyncAnyway() async {}
+}
+
+/// No biometric affordance: the passcode path is the one under test, and the
+/// real notifier probes the platform.
+class _NoBiometricNotifier extends BiometricUnlockNotifier {
+  @override
+  Future<BiometricUnlockState> build() async => BiometricUnlockState.initial;
+}
+
+PaymentRequestPrecheck _stubPrecheck() => PaymentRequestPrecheck(
+  spendableIsAuthoritativeNow: () => true,
+  validateAddress: ({required String address, required String network}) async =>
+      rust_sync.AddressValidationResult(
+        isValid: false,
+        addressType: '',
+        wrongNetwork: false,
+      ),
+  proposeTransfer:
+      ({
+        required String accountUuid,
+        required String sendFlowId,
+        required String address,
+        required String addressType,
+        required BigInt amountZatoshi,
+        String? memo,
+        bool isPaymentRequest = false,
+        String? requestedBy,
+        BigInt? requestedAmountZatoshi,
+      }) async => throw UnimplementedError('not reached'),
+  discardProposal:
+      ({
+        required BigInt proposalId,
+        required String sendFlowId,
+        required String logContext,
+      }) async {},
+);
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/unlock',
+  initialAccountState: const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+  ),
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.light,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: false,
+  passwordRotationRecoveryFailed: false,
+);
+
+List<Override> _overrides({required bool migrationGate}) => [
+  appBootstrapProvider.overrideWithValue(_bootstrap()),
+  appSecurityProvider.overrideWith(_FakeSecurityNotifier.new),
+  accountProvider.overrideWith(_FakeAccountNotifier.new),
+  syncProvider.overrideWith(_FakeUnlockSyncNotifier.new),
+  biometricUnlockProvider.overrideWith(_NoBiometricNotifier.new),
+  migrationSendGateProvider.overrideWithValue(migrationGate),
+  paymentRequestPrecheckProvider.overrideWithValue(_stubPrecheck()),
+];
+
+late GoRouter _router;
+
+Future<ProviderContainer> _pumpUnlock(
+  WidgetTester tester, {
+  bool migrationGate = false,
+}) async {
+  tester.view.physicalSize = const Size(520, 1100);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final container = ProviderContainer(
+    overrides: _overrides(migrationGate: migrationGate),
+  );
+  addTearDown(container.dispose);
+
+  _router = GoRouter(
+    initialLocation: '/unlock',
+    routes: [
+      GoRoute(
+        path: '/unlock',
+        builder: (_, _) => const MobileUnlockScreen(autoPromptBiometric: false),
+      ),
+      GoRoute(
+        path: '/home',
+        builder: (_, _) => const Scaffold(body: Text('home-route')),
+      ),
+      GoRoute(
+        path: '/payment-links',
+        builder: (_, _) => const Scaffold(body: Text('payment-links-route')),
+      ),
+    ],
+  );
+  addTearDown(_router.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        routerConfig: _router,
+        builder: (_, child) =>
+            AppTheme(data: AppThemeData.light, child: child!),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return container;
+}
+
+Future<void> _enterPasscode(WidgetTester tester, String passcode) async {
+  for (final digit in passcode.split('')) {
+    await tester.tap(find.bySemanticsLabel('Digit $digit'));
+    await tester.pump();
+  }
+  await tester.pumpAndSettle();
+}
+
+String _location() => _router.routerDelegate.currentConfiguration.uri.path;
+
+void main() {
+  testWidgets('a fresh parked link becomes a card over the unlocked wallet', (
+    tester,
+  ) async {
+    final container = await _pumpUnlock(tester);
+    container.read(paymentUriPrefillProvider.notifier).set(_parkedRequest);
+
+    await _enterPasscode(tester, _passcode);
+
+    expect(_location(), '/home');
+    final flow = container.read(paymentRequestFlowProvider);
+    expect(flow, isNotNull);
+    expect(flow!.prefill.id, _parkedRequest.id);
+    expect(flow.view.source, PaymentRequestSource.link);
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    expect(find.text(kPaymentUriExpiredMessage), findsNothing);
+  });
+
+  testWidgets('a link parked past the TTL is dropped and said out loud', (
+    tester,
+  ) async {
+    final container = await _pumpUnlock(tester);
+    container.read(paymentUriPrefillProvider.notifier)
+      ..set(_parkedRequest)
+      ..debugAgePark(kPaymentUriParkTtl + const Duration(seconds: 1));
+
+    await _enterPasscode(tester, _passcode);
+
+    expect(_location(), '/home');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    expect(find.text(kPaymentUriExpiredMessage), findsOneWidget);
+  });
+
+  testWidgets('a migration send gate that closed while locked drops the link', (
+    tester,
+  ) async {
+    // `migrationSendGateProvider` reads an Ironwood presentation that is still
+    // unresolved while the wallet is locked, so it can be false when the link
+    // parks and true once the unlock has restored the account. Delivering the
+    // card anyway would offer a send mobile Home has already disabled.
+    final container = await _pumpUnlock(tester, migrationGate: true);
+    container.read(paymentUriPrefillProvider.notifier).set(_parkedRequest);
+
+    await _enterPasscode(tester, _passcode);
+
+    expect(_location(), '/home');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    expect(find.text(kPaymentUriMigrationSendGateMessage), findsOneWidget);
+  });
+
+  testWidgets('a failed unlock leaves the link parked', (tester) async {
+    final container = await _pumpUnlock(tester);
+    container.read(paymentUriPrefillProvider.notifier).set(_parkedRequest);
+
+    await _enterPasscode(tester, _wrongPasscode);
+
+    expect(_location(), '/unlock');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(container.read(paymentUriPrefillProvider), isNotNull);
+  });
+
+  // Both link kinds can be waiting on the same unlock: a `zcash:` request
+  // parked in the prefill and a Gift Card queued in the intake. They do not
+  // compete for one destination — the Gift Card owns the route, the request
+  // card is an overlay that lands on top of it — so the unlock delivers both.
+  testWidgets('a Gift Card picks the destination and the request card lands '
+      'over it', (tester) async {
+    final container = await _pumpUnlock(tester);
+    container.read(paymentUriPrefillProvider.notifier).set(_parkedRequest);
+    expect(
+      container
+          .read(paymentLinkIntakeProvider.notifier)
+          .receive(_pendingPaymentLink.toUri().toString()),
+      PaymentLinkIntakeResult.accepted,
+    );
+
+    await _enterPasscode(tester, _passcode);
+
+    expect(_location(), '/payment-links');
+    final flow = container.read(paymentRequestFlowProvider);
+    expect(flow, isNotNull);
+    expect(flow!.prefill.id, _parkedRequest.id);
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    expect(
+      container.read(paymentLinkIntakeProvider).pendingLink,
+      isNotNull,
+      reason: 'the Payment Links screen claims the Gift Card, not the unlock',
+    );
+  });
+
+  testWidgets('a Gift Card alone routes to the Payment Links screen', (
+    tester,
+  ) async {
+    final container = await _pumpUnlock(tester);
+    expect(
+      container
+          .read(paymentLinkIntakeProvider.notifier)
+          .receive(_pendingPaymentLink.toUri().toString()),
+      PaymentLinkIntakeResult.accepted,
+    );
+
+    await _enterPasscode(tester, _passcode);
+
+    expect(_location(), '/payment-links');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+  });
+}
+
+final _pendingPaymentLink = VizorPaymentLink(
+  network: 'main',
+  address: 'u1pendinggiftcardaddress',
+  amountZatoshi: BigInt.from(100000000),
+  mnemonic: List.filled(24, 'abandon').join(' '),
+  birthdayHeight: 3000000,
+  label: 'Gift Card',
+  createdAt: DateTime.utc(2026, 8, 28),
+);

--- a/test/features/onboarding/mobile_unlock_screen_payment_uri_test.dart
+++ b/test/features/onboarding/mobile_unlock_screen_payment_uri_test.dart
@@ -83,6 +83,7 @@ class _NoBiometricNotifier extends BiometricUnlockNotifier {
 }
 
 PaymentRequestPrecheck _stubPrecheck() => PaymentRequestPrecheck(
+  readNetworkName: () => kZcashDefaultNetworkName,
   spendableIsAuthoritativeNow: () => true,
   validateAddress: ({required String address, required String network}) async =>
       rust_sync.AddressValidationResult(

--- a/test/features/onboarding/mobile_unlock_screen_payment_uri_test.dart
+++ b/test/features/onboarding/mobile_unlock_screen_payment_uri_test.dart
@@ -142,6 +142,7 @@ late GoRouter _router;
 Future<ProviderContainer> _pumpUnlock(
   WidgetTester tester, {
   bool migrationGate = false,
+  bool registerPaymentLinks = true,
 }) async {
   tester.view.physicalSize = const Size(520, 1100);
   tester.view.devicePixelRatio = 1.0;
@@ -164,10 +165,11 @@ Future<ProviderContainer> _pumpUnlock(
         path: '/home',
         builder: (_, _) => const Scaffold(body: Text('home-route')),
       ),
-      GoRoute(
-        path: '/payment-links',
-        builder: (_, _) => const Scaffold(body: Text('payment-links-route')),
-      ),
+      if (registerPaymentLinks)
+        GoRoute(
+          path: '/payment-links',
+          builder: (_, _) => const Scaffold(body: Text('payment-links-route')),
+        ),
     ],
   );
   addTearDown(_router.dispose);
@@ -286,6 +288,22 @@ void main() {
       isNotNull,
       reason: 'the Payment Links screen claims the Gift Card, not the unlock',
     );
+  });
+
+  testWidgets('a Gift Card stays pending after unlock while its surface is '
+      'not registered', (tester) async {
+    final container = await _pumpUnlock(tester, registerPaymentLinks: false);
+    expect(
+      container
+          .read(paymentLinkIntakeProvider.notifier)
+          .receive(_pendingPaymentLink.toUri().toString()),
+      PaymentLinkIntakeResult.accepted,
+    );
+
+    await _enterPasscode(tester, _passcode);
+
+    expect(_location(), '/home');
+    expect(container.read(paymentLinkIntakeProvider).pendingLink, isNotNull);
   });
 
   testWidgets('a Gift Card alone routes to the Payment Links screen', (

--- a/test/features/onboarding/mobile_unlock_screen_test.dart
+++ b/test/features/onboarding/mobile_unlock_screen_test.dart
@@ -6,18 +6,28 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/forgot_passcode_sheet.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_unlock_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/passcode_widgets.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_intake_provider.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 import 'package:zcash_wallet/src/providers/biometric_unlock_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
+import 'package:zcash_wallet/src/providers/device_owner_auth_provider.dart';
+import 'package:zcash_wallet/src/services/device_owner_auth.dart';
 import 'package:zcash_wallet/src/services/biometric_unlock.dart';
 
 /// Just enough of the Rust secret API for password verifier checks.
@@ -103,6 +113,37 @@ class _FailingBiometricNotifier extends BiometricUnlockNotifier {
   }
 }
 
+class _SuccessfulSecurityNotifier extends AppSecurityNotifier {
+  @override
+  AppSecurityState build() =>
+      const AppSecurityState(isPasswordConfigured: true, isUnlocked: false);
+
+  @override
+  Future<bool> unlock(String password) async {
+    state = state.copyWith(isUnlocked: true);
+    return true;
+  }
+}
+
+class _RestoringAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => const AccountState();
+
+  @override
+  Future<void> restoreAfterUnlock() async {}
+}
+
+class _UnlockSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncState> build() async => SyncState();
+
+  @override
+  Future<void> refreshAfterUnlock() async {}
+
+  @override
+  Future<void> startSyncAnyway() async {}
+}
+
 AppBootstrapState _bootstrap({required bool biometricEnabled}) =>
     AppBootstrapState(
       initialLocation: '/unlock',
@@ -123,6 +164,7 @@ Widget _app({
   BiometricUnlockNotifier Function()? biometricNotifier,
   AppBootstrapState? bootstrap,
   bool autoPromptBiometric = true,
+  List<Override> extraOverrides = const [],
 }) {
   return ProviderScope(
     overrides: [
@@ -131,12 +173,78 @@ Widget _app({
         biometricUnlockProvider.overrideWith(biometricNotifier)
       else if (biometric != null)
         biometricUnlockServiceProvider.overrideWithValue(biometric),
+      ...extraOverrides,
     ],
     child: MaterialApp(
       builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
       home: MobileUnlockScreen(autoPromptBiometric: autoPromptBiometric),
     ),
   );
+}
+
+({Widget app, GoRouter router}) _routedUnlockApp({
+  FakeBiometricUnlock? biometric,
+  bool autoPromptBiometric = false,
+}) {
+  final router = GoRouter(
+    initialLocation: '/unlock',
+    routes: [
+      GoRoute(
+        path: '/unlock',
+        builder: (_, _) =>
+            MobileUnlockScreen(autoPromptBiometric: autoPromptBiometric),
+      ),
+      GoRoute(
+        path: '/payment-links',
+        builder: (_, _) => const Text(
+          'Payment link destination',
+          textDirection: TextDirection.ltr,
+        ),
+      ),
+      GoRoute(
+        path: '/home',
+        builder: (_, _) =>
+            const Text('Home destination', textDirection: TextDirection.ltr),
+      ),
+    ],
+  );
+  final app = ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(
+        _bootstrap(biometricEnabled: biometric != null),
+      ),
+      appSecurityProvider.overrideWith(_SuccessfulSecurityNotifier.new),
+      accountProvider.overrideWith(_RestoringAccountNotifier.new),
+      syncProvider.overrideWith(_UnlockSyncNotifier.new),
+      if (biometric != null)
+        biometricUnlockServiceProvider.overrideWithValue(biometric),
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+    ),
+  );
+  return (app: app, router: router);
+}
+
+final _pendingPaymentLink = VizorPaymentLink(
+  network: 'main',
+  address: 'u1pendinggiftcardaddress',
+  amountZatoshi: BigInt.from(100000000),
+  mnemonic: List.filled(24, 'abandon').join(' '),
+  birthdayHeight: 3000000,
+  label: 'Gift Card',
+  createdAt: DateTime.utc(2026, 8, 28),
+);
+
+void _queuePendingPaymentLink(WidgetTester tester) {
+  final container = ProviderScope.containerOf(
+    tester.element(find.byType(MobileUnlockScreen)),
+  );
+  final result = container
+      .read(paymentLinkIntakeProvider.notifier)
+      .receive(_pendingPaymentLink.toUri().toString());
+  expect(result, PaymentLinkIntakeResult.accepted);
 }
 
 Future<void> _pumpAutoBiometricPromptWait(WidgetTester tester) async {
@@ -152,6 +260,64 @@ Future<void> _pumpUntilBiometricRead(
   for (var i = 0; i < 4 && biometric.reads == 0; i += 1) {
     await _pumpAutoBiometricPromptWait(tester);
   }
+}
+
+class _ResetBlockedAccountNotifier extends AccountNotifier {
+  var resets = 0;
+
+  @override
+  FutureOr<AccountState> build() => const AccountState();
+
+  @override
+  Future<void> restoreAfterUnlock() async {}
+
+  @override
+  Future<void> resetWallet() async {
+    resets += 1;
+    throw const WalletResetInFlightGiftCardClaimsException(count: 1);
+  }
+}
+
+class _ResetSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncState> build() async => SyncState();
+
+  // The real snapshot asks Rust whether a sync is running, which the secret-API
+  // fake in this file does not answer.
+  @override
+  bool needsPauseForWalletMutation() => false;
+
+  @override
+  Future<WalletMutationSyncPause> pauseForWalletMutation({
+    FutureOr<void> Function()? onStoppingSync,
+  }) async {
+    return const WalletMutationSyncPause(
+      hadActiveSync: false,
+      hadPolling: false,
+      hadMempoolObserver: false,
+    );
+  }
+
+  @override
+  Future<void> clearSensitiveStateForLock() async {}
+
+  @override
+  void clearCachedWalletDbPath() {}
+}
+
+class _ResetBiometricNotifier extends BiometricUnlockNotifier {
+  @override
+  Future<BiometricUnlockState> build() async => BiometricUnlockState.initial;
+
+  @override
+  Future<void> disable() async {}
+}
+
+class _AlwaysAllowingDeviceOwnerAuth extends DeviceOwnerAuth {
+  _AlwaysAllowingDeviceOwnerAuth() : super(hasOsResetGateOverride: true);
+
+  @override
+  Future<bool> verify({required String reason}) async => true;
 }
 
 void main() {
@@ -181,6 +347,104 @@ void main() {
     await tester.tap(find.text('Cancel'));
     await tester.pumpAndSettle();
     expect(find.text('Forgot Passcode?'), findsNothing);
+  });
+
+  testWidgets('the reset sheet warns about an in-flight Gift Card', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        extraOverrides: [
+          paymentLinkClaimsInFlightProvider.overrideWith((ref) async => 1),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.bySemanticsLabel('Passcode help'));
+    await tester.pumpAndSettle();
+
+    // Warned, never blocked: the claim cannot finish while the wallet stays
+    // locked, and this reset is the only way back in.
+    expect(
+      find.text(kWalletResetInFlightGiftCardWarningMessage),
+      findsOneWidget,
+    );
+    expect(find.text('Continue to reset Vizor'), findsOneWidget);
+  });
+
+  testWidgets('a refused reset reads as a Gift Card wait, not a failure', (
+    tester,
+  ) async {
+    // `resetWallet` no longer refuses on this locked path, so this pins the
+    // backstop: whatever raises the refusal, the screen must say what is
+    // happening rather than fall back to "Couldn't reset the app".
+    late _ResetBlockedAccountNotifier accountNotifier;
+    final router = GoRouter(
+      initialLocation: '/unlock',
+      routes: [
+        GoRoute(
+          path: '/unlock',
+          builder: (_, _) =>
+              const MobileUnlockScreen(autoPromptBiometric: false),
+        ),
+        GoRoute(
+          path: '/welcome',
+          builder: (_, _) => const Text(
+            'Welcome destination',
+            textDirection: TextDirection.ltr,
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(
+            _bootstrap(biometricEnabled: false),
+          ),
+          deviceOwnerAuthProvider.overrideWithValue(
+            _AlwaysAllowingDeviceOwnerAuth(),
+          ),
+          accountProvider.overrideWith(() {
+            accountNotifier = _ResetBlockedAccountNotifier();
+            return accountNotifier;
+          }),
+          syncProvider.overrideWith(_ResetSyncNotifier.new),
+          biometricUnlockProvider.overrideWith(_ResetBiometricNotifier.new),
+          paymentLinkClaimsInFlightProvider.overrideWith((ref) async => 0),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.bySemanticsLabel('Passcode help'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Continue to reset Vizor'));
+    await tester.pumpAndSettle();
+
+    // The second sheet arms after a deliberate countdown.
+    await tester.pump(kForgotPasscodeLastWarningArmDelay);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reset Vizor'));
+    await tester.pumpAndSettle();
+
+    expect(accountNotifier.resets, 1);
+    expect(
+      find.text(kWalletResetInFlightGiftCardClaimsMessage),
+      findsOneWidget,
+    );
+    expect(
+      find.text("Couldn't reset the app. Please try again."),
+      findsNothing,
+    );
+    expect(find.text('Welcome destination'), findsNothing);
   });
 
   testWidgets('renders the numpad and fills dots while typing', (tester) async {
@@ -236,6 +500,74 @@ void main() {
     expect(dots.filled, 1);
 
     await gesture.up();
+  });
+
+  group('unlock destination', () {
+    testWidgets('passcode unlock without a pending Gift Card opens home', (
+      tester,
+    ) async {
+      final routed = _routedUnlockApp();
+      addTearDown(routed.router.dispose);
+      await tester.pumpWidget(routed.app);
+
+      for (final digit in '123456'.split('')) {
+        await tester.tap(find.bySemanticsLabel('Digit $digit'));
+        await tester.pump();
+      }
+      await tester.pumpAndSettle();
+
+      expect(routed.router.state.uri.path, '/home');
+      expect(find.text('Home destination'), findsOneWidget);
+      expect(find.text('Payment link destination'), findsNothing);
+    });
+
+    testWidgets('passcode unlock opens the pending Gift Card once', (
+      tester,
+    ) async {
+      final routed = _routedUnlockApp();
+      addTearDown(routed.router.dispose);
+      await tester.pumpWidget(routed.app);
+      _queuePendingPaymentLink(tester);
+
+      for (final digit in '123456'.split('')) {
+        await tester.tap(find.bySemanticsLabel('Digit $digit'));
+        await tester.pump();
+      }
+      await tester.pumpAndSettle();
+
+      expect(routed.router.state.uri.path, '/payment-links');
+      expect(find.text('Payment link destination'), findsOneWidget);
+      expect(find.text('Home destination'), findsNothing);
+    });
+
+    testWidgets('biometric unlock opens the pending Gift Card once', (
+      tester,
+    ) async {
+      FlutterSecureStorage.setMockInitialValues({});
+      await AppSecureStore.instance.writePlain(
+        kBiometricUnlockEnabledKey,
+        'true',
+      );
+      final biometric = FakeBiometricUnlock(
+        avail: faceAvailability,
+        escrow: '123456',
+      );
+      final routed = _routedUnlockApp(
+        biometric: biometric,
+        autoPromptBiometric: true,
+      );
+      addTearDown(routed.router.dispose);
+      await tester.pumpWidget(routed.app);
+      _queuePendingPaymentLink(tester);
+
+      await _pumpUntilBiometricRead(tester, biometric);
+      await tester.pumpAndSettle();
+
+      expect(biometric.reads, 1);
+      expect(routed.router.state.uri.path, '/payment-links');
+      expect(find.text('Payment link destination'), findsOneWidget);
+      expect(find.text('Home destination'), findsNothing);
+    });
   });
 
   group('haptics', () {

--- a/test/features/onboarding/unlock_screen_payment_uri_test.dart
+++ b/test/features/onboarding/unlock_screen_payment_uri_test.dart
@@ -81,6 +81,7 @@ class _FakeUnlockSyncNotifier extends FakeSyncNotifier {
 /// Ends the card's pre-check without touching Rust: the claim is what these
 /// tests are about, not the verdict the card lands on.
 PaymentRequestPrecheck _stubPrecheck() => PaymentRequestPrecheck(
+  readNetworkName: () => kZcashDefaultNetworkName,
   spendableIsAuthoritativeNow: () => true,
   validateAddress: ({required String address, required String network}) async =>
       rust_sync.AddressValidationResult(

--- a/test/features/onboarding/unlock_screen_payment_uri_test.dart
+++ b/test/features/onboarding/unlock_screen_payment_uri_test.dart
@@ -106,7 +106,7 @@ PaymentRequestPrecheck _stubPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
-      }) async {},
+      }) async => true,
 );
 
 AppBootstrapState _bootstrap() => AppBootstrapState(

--- a/test/features/onboarding/unlock_screen_payment_uri_test.dart
+++ b/test/features/onboarding/unlock_screen_payment_uri_test.dart
@@ -1,0 +1,290 @@
+// The locked -> unlock -> claim leg of a `zcash:` payment link. The drain
+// policy answers `wait` on /unlock precisely so the unlock screen owns the
+// handoff, so nothing else in the fast lane covers it.
+//
+// Password verification itself is faked: these tests are about what the screen
+// does with the parked link once the unlock has succeeded, and the real
+// `AppSecureStore` path serialises through a lock whose first future is created
+// outside the test's fake-async zone.
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_uri_drain_policy.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/password_text_field.dart';
+import 'package:zcash_wallet/src/features/onboarding/unlock_screen.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_intake_provider.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
+import 'package:zcash_wallet/src/features/send/services/payment_request_precheck.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/migration_send_gate_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_request_flow_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+import '../../fakes/fake_sync_notifier.dart';
+
+const _password = 'Password1!';
+
+const _parkedRequest = SendPrefillArgs(
+  id: 'payment-uri-1',
+  source: kPaymentUriPrefillSource,
+  address:
+      'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+      '73d57f73c6dc05121591a83861cd190591',
+  amountText: '0.5',
+  label: 'Coffee shop',
+);
+
+class _FakeSecurityNotifier extends AppSecurityNotifier {
+  @override
+  Future<bool> unlock(String password) async {
+    if (password != _password) return false;
+    state = state.copyWith(isUnlocked: true);
+    return true;
+  }
+}
+
+class _FakeAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1unlockedaddress',
+  );
+
+  @override
+  Future<void> restoreAfterUnlock() async {}
+}
+
+/// The post-unlock sync hooks are the awaits the claim deliberately sits
+/// behind; they must not reach Rust here.
+class _FakeUnlockSyncNotifier extends FakeSyncNotifier {
+  _FakeUnlockSyncNotifier() : super(SyncState());
+
+  @override
+  Future<void> refreshAfterUnlock() async {}
+
+  @override
+  Future<void> startSyncAnyway() async {}
+}
+
+/// Ends the card's pre-check without touching Rust: the claim is what these
+/// tests are about, not the verdict the card lands on.
+PaymentRequestPrecheck _stubPrecheck() => PaymentRequestPrecheck(
+  spendableIsAuthoritativeNow: () => true,
+  validateAddress: ({required String address, required String network}) async =>
+      rust_sync.AddressValidationResult(
+        isValid: false,
+        addressType: '',
+        wrongNetwork: false,
+      ),
+  proposeTransfer:
+      ({
+        required String accountUuid,
+        required String sendFlowId,
+        required String address,
+        required String addressType,
+        required BigInt amountZatoshi,
+        String? memo,
+        bool isPaymentRequest = false,
+        String? requestedBy,
+        BigInt? requestedAmountZatoshi,
+      }) async => throw UnimplementedError('not reached'),
+  discardProposal:
+      ({
+        required BigInt proposalId,
+        required String sendFlowId,
+        required String logContext,
+      }) async {},
+);
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/unlock',
+  initialAccountState: const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+  ),
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.light,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: false,
+  passwordRotationRecoveryFailed: false,
+);
+
+List<Override> _overrides({required bool migrationGate}) => [
+  appBootstrapProvider.overrideWithValue(_bootstrap()),
+  appSecurityProvider.overrideWith(_FakeSecurityNotifier.new),
+  accountProvider.overrideWith(_FakeAccountNotifier.new),
+  syncProvider.overrideWith(_FakeUnlockSyncNotifier.new),
+  migrationSendGateProvider.overrideWithValue(migrationGate),
+  paymentRequestPrecheckProvider.overrideWithValue(_stubPrecheck()),
+];
+
+late GoRouter _router;
+
+Future<ProviderContainer> _pumpUnlock(
+  WidgetTester tester, {
+  bool migrationGate = false,
+}) async {
+  tester.view.physicalSize = const Size(1440, 1024);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final container = ProviderContainer(
+    overrides: _overrides(migrationGate: migrationGate),
+  );
+  addTearDown(container.dispose);
+
+  _router = GoRouter(
+    initialLocation: '/unlock',
+    routes: [
+      GoRoute(path: '/unlock', builder: (_, _) => const UnlockScreen()),
+      GoRoute(
+        path: '/home',
+        builder: (_, _) => const Scaffold(body: Text('home-route')),
+      ),
+      GoRoute(
+        path: '/lost-password',
+        builder: (_, _) => const Scaffold(body: Text('lost-password-route')),
+      ),
+      GoRoute(
+        path: '/payment-links',
+        builder: (_, _) => const Scaffold(body: Text('payment-links-route')),
+      ),
+    ],
+  );
+  addTearDown(_router.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        routerConfig: _router,
+        builder: (_, child) =>
+            AppTheme(data: AppThemeData.light, child: child!),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return container;
+}
+
+Future<void> _unlock(WidgetTester tester) async {
+  await tester.enterText(find.byType(PasswordTextField), _password);
+  await tester.pump();
+  await tester.tap(find.byKey(const ValueKey('unlock_submit_button')));
+  await tester.pumpAndSettle();
+}
+
+String _location() => _router.routerDelegate.currentConfiguration.uri.path;
+
+void main() {
+  testWidgets('a fresh parked link becomes a card over the unlocked wallet', (
+    tester,
+  ) async {
+    final container = await _pumpUnlock(tester);
+    container.read(paymentUriPrefillProvider.notifier).set(_parkedRequest);
+
+    await _unlock(tester);
+
+    expect(_location(), '/home');
+    final flow = container.read(paymentRequestFlowProvider);
+    expect(flow, isNotNull);
+    expect(flow!.prefill.id, _parkedRequest.id);
+    expect(flow.view.source, PaymentRequestSource.link);
+    // Claimed, so a later drain cannot deliver the same link a second time.
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    expect(find.text(kPaymentUriExpiredMessage), findsNothing);
+  });
+
+  testWidgets('a link parked past the TTL is dropped and said out loud', (
+    tester,
+  ) async {
+    final container = await _pumpUnlock(tester);
+    container.read(paymentUriPrefillProvider.notifier)
+      ..set(_parkedRequest)
+      ..debugAgePark(kPaymentUriParkTtl + const Duration(seconds: 1));
+
+    await _unlock(tester);
+
+    expect(_location(), '/home');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    expect(find.text(kPaymentUriExpiredMessage), findsOneWidget);
+  });
+
+  testWidgets('a migration send gate that closed while locked drops the link', (
+    tester,
+  ) async {
+    // The gate reads an Ironwood presentation that is still unresolved while
+    // the wallet is locked, so it can be false when the link parks and true
+    // once the unlock has restored the account. The claim runs the drain
+    // policy for exactly this.
+    final container = await _pumpUnlock(tester, migrationGate: true);
+    container.read(paymentUriPrefillProvider.notifier).set(_parkedRequest);
+
+    await _unlock(tester);
+
+    expect(_location(), '/home');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    expect(find.text(kPaymentUriMigrationSendGateMessage), findsOneWidget);
+  });
+
+  testWidgets('a failed unlock leaves the link parked', (tester) async {
+    final container = await _pumpUnlock(tester);
+    container.read(paymentUriPrefillProvider.notifier).set(_parkedRequest);
+
+    await tester.enterText(find.byType(PasswordTextField), 'WrongPass1!');
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('unlock_submit_button')));
+    await tester.pumpAndSettle();
+
+    expect(_location(), '/unlock');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(container.read(paymentUriPrefillProvider), isNotNull);
+  });
+
+  // The desktop runners never register the HTTPS deeplink, so a queued Gift
+  // Card here can only have come from inside the app. Desktop unlock keeps its
+  // single destination; the mobile sibling is the one with the branch.
+  testWidgets('a queued Gift Card does not divert the desktop unlock', (
+    tester,
+  ) async {
+    final container = await _pumpUnlock(tester);
+    expect(
+      container
+          .read(paymentLinkIntakeProvider.notifier)
+          .receive(_pendingPaymentLink.toUri().toString()),
+      PaymentLinkIntakeResult.accepted,
+    );
+
+    await _unlock(tester);
+
+    expect(_location(), '/home');
+  });
+}
+
+final _pendingPaymentLink = VizorPaymentLink(
+  network: 'main',
+  address: 'u1pendinggiftcardaddress',
+  amountZatoshi: BigInt.from(100000000),
+  mnemonic: List.filled(24, 'abandon').join(' '),
+  birthdayHeight: 3000000,
+  label: 'Gift Card',
+  createdAt: DateTime.utc(2026, 8, 28),
+);

--- a/test/features/payment_links/payment_link_claim_coordinator_provider_test.dart
+++ b/test/features/payment_links/payment_link_claim_coordinator_provider_test.dart
@@ -1,0 +1,223 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_claim_coordinator_provider.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_claim_lifecycle_registry_provider.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_service.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'different claims submit concurrently while duplicate claims join',
+    () async {
+      final first = Completer<PaymentLinkClaimResult>();
+      final second = Completer<PaymentLinkClaimResult>();
+      final submissions = <String>[];
+      final container = ProviderContainer(
+        overrides: [
+          appSecurityProvider.overrideWith(_UnlockedSecurityNotifier.new),
+          paymentLinkClaimRecoveryRunnerProvider.overrideWithValue(
+            () async => const [],
+          ),
+          paymentLinkClaimSubmitterProvider.overrideWithValue((session) {
+            submissions.add(session.link.address);
+            return session.link.address == 'claim-1'
+                ? first.future
+                : second.future;
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+      final coordinator = container.read(paymentLinkClaimCoordinatorProvider);
+      final firstSession = _session('claim-1');
+      final secondSession = _session('claim-2');
+
+      final firstResult = coordinator.submit(firstSession);
+      final duplicateResult = coordinator.submit(firstSession);
+      final secondResult = coordinator.submit(secondSession);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(identical(firstResult, duplicateResult), isTrue);
+      expect(submissions, ['claim-1', 'claim-2']);
+      expect(coordinator.activeSubmissionCount, 2);
+
+      first.complete(_result('tx-1'));
+      second.complete(_result('tx-2'));
+      expect((await firstResult).txids, 'tx-1');
+      expect((await secondResult).txids, 'tx-2');
+      expect(coordinator.activeSubmissionCount, 0);
+    },
+  );
+
+  test('submitting claims resume outside the Gift Card screen', () async {
+    var recoveryCalls = 0;
+    final secondCall = Completer<void>();
+    final container = ProviderContainer(
+      overrides: [
+        appSecurityProvider.overrideWith(_UnlockedSecurityNotifier.new),
+        paymentLinkClaimRecoveryRetryDelayProvider.overrideWithValue(
+          const Duration(milliseconds: 1),
+        ),
+        paymentLinkClaimRecoveryRunnerProvider.overrideWithValue(() async {
+          recoveryCalls++;
+          if (recoveryCalls == 1) return [_submittingRecord];
+          if (!secondCall.isCompleted) secondCall.complete();
+          return [_receivedRecord];
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(paymentLinkClaimCoordinatorProvider);
+    await secondCall.future.timeout(const Duration(seconds: 1));
+
+    expect(recoveryCalls, 2);
+  });
+
+  test('locked startup waits until unlock before restoring claims', () async {
+    final security = _MutableSecurityNotifier(locked: true);
+    final restored = Completer<void>();
+    var recoveryCalls = 0;
+    final container = ProviderContainer(
+      overrides: [
+        appSecurityProvider.overrideWith(() => security),
+        paymentLinkClaimRecoveryRunnerProvider.overrideWithValue(() async {
+          recoveryCalls++;
+          if (!restored.isCompleted) restored.complete();
+          return const [];
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(paymentLinkClaimCoordinatorProvider);
+    await Future<void>.delayed(Duration.zero);
+    expect(recoveryCalls, 0);
+
+    security.unlockForTest();
+    await restored.future.timeout(const Duration(seconds: 1));
+    expect(recoveryCalls, 1);
+  });
+
+  test('wallet reset lifecycle drains and pauses active claims', () async {
+    final first = Completer<PaymentLinkClaimResult>();
+    final container = ProviderContainer(
+      overrides: [
+        appSecurityProvider.overrideWith(_UnlockedSecurityNotifier.new),
+        paymentLinkClaimRecoveryRunnerProvider.overrideWithValue(
+          () async => const [],
+        ),
+        paymentLinkClaimSubmitterProvider.overrideWithValue((session) {
+          if (session.link.address == 'claim-1') return first.future;
+          return Future.value(_result('tx-2'));
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    final coordinator = container.read(paymentLinkClaimCoordinatorProvider);
+    final lifecycle = container.read(paymentLinkClaimLifecycleRegistryProvider);
+    final firstSubmission = coordinator.submit(_session('claim-1'));
+    await Future<void>.delayed(Duration.zero);
+
+    var drained = false;
+    final drain = lifecycle.quiesceAndDrain().then((_) => drained = true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(drained, isFalse);
+    await expectLater(
+      coordinator.submit(_session('claim-2')),
+      throwsStateError,
+    );
+
+    first.complete(_result('tx-1'));
+    await firstSubmission;
+    await drain;
+    expect(coordinator.activeSubmissionCount, 0);
+
+    lifecycle.resume();
+    expect((await coordinator.submit(_session('claim-2'))).txids, 'tx-2');
+  });
+}
+
+PaymentLinkClaimSession _session(String address) {
+  final link = _link(address);
+  return PaymentLinkClaimSession(
+    link: link,
+    destinationAddress: 'destination-$address',
+    destinationAccountUuid: 'destination-account-$address',
+    directory: Directory('/tmp/$address'),
+    dbPath: '/tmp/$address/zcash_wallet.db',
+    accountUuid: 'claim-account-$address',
+    totalZatoshi: BigInt.from(110000),
+    claimableZatoshi: BigInt.from(100000),
+    feeZatoshi: BigInt.from(10000),
+  );
+}
+
+VizorPaymentLink _link(String address) => VizorPaymentLink(
+  network: 'main',
+  address: address,
+  amountZatoshi: BigInt.from(100000),
+  mnemonic:
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+  birthdayHeight: 3000000,
+  label: address,
+  createdAt: DateTime.utc(2026, 9, 1),
+);
+
+PaymentLinkClaimResult _result(String txid) => PaymentLinkClaimResult(
+  txids: txid,
+  status: PaymentLinkClaimBroadcastStatus.broadcasted,
+);
+
+final _receivingRecord = PaymentLinkReceivedRecord(
+  network: 'main',
+  address: 'claim-1',
+  amountZatoshi: BigInt.from(100000),
+  createdAt: DateTime.utc(2026, 9, 1),
+  artworkId: null,
+  status: PaymentLinkReceivedStatus.receiving,
+  claimLink: _link('claim-1'),
+  destinationAccountUuid: 'destination-account-claim-1',
+  claimTxids: 'tx-1',
+  updatedAt: DateTime.utc(2026, 9, 1),
+);
+
+final _submittingRecord = _receivingRecord.copyWith(
+  status: PaymentLinkReceivedStatus.submitting,
+  claimTxids: null,
+);
+
+final _receivedRecord = _receivingRecord.copyWith(
+  status: PaymentLinkReceivedStatus.received,
+  claimLink: null,
+);
+
+class _UnlockedSecurityNotifier extends AppSecurityNotifier {
+  @override
+  AppSecurityState build() =>
+      const AppSecurityState(isPasswordConfigured: true, isUnlocked: true);
+}
+
+class _MutableSecurityNotifier extends AppSecurityNotifier {
+  _MutableSecurityNotifier({required this.locked});
+
+  final bool locked;
+
+  @override
+  AppSecurityState build() =>
+      AppSecurityState(isPasswordConfigured: true, isUnlocked: !locked);
+
+  void unlockForTest() {
+    state = const AppSecurityState(
+      isPasswordConfigured: true,
+      isUnlocked: true,
+    );
+  }
+}

--- a/test/features/payment_links/payment_link_intake_provider_test.dart
+++ b/test/features/payment_links/payment_link_intake_provider_test.dart
@@ -1,0 +1,192 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/navigation/vizor_deep_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_intake_provider.dart';
+
+void main() {
+  test('accepts and exposes a valid Vizor payment link', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final link = _link();
+
+    final result = container
+        .read(paymentLinkIntakeProvider.notifier)
+        .receive(link.toUri().toString());
+
+    expect(result, PaymentLinkIntakeResult.accepted);
+    expect(
+      container.read(paymentLinkIntakeProvider).pendingLink?.address,
+      link.address,
+    );
+    expect(container.read(paymentLinkIntakeProvider).errorMessage, isNull);
+  });
+
+  test('ignores unrelated links so ZIP-321 can share the channel', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final result = container
+        .read(paymentLinkIntakeProvider.notifier)
+        .receive('zcash:u1recipient?amount=1');
+
+    expect(result, PaymentLinkIntakeResult.ignored);
+    expect(container.read(paymentLinkIntakeProvider).pendingLink, isNull);
+
+    expect(
+      container
+          .read(paymentLinkIntakeProvider.notifier)
+          .receive('https://${VizorDeepLink.host}/health'),
+      PaymentLinkIntakeResult.ignored,
+    );
+  });
+
+  test('rejects malformed Vizor links without clearing an earlier secret', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final link = _link();
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    notifier.receive(link.toUri().toString());
+
+    final result = notifier.receive(
+      'https://${VizorDeepLink.host}'
+      '${VizorDeepLink.paymentLinkPath}#v1=not-base64',
+    );
+
+    expect(result, PaymentLinkIntakeResult.rejected);
+    final state = container.read(paymentLinkIntakeProvider);
+    expect(state.pendingLink?.address, link.address);
+    expect(state.errorMessage, isNotNull);
+    expect(state.errorMessage, isNot(contains('not-base64')));
+  });
+
+  test('takePending removes the link from memory', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    final link = _link();
+    notifier.receive(link.toUri().toString());
+
+    final taken = notifier.takePending();
+
+    expect(taken?.address, link.address);
+    expect(container.read(paymentLinkIntakeProvider).pendingLink, isNull);
+  });
+
+  test('queues multiple accepted links in arrival order', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    final first = _link();
+    final second = VizorPaymentLink(
+      network: first.network,
+      address: 'u1secondpaymentlinkaddress',
+      amountZatoshi: BigInt.from(200000),
+      mnemonic: first.mnemonic,
+      birthdayHeight: first.birthdayHeight,
+      label: first.label,
+      createdAt: first.createdAt.add(const Duration(minutes: 1)),
+    );
+
+    notifier.receive(first.toUri().toString());
+    notifier.receive(second.toUri().toString());
+
+    expect(notifier.takePending()?.address, first.address);
+    expect(notifier.takePending()?.address, second.address);
+    expect(notifier.takePending(), isNull);
+  });
+
+  test('coalesces duplicate links without growing the queue', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    final link = _link();
+
+    expect(
+      notifier.receive(link.toUri().toString()),
+      PaymentLinkIntakeResult.accepted,
+    );
+    expect(
+      notifier.receive(link.toUri().toString()),
+      PaymentLinkIntakeResult.accepted,
+    );
+
+    expect(
+      container.read(paymentLinkIntakeProvider).pendingLinks,
+      hasLength(1),
+    );
+  });
+
+  test('only coalesces links with the same complete canonical payload', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+    final original = _link();
+    final changedPayloads = <VizorPaymentLink>[
+      _link(amountZatoshi: original.amountZatoshi + BigInt.one),
+      _link(birthdayHeight: original.birthdayHeight - 1),
+      _link(label: '${original.label} updated'),
+      _link(createdAt: original.createdAt.add(const Duration(seconds: 1))),
+      _link(presentation: const PaymentLinkPresentation(message: 'Updated')),
+    ];
+
+    notifier.receive(original.toUri().toString());
+    for (final changed in changedPayloads) {
+      notifier.receive(changed.toUri().toString());
+    }
+
+    expect(
+      container
+          .read(paymentLinkIntakeProvider)
+          .pendingLinks
+          .map((link) => link.toUri().fragment),
+      [original, ...changedPayloads].map((link) => link.toUri().fragment),
+    );
+  });
+
+  test('rejects unique links beyond the bounded intake queue', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(paymentLinkIntakeProvider.notifier);
+
+    for (var i = 0; i < kPaymentLinkIntakeQueueCapacity; i++) {
+      expect(
+        notifier.receive(
+          _link(address: 'u1paymentlinkaddress$i').toUri().toString(),
+        ),
+        PaymentLinkIntakeResult.accepted,
+      );
+    }
+
+    expect(
+      notifier.receive(
+        _link(address: 'u1paymentlinkoverflow').toUri().toString(),
+      ),
+      PaymentLinkIntakeResult.rejected,
+    );
+    final state = container.read(paymentLinkIntakeProvider);
+    expect(state.pendingLinks, hasLength(kPaymentLinkIntakeQueueCapacity));
+    expect(state.errorMessage, 'Too many payment links are waiting to open.');
+  });
+}
+
+VizorPaymentLink _link({
+  String address = 'u1paymentlinkaddress',
+  BigInt? amountZatoshi,
+  int birthdayHeight = 3_456_789,
+  String label = 'Payment link',
+  DateTime? createdAt,
+  PaymentLinkPresentation? presentation,
+}) {
+  return VizorPaymentLink(
+    network: 'main',
+    address: address,
+    amountZatoshi: amountZatoshi ?? BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: birthdayHeight,
+    label: label,
+    createdAt: createdAt ?? DateTime.utc(2026, 8, 5, 12),
+    presentation: presentation,
+  );
+}

--- a/test/features/payment_links/payment_link_received_store_test.dart
+++ b/test/features/payment_links/payment_link_received_store_test.dart
@@ -1,0 +1,346 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_lifecycle_revision.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
+
+void main() {
+  group('PaymentLinkReceivedStore', () {
+    test('notifies listeners after a lifecycle write', () async {
+      final storage = _FakePaymentLinkReceivedStorage();
+      var revisions = 0;
+      final store = PaymentLinkReceivedStore(
+        storage,
+        onRecordsChanged: () => revisions += 1,
+      );
+
+      await store.saveReady(_link());
+
+      expect(revisions, 1);
+    });
+
+    test(
+      'restores a claim secret and in-flight transaction after restart',
+      () async {
+        final storage = _FakePaymentLinkReceivedStorage();
+        final link = _link();
+        final store = PaymentLinkReceivedStore(storage);
+
+        await store.saveReady(link);
+        await store.markReceiving(
+          address: link.address,
+          destinationAccountUuid: 'receiver-account',
+          claimTxids: 'claim-txid',
+        );
+
+        final restored = await PaymentLinkReceivedStore(storage).load();
+        expect(restored, hasLength(1));
+        expect(restored.single.status, PaymentLinkReceivedStatus.receiving);
+        expect(restored.single.destinationAccountUuid, 'receiver-account');
+        expect(restored.single.claimTxids, 'claim-txid');
+        expect(
+          restored.single.claimLink?.toUri().toString(),
+          link.toUri().toString(),
+        );
+      },
+    );
+
+    test('clears the bearer secret only after the claim is mined', () async {
+      final storage = _FakePaymentLinkReceivedStorage();
+      final link = _link();
+      final store = PaymentLinkReceivedStore(storage);
+
+      await store.saveReady(link);
+      await store.markReceiving(
+        address: link.address,
+        destinationAccountUuid: 'receiver-account',
+        claimTxids: 'claim-txid',
+      );
+      await store.markReceived(address: link.address);
+
+      final restored = await PaymentLinkReceivedStore(storage).load();
+      expect(restored.single.status, PaymentLinkReceivedStatus.received);
+      expect(restored.single.claimLink, isNull);
+      expect(restored.single.claimTxids, 'claim-txid');
+      expect(restored.single.artworkId, 'ruby');
+      expect(restored.single.message, 'Enjoy your gift!');
+      expect(restored.single.amountZatoshi, link.amountZatoshi);
+      expect(storage.value, isNot(contains(link.mnemonic)));
+    });
+
+    test('counts only in-flight claims for the destination account', () async {
+      final storage = _FakePaymentLinkReceivedStorage();
+      final link = _link();
+      final store = PaymentLinkReceivedStore(storage);
+
+      await store.saveReady(link);
+      expect(await store.countReceivingForAccount('receiver-account'), 0);
+
+      await store.markClaimStarted(
+        address: link.address,
+        destinationAccountUuid: 'receiver-account',
+      );
+      expect(await store.countReceivingForAccount('receiver-account'), 1);
+
+      await store.markReadyToClaim(address: link.address);
+      expect(await store.countReceivingForAccount('receiver-account'), 0);
+
+      await store.markReceiving(
+        address: link.address,
+        destinationAccountUuid: 'receiver-account',
+        claimTxids: 'claim-txid',
+      );
+      expect(await store.countReceivingForAccount('receiver-account'), 1);
+      expect(await store.countReceivingForAccount('other-account'), 0);
+
+      await store.markReceived(address: link.address);
+      expect(await store.countReceivingForAccount('receiver-account'), 0);
+    });
+
+    test(
+      'restores a submitting claim before its transaction id is saved',
+      () async {
+        final storage = _FakePaymentLinkReceivedStorage();
+        final link = _link();
+        final store = PaymentLinkReceivedStore(storage);
+
+        await store.saveReady(link);
+        await store.markClaimStarted(
+          address: link.address,
+          destinationAccountUuid: 'receiver-account',
+        );
+
+        final restored = await PaymentLinkReceivedStore(storage).load();
+        expect(restored.single.status, PaymentLinkReceivedStatus.submitting);
+        expect(restored.single.destinationAccountUuid, 'receiver-account');
+        expect(restored.single.claimTxids, isNull);
+        expect(restored.single.isClaimInFlight, isTrue);
+        expect(restored.single.needsClaimMetadataRecovery, isTrue);
+        expect((await store.find(link.address))?.isClaimInFlight, isTrue);
+        expect(await store.find('u1missinggiftcard'), isNull);
+      },
+    );
+
+    test('counts in-flight claims across every account', () async {
+      final storage = _FakePaymentLinkReceivedStorage();
+      final link = _link();
+      final store = PaymentLinkReceivedStore(storage);
+
+      await store.saveReady(link);
+      expect(await store.countClaimsInFlight(), 0);
+
+      await store.markClaimStarted(
+        address: link.address,
+        destinationAccountUuid: 'receiver-account',
+      );
+      expect(await store.countClaimsInFlight(), 1);
+
+      await store.markReceiving(
+        address: link.address,
+        destinationAccountUuid: 'receiver-account',
+        claimTxids: 'claim-txid',
+      );
+      expect(await store.countClaimsInFlight(), 1);
+
+      await store.markReceived(address: link.address);
+      expect(await store.countClaimsInFlight(), 0);
+    });
+
+    test(
+      'refreshes the in-flight claim count after lifecycle writes',
+      () async {
+        final store = _CountingReceivedStore();
+        final container = ProviderContainer(
+          overrides: [
+            paymentLinkReceivedStoreProvider.overrideWithValue(store),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        expect(
+          await container.read(paymentLinkClaimsInFlightProvider.future),
+          1,
+        );
+
+        store.inFlightCount = 0;
+        container.read(paymentLinkLifecycleRevisionProvider.notifier).bump();
+
+        expect(
+          await container.read(paymentLinkClaimsInFlightProvider.future),
+          0,
+        );
+      },
+    );
+
+    test(
+      'refreshes the cached receiving count after lifecycle writes',
+      () async {
+        final store = _CountingReceivedStore();
+        final container = ProviderContainer(
+          overrides: [
+            paymentLinkReceivedStoreProvider.overrideWithValue(store),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        expect(
+          await container.read(
+            paymentLinkReceivingCountProvider('receiver-account').future,
+          ),
+          1,
+        );
+
+        store.count = 0;
+        container.read(paymentLinkLifecycleRevisionProvider.notifier).bump();
+
+        expect(
+          await container.read(
+            paymentLinkReceivingCountProvider('receiver-account').future,
+          ),
+          0,
+        );
+      },
+    );
+
+    test('returns an expired claim to an actionable persisted state', () async {
+      final storage = _FakePaymentLinkReceivedStorage();
+      final link = _link();
+      final store = PaymentLinkReceivedStore(storage);
+
+      await store.saveReady(link);
+      await store.markReceiving(
+        address: link.address,
+        destinationAccountUuid: 'receiver-account',
+        claimTxids: 'claim-txid',
+      );
+      await store.markReadyToClaim(address: link.address);
+
+      final restored = await PaymentLinkReceivedStore(storage).load();
+      expect(restored.single.status, PaymentLinkReceivedStatus.readyToClaim);
+      expect(restored.single.destinationAccountUuid, isNull);
+      expect(restored.single.claimTxids, isNull);
+      expect(
+        restored.single.claimLink?.toUri().toString(),
+        link.toUri().toString(),
+      );
+    });
+
+    test('never persists Receiving without a claim transaction id', () async {
+      final storage = _FakePaymentLinkReceivedStorage();
+      final link = _link();
+      final store = PaymentLinkReceivedStore(storage);
+
+      await store.saveReady(link);
+
+      await expectLater(
+        store.markReceiving(
+          address: link.address,
+          destinationAccountUuid: 'receiver-account',
+          claimTxids: '   ',
+        ),
+        throwsArgumentError,
+      );
+      final restored = await PaymentLinkReceivedStore(storage).load();
+      expect(restored.single.status, PaymentLinkReceivedStatus.readyToClaim);
+    });
+
+    test(
+      'does not reintroduce a secret for an already received card',
+      () async {
+        final storage = _FakePaymentLinkReceivedStorage();
+        final link = _link();
+        final store = PaymentLinkReceivedStore(storage);
+
+        await store.saveReady(link);
+        await store.markReceiving(
+          address: link.address,
+          destinationAccountUuid: 'receiver-account',
+          claimTxids: 'claim-txid',
+        );
+        await store.markReceived(address: link.address);
+        await store.saveReady(link);
+
+        final restored = await PaymentLinkReceivedStore(storage).load();
+        expect(restored.single.status, PaymentLinkReceivedStatus.received);
+        expect(restored.single.claimLink, isNull);
+      },
+    );
+
+    test('fails loud instead of hiding corrupted received-card data', () async {
+      final storage = _FakePaymentLinkReceivedStorage()
+        ..value = jsonEncode({
+          'version': 1,
+          'records': [
+            {
+              'network': 'main',
+              'address': 'u1paymentlinkaddress',
+              'amountZatoshi': '100000',
+              'createdAt': DateTime.utc(2026, 8, 5).toIso8601String(),
+              'artworkId': 'ruby',
+              'status': 'unknown',
+              'claimLink': _link().toUri().toString(),
+              'destinationAccountUuid': null,
+              'claimTxids': null,
+              'updatedAt': DateTime.utc(2026, 8, 5).toIso8601String(),
+            },
+          ],
+        });
+
+      await expectLater(
+        PaymentLinkReceivedStore(storage).load(),
+        throwsA(isA<PaymentLinkReceivedStoreFormatException>()),
+      );
+    });
+  });
+}
+
+VizorPaymentLink _link() {
+  return VizorPaymentLink(
+    network: 'main',
+    address: 'u1paymentlinkaddress',
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 3_456_789,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 8, 5, 12),
+    presentation: const PaymentLinkPresentation(
+      artworkId: 'ruby',
+      message: 'Enjoy your gift!',
+    ),
+  );
+}
+
+class _FakePaymentLinkReceivedStorage implements PaymentLinkReceivedStorage {
+  String? value;
+
+  @override
+  Future<void> delete() async {
+    value = null;
+  }
+
+  @override
+  Future<String?> read() async => value;
+
+  @override
+  Future<void> write(String nextValue) async {
+    value = nextValue;
+  }
+}
+
+class _CountingReceivedStore extends PaymentLinkReceivedStore {
+  _CountingReceivedStore() : super(_FakePaymentLinkReceivedStorage());
+
+  int count = 1;
+  int inFlightCount = 1;
+
+  @override
+  Future<int> countReceivingForAccount(String destinationAccountUuid) async {
+    return count;
+  }
+
+  @override
+  Future<int> countClaimsInFlight() async => inFlightCount;
+}

--- a/test/features/payment_links/payment_link_received_store_test.dart
+++ b/test/features/payment_links/payment_link_received_store_test.dart
@@ -99,6 +99,30 @@ void main() {
       expect(await store.countReceivingForAccount('receiver-account'), 0);
     });
 
+    test('reports the in-flight count while the wallet is locked', () async {
+      final storage = _FakePaymentLinkReceivedStorage();
+      final mirror = _FakeClaimCountMirror();
+      final link = _link();
+      final store = PaymentLinkReceivedStore(storage, countMirror: mirror);
+
+      await store.saveReady(link);
+      await store.markClaimStarted(
+        address: link.address,
+        destinationAccountUuid: 'receiver-account',
+      );
+      expect(mirror.count, 1);
+
+      // The lost-password and forgot-passcode surfaces run locked.
+      storage.locked = true;
+      expect(await store.countClaimsInFlight(), 1);
+
+      storage.locked = false;
+      await store.markReceived(address: link.address);
+      expect(mirror.count, 0);
+      storage.locked = true;
+      expect(await store.countClaimsInFlight(), 0);
+    });
+
     test(
       'restores a submitting claim before its transaction id is saved',
       () async {
@@ -316,17 +340,32 @@ VizorPaymentLink _link() {
 class _FakePaymentLinkReceivedStorage implements PaymentLinkReceivedStorage {
   String? value;
 
+  /// A locked wallet reads its secrets as null.
+  bool locked = false;
+
   @override
   Future<void> delete() async {
     value = null;
   }
 
   @override
-  Future<String?> read() async => value;
+  Future<String?> read() async => locked ? null : value;
 
   @override
   Future<void> write(String nextValue) async {
     value = nextValue;
+  }
+}
+
+class _FakeClaimCountMirror implements PaymentLinkClaimCountMirror {
+  int? count;
+
+  @override
+  Future<int?> read() async => count;
+
+  @override
+  Future<void> write(int next) async {
+    count = next;
   }
 }
 

--- a/test/features/payment_links/payment_link_recovery_reconciler_test.dart
+++ b/test/features/payment_links/payment_link_recovery_reconciler_test.dart
@@ -14,6 +14,7 @@ void main() {
       loadCurrentHeight: () async => BigInt.from(119),
       loadScannedHeight: () async => BigInt.from(119),
       loadTransactionsByAccount: (_) async => const {'source-account': []},
+      loadLinkFundingHistory: (_) async => const [],
     );
 
     final record = (await reconciler.load()).single;
@@ -33,6 +34,7 @@ void main() {
         loadCurrentHeight: () async => BigInt.from(120),
         loadScannedHeight: () async => BigInt.from(120),
         loadTransactionsByAccount: (_) async => const {'source-account': []},
+        loadLinkFundingHistory: (_) async => const [],
       );
 
       expect(await reconciler.load(), isEmpty);
@@ -54,6 +56,7 @@ void main() {
         loadTransactionsByAccount: (_) async => {
           'source-account': [_transaction(txid: _preparedTxid)],
         },
+        loadLinkFundingHistory: (_) async => const [],
       );
 
       final record = (await reconciler.load()).single;
@@ -76,6 +79,7 @@ void main() {
         loadCurrentHeight: () async => BigInt.from(100000),
         loadScannedHeight: () async => BigInt.from(100000),
         loadTransactionsByAccount: (_) async => const {'source-account': []},
+        loadLinkFundingHistory: (_) async => const [],
       );
 
       final record = (await reconciler.load()).single;
@@ -100,6 +104,7 @@ void main() {
           _transaction(txid: _preparedTxid, expiredUnmined: true),
         ],
       },
+      loadLinkFundingHistory: (_) async => const [],
     );
 
     expect(await reconciler.load(), isEmpty);
@@ -115,6 +120,7 @@ void main() {
       loadTransactionsByAccount: (_) async => {
         'source-account': [_transaction(txid: _preparedTxid)],
       },
+      loadLinkFundingHistory: (_) async => const [],
     );
 
     final record = (await reconciler.load()).single;
@@ -131,6 +137,7 @@ void main() {
       loadCurrentHeight: () => throw StateError('offline'),
       loadScannedHeight: () async => BigInt.from(120),
       loadTransactionsByAccount: (_) async => const {'source-account': []},
+      loadLinkFundingHistory: (_) async => const [],
     );
 
     final record = (await reconciler.load()).single;
@@ -149,6 +156,7 @@ void main() {
         loadCurrentHeight: () async => BigInt.from(125),
         loadScannedHeight: () async => BigInt.from(119),
         loadTransactionsByAccount: (_) async => const {'source-account': []},
+        loadLinkFundingHistory: (_) async => const [],
       );
 
       final record = (await reconciler.load()).single;
@@ -169,6 +177,7 @@ void main() {
           _transaction(txid: _preparedTxid, expiredUnmined: true),
         ],
       },
+      loadLinkFundingHistory: (_) async => const [],
     );
 
     expect(await reconciler.load(), isEmpty);
@@ -191,6 +200,7 @@ void main() {
             _transaction(txid: _secondTxid),
           ],
         },
+        loadLinkFundingHistory: (_) async => const [],
       );
 
       expect(await reconciler.load(), hasLength(1));
@@ -213,11 +223,93 @@ void main() {
           _transaction(txid: _preparedTxid, expiredUnmined: true),
         ],
       },
+      loadLinkFundingHistory: (_) async => const [],
     );
 
     final record = (await reconciler.load()).single;
     expect(record.state, PaymentLinkRecoveryState.shared);
   });
+
+  test('funds an ambiguous submission its Gift Card wallet can see', () async {
+    final fixture = await _ambiguousFixture();
+    final reconciler = PaymentLinkRecoveryReconciler(
+      fixture.store,
+      loadCurrentHeight: () async => BigInt.from(200),
+      loadScannedHeight: () async => BigInt.from(200),
+      loadTransactionsByAccount: (_) async => const {'source-account': []},
+      loadLinkFundingHistory: (_) async => [
+        _transaction(txid: _preparedTxid, txKind: 'received'),
+      ],
+    );
+
+    final record = (await reconciler.load()).single;
+
+    expect(record.state, PaymentLinkRecoveryState.funded);
+    expect(record.fundingTxids, _preparedTxid);
+    expect(await reconciler.countUnsharedFundedForAccount('source-account'), 1);
+  });
+
+  test(
+    'retains an ambiguous submission until it can no longer be mined',
+    () async {
+      final fixture = await _ambiguousFixture();
+      final reconciler = PaymentLinkRecoveryReconciler(
+        fixture.store,
+        loadCurrentHeight: () async => BigInt.from(200),
+        loadScannedHeight: () async => BigInt.from(159),
+        loadTransactionsByAccount: (_) async => const {'source-account': []},
+        loadLinkFundingHistory: (_) async => const [],
+      );
+
+      final record = (await reconciler.load()).single;
+
+      expect(record.state, PaymentLinkRecoveryState.draft);
+      expect(record.isAmbiguousSubmission, isTrue);
+      expect(
+        await reconciler.countUnsharedFundedForAccount('source-account'),
+        1,
+      );
+    },
+  );
+
+  test(
+    'removes an ambiguous submission that never reached the chain',
+    () async {
+      final fixture = await _ambiguousFixture();
+      final reconciler = PaymentLinkRecoveryReconciler(
+        fixture.store,
+        loadCurrentHeight: () async => BigInt.from(200),
+        loadScannedHeight: () async => BigInt.from(160),
+        loadTransactionsByAccount: (_) async => const {'source-account': []},
+        loadLinkFundingHistory: (_) async => const [],
+      );
+
+      expect(await reconciler.load(), isEmpty);
+      expect(
+        await reconciler.countUnsharedFundedForAccount('source-account'),
+        0,
+      );
+    },
+  );
+
+  test(
+    'keeps an ambiguous submission when its wallet cannot be read',
+    () async {
+      final fixture = await _ambiguousFixture();
+      final reconciler = PaymentLinkRecoveryReconciler(
+        fixture.store,
+        loadCurrentHeight: () async => BigInt.from(200),
+        loadScannedHeight: () async => BigInt.from(200),
+        loadTransactionsByAccount: (_) async => const {'source-account': []},
+        loadLinkFundingHistory: (_) => throw StateError('claim sync failed'),
+      );
+
+      final record = (await reconciler.load()).single;
+
+      expect(record.state, PaymentLinkRecoveryState.draft);
+      expect(record.isAmbiguousSubmission, isTrue);
+    },
+  );
 
   test('refreshes the cached unshared count after lifecycle writes', () async {
     final reconciler = _CountingRecoveryReconciler();
@@ -297,6 +389,27 @@ _submittedFixture() async {
   return (store: store, storage: storage);
 }
 
+/// A software funding whose broadcast started and whose result never came
+/// back: the draft carries a submission height and no transaction id.
+Future<({PaymentLinkRecoveryStore store, _MemoryStorage storage})>
+_ambiguousFixture() async {
+  final storage = _MemoryStorage();
+  final store = PaymentLinkRecoveryStore(storage);
+  final link = VizorPaymentLink(
+    network: 'main',
+    address: _preparedAddress,
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 100,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 9, 1),
+  );
+  await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+  await store.markSubmissionStarted(address: link.address, chainHeight: 100);
+  return (store: store, storage: storage);
+}
+
 Future<({PaymentLinkRecoveryStore store, _MemoryStorage storage})>
 _fundedFixture({String fundingTxids = _preparedTxid}) async {
   final storage = _MemoryStorage();
@@ -319,6 +432,7 @@ _fundedFixture({String fundingTxids = _preparedTxid}) async {
 rust_sync.TransactionInfo _transaction({
   required String txid,
   bool expiredUnmined = false,
+  String txKind = 'sent',
 }) {
   return rust_sync.TransactionInfo(
     txidHex: txid,
@@ -328,7 +442,7 @@ rust_sync.TransactionInfo _transaction({
     fee: BigInt.from(10000),
     blockTime: BigInt.zero,
     isTransparent: false,
-    txKind: 'sent',
+    txKind: txKind,
     displayAmount: BigInt.from(-110000),
     displayPool: 'shielded',
     createdTime: BigInt.zero,
@@ -355,6 +469,7 @@ class _CountingRecoveryReconciler extends PaymentLinkRecoveryReconciler {
         loadCurrentHeight: () async => BigInt.zero,
         loadScannedHeight: () async => BigInt.zero,
         loadTransactionsByAccount: (_) async => const {},
+        loadLinkFundingHistory: (_) async => const [],
       );
 
   int count = 1;

--- a/test/features/payment_links/payment_link_recovery_reconciler_test.dart
+++ b/test/features/payment_links/payment_link_recovery_reconciler_test.dart
@@ -256,6 +256,26 @@ void main() {
     expect(record.state, PaymentLinkRecoveryState.shared);
   });
 
+  test(
+    'drops a draft that never started its broadcast once it is stale',
+    () async {
+      final fixture = await _inertFixture(
+        updatedAt: DateTime.now().toUtc().subtract(const Duration(hours: 1)),
+      );
+      final reconciler = _reconciler(fixture.store);
+
+      expect(await reconciler.load(), isEmpty);
+    },
+  );
+
+  test('keeps a draft that may still be proposing in this process', () async {
+    final fixture = await _inertFixture(updatedAt: DateTime.now().toUtc());
+    final reconciler = _reconciler(fixture.store);
+
+    final record = (await reconciler.load()).single;
+    expect(record.state, PaymentLinkRecoveryState.draft);
+  });
+
   test('funds an ambiguous submission its Gift Card wallet can see', () async {
     final fixture = await _ambiguousFixture();
     final reconciler = PaymentLinkRecoveryReconciler(
@@ -435,6 +455,39 @@ _ambiguousFixture() async {
   await store.markSubmissionStarted(address: link.address, chainHeight: 100);
   return (store: store, storage: storage);
 }
+
+/// A draft saved before the app died mid-propose: no transaction id and no
+/// submission marker.
+Future<({PaymentLinkRecoveryStore store, _MemoryStorage storage})>
+_inertFixture({required DateTime updatedAt}) async {
+  final storage = _MemoryStorage();
+  final store = PaymentLinkRecoveryStore(storage);
+  final link = VizorPaymentLink(
+    network: 'main',
+    address: _preparedAddress,
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 100,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 9, 1),
+  );
+  await store.saveDraft(
+    link: link,
+    sourceAccountUuid: 'source-account',
+    updatedAt: updatedAt,
+  );
+  return (store: store, storage: storage);
+}
+
+PaymentLinkRecoveryReconciler _reconciler(PaymentLinkRecoveryStore store) =>
+    PaymentLinkRecoveryReconciler(
+      store,
+      loadCurrentHeight: () async => BigInt.from(200),
+      loadScannedHeight: () async => BigInt.from(200),
+      loadTransactionsByAccount: (_) async => const {'source-account': []},
+      loadLinkFundingHistory: (_) async => const [],
+    );
 
 Future<({PaymentLinkRecoveryStore store, _MemoryStorage storage})>
 _fundedFixture({String fundingTxids = _preparedTxid}) async {

--- a/test/features/payment_links/payment_link_recovery_reconciler_test.dart
+++ b/test/features/payment_links/payment_link_recovery_reconciler_test.dart
@@ -1,0 +1,366 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_lifecycle_revision.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_reconciler.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+void main() {
+  test('retains a prepared Gift Card before its transaction expires', () async {
+    final fixture = await _preparedFixture();
+    final reconciler = PaymentLinkRecoveryReconciler(
+      fixture.store,
+      loadCurrentHeight: () async => BigInt.from(119),
+      loadScannedHeight: () async => BigInt.from(119),
+      loadTransactionsByAccount: (_) async => const {'source-account': []},
+    );
+
+    final record = (await reconciler.load()).single;
+
+    expect(record.state, PaymentLinkRecoveryState.draft);
+    expect(record.fundingTxids, _preparedTxid);
+    expect(record.preparedExpiryHeight, 120);
+    expect(await reconciler.countUnsharedFundedForAccount('source-account'), 1);
+  });
+
+  test(
+    'removes a prepared Gift Card once its absent transaction expires',
+    () async {
+      final fixture = await _preparedFixture();
+      final reconciler = PaymentLinkRecoveryReconciler(
+        fixture.store,
+        loadCurrentHeight: () async => BigInt.from(120),
+        loadScannedHeight: () async => BigInt.from(120),
+        loadTransactionsByAccount: (_) async => const {'source-account': []},
+      );
+
+      expect(await reconciler.load(), isEmpty);
+      expect(
+        await reconciler.countUnsharedFundedForAccount('source-account'),
+        0,
+      );
+    },
+  );
+
+  test(
+    'promotes a software draft whose markFunded never landed once it is mined',
+    () async {
+      final fixture = await _submittedFixture();
+      final reconciler = PaymentLinkRecoveryReconciler(
+        fixture.store,
+        loadCurrentHeight: () async => BigInt.from(200),
+        loadScannedHeight: () async => BigInt.from(200),
+        loadTransactionsByAccount: (_) async => {
+          'source-account': [_transaction(txid: _preparedTxid)],
+        },
+      );
+
+      final record = (await reconciler.load()).single;
+
+      expect(record.state, PaymentLinkRecoveryState.funded);
+      expect(record.fundingTxids, _preparedTxid);
+      expect(
+        await reconciler.countUnsharedFundedForAccount('source-account'),
+        1,
+      );
+    },
+  );
+
+  test(
+    'retains a software draft with no expiry height while its tx is unseen',
+    () async {
+      final fixture = await _submittedFixture();
+      final reconciler = PaymentLinkRecoveryReconciler(
+        fixture.store,
+        loadCurrentHeight: () async => BigInt.from(100000),
+        loadScannedHeight: () async => BigInt.from(100000),
+        loadTransactionsByAccount: (_) async => const {'source-account': []},
+      );
+
+      final record = (await reconciler.load()).single;
+
+      expect(record.state, PaymentLinkRecoveryState.draft);
+      expect(record.fundingTxids, _preparedTxid);
+      expect(
+        await reconciler.countUnsharedFundedForAccount('source-account'),
+        1,
+      );
+    },
+  );
+
+  test('removes a software draft whose transaction expired unmined', () async {
+    final fixture = await _submittedFixture();
+    final reconciler = PaymentLinkRecoveryReconciler(
+      fixture.store,
+      loadCurrentHeight: () async => BigInt.from(200),
+      loadScannedHeight: () async => BigInt.from(200),
+      loadTransactionsByAccount: (_) async => {
+        'source-account': [
+          _transaction(txid: _preparedTxid, expiredUnmined: true),
+        ],
+      },
+    );
+
+    expect(await reconciler.load(), isEmpty);
+    expect(await reconciler.countUnsharedFundedForAccount('source-account'), 0);
+  });
+
+  test('promotes a recorded transaction even at its expiry height', () async {
+    final fixture = await _preparedFixture();
+    final reconciler = PaymentLinkRecoveryReconciler(
+      fixture.store,
+      loadCurrentHeight: () async => BigInt.from(120),
+      loadScannedHeight: () async => BigInt.from(120),
+      loadTransactionsByAccount: (_) async => {
+        'source-account': [_transaction(txid: _preparedTxid)],
+      },
+    );
+
+    final record = (await reconciler.load()).single;
+
+    expect(record.state, PaymentLinkRecoveryState.funded);
+    expect(record.fundingTxids, _preparedTxid);
+    expect(record.preparedExpiryHeight, isNull);
+  });
+
+  test('retains prepared metadata when chain lookup is unavailable', () async {
+    final fixture = await _preparedFixture();
+    final reconciler = PaymentLinkRecoveryReconciler(
+      fixture.store,
+      loadCurrentHeight: () => throw StateError('offline'),
+      loadScannedHeight: () async => BigInt.from(120),
+      loadTransactionsByAccount: (_) async => const {'source-account': []},
+    );
+
+    final record = (await reconciler.load()).single;
+
+    expect(record.state, PaymentLinkRecoveryState.draft);
+    expect(record.fundingTxids, _preparedTxid);
+    expect(record.preparedExpiryHeight, 120);
+  });
+
+  test(
+    'retains an expired prepared Gift Card until wallet scan catches up',
+    () async {
+      final fixture = await _preparedFixture();
+      final reconciler = PaymentLinkRecoveryReconciler(
+        fixture.store,
+        loadCurrentHeight: () async => BigInt.from(125),
+        loadScannedHeight: () async => BigInt.from(119),
+        loadTransactionsByAccount: (_) async => const {'source-account': []},
+      );
+
+      final record = (await reconciler.load()).single;
+
+      expect(record.fundingTxids, _preparedTxid);
+      expect(record.preparedExpiryHeight, 120);
+    },
+  );
+
+  test('removes unshared funding when every transaction expires', () async {
+    final fixture = await _fundedFixture();
+    final reconciler = PaymentLinkRecoveryReconciler(
+      fixture.store,
+      loadCurrentHeight: () async => BigInt.zero,
+      loadScannedHeight: () async => BigInt.zero,
+      loadTransactionsByAccount: (_) async => {
+        'source-account': [
+          _transaction(txid: _preparedTxid, expiredUnmined: true),
+        ],
+      },
+    );
+
+    expect(await reconciler.load(), isEmpty);
+    expect(await reconciler.countUnsharedFundedForAccount('source-account'), 0);
+  });
+
+  test(
+    'retains unshared funding while any transaction may hold funds',
+    () async {
+      final fixture = await _fundedFixture(
+        fundingTxids: '$_preparedTxid,$_secondTxid',
+      );
+      final reconciler = PaymentLinkRecoveryReconciler(
+        fixture.store,
+        loadCurrentHeight: () async => BigInt.zero,
+        loadScannedHeight: () async => BigInt.zero,
+        loadTransactionsByAccount: (_) async => {
+          'source-account': [
+            _transaction(txid: _preparedTxid, expiredUnmined: true),
+            _transaction(txid: _secondTxid),
+          ],
+        },
+      );
+
+      expect(await reconciler.load(), hasLength(1));
+      expect(
+        await reconciler.countUnsharedFundedForAccount('source-account'),
+        1,
+      );
+    },
+  );
+
+  test('never removes a shared funding recovery', () async {
+    final fixture = await _fundedFixture();
+    await fixture.store.markShared(address: _preparedAddress);
+    final reconciler = PaymentLinkRecoveryReconciler(
+      fixture.store,
+      loadCurrentHeight: () async => BigInt.zero,
+      loadScannedHeight: () async => BigInt.zero,
+      loadTransactionsByAccount: (_) async => {
+        'source-account': [
+          _transaction(txid: _preparedTxid, expiredUnmined: true),
+        ],
+      },
+    );
+
+    final record = (await reconciler.load()).single;
+    expect(record.state, PaymentLinkRecoveryState.shared);
+  });
+
+  test('refreshes the cached unshared count after lifecycle writes', () async {
+    final reconciler = _CountingRecoveryReconciler();
+    final container = ProviderContainer(
+      overrides: [
+        paymentLinkRecoveryReconcilerProvider.overrideWithValue(reconciler),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      await container.read(
+        paymentLinkUnsharedFundedCountProvider('source-account').future,
+      ),
+      1,
+    );
+
+    reconciler.count = 0;
+    container.read(paymentLinkLifecycleRevisionProvider.notifier).bump();
+
+    expect(
+      await container.read(
+        paymentLinkUnsharedFundedCountProvider('source-account').future,
+      ),
+      0,
+    );
+  });
+}
+
+const _preparedTxid =
+    '9909fe99c789029bf118c88bd9ee33ed35965fd0f3154dd1a8ec6daa4974c7e3';
+const _secondTxid =
+    '7fe86d43f8a80849899092537e237931551574bd8e0938219d114ac0d06d1151';
+const _preparedAddress = 'u1preparedgiftcardaddress';
+
+Future<({PaymentLinkRecoveryStore store, _MemoryStorage storage})>
+_preparedFixture() async {
+  final storage = _MemoryStorage();
+  final store = PaymentLinkRecoveryStore(storage);
+  final link = VizorPaymentLink(
+    network: 'main',
+    address: _preparedAddress,
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 100,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 9, 1),
+  );
+  await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+  await store.markPrepared(
+    address: link.address,
+    fundingTxid: _preparedTxid,
+    expiryHeight: 120,
+  );
+  return (store: store, storage: storage);
+}
+
+/// A software funding whose broadcast landed but whose `markFunded` promotion
+/// never did: the draft carries its transaction id and no expiry height.
+Future<({PaymentLinkRecoveryStore store, _MemoryStorage storage})>
+_submittedFixture() async {
+  final storage = _MemoryStorage();
+  final store = PaymentLinkRecoveryStore(storage);
+  final link = VizorPaymentLink(
+    network: 'main',
+    address: _preparedAddress,
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 100,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 9, 1),
+  );
+  await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+  await store.markSubmitted(address: link.address, fundingTxids: _preparedTxid);
+  return (store: store, storage: storage);
+}
+
+Future<({PaymentLinkRecoveryStore store, _MemoryStorage storage})>
+_fundedFixture({String fundingTxids = _preparedTxid}) async {
+  final storage = _MemoryStorage();
+  final store = PaymentLinkRecoveryStore(storage);
+  final link = VizorPaymentLink(
+    network: 'main',
+    address: _preparedAddress,
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 100,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 9, 1),
+  );
+  await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+  await store.markFunded(address: _preparedAddress, fundingTxids: fundingTxids);
+  return (store: store, storage: storage);
+}
+
+rust_sync.TransactionInfo _transaction({
+  required String txid,
+  bool expiredUnmined = false,
+}) {
+  return rust_sync.TransactionInfo(
+    txidHex: txid,
+    minedHeight: expiredUnmined ? BigInt.zero : BigInt.from(119),
+    expiredUnmined: expiredUnmined,
+    accountBalanceDelta: -110000,
+    fee: BigInt.from(10000),
+    blockTime: BigInt.zero,
+    isTransparent: false,
+    txKind: 'sent',
+    displayAmount: BigInt.from(-110000),
+    displayPool: 'shielded',
+    createdTime: BigInt.zero,
+  );
+}
+
+class _MemoryStorage implements PaymentLinkRecoveryStorage {
+  String? value;
+
+  @override
+  Future<void> delete() async => value = null;
+
+  @override
+  Future<String?> read() async => value;
+
+  @override
+  Future<void> write(String nextValue) async => value = nextValue;
+}
+
+class _CountingRecoveryReconciler extends PaymentLinkRecoveryReconciler {
+  _CountingRecoveryReconciler()
+    : super(
+        PaymentLinkRecoveryStore(_MemoryStorage()),
+        loadCurrentHeight: () async => BigInt.zero,
+        loadScannedHeight: () async => BigInt.zero,
+        loadTransactionsByAccount: (_) async => const {},
+      );
+
+  int count = 1;
+
+  @override
+  Future<int> countUnsharedFundedForAccount(String sourceAccountUuid) async {
+    return count;
+  }
+}

--- a/test/features/payment_links/payment_link_recovery_reconciler_test.dart
+++ b/test/features/payment_links/payment_link_recovery_reconciler_test.dart
@@ -70,6 +70,32 @@ void main() {
     },
   );
 
+  test('promotes a multi-transaction software draft only once every id is '
+      'mined', () async {
+    final fixture = await _submittedFixture(
+      fundingTxids: '$_preparedTxid,$_secondTxid',
+    );
+    PaymentLinkRecoveryReconciler reconciler(List<String> mined) =>
+        PaymentLinkRecoveryReconciler(
+          fixture.store,
+          loadCurrentHeight: () async => BigInt.from(200),
+          loadScannedHeight: () async => BigInt.from(200),
+          loadTransactionsByAccount: (_) async => {
+            'source-account': [
+              for (final txid in mined) _transaction(txid: txid),
+            ],
+          },
+          loadLinkFundingHistory: (_) async => const [],
+        );
+
+    var record = (await reconciler([_preparedTxid]).load()).single;
+    expect(record.state, PaymentLinkRecoveryState.draft);
+
+    record = (await reconciler([_preparedTxid, _secondTxid]).load()).single;
+    expect(record.state, PaymentLinkRecoveryState.funded);
+    expect(record.fundingTxids, '$_preparedTxid,$_secondTxid');
+  });
+
   test(
     'retains a software draft with no expiry height while its tx is unseen',
     () async {
@@ -371,7 +397,7 @@ _preparedFixture() async {
 /// A software funding whose broadcast landed but whose `markFunded` promotion
 /// never did: the draft carries its transaction id and no expiry height.
 Future<({PaymentLinkRecoveryStore store, _MemoryStorage storage})>
-_submittedFixture() async {
+_submittedFixture({String fundingTxids = _preparedTxid}) async {
   final storage = _MemoryStorage();
   final store = PaymentLinkRecoveryStore(storage);
   final link = VizorPaymentLink(
@@ -385,7 +411,7 @@ _submittedFixture() async {
     createdAt: DateTime.utc(2026, 9, 1),
   );
   await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
-  await store.markSubmitted(address: link.address, fundingTxids: _preparedTxid);
+  await store.markSubmitted(address: link.address, fundingTxids: fundingTxids);
   return (store: store, storage: storage);
 }
 

--- a/test/features/payment_links/payment_link_recovery_reconciler_test.dart
+++ b/test/features/payment_links/payment_link_recovery_reconciler_test.dart
@@ -284,7 +284,12 @@ void main() {
       loadScannedHeight: () async => BigInt.from(200),
       loadTransactionsByAccount: (_) async => const {'source-account': []},
       loadLinkFundingHistory: (_) async => [
-        _transaction(txid: _preparedTxid, txKind: 'received'),
+        // The promised funding: amount plus the claim fee reserve.
+        _transaction(
+          txid: _preparedTxid,
+          txKind: 'received',
+          accountBalanceDelta: 110000,
+        ),
       ],
     );
 
@@ -293,6 +298,28 @@ void main() {
     expect(record.state, PaymentLinkRecoveryState.funded);
     expect(record.fundingTxids, _preparedTxid);
     expect(await reconciler.countUnsharedFundedForAccount('source-account'), 1);
+  });
+
+  test('an unrelated receive does not fund an ambiguous submission', () async {
+    final fixture = await _ambiguousFixture();
+    final reconciler = PaymentLinkRecoveryReconciler(
+      fixture.store,
+      loadCurrentHeight: () async => BigInt.from(120),
+      loadScannedHeight: () async => BigInt.from(120),
+      loadTransactionsByAccount: (_) async => const {'source-account': []},
+      loadLinkFundingHistory: (_) async => [
+        _transaction(
+          txid: _secondTxid,
+          txKind: 'received',
+          accountBalanceDelta: 5000,
+        ),
+      ],
+    );
+
+    final record = (await reconciler.load()).single;
+
+    expect(record.state, PaymentLinkRecoveryState.draft);
+    expect(record.fundingTxids, isNull);
   });
 
   test(
@@ -512,12 +539,13 @@ rust_sync.TransactionInfo _transaction({
   required String txid,
   bool expiredUnmined = false,
   String txKind = 'sent',
+  int accountBalanceDelta = -110000,
 }) {
   return rust_sync.TransactionInfo(
     txidHex: txid,
     minedHeight: expiredUnmined ? BigInt.zero : BigInt.from(119),
     expiredUnmined: expiredUnmined,
-    accountBalanceDelta: -110000,
+    accountBalanceDelta: accountBalanceDelta,
     fee: BigInt.from(10000),
     blockTime: BigInt.zero,
     isTransparent: false,

--- a/test/features/payment_links/payment_link_recovery_store_test.dart
+++ b/test/features/payment_links/payment_link_recovery_store_test.dart
@@ -1,0 +1,550 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
+
+void main() {
+  group('PaymentLinkRecoveryStore', () {
+    test(
+      'persists the secret before broadcast and records funding success',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage();
+        final store = PaymentLinkRecoveryStore(storage);
+        final link = _link();
+
+        final funding = await PaymentLinkFundingRecovery(store).fund(
+          link: link,
+          sourceAccountUuid: 'source-account',
+          createTransaction: () async {
+            final restartedRecords = await PaymentLinkRecoveryStore(
+              storage,
+            ).load();
+            expect(restartedRecords, hasLength(1));
+            expect(
+              restartedRecords.single.state,
+              PaymentLinkRecoveryState.draft,
+            );
+            expect(restartedRecords.single.link.mnemonic, link.mnemonic);
+            return 'funding-txid';
+          },
+          fundingTxids: (txid) => txid,
+        );
+
+        expect(funding.transaction, 'funding-txid');
+        expect(funding.recoveryError, isNull);
+        final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+        expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
+        expect(restartedRecords.single.fundingTxids, 'funding-txid');
+      },
+    );
+
+    test(
+      'transaction failure leaves the draft recoverable after restart',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage();
+        final link = _link();
+
+        await expectLater(
+          PaymentLinkFundingRecovery(
+            PaymentLinkRecoveryStore(storage),
+          ).fund<String>(
+            link: link,
+            sourceAccountUuid: 'source-account',
+            createTransaction: () => throw StateError('transaction failed'),
+            fundingTxids: (txid) => txid,
+          ),
+          throwsStateError,
+        );
+
+        final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+        expect(restartedRecords, hasLength(1));
+        expect(restartedRecords.single.state, PaymentLinkRecoveryState.draft);
+        expect(restartedRecords.single.link.toUri(), link.toUri());
+      },
+    );
+
+    test('definitive pre-submission failure removes its inert draft', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final link = _link();
+      final failure = StateError('insufficient balance');
+
+      await expectLater(
+        PaymentLinkFundingRecovery(
+          PaymentLinkRecoveryStore(storage),
+        ).fund<String>(
+          link: link,
+          sourceAccountUuid: 'source-account',
+          createTransaction: () =>
+              throw PaymentLinkFundingNotSubmittedException(
+                failure,
+                StackTrace.current,
+              ),
+          fundingTxids: (txid) => txid,
+        ),
+        throwsA(same(failure)),
+      );
+
+      expect(await PaymentLinkRecoveryStore(storage).load(), isEmpty);
+    });
+
+    test('notifies listeners after a lifecycle write', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      var revisions = 0;
+      final store = PaymentLinkRecoveryStore(
+        storage,
+        onRecordsChanged: () => revisions += 1,
+      );
+
+      await store.saveDraft(link: _link(), sourceAccountUuid: 'source-account');
+
+      expect(revisions, 1);
+    });
+
+    test('retries a transient funding metadata write failure', () async {
+      final storage = _FakePaymentLinkRecoveryStorage(failOnWrites: {2});
+      final link = _link();
+
+      final funding =
+          await PaymentLinkFundingRecovery(
+            PaymentLinkRecoveryStore(storage),
+          ).fund(
+            link: link,
+            sourceAccountUuid: 'source-account',
+            createTransaction: () async => 'funding-txid',
+            fundingTxids: (txid) => txid,
+          );
+
+      expect(funding.transaction, 'funding-txid');
+      expect(funding.recoveryError, isNull);
+      final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+      expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
+      expect(restartedRecords.single.fundingTxids, 'funding-txid');
+    });
+
+    test(
+      'returns the broadcast result when funding metadata cannot be updated',
+      () async {
+        // Writes: 1 saveDraft, 2 markSubmitted, 3+4 the two markFunded
+        // attempts. A storage outage spanning all of them is the one case that
+        // still loses the transaction id.
+        final storage = _FakePaymentLinkRecoveryStorage(
+          failOnWrites: {2, 3, 4},
+        );
+        final link = _link();
+        var transactionCount = 0;
+
+        final funding =
+            await PaymentLinkFundingRecovery(
+              PaymentLinkRecoveryStore(storage),
+            ).fund(
+              link: link,
+              sourceAccountUuid: 'source-account',
+              createTransaction: () async {
+                transactionCount += 1;
+                return 'funding-txid';
+              },
+              fundingTxids: (txid) => txid,
+            );
+
+        expect(funding.transaction, 'funding-txid');
+        expect(funding.recoveryError, isA<StateError>());
+        expect(funding.recoveryStackTrace, isNotNull);
+        expect(transactionCount, 1);
+        final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+        expect(restartedRecords.single.state, PaymentLinkRecoveryState.draft);
+        expect(restartedRecords.single.fundingTxids, isNull);
+        expect(restartedRecords.single.link.mnemonic, link.mnemonic);
+      },
+    );
+
+    test('persists the prepared hardware txid before broadcast', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+
+      await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+      await store.markPrepared(
+        address: link.address,
+        fundingTxid: 'prepared-hardware-txid',
+        expiryHeight: 3_456_829,
+      );
+
+      final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+      expect(restartedRecords.single.state, PaymentLinkRecoveryState.draft);
+      expect(restartedRecords.single.fundingTxids, 'prepared-hardware-txid');
+      expect(restartedRecords.single.preparedExpiryHeight, 3_456_829);
+      expect(await store.countUnsharedFundedForAccount('source-account'), 1);
+    });
+
+    test('removes a definitely canceled hardware draft', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+      await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+      await store.markPrepared(
+        address: link.address,
+        fundingTxid: 'prepared-hardware-txid',
+        expiryHeight: 3_456_829,
+      );
+
+      await store.removeUnbroadcastDraft(address: link.address);
+
+      expect(await store.load(), isEmpty);
+      expect(await store.countUnsharedFundedForAccount('source-account'), 0);
+    });
+
+    test(
+      'keeps the prepared txid when post-broadcast metadata retries fail',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage(failOnWrites: {3, 4});
+        final store = PaymentLinkRecoveryStore(storage);
+        final link = _link();
+        await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+        await store.markPrepared(
+          address: link.address,
+          fundingTxid: 'prepared-hardware-txid',
+          expiryHeight: 3_456_829,
+        );
+
+        final funding = await PaymentLinkFundingRecovery(store).complete(
+          transaction: 'accepted-broadcast',
+          address: link.address,
+          fundingTxids: (_) => 'prepared-hardware-txid',
+        );
+
+        expect(funding.transaction, 'accepted-broadcast');
+        expect(funding.fundingMetadataSaved, isFalse);
+        final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+        expect(restartedRecords.single.state, PaymentLinkRecoveryState.draft);
+        expect(restartedRecords.single.fundingTxids, 'prepared-hardware-txid');
+        expect(restartedRecords.single.preparedExpiryHeight, 3_456_829);
+        expect(await store.countUnsharedFundedForAccount('source-account'), 1);
+      },
+    );
+
+    test('rejects a broadcast result for a different prepared txid', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+      await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+      await store.markPrepared(
+        address: link.address,
+        fundingTxid: 'prepared-hardware-txid',
+        expiryHeight: 3_456_829,
+      );
+
+      await expectLater(
+        store.markFunded(
+          address: link.address,
+          fundingTxids: 'different-hardware-txid',
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('records pending transaction ids before status handling', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+
+      final funding = await PaymentLinkFundingRecovery(store).fund(
+        link: link,
+        sourceAccountUuid: 'source-account',
+        createTransaction: () async =>
+            (txids: 'pending-funding-txid', status: 'pending_broadcast'),
+        fundingTxids: (result) => result.txids,
+      );
+
+      expect(funding.transaction.status, 'pending_broadcast');
+      expect(funding.recoveryError, isNull);
+      final restartedRecords = await PaymentLinkRecoveryStore(storage).load();
+      expect(restartedRecords.single.state, PaymentLinkRecoveryState.funded);
+      expect(restartedRecords.single.fundingTxids, 'pending-funding-txid');
+    });
+
+    test('counts only funded links that have not been shared', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final first = _link();
+      final second = VizorPaymentLink(
+        network: first.network,
+        address: 'u1secondpaymentlinkaddress',
+        amountZatoshi: first.amountZatoshi,
+        mnemonic: first.mnemonic,
+        birthdayHeight: first.birthdayHeight,
+        label: first.label,
+        createdAt: first.createdAt,
+      );
+
+      await store.saveDraft(link: first, sourceAccountUuid: 'source-account');
+      await store.markFunded(
+        address: first.address,
+        fundingTxids: 'funding-txid',
+      );
+      await store.saveDraft(link: second, sourceAccountUuid: 'source-account');
+      await store.markFunded(
+        address: second.address,
+        fundingTxids: 'second-funding-txid',
+      );
+      await store.markShared(address: second.address);
+
+      expect(await store.countUnsharedFundedForAccount('source-account'), 1);
+      expect(await store.countUnsharedFundedForAccount('other-account'), 0);
+    });
+
+    test('removes only matching unshared funding after it expires', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+      await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+      await store.markFunded(
+        address: link.address,
+        fundingTxids: 'funding-txid',
+      );
+
+      await expectLater(
+        store.removeUnsharedExpiredFunding(
+          address: link.address,
+          fundingTxids: 'different-txid',
+        ),
+        throwsStateError,
+      );
+      expect(await store.load(), hasLength(1));
+
+      await store.removeUnsharedExpiredFunding(
+        address: link.address,
+        fundingTxids: 'funding-txid',
+      );
+      expect(await store.load(), isEmpty);
+    });
+
+    test('never removes a shared funding recovery', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+      await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+      await store.markFunded(
+        address: link.address,
+        fundingTxids: 'funding-txid',
+      );
+      await store.markShared(address: link.address);
+
+      await expectLater(
+        store.removeUnsharedExpiredFunding(
+          address: link.address,
+          fundingTxids: 'funding-txid',
+        ),
+        throwsStateError,
+      );
+
+      expect(
+        (await store.load()).single.state,
+        PaymentLinkRecoveryState.shared,
+      );
+    });
+
+    test('ignores record fields outside the v1 schema', () async {
+      final link = _link();
+      final storage = _FakePaymentLinkRecoveryStorage()
+        ..value = jsonEncode({
+          'version': 1,
+          'records': [
+            {
+              'link': link.toUri().toString(),
+              'sourceAccountUuid': 'source-account',
+              'state': 'shared',
+              'fundingTxids': 'funding-txid',
+              'archivedAt': '2026-08-05T00:00:00.000Z',
+              'updatedAt': DateTime.utc(2026, 8, 5).toIso8601String(),
+            },
+          ],
+        });
+
+      final record = (await PaymentLinkRecoveryStore(storage).load()).single;
+
+      expect(record.state, PaymentLinkRecoveryState.shared);
+      expect(record.fundingTxids, 'funding-txid');
+      expect(record.link.mnemonic, link.mnemonic);
+    });
+
+    test('rejects recovery states outside the v1 schema', () async {
+      final link = _link();
+      final storage = _FakePaymentLinkRecoveryStorage()
+        ..value = jsonEncode({
+          'version': 1,
+          'records': [
+            {
+              'link': link.toUri().toString(),
+              'sourceAccountUuid': 'source-account',
+              'state': 'unsupported',
+              'fundingTxids': 'funding-txid',
+              'updatedAt': DateTime.utc(2026, 8, 5).toIso8601String(),
+            },
+          ],
+        });
+
+      await expectLater(
+        PaymentLinkRecoveryStore(storage).load(),
+        throwsA(isA<PaymentLinkRecoveryStoreFormatException>()),
+      );
+    });
+
+    test('rejects an expiry height with no funding transaction', () async {
+      final link = _link();
+      final storage = _FakePaymentLinkRecoveryStorage()
+        ..value = jsonEncode({
+          'version': 1,
+          'records': [
+            {
+              'link': link.toUri().toString(),
+              'sourceAccountUuid': 'source-account',
+              'state': 'draft',
+              'fundingTxids': null,
+              'preparedExpiryHeight': 120,
+              'updatedAt': DateTime.utc(2026, 8, 5).toIso8601String(),
+            },
+          ],
+        });
+
+      await expectLater(
+        PaymentLinkRecoveryStore(storage).load(),
+        throwsA(isA<PaymentLinkRecoveryStoreFormatException>()),
+      );
+    });
+
+    test('reads a software draft that carries only its funding txid', () async {
+      final link = _link();
+      final storage = _FakePaymentLinkRecoveryStorage()
+        ..value = jsonEncode({
+          'version': 1,
+          'records': [
+            {
+              'link': link.toUri().toString(),
+              'sourceAccountUuid': 'source-account',
+              'state': 'draft',
+              'fundingTxids': 'submitted-software-txid',
+              'preparedExpiryHeight': null,
+              'updatedAt': DateTime.utc(2026, 8, 5).toIso8601String(),
+            },
+          ],
+        });
+
+      final record = (await PaymentLinkRecoveryStore(storage).load()).single;
+
+      expect(record.state, PaymentLinkRecoveryState.draft);
+      expect(record.fundingTxids, 'submitted-software-txid');
+      expect(record.preparedExpiryHeight, isNull);
+    });
+
+    test(
+      'a software draft whose markFunded never landed keeps its funding txid',
+      () async {
+        // Writes: 1 saveDraft, 2 markSubmitted, 3+4 the two markFunded
+        // attempts. Only the promotion fails, so the broadcast transaction has
+        // to survive on the draft.
+        final storage = _FakePaymentLinkRecoveryStorage(
+          failOnWrites: const {3, 4},
+        );
+        final link = _link();
+
+        final funding =
+            await PaymentLinkFundingRecovery(
+              PaymentLinkRecoveryStore(storage),
+            ).fund(
+              link: link,
+              sourceAccountUuid: 'source-account',
+              createTransaction: () async => 'funding-txid',
+              fundingTxids: (txid) => txid,
+            );
+
+        expect(funding.fundingMetadataSaved, isFalse);
+
+        final restarted = PaymentLinkRecoveryStore(storage);
+        final record = (await restarted.load()).single;
+        expect(record.state, PaymentLinkRecoveryState.draft);
+        expect(record.fundingTxids, 'funding-txid');
+        expect(record.preparedExpiryHeight, isNull);
+        // The account-deletion guard must still see the funded ZEC.
+        expect(
+          await restarted.countUnsharedFundedForAccount('source-account'),
+          1,
+        );
+      },
+    );
+
+    test('an inert software draft is still removable', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+      await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+
+      await store.removeUnsubmittedDraft(address: link.address);
+
+      expect(await store.load(), isEmpty);
+    });
+
+    test('a submitted software draft cannot be removed as inert', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+      await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+      await store.markSubmitted(
+        address: link.address,
+        fundingTxids: 'funding-txid',
+      );
+
+      await expectLater(
+        store.removeUnsubmittedDraft(address: link.address),
+        throwsStateError,
+      );
+    });
+
+    test('fails loud instead of hiding corrupted recovery data', () async {
+      final storage = _FakePaymentLinkRecoveryStorage()..value = '{not-json';
+
+      await expectLater(
+        PaymentLinkRecoveryStore(storage).load(),
+        throwsA(isA<PaymentLinkRecoveryStoreFormatException>()),
+      );
+    });
+  });
+}
+
+VizorPaymentLink _link() {
+  return VizorPaymentLink(
+    network: 'main',
+    address: 'u1paymentlinkaddress',
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 3_456_789,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 8, 5, 12),
+  );
+}
+
+class _FakePaymentLinkRecoveryStorage implements PaymentLinkRecoveryStorage {
+  _FakePaymentLinkRecoveryStorage({this.failOnWrites = const {}});
+
+  final Set<int> failOnWrites;
+  String? value;
+  int _writeCount = 0;
+
+  @override
+  Future<void> delete() async {
+    value = null;
+  }
+
+  @override
+  Future<String?> read() async => value;
+
+  @override
+  Future<void> write(String nextValue) async {
+    _writeCount += 1;
+    if (failOnWrites.contains(_writeCount)) {
+      throw StateError('storage write failed');
+    }
+    value = nextValue;
+  }
+}

--- a/test/features/payment_links/payment_link_recovery_store_test.dart
+++ b/test/features/payment_links/payment_link_recovery_store_test.dart
@@ -16,7 +16,8 @@ void main() {
         final funding = await PaymentLinkFundingRecovery(store).fund(
           link: link,
           sourceAccountUuid: 'source-account',
-          createTransaction: () async {
+          currentChainHeight: () async => _submissionHeight,
+          createTransaction: (_) async {
             final restartedRecords = await PaymentLinkRecoveryStore(
               storage,
             ).load();
@@ -51,7 +52,8 @@ void main() {
           ).fund<String>(
             link: link,
             sourceAccountUuid: 'source-account',
-            createTransaction: () => throw StateError('transaction failed'),
+            currentChainHeight: () async => _submissionHeight,
+            createTransaction: (_) => throw StateError('transaction failed'),
             fundingTxids: (txid) => txid,
           ),
           throwsStateError,
@@ -75,7 +77,8 @@ void main() {
         ).fund<String>(
           link: link,
           sourceAccountUuid: 'source-account',
-          createTransaction: () =>
+          currentChainHeight: () async => _submissionHeight,
+          createTransaction: (_) =>
               throw PaymentLinkFundingNotSubmittedException(
                 failure,
                 StackTrace.current,
@@ -111,7 +114,8 @@ void main() {
           ).fund(
             link: link,
             sourceAccountUuid: 'source-account',
-            createTransaction: () async => 'funding-txid',
+            currentChainHeight: () async => _submissionHeight,
+            createTransaction: (_) async => 'funding-txid',
             fundingTxids: (txid) => txid,
           );
 
@@ -140,7 +144,8 @@ void main() {
             ).fund(
               link: link,
               sourceAccountUuid: 'source-account',
-              createTransaction: () async {
+              currentChainHeight: () async => _submissionHeight,
+              createTransaction: (_) async {
                 transactionCount += 1;
                 return 'funding-txid';
               },
@@ -251,7 +256,8 @@ void main() {
       final funding = await PaymentLinkFundingRecovery(store).fund(
         link: link,
         sourceAccountUuid: 'source-account',
-        createTransaction: () async =>
+        currentChainHeight: () async => _submissionHeight,
+        createTransaction: (_) async =>
             (txids: 'pending-funding-txid', status: 'pending_broadcast'),
         fundingTxids: (result) => result.txids,
       );
@@ -454,7 +460,8 @@ void main() {
             ).fund(
               link: link,
               sourceAccountUuid: 'source-account',
-              createTransaction: () async => 'funding-txid',
+              currentChainHeight: () async => _submissionHeight,
+              createTransaction: (_) async => 'funding-txid',
               fundingTxids: (txid) => txid,
             );
 
@@ -500,6 +507,154 @@ void main() {
       );
     });
 
+    test('records the chain height a software broadcast started at', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+      await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+
+      await store.markSubmissionStarted(
+        address: link.address,
+        chainHeight: _submissionHeight,
+      );
+      // A retry must not move the marker forward: the earlier height is the
+      // one the transaction could have been mined at.
+      await store.markSubmissionStarted(
+        address: link.address,
+        chainHeight: _submissionHeight + 10,
+      );
+
+      final record = (await PaymentLinkRecoveryStore(storage).load()).single;
+      expect(record.state, PaymentLinkRecoveryState.draft);
+      expect(record.submittedAtHeight, _submissionHeight);
+      expect(record.fundingTxids, isNull);
+      expect(record.isAmbiguousSubmission, isTrue);
+    });
+
+    test(
+      'a draft that already knows its txid needs no submission marker',
+      () async {
+        final storage = _FakePaymentLinkRecoveryStorage();
+        final store = PaymentLinkRecoveryStore(storage);
+        final link = _link();
+        await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+        await store.markSubmitted(
+          address: link.address,
+          fundingTxids: 'funding-txid',
+        );
+
+        await store.markSubmissionStarted(
+          address: link.address,
+          chainHeight: _submissionHeight,
+        );
+
+        final record = (await PaymentLinkRecoveryStore(storage).load()).single;
+        expect(record.submittedAtHeight, isNull);
+        expect(record.fundingTxids, 'funding-txid');
+        expect(record.isAmbiguousSubmission, isFalse);
+      },
+    );
+
+    test('an ambiguous submission cannot be removed as inert', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+      await store.saveDraft(link: link, sourceAccountUuid: 'source-account');
+      await store.markSubmissionStarted(
+        address: link.address,
+        chainHeight: _submissionHeight,
+      );
+
+      await expectLater(
+        store.removeUnsubmittedDraft(address: link.address),
+        throwsStateError,
+      );
+      // The account-deletion guard must see it too: it may hold funds.
+      expect(await store.countUnsharedFundedForAccount('source-account'), 1);
+    });
+
+    test('a lost broadcast result leaves an ambiguous submission', () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final link = _link();
+      final failure = StateError('broadcast result unavailable');
+
+      await expectLater(
+        PaymentLinkFundingRecovery(store).fund<String>(
+          link: link,
+          sourceAccountUuid: 'source-account',
+          currentChainHeight: () async => _submissionHeight,
+          // What the send path does: mark the submission, cross the broadcast
+          // boundary, then lose the result.
+          createTransaction: (markSubmissionStarted) async {
+            await markSubmissionStarted();
+            throw failure;
+          },
+          fundingTxids: (txid) => txid,
+        ),
+        throwsA(same(failure)),
+      );
+
+      final record = (await PaymentLinkRecoveryStore(storage).load()).single;
+      expect(record.state, PaymentLinkRecoveryState.draft);
+      expect(record.fundingTxids, isNull);
+      expect(record.submittedAtHeight, _submissionHeight);
+      expect(record.isAmbiguousSubmission, isTrue);
+      expect(record.link.mnemonic, link.mnemonic);
+    });
+
+    test('reads a submission height back from stored records', () async {
+      final link = _link();
+      final storage = _FakePaymentLinkRecoveryStorage()
+        ..value = jsonEncode({
+          'version': 1,
+          'records': [
+            {
+              'link': link.toUri().toString(),
+              'sourceAccountUuid': 'source-account',
+              'state': 'draft',
+              'fundingTxids': null,
+              'preparedExpiryHeight': null,
+              'submittedAtHeight': _submissionHeight,
+              'updatedAt': DateTime.utc(2026, 8, 5).toIso8601String(),
+            },
+          ],
+        });
+
+      final record = (await PaymentLinkRecoveryStore(storage).load()).single;
+
+      expect(record.submittedAtHeight, _submissionHeight);
+      expect(record.isAmbiguousSubmission, isTrue);
+      expect(
+        countUnsharedFundedPaymentLinks([
+          record,
+        ], sourceAccountUuid: 'source-account'),
+        1,
+      );
+    });
+
+    test('rejects a negative submission height', () async {
+      final link = _link();
+      final storage = _FakePaymentLinkRecoveryStorage()
+        ..value = jsonEncode({
+          'version': 1,
+          'records': [
+            {
+              'link': link.toUri().toString(),
+              'sourceAccountUuid': 'source-account',
+              'state': 'draft',
+              'submittedAtHeight': -1,
+              'updatedAt': DateTime.utc(2026, 8, 5).toIso8601String(),
+            },
+          ],
+        });
+
+      await expectLater(
+        PaymentLinkRecoveryStore(storage).load(),
+        throwsA(isA<PaymentLinkRecoveryStoreFormatException>()),
+      );
+    });
+
     test('fails loud instead of hiding corrupted recovery data', () async {
       final storage = _FakePaymentLinkRecoveryStorage()..value = '{not-json';
 
@@ -510,6 +665,8 @@ void main() {
     });
   });
 }
+
+const _submissionHeight = 3_456_800;
 
 VizorPaymentLink _link() {
   return VizorPaymentLink(

--- a/test/features/payment_links/payment_link_service_test.dart
+++ b/test/features/payment_links/payment_link_service_test.dart
@@ -39,6 +39,61 @@ void main() {
     },
   );
 
+  test('a funding whose broadcast result is lost stays recoverable', () async {
+    final storage = _FakePaymentLinkRecoveryStorage();
+    final store = PaymentLinkRecoveryStore(storage);
+    final link = _link();
+    final failure = StateError('channel closed after broadcast');
+
+    // The composition `createFundedLink` uses: the recovery marker is awaited
+    // inside the submission classifier, immediately before the broadcast.
+    await expectLater(
+      PaymentLinkFundingRecovery(store).fund<String>(
+        link: link,
+        sourceAccountUuid: 'source-account',
+        currentChainHeight: () async => 3456800,
+        createTransaction: (markSubmissionStarted) =>
+            runPaymentLinkFundingSubmission((markLocalSubmission) async {
+              await markSubmissionStarted();
+              markLocalSubmission();
+              throw failure;
+            }),
+        fundingTxids: (txid) => txid,
+      ),
+      throwsA(same(failure)),
+    );
+
+    final record = (await PaymentLinkRecoveryStore(storage).load()).single;
+    expect(record.state, PaymentLinkRecoveryState.draft);
+    expect(record.fundingTxids, isNull);
+    expect(record.submittedAtHeight, 3456800);
+    expect(record.isAmbiguousSubmission, isTrue);
+    expect(record.link.mnemonic, link.mnemonic);
+  });
+
+  test(
+    'a funding that never reached the network leaves nothing behind',
+    () async {
+      final storage = _FakePaymentLinkRecoveryStorage();
+      final store = PaymentLinkRecoveryStore(storage);
+      final failure = StateError('proposal failed');
+
+      await expectLater(
+        PaymentLinkFundingRecovery(store).fund<String>(
+          link: _link(),
+          sourceAccountUuid: 'source-account',
+          currentChainHeight: () async => 3456800,
+          createTransaction: (markSubmissionStarted) =>
+              runPaymentLinkFundingSubmission((_) async => throw failure),
+          fundingTxids: (txid) => txid,
+        ),
+        throwsA(same(failure)),
+      );
+
+      expect(await PaymentLinkRecoveryStore(storage).load(), isEmpty);
+    },
+  );
+
   test('funding covers the exact recipient amount and claim fee', () {
     final recipientAmount = BigInt.from(100000000);
 
@@ -719,6 +774,19 @@ class _HardwareAccountNotifier extends AccountNotifier {
     activeAccountUuid: 'hardware-account',
     activeAddress: 'u1hardwareaddress',
   );
+}
+
+class _FakePaymentLinkRecoveryStorage implements PaymentLinkRecoveryStorage {
+  String? value;
+
+  @override
+  Future<void> delete() async => value = null;
+
+  @override
+  Future<String?> read() async => value;
+
+  @override
+  Future<void> write(String nextValue) async => value = nextValue;
 }
 
 class _RecordingPaymentLinkRecoveryStorage

--- a/test/features/payment_links/payment_link_service_test.dart
+++ b/test/features/payment_links/payment_link_service_test.dart
@@ -1,0 +1,773 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_service.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_transaction_matching.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+void main() {
+  test('classifies failures before funding submission starts', () async {
+    final failure = StateError('insufficient balance');
+
+    await expectLater(
+      runPaymentLinkFundingSubmission<String>((_) => throw failure),
+      throwsA(
+        isA<PaymentLinkFundingNotSubmittedException>().having(
+          (error) => error.error,
+          'error',
+          same(failure),
+        ),
+      ),
+    );
+  });
+
+  test(
+    'preserves ambiguous failures after funding submission starts',
+    () async {
+      final failure = StateError('broadcast result unavailable');
+
+      await expectLater(
+        runPaymentLinkFundingSubmission<String>((markSubmissionStarted) {
+          markSubmissionStarted();
+          throw failure;
+        }),
+        throwsA(same(failure)),
+      );
+    },
+  );
+
+  test('funding covers the exact recipient amount and claim fee', () {
+    final recipientAmount = BigInt.from(100000000);
+
+    expect(
+      paymentLinkFundingAmountZatoshi(recipientAmount),
+      BigInt.from(100010000),
+    );
+    expect(
+      () => paymentLinkFundingAmountZatoshi(BigInt.zero),
+      throwsArgumentError,
+    );
+  });
+
+  test(
+    'funding quote includes deposit and redeem fees in the sender total',
+    () {
+      final quote = PaymentLinkFundingQuote(
+        sourceAccountUuid: 'account-1',
+        recipientAmountZatoshi: BigInt.from(100000000),
+        fundingFeeZatoshi: BigInt.from(15000),
+        claimFeeReserveZatoshi: BigInt.from(10000),
+      );
+
+      expect(quote.sourceAccountUuid, 'account-1');
+      expect(quote.cardFeeZatoshi, BigInt.from(25000));
+      expect(quote.totalDeductedZatoshi, BigInt.from(100025000));
+    },
+  );
+
+  test('max funding quote reserves deposit and redeem fees', () {
+    final quote = paymentLinkMaxFundingQuote(
+      sourceAccountUuid: 'account-1',
+      maxSpendAmountZatoshi: BigInt.from(100000000),
+      fundingFeeZatoshi: BigInt.from(15000),
+    );
+
+    expect(quote.recipientAmountZatoshi, BigInt.from(99990000));
+    expect(quote.fundingFeeZatoshi, BigInt.from(15000));
+    expect(quote.claimFeeReserveZatoshi, BigInt.from(10000));
+    expect(quote.totalDeductedZatoshi, BigInt.from(100015000));
+    expect(
+      quote.totalDeductedZatoshi,
+      BigInt.from(100000000) + quote.fundingFeeZatoshi,
+    );
+    expect(
+      () => paymentLinkMaxFundingQuote(
+        sourceAccountUuid: 'account-1',
+        maxSpendAmountZatoshi: BigInt.from(10000),
+        fundingFeeZatoshi: BigInt.from(15000),
+      ),
+      throwsStateError,
+    );
+  });
+
+  test('a funding result with a known status and txid is submitted', () {
+    for (final status in const [
+      'broadcasted',
+      'pending_broadcast',
+      'partial_broadcast',
+      'broadcast_unknown',
+      'broadcasted_storage_failed',
+    ]) {
+      expect(
+        isPaymentLinkFundingSubmitted(status: status, txids: 'funding-txid'),
+        isTrue,
+        reason: status,
+      );
+    }
+
+    expect(
+      isPaymentLinkFundingSubmitted(status: 'broadcasted', txids: '  '),
+      isFalse,
+    );
+    expect(
+      isPaymentLinkFundingSubmitted(
+        status: 'unexpected',
+        txids: 'funding-txid',
+      ),
+      isFalse,
+    );
+  });
+
+  test('share readiness accepts mempool broadcast or one confirmation', () {
+    expect(
+      paymentLinkConfirmationCount(
+        minedHeight: BigInt.from(100),
+        chainTipHeight: BigInt.from(104),
+      ),
+      5,
+    );
+    expect(
+      const PaymentLinkFundingProgress(confirmationCount: 0).isReady,
+      isFalse,
+    );
+    expect(
+      const PaymentLinkFundingProgress(
+        confirmationCount: 0,
+        broadcastAccepted: true,
+      ).isReady,
+      isTrue,
+    );
+    expect(
+      const PaymentLinkFundingProgress(confirmationCount: 1).isReady,
+      isTrue,
+    );
+    expect(
+      paymentLinkConfirmationCount(
+        minedHeight: BigInt.zero,
+        chainTipHeight: BigInt.from(104),
+      ),
+      0,
+    );
+  });
+
+  test('claim confirmation count follows the matching funding receive', () {
+    final expectedFunding = paymentLinkFundingAmountZatoshi(
+      BigInt.from(100000),
+    );
+    final transactions = [
+      _transaction(
+        txid: 'funding',
+        txKind: 'received',
+        minedHeight: 100,
+        accountBalanceDelta: expectedFunding.toInt(),
+      ),
+      _transaction(
+        txid: 'dust',
+        txKind: 'received',
+        minedHeight: 90,
+        accountBalanceDelta: 1,
+      ),
+    ];
+
+    expect(
+      paymentLinkFundingConfirmationCountForClaim(
+        recipientAmountZatoshi: BigInt.from(100000),
+        transactions: transactions,
+        chainTipHeight: BigInt.from(103),
+      ),
+      4,
+    );
+  });
+
+  test(
+    'claim waits while funding is pending or still in its initial window',
+    () {
+      expect(
+        paymentLinkShouldWaitForFunding(
+          recipientAmountZatoshi: BigInt.from(100000),
+          totalZatoshi: paymentLinkFundingAmountZatoshi(BigInt.from(100000)),
+          fundingConfirmationCount: 4,
+          birthdayHeight: 100,
+          currentTipHeight: 104,
+        ),
+        isTrue,
+      );
+      expect(
+        paymentLinkShouldWaitForFunding(
+          recipientAmountZatoshi: BigInt.from(100000),
+          totalZatoshi: BigInt.zero,
+          fundingConfirmationCount: 0,
+          birthdayHeight: 100,
+          currentTipHeight: 106,
+        ),
+        isFalse,
+      );
+      expect(
+        paymentLinkShouldWaitForFunding(
+          recipientAmountZatoshi: BigInt.from(100000),
+          totalZatoshi: paymentLinkFundingAmountZatoshi(BigInt.from(100000)),
+          fundingConfirmationCount: 6,
+          birthdayHeight: 100,
+          currentTipHeight: 105,
+        ),
+        isFalse,
+      );
+    },
+  );
+
+  test('matches broadcast and history txids across byte order', () {
+    const broadcastTxid =
+        '9909fe99c789029bf118c88bd9ee33ed35965fd0f3154dd1a8ec6daa4974c7e3';
+    const historyTxid =
+        'e3c77449aa6deca8d14d15f3d05f9635ed33eed98bc818f19b0289c799fe0999';
+
+    expect(paymentLinkTxidsMatch(broadcastTxid, historyTxid), isTrue);
+    expect(paymentLinkTxidsMatch('0x$broadcastTxid', broadcastTxid), isTrue);
+    expect(paymentLinkTxidsMatch(broadcastTxid, 'not-a-txid'), isFalse);
+  });
+
+  test('prepared funding recovery requires a non-expired history txid', () {
+    const preparedTxid =
+        '9909fe99c789029bf118c88bd9ee33ed35965fd0f3154dd1a8ec6daa4974c7e3';
+    const historyTxid =
+        'e3c77449aa6deca8d14d15f3d05f9635ed33eed98bc818f19b0289c799fe0999';
+
+    expect(
+      paymentLinkFundingTransactionExists(
+        fundingTxid: preparedTxid,
+        transactions: [_transaction(txid: historyTxid, txKind: 'sent')],
+      ),
+      isTrue,
+    );
+    expect(
+      paymentLinkFundingTransactionExists(
+        fundingTxid: preparedTxid,
+        transactions: [
+          _transaction(txid: historyTxid, txKind: 'sent', expiredUnmined: true),
+        ],
+      ),
+      isFalse,
+    );
+    expect(
+      paymentLinkFundingTransactionExists(
+        fundingTxid: preparedTxid,
+        transactions: [_transaction(txid: 'different', txKind: 'sent')],
+      ),
+      isFalse,
+    );
+  });
+
+  test('funding expires only after every transaction expires unmined', () {
+    final expired = _transaction(
+      txid: 'expired',
+      txKind: 'sent',
+      expiredUnmined: true,
+    );
+
+    expect(
+      paymentLinkFundingExpired(
+        fundingTxids: 'expired',
+        transactions: [expired],
+      ),
+      isTrue,
+    );
+    expect(
+      paymentLinkFundingExpired(
+        fundingTxids: 'expired,active',
+        transactions: [
+          expired,
+          _transaction(txid: 'active', txKind: 'sent'),
+        ],
+      ),
+      isFalse,
+    );
+    expect(
+      paymentLinkFundingExpired(
+        fundingTxids: 'expired,missing',
+        transactions: [expired],
+      ),
+      isFalse,
+    );
+  });
+
+  test(
+    'claim remains Receiving until every transaction has six confirmations',
+    () {
+      expect(
+        paymentLinkReceivedStatusForTransactions(
+          claimTxids: 'claim-a,claim-b',
+          transactions: [
+            _transaction(txid: 'claim-a', txKind: 'received', minedHeight: 12),
+            _transaction(txid: 'claim-b', txKind: 'receiving'),
+          ],
+          chainTipHeight: BigInt.from(18),
+        ),
+        PaymentLinkReceivedStatus.receiving,
+      );
+      expect(
+        paymentLinkReceivedStatusForTransactions(
+          claimTxids: 'claim-a,claim-b',
+          transactions: [
+            _transaction(txid: 'claim-a', txKind: 'received', minedHeight: 12),
+            _transaction(txid: 'claim-b', txKind: 'received', minedHeight: 14),
+          ],
+          chainTipHeight: BigInt.from(18),
+        ),
+        PaymentLinkReceivedStatus.receiving,
+      );
+      expect(
+        paymentLinkReceivedStatusForTransactions(
+          claimTxids: 'claim-a,claim-b',
+          transactions: [
+            _transaction(txid: 'claim-a', txKind: 'received', minedHeight: 12),
+            _transaction(txid: 'claim-b', txKind: 'received', minedHeight: 13),
+          ],
+          chainTipHeight: BigInt.from(18),
+        ),
+        PaymentLinkReceivedStatus.received,
+      );
+    },
+  );
+
+  test('claim confirmations never outrun the scanned wallet height', () {
+    expect(
+      paymentLinkVerifiedChainHeight(scannedHeight: 105, chainTipHeight: 106),
+      BigInt.from(105),
+    );
+    expect(
+      paymentLinkVerifiedChainHeight(scannedHeight: 106, chainTipHeight: 105),
+      BigInt.from(105),
+    );
+    expect(
+      paymentLinkVerifiedChainHeight(scannedHeight: 0, chainTipHeight: 106),
+      BigInt.zero,
+    );
+  });
+
+  test('expired unmined claim becomes actionable again', () {
+    expect(
+      paymentLinkReceivedStatusForTransactions(
+        claimTxids: 'claim-txid',
+        transactions: [
+          _transaction(
+            txid: 'claim-txid',
+            txKind: 'receiving',
+            expiredUnmined: true,
+          ),
+        ],
+        chainTipHeight: BigInt.from(18),
+      ),
+      PaymentLinkReceivedStatus.readyToClaim,
+    );
+  });
+
+  test('retained claim retries only after every transaction expires', () {
+    final transactions = [
+      _transaction(txid: 'claim-a', txKind: 'sent', expiredUnmined: true),
+      _transaction(txid: 'claim-b', txKind: 'sent'),
+    ];
+
+    expect(
+      paymentLinkClaimTransactionsExpired(
+        claimTxids: 'claim-a,claim-b',
+        transactions: transactions,
+      ),
+      isFalse,
+    );
+    expect(
+      paymentLinkClaimTransactionsExpired(
+        claimTxids: 'claim-a,missing',
+        transactions: transactions,
+      ),
+      isFalse,
+    );
+    expect(
+      paymentLinkClaimTransactionsExpired(
+        claimTxids: 'claim-a',
+        transactions: transactions,
+      ),
+      isTrue,
+    );
+  });
+
+  test('recovers only active sent claim transaction ids', () {
+    expect(
+      paymentLinkActiveClaimTxids([
+        _transaction(txid: 'active', txKind: 'sent'),
+        _transaction(txid: 'expired', txKind: 'sent', expiredUnmined: true),
+        _transaction(txid: 'funding', txKind: 'received'),
+      ]),
+      ['active'],
+    );
+  });
+
+  test('claim exposes only the amount promised by the link', () {
+    final recipientAmount = BigInt.from(100000000);
+
+    expect(
+      paymentLinkClaimableAmountZatoshi(
+        recipientAmountZatoshi: recipientAmount,
+        maxSpendableZatoshi: BigInt.from(100000000),
+      ),
+      recipientAmount,
+    );
+    expect(
+      paymentLinkClaimableAmountZatoshi(
+        recipientAmountZatoshi: recipientAmount,
+        maxSpendableZatoshi: BigInt.from(120000000),
+      ),
+      recipientAmount,
+    );
+    expect(
+      paymentLinkClaimableAmountZatoshi(
+        recipientAmountZatoshi: recipientAmount,
+        maxSpendableZatoshi: BigInt.from(99999999),
+      ),
+      BigInt.zero,
+    );
+  });
+
+  test('recognizes every accepted claim broadcast status', () {
+    expect(
+      paymentLinkClaimBroadcastStatusFromWire('pending_broadcast'),
+      PaymentLinkClaimBroadcastStatus.pendingBroadcast,
+    );
+    expect(
+      paymentLinkClaimBroadcastStatusFromWire('partial_broadcast'),
+      PaymentLinkClaimBroadcastStatus.partialBroadcast,
+    );
+    expect(
+      paymentLinkClaimBroadcastStatusFromWire('broadcasted'),
+      PaymentLinkClaimBroadcastStatus.broadcasted,
+    );
+    expect(
+      () => paymentLinkClaimBroadcastStatusFromWire('unexpected'),
+      throwsStateError,
+    );
+  });
+
+  test(
+    'confirmed claims delete retained state before clearing the link',
+    () async {
+      final storage = _PaymentLinkServiceReceivedStorage();
+      final store = PaymentLinkReceivedStore(storage);
+      final link = _link();
+      await store.saveReady(link);
+      await store.markReceiving(
+        address: link.address,
+        destinationAccountUuid: 'receiver-account',
+        claimTxids: 'claim-txid',
+      );
+      final record = (await store.load()).single;
+      final events = <String>[];
+
+      final completed = await finalizeConfirmedPaymentLinkClaim(
+        record: record,
+        deleteRetainedWallet: (candidate) async {
+          expect(candidate.claimLink, isNotNull);
+          events.add('delete');
+          return true;
+        },
+        markReceived: (address) async {
+          events.add('mark');
+          await store.markReceived(address: address);
+        },
+      );
+
+      expect(completed, isTrue);
+      expect(events, ['delete', 'mark']);
+      expect((await store.load()).single.claimLink, isNull);
+    },
+  );
+
+  test(
+    'confirmed claims keep their link when retained cleanup fails',
+    () async {
+      final storage = _PaymentLinkServiceReceivedStorage();
+      final store = PaymentLinkReceivedStore(storage);
+      final link = _link();
+      await store.saveReady(link);
+      await store.markReceiving(
+        address: link.address,
+        destinationAccountUuid: 'receiver-account',
+        claimTxids: 'claim-txid',
+      );
+      final record = (await store.load()).single;
+
+      final completed = await finalizeConfirmedPaymentLinkClaim(
+        record: record,
+        deleteRetainedWallet: (_) async => false,
+        markReceived: (_) async => fail('must not clear the retained link'),
+      );
+
+      expect(completed, isFalse);
+      expect((await store.load()).single.claimLink, isNotNull);
+    },
+  );
+
+  test('only reuses a complete claim wallet for the expected address', () {
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const [],
+        expectedAddress: 'u1expected',
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const ['u1expected', 'u1unexpected'],
+        expectedAddress: 'u1expected',
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const ['u1unexpected'],
+        expectedAddress: 'u1expected',
+      ),
+      isTrue,
+    );
+    expect(
+      shouldRecreatePaymentLinkClaimWallet(
+        accountAddresses: const ['u1expected'],
+        expectedAddress: 'u1expected',
+      ),
+      isFalse,
+    );
+  });
+
+  test('claim broadcast stops when the wallet locks', () {
+    expect(
+      () => requireUnlockedPaymentLinkWallet(requiresUnlock: true),
+      throwsStateError,
+    );
+    expect(
+      () => requireUnlockedPaymentLinkWallet(requiresUnlock: false),
+      returnsNormally,
+    );
+  });
+
+  test('claim destination must still resolve to the prepared address', () {
+    expect(
+      () => requireMatchingPaymentLinkClaimDestination(
+        preparedAddress: 'u1prepared',
+        currentAddress: 'u1prepared',
+      ),
+      returnsNormally,
+    );
+    expect(
+      () => requireMatchingPaymentLinkClaimDestination(
+        preparedAddress: 'u1prepared',
+        currentAddress: 'u1changed',
+      ),
+      throwsA(isA<PaymentLinkClaimDestinationChangedException>()),
+    );
+  });
+
+  test('accepts any past claim birthday and rejects invalid heights', () {
+    const currentTip = 3500000;
+    expect(
+      validatePaymentLinkClaimBirthday(
+        advertisedBirthdayHeight: 1,
+        currentTipHeight: currentTip,
+      ),
+      1,
+    );
+    expect(
+      () => validatePaymentLinkClaimBirthday(
+        advertisedBirthdayHeight: 0,
+        currentTipHeight: currentTip,
+      ),
+      throwsFormatException,
+    );
+    expect(
+      () => validatePaymentLinkClaimBirthday(
+        advertisedBirthdayHeight: currentTip + 1,
+        currentTipHeight: currentTip,
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('flags claim scans beyond the normal lookback', () {
+    const currentTip = 3500000;
+    expect(
+      isLongPaymentLinkSync(
+        birthdayHeight: currentTip - kPaymentLinkLongSyncLookbackBlocks,
+        currentTipHeight: currentTip,
+      ),
+      isFalse,
+    );
+    expect(
+      isLongPaymentLinkSync(
+        birthdayHeight: currentTip - kPaymentLinkLongSyncLookbackBlocks - 1,
+        currentTipHeight: currentTip,
+      ),
+      isTrue,
+    );
+  });
+
+  test('claim wallet cache identity uses the account and birthday only', () {
+    final link = _link();
+    final sameLinkName = paymentLinkClaimWalletDirectoryName(link);
+    final differentSecretName = paymentLinkClaimWalletDirectoryName(
+      VizorPaymentLink(
+        network: link.network,
+        address: link.address,
+        amountZatoshi: link.amountZatoshi,
+        mnemonic:
+            'legal winner thank year wave sausage worth useful legal winner thank yellow',
+        birthdayHeight: link.birthdayHeight,
+        label: link.label,
+        createdAt: link.createdAt,
+      ),
+    );
+    final differentBirthdayName = paymentLinkClaimWalletDirectoryName(
+      VizorPaymentLink(
+        network: link.network,
+        address: link.address,
+        amountZatoshi: link.amountZatoshi,
+        mnemonic: link.mnemonic,
+        birthdayHeight: link.birthdayHeight - 1,
+        label: link.label,
+        createdAt: link.createdAt,
+      ),
+    );
+    final differentSharePayloadName = paymentLinkClaimWalletDirectoryName(
+      VizorPaymentLink(
+        network: link.network,
+        address: link.address,
+        amountZatoshi: link.amountZatoshi + BigInt.one,
+        mnemonic: link.mnemonic,
+        birthdayHeight: link.birthdayHeight,
+        label: '${link.label} updated',
+        createdAt: link.createdAt.add(const Duration(seconds: 1)),
+        presentation: const PaymentLinkPresentation(message: 'Updated'),
+      ),
+    );
+
+    expect(paymentLinkClaimWalletDirectoryName(link), sameLinkName);
+    expect(differentSecretName, isNot(sameLinkName));
+    expect(differentBirthdayName, isNot(sameLinkName));
+    expect(differentSharePayloadName, sameLinkName);
+    expect(sameLinkName, isNot(contains(link.address)));
+    expect(sameLinkName, isNot(contains('abandon')));
+  });
+
+  test(
+    'hardware funding is rejected before creating a recovery draft',
+    () async {
+      final storage = _RecordingPaymentLinkRecoveryStorage();
+      final container = ProviderContainer(
+        overrides: [
+          accountProvider.overrideWith(_HardwareAccountNotifier.new),
+          paymentLinkRecoveryStoreProvider.overrideWithValue(
+            PaymentLinkRecoveryStore(storage),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(accountProvider.future);
+
+      await expectLater(
+        container
+            .read(paymentLinkServiceProvider)
+            .createFundedLink(
+              amountZatoshi: BigInt.from(100000),
+              sourceAccountUuid: 'hardware-account',
+            ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'Keystone payment links require the hardware signing flow.',
+          ),
+        ),
+      );
+      expect(storage.writeCount, 0);
+    },
+  );
+}
+
+class _PaymentLinkServiceReceivedStorage implements PaymentLinkReceivedStorage {
+  String? value;
+
+  @override
+  Future<void> delete() async => value = null;
+
+  @override
+  Future<String?> read() async => value;
+
+  @override
+  Future<void> write(String nextValue) async => value = nextValue;
+}
+
+class _HardwareAccountNotifier extends AccountNotifier {
+  @override
+  AccountState build() => const AccountState(
+    accounts: [
+      AccountInfo(
+        uuid: 'hardware-account',
+        name: 'Keystone',
+        order: 0,
+        isHardware: true,
+      ),
+    ],
+    activeAccountUuid: 'hardware-account',
+    activeAddress: 'u1hardwareaddress',
+  );
+}
+
+class _RecordingPaymentLinkRecoveryStorage
+    implements PaymentLinkRecoveryStorage {
+  int writeCount = 0;
+
+  @override
+  Future<void> delete() async {}
+
+  @override
+  Future<String?> read() async => null;
+
+  @override
+  Future<void> write(String value) async {
+    writeCount += 1;
+  }
+}
+
+VizorPaymentLink _link() {
+  return VizorPaymentLink(
+    network: 'main',
+    address: 'u1paymentlinkaddress',
+    amountZatoshi: BigInt.from(100000),
+    mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    birthdayHeight: 3_456_789,
+    label: 'Payment link',
+    createdAt: DateTime.utc(2026, 8, 5, 12),
+  );
+}
+
+rust_sync.TransactionInfo _transaction({
+  required String txid,
+  required String txKind,
+  int minedHeight = 0,
+  bool expiredUnmined = false,
+  int accountBalanceDelta = 1,
+}) {
+  return rust_sync.TransactionInfo(
+    txidHex: txid,
+    minedHeight: BigInt.from(minedHeight),
+    expiredUnmined: expiredUnmined,
+    accountBalanceDelta: accountBalanceDelta,
+    fee: BigInt.zero,
+    blockTime: BigInt.zero,
+    isTransparent: false,
+    txKind: txKind,
+    displayAmount: BigInt.one,
+    displayPool: 'shielded',
+    createdTime: BigInt.zero,
+  );
+}

--- a/test/features/payment_links/vizor_payment_link_test.dart
+++ b/test/features/payment_links/vizor_payment_link_test.dart
@@ -1,0 +1,301 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/navigation/vizor_deep_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+
+void main() {
+  group('VizorPaymentLink', () {
+    test('round trips a payment link payload', () {
+      final link = _link(
+        presentation: const PaymentLinkPresentation(
+          artworkId: 'celebration_03',
+          message: '축하해! 🎉',
+        ),
+      );
+
+      final uri = link.toUri();
+      final decoded = VizorPaymentLink.parse(uri.toString());
+      final payload = _decodePayload(uri);
+
+      expect(uri.scheme, 'https');
+      expect(uri.host, VizorDeepLink.host);
+      expect(uri.path, '/payment-links/open');
+      expect(uri.query, isEmpty);
+      expect(uri.fragment, startsWith('v1='));
+      expect(decoded.network, 'main');
+      expect(decoded.address, link.address);
+      expect(decoded.amountZatoshi, BigInt.from(123456789));
+      expect(decoded.mnemonic, link.mnemonic);
+      expect(decoded.birthdayHeight, 3_456_789);
+      expect(decoded.label, link.label);
+      expect(decoded.createdAt, link.createdAt);
+      expect(decoded.presentation?.artworkId, 'celebration_03');
+      expect(decoded.presentation?.message, '축하해! 🎉');
+      expect(payload['presentation'], {
+        'artworkId': 'celebration_03',
+        'message': '축하해! 🎉',
+      });
+    });
+
+    test('compares the complete canonical payment-link payload', () {
+      final original = _link();
+      final roundTripped = VizorPaymentLink.parse(original.toUri().toString());
+
+      expect(original.hasSameCanonicalPayload(roundTripped), isTrue);
+      expect(
+        original.hasSameCanonicalPayload(
+          _link(
+            network: ' main ',
+            address: ' ${original.address} ',
+            mnemonic: ' ${original.mnemonic} ',
+            label: ' ${original.label} ',
+            createdAt: DateTime.parse('2026-06-21T14:00:00+02:00'),
+          ),
+        ),
+        isTrue,
+      );
+
+      final changedPayloads = <String, VizorPaymentLink>{
+        'address': _link(address: '${original.address}2'),
+        'amount': _link(amountZatoshi: original.amountZatoshi + BigInt.one),
+        'mnemonic': _link(
+          mnemonic:
+              'legal winner thank year wave sausage worth useful legal winner thank yellow',
+        ),
+        'birthday': _link(birthdayHeight: original.birthdayHeight - 1),
+        'label': _link(label: '${original.label} updated'),
+        'createdAt': _link(
+          createdAt: original.createdAt.add(const Duration(seconds: 1)),
+        ),
+        'presentation': _link(
+          presentation: const PaymentLinkPresentation(message: 'Updated'),
+        ),
+      };
+      for (final MapEntry(:key, :value) in changedPayloads.entries) {
+        expect(original.hasSameCanonicalPayload(value), isFalse, reason: key);
+      }
+    });
+
+    test('omits an empty presentation payload', () {
+      final uri = _link(
+        presentation: const PaymentLinkPresentation(
+          artworkId: '  ',
+          message: '  ',
+        ),
+      ).toUri();
+      final payload = _decodePayload(uri);
+
+      expect(payload, isNot(contains('presentation')));
+      expect(VizorPaymentLink.parse(uri.toString()).presentation, isNull);
+    });
+
+    test('rejects invalid presentation values', () {
+      final maxKoreanMessage = List.filled(128, '한').join();
+      final maxSimpleEmojiMessage = List.filled(128, '🎉').join();
+      expect(
+        PaymentLinkPresentation(
+          message: maxKoreanMessage,
+        ).toPayload()?['message'],
+        maxKoreanMessage,
+      );
+      expect(
+        PaymentLinkPresentation(
+          message: maxSimpleEmojiMessage,
+        ).toPayload()?['message'],
+        maxSimpleEmojiMessage,
+      );
+      expect(
+        () => _link(
+          presentation: const PaymentLinkPresentation(
+            artworkId: 'not an artwork id',
+          ),
+        ).toUri(),
+        throwsFormatException,
+      );
+      expect(
+        () => _link(
+          presentation: PaymentLinkPresentation(
+            message: List.filled(129, 'a').join(),
+          ),
+        ).toUri(),
+        throwsFormatException,
+      );
+      expect(
+        () => _link(
+          presentation: PaymentLinkPresentation(
+            message: List.filled(25, '👨‍👩‍👧‍👦').join(),
+          ),
+        ).toUri(),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects URLs outside the Vizor payment-link endpoint', () {
+      expect(
+        () => VizorPaymentLink.parse('vizor://payment-link?p=legacy'),
+        throwsFormatException,
+      );
+      expect(
+        () => VizorPaymentLink.parse('https://example.com/pay'),
+        throwsFormatException,
+      );
+      expect(
+        () => VizorPaymentLink.parse(
+          'https://${VizorDeepLink.host}/payment-links/other#v1=payload',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('accepts the scheme and host case-insensitively', () {
+      final link = _link();
+      final uppercaseLink = link.toUri().toString().replaceFirst(
+        'https://${VizorDeepLink.host}',
+        'HTTPS://${VizorDeepLink.host.toUpperCase()}',
+      );
+
+      final decoded = VizorPaymentLink.parse(uppercaseLink);
+
+      expect(decoded.address, link.address);
+      expect(decoded.mnemonic, link.mnemonic);
+    });
+
+    test('rejects malformed payloads', () {
+      expect(
+        () => VizorPaymentLink.parse(
+          'https://${VizorDeepLink.host}'
+          '${VizorDeepLink.paymentLinkPath}#v1=not-base64',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects oversized inbound links before decoding', () {
+      expect(
+        () => VizorPaymentLink.parse(
+          'https://${VizorDeepLink.host}'
+          '${VizorDeepLink.paymentLinkPath}#v1='
+          '${'a' * VizorPaymentLink.maxEncodedLength}',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects unsupported versions', () {
+      final encoded = Uri(
+        scheme: VizorDeepLink.scheme,
+        host: VizorDeepLink.host,
+        path: VizorDeepLink.paymentLinkPath,
+        fragment: 'v1=eyJ2IjoyfQ==',
+      ).toString();
+
+      expect(() => VizorPaymentLink.parse(encoded), throwsFormatException);
+    });
+
+    test('rejects extra URL components and malformed fragments', () {
+      final payload = _link().toUri().fragment;
+
+      expect(
+        () => VizorPaymentLink.parse(
+          'https://${VizorDeepLink.host}'
+          '${VizorDeepLink.paymentLinkPath}?payload=hidden#$payload',
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => VizorPaymentLink.parse(
+          'https://user@${VizorDeepLink.host}'
+          '${VizorDeepLink.paymentLinkPath}#$payload',
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => VizorPaymentLink.parse(
+          'https://${VizorDeepLink.host}:8443'
+          '${VizorDeepLink.paymentLinkPath}#$payload',
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => VizorPaymentLink.parse(
+          'https://${VizorDeepLink.host}'
+          '${VizorDeepLink.paymentLinkPath}#$payload&extra',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects links without network', () {
+      final payload = {
+        'v': 1,
+        'address': 'u1exampleaddress',
+        'amountZatoshi': '1',
+        'mnemonic':
+            'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+        'birthdayHeight': 1,
+        'label': 'Demo link',
+        'createdAt': DateTime.utc(2026, 6, 21).toIso8601String(),
+      };
+      final encoded = Uri(
+        scheme: VizorDeepLink.scheme,
+        host: VizorDeepLink.host,
+        path: VizorDeepLink.paymentLinkPath,
+        fragment: 'v1=${base64UrlEncode(utf8.encode(jsonEncode(payload)))}',
+      ).toString();
+
+      expect(() => VizorPaymentLink.parse(encoded), throwsFormatException);
+    });
+
+    test('rejects non-mainnet payment links by default', () {
+      final testnetLink = VizorPaymentLink(
+        network: 'test',
+        address: 'utest1exampleaddress',
+        amountZatoshi: BigInt.one,
+        mnemonic:
+            'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+        birthdayHeight: 1,
+        label: 'Test link',
+        createdAt: DateTime.utc(2026, 8, 24),
+      );
+
+      expect(testnetLink.toUri, throwsFormatException);
+      expect(
+        () => _link(
+          network: 'regtest',
+          address: 'uregtest1exampleaddress',
+        ).toUri(),
+        throwsFormatException,
+      );
+    });
+  });
+}
+
+Map<String, Object?> _decodePayload(Uri uri) {
+  final encoded = uri.fragment.substring('v1='.length);
+  return jsonDecode(utf8.decode(base64Url.decode(base64Url.normalize(encoded))))
+      as Map<String, Object?>;
+}
+
+VizorPaymentLink _link({
+  String network = 'main',
+  String address = 'u1exampleaddress',
+  BigInt? amountZatoshi,
+  String mnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+  int birthdayHeight = 3_456_789,
+  String label = 'Demo link',
+  DateTime? createdAt,
+  PaymentLinkPresentation? presentation,
+}) {
+  return VizorPaymentLink(
+    network: network,
+    address: address,
+    amountZatoshi: amountZatoshi ?? BigInt.from(123456789),
+    mnemonic: mnemonic,
+    birthdayHeight: birthdayHeight,
+    label: label,
+    createdAt: createdAt ?? DateTime.utc(2026, 6, 21, 12),
+    presentation: presentation,
+  );
+}

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -9,6 +9,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_claim_lifecycle_registry_provider.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
 import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
@@ -57,6 +62,95 @@ void main() {
       '.voting-shm',
       '.receive.redb',
     ]);
+  });
+
+  test(
+    'wallet reset cleanup removes only payment-link claim directories',
+    () async {
+      final supportDirectory = Directory.systemTemp.createTempSync(
+        'vizor-payment-link-reset',
+      );
+      addTearDown(() {
+        if (supportDirectory.existsSync()) {
+          supportDirectory.deleteSync(recursive: true);
+        }
+      });
+      final claimDirectory = Directory(
+        '${supportDirectory.path}${Platform.pathSeparator}'
+        '$kPaymentLinkClaimWalletDirectoryPrefix${List.filled(64, 'a').join()}',
+      )..createSync();
+      final unrelatedDirectory = Directory(
+        '${supportDirectory.path}${Platform.pathSeparator}'
+        '${kPaymentLinkClaimWalletDirectoryPrefix}draft',
+      )..createSync();
+
+      await deletePaymentLinkClaimWalletDirectories(
+        resolveSupportDirectory: () async => supportDirectory,
+      );
+
+      expect(claimDirectory.existsSync(), isFalse);
+      expect(unrelatedDirectory.existsSync(), isTrue);
+    },
+  );
+
+  test('wallet reset surfaces payment-link claim cleanup failure', () async {
+    await expectLater(
+      clearPaymentLinkClaimWalletsForReset(
+        deleteDirectories: () async {
+          throw StateError('claim cleanup failed');
+        },
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'claim cleanup failed',
+        ),
+      ),
+    );
+  });
+
+  test('wallet reset attempts every matching claim directory', () async {
+    final supportDirectory = Directory.systemTemp.createTempSync(
+      'vizor-payment-link-reset-failures',
+    );
+    addTearDown(() {
+      if (supportDirectory.existsSync()) {
+        supportDirectory.deleteSync(recursive: true);
+      }
+    });
+    final firstName =
+        '$kPaymentLinkClaimWalletDirectoryPrefix${List.filled(64, 'a').join()}';
+    final secondName =
+        '$kPaymentLinkClaimWalletDirectoryPrefix${List.filled(64, 'b').join()}';
+    Directory(
+      '${supportDirectory.path}${Platform.pathSeparator}$firstName',
+    ).createSync();
+    Directory(
+      '${supportDirectory.path}${Platform.pathSeparator}$secondName',
+    ).createSync();
+    final attempted = <String>[];
+
+    await expectLater(
+      deletePaymentLinkClaimWalletDirectories(
+        resolveSupportDirectory: () async => supportDirectory,
+        deleteDirectory: (directory) async {
+          final name = directory.path.split(Platform.pathSeparator).last;
+          attempted.add(name);
+          if (name == firstName) throw StateError('first delete failed');
+          await directory.delete(recursive: true);
+        },
+      ),
+      throwsStateError,
+    );
+
+    expect(attempted, containsAll([firstName, secondName]));
+    expect(
+      Directory(
+        '${supportDirectory.path}${Platform.pathSeparator}$secondName',
+      ).existsSync(),
+      isFalse,
+    );
   });
 
   test(
@@ -435,6 +529,312 @@ void main() {
   });
 
   test(
+    'wallet reset drains Gift Card claims before resolving the DB',
+    () async {
+      final lifecycle = PaymentLinkClaimLifecycleRegistry();
+      final drainStarted = Completer<void>();
+      final drainGate = Completer<void>();
+      var resumeCalls = 0;
+      lifecycle.register(
+        owner: Object(),
+        quiesceAndDrain: () async {
+          drainStarted.complete();
+          await drainGate.future;
+        },
+        resume: () => resumeCalls++,
+      );
+      final pathRequested = Completer<void>();
+      const pathProvider = MethodChannel('plugins.flutter.io/path_provider');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(pathProvider, (call) async {
+            if (!pathRequested.isCompleted) pathRequested.complete();
+            throw PlatformException(code: 'db-path-unavailable');
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(pathProvider, null);
+      });
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(_bootstrapWithAccounts()),
+          paymentLinkClaimLifecycleRegistryProvider.overrideWithValue(
+            lifecycle,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(accountProvider.future);
+
+      final reset = container.read(accountProvider.notifier).resetWallet();
+      await drainStarted.future;
+
+      expect(pathRequested.isCompleted, isFalse);
+      drainGate.complete();
+      await expectLater(reset, throwsA(isA<PlatformException>()));
+      expect(pathRequested.isCompleted, isTrue);
+      expect(resumeCalls, 1);
+    },
+  );
+
+  test('account removal drains Gift Card claims before counting the in-flight '
+      'ones', () async {
+    final receivedStorage = _AccountTestPaymentLinkReceivedStorage();
+    final receivedStore = PaymentLinkReceivedStore(receivedStorage);
+    final link = VizorPaymentLink(
+      network: 'main',
+      address: 'u1accountremovaldrainpaymentlink',
+      amountZatoshi: BigInt.from(100000),
+      mnemonic: List.filled(24, 'abandon').join(' '),
+      birthdayHeight: 3_456_789,
+      label: 'Payment link',
+      createdAt: DateTime.utc(2026, 9, 3),
+    );
+    await receivedStore.saveReady(link);
+
+    // A claim into account-2 that was already submitting when the deletion
+    // started: it finishes while the drain waits, so the record turns
+    // `receiving` only after the count would have read zero.
+    final lifecycle = PaymentLinkClaimLifecycleRegistry();
+    var resumeCalls = 0;
+    lifecycle.register(
+      owner: Object(),
+      quiesceAndDrain: () async {
+        await receivedStore.markReceiving(
+          address: link.address,
+          destinationAccountUuid: 'account-2',
+          claimTxids: 'claim-txid',
+        );
+      },
+      resume: () => resumeCalls++,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrapWithAccounts()),
+        paymentLinkReceivedStoreProvider.overrideWithValue(receivedStore),
+        paymentLinkClaimLifecycleRegistryProvider.overrideWithValue(lifecycle),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(accountProvider.future);
+
+    await expectLater(
+      container.read(accountProvider.notifier).removeAccount('account-2'),
+      throwsA(
+        isA<PaymentLinkInFlightClaimsException>().having(
+          (error) => error.count,
+          'count',
+          1,
+        ),
+      ),
+    );
+    expect(container.read(accountProvider).value!.accounts, hasLength(2));
+    expect(
+      _rustApi.deletedAccountUuids,
+      isEmpty,
+      reason: 'the account a finished claim paid into must not be deleted',
+    );
+    expect(resumeCalls, 1);
+  });
+
+  test(
+    'account removal is rejected while it owns an unshared Gift Card',
+    () async {
+      final recoveryStorage = _AccountTestPaymentLinkRecoveryStorage();
+      final recoveryStore = PaymentLinkRecoveryStore(recoveryStorage);
+      final link = VizorPaymentLink(
+        network: 'main',
+        address: 'u1accountremovalpaymentlink',
+        amountZatoshi: BigInt.from(100000),
+        mnemonic: List.filled(24, 'abandon').join(' '),
+        birthdayHeight: 3_456_789,
+        label: 'Payment link',
+        createdAt: DateTime.utc(2026, 8, 7),
+      );
+      await recoveryStore.saveDraft(link: link, sourceAccountUuid: 'account-2');
+      await recoveryStore.markFunded(
+        address: link.address,
+        fundingTxids: 'funding-txid',
+      );
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(_bootstrapWithAccounts()),
+          paymentLinkRecoveryStoreProvider.overrideWithValue(recoveryStore),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(accountProvider.future);
+
+      await expectLater(
+        container.read(accountProvider.notifier).removeAccount('account-2'),
+        throwsA(
+          isA<PaymentLinkUnsharedGiftCardsException>()
+              .having((error) => error.count, 'count', 1)
+              .having(
+                (error) => error.sourceAccountUuid,
+                'sourceAccountUuid',
+                'account-2',
+              ),
+        ),
+      );
+      expect(container.read(accountProvider).value!.accounts, hasLength(2));
+    },
+  );
+
+  test('account removal is rejected while it receives a Gift Card', () async {
+    final receivedStorage = _AccountTestPaymentLinkReceivedStorage();
+    final receivedStore = PaymentLinkReceivedStore(receivedStorage);
+    final link = VizorPaymentLink(
+      network: 'main',
+      address: 'u1accountremovalreceivedpaymentlink',
+      amountZatoshi: BigInt.from(100000),
+      mnemonic: List.filled(24, 'abandon').join(' '),
+      birthdayHeight: 3_456_789,
+      label: 'Payment link',
+      createdAt: DateTime.utc(2026, 9, 1),
+    );
+    await receivedStore.saveReady(link);
+    await receivedStore.markReceiving(
+      address: link.address,
+      destinationAccountUuid: 'account-2',
+      claimTxids: 'claim-txid',
+    );
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrapWithAccounts()),
+        paymentLinkReceivedStoreProvider.overrideWithValue(receivedStore),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(accountProvider.future);
+
+    await expectLater(
+      container.read(accountProvider.notifier).removeAccount('account-2'),
+      throwsA(
+        isA<PaymentLinkInFlightClaimsException>()
+            .having((error) => error.count, 'count', 1)
+            .having(
+              (error) => error.destinationAccountUuid,
+              'destinationAccountUuid',
+              'account-2',
+            ),
+      ),
+    );
+    expect(container.read(accountProvider).value!.accounts, hasLength(2));
+  });
+
+  test(
+    'wallet reset is rejected while a Gift Card is being received',
+    () async {
+      final receivedStorage = _AccountTestPaymentLinkReceivedStorage();
+      final receivedStore = PaymentLinkReceivedStore(receivedStorage);
+      final link = VizorPaymentLink(
+        network: 'main',
+        address: 'u1walletresetreceivedpaymentlink',
+        amountZatoshi: BigInt.from(100000),
+        mnemonic: List.filled(24, 'abandon').join(' '),
+        birthdayHeight: 3_456_789,
+        label: 'Payment link',
+        createdAt: DateTime.utc(2026, 9, 3),
+      );
+      await receivedStore.saveReady(link);
+      await receivedStore.markReceiving(
+        address: link.address,
+        destinationAccountUuid: 'account-2',
+        claimTxids: 'claim-txid',
+      );
+
+      final lifecycle = PaymentLinkClaimLifecycleRegistry();
+      var resumeCalls = 0;
+      lifecycle.register(
+        owner: Object(),
+        quiesceAndDrain: () async {},
+        resume: () => resumeCalls++,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(_bootstrapWithAccounts()),
+          paymentLinkReceivedStoreProvider.overrideWithValue(receivedStore),
+          paymentLinkClaimLifecycleRegistryProvider.overrideWithValue(
+            lifecycle,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(accountProvider.future);
+
+      await expectLater(
+        container.read(accountProvider.notifier).resetWallet(),
+        throwsA(
+          isA<WalletResetInFlightGiftCardClaimsException>().having(
+            (error) => error.count,
+            'count',
+            1,
+          ),
+        ),
+      );
+      // The refusal lands before anything is resolved or deleted, and the claim
+      // lifecycle is handed back so the claim can finish.
+      expect(container.read(accountProvider).value!.accounts, hasLength(2));
+      expect(_rustApi.deletedAccountUuids, isEmpty);
+      expect(resumeCalls, 1);
+    },
+  );
+
+  test('a locked wallet resets despite an in-flight Gift Card claim', () async {
+    // A claim cannot advance while locked, so refusing here would never lift
+    // and would trap a user whose only way back in is this reset. The DB path
+    // is the very next step after the skipped check, so its failure is the
+    // proof that the claim check did not stop the reset.
+    const pathProvider = MethodChannel('plugins.flutter.io/path_provider');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProvider, (call) async {
+          throw PlatformException(code: 'db-path-unavailable');
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(pathProvider, null);
+    });
+
+    final receivedStorage = _AccountTestPaymentLinkReceivedStorage();
+    final receivedStore = PaymentLinkReceivedStore(receivedStorage);
+    final link = VizorPaymentLink(
+      network: 'main',
+      address: 'u1lockedwalletresetpaymentlink',
+      amountZatoshi: BigInt.from(100000),
+      mnemonic: List.filled(24, 'abandon').join(' '),
+      birthdayHeight: 3_456_789,
+      label: 'Payment link',
+      createdAt: DateTime.utc(2026, 9, 3),
+    );
+    await receivedStore.saveReady(link);
+    await receivedStore.markReceiving(
+      address: link.address,
+      destinationAccountUuid: 'account-2',
+      claimTxids: 'claim-txid',
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(
+          _bootstrapWithAccounts(isUnlocked: false),
+        ),
+        paymentLinkReceivedStoreProvider.overrideWithValue(receivedStore),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(accountProvider.future);
+
+    await expectLater(
+      container.read(accountProvider.notifier).resetWallet(),
+      throwsA(isA<PlatformException>()),
+    );
+  });
+
+  test(
     'account switching is allowed while voting submission is guarded',
     () async {
       FlutterSecureStorage.setMockInitialValues({});
@@ -617,7 +1017,35 @@ Future<void> _expectAccountDeletionDrainsLiveShareTracking() async {
   expect(shareTracking.isQuiesced('account-2'), isFalse);
 }
 
-AppBootstrapState _bootstrapWithAccounts() {
+class _AccountTestPaymentLinkRecoveryStorage
+    implements PaymentLinkRecoveryStorage {
+  String? value;
+
+  @override
+  Future<void> delete() async => value = null;
+
+  @override
+  Future<String?> read() async => value;
+
+  @override
+  Future<void> write(String nextValue) async => value = nextValue;
+}
+
+class _AccountTestPaymentLinkReceivedStorage
+    implements PaymentLinkReceivedStorage {
+  String? value;
+
+  @override
+  Future<void> delete() async => value = null;
+
+  @override
+  Future<String?> read() async => value;
+
+  @override
+  Future<void> write(String nextValue) async => value = nextValue;
+}
+
+AppBootstrapState _bootstrapWithAccounts({bool isUnlocked = true}) {
   const accountState = AccountState(
     accounts: [
       AccountInfo(uuid: 'account-1', name: 'Primary', order: 0),
@@ -634,7 +1062,7 @@ AppBootstrapState _bootstrapWithAccounts() {
     themeMode: ThemeMode.system,
     privacyModeEnabled: false,
     isPasswordConfigured: true,
-    isUnlocked: true,
+    isUnlocked: isUnlocked,
     passwordRotationRecoveryFailed: false,
   );
 }

--- a/test/sync_state_test.dart
+++ b/test/sync_state_test.dart
@@ -575,6 +575,92 @@ void main() {
     expect(completed.totalBalance, BigInt.from(123));
     expect(completed.recentTransactions, hasLength(1));
   });
+
+  // The single spelling of the VZR-42 rule: "this balance may end a check as
+  // not enough". Each clause is pinned on its own, because dropping any one of
+  // them leaves both Dart lanes green while a shortfall gets announced against
+  // a balance nobody read or a stale snapshot.
+  group('hasSettledSpendableBalance', () {
+    SyncState settled() => SyncState(
+      accountUuid: 'account-a',
+      hasAccountScopedData: true,
+      hasBalanceData: true,
+      isSyncComplete: true,
+      percentage: 1.0,
+      scannedHeight: 100,
+      chainTipHeight: 100,
+      spendableBalance: BigInt.from(50),
+    );
+
+    test('settled, at the tip, with a balance read', () {
+      expect(settled().hasSettledSpendableBalance, isTrue);
+    });
+
+    test('a balance that was never fetched is not an answer', () {
+      // The wallet-wide sync fields survive `withoutAccountScopedData`, so
+      // without this clause a state carrying no balance for the account still
+      // reports `isSyncedToTip` with a zero spendable — the VZR-42 shape.
+      expect(
+        settled().copyWith(hasBalanceData: false).hasSettledSpendableBalance,
+        isFalse,
+      );
+    });
+
+    test('a last-completed-sync snapshot is not an answer either', () {
+      expect(
+        settled()
+            .copyWith(
+              displaySpendableFreshness:
+                  SpendableBalanceFreshness.lastCompletedSync,
+            )
+            .hasSettledSpendableBalance,
+        isFalse,
+      );
+    });
+
+    test('mid-scan is not settled', () {
+      expect(
+        settled().copyWith(scannedHeight: 99).hasSettledSpendableBalance,
+        isFalse,
+      );
+      expect(
+        settled().copyWith(isSyncing: true).hasSettledSpendableBalance,
+        isFalse,
+      );
+      expect(
+        settled().copyWith(isSyncComplete: false).hasSettledSpendableBalance,
+        isFalse,
+      );
+    });
+  });
+
+  group('spendableIsSettledForAccount', () {
+    SyncState settledForA() => SyncState(
+      accountUuid: 'account-a',
+      hasAccountScopedData: true,
+      hasBalanceData: true,
+      isSyncComplete: true,
+      percentage: 1.0,
+      scannedHeight: 100,
+      chainTipHeight: 100,
+      spendableBalance: BigInt.from(50),
+    );
+
+    test('answers for the account that owns the balance', () {
+      expect(spendableIsSettledForAccount(settledForA(), 'account-a'), isTrue);
+    });
+
+    test('scopes first, so it never answers with another balance', () {
+      // Without the `scopedToAccount` step the wallet-wide sync fields would
+      // read as settled while the balance on the state belongs to account A.
+      expect(spendableIsSettledForAccount(settledForA(), 'account-b'), isFalse);
+    });
+
+    test('no state and no account are both unsettled', () {
+      expect(spendableIsSettledForAccount(null, 'account-a'), isFalse);
+      expect(spendableIsSettledForAccount(settledForA(), null), isFalse);
+    });
+  });
 }
 
 rust_sync.WalletBalance _balance({


### PR DESCRIPTION
## Summary

The second product on the intake channel: Vizor Gift Cards, logic only. A Gift Card is a bearer link (`https://link.vizor.cash/payment-links/open#v1=…`) whose funds are parked in a temporary claim wallet derived from the link itself, so this layer owns a link model, a claim service with its own funding math and sync, durable received/recovery stores, and the account guards that stop a reset or an account removal from stranding a claim in flight. It is its own layer because none of it is screens — the `/payment-links` route and the Gift Cards UI land in #614 — and because it is the half that touches money and Rust.

## Changes

**Dart core — model and service**
- `payment_links/models/vizor_payment_link.dart` (271) — the link, its `#v1=` payload and validation.
- `services/payment_link_service.dart` (1314) — create, share, redeem, claim.
- `services/payment_link_claim_math.dart` (279) and `payment_link_claim_wallet.dart` (223) — funding math and the temporary claim wallet.
- `services/payment_link_received_store.dart` (615) and `payment_link_recovery_store.dart` (658), with `payment_link_recovery_reconciler.dart` (222) — durable state and its reconciliation after a crash or restart.
- `services/payment_link_entry_policy.dart`, `payment_link_transaction_matching.dart`, `payment_link_clipboard.dart`, `payment_link_lifecycle_revision.dart`, `payment_link_hardware_signing_service.dart` (362).

**Providers**
- `payment_link_intake_provider.dart` — the Gift Card lane on the shared channel; `payment_link_claim_coordinator_provider.dart` (217); `payment_link_claim_lifecycle_registry_provider.dart`; `payment_link_cards_provider.dart`.
- `lib/app.dart` (+150) — intake subscription, deferred/rejected messaging, and the navigation that will target `/payment-links`.

**Account and reset guards**
- `providers/account_provider.dart` (+121) — `quiesceAndDrain()` before a reset or account removal, and `WalletResetInFlightGiftCardClaimsException`; `accounts_screen.dart`, `mobile_accounts_screen.dart`, `account_remove_modal.dart`, `lost_password_screen.dart`, `forgot_passcode_sheet.dart`, `mobile_unlock_screen.dart` surface the refusal.
- `core/storage/wallet_paths.dart` — claim-wallet directories and their cleanup.

**Rust + generated bindings**
- `api/wallet.rs`: `generate_software_account` / `GeneratedSoftwareAccount`; `api/sync.rs`: `run_payment_link_claim_sync`, `cancel_payment_link_claim_sync`, `get_pczt_txid`, `get_pczt_expiry_height`.
- `wallet/sync_engine/mod.rs` (+238) claim-scoped sync, `wallet/keys.rs` `derive_software_address`, `wallet/sync/pczt.rs`. Regenerated `frb_generated.*` on both sides.

**Tests** (~4.9k lines)
- `payment_link_service_test.dart` (773), `payment_link_recovery_store_test.dart` (550), `payment_link_recovery_reconciler_test.dart` (366), `payment_link_received_store_test.dart` (346), `vizor_payment_link_test.dart` (301), `account_provider_test.dart` (+432), `app_incoming_link_host_test.dart` (286), plus the unlock-screen payment-URI suites and the claim coordinator / intake provider tests.

## Behaviour at this point of the stack

A Gift Card link now reaches the Gift Card lane and a claim can run end to end in logic, but **nothing is navigable**: `/payment-links` does not exist as a route until #614, so `app.dart`'s `_openPendingPaymentLink` targets a path that is not registered yet, and there is no Gift Cards screen, card list or activity row. Everything the ZIP-321 lane does on desktop and mobile is unaffected and stays working.

## Verification

- `fvm flutter analyze` clean.
- Desktop lane (`fvm flutter test`) green.
- Mobile lane (`--tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`): 20 failures, all pre-existing — the identical set fails at the base of this stack. Files: `ironwood_migration_coordinator_provider_test.dart` (15), `mobile_import_birthday_screen_test.dart` (2), `mobile_onboarding_progress_test.dart`, `mobile_keystone_use_cases_test.dart`, `mobile_receive_use_cases_test.dart`.
- `cargo test --lib`: 741 passing.

## Stack

Part 5/9 · base: `rowan/zip321-04-mobile-ui` (#612) · next: #614 — [stack #618](https://github.com/chainapsis/vizor-wallet/pull/608)

https://claude.ai/code/session_01Uybjg6JVS5RFEG8B9GHi3s
