### PR TITLE
Improve ZEC price fetch resilience over Tor

### DIFF
--- a/lib/src/providers/zec_price_change_provider.dart
+++ b/lib/src/providers/zec_price_change_provider.dart
@@ -2,12 +2,14 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/widgets.dart' show AppLifecycleListener;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../main.dart' show log;
 import '../core/config/swap_feature_config.dart';
 import '../core/formatting/zec_amount.dart';
+import '../core/layout/app_process_work_policy.dart';
 import '../core/network/network_http_client.dart';
 import '../features/swap/models/swap_fiat_value_formatting.dart';
 
@@ -17,7 +19,13 @@ const kVizorCoinGeckoPriceBaseUrl = String.fromEnvironment(
   kVizorCoinGeckoPriceBaseUrlEnvKey,
   defaultValue: kVizorCoinGeckoDefaultPriceBaseUrl,
 );
+const zecMarketDataRequestTimeout = Duration(seconds: 60);
 const zecMarketDataRefreshInterval = Duration(minutes: 3);
+const zecMarketDataRetryDelays = <Duration>[
+  Duration(seconds: 5),
+  Duration(seconds: 15),
+  Duration(seconds: 30),
+];
 const zecMarketDataCacheTtl = Duration(hours: 1);
 const zecMarketDataCacheStorageKey = 'vizor_zec_market_data_v1';
 
@@ -115,7 +123,7 @@ class CoinGeckoZecMarketDataSource implements ZecMarketDataSource {
     HttpClient? client,
     NetworkHttpClient? networkClient,
     Uri? baseUri,
-    this.timeout = const Duration(seconds: 12),
+    this.timeout = zecMarketDataRequestTimeout,
   }) : _client = networkClient ?? NetworkHttpClient(directClient: client),
        _baseUri = baseUri ?? Uri.parse(kVizorCoinGeckoPriceBaseUrl);
 
@@ -205,6 +213,15 @@ final zecMarketDataRefreshIntervalProvider = Provider<Duration>((ref) {
   return zecMarketDataRefreshInterval;
 });
 
