### PR TITLE
Omit Sapling from NEAR Intents ZEC addresses

### DIFF
--- a/lib/src/features/swap/providers/swap_zec_staging_address_service.dart
+++ b/lib/src/features/swap/providers/swap_zec_staging_address_service.dart
@@ -8,47 +8,16 @@ import '../domain/swap_contract.dart';
 final swapZecStagingAddressServiceProvider =
     Provider<SwapZecStagingAddressService>((ref) {
       return SwapZecStagingAddressService(
-        loadCurrentShieldedAddress: ({required accountUuid}) {
+        reserveFreshOrchardAddress: ({required accountUuid}) {
           return ref
               .read(receiveAddressServiceProvider)
-              .loadShieldedAddress(accountUuid: accountUuid);
-        },
-        prepareFreshShieldedAddress: ({required accountUuid}) {
-          return _loadSwapShieldedRecipientAddress(
-            ref,
-            accountUuid: accountUuid,
-          );
+              .reserveOrchardAddress(accountUuid: accountUuid);
         },
       );
     });
 
-typedef LoadShieldedAddress =
+typedef ReserveOrchardAddress =
     Future<String> Function({required String accountUuid});
-
-Future<String> _loadSwapShieldedRecipientAddress(
-  Ref ref, {
-  required String accountUuid,
-}) async {
-  final receiveAddressService = ref.read(receiveAddressServiceProvider);
-  try {
-    return await receiveAddressService.renewShieldedAddress(
-      accountUuid: accountUuid,
-    );
-  } catch (e) {
-    if (!_isSaplingReceiverUnsupported(e)) rethrow;
-    log(
-      'SwapZecStagingAddressService: diversified Sapling+Orchard UA '
-      'generation is unavailable; using current shielded UA: $e',
-    );
-    return receiveAddressService.loadShieldedAddress(accountUuid: accountUuid);
-  }
-}
-
-bool _isSaplingReceiverUnsupported(Object error) {
-  return error.toString().contains(
-    'Unified Address generation does not yet support receivers of type Sapling',
-  );
-}
 
 class SwapZecStagingAddress {
   const SwapZecStagingAddress({required this.address});
@@ -83,35 +52,23 @@ class SwapZecStagingAddressUnavailableException implements Exception {
 
 class SwapZecStagingAddressService {
   const SwapZecStagingAddressService({
-    required LoadShieldedAddress loadCurrentShieldedAddress,
-    LoadShieldedAddress? prepareFreshShieldedAddress,
-  }) : _prepareFreshShieldedAddress =
-           prepareFreshShieldedAddress ?? loadCurrentShieldedAddress;
+    required ReserveOrchardAddress reserveFreshOrchardAddress,
+  }) : _reserveFreshOrchardAddress = reserveFreshOrchardAddress;
 
-  final LoadShieldedAddress _prepareFreshShieldedAddress;
+  final ReserveOrchardAddress _reserveFreshOrchardAddress;
 
   Future<SwapZecStagingAddress> prepareForQuote({
     required String accountUuid,
   }) async {
-    return _prepareShieldedRecipient(
-      accountUuid,
-      loadShieldedAddress: _prepareFreshShieldedAddress,
-      operationLabel: 'quote',
-    );
-  }
-
-  Future<SwapZecStagingAddress> _prepareShieldedRecipient(
-    String accountUuid, {
-    required LoadShieldedAddress loadShieldedAddress,
-    required String operationLabel,
-  }) async {
     try {
-      final address = await loadShieldedAddress(accountUuid: accountUuid);
+      final address = await _reserveFreshOrchardAddress(
+        accountUuid: accountUuid,
+      );
       return SwapZecStagingAddress(address: address);
     } catch (e) {
       log(
-        'SwapZecStagingAddressService: shielded receive address preparation '
-        'failed; blocking $operationLabel: $e',
+        'SwapZecStagingAddressService: Orchard receive address preparation '
+        'failed; blocking quote: $e',
       );
       throw SwapZecStagingAddressUnavailableException(e);
     }

--- a/lib/src/providers/receive_address_provider.dart
+++ b/lib/src/providers/receive_address_provider.dart
@@ -91,15 +91,36 @@ class ReceiveAddressService {
   }
 
   Future<String> renewShieldedAddress({required String accountUuid}) async {
-    final dbPath = await getWalletDbPath();
-    final network = _network;
     final accountNotifier = _ref.read(accountProvider.notifier);
     final addressRequest = accountNotifier.isHardwareAccount(accountUuid)
         ? ReceiveAddressRequest.orchard
         : ReceiveAddressRequest.shielded;
 
-    final address = await _withDatabaseLockRetry(
-      operationName: 'renew shielded receive address',
+    final address = await _nextAvailableAddress(
+      accountUuid: accountUuid,
+      addressRequest: addressRequest,
+    );
+
+    accountNotifier.updateActiveAddressForAccount(accountUuid, address);
+    return address;
+  }
+
+  Future<String> reserveOrchardAddress({required String accountUuid}) {
+    return _nextAvailableAddress(
+      accountUuid: accountUuid,
+      addressRequest: ReceiveAddressRequest.orchard,
+    );
+  }
+
+  Future<String> _nextAvailableAddress({
+    required String accountUuid,
+    required ReceiveAddressRequest addressRequest,
+  }) async {
+    final dbPath = await getWalletDbPath();
+    final network = _network;
+
+    return _withDatabaseLockRetry(
+      operationName: 'reserve shielded receive address',
       operation: () => rust_sync.getNextAvailableAddress(
         dbPath: dbPath,
         network: network,
@@ -107,9 +128,6 @@ class ReceiveAddressService {
         addressRequest: addressRequest.wireName,
       ),
     );
-
-    accountNotifier.updateActiveAddressForAccount(accountUuid, address);
-    return address;
   }
 
   String get _network {

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -1575,6 +1575,49 @@ mod tests {
     }
 
     #[test]
+    fn test_reserved_orchard_addresses_are_distinct_without_becoming_current() {
+        use zcash_keys::address::Address;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let phrase = generate_mnemonic();
+        let seed = mnemonic_to_seed(&phrase).unwrap();
+        let (uuid, current_address) =
+            init_db_and_create_account(db_path_str, WalletNetwork::Main, &seed, None, "test")
+                .unwrap();
+
+        crate::wallet::sync::update_chain_tip(db_path_str, WalletNetwork::Main, 2_500_000).unwrap();
+        let reserve_address = || {
+            crate::wallet::sync::get_next_available_address(
+                db_path_str,
+                WalletNetwork::Main,
+                &uuid,
+                crate::wallet::sync::AddressRequestKind::Orchard,
+            )
+            .unwrap()
+        };
+        let first = reserve_address();
+        let second = reserve_address();
+
+        assert_ne!(first, second);
+        for encoded in [first, second] {
+            let address = Address::decode(&WalletNetwork::Main, &encoded).unwrap();
+            let Address::Unified(address) = address else {
+                panic!("expected a Unified Address");
+            };
+            assert!(address.has_orchard());
+            assert!(!address.has_sapling());
+            assert!(!address.has_transparent());
+        }
+        assert_eq!(
+            get_address_from_db(db_path_str, WalletNetwork::Main, Some(&uuid)).unwrap(),
+            current_address
+        );
+    }
+
+    #[test]
     fn test_get_transparent_receive_address_returns_first_unused_external_address() {
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("wallet.db");

--- a/test/features/swap/support/swap_screen_test_fakes.dart
+++ b/test/features/swap/support/swap_screen_test_fakes.dart
@@ -18,6 +18,11 @@ class _FakeReceiveAddressService extends ReceiveAddressService {
   Future<String> renewShieldedAddress({required String accountUuid}) async {
     return 'u1actualshieldedrecipient';
   }
+
+  @override
+  Future<String> reserveOrchardAddress({required String accountUuid}) async {
+    return 'u1actualshieldedrecipient';
+  }
 }
 
 class _FakeSwapSyncNotifier extends SyncNotifier {

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -7822,7 +7822,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('review quote uses shielded unified address as ZEC recipient', (
+  testWidgets('review quote uses Orchard-only UA as ZEC recipient', (
     tester,
   ) async {
     await _setDesktopViewport(tester);
@@ -9367,7 +9367,7 @@ Widget _routerHarness(
       SpendableBalanceFreshness.authoritative,
   Duration? statusPollInterval,
   Duration? priceRefreshInterval,
-  LoadShieldedAddress? loadShieldedAddress,
+  ReserveOrchardAddress? loadShieldedAddress,
   bool seedSwapActivityFixtures = true,
   AppBootstrapState? bootstrap,
   AccountNotifier Function()? accountNotifier,
@@ -9411,20 +9411,13 @@ Widget _routerHarness(
       ),
       swapZecStagingAddressServiceProvider.overrideWith(
         (ref) => SwapZecStagingAddressService(
-          loadCurrentShieldedAddress:
-              loadShieldedAddress ??
-              ({required accountUuid}) {
-                return ref
-                    .read(receiveAddressServiceProvider)
-                    .loadShieldedAddress(accountUuid: accountUuid);
-              },
-          prepareFreshShieldedAddress:
+          reserveFreshOrchardAddress:
               loadShieldedAddress ??
               ({required accountUuid}) {
                 final receiveAddressService = ref.read(
                   receiveAddressServiceProvider,
                 );
-                return receiveAddressService.renewShieldedAddress(
+                return receiveAddressService.reserveOrchardAddress(
                   accountUuid: accountUuid,
                 );
               },

--- a/test/features/swap/swap_zec_staging_address_service_test.dart
+++ b/test/features/swap/swap_zec_staging_address_service_test.dart
@@ -4,10 +4,10 @@ import 'package:zcash_wallet/src/features/swap/providers/swap_zec_staging_addres
 
 void main() {
   test(
-    'blocks quote preparation when shielded wallet address is unavailable',
+    'blocks quote preparation when Orchard wallet address is unavailable',
     () {
       final service = SwapZecStagingAddressService(
-        loadCurrentShieldedAddress: ({required accountUuid}) async {
+        reserveFreshOrchardAddress: ({required accountUuid}) async {
           throw Exception('address unavailable');
         },
       );
@@ -19,49 +19,52 @@ void main() {
     },
   );
 
-  test('uses shielded unified address for the ZEC refund path', () async {
-    var shieldedLoads = 0;
+  test('uses Orchard-only unified address for the ZEC refund path', () async {
+    var orchardLoads = 0;
     final service = SwapZecStagingAddressService(
-      loadCurrentShieldedAddress: ({required accountUuid}) async {
-        shieldedLoads++;
+      reserveFreshOrchardAddress: ({required accountUuid}) async {
+        orchardLoads++;
         expect(accountUuid, 'account-1');
-        return 'u1fresh-shielded-refund';
+        return 'u1fresh-orchard-refund';
       },
     );
 
     final staging = await service.prepareForQuote(accountUuid: 'account-1');
 
-    expect(shieldedLoads, 1);
-    expect(staging.address, 'u1fresh-shielded-refund');
+    expect(orchardLoads, 1);
+    expect(staging.address, 'u1fresh-orchard-refund');
     final plan = staging.toAddressPlan(
       direction: SwapDirection.zecToExternal,
       externalAsset: SwapAsset.usdc,
       userExternalAddress: '0xrecipient',
     );
     expect(plan.oneClickRecipient, '0xrecipient');
-    expect(plan.oneClickRefundTo, 'u1fresh-shielded-refund');
+    expect(plan.oneClickRefundTo, 'u1fresh-orchard-refund');
   });
 
-  test('uses shielded unified address for external to ZEC delivery', () async {
-    var shieldedLoads = 0;
-    final service = SwapZecStagingAddressService(
-      loadCurrentShieldedAddress: ({required accountUuid}) async {
-        shieldedLoads++;
-        expect(accountUuid, 'account-1');
-        return 'u1fresh-shielded-recipient';
-      },
-    );
+  test(
+    'uses Orchard-only unified address for external to ZEC deposit',
+    () async {
+      var orchardLoads = 0;
+      final service = SwapZecStagingAddressService(
+        reserveFreshOrchardAddress: ({required accountUuid}) async {
+          orchardLoads++;
+          expect(accountUuid, 'account-1');
+          return 'u1fresh-orchard-deposit';
+        },
+      );
 
-    final staging = await service.prepareForQuote(accountUuid: 'account-1');
+      final staging = await service.prepareForQuote(accountUuid: 'account-1');
 
-    expect(shieldedLoads, 1);
-    expect(staging.address, 'u1fresh-shielded-recipient');
-    final plan = staging.toAddressPlan(
-      direction: SwapDirection.externalToZec,
-      externalAsset: SwapAsset.usdc,
-      userExternalAddress: '0xrefund',
-    );
-    expect(plan.oneClickRecipient, 'u1fresh-shielded-recipient');
-    expect(plan.oneClickRefundTo, '0xrefund');
-  });
+      expect(orchardLoads, 1);
+      expect(staging.address, 'u1fresh-orchard-deposit');
+      final plan = staging.toAddressPlan(
+        direction: SwapDirection.externalToZec,
+        externalAsset: SwapAsset.usdc,
+        userExternalAddress: '0xrefund',
+      );
+      expect(plan.oneClickRecipient, 'u1fresh-orchard-deposit');
+      expect(plan.oneClickRefundTo, '0xrefund');
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- reserve a fresh Orchard-only unified address for every NEAR Intents quote
- use that address for the ZEC refund or destination without publishing it as the account's active Receive address
- remove the Sapling-bearing current-address fallback
- verify repeated reservations use distinct addresses, omit Sapling and transparent receivers, and leave the current Receive address unchanged

## Tests
- fvm flutter test test/features/swap/swap_zec_staging_address_service_test.dart
- fvm flutter test test/features/swap/swap_screen_test.dart --name review-quote subset
- fvm flutter analyze on changed Dart files
- cargo test --manifest-path rust/Cargo.toml test_reserved_orchard_addresses_are_distinct_without_becoming_current --lib