### PR TITLE
[7/10] Gift Cards: mobile screens and Keystone signing overlay

### DIFF
--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -57,7 +57,7 @@ ActivityRowData buildTransactionActivityRow({
   return ActivityRowData(
     stableId: 'tx:${transaction.txidHex}:${_stableTransactionRole(kind)}',
     title: giftCardKind != null
-        ? _giftCardTitle(
+        ? giftCardActivityTitle(
             giftCardKind,
             isInFlight: isInFlight,
             isFailed: isFailed,
@@ -121,7 +121,9 @@ ActivityRowData buildTransactionActivityRow({
   );
 }
 
-String _giftCardTitle(
+/// Shared by the activity row and the transaction receipt so a Gift Card
+/// keeps one title across both surfaces.
+String giftCardActivityTitle(
   GiftCardActivityKind kind, {
   required bool isInFlight,
   required bool isFailed,

--- a/lib/src/features/activity/screens/mobile/mobile_activity_screen.dart
+++ b/lib/src/features/activity/screens/mobile/mobile_activity_screen.dart
@@ -153,7 +153,7 @@ class _MobileActivityScreenState extends ConsumerState<MobileActivityScreen> {
         txKind: transaction.txKind,
         initialTransaction: transaction,
         initialDetail: detail,
-        giftCardAmountZatoshi: giftCard?.amountZatoshi,
+        giftCard: giftCard,
       ),
     );
   }

--- a/lib/src/features/activity/screens/mobile/mobile_activity_screen.dart
+++ b/lib/src/features/activity/screens/mobile/mobile_activity_screen.dart
@@ -18,6 +18,7 @@ import '../../../../providers/sync_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../activity_feed_sections.dart';
 import '../../activity_row_mapper.dart';
+import '../../gift_card_activity_index.dart';
 import '../../../swap/models/swap_activity_navigation.dart';
 import '../../../swap/widgets/swap_activity_status_auto_refresh.dart';
 import '../../swap_activity_row_items_provider.dart';
@@ -117,8 +118,9 @@ class _MobileActivityScreenState extends ConsumerState<MobileActivityScreen> {
 
   Future<void> _openTransactionStatus(
     BuildContext context,
-    rust_sync.TransactionInfo transaction,
-  ) async {
+    rust_sync.TransactionInfo transaction, {
+    GiftCardActivityMetadata? giftCard,
+  }) async {
     final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
     if (accountUuid == null) return;
 
@@ -151,6 +153,28 @@ class _MobileActivityScreenState extends ConsumerState<MobileActivityScreen> {
         txKind: transaction.txKind,
         initialTransaction: transaction,
         initialDetail: detail,
+        giftCardAmountZatoshi: giftCard?.amountZatoshi,
+      ),
+    );
+  }
+
+  ActivityEntry _transactionEntry(
+    BuildContext context,
+    rust_sync.TransactionInfo transaction,
+    GiftCardActivityMetadata? giftCard, {
+    required bool privacyModeEnabled,
+  }) {
+    return ActivityEntry(
+      timestamp: transactionActivityTimestamp(transaction),
+      row: buildTransactionActivityRow(
+        context: context,
+        transaction: transaction,
+        giftCardKind: giftCard?.kind,
+        giftCardAmountZatoshi: giftCard?.amountZatoshi,
+        privacyModeEnabled: privacyModeEnabled,
+        onTap: () => unawaited(
+          _openTransactionStatus(context, transaction, giftCard: giftCard),
+        ),
       ),
     );
   }
@@ -205,6 +229,10 @@ class _MobileActivityScreenState extends ConsumerState<MobileActivityScreen> {
     });
 
     final accountUuid = ref.watch(accountProvider).value?.activeAccountUuid;
+    final giftCardActivityIndex = accountUuid == null
+        ? GiftCardActivityIndex.empty
+        : ref.watch(giftCardActivityIndexProvider(accountUuid)).value ??
+              GiftCardActivityIndex.empty;
     final privacyModeEnabled = ref.watch(privacyModeProvider);
     final loadedTransactions = _transactionsAccountUuid == accountUuid
         ? _transactions
@@ -227,14 +255,11 @@ class _MobileActivityScreenState extends ConsumerState<MobileActivityScreen> {
       if (loadedTransactions != null)
         for (final tx in transactions)
           if (!absorption.absorbs(tx))
-            ActivityEntry(
-              timestamp: transactionActivityTimestamp(tx),
-              row: buildTransactionActivityRow(
-                context: context,
-                transaction: tx,
-                privacyModeEnabled: privacyModeEnabled,
-                onTap: () => unawaited(_openTransactionStatus(context, tx)),
-              ),
+            _transactionEntry(
+              context,
+              tx,
+              giftCardActivityIndex.metadataFor(tx),
+              privacyModeEnabled: privacyModeEnabled,
             ),
       for (final item in swapItems)
         ActivityEntry(

--- a/lib/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart
@@ -105,6 +105,7 @@ class _MobileTransactionStatusScreenState
   rust_sync.TransactionDetail? _detail;
   String? _error;
   String? _activeAccountUuid;
+  String? _argsAccountUuid;
   bool _messageExpanded = false;
 
   @override
@@ -113,6 +114,7 @@ class _MobileTransactionStatusScreenState
     _transaction = widget.args.initialTransaction;
     _detail = widget.args.initialDetail;
     _activeAccountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    _argsAccountUuid = _activeAccountUuid;
     unawaited(_loadTransaction());
   }
 
@@ -298,12 +300,11 @@ class _MobileTransactionStatusScreenState
 
   /// A row tapped before the Gift Card index finished loading arrives with no
   /// metadata, so the receipt resolves it here instead of staying generic.
-  GiftCardActivityMetadata? _resolvedGiftCard(rust_sync.TransactionInfo? tx) {
-    if (tx == null) return null;
-    final accountUuid =
-        _activeAccountUuid ??
-        ref.watch(accountProvider).value?.activeAccountUuid;
-    if (accountUuid == null) return null;
+  GiftCardActivityMetadata? _resolvedGiftCard(
+    rust_sync.TransactionInfo? tx,
+    String? accountUuid,
+  ) {
+    if (tx == null || accountUuid == null) return null;
     return ref
         .watch(giftCardActivityIndexProvider(accountUuid))
         .value
@@ -328,7 +329,17 @@ class _MobileTransactionStatusScreenState
     final tx = _transaction;
     final detail = _detail;
     final failed = _phase == _TxPhase.failed;
-    final giftCard = widget.args.giftCard ?? _resolvedGiftCard(tx);
+    final activeAccountUuid =
+        ref.watch(accountProvider).value?.activeAccountUuid ??
+        _activeAccountUuid;
+    // The args metadata was resolved for the account that was active when the
+    // row was tapped; under another account only that account's index counts.
+    final suppliedGiftCard =
+        _argsAccountUuid == null || _argsAccountUuid == activeAccountUuid
+        ? widget.args.giftCard
+        : null;
+    final giftCard =
+        suppliedGiftCard ?? _resolvedGiftCard(tx, activeAccountUuid);
 
     final amountText = _amountText(
       tx,

--- a/lib/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart
@@ -27,10 +27,15 @@ import '../../../../providers/sync_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../address_book/models/address_book_contact.dart';
 import '../../../address_book/providers/address_book_provider.dart';
+import '../../../payment_links/widgets/mobile/payment_link_mobile_views.dart'
+    show kPaymentLinkMobileCardHeight, kPaymentLinkMobileCardWidth;
+import '../../../payment_links/widgets/payment_link_gift_card.dart';
 import '../../../send/widgets/send_recipient_resolver.dart';
 import '../../../send/widgets/send_review_layout.dart'
     show SendReviewContactRecipient;
-import '../../activity_row_mapper.dart' show formatActivityTimestamp;
+import '../../activity_row_mapper.dart'
+    show formatActivityTimestamp, giftCardActivityTitle;
+import '../../gift_card_activity_index.dart';
 
 /// Route arguments for [MobileTransactionStatusScreen]. The row that
 /// was tapped passes its [initialTransaction] so the screen renders
@@ -41,14 +46,17 @@ class MobileTransactionStatusArgs {
     this.txKind,
     this.initialTransaction,
     this.initialDetail,
-    this.giftCardAmountZatoshi,
+    this.giftCard,
   });
 
   final String txidHex;
   final String? txKind;
   final rust_sync.TransactionInfo? initialTransaction;
   final rust_sync.TransactionDetail? initialDetail;
-  final BigInt? giftCardAmountZatoshi;
+
+  /// Set when the tapped row already resolved this tx as a Gift Card; the
+  /// screen re-resolves it from the index when this is null.
+  final GiftCardActivityMetadata? giftCard;
 }
 
 /// Loads the transaction history; injectable so widget tests can avoid
@@ -238,7 +246,15 @@ class _MobileTransactionStatusScreenState
   bool get _isMigration =>
       (_transaction?.txKind ?? widget.args.txKind) == 'migration';
 
-  String get _title {
+  String _titleFor(GiftCardActivityMetadata? giftCard) {
+    if (giftCard != null) {
+      // Same copy as the activity row that opened this receipt.
+      return giftCardActivityTitle(
+        giftCard.kind,
+        isInFlight: _phase == _TxPhase.pending,
+        isFailed: _phase == _TxPhase.failed,
+      );
+    }
     if (_isShielding) return 'Shielded';
     if (_isMigration) {
       return switch (_phase) {
@@ -280,6 +296,20 @@ class _MobileTransactionStatusScreenState
     );
   }
 
+  /// A row tapped before the Gift Card index finished loading arrives with no
+  /// metadata, so the receipt resolves it here instead of staying generic.
+  GiftCardActivityMetadata? _resolvedGiftCard(rust_sync.TransactionInfo? tx) {
+    if (tx == null) return null;
+    final accountUuid =
+        _activeAccountUuid ??
+        ref.watch(accountProvider).value?.activeAccountUuid;
+    if (accountUuid == null) return null;
+    return ref
+        .watch(giftCardActivityIndexProvider(accountUuid))
+        .value
+        ?.metadataFor(tx);
+  }
+
   @override
   Widget build(BuildContext context) {
     ref.listen<AsyncValue<AccountState>>(accountProvider, (previous, next) {
@@ -298,16 +328,25 @@ class _MobileTransactionStatusScreenState
     final tx = _transaction;
     final detail = _detail;
     final failed = _phase == _TxPhase.failed;
+    final giftCard = widget.args.giftCard ?? _resolvedGiftCard(tx);
 
     final amountText = _amountText(
       tx,
-      giftCardAmountZatoshi: widget.args.giftCardAmountZatoshi,
+      giftCardAmountZatoshi: giftCard?.amountZatoshi,
       privacyModeEnabled: privacyModeEnabled,
     );
-    final primaryAddress = detail?.primaryAddress?.trim();
-    final sourceAddress = detail?.sourceAddress?.trim();
+    // A Gift Card's counterparty is the single-use link address, so the
+    // receipt drops the address row and its verify affordance.
+    final primaryAddress = giftCard != null
+        ? null
+        : detail?.primaryAddress?.trim();
+    final sourceAddress = giftCard != null
+        ? null
+        : detail?.sourceAddress?.trim();
     final sourcePool = detail?.sourcePool?.trim().toLowerCase();
-    final receivingOutput = _isIncoming ? _receivingOutputFor(detail) : null;
+    final receivingOutput = giftCard == null && _isIncoming
+        ? _receivingOutputFor(detail)
+        : null;
     final receivingAddress = receivingOutput?.address?.trim();
     final address = _isIncoming ? sourceAddress : primaryAddress;
     final poolLabel = _isIncoming
@@ -317,7 +356,10 @@ class _MobileTransactionStatusScreenState
       receivingOutput?.pool,
       receivingAddress,
     );
-    final memo = detail?.memo?.trim();
+    // The card's note lives in the Gift Card record, not the funding memo.
+    final memo = giftCard != null
+        ? giftCard.message?.trim()
+        : detail?.memo?.trim();
 
     // Resolve the counterparty to a saved contact / own account so the
     // From/To row shows a name + avatar instead of a raw address — parity
@@ -415,7 +457,8 @@ class _MobileTransactionStatusScreenState
               ),
             ),
           );
-    final unknownFromLabel = _isIncoming && addressRow == null
+    final unknownFromLabel =
+        _isIncoming && addressRow == null && giftCard == null
         ? _unknownFromLabelForSourcePool(sourcePool)
         : null;
     final unknownFromRow = unknownFromLabel == null
@@ -448,7 +491,9 @@ class _MobileTransactionStatusScreenState
     // "From transparent balance" -> "Shielded balance". No Figma frame for
     // this state yet; mobile is aligned to the (more informative) desktop
     // shape pending one.
-    final reviewChildren = _isMigration
+    final reviewChildren = giftCard != null
+        ? <Widget>[amountRow]
+        : _isMigration
         ? <Widget>[
             amountRow,
             const MobileReviewFlowArrow(),
@@ -515,7 +560,7 @@ class _MobileTransactionStatusScreenState
           child: Column(
             children: [
               MobileTopNav.back(
-                title: _title,
+                title: _titleFor(giftCard),
                 onBack: () => Navigator.of(context).maybePop(),
               ),
               Expanded(
@@ -530,6 +575,27 @@ class _MobileTransactionStatusScreenState
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
+                      if (giftCard != null)
+                        Padding(
+                          padding: const EdgeInsets.only(top: AppSpacing.s),
+                          child: Center(
+                            child: FittedBox(
+                              fit: BoxFit.scaleDown,
+                              child: PaymentLinkGiftCard(
+                                artwork: PaymentLinkCardArtwork.fromProtocolId(
+                                  giftCard.artworkId,
+                                ),
+                                cardWidth: kPaymentLinkMobileCardWidth,
+                                cardHeight: kPaymentLinkMobileCardHeight,
+                                amountText: hideAmountIfPrivacyMode(
+                                  formatZecAmount(giftCard.amountZatoshi),
+                                  privacyModeEnabled: privacyModeEnabled,
+                                ),
+                                showCaret: false,
+                              ),
+                            ),
+                          ),
+                        ),
                       Padding(
                         padding: const EdgeInsets.symmetric(
                           vertical: AppSpacing.md,

--- a/lib/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart
@@ -41,12 +41,14 @@ class MobileTransactionStatusArgs {
     this.txKind,
     this.initialTransaction,
     this.initialDetail,
+    this.giftCardAmountZatoshi,
   });
 
   final String txidHex;
   final String? txKind;
   final rust_sync.TransactionInfo? initialTransaction;
   final rust_sync.TransactionDetail? initialDetail;
+  final BigInt? giftCardAmountZatoshi;
 }
 
 /// Loads the transaction history; injectable so widget tests can avoid
@@ -297,7 +299,11 @@ class _MobileTransactionStatusScreenState
     final detail = _detail;
     final failed = _phase == _TxPhase.failed;
 
-    final amountText = _amountText(tx, privacyModeEnabled: privacyModeEnabled);
+    final amountText = _amountText(
+      tx,
+      giftCardAmountZatoshi: widget.args.giftCardAmountZatoshi,
+      privacyModeEnabled: privacyModeEnabled,
+    );
     final primaryAddress = detail?.primaryAddress?.trim();
     final sourceAddress = detail?.sourceAddress?.trim();
     final sourcePool = detail?.sourcePool?.trim().toLowerCase();
@@ -578,14 +584,16 @@ class _MobileTransactionStatusScreenState
 
   String _amountText(
     rust_sync.TransactionInfo? tx, {
+    BigInt? giftCardAmountZatoshi,
     required bool privacyModeEnabled,
   }) {
     if (tx == null) return '--';
     if (privacyModeEnabled) {
       return hideAmountIfPrivacyMode('', privacyModeEnabled: true);
     }
-    if (tx.displayAmount == BigInt.zero) return '--';
-    return ZecAmount.fromZatoshi(tx.displayAmount).activityDetail.toString();
+    final amountZatoshi = giftCardAmountZatoshi ?? tx.displayAmount;
+    if (amountZatoshi == BigInt.zero) return '--';
+    return ZecAmount.fromZatoshi(amountZatoshi).activityDetail.toString();
   }
 
   String _dateText(rust_sync.TransactionInfo? tx) {

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -854,7 +854,7 @@ class _HomeContentState extends ConsumerState<_HomeContent> {
         txKind: transaction.txKind,
         initialTransaction: transaction,
         initialDetail: detail,
-        giftCardAmountZatoshi: giftCard?.amountZatoshi,
+        giftCard: giftCard,
       ),
     );
   }
@@ -1302,11 +1302,7 @@ class _MobileVotingEntryCard extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                AppIcon(
-                  AppIcons.vote,
-                  size: 20,
-                  color: colors.icon.accent,
-                ),
+                AppIcon(AppIcons.vote, size: 20, color: colors.icon.accent),
                 const SizedBox(width: AppSpacing.s),
                 Expanded(
                   child: Column(

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -22,6 +22,7 @@ import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/app_toast.dart';
 import '../../../../providers/account_provider.dart';
+import '../../../../providers/migration_send_gate_provider.dart';
 import '../../../../providers/privacy_mode_provider.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
 import '../../../../providers/sync_keep_awake_provider.dart';
@@ -31,6 +32,7 @@ import '../../../../providers/zec_price_change_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../accounts/widgets/mobile/mobile_accounts_sheet.dart';
 import '../../../activity/activity_feed_sections.dart';
+import '../../../activity/gift_card_activity_index.dart';
 import '../../../activity/activity_row_mapper.dart';
 import '../../../activity/screens/mobile/mobile_transaction_status_screen.dart';
 import '../../../activity/swap_activity_row_items_provider.dart';
@@ -816,8 +818,9 @@ class _HomeContentState extends ConsumerState<_HomeContent> {
   Future<void> _openTransactionStatus(
     BuildContext context,
     WidgetRef ref,
-    rust_sync.TransactionInfo transaction,
-  ) async {
+    rust_sync.TransactionInfo transaction, {
+    GiftCardActivityMetadata? giftCard,
+  }) async {
     final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
     if (accountUuid == null) return;
 
@@ -851,6 +854,30 @@ class _HomeContentState extends ConsumerState<_HomeContent> {
         txKind: transaction.txKind,
         initialTransaction: transaction,
         initialDetail: detail,
+        giftCardAmountZatoshi: giftCard?.amountZatoshi,
+      ),
+    );
+  }
+
+  ActivityEntry _transactionEntry(
+    BuildContext context,
+    WidgetRef ref,
+    rust_sync.TransactionInfo transaction,
+    GiftCardActivityMetadata? giftCard, {
+    required bool privacyModeEnabled,
+  }) {
+    return ActivityEntry(
+      timestamp: transactionActivityTimestamp(transaction),
+      row: buildTransactionActivityRow(
+        context: context,
+        transaction: transaction,
+        giftCardKind: giftCard?.kind,
+        giftCardAmountZatoshi: giftCard?.amountZatoshi,
+        privacyModeEnabled: privacyModeEnabled,
+        dateOnlyTimestamp: true,
+        onTap: () => unawaited(
+          _openTransactionStatus(context, ref, transaction, giftCard: giftCard),
+        ),
       ),
     );
   }
@@ -969,8 +996,10 @@ class _HomeContentState extends ConsumerState<_HomeContent> {
         widget.ironwoodMigrationCta.mode == IronwoodHomeMigrationCtaMode.start;
     final migrationInProgress =
         widget.ironwoodMigrationCta.mode == IronwoodHomeMigrationCtaMode.resume;
-    final sendDisabled =
-        migrationInProgress && sync.ironwoodBalance <= BigInt.zero;
+    // Same predicate as before, now owned by `migrationSendGateProvider` so
+    // the payment-URI drain in `app.dart` cannot drift away from what this
+    // button does.
+    final sendDisabled = ref.watch(migrationSendGateProvider);
     final shieldedBalance = migrationRequired
         ? sync.orchardBalance + sync.orchardPendingBalance
         : sync.saplingBalance +
@@ -1009,6 +1038,10 @@ class _HomeContentState extends ConsumerState<_HomeContent> {
     );
 
     final uuid = activeAccountUuid;
+    final giftCardActivityIndex = uuid == null
+        ? GiftCardActivityIndex.empty
+        : ref.watch(giftCardActivityIndexProvider(uuid)).value ??
+              GiftCardActivityIndex.empty;
     final swapItems = uuid == null
         ? const <SwapActivityRowItem>[]
         : ref.watch(swapActivityRowItemsProvider(uuid)).value ??
@@ -1023,15 +1056,12 @@ class _HomeContentState extends ConsumerState<_HomeContent> {
     final entries = <ActivityEntry>[
       for (final tx in sync.recentTransactions)
         if (!absorption.absorbs(tx))
-          ActivityEntry(
-            timestamp: transactionActivityTimestamp(tx),
-            row: buildTransactionActivityRow(
-              context: context,
-              transaction: tx,
-              privacyModeEnabled: privacyModeEnabled,
-              dateOnlyTimestamp: true,
-              onTap: () => unawaited(_openTransactionStatus(context, ref, tx)),
-            ),
+          _transactionEntry(
+            context,
+            ref,
+            tx,
+            giftCardActivityIndex.metadataFor(tx),
+            privacyModeEnabled: privacyModeEnabled,
           ),
       for (final item in swapItems)
         ActivityEntry(

--- a/lib/src/features/home/screens/mobile/mobile_keystone_shield_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_keystone_shield_screen.dart
@@ -21,7 +21,6 @@ import '../../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../../services/camera_permission_settings.dart';
 import '../../../../services/qr_scanner.dart';
-import '../../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../address_scan/widgets/mobile_address_scan_view.dart'
     show MobileScanCameraErrorOverlay, MobileScanViewfinderCorners;
 import '../../../keystone/widgets/keystone_pczt_qr_stage.dart';

--- a/lib/src/features/home/screens/mobile/mobile_keystone_shield_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_keystone_shield_screen.dart
@@ -21,6 +21,7 @@ import '../../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../../services/camera_permission_settings.dart';
 import '../../../../services/qr_scanner.dart';
+import '../../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../address_scan/widgets/mobile_address_scan_view.dart'
     show MobileScanCameraErrorOverlay, MobileScanViewfinderCorners;
 import '../../../keystone/widgets/keystone_pczt_qr_stage.dart';
@@ -58,6 +59,8 @@ class MobileKeystoneShieldScreen extends ConsumerStatefulWidget {
       _MobileKeystoneShieldScreenState();
 }
 
+// Shows the shield PCZT QR and then scans the signed result, so the whole
+// screen is a live Keystone session.
 class _MobileKeystoneShieldScreenState
     extends ConsumerState<MobileKeystoneShieldScreen>
     with WidgetsBindingObserver, PaymentUriBusySurfaceHoldMixin {

--- a/lib/src/features/voting/screens/mobile/mobile_keystone_voting_signing_screen.dart
+++ b/lib/src/features/voting/screens/mobile/mobile_keystone_voting_signing_screen.dart
@@ -40,7 +40,8 @@ class MobileKeystoneVotingSigningScreen extends StatelessWidget {
       '${presentation.urParts.first.hashCode}',
     );
 
-    // A live signing QR; a payment-request card must wait, not cover it.
+    // Above the keyed flow on purpose: the key changes per bundle, so a hold
+    // taken inside the flow would fall back to zero between bundles.
     return PaymentUriBusySurfaceHold(
       child: MobileKeystonePcztSigningFlow(
         key: flowKey,

--- a/lib/widgetbook/payment_link_mobile_use_cases.dart
+++ b/lib/widgetbook/payment_link_mobile_use_cases.dart
@@ -46,7 +46,6 @@ Widget buildMobilePaymentLinkAmountEmptyUseCase(BuildContext context) {
         artwork: _fixtureArtwork,
         cardWidth: _cardWidth,
         cardHeight: _cardHeight,
-        emptyAmountLabel: 'Enter Amount',
       ),
       cardSelector: _artworkSelector(_fixtureArtwork),
       onBack: _noop,
@@ -761,7 +760,6 @@ class _MobilePaymentLinkInteractivePreviewState
             _handleAmountChanged(_fixtureAmount);
           },
           showMaxButton: true,
-          emptyAmountLabel: 'Enter Amount',
           semanticLabel: 'Gift card amount input',
         ),
         cardSelector: PaymentLinkCardSelectorRail(

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -21,6 +21,7 @@ import 'package:zcash_wallet/src/features/home/screens/mobile/mobile_home_screen
 import 'package:zcash_wallet/src/features/pay/screens/mobile/mobile_pay_screen.dart';
 import 'package:zcash_wallet/src/features/pay/screens/mobile/mobile_pay_submitted_screen.dart';
 import 'package:zcash_wallet/src/features/receive/screens/mobile/mobile_receive_screen.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
 import 'package:zcash_wallet/src/features/send/screens/mobile/mobile_send_screen.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_activity_navigation.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
@@ -31,6 +32,7 @@ import 'package:zcash_wallet/src/features/swap/screens/mobile/mobile_swap_keysto
 import 'package:zcash_wallet/src/features/swap/screens/mobile/mobile_swap_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 import '../../fakes/fake_sync_notifier.dart';
@@ -95,7 +97,20 @@ Widget _app(
   ),
 );
 
+LocalKey? _sendPageKey(WidgetTester tester) =>
+    (ModalRoute.of(tester.element(find.byType(MobileSendScreen)))!.settings
+            as Page<dynamic>)
+        .key;
+
 void main() {
+  test('registers the mobile payment-link intake route', () {
+    final paths = buildMobileRoutes(
+      entryRoutes: const [],
+    ).whereType<GoRoute>().map((route) => route.path);
+
+    expect(paths, contains('/payment-links'));
+  });
+
   test('does not register the removed private review route', () {
     final paths = buildMobileRoutes(
       entryRoutes: const [],
@@ -193,6 +208,92 @@ void main() {
     expect(find.byType(MobileHomeScreen), findsOneWidget);
   });
 
+  testWidgets(
+    'a ZIP-321 SendPrefillArgs on /send populates the mobile send screen',
+    (tester) async {
+      final router = _router();
+      await tester.pumpWidget(
+        _app(
+          router,
+          // The amount step's price placeholder shimmers forever while the
+          // live ZEC/USD price is null, which would hang pumpAndSettle.
+          overrides: [zecLiveUsdUnitPriceProvider.overrideWithValue(210)],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      unawaited(
+        router.push<void>(
+          '/send',
+          extra: const SendPrefillArgs(
+            id: 'payment-uri-1',
+            source: 'zcash-uri',
+            address: 'u1routeraddress',
+            amountText: '0.25',
+            memoText: '  coffee  ',
+            preserveMemoText: true,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The mobile /send route must unpack SendPrefillArgs (a ZIP-321 payment
+      // URI) into the recipient + amount + memo, not drop it like a bare
+      // recipient string would.
+      final sendScreen = tester.widget<MobileSendScreen>(
+        find.byType(MobileSendScreen),
+      );
+      expect(sendScreen.initialRecipient, 'u1routeraddress');
+      expect(sendScreen.initialAmount, '0.25');
+      expect(sendScreen.initialMemo, '  coffee  ');
+      expect(sendScreen.preserveInitialMemoWhitespace, isTrue);
+    },
+  );
+
+  testWidgets(
+    'a second payment request answered onto /send re-seeds the composer',
+    (tester) async {
+      final router = _router();
+      await tester.pumpWidget(
+        _app(
+          router,
+          overrides: [zecLiveUsdUnitPriceProvider.overrideWithValue(210)],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      router.go(
+        '/send',
+        extra: const SendPrefillArgs(
+          id: 'payment-uri-1',
+          source: kPaymentUriPrefillSource,
+          address: 'u1firstrequestaddress',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final firstPageKey = _sendPageKey(tester);
+      expect(find.text('u1firstrequestaddress'), findsOneWidget);
+
+      // What the payment-request card's Edit does when the user is already
+      // standing on /send. A shared page key would update the page in place,
+      // and `_MobileSendScreenState` only reads the prefill in `initState`.
+      router.go(
+        '/send',
+        extra: const SendPrefillArgs(
+          id: 'payment-uri-2',
+          source: kPaymentUriPrefillSource,
+          address: 'u1secondrequestaddress',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(_sendPageKey(tester), isNot(firstPageKey));
+      expect(find.text('u1secondrequestaddress'), findsOneWidget);
+      expect(find.text('u1firstrequestaddress'), findsNothing);
+    },
+  );
+
   testWidgets('send amount and review routes push Cupertino pages', (
     tester,
   ) async {
@@ -207,6 +308,7 @@ void main() {
           sendFlowId: 'flow-1',
           recipient: 'u1routeraddress',
           addressType: 'unified',
+          amountText: '0.25',
         ),
       ),
     );
@@ -218,6 +320,15 @@ void main() {
       tester.element(find.byType(MobileSendAmountScreen)),
     );
     expect(route, isA<CupertinoRouteTransitionMixin<dynamic>>());
+    // An amount already composed on the recipient step (a ZIP-321 deep link
+    // that stepped back in place) has to reach the pushed amount page.
+    final amountScreen = tester.widget<MobileSendScreen>(
+      find.descendant(
+        of: find.byType(MobileSendAmountScreen),
+        matching: find.byType(MobileSendScreen),
+      ),
+    );
+    expect(amountScreen.initialAmount, '0.25');
 
     unawaited(
       router.push<void>(

--- a/test/features/activity/mobile_activity_screen_test.dart
+++ b/test/features/activity/mobile_activity_screen_test.dart
@@ -247,9 +247,25 @@ void main() {
             kind: 'sent',
           ),
         ],
-        giftCardActivityIndex: const GiftCardActivityIndex(
-          createdTxids: {'gift-created'},
-          redeemedTxids: {'gift-redeemed'},
+        giftCardActivityIndex: GiftCardActivityIndex(
+          createdTxids: const {'gift-created'},
+          redeemedTxids: const {'gift-redeemed'},
+          createdMetadataByTxid: {
+            'gift-created': GiftCardActivityMetadata(
+              kind: GiftCardActivityKind.created,
+              amountZatoshi: BigInt.from(50000000),
+              artworkId: 'ruby',
+              message: 'Happy birthday!',
+            ),
+          },
+          redeemedMetadataByTxid: {
+            'gift-redeemed': GiftCardActivityMetadata(
+              kind: GiftCardActivityKind.redeemed,
+              amountZatoshi: BigInt.from(30000000),
+              artworkId: 'crystal',
+              message: null,
+            ),
+          },
         ),
       ),
     );
@@ -257,6 +273,11 @@ void main() {
 
     expect(find.text('Redeemed a Gift Card'), findsOneWidget);
     expect(find.text('Created a Gift Card'), findsOneWidget);
+    // The card amount, not the funding total the transaction carries.
+    expect(find.text('-0.5 ZEC'), findsOneWidget);
+    expect(find.text('+0.3 ZEC'), findsOneWidget);
+    expect(find.text('-1 ZEC'), findsNothing);
+    expect(find.text('+1 ZEC'), findsNothing);
     expect(
       find.byWidgetPredicate(
         (widget) => widget is AppIcon && widget.name == AppIcons.giftCard,

--- a/test/features/activity/mobile_activity_screen_test.dart
+++ b/test/features/activity/mobile_activity_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/activity/screens/mobile/mobile_activity_screen.dart';
+import 'package:zcash_wallet/src/features/activity/gift_card_activity_index.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_activity_store.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
@@ -97,6 +98,7 @@ SwapIntentRecord _payActivityRecord({
 Widget _app(
   MobileActivityHistoryLoader loader, {
   SwapActivityStore? swapActivityStore,
+  GiftCardActivityIndex giftCardActivityIndex = GiftCardActivityIndex.empty,
 }) {
   return ProviderScope(
     overrides: [
@@ -108,6 +110,9 @@ Widget _app(
       ),
       if (swapActivityStore != null)
         swapActivityStoreProvider.overrideWithValue(swapActivityStore),
+      giftCardActivityIndexProvider.overrideWith((ref, accountUuid) async {
+        return giftCardActivityIndex;
+      }),
     ],
     child: MaterialApp(
       home: AppTheme(
@@ -229,6 +234,35 @@ void main() {
       moreOrLessEquals(kMobileTopNavHeight + AppSpacing.s),
     );
     expect(find.text('No activity yet'), findsOneWidget);
+  });
+
+  testWidgets('renders Gift Card creation and redemption rows', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        (_) async => [
+          _tx(txidHex: 'gift-redeemed', blockTime: BigInt.from(1800000001)),
+          _tx(
+            txidHex: 'gift-created',
+            blockTime: BigInt.from(1800000000),
+            kind: 'sent',
+          ),
+        ],
+        giftCardActivityIndex: const GiftCardActivityIndex(
+          createdTxids: {'gift-created'},
+          redeemedTxids: {'gift-redeemed'},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Redeemed a Gift Card'), findsOneWidget);
+    expect(find.text('Created a Gift Card'), findsOneWidget);
+    expect(
+      find.byWidgetPredicate(
+        (widget) => widget is AppIcon && widget.name == AppIcons.giftCard,
+      ),
+      findsNWidgets(2),
+    );
   });
 
   testWidgets('surfaces a friendly error when loading fails', (tester) async {

--- a/test/features/activity/mobile_transaction_status_screen_test.dart
+++ b/test/features/activity/mobile_transaction_status_screen_test.dart
@@ -119,6 +119,7 @@ Widget _app(
   rust_sync.TransactionDetail? detail,
   GiftCardActivityMetadata? giftCard,
   GiftCardActivityIndex giftCardIndex = GiftCardActivityIndex.empty,
+  AccountNotifier? accountNotifier,
   List<AddressBookContact> contacts = const [],
   Map<String, AccountInfo> ownAccounts = const {},
 }) {
@@ -138,6 +139,8 @@ Widget _app(
       giftCardActivityIndexProvider.overrideWith(
         (ref, _) async => giftCardIndex,
       ),
+      if (accountNotifier != null)
+        accountProvider.overrideWith(() => accountNotifier),
     ],
     child: MaterialApp(
       home: AppTheme(
@@ -219,6 +222,38 @@ void main() {
     await tester.pump();
     expect(find.text('Happy birthday!'), findsOneWidget);
   });
+
+  testWidgets(
+    'Gift Card receipt drops route metadata after an account switch',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(393, 1200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final accountNotifier = _SwitchableAccountNotifier();
+      await tester.pumpWidget(
+        _app(
+          _tx(),
+          giftCard: _giftCard(message: 'Happy birthday!'),
+          accountNotifier: accountNotifier,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Created a Gift Card'), findsOneWidget);
+      expect(find.byType(PaymentLinkGiftCard), findsOneWidget);
+
+      // account-2's index knows nothing about this txid, so the receipt must
+      // fall back to the generic one instead of keeping account-1's card.
+      accountNotifier.setActiveAccount('account-2');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Created a Gift Card'), findsNothing);
+      expect(find.byType(PaymentLinkGiftCard), findsNothing);
+      expect(find.text('Message'), findsNothing);
+      expect(find.text('Sent successfully'), findsOneWidget);
+      expect(find.text('To'), findsOneWidget);
+    },
+  );
 
   testWidgets('Gift Card receipt resolves metadata the route did not carry', (
     tester,
@@ -586,6 +621,33 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.textContaining('ZIP 317'), findsOneWidget);
   });
+}
+
+class _SwitchableAccountNotifier extends AccountNotifier {
+  @override
+  AccountState build() => const AccountState(
+    accounts: [
+      AccountInfo(
+        uuid: 'account-1',
+        name: 'Account1',
+        order: 0,
+        profilePictureId: kDefaultProfilePictureId,
+      ),
+      AccountInfo(
+        uuid: 'account-2',
+        name: 'Account2',
+        order: 1,
+        profilePictureId: kDefaultProfilePictureId,
+      ),
+    ],
+    activeAccountUuid: 'account-1',
+  );
+
+  void setActiveAccount(String uuid) {
+    state = AsyncData(
+      state.requireValue.copyWith(activeAccountUuid: uuid, activeAddress: null),
+    );
+  }
 }
 
 class _FakeAddressBookRepository implements AddressBookRepository {

--- a/test/features/activity/mobile_transaction_status_screen_test.dart
+++ b/test/features/activity/mobile_transaction_status_screen_test.dart
@@ -11,9 +11,11 @@ import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_profile_picture.dart';
+import 'package:zcash_wallet/src/features/activity/gift_card_activity_index.dart';
 import 'package:zcash_wallet/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
+import 'package:zcash_wallet/src/features/payment_links/widgets/payment_link_gift_card.dart';
 import 'package:zcash_wallet/src/features/send/widgets/send_recipient_resolver.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
@@ -99,10 +101,24 @@ rust_sync.TransactionDetail _detail({
   );
 }
 
+GiftCardActivityMetadata _giftCard({
+  GiftCardActivityKind kind = GiftCardActivityKind.created,
+  BigInt? amountZatoshi,
+  String? message,
+}) {
+  return GiftCardActivityMetadata(
+    kind: kind,
+    amountZatoshi: amountZatoshi ?? BigInt.from(100000),
+    artworkId: 'ruby',
+    message: message,
+  );
+}
+
 Widget _app(
   rust_sync.TransactionInfo tx, {
   rust_sync.TransactionDetail? detail,
-  BigInt? giftCardAmountZatoshi,
+  GiftCardActivityMetadata? giftCard,
+  GiftCardActivityIndex giftCardIndex = GiftCardActivityIndex.empty,
   List<AddressBookContact> contacts = const [],
   Map<String, AccountInfo> ownAccounts = const {},
 }) {
@@ -119,6 +135,9 @@ Widget _app(
         _FakeAddressBookRepository(contacts),
       ),
       ownAccountAddressesProvider.overrideWith((ref) async => ownAccounts),
+      giftCardActivityIndexProvider.overrideWith(
+        (ref, _) async => giftCardIndex,
+      ),
     ],
     child: MaterialApp(
       home: AppTheme(
@@ -129,7 +148,7 @@ Widget _app(
             txKind: tx.txKind,
             initialTransaction: tx,
             initialDetail: resolvedDetail,
-            giftCardAmountZatoshi: giftCardAmountZatoshi,
+            giftCard: giftCard,
           ),
           historyLoader: (_) async => [tx],
           detailLoader: (_, _) async => resolvedDetail,
@@ -155,12 +174,72 @@ void main() {
   testWidgets('Gift Card detail shows the promised amount, not its funding', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      _app(_tx(), giftCardAmountZatoshi: BigInt.from(100000)),
-    );
+    await tester.binding.setSurfaceSize(const Size(393, 1200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(_app(_tx(), giftCard: _giftCard()));
     await tester.pumpAndSettle();
 
     expect(find.text('0.001 ZEC'), findsOneWidget);
+    expect(find.text('123.12 ZEC'), findsNothing);
+  });
+
+  testWidgets('Gift Card receipt titles the card and hides the link address', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(393, 1200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      _app(_tx(), giftCard: _giftCard(message: 'Happy birthday!')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Created a Gift Card'), findsOneWidget);
+    expect(find.text('Sent successfully'), findsNothing);
+    // The single-use link address is not a counterparty worth verifying.
+    expect(find.text('To'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('mobile_tx_status_show_full_address')),
+      findsNothing,
+    );
+    expect(
+      find.text(
+        '${_address.substring(0, 6)} ... '
+        '${_address.substring(_address.length - 5)}',
+      ),
+      findsNothing,
+    );
+    expect(find.byType(PaymentLinkGiftCard), findsOneWidget);
+
+    expect(find.text('Message'), findsOneWidget);
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_tx_status_message_toggle')),
+    );
+    await tester.pump();
+    expect(find.text('Happy birthday!'), findsOneWidget);
+  });
+
+  testWidgets('Gift Card receipt resolves metadata the route did not carry', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(393, 1200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      _app(
+        _tx(),
+        giftCardIndex: GiftCardActivityIndex(
+          createdTxids: const {_txid},
+          createdMetadataByTxid: {_txid: _giftCard()},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Created a Gift Card'), findsOneWidget);
+    expect(find.text('0.001 ZEC'), findsOneWidget);
+    // Not the raw funding total the transaction carries.
     expect(find.text('123.12 ZEC'), findsNothing);
   });
 

--- a/test/features/activity/mobile_transaction_status_screen_test.dart
+++ b/test/features/activity/mobile_transaction_status_screen_test.dart
@@ -102,6 +102,7 @@ rust_sync.TransactionDetail _detail({
 Widget _app(
   rust_sync.TransactionInfo tx, {
   rust_sync.TransactionDetail? detail,
+  BigInt? giftCardAmountZatoshi,
   List<AddressBookContact> contacts = const [],
   Map<String, AccountInfo> ownAccounts = const {},
 }) {
@@ -128,6 +129,7 @@ Widget _app(
             txKind: tx.txKind,
             initialTransaction: tx,
             initialDetail: resolvedDetail,
+            giftCardAmountZatoshi: giftCardAmountZatoshi,
           ),
           historyLoader: (_) async => [tx],
           detailLoader: (_, _) async => resolvedDetail,
@@ -148,6 +150,18 @@ void main() {
 
     expect(find.text('Amount'), findsOneWidget);
     expect(find.text('To'), findsOneWidget);
+  });
+
+  testWidgets('Gift Card detail shows the promised amount, not its funding', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(_tx(), giftCardAmountZatoshi: BigInt.from(100000)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('0.001 ZEC'), findsOneWidget);
+    expect(find.text('123.12 ZEC'), findsNothing);
   });
 
   testWidgets('mined sent tx shows success title, chip, fee, and address', (

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -607,8 +607,7 @@ void main() {
       find.descendant(
         of: entry,
         matching: find.byWidgetPredicate(
-          (widget) =>
-              widget is AppIcon && widget.name == AppIcons.vote,
+          (widget) => widget is AppIcon && widget.name == AppIcons.vote,
         ),
       ),
       findsOneWidget,
@@ -2384,7 +2383,7 @@ void main() {
           recentTransactions: [
             _receivedZecTx(
               txidHex: 'gift-redeemed',
-              zatoshi: BigInt.from(100000),
+              zatoshi: BigInt.from(200000000),
             ),
             _sentZecTx(txidHex: 'gift-created'),
           ],
@@ -2395,7 +2394,7 @@ void main() {
           createdMetadataByTxid: {
             'gift-created': GiftCardActivityMetadata(
               kind: GiftCardActivityKind.created,
-              amountZatoshi: BigInt.from(100000),
+              amountZatoshi: BigInt.from(50000000),
               artworkId: 'ruby',
               message: 'Happy birthday!',
             ),
@@ -2403,7 +2402,7 @@ void main() {
           redeemedMetadataByTxid: {
             'gift-redeemed': GiftCardActivityMetadata(
               kind: GiftCardActivityKind.redeemed,
-              amountZatoshi: BigInt.from(100000),
+              amountZatoshi: BigInt.from(30000000),
               artworkId: 'crystal',
               message: null,
             ),
@@ -2420,6 +2419,11 @@ void main() {
     expect(find.text('Redeemed a Gift Card'), findsOneWidget);
     expect(find.text('Sent'), findsNothing);
     expect(find.text('Received'), findsNothing);
+    // The card amount, not the funding total the transaction carries.
+    expect(find.text('-0.5 ZEC'), findsOneWidget);
+    expect(find.text('+0.3 ZEC'), findsOneWidget);
+    expect(find.text('-0.1954 ZEC'), findsNothing);
+    expect(find.text('+2 ZEC'), findsNothing);
   });
 
   testWidgets('recent activity absorbs a Pay deposit transaction duplicate', (

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/home/screens/mobile/mobile_home_screen.dart';
+import 'package:zcash_wallet/src/features/activity/gift_card_activity_index.dart';
 import 'package:zcash_wallet/src/features/migration/models/mobile_ironwood_migration_attention_state.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
@@ -201,6 +202,7 @@ Widget _app(
   IronwoodMigrationCoordinator Function()? migrationCoordinator,
   Set<String> seenMigrationAttentionFingerprints = const {},
   SwapActivityStore? swapActivityStore,
+  GiftCardActivityIndex? giftCardActivityIndex,
   AppThemeData theme = AppThemeData.dark,
 }) {
   final effectiveSyncNotifier = syncNotifier ?? FakeSyncNotifier(syncState);
@@ -318,6 +320,10 @@ Widget _app(
       ),
       if (swapActivityStore != null)
         swapActivityStoreProvider.overrideWithValue(swapActivityStore),
+      if (giftCardActivityIndex != null)
+        giftCardActivityIndexProvider.overrideWith(
+          (ref, accountUuid) async => giftCardActivityIndex,
+        ),
     ],
     child: MaterialApp.router(
       routerConfig: router,
@@ -2364,6 +2370,56 @@ void main() {
       find.byKey(const ValueKey('mobile_home_activity_row_10')),
       findsNothing,
     );
+  });
+
+  testWidgets('recent activity labels Gift Card transactions', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1400));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(
+      _app(
+        _syncedState(orchardBalance: BigInt.from(100000000)).copyWith(
+          recentTransactions: [
+            _receivedZecTx(
+              txidHex: 'gift-redeemed',
+              zatoshi: BigInt.from(100000),
+            ),
+            _sentZecTx(txidHex: 'gift-created'),
+          ],
+        ),
+        giftCardActivityIndex: GiftCardActivityIndex(
+          createdTxids: const {'gift-created'},
+          redeemedTxids: const {'gift-redeemed'},
+          createdMetadataByTxid: {
+            'gift-created': GiftCardActivityMetadata(
+              kind: GiftCardActivityKind.created,
+              amountZatoshi: BigInt.from(100000),
+              artworkId: 'ruby',
+              message: 'Happy birthday!',
+            ),
+          },
+          redeemedMetadataByTxid: {
+            'gift-redeemed': GiftCardActivityMetadata(
+              kind: GiftCardActivityKind.redeemed,
+              amountZatoshi: BigInt.from(100000),
+              artworkId: 'crystal',
+              message: null,
+            ),
+          },
+        ),
+      ),
+    );
+    for (var i = 0; i < 10; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+      if (find.text('Creating a Gift Card...').evaluate().isNotEmpty) break;
+    }
+
+    expect(find.text('Creating a Gift Card...'), findsOneWidget);
+    expect(find.text('Redeemed a Gift Card'), findsOneWidget);
+    expect(find.text('Sent'), findsNothing);
+    expect(find.text('Received'), findsNothing);
   });
 
   testWidgets('recent activity absorbs a Pay deposit transaction duplicate', (

--- a/test/features/home/mobile_keystone_shield_screen_busy_surface_test.dart
+++ b/test/features/home/mobile_keystone_shield_screen_busy_surface_test.dart
@@ -1,0 +1,79 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/home/screens/mobile/mobile_keystone_shield_screen.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+import '../../support/payment_uri_busy_surface_expectations.dart';
+
+/// The mobile shielding screen is the phone-side twin of the desktop shield
+/// overlay: it shows the shield PCZT QR and then scans the signed result, so
+/// the whole screen is a live Keystone session.
+void main() {
+  testWidgets('the mobile shield signing screen holds the payment-URI busy '
+      'latch', (tester) async {
+    final container = _container();
+    await expectPaymentUriBusySurfaceHeldWhileMounted(
+      tester,
+      container: container,
+      host: _host(container),
+      surface: const MobileKeystoneShieldScreen(),
+      drainExceptions: true,
+      postUnmountSettle: const Duration(seconds: 2),
+    );
+  });
+}
+
+ProviderContainer _container() {
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap()),
+      syncProvider.overrideWith(FakeSyncNotifier.new),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+Widget Function(Widget) _host(ProviderContainer container) =>
+    (child) => UncontrolledProviderScope(
+      container: container,
+      child: AppTheme(
+        data: AppThemeData.dark,
+        child: MaterialApp(home: Scaffold(body: child)),
+      ),
+    );
+
+const _accountState = AccountState(
+  accounts: [
+    AccountInfo(
+      uuid: 'account-1',
+      name: 'Account1',
+      order: 0,
+      isHardware: true,
+    ),
+  ],
+  activeAccountUuid: 'account-1',
+  activeAddress: 'u1mobileshield',
+);
+
+AppBootstrapState _bootstrap() => AppBootstrapState(
+  initialLocation: '/home/keystone-shield',
+  initialAccountState: _accountState,
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);

--- a/test/features/payment_links/payment_link_cards_mobile_view_test.dart
+++ b/test/features/payment_links/payment_link_cards_mobile_view_test.dart
@@ -1,0 +1,184 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/payment_links/widgets/mobile/payment_link_mobile_views.dart';
+import 'package:zcash_wallet/src/features/payment_links/widgets/payment_link_copy.dart';
+
+import '../../figma_compare/figma_compare_font_loader.dart';
+
+void main() {
+  setUpAll(loadFigmaCompareFonts);
+
+  testWidgets('an empty tab keeps the create and redeem actions reachable', (
+    tester,
+  ) async {
+    await _pumpCards(
+      tester,
+      sections: const [PaymentLinkCardsSection(label: 'Received', cards: [])],
+      activeTab: PaymentLinkCardsTab.received,
+      emptyLabel: kPaymentLinkNoReceivedCardsText,
+    );
+
+    expect(find.text(kPaymentLinkNoReceivedCardsText), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('payment_links_mobile_cards_list')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('payment_links_mobile_create_button')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('payment_links_mobile_redeem_button')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a funded unshared card exposes its copy-link action', (
+    tester,
+  ) async {
+    var copies = 0;
+    await _pumpCards(
+      tester,
+      sections: [
+        PaymentLinkCardsSection(
+          label: kPaymentLinkPendingSectionLabel,
+          cards: [
+            PaymentLinkCardListMobileRow(
+              thumbnail: const SizedBox(),
+              amountText: '4.45 ZEC',
+              dateText: 'August 7',
+              showCopyAction: true,
+              onCopyLink: () => copies += 1,
+            ),
+          ],
+        ),
+      ],
+    );
+
+    expect(find.text('4.45 ZEC'), findsOneWidget);
+    expect(find.text('August 7'), findsOneWidget);
+    expect(find.text(kPaymentLinkPendingSectionLabel), findsOneWidget);
+    // A funded card shows the copy action instead of a status label — this is
+    // the affordance that was missing once the user left the Ready page.
+    expect(find.bySemanticsLabel(kPaymentLinkCopyLinkSemanticLabel), findsOne);
+
+    await tester.tap(
+      find.byKey(const ValueKey('payment_link_mobile_card_copy_action')),
+    );
+    await tester.pump();
+
+    expect(copies, 1);
+  });
+
+  testWidgets('an incomplete card shows its status instead of a copy action', (
+    tester,
+  ) async {
+    await _pumpCards(
+      tester,
+      sections: const [
+        PaymentLinkCardsSection(
+          label: kPaymentLinkCreatingSectionLabel,
+          cards: [
+            PaymentLinkCardListMobileRow(
+              thumbnail: SizedBox(),
+              amountText: '0.25 ZEC',
+              dateText: 'July 2',
+              statusText: kPaymentLinkFundingIncompleteStatus,
+            ),
+          ],
+        ),
+      ],
+    );
+
+    expect(find.text(kPaymentLinkFundingIncompleteStatus), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('payment_link_mobile_card_copy_action')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('a receiving card shows its status and forwards no tap', (
+    tester,
+  ) async {
+    await _pumpCards(
+      tester,
+      activeTab: PaymentLinkCardsTab.received,
+      sections: const [
+        PaymentLinkCardsSection(
+          label: kPaymentLinkReceivedTabLabel,
+          cards: [
+            PaymentLinkCardListMobileRow(
+              thumbnail: SizedBox(),
+              amountText: '0.75 ZEC',
+              dateText: 'August 4',
+              statusText: 'Receiving...',
+              showLoader: true,
+            ),
+          ],
+        ),
+      ],
+    );
+
+    expect(find.text('Receiving...'), findsOneWidget);
+    expect(find.text('0.75 ZEC'), findsOneWidget);
+    // A claim already in flight is not re-openable from the row.
+    expect(find.bySemanticsLabel('Receiving...'), findsNothing);
+  });
+
+  testWidgets('tapping a tab reports the selection', (tester) async {
+    final selections = <PaymentLinkCardsTab>[];
+    await _pumpCards(
+      tester,
+      sections: const [PaymentLinkCardsSection(label: 'Received', cards: [])],
+      onTabSelected: selections.add,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('payment_links_mobile_received_tab')),
+    );
+    await tester.pump();
+
+    expect(selections, [PaymentLinkCardsTab.received]);
+  });
+}
+
+Future<void> _pumpCards(
+  WidgetTester tester, {
+  required List<PaymentLinkCardsSection> sections,
+  PaymentLinkCardsTab activeTab = PaymentLinkCardsTab.created,
+  ValueChanged<PaymentLinkCardsTab>? onTabSelected,
+  String? emptyLabel,
+}) async {
+  await tester.binding.setSurfaceSize(const Size(393, 773));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpWidget(
+    MaterialApp(
+      builder: (_, navigator) =>
+          AppTheme(data: AppThemeData.dark, child: navigator!),
+      home: Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 393,
+          height: 773,
+          child: PaymentLinkCardsMobileView(
+            sections: sections,
+            activeTab: activeTab,
+            onTabSelected: onTabSelected,
+            emptyLabel: emptyLabel,
+            onBack: _noop,
+            onCreate: _noop,
+            onRedeem: _noop,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void _noop() {}

--- a/test/features/payment_links/payment_link_mobile_views_test.dart
+++ b/test/features/payment_links/payment_link_mobile_views_test.dart
@@ -1,0 +1,320 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/payment_links/widgets/mobile/payment_link_mobile_views.dart';
+
+import '../../figma_compare/figma_compare_font_loader.dart';
+
+const _feeHelpText =
+    'Includes the fee to fund the Gift Card and the fee reserved for '
+    'the recipient to claim it.';
+
+void main() {
+  setUpAll(loadFigmaCompareFonts);
+
+  testWidgets('review defaults describe review and card creation', (
+    tester,
+  ) async {
+    await _pumpReview(tester);
+
+    expect(find.text('Review a Card'), findsOneWidget);
+    expect(
+      find.text('Attach a short encrypted memo (optional).'),
+      findsOneWidget,
+    );
+    expect(find.text('Approve & create'), findsOneWidget);
+    expect(find.text('Enter a message'), findsNothing);
+  });
+
+  testWidgets('fee help tap shows its tooltip and forwards the callback', (
+    tester,
+  ) async {
+    var helpCalls = 0;
+    await _pumpReview(tester, onFeeHelp: () => helpCalls++);
+
+    expect(find.text(_feeHelpText), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey('payment_link_mobile_fee_help')),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(helpCalls, 1);
+    expect(find.text(_feeHelpText), findsOneWidget);
+  });
+
+  testWidgets('wizard and review subtitles are centered', (tester) async {
+    await _pumpAmount(tester);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('payment_link_mobile_step_subtitle')),
+          )
+          .textAlign,
+      TextAlign.center,
+    );
+
+    await _pumpReview(tester);
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('payment_link_mobile_review_subtitle')),
+          )
+          .textAlign,
+      TextAlign.center,
+    );
+  });
+
+  testWidgets('review summary matches the mobile Figma surface geometry', (
+    tester,
+  ) async {
+    await _pumpReview(tester);
+
+    final summary = find.byKey(
+      const ValueKey('payment_link_mobile_review_summary'),
+    );
+    expect(tester.getSize(summary), const Size(361, 193));
+    expect(tester.getTopLeft(summary).dx, 16);
+    expect(tester.getTopLeft(summary).dy, closeTo(456.625, 0.01));
+
+    final container = tester.widget<Container>(summary);
+    expect(
+      container.padding,
+      const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: AppSpacing.base,
+      ),
+    );
+    final decoration = container.decoration! as BoxDecoration;
+    expect(decoration.color, AppThemeData.light.colors.background.ground);
+    expect(decoration.borderRadius, BorderRadius.circular(AppRadii.large));
+  });
+
+  testWidgets('amount selector strip uses the lowered mobile anchor', (
+    tester,
+  ) async {
+    await _pumpAmount(tester);
+
+    final selector = find.byKey(const ValueKey('mobile_selector_probe'));
+    expect(tester.getTopLeft(selector).dy, closeTo(452.625, 0.01));
+  });
+
+  testWidgets('redeem states match paste, checking, and invalid surfaces', (
+    tester,
+  ) async {
+    await _pumpRedeem(tester, PaymentLinkRedeemMobileState.paste);
+    final pasteZone = find.byKey(
+      const ValueKey('payment_link_mobile_redeem_drop_zone'),
+    );
+    expect(tester.getSize(pasteZone), const Size(361, 225.625));
+    expect(tester.getTopLeft(pasteZone), const Offset(16, 218));
+    expect(find.text('Paste card link'), findsOneWidget);
+
+    await _pumpRedeem(tester, PaymentLinkRedeemMobileState.loading);
+    final loadingCard = find.byKey(
+      const ValueKey('payment_link_mobile_loading_card'),
+    );
+    expect(tester.getSize(loadingCard), const Size(320, 200));
+    expect(tester.getTopLeft(loadingCard), const Offset(36.5, 218));
+    expect(find.text('Checking ...'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('payment_link_mobile_paste_button')),
+      findsNothing,
+    );
+
+    await _pumpRedeem(tester, PaymentLinkRedeemMobileState.invalid);
+    expect(tester.getTopLeft(pasteZone), const Offset(16, 218));
+    expect(find.text('The link doesn’t look legit.'), findsOneWidget);
+    expect(find.text('Clear clipboard'), findsOneWidget);
+  });
+
+  testWidgets('received waiting copy explains the six-confirmation gate', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(393, 773));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (_, navigator) =>
+            AppTheme(data: AppThemeData.light, child: navigator!),
+        home: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: SizedBox(
+            width: 393,
+            height: 773,
+            child: PaymentLinkReadyMobileView(
+              state: PaymentLinkReadyMobileState.soon,
+              card: SizedBox(
+                width: kPaymentLinkMobileCardWidth,
+                height: kPaymentLinkMobileCardHeight,
+              ),
+              cardTop: kPaymentLinkMobileReceivedCardTop,
+              onHome: _noop,
+              waitingHeading: 'Your Gift Card\nis almost ready!',
+              waitingDescription: 'Waiting for 6 confirmations.',
+              waitingStatusLabel: 'Wait 5:00 to claim',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Waiting for 6 confirmations.'), findsOneWidget);
+    expect(find.text('Wait 5:00 to claim'), findsOneWidget);
+    expect(find.text('Copy link'), findsNothing);
+    expect(
+      tester
+          .getTopLeft(
+            find.byKey(const ValueKey('payment_link_mobile_card_slot')),
+          )
+          .dy,
+      kPaymentLinkMobileReceivedCardTop,
+    );
+  });
+
+  testWidgets('received card exposes Figma claim copy and action', (
+    tester,
+  ) async {
+    var claimCalls = 0;
+    var closeCalls = 0;
+    await _pumpReceived(
+      tester,
+      onClaim: () => claimCalls++,
+      onClose: () => closeCalls++,
+    );
+
+    expect(find.text('You’ve received a gift!'), findsOneWidget);
+    expect(find.text('Message attached.'), findsOneWidget);
+    expect(find.text('Claim the gift'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('Close'));
+    expect(closeCalls, 1);
+
+    await tester.tap(
+      find.byKey(const ValueKey('payment_link_mobile_claim_button')),
+    );
+    expect(claimCalls, 1);
+  });
+}
+
+Future<void> _pumpReview(WidgetTester tester, {VoidCallback? onFeeHelp}) async {
+  await tester.binding.setSurfaceSize(const Size(393, 773));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpWidget(
+    MaterialApp(
+      builder: (_, navigator) =>
+          AppTheme(data: AppThemeData.light, child: navigator!),
+      home: Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 393,
+          height: 773,
+          child: PaymentLinkReviewMobileView(
+            card: const SizedBox(width: 361, height: 225.625),
+            onBack: _noop,
+            cardAmountText: '4.45 ZEC',
+            cardFeeText: '0.04 ZEC',
+            totalAmountText: '4.49 ZEC',
+            onContinue: _noop,
+            onFeeHelp: onFeeHelp,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void _noop() {}
+
+Future<void> _pumpAmount(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(393, 773));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpWidget(
+    MaterialApp(
+      builder: (_, navigator) =>
+          AppTheme(data: AppThemeData.light, child: navigator!),
+      home: Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 393,
+          height: 773,
+          child: PaymentLinkAmountMobileView(
+            card: const SizedBox(width: 361, height: 225.625),
+            cardSelector: const SizedBox(
+              key: ValueKey('mobile_selector_probe'),
+              width: 361,
+              height: 60,
+            ),
+            onBack: _noop,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _pumpRedeem(
+  WidgetTester tester,
+  PaymentLinkRedeemMobileState state,
+) async {
+  await tester.binding.setSurfaceSize(const Size(393, 773));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpWidget(
+    MaterialApp(
+      builder: (_, navigator) =>
+          AppTheme(data: AppThemeData.light, child: navigator!),
+      home: Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 393,
+          height: 773,
+          child: PaymentLinkRedeemMobileView(
+            state: state,
+            onBack: _noop,
+            onPaste: _noop,
+            onClearClipboard: _noop,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _pumpReceived(
+  WidgetTester tester, {
+  VoidCallback? onClaim,
+  VoidCallback? onClose,
+}) async {
+  await tester.binding.setSurfaceSize(const Size(393, 773));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpWidget(
+    MaterialApp(
+      builder: (_, navigator) =>
+          AppTheme(data: AppThemeData.light, child: navigator!),
+      home: Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 393,
+          height: 773,
+          child: PaymentLinkReceivedMobileView(
+            card: const SizedBox(
+              width: kPaymentLinkMobileCardWidth,
+              height: kPaymentLinkMobileCardHeight,
+            ),
+            hasMessage: true,
+            onClose: onClose ?? _noop,
+            onClaim: onClaim,
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/test/features/payment_links/payment_links_mobile_keystone_test.dart
+++ b/test/features/payment_links/payment_links_mobile_keystone_test.dart
@@ -225,6 +225,9 @@ class _FakePaymentLinkOperations implements PaymentLinkOperations {
   Future<void> retainPendingClaim(PaymentLinkClaimSession session) async {}
 
   @override
+  Future<void> keepReceivedLink(VizorPaymentLink link) async {}
+
+  @override
   Future<PaymentLinkFundingQuote> quoteMaxFunding({
     required String sourceAccountUuid,
   }) async {

--- a/test/features/payment_links/payment_links_mobile_keystone_test.dart
+++ b/test/features/payment_links/payment_links_mobile_keystone_test.dart
@@ -222,6 +222,9 @@ class _FakePaymentLinkOperations implements PaymentLinkOperations {
   final List<BigInt> createdAmounts = [];
 
   @override
+  Future<void> retainPendingClaim(PaymentLinkClaimSession session) async {}
+
+  @override
   Future<PaymentLinkFundingQuote> quoteMaxFunding({
     required String sourceAccountUuid,
   }) async {

--- a/test/features/payment_links/payment_links_mobile_keystone_test.dart
+++ b/test/features/payment_links/payment_links_mobile_keystone_test.dart
@@ -228,6 +228,9 @@ class _FakePaymentLinkOperations implements PaymentLinkOperations {
   Future<void> keepReceivedLink(VizorPaymentLink link) async {}
 
   @override
+  Future<void> forgetReceivedLink(VizorPaymentLink link) async {}
+
+  @override
   Future<PaymentLinkFundingQuote> quoteMaxFunding({
     required String sourceAccountUuid,
   }) async {

--- a/test/features/payment_links/payment_links_mobile_keystone_test.dart
+++ b/test/features/payment_links/payment_links_mobile_keystone_test.dart
@@ -1,0 +1,381 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/core/profile_pictures.dart';
+import 'package:zcash_wallet/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart';
+import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
+import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_hardware_signing_service.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_service.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+
+void main() {
+  setUpAll(() async {
+    final loader = FontLoader('Geist')
+      ..addFont(rootBundle.load('assets/fonts/Geist-Regular.ttf'))
+      ..addFont(rootBundle.load('assets/fonts/Geist-Medium.ttf'))
+      ..addFont(rootBundle.load('assets/fonts/Geist-SemiBold.ttf'));
+    await loader.load();
+  });
+
+  testWidgets(
+    'a hardware account reaches the Keystone signing round on mobile',
+    (tester) async {
+      final hardwareSigning = _FakePaymentLinkHardwareSigningService();
+      final operations = _FakePaymentLinkOperations();
+      await _pumpMobilePaymentLinks(
+        tester,
+        operations: operations,
+        hardwareSigning: hardwareSigning,
+      );
+
+      await _walkToApproveAndCreate(tester);
+
+      // The review CTA must not be left spinning on "Creating..." — the
+      // Keystone round trip owns the surface from here.
+      expect(
+        find.byKey(
+          const ValueKey('payment_link_keystone_signing_overlay_surface'),
+        ),
+        findsOneWidget,
+      );
+      expect(find.byType(MobileKeystonePcztSigningFlow), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('payment_link_keystone_sign_screen')),
+        findsOneWidget,
+      );
+      expect(hardwareSigning.createdAmounts, [BigInt.from(10000000)]);
+      expect(hardwareSigning.createdFromAccounts, ['hardware-account']);
+      expect(operations.createdAmounts, isEmpty);
+    },
+  );
+
+  testWidgets('cancelling the mobile Keystone round returns a usable review', (
+    tester,
+  ) async {
+    final hardwareSigning = _FakePaymentLinkHardwareSigningService();
+    await _pumpMobilePaymentLinks(tester, hardwareSigning: hardwareSigning);
+
+    await _walkToApproveAndCreate(tester);
+    expect(find.byType(MobileKeystonePcztSigningFlow), findsOneWidget);
+
+    final semantics = tester.ensureSemantics();
+    await tester.tap(find.bySemanticsLabel('Back').last);
+    await tester.pumpAndSettle();
+    semantics.dispose();
+
+    expect(find.byType(MobileKeystonePcztSigningFlow), findsNothing);
+    expect(hardwareSigning.discardedDrafts, [BigInt.one]);
+    final cta = tester.widget<AppButton>(
+      find.byKey(const ValueKey('payment_link_mobile_review_continue_button')),
+    );
+    expect(cta.onPressed, isNotNull);
+    expect(find.text('Approve & create'), findsOneWidget);
+  });
+}
+
+Future<void> _walkToApproveAndCreate(WidgetTester tester) async {
+  await tester.tap(
+    find.byKey(const ValueKey('payment_links_mobile_create_button')),
+  );
+  await tester.pumpAndSettle();
+
+  await tester.enterText(
+    find.byKey(const ValueKey('payment_link_amount_editor')),
+    '0.1',
+  );
+  await tester.pump(const Duration(milliseconds: 350));
+  await tester.pumpAndSettle();
+
+  await tester.tap(
+    find.byKey(const ValueKey('payment_link_mobile_amount_continue_button')),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(
+    find.byKey(const ValueKey('payment_link_mobile_message_continue_button')),
+  );
+  await tester.pumpAndSettle();
+
+  expect(find.text('Approve & create'), findsOneWidget);
+  await tester.tap(
+    find.byKey(const ValueKey('payment_link_mobile_review_continue_button')),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _pumpMobilePaymentLinks(
+  WidgetTester tester, {
+  _FakePaymentLinkOperations? operations,
+  PaymentLinkHardwareSigningService? hardwareSigning,
+}) async {
+  await tester.binding.setSurfaceSize(const Size(393, 852));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_hardwareBootstrap),
+        paymentLinkOperationsProvider.overrideWithValue(
+          operations ?? _FakePaymentLinkOperations(),
+        ),
+        if (hardwareSigning != null)
+          paymentLinkHardwareSigningServiceProvider.overrideWithValue(
+            hardwareSigning,
+          ),
+        syncProvider.overrideWith(
+          () => FakeSyncNotifier(
+            SyncState(
+              accountUuid: 'hardware-account',
+              hasAccountScopedData: true,
+              isSyncComplete: true,
+              percentage: 1,
+              displayTargetPercentage: 1,
+              spendableBalance: BigInt.from(14223000000),
+              displaySpendableBalance: BigInt.from(14223000000),
+            ),
+          ),
+        ),
+        ironwoodHomeMigrationCtaProvider.overrideWith((ref) async {
+          return const IronwoodHomeMigrationCtaState.hidden();
+        }),
+        ironwoodHomeMigrationPresentationProvider.overrideWithValue(
+          const IronwoodHomeMigrationCtaState.hidden(),
+        ),
+        ironwoodPostMigrationStateProvider.overrideWith((ref) async {
+          return const IronwoodPostMigrationState.unavailable();
+        }),
+        ironwoodMigrationAnnouncementProvider.overrideWith((ref) async {
+          return const IronwoodMigrationAnnouncementState.hidden();
+        }),
+        ironwoodMigrationCoordinatorProvider.overrideWith(
+          _FakeMigrationCoordinator.new,
+        ),
+      ],
+      child: const ZcashWalletApp(),
+    ),
+  );
+  await tester.pump();
+  for (var i = 0; i < 20; i++) {
+    if (find
+        .byKey(const ValueKey('payment_links_mobile_screen'))
+        .evaluate()
+        .isNotEmpty) {
+      break;
+    }
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  await tester.pumpAndSettle();
+}
+
+const _hardwareAccountState = AccountState(
+  accounts: [
+    AccountInfo(
+      uuid: 'hardware-account',
+      name: 'Keystone',
+      order: 0,
+      profilePictureId: kDefaultProfilePictureId,
+      isHardware: true,
+    ),
+  ],
+  activeAccountUuid: 'hardware-account',
+  activeAddress: 'u1hardwareaddress',
+);
+
+final _hardwareBootstrap = AppBootstrapState(
+  initialLocation: '/payment-links',
+  initialAccountState: _hardwareAccountState,
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);
+
+final _hardwareLink = VizorPaymentLink(
+  network: 'main',
+  address: 'u1hardwarepaymentlinkaddress',
+  amountZatoshi: BigInt.from(10000000),
+  mnemonic: List.filled(24, 'abandon').join(' '),
+  birthdayHeight: 3000000,
+  label: 'Payment link',
+  createdAt: DateTime.utc(2026, 8, 6),
+);
+
+class _FakePaymentLinkOperations implements PaymentLinkOperations {
+  final List<BigInt> createdAmounts = [];
+
+  @override
+  Future<PaymentLinkFundingQuote> quoteMaxFunding({
+    required String sourceAccountUuid,
+  }) async {
+    return PaymentLinkFundingQuote(
+      sourceAccountUuid: sourceAccountUuid,
+      recipientAmountZatoshi: BigInt.from(14222980000),
+      fundingFeeZatoshi: BigInt.from(10000),
+      claimFeeReserveZatoshi: BigInt.from(kPaymentLinkClaimFeeReserveZatoshi),
+    );
+  }
+
+  @override
+  Future<PaymentLinkFundingQuote> quoteFunding({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+  }) async {
+    return PaymentLinkFundingQuote(
+      sourceAccountUuid: sourceAccountUuid,
+      recipientAmountZatoshi: amountZatoshi,
+      fundingFeeZatoshi: BigInt.from(10000),
+      claimFeeReserveZatoshi: BigInt.from(kPaymentLinkClaimFeeReserveZatoshi),
+    );
+  }
+
+  @override
+  Future<PaymentLinkFundingResult> createFundedLink({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+    PaymentLinkPresentation? presentation,
+  }) async {
+    createdAmounts.add(amountZatoshi);
+    throw StateError('Keystone payment links require the hardware flow.');
+  }
+
+  @override
+  Future<void> retryFundingMetadata({
+    required String address,
+    required String fundingTxids,
+  }) async {}
+
+  @override
+  Future<List<PaymentLinkRecoveryRecord>> loadCreatedLinkRecoveries() async =>
+      const [];
+
+  @override
+  Future<PaymentLinkRecoveryRecord> markCreatedLinkShared(
+    VizorPaymentLink link,
+  ) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Map<String, PaymentLinkFundingProgress>> inspectCreatedLinkFundings(
+    List<PaymentLinkRecoveryRecord> records,
+  ) async => const {};
+
+  @override
+  Future<List<PaymentLinkReceivedRecord>> loadReceivedLinkRecoveries() async =>
+      const [];
+
+  @override
+  Future<List<PaymentLinkReceivedRecord>> inspectReceivedLinkClaims(
+    List<PaymentLinkReceivedRecord> records,
+  ) async => const [];
+
+  @override
+  Future<PaymentLinkClaimSession> prepareClaim(
+    VizorPaymentLink link, {
+    bool allowLongSync = false,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<PaymentLinkClaimResult> claimPreparedLink(
+    PaymentLinkClaimSession session,
+  ) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> discardClaimSession(PaymentLinkClaimSession session) async {}
+}
+
+class _FakePaymentLinkHardwareSigningService
+    implements PaymentLinkHardwareSigningService {
+  final createdAmounts = <BigInt>[];
+  final createdFromAccounts = <String>[];
+  final discardedDrafts = <BigInt>[];
+
+  PaymentLinkHardwarePcztDraft get draft => PaymentLinkHardwarePcztDraft(
+    link: _hardwareLink,
+    pcztBytes: const [1, 2, 3],
+    needsSaplingParams: false,
+    feeZatoshi: BigInt.from(10000),
+    proposalId: BigInt.one,
+    sendFlowId: 'test-payment-link-hardware',
+  );
+
+  @override
+  Future<PaymentLinkHardwarePcztDraft> createFundingPczt({
+    required BigInt amountZatoshi,
+    required String sourceAccountUuid,
+    PaymentLinkPresentation? presentation,
+  }) async {
+    createdAmounts.add(amountZatoshi);
+    createdFromAccounts.add(sourceAccountUuid);
+    return draft;
+  }
+
+  @override
+  Future<List<String>> encodeSigningUrParts({
+    required PaymentLinkHardwarePcztDraft draft,
+  }) async => const ['ur:zcash-sign-batch/test'];
+
+  @override
+  Future<List<int>> decodeSigningResponse({
+    required PaymentLinkHardwarePcztDraft draft,
+    required List<int> responseCbor,
+  }) async => const [10, 11];
+
+  @override
+  Future<List<int>> addProofsForSigning({
+    required PaymentLinkHardwarePcztDraft draft,
+    String? spendParamsPath,
+    String? outputParamsPath,
+  }) async => const [7, 8, 9];
+
+  @override
+  Future<void> discardPcztDraft({
+    required PaymentLinkHardwarePcztDraft draft,
+  }) async {
+    discardedDrafts.add(draft.proposalId);
+  }
+
+  @override
+  Future<PaymentLinkHardwareFundingResult> broadcastSignedPczt({
+    required PaymentLinkHardwarePcztDraft draft,
+    required List<int> pcztWithProofsBytes,
+    required List<int> pcztWithSignaturesBytes,
+    String? spendParamsPath,
+    String? outputParamsPath,
+    void Function()? onSubmissionStarted,
+  }) async {
+    return const PaymentLinkHardwareFundingResult(
+      txids: 'hardware-funding-txid',
+      status: 'broadcasted',
+      fundingMetadataSaved: true,
+    );
+  }
+}
+
+class _FakeMigrationCoordinator extends IronwoodMigrationCoordinator {
+  @override
+  IronwoodMigrationCoordinatorState build() =>
+      const IronwoodMigrationCoordinatorState();
+}

--- a/test/features/voting/mobile_keystone_voting_signing_busy_surface_test.dart
+++ b/test/features/voting/mobile_keystone_voting_signing_busy_surface_test.dart
@@ -1,0 +1,64 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/voting/screens/mobile/mobile_keystone_voting_signing_screen.dart';
+import 'package:zcash_wallet/src/features/voting/screens/voting_status_screen.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_submission_job_provider.dart';
+
+import '../../support/payment_uri_busy_surface_expectations.dart';
+
+/// The mobile voting signing screen replaces the status content while the
+/// bundles are being signed, so its whole lifetime is a live Keystone session.
+/// The hold sits above the flow, which is keyed per bundle — a hold inside the
+/// flow would dip to zero between bundles.
+void main() {
+  testWidgets('the mobile voting signing screen holds the payment-URI busy '
+      'latch', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await expectPaymentUriBusySurfaceHeldWhileMounted(
+      tester,
+      container: container,
+      host: _host(container),
+      surface: MobileKeystoneVotingSigningScreen(
+        presentation: VotingKeystoneStatusPresentation(
+          bundleIndex: 0,
+          urParts: const [_previewVotingUr],
+          batchMemos: const [
+            VotingKeystoneBatchMemo(
+              bundleIndex: 0,
+              bundleCount: 1,
+              displayMemo: 'Amount: 1.25 ZEC\nProposal: Community grants',
+            ),
+          ],
+          batchMessageCount: 1,
+          batchTotalCount: 1,
+          onSigned: _noopSigned,
+          onSkipRemainingBundles: _noop,
+        ),
+      ),
+      drainExceptions: true,
+      postUnmountSettle: const Duration(seconds: 2),
+    );
+  });
+}
+
+Widget Function(Widget) _host(ProviderContainer container) =>
+    (child) => UncontrolledProviderScope(
+      container: container,
+      child: AppTheme(
+        data: AppThemeData.dark,
+        child: MaterialApp(home: Scaffold(body: child)),
+      ),
+    );
+
+Future<void> _noopSigned(List<int> _) async {}
+void _noop() {}
+
+const _previewVotingUr =
+    'ur:zcash-sign-batch/1-1/lpadaxcsfwdmfwfwhdcxhdcxfwcxhdcxhdcxfwcx';

--- a/test/figma_compare/figma_compare_mobile_scenarios_test.dart
+++ b/test/figma_compare/figma_compare_mobile_scenarios_test.dart
@@ -1,0 +1,81 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/figma_compare/figma_compare_app.dart';
+import 'package:zcash_wallet/figma_compare/figma_compare_scenarios.dart';
+
+import 'figma_compare_font_loader.dart';
+
+/// Mobile scenarios that cannot render inside [FigmaCompareApp] today.
+///
+/// Each of these is a Widgetbook use case that reads `GoRouter.of(context)`
+/// while building, which the comparison app does not provide, so
+/// `scripts/figma-compare.sh widget --form-factor mobile --scenario <id>`
+/// throws `No GoRouter found in context` instead of writing a PNG. The
+/// breakage predates the smoke loop below — it is exactly what having no
+/// mobile loop hid — and fixing it means changing the scenarios, not the test.
+///
+/// The list is pinned rather than filtered so it cannot silently grow: adding
+/// an id here is a deliberate edit, and a stale id fails the guard below.
+const _scenariosThatNeedARouter = {
+  'mobile-ironwood-migration-intro',
+  'mobile-ironwood-migration-how-it-works',
+  'mobile-ironwood-migration-options',
+  'mobile-ironwood-migration-android-options',
+  'mobile-ironwood-migration-fast-review',
+};
+
+// The desktop loop in figma_compare_test.dart smokes every `desktop: true`
+// scenario; the mobile half had no equivalent, so a scenario registered with a
+// missing provider override or a stale fixture constructor stayed green in
+// both lanes and only failed weeks later, by hand, mid design review.
+void main() {
+  setUpAll(loadFigmaCompareFonts);
+
+  final mobileScenarios = figmaCompareScenarios
+      .where((scenario) => scenario.mobile)
+      .toList();
+
+  test('the mobile lane has scenarios to smoke', () {
+    expect(mobileScenarios, isNotEmpty);
+  });
+
+  test('every known-broken id is still a registered mobile scenario', () {
+    final mobileIds = mobileScenarios.map((scenario) => scenario.id).toSet();
+
+    expect(
+      _scenariosThatNeedARouter.difference(mobileIds),
+      isEmpty,
+      reason:
+          'a scenario in the exclusion list was renamed or removed — drop it '
+          'from the list rather than leaving a dead exemption behind',
+    );
+  });
+
+  for (final scenario in mobileScenarios) {
+    if (_scenariosThatNeedARouter.contains(scenario.id)) continue;
+
+    testWidgets('${scenario.id} renders at the mobile comparison viewport', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(393, 852));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final boundaryKey = GlobalKey();
+
+      await tester.pumpWidget(
+        FigmaCompareApp(
+          scenario: scenario,
+          themeMode: ThemeMode.dark,
+          captureBoundaryKey: boundaryKey,
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(boundaryKey.currentContext, isNotNull);
+      expect(tester.takeException(), isNull);
+    });
+  }
+}

--- a/test/widgetbook/mobile_payment_request_use_cases_test.dart
+++ b/test/widgetbook/mobile_payment_request_use_cases_test.dart
@@ -1,0 +1,144 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_card.dart';
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_surface.dart';
+import 'package:zcash_wallet/widgetbook/payment_request_use_cases.dart';
+
+void main() {
+  testWidgets('collapsed address and pool badge fit at 2x text scale', (
+    tester,
+  ) async {
+    // Keep the narrow width that exercises the horizontal overflow without
+    // changing the card's pinned-amount contract for unusually short screens.
+    const size = Size(320, 852);
+    await _pumpPaymentRequest(
+      tester,
+      size: size,
+      textScaler: const TextScaler.linear(2),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(
+      tester.widget<Text>(find.text('u195091 ... 190591')).overflow,
+      TextOverflow.ellipsis,
+    );
+  });
+
+  testWidgets('disclosure heights follow nonlinear text scaling', (
+    tester,
+  ) async {
+    const scaler = _NonlinearTestScaler();
+    await _pumpPaymentRequest(
+      tester,
+      size: const Size(393, 852),
+      textScaler: scaler,
+    );
+
+    final style = AppTypography.bodyMediumStrong;
+    final lineHeight = scaler.scale(style.fontSize!) * style.height!;
+    final expectedHeight = (lineHeight * 2 + AppSpacing.xxs).ceilToDouble() + 1;
+
+    for (final key in <String>[
+      'payment_request_requester_toggle',
+      'payment_request_memo_toggle',
+    ]) {
+      expect(
+        tester.widget<AppButton>(find.byKey(ValueKey(key))).height,
+        expectedHeight,
+      );
+    }
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('default mobile requests fit without scrolling', (tester) async {
+    for (final (builder, size) in <(WidgetBuilder, Size)>[
+      (buildMobilePaymentRequestFullUseCase, const Size(393, 852)),
+      (buildMobilePaymentRequestFullUseCase, const Size(375, 812)),
+      (buildMobilePaymentRequestContactUseCase, const Size(393, 852)),
+      (buildMobilePaymentRequestContactUseCase, const Size(375, 812)),
+    ]) {
+      await _pumpPaymentRequest(
+        tester,
+        size: size,
+        child: Builder(builder: builder),
+      );
+
+      expect(tester.takeException(), isNull, reason: '$builder at $size');
+      expect(_maxScrollExtent(tester), 0, reason: '$builder at $size');
+      expect(find.text('Review'), findsOneWidget);
+      expect(find.text('Edit'), findsOneWidget);
+    }
+  });
+}
+
+double _maxScrollExtent(WidgetTester tester) => tester
+    .widget<SingleChildScrollView>(find.byKey(kPaymentRequestScrollViewKey))
+    .controller!
+    .position
+    .maxScrollExtent;
+
+Future<void> _pumpPaymentRequest(
+  WidgetTester tester, {
+  required Size size,
+  TextScaler textScaler = TextScaler.noScaling,
+  Widget? child,
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(textScaler: textScaler),
+        child: child!,
+      ),
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: Center(
+          child: SizedBox(
+            width: size.width,
+            height: size.height,
+            child:
+                child ??
+                PaymentRequestSurface(
+                  layout: PaymentRequestLayout.mobile,
+                  request: const PaymentRequestView(
+                    source: PaymentRequestSource.link,
+                    requesterLabel: 'Blue Door Coffee',
+                    note: 'Meet at the side entrance.',
+                    amountZecText: '0.5 ZEC',
+                    address:
+                        'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+                        '73d57f73c6dc05121591a83861cd190591',
+                    memo: 'Table 4',
+                  ),
+                  onContinue: () {},
+                  onEdit: () {},
+                  onCancel: () {},
+                ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+final class _NonlinearTestScaler extends TextScaler {
+  const _NonlinearTestScaler();
+
+  @override
+  double scale(double fontSize) =>
+      fontSize <= 16 ? fontSize * 2 : fontSize * 1.5;
+
+  @override
+  double get textScaleFactor => 2;
+}

--- a/test/widgetbook/payment_link_mobile_use_cases_test.dart
+++ b/test/widgetbook/payment_link_mobile_use_cases_test.dart
@@ -1,0 +1,209 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/features/payment_links/widgets/payment_link_card_flip.dart';
+import 'package:zcash_wallet/widgetbook/payment_link_mobile_use_cases.dart';
+
+void main() {
+  testWidgets('home matches the mobile device and action geometry', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildMobilePaymentLinkHomeEmptyUseCase);
+
+    expect(
+      tester.getTopLeft(
+        find.byKey(const ValueKey('mobile_payment_link_preview_frame')),
+      ),
+      const Offset(0, 55),
+    );
+
+    final redeem = find.byKey(
+      const ValueKey('payment_links_mobile_redeem_button'),
+    );
+    final create = find.byKey(
+      const ValueKey('payment_links_mobile_create_button'),
+    );
+    expect(tester.getRect(redeem), const Rect.fromLTWH(16, 716, 361, 50));
+    expect(tester.getRect(create), const Rect.fromLTWH(16, 778, 361, 50));
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is AppIcon && widget.name == AppIcons.giftCardOutline,
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('home help icon opens the Gift Card explanation sheet', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildMobilePaymentLinkHomeEmptyUseCase);
+
+    expect(find.text('How Gift Cards work'), findsNothing);
+    await tester.tap(
+      find.byKey(const ValueKey('payment_links_mobile_help_action')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('How Gift Cards work'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('payment_link_mobile_help_close_button')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('received Gift Card flips to its message', (tester) async {
+    await _pumpUseCase(tester, buildMobilePaymentLinkReceivedUseCase);
+
+    expect(
+      find.byKey(const ValueKey('payment_link_flip_front')),
+      findsOneWidget,
+    );
+    await tester.tap(find.bySemanticsLabel('Reveal gift card message'));
+    await tester.pump();
+    await tester.pump(PaymentLinkCardFlip.settleDuration);
+
+    expect(
+      find.byKey(const ValueKey('payment_link_flip_back')),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Hey there! Welcome to the Shielded World ;)'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('long sync warning uses the standard mobile sheet', (
+    tester,
+  ) async {
+    await _pumpUseCase(
+      tester,
+      buildMobilePaymentLinkRedeemLongSyncWarningUseCase,
+    );
+
+    expect(
+      find.byKey(const ValueKey('payment_link_long_sync_warning_sheet')),
+      findsOneWidget,
+    );
+    expect(find.text('This Gift Card may take a while'), findsOneWidget);
+    expect(find.text('Check Gift Card'), findsOneWidget);
+    expect(find.text('Go back'), findsOneWidget);
+    expect(find.textContaining('100000'), findsNothing);
+  });
+
+  testWidgets('interactive preview accepts amount and message input', (
+    tester,
+  ) async {
+    await _pumpInteractivePreview(tester);
+
+    final amountEditor = find.byKey(
+      const ValueKey('mobile_payment_link_interactive_amount_editor'),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('payment_link_mobile_card_slot')),
+    );
+    await tester.pump();
+    expect(
+      tester.widget<EditableText>(amountEditor).focusNode.hasFocus,
+      isTrue,
+    );
+
+    await tester.enterText(amountEditor, '4.45');
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey('payment_link_max_button')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('payment_link_fiat_loading_placeholder')),
+      findsOneWidget,
+    );
+    await tester.pump(kMobilePaymentLinkPreviewFiatDelay);
+    expect(find.text(r'$1,210.40'), findsOneWidget);
+
+    final amountContinue = find.byKey(
+      const ValueKey('payment_link_mobile_amount_continue_button'),
+    );
+    expect(tester.widget<AppButton>(amountContinue).onPressed, isNotNull);
+    await tester.tap(amountContinue);
+    await tester.pump();
+
+    expect(find.text('Enter a message'), findsOneWidget);
+    final messageEditor = find.byKey(
+      const ValueKey('mobile_payment_link_interactive_message_editor'),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('payment_link_mobile_card_slot')),
+    );
+    await tester.pump();
+    expect(tester.widget<TextField>(messageEditor).focusNode?.hasFocus, isTrue);
+    expect(
+      tester.widget<TextField>(messageEditor).decoration?.hintText,
+      isNull,
+    );
+
+    await tester.enterText(messageEditor, 'Congratulations!');
+    await tester.pump();
+    final messageContinue = find.byKey(
+      const ValueKey('payment_link_mobile_message_continue_button'),
+    );
+    expect(tester.widget<AppButton>(messageContinue).onPressed, isNotNull);
+    await tester.tap(messageContinue);
+    await tester.pump();
+
+    expect(find.text('Review a Card'), findsOneWidget);
+    expect(find.text('Card amount'), findsOneWidget);
+    expect(find.text('4.49 ZEC'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpUseCase(WidgetTester tester, WidgetBuilder builder) async {
+  tester.view
+    ..physicalSize = const Size(393, 852)
+    ..devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: Builder(builder: builder),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+Future<void> _pumpInteractivePreview(WidgetTester tester) async {
+  tester.view
+    ..physicalSize = const Size(393, 773)
+    ..devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () {
+            final primary = FocusManager.instance.primaryFocus;
+            if (primary != null && primary is! FocusScopeNode) {
+              primary.unfocus();
+            }
+          },
+          child: Builder(builder: buildMobilePaymentLinkInteractiveUseCase),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}


### PR DESCRIPTION
## Summary

Wires Gift Cards into the mobile shell. The mobile views themselves landed in #614; what was missing was mobile's own home, activity and transaction-detail screens reading the Gift Card activity index, and the mobile Keystone signing screens holding off an incoming link while a device is being scanned. Small diff, but it is the point at which a Gift Card is visible on a phone rather than only reachable.

## Changes

**UI (mobile)**
- `home/screens/mobile/mobile_home_screen.dart` (+56) and `activity/screens/mobile/mobile_activity_screen.dart` (+45) — watch `giftCardActivityIndexProvider` and pass `giftCardKind` / `giftCardAmountZatoshi` into the activity rows; the home send button now reads `migrationSendGateProvider` (added in #609) instead of recomputing the predicate, so it cannot drift from the payment-URI drain.
- `activity/screens/mobile/mobile_transaction_status_screen.dart` — Gift Card transaction detail.
- `home/screens/mobile/mobile_keystone_shield_screen.dart` and `voting/screens/mobile/mobile_keystone_voting_signing_screen.dart` (+84) — adopt `PaymentUriBusySurfaceHold` / its mixin, placed above the keyed flow so a per-bundle key change does not drop the hold.

**Tests** (~1.8k lines)
- `payment_links_mobile_keystone_test.dart` (381), `payment_link_mobile_views_test.dart` (320), `payment_link_mobile_use_cases_test.dart` (209), `payment_link_cards_mobile_view_test.dart` (184), `mobile_payment_request_use_cases_test.dart` (144), `mobile_routes_test.dart` (111), `figma_compare_mobile_scenarios_test.dart` (81), plus mobile home / activity / transaction-status and busy-surface suites.

## Behaviour at this point of the stack

Both products are now complete on both form factors: ZIP-321 payment requests (#611/#612) and Gift Cards (#614/#615). The remaining gap is discovery — there is still no "My Gift Cards" entry in settings on either form factor, which is #616.

## Verification

- `fvm flutter analyze` clean.
- Desktop lane (`fvm flutter test`) green.
- Mobile lane (`--tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`): 20 failures, all pre-existing — the identical set fails at the base of this stack. Files: `ironwood_migration_coordinator_provider_test.dart` (15), `mobile_import_birthday_screen_test.dart` (2), `mobile_onboarding_progress_test.dart`, `mobile_keystone_use_cases_test.dart`, `mobile_receive_use_cases_test.dart`.

## Stack

Part 7/9 · base: `rowan/giftcard-06-desktop-ui` (#614) · next: #616 — [stack #618](https://github.com/chainapsis/vizor-wallet/pull/608)

https://claude.ai/code/session_01Uybjg6JVS5RFEG8B9GHi3s