+final zecMarketDataRetryDelaysProvider = Provider<List<Duration>>((ref) {
+  return zecMarketDataRetryDelays;
+});
+
+final zecMarketDataProcessWorkPolicyProvider =
+    Provider<bool Function({required bool isInForeground})>(
+      (_) => canRunAppProcessWork,
+    );
+
 class ZecHomeMarketDataState {
   const ZecHomeMarketDataState({
     this.displayData,
@@ -238,6 +255,14 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
   Timer? _refreshTimer;
   Timer? _expiryTimer;
   int _epoch = 0;
+  int _consecutiveFailures = 0;
+  AppLifecycleListener? _lifecycle;
+  bool _isInForeground = true;
+  bool _refreshDeferredToForeground = false;
+
+  bool get _mayRunNow => ref.read(zecMarketDataProcessWorkPolicyProvider)(
+    isInForeground: _isInForeground,
+  );
 
   @override
   ZecHomeMarketDataState build() {
@@ -251,11 +276,15 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
     final cache = ref.watch(zecMarketDataCacheProvider);
     final now = ref.watch(zecMarketDataNowProvider);
     final refreshInterval = ref.watch(zecMarketDataRefreshIntervalProvider);
+    final retryDelays = ref.watch(zecMarketDataRetryDelaysProvider);
+    _consecutiveFailures = 0;
 
     ref.onDispose(() {
       _epoch++;
       _refreshTimer?.cancel();
       _expiryTimer?.cancel();
+      _lifecycle?.dispose();
+      _lifecycle = null;
     });
 
     void clearMarketData() {
@@ -290,12 +319,17 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
     }
 
     Future<void> tick() async {
+      if (!_mayRunNow) {
+        _refreshDeferredToForeground = true;
+        return;
+      }
       if (state.displayData != null && !state.isFreshAt(now())) {
         clearMarketData();
       }
       final data = await source.fetchMarketData();
       if (epoch != _epoch) return;
       if (data != null) {
+        _consecutiveFailures = 0;
         final fetchedAt = now().toUtc();
         state = ZecHomeMarketDataState(
           displayData: data,
@@ -309,7 +343,16 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
       } else if (state.displayData != null && !state.isFreshAt(now())) {
         clearMarketData();
       }
-      _refreshTimer = Timer(refreshInterval, () => unawaited(tick()));
+      final nextDelay = data != null
+          ? refreshInterval
+          : _consecutiveFailures < retryDelays.length
+          ? retryDelays[_consecutiveFailures++]
+          : refreshInterval;
+      if (_mayRunNow) {
+        _refreshTimer = Timer(nextDelay, () => unawaited(tick()));
+      } else {
+        _refreshDeferredToForeground = true;
+      }
     }
 
     Future<void> initialize() async {
@@ -328,6 +371,23 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
       }
       if (epoch == _epoch) await tick();
     }
+
+    _lifecycle?.dispose();
+    _lifecycle = AppLifecycleListener(
+      onHide: () {
+        _isInForeground = false;
+        if (_mayRunNow || _refreshTimer == null) return;
+        _refreshTimer?.cancel();
+        _refreshTimer = null;
+        _refreshDeferredToForeground = true;
+      },
+      onResume: () {
+        _isInForeground = true;
+        if (!_refreshDeferredToForeground || epoch != _epoch) return;
+        _refreshDeferredToForeground = false;
+        unawaited(tick());
+      },
+    );
 
     scheduleMicrotask(() {
       if (epoch == _epoch) unawaited(initialize());

--- a/lib/src/providers/zec_price_change_provider.dart
+++ b/lib/src/providers/zec_price_change_provider.dart
@@ -255,6 +255,7 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
   Timer? _refreshTimer;
   Timer? _expiryTimer;
   int _epoch = 0;
+  int? _fetchInFlightEpoch;
   int _consecutiveFailures = 0;
   AppLifecycleListener? _lifecycle;
   bool _isInForeground = true;
@@ -319,39 +320,50 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
     }
 
     Future<void> tick() async {
+      if (_fetchInFlightEpoch == epoch) return;
       if (!_mayRunNow) {
         _refreshDeferredToForeground = true;
         return;
       }
-      if (state.displayData != null && !state.isFreshAt(now())) {
-        clearMarketData();
-      }
-      final data = await source.fetchMarketData();
-      if (epoch != _epoch) return;
-      if (data != null) {
-        _consecutiveFailures = 0;
-        final fetchedAt = now().toUtc();
-        state = ZecHomeMarketDataState(
-          displayData: data,
-          liveData: data,
-          fetchedAt: fetchedAt,
-        );
-        scheduleExpiry(fetchedAt);
-        unawaited(
-          persist(CachedZecMarketData(data: data, fetchedAt: fetchedAt)),
-        );
-      } else if (state.displayData != null && !state.isFreshAt(now())) {
-        clearMarketData();
-      }
-      final nextDelay = data != null
-          ? refreshInterval
-          : _consecutiveFailures < retryDelays.length
-          ? retryDelays[_consecutiveFailures++]
-          : refreshInterval;
-      if (_mayRunNow) {
-        _refreshTimer = Timer(nextDelay, () => unawaited(tick()));
-      } else {
-        _refreshDeferredToForeground = true;
+      _fetchInFlightEpoch = epoch;
+      try {
+        if (state.displayData != null && !state.isFreshAt(now())) {
+          clearMarketData();
+        }
+        final data = await source.fetchMarketData();
+        if (epoch != _epoch) return;
+        if (data != null) {
+          _consecutiveFailures = 0;
+          final fetchedAt = now().toUtc();
+          state = ZecHomeMarketDataState(
+            displayData: data,
+            liveData: data,
+            fetchedAt: fetchedAt,
+          );
+          scheduleExpiry(fetchedAt);
+          unawaited(
+            persist(CachedZecMarketData(data: data, fetchedAt: fetchedAt)),
+          );
+        } else if (state.displayData != null && !state.isFreshAt(now())) {
+          clearMarketData();
+        }
+        final nextDelay = data != null
+            ? refreshInterval
+            : _consecutiveFailures < retryDelays.length
+            ? retryDelays[_consecutiveFailures++]
+            : refreshInterval;
+        if (_mayRunNow) {
+          _refreshTimer = Timer(nextDelay, () {
+            _refreshTimer = null;
+            unawaited(tick());
+          });
+        } else {
+          _refreshDeferredToForeground = true;
+        }
+      } finally {
+        if (_fetchInFlightEpoch == epoch) {
+          _fetchInFlightEpoch = null;
+        }
       }
     }
 

--- a/test/providers/zec_price_change_provider_test.dart
+++ b/test/providers/zec_price_change_provider_test.dart
@@ -44,6 +44,18 @@ class _SequenceSource implements ZecMarketDataSource {
   }
 }
 
+class _PendingRetrySource implements ZecMarketDataSource {
+  final retryCompleter = Completer<ZecMarketData?>();
+  int fetchCount = 0;
+
+  @override
+  Future<ZecMarketData?> fetchMarketData() {
+    fetchCount += 1;
+    if (fetchCount == 1) return Future.value(null);
+    return retryCompleter.future;
+  }
+}
+
 class _FakeCache implements ZecMarketDataCache {
   _FakeCache({this.value, this.readError, this.writeError});
 
@@ -554,6 +566,46 @@ void main() {
         TestWidgetsFlutterBinding.instance.handleAppLifecycleStateChanged(
           AppLifecycleState.resumed,
         );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(source.fetchCount, 2);
+        expect(sub.read(), 33.45);
+      },
+    );
+
+    test(
+      'does not overlap an in-flight retry across hide and resume',
+      () async {
+        final source = _PendingRetrySource();
+        final container = makeContainer(
+          swapEnabled: true,
+          source: source,
+          refreshInterval: const Duration(hours: 1),
+          retryDelays: const [Duration(milliseconds: 5)],
+          processWorkPolicy: ({required isInForeground}) => isInForeground,
+        );
+        final sub = container.listen(zecLiveUsdUnitPriceProvider, (_, _) {});
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(source.fetchCount, 2);
+
+        TestWidgetsFlutterBinding.instance.handleAppLifecycleStateChanged(
+          AppLifecycleState.inactive,
+        );
+        TestWidgetsFlutterBinding.instance.handleAppLifecycleStateChanged(
+          AppLifecycleState.hidden,
+        );
+        TestWidgetsFlutterBinding.instance.handleAppLifecycleStateChanged(
+          AppLifecycleState.inactive,
+        );
+        TestWidgetsFlutterBinding.instance.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(source.fetchCount, 2);
+
+        source.retryCompleter.complete(const ZecMarketData(usdPrice: 33.45));
         await Future<void>.delayed(Duration.zero);
 
         expect(source.fetchCount, 2);

--- a/test/providers/zec_price_change_provider_test.dart
+++ b/test/providers/zec_price_change_provider_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -30,6 +31,19 @@ class _CompleterSource implements ZecMarketDataSource {
   }
 }
 
+class _SequenceSource implements ZecMarketDataSource {
+  _SequenceSource(this.results);
+
+  final List<ZecMarketData?> results;
+  int fetchCount = 0;
+
+  @override
+  Future<ZecMarketData?> fetchMarketData() async {
+    final index = fetchCount++;
+    return index < results.length ? results[index] : results.last;
+  }
+}
+
 class _FakeCache implements ZecMarketDataCache {
   _FakeCache({this.value, this.readError, this.writeError});
 
@@ -56,6 +70,10 @@ class _FakeCache implements ZecMarketDataCache {
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('uses a Tor-tolerant market data request timeout', () {
+    expect(zecMarketDataRequestTimeout, const Duration(seconds: 60));
+  });
 
   group('parseZecMarketData', () {
     test('reads ZEC price and 24h change from a CoinGecko response', () {
@@ -200,6 +218,8 @@ void main() {
       ZecMarketDataCache? cache,
       DateTime Function()? now,
       Duration refreshInterval = zecMarketDataRefreshInterval,
+      List<Duration> retryDelays = zecMarketDataRetryDelays,
+      bool Function({required bool isInForeground})? processWorkPolicy,
     }) {
       final container = ProviderContainer(
         overrides: [
@@ -210,6 +230,11 @@ void main() {
           zecMarketDataRefreshIntervalProvider.overrideWithValue(
             refreshInterval,
           ),
+          zecMarketDataRetryDelaysProvider.overrideWithValue(retryDelays),
+          if (processWorkPolicy != null)
+            zecMarketDataProcessWorkPolicyProvider.overrideWithValue(
+              processWorkPolicy,
+            ),
         ],
       );
       addTearDown(container.dispose);
@@ -382,6 +407,7 @@ void main() {
         cache: cache,
         now: () => now,
         refreshInterval: const Duration(milliseconds: 5),
+        retryDelays: const [Duration(milliseconds: 5)],
       );
       final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
       await Future<void>.delayed(Duration.zero);
@@ -435,6 +461,105 @@ void main() {
       expect(sub.read(), isNull);
       expect(source.fetchCount, 1);
     });
+
+    test('retries transient failures before the regular refresh', () async {
+      final source = _SequenceSource([
+        null,
+        const ZecMarketData(usdPrice: 33.45),
+      ]);
+      final container = makeContainer(
+        swapEnabled: true,
+        source: source,
+        refreshInterval: const Duration(hours: 1),
+        retryDelays: const [Duration(milliseconds: 5)],
+      );
+      final sub = container.listen(zecLiveUsdUnitPriceProvider, (_, _) {});
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(source.fetchCount, 2);
+      expect(sub.read(), 33.45);
+    });
+
+    test(
+      'returns to the regular interval after fast retries are exhausted',
+      () async {
+        final source = _FakeSource(null);
+        final container = makeContainer(
+          swapEnabled: true,
+          source: source,
+          refreshInterval: const Duration(milliseconds: 100),
+          retryDelays: const [
+            Duration(milliseconds: 2),
+            Duration(milliseconds: 4),
+            Duration(milliseconds: 6),
+          ],
+        );
+        container.listen(zecLiveUsdUnitPriceProvider, (_, _) {});
+
+        await Future<void>.delayed(const Duration(milliseconds: 40));
+        expect(source.fetchCount, 4);
+
+        await Future<void>.delayed(const Duration(milliseconds: 90));
+        expect(source.fetchCount, 5);
+      },
+    );
+
+    test('cancels a pending fast retry when disposed', () async {
+      final source = _FakeSource(null);
+      final container = makeContainer(
+        swapEnabled: true,
+        source: source,
+        refreshInterval: const Duration(hours: 1),
+        retryDelays: const [Duration(milliseconds: 50)],
+      );
+      final sub = container.listen(zecLiveUsdUnitPriceProvider, (_, _) {});
+
+      await Future<void>.delayed(Duration.zero);
+      expect(source.fetchCount, 1);
+
+      sub.close();
+      await Future<void>.delayed(const Duration(milliseconds: 70));
+      expect(source.fetchCount, 1);
+    });
+
+    test(
+      'defers mobile retry while hidden and resumes it in foreground',
+      () async {
+        final source = _SequenceSource([
+          null,
+          const ZecMarketData(usdPrice: 33.45),
+        ]);
+        final container = makeContainer(
+          swapEnabled: true,
+          source: source,
+          refreshInterval: const Duration(hours: 1),
+          retryDelays: const [Duration(milliseconds: 50)],
+          processWorkPolicy: ({required isInForeground}) => isInForeground,
+        );
+        final sub = container.listen(zecLiveUsdUnitPriceProvider, (_, _) {});
+
+        await Future<void>.delayed(Duration.zero);
+        expect(source.fetchCount, 1);
+
+        TestWidgetsFlutterBinding.instance.handleAppLifecycleStateChanged(
+          AppLifecycleState.hidden,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 70));
+        expect(source.fetchCount, 1);
+
+        TestWidgetsFlutterBinding.instance.handleAppLifecycleStateChanged(
+          AppLifecycleState.inactive,
+        );
+        TestWidgetsFlutterBinding.instance.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(source.fetchCount, 2);
+        expect(sub.read(), 33.45);
+      },
+    );
 
     test('does not fetch while market-price UI is disabled', () async {
       final source = _FakeSource(


### PR DESCRIPTION
## Summary

- increase the CoinGecko request timeout from 12 seconds to 60 seconds
- retry failed ZEC price requests after 5, 15, and 30 seconds before returning to the regular three-minute interval
- defer mobile retries while backgrounded and resume them when the app returns to the foreground
- add regression coverage for timeout, retry exhaustion, disposal, and mobile lifecycle behavior

## Validation

- `fvm flutter analyze`
- `fvm flutter test`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/send/mobile_send_screen_test.dart`