### PR TITLE
fix(desktop): free window resize and grow content with extra width

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -801,7 +801,7 @@ Desktop window appearance is managed by the external [`desktop_window_bootstrap`
   - The app calls `DesktopWindowBootstrap.initialize()` in `lib/main.dart` after `initializeDesktopWindow()` has created the OS window but before `showDesktopWindow()` reveals it.
   - `DesktopWindowTitlebarSafeArea` in `lib/app.dart` pads Flutter content below the macOS traffic-light/titlebar area. Keep it wrapped around the app root.
 - `window_manager` owns sizing/lifecycle only.
-  - `lib/src/core/layout/app_layout.dart` should remain responsible for initial size, minimum size, aspect ratio, `show()`, `focus()`, and layout-mode reconciliation from window events.
+  - `lib/src/core/layout/app_layout.dart` should remain responsible for initial size, minimum size, `show()`, `focus()`, and layout-mode reconciliation from window events. Do not lock the window to a fixed aspect ratio; after launch the user resizes width and height independently.
   - Do not reintroduce `TitleBarStyle` ownership or other appearance writes through `window_manager`; that overlaps with `desktop_window_bootstrap`.
 
 Current startup order for desktop platforms:

--- a/lib/src/core/layout/app_desktop_content.dart
+++ b/lib/src/core/layout/app_desktop_content.dart
@@ -1,0 +1,119 @@
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+
+import '../theme/app_theme.dart';
+import 'app_desktop_shell.dart';
+
+/// Metrics for the desktop trailing-pane content column.
+///
+/// Figma's content-area token ([AppWindowSizing.contentAreaMaxWidth]) is
+/// the column width at the 1080×720 design window. Extra pane width
+/// beyond that design is given to the column so a maximized window is
+/// not a 420px strip in empty space. At the design size the column stays
+/// 420px, preserving Figma layout.
+abstract final class AppDesktopContentMetrics {
+  /// Trailing pane width at [AppWindowSizing.minWidth]:
+  /// window − left pad − sidebar − gap − right pad.
+  static const double designPaneWidth =
+      AppWindowSizing.minWidth -
+      AppSpacing.xs * 3 -
+      AppDesktopShell.defaultSidebarWidth;
+
+  /// Horizontal inset from the 420px content column to the inner 396px
+  /// surface used by activity cards and send fields.
+  static const double surfaceInset = AppSpacing.s;
+
+  /// Content column width for a trailing pane of [paneWidth].
+  static double widthForPane(double paneWidth) {
+    if (!paneWidth.isFinite || paneWidth <= 0) {
+      return AppWindowSizing.contentAreaMaxWidth;
+    }
+    if (paneWidth <= designPaneWidth) {
+      return math.min(paneWidth, AppWindowSizing.contentAreaMaxWidth);
+    }
+    return paneWidth - (designPaneWidth - AppWindowSizing.contentAreaMaxWidth);
+  }
+
+  /// Inner surface width (content column minus the 12px side inset
+  /// on each side).
+  static double surfaceWidthForPane(double paneWidth) {
+    return math.max(0.0, widthForPane(paneWidth) - surfaceInset * 2);
+  }
+}
+
+/// Centers a child in the trailing pane at [AppDesktopContentMetrics.widthForPane].
+class AppDesktopContentColumn extends StatelessWidget {
+  const AppDesktopContentColumn({
+    required this.child,
+    this.padding,
+    this.alignment = Alignment.topCenter,
+    this.contentKey,
+    super.key,
+  });
+
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final AlignmentGeometry alignment;
+  final Key? contentKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = AppDesktopContentMetrics.widthForPane(
+          constraints.maxWidth,
+        );
+        final padding = this.padding;
+        return Align(
+          alignment: alignment,
+          child: SizedBox(
+            key: contentKey,
+            width: width,
+            child: padding == null
+                ? child
+                : Padding(padding: padding, child: child),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Sliver counterpart of [AppDesktopContentColumn].
+class AppDesktopContentSliver extends StatelessWidget {
+  const AppDesktopContentSliver({
+    required this.child,
+    this.padding,
+    this.contentKey,
+    super.key,
+  });
+
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final Key? contentKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverLayoutBuilder(
+      builder: (context, constraints) {
+        final width = AppDesktopContentMetrics.widthForPane(
+          constraints.crossAxisExtent,
+        );
+        final padding = this.padding;
+        return SliverToBoxAdapter(
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              key: contentKey,
+              width: width,
+              child: padding == null
+                  ? child
+                  : Padding(padding: padding, child: child),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/src/core/layout/app_desktop_shell.dart
+++ b/lib/src/core/layout/app_desktop_shell.dart
@@ -16,9 +16,12 @@ class AppDesktopShell extends StatelessWidget {
     required this.pane,
     this.background,
     this.backgroundColor,
-    this.sidebarWidth = 256,
+    this.sidebarWidth = defaultSidebarWidth,
     super.key,
   });
+
+  /// Default trailing-pane sidebar width from the desktop window chrome.
+  static const double defaultSidebarWidth = 256;
 
   final Widget sidebar;
   final Widget pane;

--- a/lib/src/core/layout/app_layout.dart
+++ b/lib/src/core/layout/app_layout.dart
@@ -17,19 +17,22 @@ const _windowAppearanceChannel = MethodChannel(
   'com.zcash.wallet/window_appearance',
 );
 
-/// Two fixed-aspect-ratio layouts the desktop app supports.
+/// Two desktop window shapes the app can boot into or infer from the
+/// current size.
 ///
-/// - [large]: landscape, width:height = 1080:720 (3:2 = 1.5, wider than tall)
-/// - [small]: portrait,  width:height =  65:133  (≈ 0.489, taller than wide)
+/// - [large]: landscape default, 1080×720
+/// - [small]: portrait default, 416×851
 ///
-/// Mobile and web are permanently [small]. On desktop the OS window is
-/// reshaped to the selected ratio and its aspect ratio is enforced for
-/// user drag-resize.
+/// Mobile and web are permanently [small]. On desktop the OS window
+/// starts at [defaultSize] with [minimumSize] as the drag-resize floor.
+/// After launch, width and height resize independently — the window is
+/// not locked to [aspectRatio].
 enum AppLayoutMode {
   large,
   small;
 
-  /// Width / height for this layout.
+  /// Width / height for this layout's default size. Used only to infer
+  /// the current mode from an observed window; it is not enforced.
   double get aspectRatio {
     switch (this) {
       case AppLayoutMode.large:
@@ -39,7 +42,7 @@ enum AppLayoutMode {
     }
   }
 
-  /// Default window size applied at startup and on explicit toggle.
+  /// Default window size applied at startup.
   Size get defaultSize {
     switch (this) {
       case AppLayoutMode.large:
@@ -49,12 +52,15 @@ enum AppLayoutMode {
     }
   }
 
-  /// Minimum allowed drag-resize size — prevents the window from
-  /// collapsing below the design system's large desktop canvas.
+  /// Minimum allowed drag-resize size.
+  ///
+  /// Large-mode width is 75% of the 1080 Figma canvas so the window can
+  /// sit closer to the 420px content column. Height stays at the design
+  /// canvas (720).
   Size get minimumSize {
     switch (this) {
       case AppLayoutMode.large:
-        return const Size(1080, 720);
+        return const Size(810, 720);
       case AppLayoutMode.small:
         return const Size(416, 851);
     }
@@ -94,7 +100,8 @@ Future<void> initializeDesktopWindow({
     await _applyWindowsClientAreaLayout(initialMode, center: true);
   } else {
     await windowManager.setMinimumSize(initialMode.minimumSize);
-    await windowManager.setAspectRatio(initialMode.aspectRatio);
+    // 0 clears any leftover ratio lock so drag-resize is free on both axes.
+    await windowManager.setAspectRatio(0);
     await windowManager.setSize(initialMode.defaultSize, animate: false);
   }
 }
@@ -125,21 +132,13 @@ class AppLayoutState {
   const AppLayoutState(this.mode);
 }
 
-/// Riverpod notifier that owns the current layout mode and, on desktop,
-/// drives the OS window to match.
+/// Riverpod notifier that owns the current layout mode.
 ///
-/// Observes [WindowListener] events so that when the user breaks out of
-/// the configured aspect-ratio constraint (macOS green-button zoom,
-/// Windows maximize/snap, manual drag past the limit) — or restores
-/// the window back to the other ratio's shape — the notifier infers
-/// the current layout from the observed window ratio using a single
-/// midpoint threshold.
-///
-/// The inference is idempotent, so the listener doesn't need a
-/// re-entrancy guard against the notifier's own `setSize` events:
-/// `setSize(large default)` → observed ratio ≈ 1.33 → infers large →
-/// state was already large → no-op. `setSize(small default)` → observed
-/// ratio ≈ 0.489 → infers small → state was already small → no-op.
+/// Startup sizes the window once. After that, the user resizes freely;
+/// [setMode] does not snap the window back to a default size. Window
+/// listener events only infer [AppLayoutMode] from the observed ratio
+/// so screens that still call [setMode] stay in sync without reshaping
+/// the window.
 class AppLayoutNotifier extends Notifier<AppLayoutState> with WindowListener {
   @override
   AppLayoutState build() {
@@ -157,23 +156,9 @@ class AppLayoutNotifier extends Notifier<AppLayoutState> with WindowListener {
   Future<void> setMode(AppLayoutMode mode) async {
     if (!isDesktopLayoutPlatform) return;
     if (state.mode == mode) return;
+    // Geometry is user-controlled after [initializeDesktopWindow]. Keep
+    // the recorded mode in sync without resetting size or aspect ratio.
     state = AppLayoutState(mode);
-    try {
-      if (Platform.isWindows) {
-        await _applyWindowsClientAreaLayout(mode);
-      } else {
-        await windowManager.setMinimumSize(mode.minimumSize);
-        await windowManager.setAspectRatio(mode.aspectRatio);
-        await windowManager.setSize(mode.defaultSize, animate: false);
-      }
-    } catch (e, st) {
-      // On platform-call failure, log and fall back to the assumption
-      // that the window is in [large]. The auto-switch listener will
-      // subsequently correct this if the window is actually shaped
-      // like small.
-      debugPrint('AppLayoutNotifier.setMode($mode) failed: $e\n$st');
-      state = const AppLayoutState(AppLayoutMode.large);
-    }
   }
 
   Future<void> toggle() => setMode(
@@ -231,6 +216,7 @@ Future<void> _applyWindowsClientAreaLayout(
     // Windows targets the redesigned content area directly. Its native frame is
     // added by the plugin after the Flutter client-area size is selected.
     contentTopInset: _windowsContentTopInset,
+    enforceAspectRatio: false,
     resize: resize,
     center: center,
   );

--- a/lib/src/core/theme/app_sizing.dart
+++ b/lib/src/core/theme/app_sizing.dart
@@ -116,6 +116,9 @@ abstract final class AppWindowSizing {
   static const double minHeight = 720;
   static const double maxWidth = 1296;
   static const double maxHeight = 864;
+
+  /// Content column width at the 1080×720 design window. Larger panes
+  /// grow the column with extra window width.
   static const double contentAreaMaxWidth = 420;
   static const double paneRadius = 20;
 }

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/layout/app_desktop_content.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_pane_floating_bar.dart';
 import '../../../core/layout/app_pane_scroll_scaffold.dart';
@@ -33,8 +34,6 @@ import '../widgets/account_profile_picture_modal.dart';
 import '../widgets/account_remove_modal.dart';
 
 const _accountRowHeight = 44.0;
-const _accountsContentWidth = 420.0;
-const _accountsSurfaceWidth = 396.0;
 const _accountsCurrentSurfaceHeight = 124.0;
 const _accountsSurfaceVerticalPadding = AppSpacing.md;
 const _accountsSurfaceHorizontalPadding = AppSpacing.sm;
@@ -537,40 +536,34 @@ class _AccountsPane extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.topCenter,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: _accountsContentWidth),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: _accountsContentHorizontalPadding,
-            vertical: _accountsContentVerticalPadding,
+    return AppDesktopContentColumn(
+      padding: const EdgeInsets.symmetric(
+        horizontal: _accountsContentHorizontalPadding,
+        vertical: _accountsContentVerticalPadding,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Accounts',
+            textAlign: TextAlign.center,
+            style: AppTypography.headlineLarge.copyWith(
+              color: context.colors.text.accent,
+            ),
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text(
-                'Accounts',
-                textAlign: TextAlign.center,
-                style: AppTypography.headlineLarge.copyWith(
-                  color: context.colors.text.accent,
-                ),
-              ),
-              const SizedBox(height: _accountsTitleSurfaceGap),
-              _AccountsList(
-                activeAccount: activeAccount,
-                otherAccounts: otherAccounts,
-                onSelectAccount: onSelectAccount,
-                onCopyAddress: onCopyAddress,
-                onSendZec: onSendZec,
-                onEditAccount: onEditAccount,
-                onRemoveAccount: onRemoveAccount,
-                initialOpenMenuAccountUuid: initialOpenMenuAccountUuid,
-              ),
-            ],
+          const SizedBox(height: _accountsTitleSurfaceGap),
+          _AccountsList(
+            activeAccount: activeAccount,
+            otherAccounts: otherAccounts,
+            onSelectAccount: onSelectAccount,
+            onCopyAddress: onCopyAddress,
+            onSendZec: onSendZec,
+            onEditAccount: onEditAccount,
+            onRemoveAccount: onRemoveAccount,
+            initialOpenMenuAccountUuid: initialOpenMenuAccountUuid,
           ),
-        ),
+        ],
       ),
     );
   }
@@ -697,8 +690,6 @@ class _AccountsList extends StatelessWidget {
     required this.initialOpenMenuAccountUuid,
   });
 
-  static const _width = _accountsSurfaceWidth;
-
   final AccountInfo? activeAccount;
   final List<AccountInfo> otherAccounts;
   final Future<void> Function(String uuid) onSelectAccount;
@@ -711,68 +702,60 @@ class _AccountsList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final accountCount = otherAccounts.length + (activeAccount == null ? 0 : 1);
-    return Align(
-      alignment: Alignment.topCenter,
-      child: SizedBox(
-        width: _width,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            if (activeAccount != null) ...[
-              _AccountsSurface(
-                key: const ValueKey('accounts_current_surface'),
-                height: _accountsCurrentSurfaceHeight,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    const _AccountsSectionLabel(label: 'Current'),
-                    const SizedBox(height: _accountsRowGap),
-                    _AccountRow(
-                      key: ValueKey(
-                        'accounts_active_row_${activeAccount!.uuid}',
-                      ),
-                      account: activeAccount!,
-                      onTap: null,
-                      showSendZec: false,
-                      onCopyAddress: onCopyAddress,
-                      onSendZec: onSendZec,
-                      onEditAccount: onEditAccount,
-                      onRemove: onRemoveAccount,
-                      showRemove: _AccountsList._canRemoveAccount(accountCount),
-                      initiallyOpenMenu:
-                          initialOpenMenuAccountUuid == activeAccount!.uuid,
-                    ),
-                  ],
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (activeAccount != null) ...[
+          _AccountsSurface(
+            key: const ValueKey('accounts_current_surface'),
+            height: _accountsCurrentSurfaceHeight,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const _AccountsSectionLabel(label: 'Current'),
+                const SizedBox(height: _accountsRowGap),
+                _AccountRow(
+                  key: ValueKey('accounts_active_row_${activeAccount!.uuid}'),
+                  account: activeAccount!,
+                  onTap: null,
+                  showSendZec: false,
+                  onCopyAddress: onCopyAddress,
+                  onSendZec: onSendZec,
+                  onEditAccount: onEditAccount,
+                  onRemove: onRemoveAccount,
+                  showRemove: _AccountsList._canRemoveAccount(accountCount),
+                  initiallyOpenMenu:
+                      initialOpenMenuAccountUuid == activeAccount!.uuid,
                 ),
-              ),
-            ],
-            if (otherAccounts.isNotEmpty) ...[
-              if (activeAccount != null) const SizedBox(height: AppSpacing.sm),
-              _AccountsSurface(
-                key: const ValueKey('accounts_other_surface'),
-                height: _otherAccountsSurfaceHeight(otherAccounts.length),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    const _AccountsSectionLabel(label: 'Other'),
-                    const SizedBox(height: _accountsRowGap),
-                    _OtherAccountsRows(
-                      accounts: otherAccounts,
-                      accountCount: accountCount,
-                      onSelectAccount: onSelectAccount,
-                      onCopyAddress: onCopyAddress,
-                      onSendZec: onSendZec,
-                      onEditAccount: onEditAccount,
-                      onRemoveAccount: onRemoveAccount,
-                      initialOpenMenuAccountUuid: initialOpenMenuAccountUuid,
-                    ),
-                  ],
+              ],
+            ),
+          ),
+        ],
+        if (otherAccounts.isNotEmpty) ...[
+          if (activeAccount != null) const SizedBox(height: AppSpacing.sm),
+          _AccountsSurface(
+            key: const ValueKey('accounts_other_surface'),
+            height: _otherAccountsSurfaceHeight(otherAccounts.length),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const _AccountsSectionLabel(label: 'Other'),
+                const SizedBox(height: _accountsRowGap),
+                _OtherAccountsRows(
+                  accounts: otherAccounts,
+                  accountCount: accountCount,
+                  onSelectAccount: onSelectAccount,
+                  onCopyAddress: onCopyAddress,
+                  onSendZec: onSendZec,
+                  onEditAccount: onEditAccount,
+                  onRemoveAccount: onRemoveAccount,
+                  initialOpenMenuAccountUuid: initialOpenMenuAccountUuid,
                 ),
-              ),
-            ],
-          ],
-        ),
-      ),
+              ],
+            ),
+          ),
+        ],
+      ],
     );
   }
 

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -8,10 +8,11 @@ import '../../../core/formatting/address_display.dart';
 import '../../../core/formatting/date_format.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../core/config/zcash_explorer.dart';
+import '../../../core/layout/app_desktop_content.dart';
 import '../../../core/layout/app_desktop_shell.dart';
-import '../../../core/layout/app_pane_scroll_scaffold.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/layout/app_pane_scroll_scaffold.dart';
 import '../../../core/privacy/privacy_mask.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
@@ -701,18 +702,12 @@ class _ReceiptContentColumn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.topCenter,
-      child: SizedBox(
-        width: AppWindowSizing.contentAreaMaxWidth,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSpacing.s,
-            vertical: AppSpacing.sm,
-          ),
-          child: child,
-        ),
+    return AppDesktopContentColumn(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.s,
+        vertical: AppSpacing.sm,
       ),
+      child: child,
     );
   }
 }

--- a/lib/src/features/activity/widgets/activity_feed.dart
+++ b/lib/src/features/activity/widgets/activity_feed.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import '../../../core/layout/app_desktop_content.dart';
 import '../../../core/layout/app_form_factor.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -293,7 +294,6 @@ class _ActivityFeedSliverItemView extends StatelessWidget {
   Widget build(BuildContext context) {
     return switch (item.type) {
       _ActivityFeedSliverItemType.title => const _ActivityFeedCentered(
-        width: 420,
         child: Padding(
           padding: EdgeInsets.symmetric(horizontal: AppSpacing.s),
           child: _ActivityFeedTitleRow(),
@@ -301,10 +301,9 @@ class _ActivityFeedSliverItemView extends StatelessWidget {
       ),
       _ActivityFeedSliverItemType.gap => SizedBox(height: item.height),
       _ActivityFeedSliverItemType.message => _ActivityFeedCentered(
-        width: 396,
+        surface: true,
         child: _ActivityFeedMessageCard(
           text: item.text!,
-          width: 396,
           isError: item.isError,
         ),
       ),
@@ -324,16 +323,24 @@ class _ActivityFeedSliverItemView extends StatelessWidget {
 }
 
 class _ActivityFeedCentered extends StatelessWidget {
-  const _ActivityFeedCentered({required this.width, required this.child});
+  const _ActivityFeedCentered({required this.child, this.surface = false});
 
-  final double width;
   final Widget child;
+  final bool surface;
 
   @override
   Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.topCenter,
-      child: SizedBox(width: width, child: child),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final paneWidth = constraints.maxWidth;
+        final width = surface
+            ? AppDesktopContentMetrics.surfaceWidthForPane(paneWidth)
+            : AppDesktopContentMetrics.widthForPane(paneWidth);
+        return Align(
+          alignment: Alignment.topCenter,
+          child: SizedBox(width: width, child: child),
+        );
+      },
     );
   }
 }
@@ -412,7 +419,7 @@ class _ActivityFeedCardSegment extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     return _ActivityFeedCentered(
-      width: 396,
+      surface: true,
       child: CustomPaint(
         painter: _ActivityFeedCardSegmentShadowPainter(
           position: position,
@@ -598,7 +605,7 @@ ValueKey<String>? _stableRowKey(ActivityRowData row) {
 class _ActivityFeedMessageCard extends StatelessWidget {
   const _ActivityFeedMessageCard({
     required this.text,
-    required this.width,
+    this.width,
     this.isError = false,
   });
 

--- a/lib/src/features/donation/widgets/donation_views.dart
+++ b/lib/src/features/donation/widgets/donation_views.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../../../core/layout/app_desktop_content.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -48,78 +49,72 @@ class DonationComposeView extends StatelessWidget {
     return Stack(
       fit: StackFit.expand,
       children: [
-        Align(
-          alignment: Alignment.topCenter,
-          child: SizedBox(
-            width: AppWindowSizing.contentAreaMaxWidth,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSpacing.s,
-              ).copyWith(top: AppSpacing.sm),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
+        AppDesktopContentColumn(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.s,
+          ).copyWith(top: AppSpacing.sm),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Support Vizor',
+                textAlign: TextAlign.center,
+                style: AppTypography.headlineLarge.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+              const SizedBox(height: 56),
+              _DonationAmountCard(
+                controller: controller,
+                isUsd: isUsd,
+                conversionText: conversionText,
+                errorText: errorText,
+                onChanged: onAmountChanged,
+                onToggleMode: onToggleMode,
+              ),
+              const SizedBox(height: AppSpacing.md),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(
-                    'Support Vizor',
-                    textAlign: TextAlign.center,
-                    style: AppTypography.headlineLarge.copyWith(
-                      color: colors.text.accent,
+                  for (final preset in presets)
+                    _DonationPreset(
+                      label: isUsd ? '\$$preset' : '$preset ZEC',
+                      selected: selectedPreset == preset,
+                      onTap: () => onPresetSelected(preset),
                     ),
-                  ),
-                  const SizedBox(height: 56),
-                  _DonationAmountCard(
-                    controller: controller,
-                    isUsd: isUsd,
-                    conversionText: conversionText,
-                    errorText: errorText,
-                    onChanged: onAmountChanged,
-                    onToggleMode: onToggleMode,
-                  ),
-                  const SizedBox(height: AppSpacing.md),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      for (final preset in presets)
-                        _DonationPreset(
-                          label: isUsd ? '\$$preset' : '$preset ZEC',
-                          selected: selectedPreset == preset,
-                          onTap: () => onPresetSelected(preset),
-                        ),
-                    ],
-                  ),
-                  const SizedBox(height: AppSpacing.md),
-                  SizedBox(
-                    height: 28,
-                    child: Wrap(
-                      alignment: WrapAlignment.center,
-                      crossAxisAlignment: WrapCrossAlignment.center,
-                      children: [
-                        Text(
-                          'Sending from your',
-                          style: AppTypography.labelLarge.copyWith(
-                            color: colors.text.primary,
-                          ),
-                        ),
-                        const SizedBox(width: AppSpacing.xs),
-                        AppIcon(
-                          AppIcons.shieldKeyhole,
-                          size: 20,
-                          color: colors.icon.accent,
-                        ),
-                        const SizedBox(width: AppSpacing.xs),
-                        Text(
-                          'Shielded balance',
-                          style: AppTypography.labelLarge.copyWith(
-                            color: colors.text.accent,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
                 ],
               ),
-            ),
+              const SizedBox(height: AppSpacing.md),
+              SizedBox(
+                height: 28,
+                child: Wrap(
+                  alignment: WrapAlignment.center,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    Text(
+                      'Sending from your',
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.primary,
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.xs),
+                    AppIcon(
+                      AppIcons.shieldKeyhole,
+                      size: 20,
+                      color: colors.icon.accent,
+                    ),
+                    const SizedBox(width: AppSpacing.xs),
+                    Text(
+                      'Shielded balance',
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.accent,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
         ),
         Positioned(

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -18,6 +18,7 @@ import '../../../core/config/swap_feature_config.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_desktop_backdrop_shell.dart';
+import '../../../core/layout/app_desktop_content.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_pane_scroll_scaffold.dart';
 import '../../../core/privacy/privacy_mask.dart';
@@ -1313,15 +1314,10 @@ class _HomeDesktopCenteredSliver extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SliverToBoxAdapter(
-      child: Align(
-        alignment: Alignment.topCenter,
-        child: SizedBox(
-          key: contentKey,
-          width: 420,
-          child: Padding(padding: padding, child: child),
-        ),
-      ),
+    return AppDesktopContentSliver(
+      contentKey: contentKey,
+      padding: padding,
+      child: child,
     );
   }
 }
@@ -2326,24 +2322,16 @@ class _HomeDesktopEmptyActivitySliver extends StatelessWidget {
             constraints.precedingScrollExtent;
         final height = math.max(160.0, remainingHeight - AppSpacing.sm);
 
-        return SliverToBoxAdapter(
-          child: Align(
-            alignment: Alignment.topCenter,
-            child: SizedBox(
-              width: 420,
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(
-                  AppSpacing.s,
-                  0,
-                  AppSpacing.s,
-                  AppSpacing.sm,
-                ),
-                child: SizedBox(
-                  height: height,
-                  child: _HomeDesktopEmptyActivity(isLoading: isLoading),
-                ),
-              ),
-            ),
+        return AppDesktopContentSliver(
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.s,
+            0,
+            AppSpacing.s,
+            AppSpacing.sm,
+          ),
+          child: SizedBox(
+            height: height,
+            child: _HomeDesktopEmptyActivity(isLoading: isLoading),
           ),
         );
       },

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -9,6 +9,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../main.dart' show log;
 import '../../../core/config/network_config.dart';
 import '../../../core/formatting/zec_amount.dart';
+import '../../../core/layout/app_desktop_content.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
@@ -1419,8 +1420,6 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 class _SendComposeLayout extends StatelessWidget {
   const _SendComposeLayout({required this.child, required this.reviewButton});
 
-  static const contentWidth = 420.0;
-  static const fieldsWidth = 396.0;
   static const reviewButtonWidth = 196.0;
   static const _containerHorizontalPadding = AppSpacing.s;
   static const _containerVerticalPadding = AppSpacing.sm;
@@ -1442,6 +1441,12 @@ class _SendComposeLayout extends StatelessWidget {
             : height < (_containerVerticalPadding * 2)
             ? 0.0
             : height - (_containerVerticalPadding * 2);
+        final contentWidth = AppDesktopContentMetrics.widthForPane(
+          constraints.maxWidth,
+        );
+        final fieldsWidth = AppDesktopContentMetrics.surfaceWidthForPane(
+          constraints.maxWidth,
+        );
 
         return Center(
           child: SizedBox(
@@ -1616,7 +1621,7 @@ class _SendContactAutocompleteOptionsState
 
     return SizedBox(
       key: const ValueKey('send_contact_autocomplete_options'),
-      width: _SendComposeLayout.fieldsWidth,
+      width: double.infinity,
       height: popoverHeight,
       child: DecoratedBox(
         key: const ValueKey('send_contact_autocomplete_surface'),

--- a/lib/src/features/send/widgets/send_review_layout.dart
+++ b/lib/src/features/send/widgets/send_review_layout.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../../../core/formatting/address_display.dart';
+import '../../../core/layout/app_desktop_content.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_profile_picture.dart';
@@ -175,12 +176,13 @@ class SendReviewInfoSection extends StatelessWidget {
   }
 }
 
-/// The 420px content column shared by the review and status views: Body-L
-/// SemiBold title over the screen sections with the Figma 32px gap.
+/// Content column shared by the review and status views: Body-L SemiBold
+/// title over the screen sections with the Figma 32px gap.
 ///
-/// The column is horizontally centered but top-pinned in the content area. In
-/// the Figma frames, the title starts 16px below `Content Area` rather than
-/// vertically centering the whole group in the pane.
+/// At the 1080 design window this is 420px; extra pane width is given to
+/// the column. It is horizontally centered but top-pinned in the content
+/// area. In the Figma frames, the title starts 16px below `Content Area`
+/// rather than vertically centering the whole group in the pane.
 ///
 /// Scrolling is owned by the containing pane scaffold.
 class SendReviewContentColumn extends StatelessWidget {
@@ -202,36 +204,30 @@ class SendReviewContentColumn extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
 
-    return Align(
-      alignment: Alignment.topCenter,
-      child: SizedBox(
-        width: AppWindowSizing.contentAreaMaxWidth,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSpacing.s,
-            vertical: AppSpacing.sm,
+    return AppDesktopContentColumn(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.s,
+        vertical: AppSpacing.sm,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            title,
+            textAlign: TextAlign.center,
+            // Figma `Body L` SemiBold — branch pattern is the
+            // bodyLarge token with an inline weight bump.
+            style: AppTypography.bodyLarge.copyWith(
+              color: colors.text.accent,
+              fontWeight: FontWeight.w600,
+            ),
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                title,
-                textAlign: TextAlign.center,
-                // Figma `Body L` SemiBold — branch pattern is the
-                // bodyLarge token with an inline weight bump.
-                style: AppTypography.bodyLarge.copyWith(
-                  color: colors.text.accent,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              for (final child in children) ...[
-                const SizedBox(height: _sectionGap),
-                child,
-              ],
-            ],
-          ),
-        ),
+          for (final child in children) ...[
+            const SizedBox(height: _sectionGap),
+            child,
+          ],
+        ],
       ),
     );
   }

--- a/lib/src/features/settings/screens/settings_endpoint_screen.dart
+++ b/lib/src/features/settings/screens/settings_endpoint_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/config/rpc_endpoint_config.dart';
+import '../../../core/layout/app_desktop_content.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_pane_floating_bar.dart';
@@ -235,8 +236,6 @@ class _SettingsEndpointPane extends StatefulWidget {
 }
 
 class _SettingsEndpointPaneState extends State<_SettingsEndpointPane> {
-  static const _contentWidth = 420.0;
-
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
@@ -244,26 +243,25 @@ class _SettingsEndpointPaneState extends State<_SettingsEndpointPane> {
         widget.activeTab == _EndpointTab.list &&
         (widget.canUpdate || widget.isSubmitting || widget.submitError != null);
 
-    return AppPaneFloatingBar(
-      visible: showFloatingBar,
-      // The scrim box is the 420 content column in the design, not the full
-      // pane width.
-      overlayWidth: _contentWidth,
-      bar: _FloatingUpdateBar(
-        submitError: widget.submitError,
-        isSubmitting: widget.isSubmitting,
-        canUpdate: widget.canUpdate,
-        showButton: widget.canUpdate || widget.isSubmitting,
-        onSubmit: widget.onSubmit,
-      ),
-      builder: (context, bottomReserve) => AppPaneScrollScaffold(
-        toolbar: const AppPaneToolbar(backLinkMinWidth: 60),
-        padding: EdgeInsets.only(bottom: bottomReserve),
-        child: Align(
-          alignment: Alignment.topCenter,
-          child: SizedBox(
-            width: _contentWidth,
-            child: Padding(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final contentWidth = AppDesktopContentMetrics.widthForPane(
+          constraints.maxWidth,
+        );
+        return AppPaneFloatingBar(
+          visible: showFloatingBar,
+          overlayWidth: contentWidth,
+          bar: _FloatingUpdateBar(
+            submitError: widget.submitError,
+            isSubmitting: widget.isSubmitting,
+            canUpdate: widget.canUpdate,
+            showButton: widget.canUpdate || widget.isSubmitting,
+            onSubmit: widget.onSubmit,
+          ),
+          builder: (context, bottomReserve) => AppPaneScrollScaffold(
+            toolbar: const AppPaneToolbar(backLinkMinWidth: 60),
+            padding: EdgeInsets.only(bottom: bottomReserve),
+            child: AppDesktopContentColumn(
               padding: const EdgeInsets.symmetric(
                 horizontal: AppSpacing.s,
                 vertical: AppSpacing.sm,
@@ -322,8 +320,8 @@ class _SettingsEndpointPaneState extends State<_SettingsEndpointPane> {
               ),
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/src/features/settings/screens/settings_explorer_screen.dart
+++ b/lib/src/features/settings/screens/settings_explorer_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/config/zcash_explorer.dart';
+import '../../../core/layout/app_desktop_content.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_pane_scroll_scaffold.dart';
@@ -128,127 +129,121 @@ class _SettingsExplorerScreenState
         padding: EdgeInsets.zero,
         child: AppPaneScrollScaffold(
           toolbar: const AppPaneToolbar(backLinkMinWidth: 60),
-          child: Align(
-            alignment: Alignment.topCenter,
-            child: SizedBox(
-              width: 420,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppSpacing.s,
-                  vertical: AppSpacing.sm,
+          child: AppDesktopContentColumn(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.s,
+              vertical: AppSpacing.sm,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Explorer',
+                  textAlign: TextAlign.center,
+                  style: AppTypography.headlineLarge.copyWith(
+                    color: colors.text.accent,
+                  ),
                 ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Text(
-                      'Explorer',
-                      textAlign: TextAlign.center,
-                      style: AppTypography.headlineLarge.copyWith(
-                        color: colors.text.accent,
-                      ),
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    Text(
-                      current.trim().isEmpty
-                          ? 'Current: ${defaultZcashExplorerHost(networkName)} (default)'
-                          : 'Current: ${explorerSettingsLabel(current, networkName: networkName)}',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      textAlign: TextAlign.center,
-                      style: AppTypography.labelLarge.copyWith(
-                        color: colors.text.accent,
-                      ),
-                    ),
-                    const SizedBox(height: AppSpacing.base),
-                    _ExplorerOptionCard(
-                      key: const ValueKey('explorer_option_cipherscan'),
-                      iconName: AppIcons.globe,
-                      label: kDefaultZcashExplorerLabel,
-                      subtitle: defaultZcashExplorerHost(networkName),
-                      selected: _choice == _ExplorerChoice.cipherscan,
-                      onTap: _isSubmitting
-                          ? null
-                          : () => setState(() {
-                              _choice = _ExplorerChoice.cipherscan;
-                              _submitError = null;
-                            }),
-                    ),
-                    const SizedBox(height: AppSpacing.xs),
-                    _ExplorerOptionCard(
-                      key: const ValueKey('explorer_option_custom'),
-                      iconName: AppIcons.edit,
-                      label: 'Custom',
-                      subtitle: 'Any explorer you prefer',
-                      selected: _choice == _ExplorerChoice.custom,
-                      onTap: _isSubmitting
-                          ? null
-                          : () => setState(() {
-                              _choice = _ExplorerChoice.custom;
-                              _submitError = null;
-                              if (_customController.text.trim().isEmpty &&
-                                  current.trim().isNotEmpty) {
-                                _customController.text = current;
-                              }
-                            }),
-                    ),
-                    if (_choice == _ExplorerChoice.custom) ...[
-                      const SizedBox(height: AppSpacing.md),
-                      AppTextField(
-                        key: const ValueKey('explorer_custom_field'),
-                        label: 'Explorer URL',
-                        hintText: 'https://explorer.example/tx/{txid}',
-                        controller: _customController,
-                        keyboardType: TextInputType.url,
-                        textInputAction: TextInputAction.done,
-                        messageText: customMessage,
-                        tone: customMessage == null
-                            ? AppTextFieldTone.neutral
-                            : AppTextFieldTone.destructive,
-                        onChanged: (_) => setState(() => _submitError = null),
-                        onSubmitted: (_) => _submit(),
-                      ),
-                      const SizedBox(height: AppSpacing.xs),
-                      Text(
-                        kZcashExplorerTemplateHint,
-                        style: AppTypography.bodySmall.copyWith(
-                          color: colors.text.secondary,
-                        ),
-                      ),
-                    ],
-                    const SizedBox(height: AppSpacing.md),
-                    AppIcon(AppIcons.book, size: 20, color: colors.icon.accent),
-                    const SizedBox(height: AppSpacing.xs),
-                    Text(
-                      kZcashExplorerPrivacyCopy,
-                      style: AppTypography.bodyMedium.copyWith(
-                        color: colors.text.primary,
-                      ),
-                    ),
-                    if (_submitError != null) ...[
-                      const SizedBox(height: AppSpacing.sm),
-                      Text(
-                        _submitError!,
-                        textAlign: TextAlign.center,
-                        style: AppTypography.bodyMedium.copyWith(
-                          color: colors.text.destructive,
-                        ),
-                      ),
-                    ],
-                    const SizedBox(height: AppSpacing.md),
-                    Center(
-                      child: AppButton(
-                        key: const ValueKey('explorer_update'),
-                        onPressed: _canUpdate(current) ? _submit : null,
-                        minWidth: 196,
-                        child: Text(
-                          _isSubmitting ? 'Updating...' : 'Update explorer',
-                        ),
-                      ),
-                    ),
-                  ],
+                const SizedBox(height: AppSpacing.s),
+                Text(
+                  current.trim().isEmpty
+                      ? 'Current: ${defaultZcashExplorerHost(networkName)} (default)'
+                      : 'Current: ${explorerSettingsLabel(current, networkName: networkName)}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                  style: AppTypography.labelLarge.copyWith(
+                    color: colors.text.accent,
+                  ),
                 ),
-              ),
+                const SizedBox(height: AppSpacing.base),
+                _ExplorerOptionCard(
+                  key: const ValueKey('explorer_option_cipherscan'),
+                  iconName: AppIcons.globe,
+                  label: kDefaultZcashExplorerLabel,
+                  subtitle: defaultZcashExplorerHost(networkName),
+                  selected: _choice == _ExplorerChoice.cipherscan,
+                  onTap: _isSubmitting
+                      ? null
+                      : () => setState(() {
+                          _choice = _ExplorerChoice.cipherscan;
+                          _submitError = null;
+                        }),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                _ExplorerOptionCard(
+                  key: const ValueKey('explorer_option_custom'),
+                  iconName: AppIcons.edit,
+                  label: 'Custom',
+                  subtitle: 'Any explorer you prefer',
+                  selected: _choice == _ExplorerChoice.custom,
+                  onTap: _isSubmitting
+                      ? null
+                      : () => setState(() {
+                          _choice = _ExplorerChoice.custom;
+                          _submitError = null;
+                          if (_customController.text.trim().isEmpty &&
+                              current.trim().isNotEmpty) {
+                            _customController.text = current;
+                          }
+                        }),
+                ),
+                if (_choice == _ExplorerChoice.custom) ...[
+                  const SizedBox(height: AppSpacing.md),
+                  AppTextField(
+                    key: const ValueKey('explorer_custom_field'),
+                    label: 'Explorer URL',
+                    hintText: 'https://explorer.example/tx/{txid}',
+                    controller: _customController,
+                    keyboardType: TextInputType.url,
+                    textInputAction: TextInputAction.done,
+                    messageText: customMessage,
+                    tone: customMessage == null
+                        ? AppTextFieldTone.neutral
+                        : AppTextFieldTone.destructive,
+                    onChanged: (_) => setState(() => _submitError = null),
+                    onSubmitted: (_) => _submit(),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    kZcashExplorerTemplateHint,
+                    style: AppTypography.bodySmall.copyWith(
+                      color: colors.text.secondary,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: AppSpacing.md),
+                AppIcon(AppIcons.book, size: 20, color: colors.icon.accent),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  kZcashExplorerPrivacyCopy,
+                  style: AppTypography.bodyMedium.copyWith(
+                    color: colors.text.primary,
+                  ),
+                ),
+                if (_submitError != null) ...[
+                  const SizedBox(height: AppSpacing.sm),
+                  Text(
+                    _submitError!,
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.destructive,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: AppSpacing.md),
+                Center(
+                  child: AppButton(
+                    key: const ValueKey('explorer_update'),
+                    onPressed: _canUpdate(current) ? _submit : null,
+                    minWidth: 196,
+                    child: Text(
+                      _isSubmitting ? 'Updating...' : 'Update explorer',
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../core/formatting/zec_amount.dart';
+import '../../../core/layout/app_desktop_content.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_pane_scroll_scaffold.dart';
@@ -270,12 +271,14 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                             const [],
                       )?.label,
                     );
-                    // Figma container (420×656, 16px vertical padding): the
-                    // title is pinned under the toolbar, the attribution and
-                    // CTA are pinned at the bottom, and the swap section
-                    // flexes to center the widget between them. Pinning only
-                    // engages when the pane offers the design height;
-                    // shorter panes pack the column and scroll instead.
+                    // Figma container (420×656 at the design window, 16px
+                    // vertical padding): the title is pinned under the
+                    // toolbar, the attribution and CTA are pinned at the
+                    // bottom, and the swap section flexes to center the
+                    // widget between them. Extra pane width grows the
+                    // column. Pinning only engages when the pane offers
+                    // the design height; shorter panes pack the column
+                    // and scroll instead.
                     final pinned =
                         constraints.minHeight >= _swapBodyPinnedMinHeight;
                     final column = Column(
@@ -298,21 +301,17 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                         ),
                       ],
                     );
-                    return Center(
-                      child: ConstrainedBox(
-                        constraints: const BoxConstraints(maxWidth: 420),
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: AppSpacing.s,
-                          ),
-                          child: pinned
-                              ? SizedBox(
-                                  height: constraints.minHeight,
-                                  child: column,
-                                )
-                              : column,
-                        ),
+                    return AppDesktopContentColumn(
+                      alignment: Alignment.center,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.s,
                       ),
+                      child: pinned
+                          ? SizedBox(
+                              height: constraints.minHeight,
+                              child: column,
+                            )
+                          : column,
                     );
                   },
                 ),

--- a/lib/widgetbook.dart
+++ b/lib/widgetbook.dart
@@ -18,7 +18,7 @@ import 'widgetbook/widgetbook_app.dart';
 /// so the Dart side must explicitly `show()` it. The production
 /// `main.dart` does this via `initializeDesktopWindow()`; we reuse the
 /// same helper here so the Widgetbook window lands at the same default
-/// size / aspect ratio as the real app. Skipping the acrylic + transparent
+/// size as the real app. Skipping the acrylic + transparent
 /// setup on purpose — Widgetbook doesn't need window effects, and the
 /// opaque chrome is better for inspecting flat component previews.
 Future<void> main() async {

--- a/test/core/layout/app_desktop_content_test.dart
+++ b/test/core/layout/app_desktop_content_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/app_desktop_content.dart';
+import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
+import 'package:zcash_wallet/src/core/layout/app_layout.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+
+void main() {
+  test('large desktop window min width is 75% of the 1080 canvas', () {
+    expect(AppLayoutMode.large.minimumSize, const Size(810, 720));
+    expect(AppLayoutMode.large.defaultSize, const Size(1080, 720));
+  });
+
+  test('design pane width matches the 1080 desktop chrome', () {
+    expect(
+      AppDesktopContentMetrics.designPaneWidth,
+      AppWindowSizing.minWidth -
+          AppSpacing.xs * 3 -
+          AppDesktopShell.defaultSidebarWidth,
+    );
+    expect(AppDesktopContentMetrics.designPaneWidth, 800);
+  });
+
+  test('content column stays 420 at the design pane and smaller', () {
+    expect(AppDesktopContentMetrics.widthForPane(800), 420);
+    expect(AppDesktopContentMetrics.widthForPane(520), 420);
+    expect(AppDesktopContentMetrics.widthForPane(300), 300);
+    expect(AppDesktopContentMetrics.surfaceWidthForPane(800), 396);
+  });
+
+  test('content column grows with extra pane width', () {
+    expect(AppDesktopContentMetrics.widthForPane(1120), 740);
+    expect(AppDesktopContentMetrics.surfaceWidthForPane(1120), 716);
+  });
+
+  testWidgets('AppDesktopContentColumn uses the design width in an 800 pane', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(800, 720);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 800,
+          height: 720,
+          child: AppDesktopContentColumn(
+            contentKey: ValueKey('column'),
+            child: SizedBox(height: 10),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(const ValueKey('column'))).width, 420);
+  });
+
+  testWidgets('AppDesktopContentColumn grows in a wider pane', (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 1120,
+            height: 720,
+            child: AppDesktopContentColumn(
+              contentKey: ValueKey('column'),
+              child: SizedBox(height: 10),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(const ValueKey('column'))).width, 740);
+  });
+}

--- a/test/features/home/home_desktop_screen_test.dart
+++ b/test/features/home/home_desktop_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/app.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/layout/app_desktop_content.dart';
 import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
@@ -225,6 +226,14 @@ void main() {
 
     expect(contentCenter, moreOrLessEquals(paneCenter, epsilon: 0.1));
     expect(contentTop, moreOrLessEquals(expectedContentTop, epsilon: 0.1));
+    expect(
+      tester.getSize(contentFinder).width,
+      moreOrLessEquals(
+        AppDesktopContentMetrics.widthForPane(paneWidth),
+        epsilon: 0.1,
+      ),
+    );
+    expect(tester.getSize(contentFinder).width, greaterThan(420));
   });
 
   testWidgets('home desktop send action opens send screen', (tester) async {


### PR DESCRIPTION
Fixes #574.

## Problem

On desktop, the main window was locked to a fixed aspect ratio. Making it taller also made it much wider, and the trailing-pane column stayed 420px even when the window was maximized.

## Approach

- Stop enforcing aspect ratio on Windows (`enforceAspectRatio: false`), macOS, and Linux (`setAspectRatio(0)`).
- Size the window once at startup. `setMode` no longer snaps geometry back when navigating.
- Keep the Figma 420px column at the 1080 design window; extra pane width beyond that goes to the column (`AppDesktopContentColumn`).
- Lower the large-mode minimum width to 810 (75% of the 1080 canvas). Default size remains 1080x720.

Pixel-perfect stacked canvases (receive QR, migration heroes, home importing art) stay 420px.

## User-visible behavior

**Before:** Resize was locked to 3:2; a large window still showed a narrow 420px column.

**After:** Width and height resize independently. The content column grows with extra window width. The window can shrink to 810px wide.

Desktop only (Windows, macOS, Linux). No wallet-state, sync, or privacy changes.

## Tests

```
fvm flutter test test/core/layout/app_desktop_content_test.dart
```

Also exercised on Windows desktop: free resize, content growth when maximized, and the 810px minimum width.