### PR TITLE
Drive voting rounds through the SDK round driver

### DIFF
--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -11,7 +11,6 @@ import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/voting/voting_submission_job_provider.dart';
 import '../../../providers/voting/voting_state.dart';
-import '../../../services/voting/pir_snapshot_resolver.dart';
 import '../../keystone/widgets/keystone_pczt_qr_stage.dart';
 import '../../keystone/widgets/keystone_scan_help_overlay.dart';
 import '../voting_error_messages.dart';
@@ -497,7 +496,7 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
     if (error != null) return friendlyVotingErrorText(error.message);
     final round = state.round;
     if (round != null && state.pirDiagnostics.isNotEmpty) {
-      return _pirDiagnosticsErrorMessage(
+      return pirSnapshotMismatchMessage(
         expectedSnapshotHeight: round.snapshotHeight,
         diagnostics: state.pirDiagnostics,
       );
@@ -512,28 +511,7 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
       'Voting could not continue for this account. Retry, or switch to an '
       'eligible account if this account cannot vote in this voting round.';
 
-  String _pirDiagnosticsErrorMessage({
-    required int expectedSnapshotHeight,
-    required List<PirSnapshotEndpointDiagnostic> diagnostics,
-  }) {
-    final expected = formatBlockHeight(expectedSnapshotHeight);
-    final reportedHeights = diagnostics
-        .map((diagnostic) => diagnostic.reportedHeight)
-        .nonNulls
-        .toSet();
-    if (diagnostics.every(
-          (diagnostic) => diagnostic.status == PirSnapshotEndpointStatus.behind,
-        ) &&
-        reportedHeights.isNotEmpty) {
-      final highest = formatBlockHeight(
-        reportedHeights.reduce((left, right) => left > right ? left : right),
-      );
-      return 'Voting PIR data is not ready for this voting round yet. Expected '
-          'snapshot block $expected; PIR endpoints report $highest.';
-    }
-    return 'No PIR endpoint matched this voting round snapshot. Expected snapshot '
-        'block $expected.';
-  }
+
 
   String? _shareSubmissionDetail(VotingSessionState state) {
     final key = state.currentVoteKey;

--- a/lib/src/features/voting/voting_formatters.dart
+++ b/lib/src/features/voting/voting_formatters.dart
@@ -1,5 +1,6 @@
 import '../../core/formatting/number_format.dart';
 import '../../core/formatting/zec_amount.dart';
+import '../../services/voting/pir_snapshot_resolver.dart';
 
 /// Formats raw zatoshi voting power as e.g. `12.5 ZEC`.
 ///
@@ -12,3 +13,81 @@ String formatVotingPower(BigInt zatoshi) {
 }
 
 String formatBlockHeight(int height) => formatGroupedInteger(height);
+
+/// Explains why no PIR endpoint could serve a round's snapshot height.
+///
+/// The wallet reports this from two places — the session provider when
+/// resolution fails, and the status screen when it renders the diagnostics a
+/// failed session left behind — so the wording lives here rather than being
+/// written twice and drifting.
+///
+/// Set [includeDiagnostics] for the provider's log-facing copy; the screen
+/// leaves it off, because a per-endpoint dump is not something a user can act
+/// on.
+String pirSnapshotMismatchMessage({
+  required int expectedSnapshotHeight,
+  required List<PirSnapshotEndpointDiagnostic> diagnostics,
+  bool includeDiagnostics = false,
+}) {
+  final expected = formatBlockHeight(expectedSnapshotHeight);
+  final reportedHeights = diagnostics
+      .map((diagnostic) => diagnostic.reportedHeight)
+      .nonNulls
+      .toSet();
+
+  bool everyStatusIs(PirSnapshotEndpointStatus status) =>
+      diagnostics.isNotEmpty &&
+      diagnostics.every((diagnostic) => diagnostic.status == status);
+
+  if (everyStatusIs(PirSnapshotEndpointStatus.behind) &&
+      reportedHeights.isNotEmpty) {
+    final highest = formatBlockHeight(
+      reportedHeights.reduce((left, right) => left > right ? left : right),
+    );
+    return 'Voting PIR data is not ready for this voting round yet. Expected '
+        'snapshot block $expected; PIR endpoints report $highest. Retry '
+        'once the PIR service catches up.';
+  }
+
+  if (everyStatusIs(PirSnapshotEndpointStatus.ahead) &&
+      reportedHeights.isNotEmpty) {
+    final lowest = formatBlockHeight(
+      reportedHeights.reduce((left, right) => left < right ? left : right),
+    );
+    return 'Configured PIR endpoints are ahead of this voting round snapshot. '
+        'Expected snapshot block $expected; endpoints report $lowest.';
+  }
+
+  if (everyStatusIs(PirSnapshotEndpointStatus.timeoutOrNetworkError)) {
+    return "Couldn't reach any configured PIR endpoint. Check your network "
+        'connection and retry.';
+  }
+
+  final base =
+      'No PIR endpoint matched this voting round snapshot. Expected snapshot '
+      'block $expected';
+  if (!includeDiagnostics) return '$base.';
+  return '$base. Diagnostics: ${pirSnapshotDiagnosticsLog(diagnostics)}.';
+}
+
+/// One-line per-endpoint dump for logs and the provider's error detail.
+String pirSnapshotDiagnosticsLog(
+  List<PirSnapshotEndpointDiagnostic> diagnostics,
+) {
+  if (diagnostics.isEmpty) return 'none';
+  return diagnostics.map(_pirSnapshotDiagnosticLog).join('; ');
+}
+
+String _pirSnapshotDiagnosticLog(PirSnapshotEndpointDiagnostic diagnostic) {
+  final height = diagnostic.reportedHeight == null
+      ? ''
+      : ' height=${diagnostic.reportedHeight}';
+  final statusCode = diagnostic.httpStatusCode == null
+      ? ''
+      : ' http=${diagnostic.httpStatusCode}';
+  final message = diagnostic.message == null || diagnostic.message!.isEmpty
+      ? ''
+      : ' message=${diagnostic.message}';
+  return '${diagnostic.endpoint} status=${diagnostic.status.name}'
+      '$height$statusCode$message';
+}

--- a/lib/src/features/voting/voting_recovery_api.dart
+++ b/lib/src/features/voting/voting_recovery_api.dart
@@ -14,16 +14,6 @@ abstract interface class VotingRecoveryApi {
     required String roundId,
     required List<int> proposalIds,
   });
-
-  Future<void> setBallotIntent({
-    required String dbPath,
-    required String accountUuid,
-    required String roundId,
-    required int proposalId,
-    required int numOptions,
-    required bool skipped,
-    int? choice,
-  });
 }
 
 /// Production recovery API implementation backed by generated FRB bindings.
@@ -43,29 +33,6 @@ class RustVotingRecoveryApi implements VotingRecoveryApi {
         accountUuid: accountUuid,
         roundId: roundId,
         proposalIds: proposalIds,
-      ),
-    );
-  }
-
-  @override
-  Future<void> setBallotIntent({
-    required String dbPath,
-    required String accountUuid,
-    required String roundId,
-    required int proposalId,
-    required int numOptions,
-    required bool skipped,
-    int? choice,
-  }) {
-    return _typed(
-      () => rust_voting.setBallotIntent(
-        dbPath: dbPath,
-        accountUuid: accountUuid,
-        roundId: roundId,
-        proposalId: proposalId,
-        numOptions: numOptions,
-        skipped: skipped,
-        choice: choice,
       ),
     );
   }

--- a/lib/src/features/voting/voting_recovery_service.dart
+++ b/lib/src/features/voting/voting_recovery_service.dart
@@ -31,25 +31,4 @@ class VotingRecoveryService {
       proposalIds: proposalIds,
     );
   }
-
-  /// Persists the voter's ballot intent for one proposal before casting.
-  Future<void> setBallotIntent({
-    required String dbPath,
-    required String accountUuid,
-    required String roundId,
-    required int proposalId,
-    required int numOptions,
-    required bool skipped,
-    int? choice,
-  }) {
-    return _api.setBallotIntent(
-      dbPath: dbPath,
-      accountUuid: accountUuid,
-      roundId: roundId,
-      proposalId: proposalId,
-      numOptions: numOptions,
-      skipped: skipped,
-      choice: choice,
-    );
-  }
 }

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -81,23 +81,11 @@ final votingShareTrackingRoundRefreshIntervalProvider = Provider<Duration>((
 });
 
 /// Timeout for PIR `/root` probe requests.
-final votingPirProbeTimeoutProvider = Provider<Duration>((ref) {
-  return const Duration(seconds: 10);
-});
-
 /// Baseline policy for transient voting transport errors.
 final votingTransportRetryPolicyProvider = Provider<VotingRetryPolicy>((ref) {
   return VotingRetryPolicy.transientHttp(
     name: 'voting-transport',
     delays: const [Duration(milliseconds: 300), Duration(seconds: 1)],
-  );
-});
-
-/// Retry policy for PIR endpoint probes.
-final votingPirProbeRetryPolicyProvider = Provider<VotingRetryPolicy>((ref) {
-  return VotingRetryPolicy.transientHttp(
-    name: 'voting-pir-probe',
-    delays: const [Duration.zero],
   );
 });
 
@@ -129,59 +117,13 @@ final votingApiClientProvider =
     });
 
 /// Resolves PIR endpoints before proof generation.
+///
+/// Probing and selection both run in Rust, so this provider only exists as
+/// the seam tests replace.
 final votingPirResolverProvider = Provider<PirSnapshotResolver>((ref) {
-  final rust = ref.watch(votingRustApiProvider);
-  return PirSnapshotResolver(
-    httpClient: ref.watch(votingHttpClientProvider),
-    selectEndpoint:
-        ({
-          required diagnostics,
-          required expectedSnapshotHeight,
-          required matchIndex,
-        }) {
-          final endpoint = rust.selectPirSnapshotEndpoint(
-            diagnostics: [
-              for (final diagnostic in diagnostics)
-                rust_api.ApiPirSnapshotEndpointDiagnostic(
-                  endpoint: diagnostic.endpoint.toString(),
-                  status: _apiPirSnapshotStatus(diagnostic.status),
-                  reportedHeight: diagnostic.reportedHeight == null
-                      ? null
-                      : BigInt.from(diagnostic.reportedHeight!),
-                  httpStatusCode: diagnostic.httpStatusCode,
-                  message: diagnostic.message,
-                ),
-            ],
-            expectedSnapshotHeight: BigInt.from(expectedSnapshotHeight),
-            matchIndex: BigInt.from(matchIndex),
-          );
-          return endpoint == null ? null : Uri.parse(endpoint);
-        },
-    timeout: ref.watch(votingPirProbeTimeoutProvider),
-    retryPolicy: ref.watch(votingPirProbeRetryPolicyProvider),
-  );
+  return const PirSnapshotResolver();
 });
 
-rust_api.ApiPirSnapshotEndpointStatus _apiPirSnapshotStatus(
-  PirSnapshotEndpointStatus status,
-) {
-  return switch (status) {
-    PirSnapshotEndpointStatus.matched =>
-      rust_api.ApiPirSnapshotEndpointStatus.matched,
-    PirSnapshotEndpointStatus.behind =>
-      rust_api.ApiPirSnapshotEndpointStatus.behind,
-    PirSnapshotEndpointStatus.ahead =>
-      rust_api.ApiPirSnapshotEndpointStatus.ahead,
-    PirSnapshotEndpointStatus.missingHeight =>
-      rust_api.ApiPirSnapshotEndpointStatus.missingHeight,
-    PirSnapshotEndpointStatus.malformedJson =>
-      rust_api.ApiPirSnapshotEndpointStatus.malformedJson,
-    PirSnapshotEndpointStatus.nonSuccessStatus =>
-      rust_api.ApiPirSnapshotEndpointStatus.nonSuccessStatus,
-    PirSnapshotEndpointStatus.timeoutOrNetworkError =>
-      rust_api.ApiPirSnapshotEndpointStatus.timeoutOrNetworkError,
-  };
-}
 
 /// Adapter over durable Rust recovery/share-tracking state.
 final votingRecoveryServiceProvider = Provider<VotingRecoveryService>((ref) {

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -410,13 +410,6 @@ abstract interface class VotingRustApi {
     required BigInt operationEpoch,
   });
 
-  /// Selects an exact-height PIR endpoint using the SDK's protocol policy.
-  String? selectPirSnapshotEndpoint({
-    required List<rust_api.ApiPirSnapshotEndpointDiagnostic> diagnostics,
-    required BigInt expectedSnapshotHeight,
-    required BigInt matchIndex,
-  });
-
   Future<rust_voting.VotingRoundParams> trustedVotingRoundParamsFromConfig({
     required rust_config.ResolvedVotingConfig config,
     required String roundId,
@@ -797,21 +790,6 @@ class FrbVotingRustApi implements VotingRustApi {
               : Uint8List.fromList(storedHotkeySecret),
           operationEpoch: operationEpoch,
         ),
-      ),
-    );
-  }
-
-  @override
-  String? selectPirSnapshotEndpoint({
-    required List<rust_api.ApiPirSnapshotEndpointDiagnostic> diagnostics,
-    required BigInt expectedSnapshotHeight,
-    required BigInt matchIndex,
-  }) {
-    return _typedSync(
-      () => rust_api.selectPirSnapshotEndpoint(
-        diagnostics: diagnostics,
-        expectedSnapshotHeight: expectedSnapshotHeight,
-        matchIndex: matchIndex,
       ),
     );
   }

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -433,11 +433,16 @@ abstract interface class VotingRoundSession {
   /// non-empty, so these must be cleared before a cast can be planned.
   Future<rust_voting.RoundPlanView> clearBallotIntents(List<int> proposalIds);
 
-  /// Runs one planned step, streaming progress and then exactly one result.
-  Stream<rust_session.ApiRoundStepEvent> advanceStep({
-    required rust_voting.NextStepView step,
+  /// Drives the round to quiescence, streaming events then exactly one report.
+  ///
+  /// The SDK owns the loop: it plans, dispatches, overlaps independent
+  /// bundles, isolates failures per bundle, and stops at the first state only
+  /// this app can resolve. `host` is a template whose clock the bridge
+  /// restamps per dispatch.
+  Stream<rust_session.ApiRoundRunEvent> runRound({
     required rust_session.ApiRoundHostContext host,
     rust_session.ApiDelegationSignerInput? signer,
+    rust_session.ApiRoundDrivePolicy? policy,
   });
 
   Future<List<rust_delegate.KeystoneSigningRequest>> keystoneSigningRequests(
@@ -773,11 +778,13 @@ final class _FrbVotingRoundSession implements VotingRoundSession {
   ) => _typed(() => inner.clearBallotIntents(proposalIds: proposalIds));
 
   @override
-  Stream<rust_session.ApiRoundStepEvent> advanceStep({
-    required rust_voting.NextStepView step,
+  Stream<rust_session.ApiRoundRunEvent> runRound({
     required rust_session.ApiRoundHostContext host,
     rust_session.ApiDelegationSignerInput? signer,
-  }) => _typedStream(inner.advanceStep(step: step, host: host, signer: signer));
+    rust_session.ApiRoundDrivePolicy? policy,
+  }) => _typedStream(
+    inner.runRound(host: host, signer: signer, policy: policy),
+  );
 
   @override
   Future<List<rust_delegate.KeystoneSigningRequest>> keystoneSigningRequests(

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -121,7 +121,9 @@ final votingApiClientProvider =
 /// Probing and selection both run in Rust, so this provider only exists as
 /// the seam tests replace.
 final votingPirResolverProvider = Provider<PirSnapshotResolver>((ref) {
-  return const PirSnapshotResolver();
+  return PirSnapshotResolver(
+    mapper: ref.watch(votingEndpointMapperProvider),
+  );
 });
 
 

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1106,6 +1106,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   }) {
     return _enqueue(() async {
       final context = await _loadContext(_roundId);
+      // An empty ballot records nothing. `_ballotIntentsFor` marks every listed
+      // proposal without a draft vote as skipped, so recording here with no
+      // draft would overwrite stored choices rather than leave them alone.
+      if (draftVotes.isEmpty) return;
       final intents = _ballotIntentsFor(
         draftVotes: draftVotes,
         allProposalIds: allProposalIds,
@@ -1140,7 +1144,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   Future<void> castVotes({
     required List<VotingDraftVote> draftVotes,
     List<int>? allProposalIds,
-    Map<int, int>? proposalOptionCounts,
   }) {
     final operation = _enqueue(() async {
       final current = await future;
@@ -1154,14 +1157,16 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       final draftVotesByProposal = {
         for (final draftVote in draftVotes) draftVote.proposalId: draftVote,
       };
-      final rosterOptionCounts = {
-        for (final proposal in proposalsFromRound(context.round))
-          proposal.id: proposal.options.length,
-      };
-      final intents = _ballotIntentsFor(
-        draftVotes: draftVotes,
-        allProposalIds: allProposalIds,
-      );
+      // An empty ballot must not reach `set_ballot_intents`: `_ballotIntentsFor`
+      // marks every listed proposal without a draft vote as skipped, so a
+      // recovery-only run would overwrite the stored choices it exists to
+      // resume. Fall through to a plain plan instead.
+      final intents = draftVotes.isEmpty
+          ? const <rust_session.ApiBallotIntent>[]
+          : _ballotIntentsFor(
+              draftVotes: draftVotes,
+              allProposalIds: allProposalIds,
+            );
 
       List<int>? storedHotkeySecret;
       if (draftVotes.isNotEmpty) {
@@ -1173,39 +1178,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             context: context,
           );
           return;
-        }
-      }
-
-      // Write durable ballot intent before any cast work so recovery resumes
-      // from the correct choice if the user quits mid-vote. The session
-      // re-applies the same intents when it plans, so the two stay equal.
-      if (draftVotes.isNotEmpty) {
-        for (final intent in intents) {
-          final proposalId = intent.proposalId;
-          final numOptions =
-              draftVotesByProposal[proposalId]?.numOptions ??
-              proposalOptionCounts?[proposalId] ??
-              rosterOptionCounts[proposalId];
-          if (numOptions == null) {
-            _setError(
-              'Voting proposal details are missing. Retry after the round reloads.',
-              cause: StateError(
-                'missing numOptions for proposal_id $proposalId',
-              ),
-            );
-            return;
-          }
-          await ref
-              .read(votingRecoveryServiceProvider)
-              .setBallotIntent(
-                dbPath: context.dbPath,
-                accountUuid: context.accountUuid,
-                roundId: context.round.roundId,
-                proposalId: proposalId,
-                numOptions: numOptions,
-                skipped: intent.skipped,
-                choice: intent.choice,
-              );
         }
       }
 
@@ -1255,6 +1227,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         storedHotkeySecret: storedHotkeySecret,
       );
       try {
+        // This is the ballot's durable write: the SDK commits every intent in
+        // one transaction before it plans, so recovery resumes from the
+        // correct choice if the user quits mid-vote.
         roundPlan = intents.isEmpty
             ? await session.plan()
             : await session.setBallotIntents(intents);

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -35,9 +35,6 @@ const _ironwoodPcztPool = 1;
 const _votingWorkConcurrency = 3;
 const _votingBatchProofConcurrency = 3;
 
-/// Wait between passes while the SDK reports a chain step as pending.
-const _chainSubmissionRepollDelay = Duration(seconds: 2);
-
 /// How often a running share-tracking pass re-checks Dart-owned stop
 /// conditions.
 ///
@@ -603,11 +600,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
         try {
           completedBundleIndexes.addAll(
-            await _runDelegationSteps(
+            await _runDelegationRound(
               session: session,
               context: context,
               fallbackState: current,
-              steps: _delegationStepsFor(roundPlan, delegationBundleIndexes),
               signer: rust_session.ApiDelegationSignerInput(
                 kind: rust_session.ApiDelegationSignerKind.mnemonic,
                 mnemonic: mnemonic,
@@ -1013,11 +1009,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
         try {
           completedBundleIndexes.addAll(
-            await _runDelegationSteps(
+            await _runDelegationRound(
               session: session,
               context: context,
               fallbackState: current,
-              steps: _delegationStepsFor(roundPlan, delegationBundleIndexes),
               // The device signatures are durable in the sidecar; the SDK
               // loads the record for each bundle and verifies it against the
               // stored PCZT sighash.
@@ -1327,133 +1322,109 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             ),
           );
         }
-        // A failing bundle does not stop the others: its remaining steps are
-        // skipped, the rest of the plan runs, and every failure surfaces at
-        // the end so successful bundles keep their durable progress.
-        final failures = <_VoteBundleFailure>[];
-        final failedBundles = <int>{};
-        while (true) {
-          _throwIfContextStale(context, 'vote-plan');
-          final step = roundPlan.nextSteps
-              .where(
-                (step) =>
-                    _isVoteStep(step) &&
-                    !failedBundles.contains(step.bundleIndex),
-              )
-              .firstOrNull;
-          if (step == null) break;
-          final stepKeys = <VotingVoteKey>{_voteKeyForStep(step)};
-          final stepTimer = Stopwatch()..start();
-          publishState(
-            currentBundleIndex: step.bundleIndex,
-            currentVoteKey: _voteKeyForStep(step),
-            inFlightKeys: stepKeys.toList(),
-          );
-          final rust_wire.RoundStepOutcomeView outcome;
-          try {
-            outcome = await _advanceStep(
-              session,
-              context,
-              step,
-              label: 'vote',
-              onProgress: (update) {
-                _applyVoteProgress(update, step, stepKeys, progress);
+        // A failing bundle does not stop the others: the SDK skips its
+        // remaining obligations, runs the rest of the round, and reports every
+        // failure together so successful bundles keep their durable progress.
+        final report = await _runRound(
+          session,
+          context,
+          label: 'vote',
+          onEvent: (event) {
+            // A refreshed plan carries no step: it is the whole round's
+            // remaining work, and it is what the question counters read.
+            if (event.kind ==
+                rust_wire.RoundDriveEventKind.planRefreshed) {
+              final plan = event.plan;
+              if (plan == null) return;
+              // Count against the ballot the run started with, which is what
+              // "question N of M" shows. The SDK's own tally is run-relative
+              // and is reported separately; using it here would renumber the
+              // label mid-run on a resume.
+              final remaining = plan.nextSteps.where(_isVoteStep).toList();
+              completedBundleTasks = totalBundleTasks - remaining.length;
+              if (hasBatchStep) {
+                // Per-proposal completion does not exist inside a batch: its
+                // proposals land together, so track the ballot against the
+                // batch work and the count still ends at the full ballot.
+                completedQuestions = totalBundleTasks == 0
+                    ? 0
+                    : (totalQuestions * completedBundleTasks) ~/
+                          totalBundleTasks;
+              } else {
+                final remainingProposals = {
+                  for (final step in remaining) step.proposalId,
+                };
+                completedQuestions = totalQuestions - remainingProposals.length;
+              }
+              publishState();
+              return;
+            }
+            final step = event.step;
+            if (step == null || !_isVoteStep(step)) return;
+            final key = _voteKeyForStep(step);
+            switch (event.kind) {
+              case rust_wire.RoundDriveEventKind.stepSelected:
                 publishState(
                   currentBundleIndex: step.bundleIndex,
-                  currentVoteKey: _voteKeyForStep(step),
-                  inFlightKeys: stepKeys.toList(),
+                  currentVoteKey: key,
+                  inFlightKeys: [key],
                 );
-              },
-            );
-            if (outcome.disposition ==
-                    rust_wire.RoundStepDispositionView.noWork &&
-                outcome.plan.nextSteps.any((candidate) => candidate == step)) {
-              // A no-work answer is normally benign — a background tracking
-              // pass can confirm the share a `submitShares` step was for, and
-              // the SDK drops the step when it re-plans. Only a step the
-              // refreshed plan still lists is stuck, and re-selecting it would
-              // loop forever. This throws inside the per-bundle try so the
-              // bundle fails and the rest of the plan still runs, which is
-              // what this loop promises everywhere else.
-              throw StateError(
-                'The SDK reported no work for a step its plan still lists: '
-                '${step.kind} bundle=${step.bundleIndex} '
-                'proposal=${step.proposalId}.',
-              );
-            }
-          } on _StaleVotingSessionAction {
-            rethrow;
-          } on _ChainSubmissionCancelled {
-            rethrow;
-          } catch (error) {
-            failedBundles.add(step.bundleIndex);
-            failures.add(
-              _VoteBundleFailure(
-                bundleIndex: step.bundleIndex,
-                proposalId: step.proposalId,
-                error: error,
-              ),
-            );
-            for (final key in stepKeys) {
-              final item = progress[key];
-              progress[key] = VotingSessionProgress(
-                phase: VotingProgressPhase.failed,
-                bundleIndex: key.bundleIndex,
-                proposalId: key.proposalId,
-                proofProgress: item?.proofProgress,
-                message: error.toString(),
-              );
-            }
-            roundPlan =
-                (error is VotingRoundStepFailure ? error.failure.plan : null) ??
-                await session.plan();
-            _logVoteTiming(
-              'step ${step.kind.name} bundle=${step.bundleIndex} '
-              'proposal=${step.proposalId} failed '
-              'elapsed=${formatElapsedSeconds(stepTimer.elapsed)}: $error',
-            );
-            publishState(inFlightKeys: allVoteKeys.toList());
-            continue;
-          }
-          roundPlan = outcome.plan;
-          final remaining = roundPlan.nextSteps.where(_isVoteStep).toList();
-          completedBundleTasks = totalBundleTasks - remaining.length;
-          if (hasBatchStep) {
-            // Per-proposal completion does not exist inside a batch: its
-            // proposals land together. Track the ballot against the batch work
-            // instead, so the count still ends at the full ballot.
-            completedQuestions = totalBundleTasks == 0
-                ? 0
-                : (totalQuestions * completedBundleTasks) ~/ totalBundleTasks;
-          } else {
-            final remainingProposals = {
-              for (final remainingStep in remaining) remainingStep.proposalId,
-            };
-            completedQuestions = totalQuestions - remainingProposals.length;
-          }
-          if (outcome.disposition ==
-              rust_wire.RoundStepDispositionView.advanced) {
-            for (final key in stepKeys) {
-              if (progress[key]?.phase != VotingProgressPhase.completed) {
-                progress[key] = VotingSessionProgress(
-                  phase: VotingProgressPhase.completed,
-                  bundleIndex: key.bundleIndex,
-                  proposalId: key.proposalId,
-                  proofProgress: 1,
+              case rust_wire.RoundDriveEventKind.stepProgress:
+                final update = event.progress;
+                if (update == null) return;
+                _applyVoteProgress(update, step, {key}, progress);
+                publishState(
+                  currentBundleIndex: step.bundleIndex,
+                  currentVoteKey: key,
+                  inFlightKeys: [key],
                 );
-              }
+              case rust_wire.RoundDriveEventKind.stepFinished:
+                if (event.disposition ==
+                        rust_wire.RoundStepDispositionView.advanced &&
+                    progress[key]?.phase != VotingProgressPhase.completed) {
+                  progress[key] = VotingSessionProgress(
+                    phase: VotingProgressPhase.completed,
+                    bundleIndex: key.bundleIndex,
+                    proposalId: key.proposalId,
+                    proofProgress: 1,
+                  );
+                }
+                _logVoteTiming(
+                  'step ${step.kind.name} bundle=${step.bundleIndex} '
+                  'proposal=${step.proposalId} '
+                  'disposition=${event.disposition?.name}',
+                );
+                publishState();
+              default:
+                break;
             }
-          }
-          _logVoteTiming(
-            'step ${step.kind.name} bundle=${step.bundleIndex} '
-            'proposal=${step.proposalId} '
-            'disposition=${outcome.disposition.name} '
-            'elapsed=${formatElapsedSeconds(stepTimer.elapsed)}',
+          },
+        );
+
+        final failures = [
+          for (final record in report.failures)
+            _VoteBundleFailure(
+              bundleIndex: record.bundleIndex ?? 0,
+              proposalId: record.step?.proposalId ?? 0,
+              error: _failureFromRecord(record),
+            ),
+        ];
+        for (final failure in failures) {
+          final key = VotingVoteKey(
+            bundleIndex: failure.bundleIndex,
+            proposalId: failure.proposalId,
           );
-          // Completed steps are already counted in `completedBundleTasks`;
-          // listing them again as in-flight would double count.
-          publishState();
+          final item = progress[key];
+          progress[key] = VotingSessionProgress(
+            phase: VotingProgressPhase.failed,
+            bundleIndex: key.bundleIndex,
+            proposalId: key.proposalId,
+            proofProgress: item?.proofProgress,
+            message: failure.error.toString(),
+          );
         }
+        roundPlan = report.plan ?? roundPlan;
+        publishState();
         if (failures.isNotEmpty) throw _VoteBundleBatchException(failures);
       } on _StaleVotingSessionAction {
         rethrow;
@@ -1748,91 +1719,26 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     );
   }
 
-  /// Runs one planned step through the SDK, re-invoking it while the chain
-  /// or helper work is pending. Returns the outcome that ended the step.
+  /// Drives the round's delegation work through the SDK, publishing
+  /// per-bundle progress.
   ///
-  /// A `pending` disposition waits the re-poll delay or until the session is
-  /// invalidated; `cancelled` and `chainTerminal` become exceptions so the
-  /// caller's failure path runs.
-  Future<rust_wire.RoundStepOutcomeView> _advanceStep(
-    VotingRoundSession session,
-    _VotingSessionContext context,
-    rust_wire.NextStepView step, {
-    required String label,
-    required void Function(rust_wire.RoundStepProgressView progress) onProgress,
-    rust_session.ApiDelegationSignerInput? signer,
-  }) async {
-    while (true) {
-      _throwIfContextStale(context, '$label-advance');
-      rust_session.ApiRoundStepEvent? terminal;
-      await for (final event in session.advanceStep(
-        step: step,
-        host: _hostContext(context),
-        signer: signer,
-      )) {
-        _throwIfContextStale(context, '$label-progress');
-        final progress = event.progress;
-        if (progress != null) onProgress(progress);
-        if (event.kind == rust_session.ApiRoundStepEventKind.result) {
-          terminal = event;
-        }
-      }
-      if (terminal == null) {
-        throw StateError('Round step completed without a result.');
-      }
-      // Work the bridge does before the SDK sees the step — the delegation
-      // pipeline's lightwalletd anchor fetch, signer material, the PIR fleet —
-      // reports here rather than as a step failure, so its kind and
-      // retryability survive.
-      final error = terminal.error;
-      if (error != null) throw votingRustExceptionFromStepError(error);
-      final failure = terminal.failure;
-      if (failure != null) throw VotingRoundStepFailure(step, failure);
-      final outcome = terminal.outcome;
-      if (outcome == null) {
-        throw StateError('Round step returned neither outcome nor failure.');
-      }
-      switch (outcome.disposition) {
-        case rust_wire.RoundStepDispositionView.pending:
-          // The SDK already re-polled a tracking submission and escalated to
-          // exact-tree recovery once. Keep waiting only while the chain is
-          // still tracking; a submission stuck in recovery surfaces so the
-          // user can retry later.
-          if (outcome.chainOutcome?.kind !=
-              rust_wire.ChainSubmissionOutcomeKind.tracking) {
-            throw VotingChainPendingOutcome(step, outcome);
-          }
-          await Future.any<void>([
-            Future<void>.delayed(_chainSubmissionRepollDelay),
-            _sessionInvalidated.future,
-          ]);
-          continue;
-        case rust_wire.RoundStepDispositionView.cancelled:
-          _throwIfContextStale(context, '$label-cancelled');
-          throw const _ChainSubmissionCancelled();
-        case rust_wire.RoundStepDispositionView.chainTerminal:
-          throw VotingChainTerminalOutcome(step, outcome);
-        case rust_wire.RoundStepDispositionView.advanced ||
-            rust_wire.RoundStepDispositionView.noWork:
-          return outcome;
-      }
-    }
-  }
-
-  /// Advances every delegation step in `steps` through the SDK, bundles
-  /// concurrently, publishing per-bundle progress.
-  Future<Set<int>> _runDelegationSteps({
+  /// The SDK owns the loop: it plans, overlaps bundles, isolates a failure to
+  /// its bundle, and stops when only this app can make progress. Dart reads
+  /// the event stream and keeps the UI state.
+  ///
+  /// Returns the bundles that completed. Failures the run isolated are raised
+  /// together, as the per-bundle batch the caller already handles, so a
+  /// healthy bundle keeps its durable progress.
+  Future<Set<int>> _runDelegationRound({
     required VotingRoundSession session,
     required _VotingSessionContext context,
     required VotingSessionState fallbackState,
-    required List<rust_wire.NextStepView> steps,
     required rust_session.ApiDelegationSignerInput signer,
     required Map<int, VotingSessionProgress> progress,
     required String logLabel,
   }) async {
     final batchTimer = Stopwatch()..start();
-    final stepsByBundle = {for (final step in steps) step.bundleIndex: step};
-    final bundleIndexes = stepsByBundle.keys.toList()..sort();
+    final completed = <int>{};
 
     void publishProgress(VotingSessionProgress update) {
       final bundleIndex = update.bundleIndex;
@@ -1848,23 +1754,19 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       );
     }
 
-    final outcomes = await _runBoundedBundleWork(
-      bundleIndexes,
-      concurrency: _votingWorkConcurrency,
-      work: (bundleIndex) async {
-        final step = stepsByBundle[bundleIndex]!;
-        final pipelineTimer = Stopwatch()..start();
-        debugPrint(
-          '[zcash] Voting: $logLabel delegation bundle start '
-          'round=${context.round.roundId} bundle=$bundleIndex',
-        );
-        final outcome = await _advanceStep(
-          session,
-          context,
-          step,
-          label: '$logLabel-delegation',
-          signer: signer,
-          onProgress: (update) {
+    final report = await _runRound(
+      session,
+      context,
+      signer: signer,
+      label: '$logLabel-delegation',
+      onEvent: (event) {
+        final step = event.step;
+        final bundleIndex = step?.bundleIndex;
+        if (bundleIndex == null) return;
+        switch (event.kind) {
+          case rust_wire.RoundDriveEventKind.stepProgress:
+            final update = event.progress;
+            if (update == null) return;
             switch (update.kind) {
               case rust_wire.RoundStepProgressKind.delegation:
                 final kind = update.delegationProgress;
@@ -1894,111 +1796,113 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
               default:
                 break;
             }
-          },
-        );
-        if (outcome.disposition == rust_wire.RoundStepDispositionView.noWork) {
-          throw StateError(
-            'Delegation bundle $bundleIndex is no longer in the round plan.',
-          );
+          case rust_wire.RoundDriveEventKind.stepFinished:
+            if (_isDelegationStep(step!) &&
+                event.disposition ==
+                    rust_wire.RoundStepDispositionView.advanced) {
+              completed.add(bundleIndex);
+            }
+          default:
+            break;
         }
-        debugPrint(
-          '[zcash] Voting: $logLabel delegation bundle completed '
-          'round=${context.round.roundId} bundle=$bundleIndex '
-          'txHash=${outcome.chainOutcome?.transactionHash} '
-          'leafIndex=${outcome.chainOutcome?.finalVanPosition} '
-          'total=${formatElapsedSeconds(pipelineTimer.elapsed)}',
-        );
-        return bundleIndex;
       },
     );
 
-    final failures = <_DelegationBundleFailure>[];
-    final completed = <int>{};
-    for (final bundleIndex in bundleIndexes) {
-      final outcome = outcomes[bundleIndex]!;
-      final error = outcome.error;
-      if (error != null) {
-        publishProgress(
-          VotingSessionProgress(
-            phase: VotingProgressPhase.failed,
-            bundleIndex: bundleIndex,
-            message: error.toString(),
-          ),
-        );
-        failures.add(
+    final failures = [
+      for (final record in report.failures)
+        if (record.bundleIndex != null)
           _DelegationBundleFailure(
-            bundleIndex: bundleIndex,
+            bundleIndex: record.bundleIndex!,
             stage: 'step',
-            error: error,
+            error: _failureFromRecord(record),
           ),
-        );
-      } else {
-        completed.add(outcome.value!);
-      }
-    }
+    ];
     for (final failure in failures) {
-      if (failure.error is _StaleVotingSessionAction) throw failure.error;
+      completed.remove(failure.bundleIndex);
+      publishProgress(
+        VotingSessionProgress(
+          phase: VotingProgressPhase.failed,
+          bundleIndex: failure.bundleIndex,
+          message: failure.error.toString(),
+        ),
+      );
     }
-    if (failures.isNotEmpty) throw _DelegationBundleBatchException(failures);
     debugPrint(
-      '[zcash] Voting: $logLabel delegation batch completed '
-      'round=${context.round.roundId} bundles=${bundleIndexes.length} '
+      '[zcash] Voting: $logLabel delegation run finished '
+      'round=${context.round.roundId} completed=${completed.length} '
+      'failed=${failures.length} '
+      'quiescence=${report.quiescence.kind.name} '
       'elapsed=${formatElapsedSeconds(batchTimer.elapsed)}',
     );
+    if (failures.isNotEmpty) throw _DelegationBundleBatchException(failures);
     return completed;
   }
 
-  /// Delegation steps the plan lists for the given bundles. A plan that
-  /// predates the SDK planner yields synthetic `Delegate` steps, which the
-  /// SDK validates against its own fresh plan.
-  /// The delegation steps to dispatch for `bundleIndexes`.
+  /// The typed error a host raises for one isolated step failure.
   ///
-  /// The two inputs come from different places: the wanted set is derived from
-  /// `delegation_statuses`, while dispatch is driven by `next_steps`. When
-  /// they disagree a `Delegate` step is still dispatched for the uncovered
-  /// bundle, and the disagreement is logged.
-  ///
-  /// That disagreement should no longer happen for the case that caused it:
-  /// the SDK plans a `Delegate` obligation only for a bundle that still has a
-  /// vote to cast, so delegating before the ballot was durable found no work
-  /// at all. The ballot is now recorded first, which is what makes the two
-  /// agree. The synthesised step is kept for the cases that remain, but it is
-  /// not a fix: the SDK resolves each step to an obligation under the round
-  /// lock, so a step matching no obligation comes back `NoWork` and surfaces
-  /// as "the round has no delegation work for it". The log line is what says
-  /// the plan and the statuses disagreed in the first place.
-  static List<rust_wire.NextStepView> _delegationStepsFor(
-    rust_wire.RoundPlanView? roundPlan,
-    List<int> bundleIndexes,
+  /// A record always names a step in practice; the SDK leaves it absent only
+  /// for a failure that belonged to no step, such as a plan it could not read.
+  static Object _failureFromRecord(
+    rust_wire.RoundStepFailureRecordView record,
   ) {
-    final wanted = bundleIndexes.toSet();
-    final planned = [
-      for (final step
-          in roundPlan?.nextSteps ?? const <rust_wire.NextStepView>[])
-        if (_isDelegationStep(step) && wanted.contains(step.bundleIndex)) step,
-    ];
-    final covered = {for (final step in planned) step.bundleIndex};
-    final uncovered = [
-      for (final bundleIndex in bundleIndexes)
-        if (!covered.contains(bundleIndex)) bundleIndex,
-    ];
-    if (uncovered.isNotEmpty) {
-      debugPrint(
-        '[zcash] Voting: no planned delegation step for '
-        'bundles ${uncovered.join(',')}; dispatching one anyway',
-      );
+    final step = record.step;
+    return step == null
+        ? StateError(record.failure.message)
+        : VotingRoundStepFailure(step, record.failure);
+  }
+
+  /// Streams one SDK round run, forwarding every event and returning its
+  /// report.
+  ///
+  /// The run's own failures ride on the report; only a bridge error or a
+  /// stale session throws, so a caller decides what an isolated bundle means
+  /// for its flow.
+  Future<rust_wire.RoundRunReportView> _runRound(
+    VotingRoundSession session,
+    _VotingSessionContext context, {
+    required String label,
+    required void Function(rust_wire.RoundDriveEventView event) onEvent,
+    rust_session.ApiDelegationSignerInput? signer,
+  }) async {
+    _throwIfContextStale(context, '$label-run');
+    rust_wire.RoundRunReportView? report;
+    await for (final event in session.runRound(
+      host: _hostContext(context),
+      signer: signer,
+    )) {
+      _throwIfContextStale(context, '$label-run-event');
+      final observed = event.event;
+      if (observed != null) onEvent(observed);
+      final error = event.error;
+      if (error != null) throw votingRustExceptionFromStepError(error);
+      final finished = event.report;
+      if (finished != null) report = finished;
     }
-    return [
-      ...planned,
-      for (final bundleIndex in uncovered)
-        rust_wire.NextStepView(
-          kind: rust_wire.NextStepKind.delegate,
-          bundleIndex: bundleIndex,
-          proposalId: 0,
-          choice: 0,
-          shareIndex: 0,
-        ),
-    ];
+    if (report == null) {
+      throw StateError('Round run completed without a report.');
+    }
+    final quiescence = report.quiescence;
+    switch (quiescence.kind) {
+      case rust_wire.RoundQuiescenceKind.cancelled:
+        _throwIfContextStale(context, '$label-run-cancelled');
+        throw const _ChainSubmissionCancelled();
+      case rust_wire.RoundQuiescenceKind.chainTerminal:
+      case rust_wire.RoundQuiescenceKind.persistedChainTerminal:
+        // The SDK plans no retry for a rejected or hashless submission, so
+        // this has to surface rather than read as a finished round.
+        throw VotingChainTerminalOutcome(
+          quiescence.step,
+          quiescence.chainOutcome,
+        );
+      case rust_wire.RoundQuiescenceKind.chainRecoveryStalled:
+        throw VotingChainPendingOutcome(
+          quiescence.step,
+          quiescence.chainOutcome,
+        );
+      default:
+        break;
+    }
+    return report;
   }
 
   /// TEMPORARY diagnostic: the network the voting layer binds.
@@ -3971,15 +3875,18 @@ class VotingRoundStepFailure implements Exception, VotingRustExceptionSource {
 }
 
 /// The chain reported a terminal outcome for a step.
+///
+/// Terminal means the submission ended without a confirmation and the SDK
+/// plans no retry for it, so the diagnostic it carries is the only account of
+/// what happened.
 class VotingChainTerminalOutcome implements Exception {
-  const VotingChainTerminalOutcome(this.step, this.outcome);
+  const VotingChainTerminalOutcome(this.step, this.chainOutcome);
 
-  final rust_wire.NextStepView step;
-  final rust_wire.RoundStepOutcomeView outcome;
+  final rust_wire.NextStepView? step;
+  final rust_wire.ChainSubmissionOutcomeView? chainOutcome;
 
   @override
   String toString() {
-    final chainOutcome = outcome.chainOutcome;
     final diagnostic = chainOutcome?.diagnostic?.message;
     if (diagnostic != null) return diagnostic;
     return switch (chainOutcome?.kind) {
@@ -3993,15 +3900,18 @@ class VotingChainTerminalOutcome implements Exception {
 }
 
 /// The chain step is still reconciling after the SDK's recovery pass.
+///
+/// Not terminal: running the round again later may still resolve it, which is
+/// why it is reported separately from a rejection.
 class VotingChainPendingOutcome implements Exception {
-  const VotingChainPendingOutcome(this.step, this.outcome);
+  const VotingChainPendingOutcome(this.step, this.chainOutcome);
 
-  final rust_wire.NextStepView step;
-  final rust_wire.RoundStepOutcomeView outcome;
+  final rust_wire.NextStepView? step;
+  final rust_wire.ChainSubmissionOutcomeView? chainOutcome;
 
   @override
   String toString() =>
-      outcome.chainOutcome?.diagnostic?.message ??
+      chainOutcome?.diagnostic?.message ??
       'Chain submission recovery is still pending.';
 }
 

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -2705,79 +2704,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       '[zcash] Voting: PIR endpoint mismatch '
       'round=${context.round.roundId} '
       'expected=${error.expectedSnapshotHeight} '
-      'diagnostics=${_pirDiagnosticsLog(error.diagnostics)}',
+      'diagnostics=${pirSnapshotDiagnosticsLog(error.diagnostics)}',
     );
   }
 
-  static String _pirSnapshotMismatchMessage(
-    PirSnapshotNoMatchingEndpoint error,
-  ) {
-    final diagnostics = error.diagnostics;
-    final expected = formatBlockHeight(error.expectedSnapshotHeight);
-    final reportedHeights = diagnostics
-        .map((diagnostic) => diagnostic.reportedHeight)
-        .nonNulls
-        .toSet();
 
-    if (diagnostics.isNotEmpty &&
-        diagnostics.every(
-          (diagnostic) => diagnostic.status == PirSnapshotEndpointStatus.behind,
-        ) &&
-        reportedHeights.isNotEmpty) {
-      final highest = formatBlockHeight(
-        reportedHeights.reduce((left, right) => left > right ? left : right),
-      );
-      return 'Voting PIR data is not ready for this voting round yet. Expected '
-          'snapshot block $expected; PIR endpoints report $highest. Retry '
-          'once the PIR service catches up.';
-    }
-
-    if (diagnostics.isNotEmpty &&
-        diagnostics.every(
-          (diagnostic) => diagnostic.status == PirSnapshotEndpointStatus.ahead,
-        ) &&
-        reportedHeights.isNotEmpty) {
-      final lowest = formatBlockHeight(
-        reportedHeights.reduce((left, right) => left < right ? left : right),
-      );
-      return 'Configured PIR endpoints are ahead of this voting round snapshot. '
-          'Expected snapshot block $expected; endpoints report $lowest.';
-    }
-
-    if (diagnostics.isNotEmpty &&
-        diagnostics.every(
-          (diagnostic) =>
-              diagnostic.status ==
-              PirSnapshotEndpointStatus.timeoutOrNetworkError,
-        )) {
-      return "Couldn't reach any configured PIR endpoint. Check your network "
-          'connection and retry.';
-    }
-
-    return 'No PIR endpoint matched this voting round snapshot. Expected snapshot '
-        'block $expected. Diagnostics: ${_pirDiagnosticsLog(diagnostics)}.';
-  }
-
-  static String _pirDiagnosticsLog(
-    List<PirSnapshotEndpointDiagnostic> diagnostics,
-  ) {
-    if (diagnostics.isEmpty) return 'none';
-    return diagnostics.map(_pirDiagnosticLog).join('; ');
-  }
-
-  static String _pirDiagnosticLog(PirSnapshotEndpointDiagnostic diagnostic) {
-    final height = diagnostic.reportedHeight == null
-        ? ''
-        : ' height=${diagnostic.reportedHeight}';
-    final statusCode = diagnostic.httpStatusCode == null
-        ? ''
-        : ' http=${diagnostic.httpStatusCode}';
-    final message = diagnostic.message == null || diagnostic.message!.isEmpty
-        ? ''
-        : ' message=${diagnostic.message}';
-    return '${diagnostic.endpoint} status=${diagnostic.status.name}'
-        '$height$statusCode$message';
-  }
 
   Future<void> _enqueue(
     Future<void> Function() action, {
@@ -3039,7 +2970,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     } on PirSnapshotNoMatchingEndpoint catch (e) {
       _logPirSnapshotMismatch(context: context, error: e);
       _setError(
-        _pirSnapshotMismatchMessage(e),
+        pirSnapshotMismatchMessage(
+          expectedSnapshotHeight: e.expectedSnapshotHeight,
+          diagnostics: e.diagnostics,
+          includeDiagnostics: true,
+        ),
         cause: e,
         pirDiagnostics: e.diagnostics,
         context: context,

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -511,13 +511,48 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     );
   }
 
+  /// Delegates this round's pending bundles with the account mnemonic.
+  ///
+  /// Software accounts only; Keystone accounts sign on the device and go
+  /// through [delegatePendingBundlesWithKeystoneSignatures].
   Future<void> delegatePendingBundles({String? mnemonic}) {
+    return _delegatePendingBundles(hardware: false, mnemonic: mnemonic);
+  }
+
+  /// Delegates this round's pending bundles with the signatures the Keystone
+  /// device already returned.
+  ///
+  /// The signatures are durable in the sidecar; the SDK loads the record for
+  /// each bundle and verifies it against the stored PCZT sighash.
+  Future<void> delegatePendingBundlesWithKeystoneSignatures() {
+    return _delegatePendingBundles(hardware: true);
+  }
+
+  /// Runs the delegation round for whichever signer this account uses.
+  ///
+  /// The two entry points differ only in how a bundle is signed and in what
+  /// has to be true before signing can start: software needs the account
+  /// mnemonic, hardware needs a device signature for every pending bundle and
+  /// must never mint a fresh hotkey once those signatures exist. Everything
+  /// around that — preparation, the terminal check, PIR resolution, the round
+  /// itself, and the state it publishes — is one path.
+  ///
+  /// `hardware` is the entry point the caller used, not the account's kind.
+  /// The two are checked against each other so calling the wrong one for the
+  /// active account reports that mismatch rather than quietly signing the
+  /// other way.
+  Future<void> _delegatePendingBundles({
+    required bool hardware,
+    String? mnemonic,
+  }) {
     return _enqueue(() async {
       var current = await future;
       var context = await _loadContext(_roundId);
-      if (context.isHardwareAccount) {
+      if (hardware != context.isHardwareAccount) {
         _setError(
-          'Sign delegation bundles with Keystone before submitting.',
+          hardware
+              ? 'Keystone voting is only available for hardware accounts.'
+              : 'Sign delegation bundles with Keystone before submitting.',
           context: context,
         );
         return;
@@ -547,6 +582,16 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         }
       }
       final needsPir = _needsFreshDelegationPreparation(roundPlan);
+
+      // Hardware signing binds each signature to the hotkey that was current
+      // when the device signed, so the signatures have to be known before the
+      // hotkey is ensured.
+      final Map<int, rust_wire.KeystoneSignatureRecord> signatures = hardware
+          ? (hasPendingBundles
+                ? await _loadKeystoneSignatures(context)
+                : current.keystoneSignatures)
+          : const {};
+
       var pirEndpoint = current.pirEndpoint;
       if (needsPir && pirEndpoint == null) {
         pirEndpoint = await _resolvePirEndpoint(context);
@@ -556,15 +601,27 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           _setStateForContext(context, current);
         }
       }
+
       if (hasPendingBundles) {
+        // PIR only matters because a bundle needs a proof built against it, so
+        // this is checked where there is a bundle to prove.
         if (needsPir && pirEndpoint == null) {
           _setError('PIR endpoint has not been resolved.', context: context);
           return;
         }
-        // Software delegation signs with the account seed at the wallet
-        // boundary; the SDK receives only the SpendAuth signature. Keystone
-        // signing uses `delegatePendingBundlesWithKeystoneSignatures`.
-        if (mnemonic == null || mnemonic.isEmpty) {
+        if (hardware) {
+          for (final bundleIndex in delegationBundleIndexes) {
+            if (!signatures.containsKey(bundleIndex)) {
+              _setError(
+                'Sign delegation bundle ${bundleIndex + 1} with Keystone before submitting.',
+                context: context,
+              );
+              return;
+            }
+          }
+        } else if (mnemonic == null || mnemonic.isEmpty) {
+          // Software delegation signs with the account seed at the wallet
+          // boundary; the SDK receives only the SpendAuth signature.
           _setError(
             'Software delegation requires this account mnemonic. Unlock this account or switch to one with mnemonic access.',
             context: context,
@@ -574,13 +631,24 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         final nextState = (state.value ?? current).copyWith(
           phase: VotingSessionPhase.delegating,
           clearCurrentBundleIndex: true,
-          clearError: true,
+          // Hardware keeps any standing error until the round reports its own
+          // outcome; software clears it as the run starts.
+          clearError: !hardware,
+          keystoneSignatures: hardware ? signatures : null,
+          clearKeystoneSigningRequest: hardware,
+          clearKeystoneScanError: hardware,
         );
         _setStateForContext(context, nextState);
         current = nextState;
       }
       final storedHotkeySecret = hasPendingBundles
-          ? await _ensureHotkey(context)
+          ? await _ensureHotkey(
+              context,
+              // A device signature is bound to the hotkey it was made with, so
+              // once signatures exist a missing hotkey is a failure rather than
+              // a reason to generate one.
+              alreadyBound: hardware && signatures.isNotEmpty,
+            )
           : null;
 
       final progress = Map<int, VotingSessionProgress>.from(
@@ -603,14 +671,21 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
               session: session,
               context: context,
               fallbackState: current,
-              signer: rust_session.ApiDelegationSignerInput(
-                kind: rust_session.ApiDelegationSignerKind.mnemonic,
-                mnemonic: mnemonic,
-                keystoneSig: null,
-                keystoneSighash: null,
-              ),
+              signer: hardware
+                  ? const rust_session.ApiDelegationSignerInput(
+                      kind: rust_session.ApiDelegationSignerKind.keystoneStored,
+                      mnemonic: null,
+                      keystoneSig: null,
+                      keystoneSighash: null,
+                    )
+                  : rust_session.ApiDelegationSignerInput(
+                      kind: rust_session.ApiDelegationSignerKind.mnemonic,
+                      mnemonic: mnemonic,
+                      keystoneSig: null,
+                      keystoneSighash: null,
+                    ),
               progress: progress,
-              logLabel: 'software',
+              logLabel: hardware ? 'Keystone' : 'software',
             ),
           );
         } on _StaleVotingSessionAction {
@@ -655,6 +730,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           roundPlan: refreshedRoundPlan,
           delegationProgress: progress,
           clearCurrentBundleIndex: true,
+          keystoneSignatures: hardware ? signatures : null,
+          clearKeystoneSigningRequest: hardware,
+          clearKeystoneScanError: hardware,
         ),
       );
       _noteTerminalDelegation(
@@ -912,158 +990,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         ),
       );
     });
-  }
-
-  Future<void> delegatePendingBundlesWithKeystoneSignatures() {
-    return _enqueue(() async {
-      var current = await future;
-      var context = await _loadContext(_roundId);
-      if (!context.isHardwareAccount) {
-        _setError(
-          'Keystone voting is only available for hardware accounts.',
-          context: context,
-        );
-        return;
-      }
-      var roundPlan = context.roundPlan;
-      if (_needsFreshDelegationPreparation(roundPlan) &&
-          _needsDelegationPreparation(current)) {
-        await _prepareDelegationUnlocked();
-        current = await future;
-        if (current.phase == VotingSessionPhase.error ||
-            current.phase == VotingSessionPhase.waitingForWalletSync) {
-          return;
-        }
-        context = await _loadContext(_roundId);
-        roundPlan = context.roundPlan;
-      }
-      final progress = Map<int, VotingSessionProgress>.from(
-        current.delegationProgress,
-      );
-      final completedBundleIndexes = <int>{};
-      final delegationBundleIndexes = delegationBundleIndexesNeedingWork(
-        roundPlan,
-      );
-      final hasPendingBundles = delegationBundleIndexes.isNotEmpty;
-      if (!hasPendingBundles) {
-        final terminal = terminalDelegationMessage(roundPlan);
-        if (terminal != null) {
-          _setError(terminal, context: context);
-          return;
-        }
-      }
-      final needsPir = _needsFreshDelegationPreparation(roundPlan);
-      final signatures = hasPendingBundles
-          ? await _loadKeystoneSignatures(context)
-          : current.keystoneSignatures;
-      final List<int>? storedHotkeySecret;
-      if (hasPendingBundles) {
-        storedHotkeySecret = await _ensureHotkey(
-          context,
-          alreadyBound: signatures.isNotEmpty,
-        );
-      } else {
-        storedHotkeySecret = null;
-      }
-      var pirEndpoint = current.pirEndpoint;
-      if (needsPir && pirEndpoint == null) {
-        pirEndpoint = await _resolvePirEndpoint(context);
-        _throwIfContextStale(context, 'keystone-delegation-pir-resolution');
-        if (pirEndpoint != null) {
-          current = (state.value ?? current).copyWith(pirEndpoint: pirEndpoint);
-          _setStateForContext(context, current);
-        }
-      }
-      if (needsPir && pirEndpoint == null) {
-        _setError('PIR endpoint has not been resolved.', context: context);
-        return;
-      }
-
-      final rust = ref.read(votingRustApiProvider);
-      for (final bundleIndex in delegationBundleIndexes) {
-        if (!signatures.containsKey(bundleIndex)) {
-          _setError(
-            'Sign delegation bundle ${bundleIndex + 1} with Keystone before submitting.',
-            context: context,
-          );
-          return;
-        }
-      }
-      _setStateForContext(
-        context,
-        (state.value ?? current).copyWith(
-          phase: VotingSessionPhase.delegating,
-          keystoneSignatures: signatures,
-          clearKeystoneSigningRequest: true,
-          clearKeystoneScanError: true,
-          clearCurrentBundleIndex: true,
-        ),
-      );
-      if (hasPendingBundles) {
-        final session = _openRoundSession(
-          rust,
-          context,
-          storedHotkeySecret: storedHotkeySecret,
-          pirServerUrls: _delegationPirTransportUrls(state.value ?? current),
-        );
-        try {
-          completedBundleIndexes.addAll(
-            await _runDelegationRound(
-              session: session,
-              context: context,
-              fallbackState: current,
-              // The device signatures are durable in the sidecar; the SDK
-              // loads the record for each bundle and verifies it against the
-              // stored PCZT sighash.
-              signer: const rust_session.ApiDelegationSignerInput(
-                kind: rust_session.ApiDelegationSignerKind.keystoneStored,
-                mnemonic: null,
-                keystoneSig: null,
-                keystoneSighash: null,
-              ),
-              progress: progress,
-              logLabel: 'Keystone',
-            ),
-          );
-        } on _StaleVotingSessionAction {
-          rethrow;
-        } catch (error, stackTrace) {
-          await _refreshDelegationPlansAfterBatchFailure(
-            context: context,
-            fallbackState: current,
-            progress: progress,
-          );
-          Error.throwWithStackTrace(error, stackTrace);
-        } finally {
-          _closeRoundSession(session);
-        }
-      }
-
-      final refreshedRoundPlan = await _loadRoundPlan(context);
-      final nextPhase =
-          delegationBundleIndexesNeedingSigning(
-            refreshedRoundPlan,
-          ).where((index) => !completedBundleIndexes.contains(index)).isEmpty
-          ? VotingSessionPhase.delegated
-          : VotingSessionPhase.readyToDelegate;
-      _setStateForContext(
-        context,
-        (state.value ?? current).copyWith(
-          phase: nextPhase,
-          roundPlan: refreshedRoundPlan,
-          delegationProgress: progress,
-          keystoneSignatures: signatures,
-          clearKeystoneSigningRequest: true,
-          clearKeystoneScanError: true,
-          clearCurrentBundleIndex: true,
-        ),
-      );
-      _noteTerminalDelegation(
-        context,
-        state.value ?? current,
-        refreshedRoundPlan,
-      );
-    }, cleanupProcessStateOnError: false);
   }
 
   /// The ballot intents for `draftVotes`, skipping every other listed proposal.

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -55,7 +55,6 @@ class VotingSubmissionJobState {
     this.keystoneQrError,
     this.pendingDraftVotes,
     this.pendingProposalIds = const [],
-    this.pendingProposalOptionCounts = const {},
     this.pendingRecoveryWithoutDraft = false,
   });
 
@@ -71,7 +70,6 @@ class VotingSubmissionJobState {
   final String? keystoneQrError;
   final List<VotingDraftVote>? pendingDraftVotes;
   final List<int> pendingProposalIds;
-  final Map<int, int> pendingProposalOptionCounts;
   final bool pendingRecoveryWithoutDraft;
 
   bool get hasVisibleJob =>
@@ -97,7 +95,6 @@ class VotingSubmissionJobState {
     List<VotingDraftVote>? pendingDraftVotes,
     bool clearPendingDraftVotes = false,
     List<int>? pendingProposalIds,
-    Map<int, int>? pendingProposalOptionCounts,
     bool? pendingRecoveryWithoutDraft,
   }) {
     return VotingSubmissionJobState(
@@ -122,8 +119,6 @@ class VotingSubmissionJobState {
           ? null
           : pendingDraftVotes ?? this.pendingDraftVotes,
       pendingProposalIds: pendingProposalIds ?? this.pendingProposalIds,
-      pendingProposalOptionCounts:
-          pendingProposalOptionCounts ?? this.pendingProposalOptionCounts,
       pendingRecoveryWithoutDraft:
           pendingRecoveryWithoutDraft ?? this.pendingRecoveryWithoutDraft,
     );
@@ -479,9 +474,6 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       }
 
       final proposals = proposalsFromRound(round);
-      final proposalOptionCounts = {
-        for (final proposal in proposals) proposal.id: proposal.options.length,
-      };
       final VotingDraftState draft;
       try {
         draft = await ref
@@ -615,7 +607,6 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
           generation: generation,
           draftVotes: draftVotes,
           intentProposalIds: intentProposalIds,
-          proposalOptionCounts: proposalOptionCounts,
           pendingRecoveryWithoutDraft:
               canRecoverWithoutDraft || canPollDelegationWithoutDraft,
         );
@@ -635,8 +626,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
             generation: generation,
             draftVotes: draftVotes,
             intentProposalIds: intentProposalIds,
-            proposalOptionCounts: proposalOptionCounts,
-            pendingRecoveryWithoutDraft:
+              pendingRecoveryWithoutDraft:
                 canRecoverWithoutDraft || canPollDelegationWithoutDraft,
           );
           await _submitAfterKeystoneSignatures(
@@ -651,8 +641,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
             generation: generation,
             draftVotes: draftVotes,
             intentProposalIds: intentProposalIds,
-            proposalOptionCounts: proposalOptionCounts,
-            initialSession: activeSession,
+              initialSession: activeSession,
           );
         }
         return;
@@ -725,7 +714,6 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
         generation: generation,
         draftVotes: draftVotes,
         intentProposalIds: intentProposalIds,
-        proposalOptionCounts: proposalOptionCounts,
         initialSession: afterDelegation ?? activeSession,
       );
     } catch (error) {
@@ -881,7 +869,6 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
         generation: generation,
         draftVotes: draftVotes,
         intentProposalIds: state.pendingProposalIds,
-        proposalOptionCounts: state.pendingProposalOptionCounts,
         initialSession: afterDelegation ?? beforeDelegation,
       );
       return;
@@ -892,7 +879,6 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       generation: generation,
       draftVotes: draftVotes,
       intentProposalIds: state.pendingProposalIds,
-      proposalOptionCounts: state.pendingProposalOptionCounts,
       initialSession: beforeDelegation,
     );
   }
@@ -903,7 +889,6 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     required int generation,
     required List<VotingDraftVote> draftVotes,
     required List<int> intentProposalIds,
-    required Map<int, int> proposalOptionCounts,
     VotingSessionState? initialSession,
   }) async {
     if (!_isCurrentJob(key: key, generation: generation)) return;
@@ -945,7 +930,6 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       await sessionNotifier.castVotes(
         draftVotes: draftVotes,
         allProposalIds: intentProposalIds,
-        proposalOptionCounts: proposalOptionCounts,
       );
     }
     if (!_isCurrentJob(key: key, generation: generation)) return;
@@ -1010,14 +994,12 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     required int generation,
     required List<VotingDraftVote> draftVotes,
     required List<int> intentProposalIds,
-    required Map<int, int> proposalOptionCounts,
     required bool pendingRecoveryWithoutDraft,
   }) {
     if (!_isCurrentJob(key: key, generation: generation)) return;
     state = state.copyWith(
       pendingDraftVotes: draftVotes,
       pendingProposalIds: intentProposalIds,
-      pendingProposalOptionCounts: proposalOptionCounts,
       pendingRecoveryWithoutDraft: pendingRecoveryWithoutDraft,
     );
   }
@@ -1058,7 +1040,6 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       clearKeystoneQrError: true,
       clearPendingDraftVotes: true,
       pendingProposalIds: const [],
-      pendingProposalOptionCounts: const {},
       pendingRecoveryWithoutDraft: false,
     );
   }
@@ -1097,7 +1078,6 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       clearKeystoneQrError: true,
       clearPendingDraftVotes: true,
       pendingProposalIds: const [],
-      pendingProposalOptionCounts: const {},
       pendingRecoveryWithoutDraft: false,
     );
   }

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -10,8 +10,28 @@ import '../third_party/zcash_voting/share_policy.dart';
 import '../third_party/zcash_voting/wire.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `catch`, `config_error`, `delegation_static_inputs_for`, `helper_client`, `helper_delivery_db`, `internal`, `invalid_input`, `is_cancelled`, `round_inputs`, `routed_transport`, `share_tracking_pass_for`, `view`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
+// These functions are ignored because they are not marked as `pub`: `catch`, `config_error`, `delegation_static_inputs_for`, `helper_client`, `helper_delivery_db`, `internal`, `invalid_input`, `is_cancelled`, `pir_snapshot_failure`, `pir_snapshot_height_field`, `pir_snapshot_probe_attempt`, `pir_snapshot_root_url`, `probe_pir_snapshot_endpoint`, `round_inputs`, `routed_transport`, `share_tracking_pass_for`, `view`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `PirSnapshotProbeAttempt`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
+
+/// Probe every configured PIR endpoint and select one at the round's height.
+///
+/// Probing runs here rather than in Dart so the wallet has one PIR resolution
+/// path instead of a probe on one side of the bridge and the selection policy
+/// on the other. Traffic uses the routed transport, so the probe follows the
+/// same network route as the rest of the wallet's foreground voting traffic.
+///
+/// Returns `endpoint: None` when endpoints were probed but none served the
+/// round's snapshot height; that is a normal, recoverable outcome the caller
+/// reports from the diagnostics. An empty `endpoints` list is an error,
+/// because it means the round is misconfigured rather than the fleet behind.
+Future<ApiPirSnapshotResolution> resolvePirSnapshotEndpoint({
+  required List<String> endpoints,
+  required BigInt expectedSnapshotHeight,
+}) => RustLib.instance.api.crateApiVotingResolvePirSnapshotEndpoint(
+  endpoints: endpoints,
+  expectedSnapshotHeight: expectedSnapshotHeight,
+);
 
 /// Select an exact-height PIR endpoint using the SDK's snapshot policy.
 ///
@@ -794,6 +814,31 @@ enum ApiPirSnapshotEndpointStatus {
   malformedJson,
   nonSuccessStatus,
   timeoutOrNetworkError,
+}
+
+/// Selected PIR endpoint plus a diagnostic for every endpoint probed.
+///
+/// The full diagnostic set is part of the result, not debug output: the
+/// delegation path builds its PIR failover list from the endpoints that
+/// matched, and the status screen explains a failed resolution from the
+/// heights the endpoints reported.
+class ApiPirSnapshotResolution {
+  /// `None` when every endpoint was probed and none matched the round.
+  final String? endpoint;
+  final List<ApiPirSnapshotEndpointDiagnostic> diagnostics;
+
+  const ApiPirSnapshotResolution({this.endpoint, required this.diagnostics});
+
+  @override
+  int get hashCode => endpoint.hashCode ^ diagnostics.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ApiPirSnapshotResolution &&
+          runtimeType == other.runtimeType &&
+          endpoint == other.endpoint &&
+          diagnostics == other.diagnostics;
 }
 
 /// One share that reached a new helper during a tracking pass.

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -12,7 +12,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `catch`, `config_error`, `delegation_static_inputs_for`, `helper_client`, `helper_delivery_db`, `internal`, `invalid_input`, `is_cancelled`, `pir_snapshot_failure`, `pir_snapshot_height_field`, `pir_snapshot_probe_attempt`, `pir_snapshot_root_url`, `probe_pir_snapshot_endpoint`, `round_inputs`, `routed_transport`, `share_tracking_pass_for`, `view`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `PirSnapshotProbeAttempt`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
 
 /// Probe every configured PIR endpoint and select one at the round's height.
 ///
@@ -31,20 +31,6 @@ Future<ApiPirSnapshotResolution> resolvePirSnapshotEndpoint({
 }) => RustLib.instance.api.crateApiVotingResolvePirSnapshotEndpoint(
   endpoints: endpoints,
   expectedSnapshotHeight: expectedSnapshotHeight,
-);
-
-/// Select an exact-height PIR endpoint using the SDK's snapshot policy.
-///
-/// Dart owns probing and diagnostics because it owns the routed HTTP client.
-/// The protocol decision about which diagnostics are eligible remains here.
-String? selectPirSnapshotEndpoint({
-  required List<ApiPirSnapshotEndpointDiagnostic> diagnostics,
-  required BigInt expectedSnapshotHeight,
-  required BigInt matchIndex,
-}) => RustLib.instance.api.crateApiVotingSelectPirSnapshotEndpoint(
-  diagnostics: diagnostics,
-  expectedSnapshotHeight: expectedSnapshotHeight,
-  matchIndex: matchIndex,
 );
 
 /// Return the shared last-moment helper-share buffer, in Unix seconds.

--- a/lib/src/rust/api/voting_session.dart
+++ b/lib/src/rust/api/voting_session.dart
@@ -11,8 +11,8 @@ import '../third_party/zcash_voting/wire.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'voting.dart';
 
-// These functions are ignored because they are not marked as `pub`: `advance`, `delegation_inputs`, `internal`, `invalid_input`, `pipeline`, `run_step`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`
+// These functions are ignored because they are not marked as `pub`: `delegation_inputs`, `drive`, `internal`, `invalid_input`, `pipeline`, `round_drive_policy`, `unix_now_seconds`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`
 
 /// Opens a session bound to `ctx`'s account and round.
 ///
@@ -43,25 +43,6 @@ VotingRoundSession openVotingRoundSession({
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VotingRoundSession>>
 abstract class VotingRoundSession implements RustOpaqueInterface {
-  /// Runs the first planned step, streaming progress then one result.
-  ///
-  /// See [`VotingRoundSession::advance`] for why this reports failures on
-  /// the sink instead of returning them.
-  Stream<ApiRoundStepEvent> advanceNext({
-    required ApiRoundHostContext host,
-    ApiDelegationSignerInput? signer,
-  });
-
-  /// Runs one planned step, streaming progress then one result.
-  ///
-  /// See [`VotingRoundSession::advance`] for why this reports failures on
-  /// the sink instead of returning them.
-  Stream<ApiRoundStepEvent> advanceStep({
-    required NextStepView step,
-    required ApiRoundHostContext host,
-    ApiDelegationSignerInput? signer,
-  });
-
   /// Cancellation handle for one helper-share tracking pass on this round.
   ///
   /// Tracking passes are cancelled by the destructive drain independently
@@ -95,6 +76,22 @@ abstract class VotingRoundSession implements RustOpaqueInterface {
 
   /// Plans the round from durable state.
   Future<RoundPlanView> plan();
+
+  /// Drives the bound round to quiescence, streaming events then one report.
+  ///
+  /// Emits exactly one `Result` event for the reason [`Self::advance`]
+  /// documents: a streaming function's `Err` return never reaches Dart.
+  ///
+  /// `host` is a template. The driver reads the host context once per
+  /// dispatch and this bridge restamps `now_seconds` each time, because a
+  /// run can take minutes and a long proof can cross the last-moment or
+  /// vote-end boundary. Every other field is fixed for the run, so a helper
+  /// fleet that changes mid-run needs a new call.
+  Stream<ApiRoundRunEvent> runRound({
+    required ApiRoundHostContext host,
+    ApiDelegationSignerInput? signer,
+    ApiRoundDrivePolicy? policy,
+  });
 
   /// Records ballot decisions against the bound roster and re-plans.
   Future<RoundPlanView> setBallotIntents({
@@ -196,6 +193,41 @@ class ApiProposalRosterEntry {
           numOptions == other.numOptions;
 }
 
+/// How a run paces itself. Omitted fields keep the SDK defaults, which are the
+/// cadence the Dart driver used before the SDK owned the loop.
+class ApiRoundDrivePolicy {
+  final double? pendingRepollSeconds;
+  final int? maxBundleConcurrency;
+  final int? maxDispatches;
+
+  /// `true` keeps every other bundle running after one fails.
+  final bool? skipFailedBundle;
+
+  const ApiRoundDrivePolicy({
+    this.pendingRepollSeconds,
+    this.maxBundleConcurrency,
+    this.maxDispatches,
+    this.skipFailedBundle,
+  });
+
+  @override
+  int get hashCode =>
+      pendingRepollSeconds.hashCode ^
+      maxBundleConcurrency.hashCode ^
+      maxDispatches.hashCode ^
+      skipFailedBundle.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ApiRoundDrivePolicy &&
+          runtimeType == other.runtimeType &&
+          pendingRepollSeconds == other.pendingRepollSeconds &&
+          maxBundleConcurrency == other.maxBundleConcurrency &&
+          maxDispatches == other.maxDispatches &&
+          skipFailedBundle == other.skipFailedBundle;
+}
+
 /// Host inputs that change per step call.
 class ApiRoundHostContext {
   /// Complete current helper fleet, already mapped to transport URLs.
@@ -237,6 +269,38 @@ class ApiRoundHostContext {
           voteEndTimeSeconds == other.voteEndTimeSeconds &&
           voteTreeNodeUrls == other.voteTreeNodeUrls &&
           maxProofConcurrency == other.maxProofConcurrency;
+}
+
+/// One observation from a round run, or its single terminal report.
+///
+/// Exactly one `Result`-kind event is emitted however the run ends, carrying
+/// either the report or a bridge error.
+class ApiRoundRunEvent {
+  final ApiRoundStepEventKind kind;
+  final RoundDriveEventView? event;
+  final RoundRunReportView? report;
+  final ApiRoundStepError? error;
+
+  const ApiRoundRunEvent({
+    required this.kind,
+    this.event,
+    this.report,
+    this.error,
+  });
+
+  @override
+  int get hashCode =>
+      kind.hashCode ^ event.hashCode ^ report.hashCode ^ error.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ApiRoundRunEvent &&
+          runtimeType == other.runtimeType &&
+          kind == other.kind &&
+          event == other.event &&
+          report == other.report &&
+          error == other.error;
 }
 
 /// A typed bridge failure carried by a result event.
@@ -312,48 +376,6 @@ class ApiRoundStepError {
           selectedNotes == other.selectedNotes &&
           httpStatus == other.httpStatus &&
           endpoint == other.endpoint;
-}
-
-/// One event of a streamed step: progress while it runs, then one result.
-///
-/// The result event carries exactly one of `outcome`, `failure`, or `error`.
-/// `failure` is a step the SDK ran and rejected; `error` is everything that
-/// stopped the step from producing either, including the work this boundary
-/// does before handing over (signer material, delegation pipeline, PIR fleet)
-/// and a view conversion that fails after the step already ran.
-class ApiRoundStepEvent {
-  final ApiRoundStepEventKind kind;
-  final RoundStepProgressView? progress;
-  final RoundStepOutcomeView? outcome;
-  final RoundStepFailureView? failure;
-  final ApiRoundStepError? error;
-
-  const ApiRoundStepEvent({
-    required this.kind,
-    this.progress,
-    this.outcome,
-    this.failure,
-    this.error,
-  });
-
-  @override
-  int get hashCode =>
-      kind.hashCode ^
-      progress.hashCode ^
-      outcome.hashCode ^
-      failure.hashCode ^
-      error.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is ApiRoundStepEvent &&
-          runtimeType == other.runtimeType &&
-          kind == other.kind &&
-          progress == other.progress &&
-          outcome == other.outcome &&
-          failure == other.failure &&
-          error == other.error;
 }
 
 enum ApiRoundStepEventKind { progress, result }

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1962890698;
+  int get rustContentHash => 444974405;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -945,6 +945,11 @@ abstract class RustLibApi extends BaseApi {
     required String dbPath,
     required String accountUuid,
     String? roundId,
+  });
+
+  Future<ApiPirSnapshotResolution> crateApiVotingResolvePirSnapshotEndpoint({
+    required List<String> endpoints,
+    required BigInt expectedSnapshotHeight,
   });
 
   Future<List<String>> crateApiVotingResolveStaticVotingConfig({
@@ -6943,6 +6948,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<ApiPirSnapshotResolution> crateApiVotingResolvePirSnapshotEndpoint({
+    required List<String> endpoints,
+    required BigInt expectedSnapshotHeight,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_list_String(endpoints, serializer);
+          sse_encode_u_64(expectedSnapshotHeight, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 139,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_api_pir_snapshot_resolution,
+          decodeErrorData: sse_decode_voting_error_view,
+        ),
+        constMeta: kCrateApiVotingResolvePirSnapshotEndpointConstMeta,
+        argValues: [endpoints, expectedSnapshotHeight],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVotingResolvePirSnapshotEndpointConstMeta =>
+      const TaskConstMeta(
+        debugName: "resolve_pir_snapshot_endpoint",
+        argNames: ["endpoints", "expectedSnapshotHeight"],
+      );
+
+  @override
   Future<List<String>> crateApiVotingResolveStaticVotingConfig({
     required String source,
     required List<int> staticBytes,
@@ -6956,7 +6996,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 140,
             port: port_,
           );
         },
@@ -6998,7 +7038,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7033,7 +7073,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7074,7 +7114,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7123,7 +7163,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 144,
             port: port_,
           );
         },
@@ -7152,7 +7192,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7191,7 +7231,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
             port: port_,
           );
         },
@@ -7246,7 +7286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7311,7 +7351,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
           )!;
         },
         codec: SseCodec(
@@ -7341,7 +7381,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
           )!;
         },
         codec: SseCodec(
@@ -7385,7 +7425,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7432,7 +7472,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
           )!;
         },
         codec: SseCodec(
@@ -7462,7 +7502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 152,
           )!;
         },
         codec: SseCodec(
@@ -7497,7 +7537,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7530,7 +7570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7571,7 +7611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
             port: port_,
           );
         },
@@ -7625,7 +7665,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7675,7 +7715,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 156,
+              funcId: 157,
               port: port_,
             );
           },
@@ -7716,7 +7756,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 157,
+              funcId: 158,
               port: port_,
             );
           },
@@ -7748,7 +7788,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 159,
             port: port_,
           );
         },
@@ -7775,7 +7815,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 160,
           )!;
         },
         codec: SseCodec(
@@ -7801,7 +7841,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
             port: port_,
           );
         },
@@ -7848,7 +7888,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
             port: port_,
           );
         },
@@ -7921,7 +7961,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -7983,7 +8023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8018,7 +8058,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8057,7 +8097,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
             port: port_,
           );
         },
@@ -8086,7 +8126,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 167,
           )!;
         },
         codec: SseCodec(
@@ -8113,7 +8153,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 168,
           )!;
         },
         codec: SseCodec(
@@ -8149,7 +8189,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8188,7 +8228,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8229,7 +8269,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 171,
             port: port_,
           );
         },
@@ -8277,7 +8317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8331,7 +8371,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 173,
             port: port_,
           );
         },
@@ -8381,7 +8421,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 174,
             port: port_,
           );
         },
@@ -8413,7 +8453,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 175,
             port: port_,
           );
         },
@@ -8441,7 +8481,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 176,
           )!;
         },
         codec: SseCodec(
@@ -8471,7 +8511,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 177,
           )!;
         },
         codec: SseCodec(
@@ -8497,7 +8537,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 178,
           )!;
         },
         codec: SseCodec(
@@ -8543,7 +8583,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 178,
+            funcId: 179,
             port: port_,
           );
         },
@@ -8591,7 +8631,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 179,
+            funcId: 180,
           )!;
         },
         codec: SseCodec(
@@ -8625,7 +8665,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 180,
+            funcId: 181,
             port: port_,
           );
         },
@@ -8662,7 +8702,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 181,
+            funcId: 182,
             port: port_,
           );
         },
@@ -9054,6 +9094,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ApiPirSnapshotEndpointStatus.values[raw as int];
+  }
+
+  @protected
+  ApiPirSnapshotResolution dco_decode_api_pir_snapshot_resolution(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return ApiPirSnapshotResolution(
+      endpoint: dco_decode_opt_String(arr[0]),
+      diagnostics: dco_decode_list_api_pir_snapshot_endpoint_diagnostic(arr[1]),
+    );
   }
 
   @protected
@@ -12441,6 +12493,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_32(deserializer);
     return ApiPirSnapshotEndpointStatus.values[inner];
+  }
+
+  @protected
+  ApiPirSnapshotResolution sse_decode_api_pir_snapshot_resolution(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_endpoint = sse_decode_opt_String(deserializer);
+    var var_diagnostics = sse_decode_list_api_pir_snapshot_endpoint_diagnostic(
+      deserializer,
+    );
+    return ApiPirSnapshotResolution(
+      endpoint: var_endpoint,
+      diagnostics: var_diagnostics,
+    );
   }
 
   @protected
@@ -16851,6 +16918,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_api_pir_snapshot_resolution(
+    ApiPirSnapshotResolution self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_opt_String(self.endpoint, serializer);
+    sse_encode_list_api_pir_snapshot_endpoint_diagnostic(
+      self.diagnostics,
+      serializer,
+    );
   }
 
   @protected

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -949149006;
+  int get rustContentHash => 1962890698;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -90,19 +90,6 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
 }
 
 abstract class RustLibApi extends BaseApi {
-  Stream<ApiRoundStepEvent> crateApiVotingSessionVotingRoundSessionAdvanceNext({
-    required VotingRoundSession that,
-    required ApiRoundHostContext host,
-    ApiDelegationSignerInput? signer,
-  });
-
-  Stream<ApiRoundStepEvent> crateApiVotingSessionVotingRoundSessionAdvanceStep({
-    required VotingRoundSession that,
-    required NextStepView step,
-    required ApiRoundHostContext host,
-    ApiDelegationSignerInput? signer,
-  });
-
   VotingShareTrackingPassHandle
   crateApiVotingSessionVotingRoundSessionBeginShareTrackingPass({
     required VotingRoundSession that,
@@ -126,6 +113,13 @@ abstract class RustLibApi extends BaseApi {
 
   Future<RoundPlanView> crateApiVotingSessionVotingRoundSessionPlan({
     required VotingRoundSession that,
+  });
+
+  Stream<ApiRoundRunEvent> crateApiVotingSessionVotingRoundSessionRunRound({
+    required VotingRoundSession that,
+    required ApiRoundHostContext host,
+    ApiDelegationSignerInput? signer,
+    ApiRoundDrivePolicy? policy,
   });
 
   Future<RoundPlanView>
@@ -984,6 +978,8 @@ abstract class RustLibApi extends BaseApi {
     required BigInt height,
   });
 
+  Future<RoundWorkTallyView> zcashVotingWireRoundWorkTallyViewDefault();
+
   Future<void> crateApiSyncRunFullSyncBlocking({
     required String dbPath,
     required String lightwalletdUrl,
@@ -1238,108 +1234,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   });
 
   @override
-  Stream<ApiRoundStepEvent> crateApiVotingSessionVotingRoundSessionAdvanceNext({
-    required VotingRoundSession that,
-    required ApiRoundHostContext host,
-    ApiDelegationSignerInput? signer,
-  }) {
-    final sink = RustStreamSink<ApiRoundStepEvent>();
-    unawaited(
-      handler.executeNormal(
-        NormalTask(
-          callFfi: (port_) {
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVotingRoundSession(
-              that,
-              serializer,
-            );
-            sse_encode_box_autoadd_api_round_host_context(host, serializer);
-            sse_encode_opt_box_autoadd_api_delegation_signer_input(
-              signer,
-              serializer,
-            );
-            sse_encode_StreamSink_api_round_step_event_Sse(sink, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 1,
-              port: port_,
-            );
-          },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: null,
-          ),
-          constMeta:
-              kCrateApiVotingSessionVotingRoundSessionAdvanceNextConstMeta,
-          argValues: [that, host, signer, sink],
-          apiImpl: this,
-        ),
-      ),
-    );
-    return sink.stream;
-  }
-
-  TaskConstMeta
-  get kCrateApiVotingSessionVotingRoundSessionAdvanceNextConstMeta =>
-      const TaskConstMeta(
-        debugName: "VotingRoundSession_advance_next",
-        argNames: ["that", "host", "signer", "sink"],
-      );
-
-  @override
-  Stream<ApiRoundStepEvent> crateApiVotingSessionVotingRoundSessionAdvanceStep({
-    required VotingRoundSession that,
-    required NextStepView step,
-    required ApiRoundHostContext host,
-    ApiDelegationSignerInput? signer,
-  }) {
-    final sink = RustStreamSink<ApiRoundStepEvent>();
-    unawaited(
-      handler.executeNormal(
-        NormalTask(
-          callFfi: (port_) {
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVotingRoundSession(
-              that,
-              serializer,
-            );
-            sse_encode_box_autoadd_next_step_view(step, serializer);
-            sse_encode_box_autoadd_api_round_host_context(host, serializer);
-            sse_encode_opt_box_autoadd_api_delegation_signer_input(
-              signer,
-              serializer,
-            );
-            sse_encode_StreamSink_api_round_step_event_Sse(sink, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 2,
-              port: port_,
-            );
-          },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: null,
-          ),
-          constMeta:
-              kCrateApiVotingSessionVotingRoundSessionAdvanceStepConstMeta,
-          argValues: [that, step, host, signer, sink],
-          apiImpl: this,
-        ),
-      ),
-    );
-    return sink.stream;
-  }
-
-  TaskConstMeta
-  get kCrateApiVotingSessionVotingRoundSessionAdvanceStepConstMeta =>
-      const TaskConstMeta(
-        debugName: "VotingRoundSession_advance_step",
-        argNames: ["that", "step", "host", "signer", "sink"],
-      );
-
-  @override
   VotingShareTrackingPassHandle
   crateApiVotingSessionVotingRoundSessionBeginShareTrackingPass({
     required VotingRoundSession that,
@@ -1352,7 +1246,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 3)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1386,7 +1280,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1423,7 +1317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 3,
             port: port_,
           );
         },
@@ -1464,7 +1358,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 4,
             port: port_,
           );
         },
@@ -1502,7 +1396,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 5,
             port: port_,
           );
         },
@@ -1524,6 +1418,59 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Stream<ApiRoundRunEvent> crateApiVotingSessionVotingRoundSessionRunRound({
+    required VotingRoundSession that,
+    required ApiRoundHostContext host,
+    ApiDelegationSignerInput? signer,
+    ApiRoundDrivePolicy? policy,
+  }) {
+    final sink = RustStreamSink<ApiRoundRunEvent>();
+    unawaited(
+      handler.executeNormal(
+        NormalTask(
+          callFfi: (port_) {
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVotingRoundSession(
+              that,
+              serializer,
+            );
+            sse_encode_box_autoadd_api_round_host_context(host, serializer);
+            sse_encode_opt_box_autoadd_api_delegation_signer_input(
+              signer,
+              serializer,
+            );
+            sse_encode_opt_box_autoadd_api_round_drive_policy(
+              policy,
+              serializer,
+            );
+            sse_encode_StreamSink_api_round_run_event_Sse(sink, serializer);
+            pdeCallFfi(
+              generalizedFrbRustBinding,
+              serializer,
+              funcId: 6,
+              port: port_,
+            );
+          },
+          codec: SseCodec(
+            decodeSuccessData: sse_decode_unit,
+            decodeErrorData: null,
+          ),
+          constMeta: kCrateApiVotingSessionVotingRoundSessionRunRoundConstMeta,
+          argValues: [that, host, signer, policy, sink],
+          apiImpl: this,
+        ),
+      ),
+    );
+    return sink.stream;
+  }
+
+  TaskConstMeta get kCrateApiVotingSessionVotingRoundSessionRunRoundConstMeta =>
+      const TaskConstMeta(
+        debugName: "VotingRoundSession_run_round",
+        argNames: ["that", "host", "signer", "policy", "sink"],
+      );
+
+  @override
   Future<RoundPlanView>
   crateApiVotingSessionVotingRoundSessionSetBallotIntents({
     required VotingRoundSession that,
@@ -1541,7 +1488,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 7,
             port: port_,
           );
         },
@@ -1578,7 +1525,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_u_64(operationEpoch, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1611,7 +1558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1653,7 +1600,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 10,
             port: port_,
           );
         },
@@ -1710,7 +1657,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 11,
             port: port_,
           );
         },
@@ -1760,7 +1707,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 12,
             port: port_,
           );
         },
@@ -1787,7 +1734,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1818,7 +1765,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             context,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1861,7 +1808,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 15,
             port: port_,
           );
         },
@@ -1923,7 +1870,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 16,
             port: port_,
           );
         },
@@ -1979,7 +1926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 17,
             port: port_,
           );
         },
@@ -2006,7 +1953,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2034,7 +1981,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 19,
             port: port_,
           );
         },
@@ -2083,7 +2030,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 20,
             port: port_,
           );
         },
@@ -2155,7 +2102,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 21,
             port: port_,
           );
         },
@@ -2224,7 +2171,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 22,
             port: port_,
           );
         },
@@ -2290,7 +2237,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 23,
             port: port_,
           );
         },
@@ -2342,7 +2289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 24,
             port: port_,
           );
         },
@@ -2377,7 +2324,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 25,
             port: port_,
           );
         },
@@ -2410,7 +2357,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 26,
             port: port_,
           );
         },
@@ -2458,7 +2405,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 27,
             port: port_,
           );
         },
@@ -2516,7 +2463,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 28,
             port: port_,
           );
         },
@@ -2569,7 +2516,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 29,
             port: port_,
           );
         },
@@ -2614,7 +2561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 30,
             port: port_,
           );
         },
@@ -2655,7 +2602,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 31,
             port: port_,
           );
         },
@@ -2695,7 +2642,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(dbPath, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(roundId, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2733,7 +2680,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 33,
             port: port_,
           );
         },
@@ -2765,7 +2712,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 34,
             port: port_,
           );
         },
@@ -2798,7 +2745,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 35,
             port: port_,
           );
         },
@@ -2831,7 +2778,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 36,
             port: port_,
           );
         },
@@ -2866,7 +2813,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 37,
             port: port_,
           );
         },
@@ -2897,7 +2844,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 38,
             port: port_,
           );
         },
@@ -2934,7 +2881,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 39,
             port: port_,
           );
         },
@@ -2967,7 +2914,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 40,
             port: port_,
           );
         },
@@ -3001,7 +2948,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 41,
             port: port_,
           );
         },
@@ -3042,7 +2989,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 42,
             port: port_,
           );
         },
@@ -3079,7 +3026,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 43,
             port: port_,
           );
         },
@@ -3116,7 +3063,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 44,
             port: port_,
           );
         },
@@ -3155,7 +3102,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 45,
             port: port_,
           );
         },
@@ -3190,7 +3137,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 46,
             port: port_,
           );
         },
@@ -3225,7 +3172,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 47,
             port: port_,
           );
         },
@@ -3255,7 +3202,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 48,
             port: port_,
           );
         },
@@ -3288,7 +3235,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 49,
             port: port_,
           );
         },
@@ -3323,7 +3270,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 50,
             port: port_,
           );
         },
@@ -3369,7 +3316,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 51,
             port: port_,
           );
         },
@@ -3419,7 +3366,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 52,
             port: port_,
           );
         },
@@ -3452,7 +3399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 53,
             port: port_,
           );
         },
@@ -3487,7 +3434,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 54,
             port: port_,
           );
         },
@@ -3524,7 +3471,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 55,
             port: port_,
           );
         },
@@ -3561,7 +3508,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 56,
             port: port_,
           );
         },
@@ -3596,7 +3543,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 57,
             port: port_,
           );
         },
@@ -3639,7 +3586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 58,
             port: port_,
           );
         },
@@ -3693,7 +3640,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 59,
             port: port_,
           );
         },
@@ -3747,7 +3694,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 60,
             port: port_,
           );
         },
@@ -3778,7 +3725,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 61,
             port: port_,
           );
         },
@@ -3823,7 +3770,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 62,
             port: port_,
           );
         },
@@ -3885,7 +3832,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 63,
             port: port_,
           );
         },
@@ -3943,7 +3890,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 64,
             port: port_,
           );
         },
@@ -3994,7 +3941,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 65,
             port: port_,
           );
         },
@@ -4037,7 +3984,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4062,7 +4009,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4090,7 +4037,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 68,
             port: port_,
           );
         },
@@ -4127,7 +4074,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 69,
             port: port_,
           );
         },
@@ -4164,7 +4111,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 70,
             port: port_,
           );
         },
@@ -4201,7 +4148,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 71,
             port: port_,
           );
         },
@@ -4235,7 +4182,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 72,
             port: port_,
           );
         },
@@ -4262,7 +4209,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4292,7 +4239,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 74,
             port: port_,
           );
         },
@@ -4328,7 +4275,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 75,
             port: port_,
           );
         },
@@ -4365,7 +4312,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 76,
             port: port_,
           );
         },
@@ -4401,7 +4348,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 77,
             port: port_,
           );
         },
@@ -4438,7 +4385,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 78,
             port: port_,
           );
         },
@@ -4471,7 +4418,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 79,
             port: port_,
           );
         },
@@ -4504,7 +4451,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 80,
             port: port_,
           );
         },
@@ -4531,7 +4478,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_network_privacy_status,
@@ -4568,7 +4515,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 82,
             port: port_,
           );
         },
@@ -4603,7 +4550,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 83,
             port: port_,
           );
         },
@@ -4641,7 +4588,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 84,
             port: port_,
           );
         },
@@ -4682,7 +4629,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4725,7 +4672,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 86,
             port: port_,
           );
         },
@@ -4762,7 +4709,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 87,
             port: port_,
           );
         },
@@ -4801,7 +4748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4841,7 +4788,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 89,
             port: port_,
           );
         },
@@ -4881,7 +4828,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4917,7 +4864,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4944,7 +4891,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -4974,7 +4921,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 93,
             port: port_,
           );
         },
@@ -5008,7 +4955,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 94,
             port: port_,
           );
         },
@@ -5049,7 +4996,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 95,
             port: port_,
           );
         },
@@ -5088,7 +5035,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 96,
             port: port_,
           );
         },
@@ -5125,7 +5072,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 97,
             port: port_,
           );
         },
@@ -5162,7 +5109,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 98,
             port: port_,
           );
         },
@@ -5190,11 +5137,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 100,
-          )!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -5234,7 +5177,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 100,
             port: port_,
           );
         },
@@ -5298,7 +5241,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 101,
             port: port_,
           );
         },
@@ -5366,7 +5309,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 102,
             port: port_,
           );
         },
@@ -5432,7 +5375,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 103,
             port: port_,
           );
         },
@@ -5475,7 +5418,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 104,
             port: port_,
           );
         },
@@ -5509,7 +5452,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 105,
           )!;
         },
         codec: SseCodec(
@@ -5537,7 +5480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 106,
           )!;
         },
         codec: SseCodec(
@@ -5577,7 +5520,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 107,
             port: port_,
           );
         },
@@ -5620,7 +5563,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 108,
           )!;
         },
         codec: SseCodec(
@@ -5646,7 +5589,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 109,
           )!;
         },
         codec: SseCodec(
@@ -5672,7 +5615,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 110,
           )!;
         },
         codec: SseCodec(
@@ -5700,7 +5643,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5735,7 +5678,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 112,
           )!;
         },
         codec: SseCodec(
@@ -5769,7 +5712,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5803,7 +5746,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 114,
             port: port_,
           );
         },
@@ -5855,7 +5798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 115,
             port: port_,
           );
         },
@@ -5925,7 +5868,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 116,
             port: port_,
           );
         },
@@ -5996,7 +5939,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 117,
             port: port_,
           );
         },
@@ -6046,7 +5989,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 118,
           )!;
         },
         codec: SseCodec(
@@ -6081,7 +6024,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 119,
             port: port_,
           );
         },
@@ -6124,7 +6067,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 120,
           )!;
         },
         codec: SseCodec(
@@ -6171,7 +6114,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 121,
             port: port_,
           );
         },
@@ -6210,7 +6153,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 122,
             port: port_,
           );
         },
@@ -6246,7 +6189,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 123,
             port: port_,
           );
         },
@@ -6284,7 +6227,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 124,
             port: port_,
           );
         },
@@ -6329,7 +6272,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 125,
             port: port_,
           );
         },
@@ -6389,7 +6332,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6449,7 +6392,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6508,7 +6451,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6553,7 +6496,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6594,7 +6537,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6653,7 +6596,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6715,7 +6658,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6763,7 +6706,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6822,7 +6765,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 134,
             port: port_,
           );
         },
@@ -6878,7 +6821,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 135,
             port: port_,
           );
         },
@@ -6908,7 +6851,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 136,
           )!;
         },
         codec: SseCodec(
@@ -6941,7 +6884,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 137,
             port: port_,
           );
         },
@@ -6978,7 +6921,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 138,
             port: port_,
           );
         },
@@ -7013,7 +6956,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7055,7 +6998,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7090,7 +7033,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7131,7 +7074,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7180,7 +7123,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7199,6 +7142,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     debugName: "rewind_to_height",
     argNames: ["dbPath", "network", "height"],
   );
+
+  @override
+  Future<RoundWorkTallyView> zcashVotingWireRoundWorkTallyViewDefault() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 144,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_round_work_tally_view,
+          decodeErrorData: null,
+        ),
+        constMeta: kZcashVotingWireRoundWorkTallyViewDefaultConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kZcashVotingWireRoundWorkTallyViewDefaultConstMeta =>
+      const TaskConstMeta(
+        debugName: "round_work_tally_view_default",
+        argNames: [],
+      );
 
   @override
   Future<void> crateApiSyncRunFullSyncBlocking({
@@ -8842,8 +8815,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RustStreamSink<ApiRoundStepEvent>
-  dco_decode_StreamSink_api_round_step_event_Sse(dynamic raw) {
+  RustStreamSink<ApiRoundRunEvent>
+  dco_decode_StreamSink_api_round_run_event_Sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     throw UnimplementedError();
   }
@@ -9108,6 +9081,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ApiRoundDrivePolicy dco_decode_api_round_drive_policy(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return ApiRoundDrivePolicy(
+      pendingRepollSeconds: dco_decode_opt_box_autoadd_f_64(arr[0]),
+      maxBundleConcurrency: dco_decode_opt_box_autoadd_u_32(arr[1]),
+      maxDispatches: dco_decode_opt_box_autoadd_u_32(arr[2]),
+      skipFailedBundle: dco_decode_opt_box_autoadd_bool(arr[3]),
+    );
+  }
+
+  @protected
   ApiRoundHostContext dco_decode_api_round_host_context(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -9120,6 +9107,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       voteEndTimeSeconds: dco_decode_opt_box_autoadd_u_64(arr[3]),
       voteTreeNodeUrls: dco_decode_list_String(arr[4]),
       maxProofConcurrency: dco_decode_u_32(arr[5]),
+    );
+  }
+
+  @protected
+  ApiRoundRunEvent dco_decode_api_round_run_event(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return ApiRoundRunEvent(
+      kind: dco_decode_api_round_step_event_kind(arr[0]),
+      event: dco_decode_opt_box_autoadd_round_drive_event_view(arr[1]),
+      report: dco_decode_opt_box_autoadd_round_run_report_view(arr[2]),
+      error: dco_decode_opt_box_autoadd_api_round_step_error(arr[3]),
     );
   }
 
@@ -9144,21 +9145,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       selectedNotes: dco_decode_opt_box_autoadd_u_32(arr[9]),
       httpStatus: dco_decode_opt_box_autoadd_u_16(arr[10]),
       endpoint: dco_decode_opt_String(arr[11]),
-    );
-  }
-
-  @protected
-  ApiRoundStepEvent dco_decode_api_round_step_event(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 5)
-      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
-    return ApiRoundStepEvent(
-      kind: dco_decode_api_round_step_event_kind(arr[0]),
-      progress: dco_decode_opt_box_autoadd_round_step_progress_view(arr[1]),
-      outcome: dco_decode_opt_box_autoadd_round_step_outcome_view(arr[2]),
-      failure: dco_decode_opt_box_autoadd_round_step_failure_view(arr[3]),
-      error: dco_decode_opt_box_autoadd_api_round_step_error(arr[4]),
     );
   }
 
@@ -9325,6 +9311,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ApiRoundDrivePolicy dco_decode_box_autoadd_api_round_drive_policy(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_api_round_drive_policy(raw);
+  }
+
+  @protected
   ApiRoundHostContext dco_decode_box_autoadd_api_round_host_context(
     dynamic raw,
   ) {
@@ -9466,25 +9460,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RoundDriveEventView dco_decode_box_autoadd_round_drive_event_view(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_round_drive_event_view(raw);
+  }
+
+  @protected
   RoundPlanView dco_decode_box_autoadd_round_plan_view(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_round_plan_view(raw);
   }
 
   @protected
-  RoundStepFailureView dco_decode_box_autoadd_round_step_failure_view(
-    dynamic raw,
-  ) {
+  RoundRunReportView dco_decode_box_autoadd_round_run_report_view(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_round_step_failure_view(raw);
+    return dco_decode_round_run_report_view(raw);
   }
 
   @protected
-  RoundStepOutcomeView dco_decode_box_autoadd_round_step_outcome_view(
+  RoundStepDispositionView dco_decode_box_autoadd_round_step_disposition_view(
     dynamic raw,
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_round_step_outcome_view(raw);
+    return dco_decode_round_step_disposition_view(raw);
+  }
+
+  @protected
+  RoundStepFailureKindView dco_decode_box_autoadd_round_step_failure_kind_view(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_round_step_failure_kind_view(raw);
   }
 
   @protected
@@ -9493,6 +9501,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_round_step_progress_view(raw);
+  }
+
+  @protected
+  RoundWorkTallyView dco_decode_box_autoadd_round_work_tally_view(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_round_work_tally_view(raw);
   }
 
   @protected
@@ -9506,13 +9520,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ShareKeyView dco_decode_box_autoadd_share_key_view(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_share_key_view(raw);
-  }
-
-  @protected
-  SignedDelegationPayloadView
-  dco_decode_box_autoadd_signed_delegation_payload_view(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_signed_delegation_payload_view(raw);
   }
 
   @protected
@@ -10361,6 +10368,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<RoundChainOutcomeView> dco_decode_list_round_chain_outcome_view(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_round_chain_outcome_view)
+        .toList();
+  }
+
+  @protected
+  List<RoundStepFailureRecordView>
+  dco_decode_list_round_step_failure_record_view(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_round_step_failure_record_view)
+        .toList();
+  }
+
+  @protected
   List<ScanRangeInfo> dco_decode_list_scan_range_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_scan_range_info).toList();
@@ -10388,6 +10414,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>)
         .map(dco_decode_share_delivery_outcome_view)
+        .toList();
+  }
+
+  @protected
+  List<ShareKeyView> dco_decode_list_share_key_view(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_share_key_view).toList();
+  }
+
+  @protected
+  List<SignedDelegationPayloadView>
+  dco_decode_list_signed_delegation_payload_view(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_signed_delegation_payload_view)
         .toList();
   }
 
@@ -10760,6 +10801,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ApiRoundDrivePolicy? dco_decode_opt_box_autoadd_api_round_drive_policy(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null
+        ? null
+        : dco_decode_box_autoadd_api_round_drive_policy(raw);
+  }
+
+  @protected
   ApiRoundStepError? dco_decode_opt_box_autoadd_api_round_step_error(
     dynamic raw,
   ) {
@@ -10905,29 +10956,47 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RoundDriveEventView? dco_decode_opt_box_autoadd_round_drive_event_view(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null
+        ? null
+        : dco_decode_box_autoadd_round_drive_event_view(raw);
+  }
+
+  @protected
   RoundPlanView? dco_decode_opt_box_autoadd_round_plan_view(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_round_plan_view(raw);
   }
 
   @protected
-  RoundStepFailureView? dco_decode_opt_box_autoadd_round_step_failure_view(
+  RoundRunReportView? dco_decode_opt_box_autoadd_round_run_report_view(
     dynamic raw,
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null
         ? null
-        : dco_decode_box_autoadd_round_step_failure_view(raw);
+        : dco_decode_box_autoadd_round_run_report_view(raw);
   }
 
   @protected
-  RoundStepOutcomeView? dco_decode_opt_box_autoadd_round_step_outcome_view(
-    dynamic raw,
-  ) {
+  RoundStepDispositionView?
+  dco_decode_opt_box_autoadd_round_step_disposition_view(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null
         ? null
-        : dco_decode_box_autoadd_round_step_outcome_view(raw);
+        : dco_decode_box_autoadd_round_step_disposition_view(raw);
+  }
+
+  @protected
+  RoundStepFailureKindView?
+  dco_decode_opt_box_autoadd_round_step_failure_kind_view(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null
+        ? null
+        : dco_decode_box_autoadd_round_step_failure_kind_view(raw);
   }
 
   @protected
@@ -10938,6 +11007,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return raw == null
         ? null
         : dco_decode_box_autoadd_round_step_progress_view(raw);
+  }
+
+  @protected
+  RoundWorkTallyView? dco_decode_opt_box_autoadd_round_work_tally_view(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null
+        ? null
+        : dco_decode_box_autoadd_round_work_tally_view(raw);
   }
 
   @protected
@@ -10953,15 +11032,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ShareKeyView? dco_decode_opt_box_autoadd_share_key_view(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_share_key_view(raw);
-  }
-
-  @protected
-  SignedDelegationPayloadView?
-  dco_decode_opt_box_autoadd_signed_delegation_payload_view(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw == null
-        ? null
-        : dco_decode_box_autoadd_signed_delegation_payload_view(raw);
   }
 
   @protected
@@ -11114,6 +11184,48 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RoundChainOutcomeView dco_decode_round_chain_outcome_view(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return RoundChainOutcomeView(
+      step: dco_decode_next_step_view(arr[0]),
+      outcome: dco_decode_chain_submission_outcome_view(arr[1]),
+    );
+  }
+
+  @protected
+  RoundDriveEventKind dco_decode_round_drive_event_kind(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return RoundDriveEventKind.values[raw as int];
+  }
+
+  @protected
+  RoundDriveEventView dco_decode_round_drive_event_view(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 10)
+      throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+    return RoundDriveEventView(
+      kind: dco_decode_round_drive_event_kind(arr[0]),
+      step: dco_decode_opt_box_autoadd_next_step_view(arr[1]),
+      plan: dco_decode_opt_box_autoadd_round_plan_view(arr[2]),
+      tally: dco_decode_opt_box_autoadd_round_work_tally_view(arr[3]),
+      progress: dco_decode_opt_box_autoadd_round_step_progress_view(arr[4]),
+      disposition: dco_decode_opt_box_autoadd_round_step_disposition_view(
+        arr[5],
+      ),
+      failureKind: dco_decode_opt_box_autoadd_round_step_failure_kind_view(
+        arr[6],
+      ),
+      message: dco_decode_opt_String(arr[7]),
+      delaySeconds: dco_decode_opt_box_autoadd_f_64(arr[8]),
+      bundleIndex: dco_decode_opt_box_autoadd_u_32(arr[9]),
+    );
+  }
+
+  @protected
   RoundPlanActionKind dco_decode_round_plan_action_kind(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RoundPlanActionKind.values[raw as int];
@@ -11161,6 +11273,50 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RoundQuiescenceKind dco_decode_round_quiescence_kind(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return RoundQuiescenceKind.values[raw as int];
+  }
+
+  @protected
+  RoundQuiescenceView dco_decode_round_quiescence_view(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 8)
+      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    return RoundQuiescenceView(
+      kind: dco_decode_round_quiescence_kind(arr[0]),
+      openProposals: dco_decode_list_prim_u_32_strict(arr[1]),
+      unrosteredIntents: dco_decode_list_prim_u_32_strict(arr[2]),
+      bundles: dco_decode_list_prim_u_32_strict(arr[3]),
+      shares: dco_decode_list_share_key_view(arr[4]),
+      step: dco_decode_opt_box_autoadd_next_step_view(arr[5]),
+      chainOutcome: dco_decode_opt_box_autoadd_chain_submission_outcome_view(
+        arr[6],
+      ),
+      remaining: dco_decode_list_next_step_view(arr[7]),
+    );
+  }
+
+  @protected
+  RoundRunReportView dco_decode_round_run_report_view(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 8)
+      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    return RoundRunReportView(
+      quiescence: dco_decode_round_quiescence_view(arr[0]),
+      plan: dco_decode_opt_box_autoadd_round_plan_view(arr[1]),
+      tally: dco_decode_round_work_tally_view(arr[2]),
+      failures: dco_decode_list_round_step_failure_record_view(arr[3]),
+      skippedBundles: dco_decode_list_prim_u_32_strict(arr[4]),
+      chainOutcomes: dco_decode_list_round_chain_outcome_view(arr[5]),
+      shareDeliveries: dco_decode_list_share_batch_delivery_report_view(arr[6]),
+      delegations: dco_decode_list_signed_delegation_payload_view(arr[7]),
+    );
+  }
+
+  @protected
   RoundStepDispositionView dco_decode_round_step_disposition_view(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RoundStepDispositionView.values[raw as int];
@@ -11172,6 +11328,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RoundStepFailureKindView.values[raw as int];
+  }
+
+  @protected
+  RoundStepFailureRecordView dco_decode_round_step_failure_record_view(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return RoundStepFailureRecordView(
+      step: dco_decode_opt_box_autoadd_next_step_view(arr[0]),
+      bundleIndex: dco_decode_opt_box_autoadd_u_32(arr[1]),
+      failure: dco_decode_round_step_failure_view(arr[2]),
+    );
   }
 
   @protected
@@ -11193,26 +11364,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       message: dco_decode_String(arr[4]),
       plan: dco_decode_opt_box_autoadd_round_plan_view(arr[5]),
       shareDeliveries: dco_decode_list_share_batch_delivery_report_view(arr[6]),
-    );
-  }
-
-  @protected
-  RoundStepOutcomeView dco_decode_round_step_outcome_view(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 6)
-      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
-    return RoundStepOutcomeView(
-      step: dco_decode_opt_box_autoadd_next_step_view(arr[0]),
-      disposition: dco_decode_round_step_disposition_view(arr[1]),
-      chainOutcome: dco_decode_opt_box_autoadd_chain_submission_outcome_view(
-        arr[2],
-      ),
-      shareDeliveries: dco_decode_list_share_batch_delivery_report_view(arr[3]),
-      delegation: dco_decode_opt_box_autoadd_signed_delegation_payload_view(
-        arr[4],
-      ),
-      plan: dco_decode_round_plan_view(arr[5]),
     );
   }
 
@@ -11249,6 +11400,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dco_decode_opt_box_autoadd_share_batch_delivery_report_view(arr[10]),
       share: dco_decode_opt_box_autoadd_share_key_view(arr[11]),
       shareConfirmed: dco_decode_opt_box_autoadd_bool(arr[12]),
+    );
+  }
+
+  @protected
+  RoundWorkTallyView dco_decode_round_work_tally_view(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return RoundWorkTallyView(
+      completedProposals: dco_decode_u_32(arr[0]),
+      totalProposals: dco_decode_u_32(arr[1]),
+      remainingObligations: dco_decode_u_32(arr[2]),
     );
   }
 
@@ -12009,8 +12173,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RustStreamSink<ApiRoundStepEvent>
-  sse_decode_StreamSink_api_round_step_event_Sse(SseDeserializer deserializer) {
+  RustStreamSink<ApiRoundRunEvent>
+  sse_decode_StreamSink_api_round_run_event_Sse(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     throw UnimplementedError('Unreachable ()');
   }
@@ -12303,6 +12467,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ApiRoundDrivePolicy sse_decode_api_round_drive_policy(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_pendingRepollSeconds = sse_decode_opt_box_autoadd_f_64(
+      deserializer,
+    );
+    var var_maxBundleConcurrency = sse_decode_opt_box_autoadd_u_32(
+      deserializer,
+    );
+    var var_maxDispatches = sse_decode_opt_box_autoadd_u_32(deserializer);
+    var var_skipFailedBundle = sse_decode_opt_box_autoadd_bool(deserializer);
+    return ApiRoundDrivePolicy(
+      pendingRepollSeconds: var_pendingRepollSeconds,
+      maxBundleConcurrency: var_maxBundleConcurrency,
+      maxDispatches: var_maxDispatches,
+      skipFailedBundle: var_skipFailedBundle,
+    );
+  }
+
+  @protected
   ApiRoundHostContext sse_decode_api_round_host_context(
     SseDeserializer deserializer,
   ) {
@@ -12322,6 +12507,29 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       voteEndTimeSeconds: var_voteEndTimeSeconds,
       voteTreeNodeUrls: var_voteTreeNodeUrls,
       maxProofConcurrency: var_maxProofConcurrency,
+    );
+  }
+
+  @protected
+  ApiRoundRunEvent sse_decode_api_round_run_event(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_kind = sse_decode_api_round_step_event_kind(deserializer);
+    var var_event = sse_decode_opt_box_autoadd_round_drive_event_view(
+      deserializer,
+    );
+    var var_report = sse_decode_opt_box_autoadd_round_run_report_view(
+      deserializer,
+    );
+    var var_error = sse_decode_opt_box_autoadd_api_round_step_error(
+      deserializer,
+    );
+    return ApiRoundRunEvent(
+      kind: var_kind,
+      event: var_event,
+      report: var_report,
+      error: var_error,
     );
   }
 
@@ -12361,33 +12569,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       selectedNotes: var_selectedNotes,
       httpStatus: var_httpStatus,
       endpoint: var_endpoint,
-    );
-  }
-
-  @protected
-  ApiRoundStepEvent sse_decode_api_round_step_event(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_kind = sse_decode_api_round_step_event_kind(deserializer);
-    var var_progress = sse_decode_opt_box_autoadd_round_step_progress_view(
-      deserializer,
-    );
-    var var_outcome = sse_decode_opt_box_autoadd_round_step_outcome_view(
-      deserializer,
-    );
-    var var_failure = sse_decode_opt_box_autoadd_round_step_failure_view(
-      deserializer,
-    );
-    var var_error = sse_decode_opt_box_autoadd_api_round_step_error(
-      deserializer,
-    );
-    return ApiRoundStepEvent(
-      kind: var_kind,
-      progress: var_progress,
-      outcome: var_outcome,
-      failure: var_failure,
-      error: var_error,
     );
   }
 
@@ -12592,6 +12773,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ApiRoundDrivePolicy sse_decode_box_autoadd_api_round_drive_policy(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_api_round_drive_policy(deserializer));
+  }
+
+  @protected
   ApiRoundHostContext sse_decode_box_autoadd_api_round_host_context(
     SseDeserializer deserializer,
   ) {
@@ -12751,6 +12940,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RoundDriveEventView sse_decode_box_autoadd_round_drive_event_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_round_drive_event_view(deserializer));
+  }
+
+  @protected
   RoundPlanView sse_decode_box_autoadd_round_plan_view(
     SseDeserializer deserializer,
   ) {
@@ -12759,19 +12956,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RoundStepFailureView sse_decode_box_autoadd_round_step_failure_view(
+  RoundRunReportView sse_decode_box_autoadd_round_run_report_view(
     SseDeserializer deserializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_round_step_failure_view(deserializer));
+    return (sse_decode_round_run_report_view(deserializer));
   }
 
   @protected
-  RoundStepOutcomeView sse_decode_box_autoadd_round_step_outcome_view(
+  RoundStepDispositionView sse_decode_box_autoadd_round_step_disposition_view(
     SseDeserializer deserializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_round_step_outcome_view(deserializer));
+    return (sse_decode_round_step_disposition_view(deserializer));
+  }
+
+  @protected
+  RoundStepFailureKindView sse_decode_box_autoadd_round_step_failure_kind_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_round_step_failure_kind_view(deserializer));
   }
 
   @protected
@@ -12780,6 +12985,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_round_step_progress_view(deserializer));
+  }
+
+  @protected
+  RoundWorkTallyView sse_decode_box_autoadd_round_work_tally_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_round_work_tally_view(deserializer));
   }
 
   @protected
@@ -12797,15 +13010,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_share_key_view(deserializer));
-  }
-
-  @protected
-  SignedDelegationPayloadView
-  sse_decode_box_autoadd_signed_delegation_payload_view(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_signed_delegation_payload_view(deserializer));
   }
 
   @protected
@@ -13956,6 +14160,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<RoundChainOutcomeView> sse_decode_list_round_chain_outcome_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <RoundChainOutcomeView>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_round_chain_outcome_view(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<RoundStepFailureRecordView>
+  sse_decode_list_round_step_failure_record_view(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <RoundStepFailureRecordView>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_round_step_failure_record_view(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<ScanRangeInfo> sse_decode_list_scan_range_info(
     SseDeserializer deserializer,
   ) {
@@ -14008,6 +14239,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var ans_ = <ShareDeliveryOutcomeView>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_share_delivery_outcome_view(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<ShareKeyView> sse_decode_list_share_key_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <ShareKeyView>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_share_key_view(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<SignedDelegationPayloadView>
+  sse_decode_list_signed_delegation_payload_view(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <SignedDelegationPayloadView>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_signed_delegation_payload_view(deserializer));
     }
     return ans_;
   }
@@ -14549,6 +14807,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ApiRoundDrivePolicy? sse_decode_opt_box_autoadd_api_round_drive_policy(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_api_round_drive_policy(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   ApiRoundStepError? sse_decode_opt_box_autoadd_api_round_step_error(
     SseDeserializer deserializer,
   ) {
@@ -14783,6 +15054,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RoundDriveEventView? sse_decode_opt_box_autoadd_round_drive_event_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_round_drive_event_view(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   RoundPlanView? sse_decode_opt_box_autoadd_round_plan_view(
     SseDeserializer deserializer,
   ) {
@@ -14796,26 +15080,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RoundStepFailureView? sse_decode_opt_box_autoadd_round_step_failure_view(
+  RoundRunReportView? sse_decode_opt_box_autoadd_round_run_report_view(
     SseDeserializer deserializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
     if (sse_decode_bool(deserializer)) {
-      return (sse_decode_box_autoadd_round_step_failure_view(deserializer));
+      return (sse_decode_box_autoadd_round_run_report_view(deserializer));
     } else {
       return null;
     }
   }
 
   @protected
-  RoundStepOutcomeView? sse_decode_opt_box_autoadd_round_step_outcome_view(
+  RoundStepDispositionView?
+  sse_decode_opt_box_autoadd_round_step_disposition_view(
     SseDeserializer deserializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
     if (sse_decode_bool(deserializer)) {
-      return (sse_decode_box_autoadd_round_step_outcome_view(deserializer));
+      return (sse_decode_box_autoadd_round_step_disposition_view(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  RoundStepFailureKindView?
+  sse_decode_opt_box_autoadd_round_step_failure_kind_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_round_step_failure_kind_view(
+        deserializer,
+      ));
     } else {
       return null;
     }
@@ -14829,6 +15130,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_box_autoadd_round_step_progress_view(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  RoundWorkTallyView? sse_decode_opt_box_autoadd_round_work_tally_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_round_work_tally_view(deserializer));
     } else {
       return null;
     }
@@ -14858,22 +15172,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_box_autoadd_share_key_view(deserializer));
-    } else {
-      return null;
-    }
-  }
-
-  @protected
-  SignedDelegationPayloadView?
-  sse_decode_opt_box_autoadd_signed_delegation_payload_view(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-
-    if (sse_decode_bool(deserializer)) {
-      return (sse_decode_box_autoadd_signed_delegation_payload_view(
-        deserializer,
-      ));
     } else {
       return null;
     }
@@ -15105,6 +15403,60 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RoundChainOutcomeView sse_decode_round_chain_outcome_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_step = sse_decode_next_step_view(deserializer);
+    var var_outcome = sse_decode_chain_submission_outcome_view(deserializer);
+    return RoundChainOutcomeView(step: var_step, outcome: var_outcome);
+  }
+
+  @protected
+  RoundDriveEventKind sse_decode_round_drive_event_kind(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return RoundDriveEventKind.values[inner];
+  }
+
+  @protected
+  RoundDriveEventView sse_decode_round_drive_event_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_kind = sse_decode_round_drive_event_kind(deserializer);
+    var var_step = sse_decode_opt_box_autoadd_next_step_view(deserializer);
+    var var_plan = sse_decode_opt_box_autoadd_round_plan_view(deserializer);
+    var var_tally = sse_decode_opt_box_autoadd_round_work_tally_view(
+      deserializer,
+    );
+    var var_progress = sse_decode_opt_box_autoadd_round_step_progress_view(
+      deserializer,
+    );
+    var var_disposition =
+        sse_decode_opt_box_autoadd_round_step_disposition_view(deserializer);
+    var var_failureKind =
+        sse_decode_opt_box_autoadd_round_step_failure_kind_view(deserializer);
+    var var_message = sse_decode_opt_String(deserializer);
+    var var_delaySeconds = sse_decode_opt_box_autoadd_f_64(deserializer);
+    var var_bundleIndex = sse_decode_opt_box_autoadd_u_32(deserializer);
+    return RoundDriveEventView(
+      kind: var_kind,
+      step: var_step,
+      plan: var_plan,
+      tally: var_tally,
+      progress: var_progress,
+      disposition: var_disposition,
+      failureKind: var_failureKind,
+      message: var_message,
+      delaySeconds: var_delaySeconds,
+      bundleIndex: var_bundleIndex,
+    );
+  }
+
+  @protected
   RoundPlanActionKind sse_decode_round_plan_action_kind(
     SseDeserializer deserializer,
   ) {
@@ -15181,6 +15533,74 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RoundQuiescenceKind sse_decode_round_quiescence_kind(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return RoundQuiescenceKind.values[inner];
+  }
+
+  @protected
+  RoundQuiescenceView sse_decode_round_quiescence_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_kind = sse_decode_round_quiescence_kind(deserializer);
+    var var_openProposals = sse_decode_list_prim_u_32_strict(deserializer);
+    var var_unrosteredIntents = sse_decode_list_prim_u_32_strict(deserializer);
+    var var_bundles = sse_decode_list_prim_u_32_strict(deserializer);
+    var var_shares = sse_decode_list_share_key_view(deserializer);
+    var var_step = sse_decode_opt_box_autoadd_next_step_view(deserializer);
+    var var_chainOutcome =
+        sse_decode_opt_box_autoadd_chain_submission_outcome_view(deserializer);
+    var var_remaining = sse_decode_list_next_step_view(deserializer);
+    return RoundQuiescenceView(
+      kind: var_kind,
+      openProposals: var_openProposals,
+      unrosteredIntents: var_unrosteredIntents,
+      bundles: var_bundles,
+      shares: var_shares,
+      step: var_step,
+      chainOutcome: var_chainOutcome,
+      remaining: var_remaining,
+    );
+  }
+
+  @protected
+  RoundRunReportView sse_decode_round_run_report_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_quiescence = sse_decode_round_quiescence_view(deserializer);
+    var var_plan = sse_decode_opt_box_autoadd_round_plan_view(deserializer);
+    var var_tally = sse_decode_round_work_tally_view(deserializer);
+    var var_failures = sse_decode_list_round_step_failure_record_view(
+      deserializer,
+    );
+    var var_skippedBundles = sse_decode_list_prim_u_32_strict(deserializer);
+    var var_chainOutcomes = sse_decode_list_round_chain_outcome_view(
+      deserializer,
+    );
+    var var_shareDeliveries = sse_decode_list_share_batch_delivery_report_view(
+      deserializer,
+    );
+    var var_delegations = sse_decode_list_signed_delegation_payload_view(
+      deserializer,
+    );
+    return RoundRunReportView(
+      quiescence: var_quiescence,
+      plan: var_plan,
+      tally: var_tally,
+      failures: var_failures,
+      skippedBundles: var_skippedBundles,
+      chainOutcomes: var_chainOutcomes,
+      shareDeliveries: var_shareDeliveries,
+      delegations: var_delegations,
+    );
+  }
+
+  @protected
   RoundStepDispositionView sse_decode_round_step_disposition_view(
     SseDeserializer deserializer,
   ) {
@@ -15196,6 +15616,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_32(deserializer);
     return RoundStepFailureKindView.values[inner];
+  }
+
+  @protected
+  RoundStepFailureRecordView sse_decode_round_step_failure_record_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_step = sse_decode_opt_box_autoadd_next_step_view(deserializer);
+    var var_bundleIndex = sse_decode_opt_box_autoadd_u_32(deserializer);
+    var var_failure = sse_decode_round_step_failure_view(deserializer);
+    return RoundStepFailureRecordView(
+      step: var_step,
+      bundleIndex: var_bundleIndex,
+      failure: var_failure,
+    );
   }
 
   @protected
@@ -15224,31 +15659,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       message: var_message,
       plan: var_plan,
       shareDeliveries: var_shareDeliveries,
-    );
-  }
-
-  @protected
-  RoundStepOutcomeView sse_decode_round_step_outcome_view(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_step = sse_decode_opt_box_autoadd_next_step_view(deserializer);
-    var var_disposition = sse_decode_round_step_disposition_view(deserializer);
-    var var_chainOutcome =
-        sse_decode_opt_box_autoadd_chain_submission_outcome_view(deserializer);
-    var var_shareDeliveries = sse_decode_list_share_batch_delivery_report_view(
-      deserializer,
-    );
-    var var_delegation =
-        sse_decode_opt_box_autoadd_signed_delegation_payload_view(deserializer);
-    var var_plan = sse_decode_round_plan_view(deserializer);
-    return RoundStepOutcomeView(
-      step: var_step,
-      disposition: var_disposition,
-      chainOutcome: var_chainOutcome,
-      shareDeliveries: var_shareDeliveries,
-      delegation: var_delegation,
-      plan: var_plan,
     );
   }
 
@@ -15300,6 +15710,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       shareDelivery: var_shareDelivery,
       share: var_share,
       shareConfirmed: var_shareConfirmed,
+    );
+  }
+
+  @protected
+  RoundWorkTallyView sse_decode_round_work_tally_view(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_completedProposals = sse_decode_u_32(deserializer);
+    var var_totalProposals = sse_decode_u_32(deserializer);
+    var var_remainingObligations = sse_decode_u_32(deserializer);
+    return RoundWorkTallyView(
+      completedProposals: var_completedProposals,
+      totalProposals: var_totalProposals,
+      remainingObligations: var_remainingObligations,
     );
   }
 
@@ -16202,15 +16627,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_StreamSink_api_round_step_event_Sse(
-    RustStreamSink<ApiRoundStepEvent> self,
+  void sse_encode_StreamSink_api_round_run_event_Sse(
+    RustStreamSink<ApiRoundRunEvent> self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(
       self.setupAndSerialize(
         codec: SseCodec(
-          decodeSuccessData: sse_decode_api_round_step_event,
+          decodeSuccessData: sse_decode_api_round_run_event,
           decodeErrorData: sse_decode_AnyhowException,
         ),
       ),
@@ -16449,6 +16874,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_api_round_drive_policy(
+    ApiRoundDrivePolicy self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_opt_box_autoadd_f_64(self.pendingRepollSeconds, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.maxBundleConcurrency, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.maxDispatches, serializer);
+    sse_encode_opt_box_autoadd_bool(self.skipFailedBundle, serializer);
+  }
+
+  @protected
   void sse_encode_api_round_host_context(
     ApiRoundHostContext self,
     SseSerializer serializer,
@@ -16460,6 +16897,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_box_autoadd_u_64(self.voteEndTimeSeconds, serializer);
     sse_encode_list_String(self.voteTreeNodeUrls, serializer);
     sse_encode_u_32(self.maxProofConcurrency, serializer);
+  }
+
+  @protected
+  void sse_encode_api_round_run_event(
+    ApiRoundRunEvent self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_api_round_step_event_kind(self.kind, serializer);
+    sse_encode_opt_box_autoadd_round_drive_event_view(self.event, serializer);
+    sse_encode_opt_box_autoadd_round_run_report_view(self.report, serializer);
+    sse_encode_opt_box_autoadd_api_round_step_error(self.error, serializer);
   }
 
   @protected
@@ -16483,28 +16932,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_box_autoadd_u_32(self.selectedNotes, serializer);
     sse_encode_opt_box_autoadd_u_16(self.httpStatus, serializer);
     sse_encode_opt_String(self.endpoint, serializer);
-  }
-
-  @protected
-  void sse_encode_api_round_step_event(
-    ApiRoundStepEvent self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_api_round_step_event_kind(self.kind, serializer);
-    sse_encode_opt_box_autoadd_round_step_progress_view(
-      self.progress,
-      serializer,
-    );
-    sse_encode_opt_box_autoadd_round_step_outcome_view(
-      self.outcome,
-      serializer,
-    );
-    sse_encode_opt_box_autoadd_round_step_failure_view(
-      self.failure,
-      serializer,
-    );
-    sse_encode_opt_box_autoadd_api_round_step_error(self.error, serializer);
   }
 
   @protected
@@ -16647,6 +17074,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_api_delegation_signer_input(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_api_round_drive_policy(
+    ApiRoundDrivePolicy self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_api_round_drive_policy(self, serializer);
   }
 
   @protected
@@ -16824,6 +17260,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_round_drive_event_view(
+    RoundDriveEventView self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_round_drive_event_view(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_round_plan_view(
     RoundPlanView self,
     SseSerializer serializer,
@@ -16833,21 +17278,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_box_autoadd_round_step_failure_view(
-    RoundStepFailureView self,
+  void sse_encode_box_autoadd_round_run_report_view(
+    RoundRunReportView self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_round_step_failure_view(self, serializer);
+    sse_encode_round_run_report_view(self, serializer);
   }
 
   @protected
-  void sse_encode_box_autoadd_round_step_outcome_view(
-    RoundStepOutcomeView self,
+  void sse_encode_box_autoadd_round_step_disposition_view(
+    RoundStepDispositionView self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_round_step_outcome_view(self, serializer);
+    sse_encode_round_step_disposition_view(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_round_step_failure_kind_view(
+    RoundStepFailureKindView self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_round_step_failure_kind_view(self, serializer);
   }
 
   @protected
@@ -16857,6 +17311,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_round_step_progress_view(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_round_work_tally_view(
+    RoundWorkTallyView self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_round_work_tally_view(self, serializer);
   }
 
   @protected
@@ -16875,15 +17338,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_share_key_view(self, serializer);
-  }
-
-  @protected
-  void sse_encode_box_autoadd_signed_delegation_payload_view(
-    SignedDelegationPayloadView self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_signed_delegation_payload_view(self, serializer);
   }
 
   @protected
@@ -17853,6 +18307,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_round_chain_outcome_view(
+    List<RoundChainOutcomeView> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_round_chain_outcome_view(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_round_step_failure_record_view(
+    List<RoundStepFailureRecordView> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_round_step_failure_record_view(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_scan_range_info(
     List<ScanRangeInfo> self,
     SseSerializer serializer,
@@ -17897,6 +18375,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
       sse_encode_share_delivery_outcome_view(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_share_key_view(
+    List<ShareKeyView> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_share_key_view(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_signed_delegation_payload_view(
+    List<SignedDelegationPayloadView> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_signed_delegation_payload_view(item, serializer);
     }
   }
 
@@ -18302,6 +18804,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_opt_box_autoadd_api_round_drive_policy(
+    ApiRoundDrivePolicy? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_api_round_drive_policy(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_opt_box_autoadd_api_round_step_error(
     ApiRoundStepError? self,
     SseSerializer serializer,
@@ -18520,6 +19035,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_opt_box_autoadd_round_drive_event_view(
+    RoundDriveEventView? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_round_drive_event_view(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_opt_box_autoadd_round_plan_view(
     RoundPlanView? self,
     SseSerializer serializer,
@@ -18533,28 +19061,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_opt_box_autoadd_round_step_failure_view(
-    RoundStepFailureView? self,
+  void sse_encode_opt_box_autoadd_round_run_report_view(
+    RoundRunReportView? self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
     sse_encode_bool(self != null, serializer);
     if (self != null) {
-      sse_encode_box_autoadd_round_step_failure_view(self, serializer);
+      sse_encode_box_autoadd_round_run_report_view(self, serializer);
     }
   }
 
   @protected
-  void sse_encode_opt_box_autoadd_round_step_outcome_view(
-    RoundStepOutcomeView? self,
+  void sse_encode_opt_box_autoadd_round_step_disposition_view(
+    RoundStepDispositionView? self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
     sse_encode_bool(self != null, serializer);
     if (self != null) {
-      sse_encode_box_autoadd_round_step_outcome_view(self, serializer);
+      sse_encode_box_autoadd_round_step_disposition_view(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_round_step_failure_kind_view(
+    RoundStepFailureKindView? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_round_step_failure_kind_view(self, serializer);
     }
   }
 
@@ -18568,6 +19109,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_round_step_progress_view(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_round_work_tally_view(
+    RoundWorkTallyView? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_round_work_tally_view(self, serializer);
     }
   }
 
@@ -18594,19 +19148,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_share_key_view(self, serializer);
-    }
-  }
-
-  @protected
-  void sse_encode_opt_box_autoadd_signed_delegation_payload_view(
-    SignedDelegationPayloadView? self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-
-    sse_encode_bool(self != null, serializer);
-    if (self != null) {
-      sse_encode_box_autoadd_signed_delegation_payload_view(self, serializer);
     }
   }
 
@@ -18786,6 +19327,52 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_round_chain_outcome_view(
+    RoundChainOutcomeView self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_next_step_view(self.step, serializer);
+    sse_encode_chain_submission_outcome_view(self.outcome, serializer);
+  }
+
+  @protected
+  void sse_encode_round_drive_event_kind(
+    RoundDriveEventKind self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_round_drive_event_view(
+    RoundDriveEventView self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_round_drive_event_kind(self.kind, serializer);
+    sse_encode_opt_box_autoadd_next_step_view(self.step, serializer);
+    sse_encode_opt_box_autoadd_round_plan_view(self.plan, serializer);
+    sse_encode_opt_box_autoadd_round_work_tally_view(self.tally, serializer);
+    sse_encode_opt_box_autoadd_round_step_progress_view(
+      self.progress,
+      serializer,
+    );
+    sse_encode_opt_box_autoadd_round_step_disposition_view(
+      self.disposition,
+      serializer,
+    );
+    sse_encode_opt_box_autoadd_round_step_failure_kind_view(
+      self.failureKind,
+      serializer,
+    );
+    sse_encode_opt_String(self.message, serializer);
+    sse_encode_opt_box_autoadd_f_64(self.delaySeconds, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.bundleIndex, serializer);
+  }
+
+  @protected
   void sse_encode_round_plan_action_kind(
     RoundPlanActionKind self,
     SseSerializer serializer,
@@ -18838,6 +19425,56 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_round_quiescence_kind(
+    RoundQuiescenceKind self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_round_quiescence_view(
+    RoundQuiescenceView self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_round_quiescence_kind(self.kind, serializer);
+    sse_encode_list_prim_u_32_strict(self.openProposals, serializer);
+    sse_encode_list_prim_u_32_strict(self.unrosteredIntents, serializer);
+    sse_encode_list_prim_u_32_strict(self.bundles, serializer);
+    sse_encode_list_share_key_view(self.shares, serializer);
+    sse_encode_opt_box_autoadd_next_step_view(self.step, serializer);
+    sse_encode_opt_box_autoadd_chain_submission_outcome_view(
+      self.chainOutcome,
+      serializer,
+    );
+    sse_encode_list_next_step_view(self.remaining, serializer);
+  }
+
+  @protected
+  void sse_encode_round_run_report_view(
+    RoundRunReportView self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_round_quiescence_view(self.quiescence, serializer);
+    sse_encode_opt_box_autoadd_round_plan_view(self.plan, serializer);
+    sse_encode_round_work_tally_view(self.tally, serializer);
+    sse_encode_list_round_step_failure_record_view(self.failures, serializer);
+    sse_encode_list_prim_u_32_strict(self.skippedBundles, serializer);
+    sse_encode_list_round_chain_outcome_view(self.chainOutcomes, serializer);
+    sse_encode_list_share_batch_delivery_report_view(
+      self.shareDeliveries,
+      serializer,
+    );
+    sse_encode_list_signed_delegation_payload_view(
+      self.delegations,
+      serializer,
+    );
+  }
+
+  @protected
   void sse_encode_round_step_disposition_view(
     RoundStepDispositionView self,
     SseSerializer serializer,
@@ -18853,6 +19490,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_round_step_failure_record_view(
+    RoundStepFailureRecordView self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_opt_box_autoadd_next_step_view(self.step, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.bundleIndex, serializer);
+    sse_encode_round_step_failure_view(self.failure, serializer);
   }
 
   @protected
@@ -18877,29 +19525,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       self.shareDeliveries,
       serializer,
     );
-  }
-
-  @protected
-  void sse_encode_round_step_outcome_view(
-    RoundStepOutcomeView self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_opt_box_autoadd_next_step_view(self.step, serializer);
-    sse_encode_round_step_disposition_view(self.disposition, serializer);
-    sse_encode_opt_box_autoadd_chain_submission_outcome_view(
-      self.chainOutcome,
-      serializer,
-    );
-    sse_encode_list_share_batch_delivery_report_view(
-      self.shareDeliveries,
-      serializer,
-    );
-    sse_encode_opt_box_autoadd_signed_delegation_payload_view(
-      self.delegation,
-      serializer,
-    );
-    sse_encode_round_plan_view(self.plan, serializer);
   }
 
   @protected
@@ -18942,6 +19567,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     );
     sse_encode_opt_box_autoadd_share_key_view(self.share, serializer);
     sse_encode_opt_box_autoadd_bool(self.shareConfirmed, serializer);
+  }
+
+  @protected
+  void sse_encode_round_work_tally_view(
+    RoundWorkTallyView self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_32(self.completedProposals, serializer);
+    sse_encode_u_32(self.totalProposals, serializer);
+    sse_encode_u_32(self.remainingObligations, serializer);
   }
 
   @protected
@@ -19542,34 +20178,6 @@ class VotingRoundSessionImpl extends RustOpaque implements VotingRoundSession {
         .rust_arc_decrement_strong_count_VotingRoundSessionPtr,
   );
 
-  /// Runs the first planned step, streaming progress then one result.
-  ///
-  /// See [`VotingRoundSession::advance`] for why this reports failures on
-  /// the sink instead of returning them.
-  Stream<ApiRoundStepEvent> advanceNext({
-    required ApiRoundHostContext host,
-    ApiDelegationSignerInput? signer,
-  }) => RustLib.instance.api.crateApiVotingSessionVotingRoundSessionAdvanceNext(
-    that: this,
-    host: host,
-    signer: signer,
-  );
-
-  /// Runs one planned step, streaming progress then one result.
-  ///
-  /// See [`VotingRoundSession::advance`] for why this reports failures on
-  /// the sink instead of returning them.
-  Stream<ApiRoundStepEvent> advanceStep({
-    required NextStepView step,
-    required ApiRoundHostContext host,
-    ApiDelegationSignerInput? signer,
-  }) => RustLib.instance.api.crateApiVotingSessionVotingRoundSessionAdvanceStep(
-    that: this,
-    step: step,
-    host: host,
-    signer: signer,
-  );
-
   /// Cancellation handle for one helper-share tracking pass on this round.
   ///
   /// Tracking passes are cancelled by the destructive drain independently
@@ -19617,6 +20225,27 @@ class VotingRoundSessionImpl extends RustOpaque implements VotingRoundSession {
   /// Plans the round from durable state.
   Future<RoundPlanView> plan() => RustLib.instance.api
       .crateApiVotingSessionVotingRoundSessionPlan(that: this);
+
+  /// Drives the bound round to quiescence, streaming events then one report.
+  ///
+  /// Emits exactly one `Result` event for the reason [`Self::advance`]
+  /// documents: a streaming function's `Err` return never reaches Dart.
+  ///
+  /// `host` is a template. The driver reads the host context once per
+  /// dispatch and this bridge restamps `now_seconds` each time, because a
+  /// run can take minutes and a long proof can cross the last-moment or
+  /// vote-end boundary. Every other field is fixed for the run, so a helper
+  /// fleet that changes mid-run needs a new call.
+  Stream<ApiRoundRunEvent> runRound({
+    required ApiRoundHostContext host,
+    ApiDelegationSignerInput? signer,
+    ApiRoundDrivePolicy? policy,
+  }) => RustLib.instance.api.crateApiVotingSessionVotingRoundSessionRunRound(
+    that: this,
+    host: host,
+    signer: signer,
+    policy: policy,
+  );
 
   /// Records ballot decisions against the bound roster and re-plans.
   Future<RoundPlanView> setBallotIntents({

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 444974405;
+  int get rustContentHash => -1745036447;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -1005,12 +1005,6 @@ abstract class RustLibApi extends BaseApi {
     required String treeStateOrchardTree,
     required String treeStateIronwoodTree,
     required BigInt limit,
-  });
-
-  String? crateApiVotingSelectPirSnapshotEndpoint({
-    required List<ApiPirSnapshotEndpointDiagnostic> diagnostics,
-    required BigInt expectedSnapshotHeight,
-    required BigInt matchIndex,
   });
 
   void crateApiSyncSetActiveSyncAccount({String? accountUuid});
@@ -7333,45 +7327,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
-  String? crateApiVotingSelectPirSnapshotEndpoint({
-    required List<ApiPirSnapshotEndpointDiagnostic> diagnostics,
-    required BigInt expectedSnapshotHeight,
-    required BigInt matchIndex,
-  }) {
-    return handler.executeSync(
-      SyncTask(
-        callFfi: () {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_list_api_pir_snapshot_endpoint_diagnostic(
-            diagnostics,
-            serializer,
-          );
-          sse_encode_u_64(expectedSnapshotHeight, serializer);
-          sse_encode_u_64(matchIndex, serializer);
-          return pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 148,
-          )!;
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_opt_String,
-          decodeErrorData: sse_decode_voting_error_view,
-        ),
-        constMeta: kCrateApiVotingSelectPirSnapshotEndpointConstMeta,
-        argValues: [diagnostics, expectedSnapshotHeight, matchIndex],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiVotingSelectPirSnapshotEndpointConstMeta =>
-      const TaskConstMeta(
-        debugName: "select_pir_snapshot_endpoint",
-        argNames: ["diagnostics", "expectedSnapshotHeight", "matchIndex"],
-      );
-
-  @override
   void crateApiSyncSetActiveSyncAccount({String? accountUuid}) {
     return handler.executeSync(
       SyncTask(
@@ -7381,7 +7336,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 148,
           )!;
         },
         codec: SseCodec(
@@ -7425,7 +7380,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7472,7 +7427,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 150,
           )!;
         },
         codec: SseCodec(
@@ -7502,7 +7457,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 151,
           )!;
         },
         codec: SseCodec(
@@ -7537,7 +7492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7570,7 +7525,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7611,7 +7566,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7665,7 +7620,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 155,
             port: port_,
           );
         },
@@ -7715,7 +7670,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 157,
+              funcId: 156,
               port: port_,
             );
           },
@@ -7756,7 +7711,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 158,
+              funcId: 157,
               port: port_,
             );
           },
@@ -7788,7 +7743,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7815,7 +7770,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 159,
           )!;
         },
         codec: SseCodec(
@@ -7841,7 +7796,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 160,
             port: port_,
           );
         },
@@ -7888,7 +7843,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 161,
             port: port_,
           );
         },
@@ -7961,7 +7916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 162,
             port: port_,
           );
         },
@@ -8023,7 +7978,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8058,7 +8013,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 164,
             port: port_,
           );
         },
@@ -8097,7 +8052,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 165,
             port: port_,
           );
         },
@@ -8126,7 +8081,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 166,
           )!;
         },
         codec: SseCodec(
@@ -8153,7 +8108,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 167,
           )!;
         },
         codec: SseCodec(
@@ -8189,7 +8144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8228,7 +8183,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8269,7 +8224,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8317,7 +8272,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 171,
             port: port_,
           );
         },
@@ -8371,7 +8326,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8421,7 +8376,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 173,
             port: port_,
           );
         },
@@ -8453,7 +8408,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 174,
             port: port_,
           );
         },
@@ -8481,7 +8436,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 175,
           )!;
         },
         codec: SseCodec(
@@ -8511,7 +8466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 176,
           )!;
         },
         codec: SseCodec(
@@ -8537,7 +8492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 178,
+            funcId: 177,
           )!;
         },
         codec: SseCodec(
@@ -8583,7 +8538,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 179,
+            funcId: 178,
             port: port_,
           );
         },
@@ -8631,7 +8586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 180,
+            funcId: 179,
           )!;
         },
         codec: SseCodec(
@@ -8665,7 +8620,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 181,
+            funcId: 180,
             port: port_,
           );
         },
@@ -8702,7 +8657,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 182,
+            funcId: 181,
             port: port_,
           );
         },

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -175,6 +175,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ApiPirSnapshotResolution dco_decode_api_pir_snapshot_resolution(dynamic raw);
+
+  @protected
   ApiProposalRosterEntry dco_decode_api_proposal_roster_entry(dynamic raw);
 
   @protected
@@ -1327,6 +1330,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiPirSnapshotEndpointStatus sse_decode_api_pir_snapshot_endpoint_status(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ApiPirSnapshotResolution sse_decode_api_pir_snapshot_resolution(
     SseDeserializer deserializer,
   );
 
@@ -2799,6 +2807,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_api_pir_snapshot_endpoint_status(
     ApiPirSnapshotEndpointStatus self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_api_pir_snapshot_resolution(
+    ApiPirSnapshotResolution self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -105,8 +105,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_StreamSink_api_mempool_tx_event_Sse(dynamic raw);
 
   @protected
-  RustStreamSink<ApiRoundStepEvent>
-  dco_decode_StreamSink_api_round_step_event_Sse(dynamic raw);
+  RustStreamSink<ApiRoundRunEvent>
+  dco_decode_StreamSink_api_round_run_event_Sse(dynamic raw);
 
   @protected
   RustStreamSink<ApiSyncProgressEvent>
@@ -181,13 +181,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ApiResubmittedShare dco_decode_api_resubmitted_share(dynamic raw);
 
   @protected
+  ApiRoundDrivePolicy dco_decode_api_round_drive_policy(dynamic raw);
+
+  @protected
   ApiRoundHostContext dco_decode_api_round_host_context(dynamic raw);
 
   @protected
-  ApiRoundStepError dco_decode_api_round_step_error(dynamic raw);
+  ApiRoundRunEvent dco_decode_api_round_run_event(dynamic raw);
 
   @protected
-  ApiRoundStepEvent dco_decode_api_round_step_event(dynamic raw);
+  ApiRoundStepError dco_decode_api_round_step_error(dynamic raw);
 
   @protected
   ApiRoundStepEventKind dco_decode_api_round_step_event_kind(dynamic raw);
@@ -227,6 +230,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiDelegationSignerInput dco_decode_box_autoadd_api_delegation_signer_input(
+    dynamic raw,
+  );
+
+  @protected
+  ApiRoundDrivePolicy dco_decode_box_autoadd_api_round_drive_policy(
     dynamic raw,
   );
 
@@ -310,15 +318,23 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RoundPlanView dco_decode_box_autoadd_round_plan_view(dynamic raw);
-
-  @protected
-  RoundStepFailureView dco_decode_box_autoadd_round_step_failure_view(
+  RoundDriveEventView dco_decode_box_autoadd_round_drive_event_view(
     dynamic raw,
   );
 
   @protected
-  RoundStepOutcomeView dco_decode_box_autoadd_round_step_outcome_view(
+  RoundPlanView dco_decode_box_autoadd_round_plan_view(dynamic raw);
+
+  @protected
+  RoundRunReportView dco_decode_box_autoadd_round_run_report_view(dynamic raw);
+
+  @protected
+  RoundStepDispositionView dco_decode_box_autoadd_round_step_disposition_view(
+    dynamic raw,
+  );
+
+  @protected
+  RoundStepFailureKindView dco_decode_box_autoadd_round_step_failure_kind_view(
     dynamic raw,
   );
 
@@ -328,15 +344,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RoundWorkTallyView dco_decode_box_autoadd_round_work_tally_view(dynamic raw);
+
+  @protected
   ShareBatchDeliveryReportView
   dco_decode_box_autoadd_share_batch_delivery_report_view(dynamic raw);
 
   @protected
   ShareKeyView dco_decode_box_autoadd_share_key_view(dynamic raw);
-
-  @protected
-  SignedDelegationPayloadView
-  dco_decode_box_autoadd_signed_delegation_payload_view(dynamic raw);
 
   @protected
   SubmissionDiagnosticView dco_decode_box_autoadd_submission_diagnostic_view(
@@ -654,6 +669,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
+  List<RoundChainOutcomeView> dco_decode_list_round_chain_outcome_view(
+    dynamic raw,
+  );
+
+  @protected
+  List<RoundStepFailureRecordView>
+  dco_decode_list_round_step_failure_record_view(dynamic raw);
+
+  @protected
   List<ScanRangeInfo> dco_decode_list_scan_range_info(dynamic raw);
 
   @protected
@@ -667,6 +691,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<ShareDeliveryOutcomeView> dco_decode_list_share_delivery_outcome_view(
     dynamic raw,
   );
+
+  @protected
+  List<ShareKeyView> dco_decode_list_share_key_view(dynamic raw);
+
+  @protected
+  List<SignedDelegationPayloadView>
+  dco_decode_list_signed_delegation_payload_view(dynamic raw);
 
   @protected
   List<SoftwareWalletDiscoveredAccount>
@@ -781,6 +812,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_opt_box_autoadd_api_delegation_signer_input(dynamic raw);
 
   @protected
+  ApiRoundDrivePolicy? dco_decode_opt_box_autoadd_api_round_drive_policy(
+    dynamic raw,
+  );
+
+  @protected
   ApiRoundStepError? dco_decode_opt_box_autoadd_api_round_step_error(
     dynamic raw,
   );
@@ -851,20 +887,33 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RoundDriveEventView? dco_decode_opt_box_autoadd_round_drive_event_view(
+    dynamic raw,
+  );
+
+  @protected
   RoundPlanView? dco_decode_opt_box_autoadd_round_plan_view(dynamic raw);
 
   @protected
-  RoundStepFailureView? dco_decode_opt_box_autoadd_round_step_failure_view(
+  RoundRunReportView? dco_decode_opt_box_autoadd_round_run_report_view(
     dynamic raw,
   );
 
   @protected
-  RoundStepOutcomeView? dco_decode_opt_box_autoadd_round_step_outcome_view(
-    dynamic raw,
-  );
+  RoundStepDispositionView?
+  dco_decode_opt_box_autoadd_round_step_disposition_view(dynamic raw);
+
+  @protected
+  RoundStepFailureKindView?
+  dco_decode_opt_box_autoadd_round_step_failure_kind_view(dynamic raw);
 
   @protected
   RoundStepProgressView? dco_decode_opt_box_autoadd_round_step_progress_view(
+    dynamic raw,
+  );
+
+  @protected
+  RoundWorkTallyView? dco_decode_opt_box_autoadd_round_work_tally_view(
     dynamic raw,
   );
 
@@ -874,10 +923,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ShareKeyView? dco_decode_opt_box_autoadd_share_key_view(dynamic raw);
-
-  @protected
-  SignedDelegationPayloadView?
-  dco_decode_opt_box_autoadd_signed_delegation_payload_view(dynamic raw);
 
   @protected
   SubmissionDiagnosticView?
@@ -927,10 +972,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ResolvedVotingConfig dco_decode_resolved_voting_config(dynamic raw);
 
   @protected
+  RoundChainOutcomeView dco_decode_round_chain_outcome_view(dynamic raw);
+
+  @protected
+  RoundDriveEventKind dco_decode_round_drive_event_kind(dynamic raw);
+
+  @protected
+  RoundDriveEventView dco_decode_round_drive_event_view(dynamic raw);
+
+  @protected
   RoundPlanActionKind dco_decode_round_plan_action_kind(dynamic raw);
 
   @protected
   RoundPlanView dco_decode_round_plan_view(dynamic raw);
+
+  @protected
+  RoundQuiescenceKind dco_decode_round_quiescence_kind(dynamic raw);
+
+  @protected
+  RoundQuiescenceView dco_decode_round_quiescence_view(dynamic raw);
+
+  @protected
+  RoundRunReportView dco_decode_round_run_report_view(dynamic raw);
 
   @protected
   RoundStepDispositionView dco_decode_round_step_disposition_view(dynamic raw);
@@ -939,16 +1002,21 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   RoundStepFailureKindView dco_decode_round_step_failure_kind_view(dynamic raw);
 
   @protected
-  RoundStepFailureView dco_decode_round_step_failure_view(dynamic raw);
+  RoundStepFailureRecordView dco_decode_round_step_failure_record_view(
+    dynamic raw,
+  );
 
   @protected
-  RoundStepOutcomeView dco_decode_round_step_outcome_view(dynamic raw);
+  RoundStepFailureView dco_decode_round_step_failure_view(dynamic raw);
 
   @protected
   RoundStepProgressKind dco_decode_round_step_progress_kind(dynamic raw);
 
   @protected
   RoundStepProgressView dco_decode_round_step_progress_view(dynamic raw);
+
+  @protected
+  RoundWorkTallyView dco_decode_round_work_tally_view(dynamic raw);
 
   @protected
   ScanRangeInfo dco_decode_scan_range_info(dynamic raw);
@@ -1173,8 +1241,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   sse_decode_StreamSink_api_mempool_tx_event_Sse(SseDeserializer deserializer);
 
   @protected
-  RustStreamSink<ApiRoundStepEvent>
-  sse_decode_StreamSink_api_round_step_event_Sse(SseDeserializer deserializer);
+  RustStreamSink<ApiRoundRunEvent>
+  sse_decode_StreamSink_api_round_run_event_Sse(SseDeserializer deserializer);
 
   @protected
   RustStreamSink<ApiSyncProgressEvent>
@@ -1273,17 +1341,20 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ApiRoundDrivePolicy sse_decode_api_round_drive_policy(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   ApiRoundHostContext sse_decode_api_round_host_context(
     SseDeserializer deserializer,
   );
 
   @protected
-  ApiRoundStepError sse_decode_api_round_step_error(
-    SseDeserializer deserializer,
-  );
+  ApiRoundRunEvent sse_decode_api_round_run_event(SseDeserializer deserializer);
 
   @protected
-  ApiRoundStepEvent sse_decode_api_round_step_event(
+  ApiRoundStepError sse_decode_api_round_step_error(
     SseDeserializer deserializer,
   );
 
@@ -1339,6 +1410,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiDelegationSignerInput sse_decode_box_autoadd_api_delegation_signer_input(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ApiRoundDrivePolicy sse_decode_box_autoadd_api_round_drive_policy(
     SseDeserializer deserializer,
   );
 
@@ -1442,22 +1518,37 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RoundDriveEventView sse_decode_box_autoadd_round_drive_event_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RoundPlanView sse_decode_box_autoadd_round_plan_view(
     SseDeserializer deserializer,
   );
 
   @protected
-  RoundStepFailureView sse_decode_box_autoadd_round_step_failure_view(
+  RoundRunReportView sse_decode_box_autoadd_round_run_report_view(
     SseDeserializer deserializer,
   );
 
   @protected
-  RoundStepOutcomeView sse_decode_box_autoadd_round_step_outcome_view(
+  RoundStepDispositionView sse_decode_box_autoadd_round_step_disposition_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundStepFailureKindView sse_decode_box_autoadd_round_step_failure_kind_view(
     SseDeserializer deserializer,
   );
 
   @protected
   RoundStepProgressView sse_decode_box_autoadd_round_step_progress_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundWorkTallyView sse_decode_box_autoadd_round_work_tally_view(
     SseDeserializer deserializer,
   );
 
@@ -1469,12 +1560,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ShareKeyView sse_decode_box_autoadd_share_key_view(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  SignedDelegationPayloadView
-  sse_decode_box_autoadd_signed_delegation_payload_view(
     SseDeserializer deserializer,
   );
 
@@ -1876,6 +1961,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
   @protected
+  List<RoundChainOutcomeView> sse_decode_list_round_chain_outcome_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  List<RoundStepFailureRecordView>
+  sse_decode_list_round_step_failure_record_view(SseDeserializer deserializer);
+
+  @protected
   List<ScanRangeInfo> sse_decode_list_scan_range_info(
     SseDeserializer deserializer,
   );
@@ -1895,6 +1989,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<ShareDeliveryOutcomeView> sse_decode_list_share_delivery_outcome_view(
     SseDeserializer deserializer,
   );
+
+  @protected
+  List<ShareKeyView> sse_decode_list_share_key_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  List<SignedDelegationPayloadView>
+  sse_decode_list_signed_delegation_payload_view(SseDeserializer deserializer);
 
   @protected
   List<SoftwareWalletDiscoveredAccount>
@@ -2037,6 +2140,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ApiRoundDrivePolicy? sse_decode_opt_box_autoadd_api_round_drive_policy(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   ApiRoundStepError? sse_decode_opt_box_autoadd_api_round_step_error(
     SseDeserializer deserializer,
   );
@@ -2125,22 +2233,39 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RoundDriveEventView? sse_decode_opt_box_autoadd_round_drive_event_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RoundPlanView? sse_decode_opt_box_autoadd_round_plan_view(
     SseDeserializer deserializer,
   );
 
   @protected
-  RoundStepFailureView? sse_decode_opt_box_autoadd_round_step_failure_view(
+  RoundRunReportView? sse_decode_opt_box_autoadd_round_run_report_view(
     SseDeserializer deserializer,
   );
 
   @protected
-  RoundStepOutcomeView? sse_decode_opt_box_autoadd_round_step_outcome_view(
+  RoundStepDispositionView?
+  sse_decode_opt_box_autoadd_round_step_disposition_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundStepFailureKindView?
+  sse_decode_opt_box_autoadd_round_step_failure_kind_view(
     SseDeserializer deserializer,
   );
 
   @protected
   RoundStepProgressView? sse_decode_opt_box_autoadd_round_step_progress_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundWorkTallyView? sse_decode_opt_box_autoadd_round_work_tally_view(
     SseDeserializer deserializer,
   );
 
@@ -2152,12 +2277,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ShareKeyView? sse_decode_opt_box_autoadd_share_key_view(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  SignedDelegationPayloadView?
-  sse_decode_opt_box_autoadd_signed_delegation_payload_view(
     SseDeserializer deserializer,
   );
 
@@ -2217,12 +2336,42 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RoundChainOutcomeView sse_decode_round_chain_outcome_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundDriveEventKind sse_decode_round_drive_event_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundDriveEventView sse_decode_round_drive_event_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RoundPlanActionKind sse_decode_round_plan_action_kind(
     SseDeserializer deserializer,
   );
 
   @protected
   RoundPlanView sse_decode_round_plan_view(SseDeserializer deserializer);
+
+  @protected
+  RoundQuiescenceKind sse_decode_round_quiescence_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundQuiescenceView sse_decode_round_quiescence_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundRunReportView sse_decode_round_run_report_view(
+    SseDeserializer deserializer,
+  );
 
   @protected
   RoundStepDispositionView sse_decode_round_step_disposition_view(
@@ -2235,12 +2384,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RoundStepFailureView sse_decode_round_step_failure_view(
+  RoundStepFailureRecordView sse_decode_round_step_failure_record_view(
     SseDeserializer deserializer,
   );
 
   @protected
-  RoundStepOutcomeView sse_decode_round_step_outcome_view(
+  RoundStepFailureView sse_decode_round_step_failure_view(
     SseDeserializer deserializer,
   );
 
@@ -2251,6 +2400,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   RoundStepProgressView sse_decode_round_step_progress_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundWorkTallyView sse_decode_round_work_tally_view(
     SseDeserializer deserializer,
   );
 
@@ -2535,8 +2689,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_StreamSink_api_round_step_event_Sse(
-    RustStreamSink<ApiRoundStepEvent> self,
+  void sse_encode_StreamSink_api_round_run_event_Sse(
+    RustStreamSink<ApiRoundRunEvent> self,
     SseSerializer serializer,
   );
 
@@ -2661,20 +2815,26 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_api_round_drive_policy(
+    ApiRoundDrivePolicy self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_api_round_host_context(
     ApiRoundHostContext self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_api_round_step_error(
-    ApiRoundStepError self,
+  void sse_encode_api_round_run_event(
+    ApiRoundRunEvent self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_api_round_step_event(
-    ApiRoundStepEvent self,
+  void sse_encode_api_round_step_error(
+    ApiRoundStepError self,
     SseSerializer serializer,
   );
 
@@ -2738,6 +2898,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_api_delegation_signer_input(
     ApiDelegationSignerInput self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_api_round_drive_policy(
+    ApiRoundDrivePolicy self,
     SseSerializer serializer,
   );
 
@@ -2856,26 +3022,44 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_round_drive_event_view(
+    RoundDriveEventView self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_round_plan_view(
     RoundPlanView self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_box_autoadd_round_step_failure_view(
-    RoundStepFailureView self,
+  void sse_encode_box_autoadd_round_run_report_view(
+    RoundRunReportView self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_box_autoadd_round_step_outcome_view(
-    RoundStepOutcomeView self,
+  void sse_encode_box_autoadd_round_step_disposition_view(
+    RoundStepDispositionView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_round_step_failure_kind_view(
+    RoundStepFailureKindView self,
     SseSerializer serializer,
   );
 
   @protected
   void sse_encode_box_autoadd_round_step_progress_view(
     RoundStepProgressView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_round_work_tally_view(
+    RoundWorkTallyView self,
     SseSerializer serializer,
   );
 
@@ -2888,12 +3072,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_share_key_view(
     ShareKeyView self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_box_autoadd_signed_delegation_payload_view(
-    SignedDelegationPayloadView self,
     SseSerializer serializer,
   );
 
@@ -3390,6 +3568,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_round_chain_outcome_view(
+    List<RoundChainOutcomeView> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_round_step_failure_record_view(
+    List<RoundStepFailureRecordView> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_scan_range_info(
     List<ScanRangeInfo> self,
     SseSerializer serializer,
@@ -3410,6 +3600,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_list_share_delivery_outcome_view(
     List<ShareDeliveryOutcomeView> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_share_key_view(
+    List<ShareKeyView> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_signed_delegation_payload_view(
+    List<SignedDelegationPayloadView> self,
     SseSerializer serializer,
   );
 
@@ -3585,6 +3787,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_opt_box_autoadd_api_round_drive_policy(
+    ApiRoundDrivePolicy? self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_opt_box_autoadd_api_round_step_error(
     ApiRoundStepError? self,
     SseSerializer serializer,
@@ -3681,26 +3889,44 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_opt_box_autoadd_round_drive_event_view(
+    RoundDriveEventView? self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_opt_box_autoadd_round_plan_view(
     RoundPlanView? self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_opt_box_autoadd_round_step_failure_view(
-    RoundStepFailureView? self,
+  void sse_encode_opt_box_autoadd_round_run_report_view(
+    RoundRunReportView? self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_opt_box_autoadd_round_step_outcome_view(
-    RoundStepOutcomeView? self,
+  void sse_encode_opt_box_autoadd_round_step_disposition_view(
+    RoundStepDispositionView? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_round_step_failure_kind_view(
+    RoundStepFailureKindView? self,
     SseSerializer serializer,
   );
 
   @protected
   void sse_encode_opt_box_autoadd_round_step_progress_view(
     RoundStepProgressView? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_round_work_tally_view(
+    RoundWorkTallyView? self,
     SseSerializer serializer,
   );
 
@@ -3713,12 +3939,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_opt_box_autoadd_share_key_view(
     ShareKeyView? self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_opt_box_autoadd_signed_delegation_payload_view(
-    SignedDelegationPayloadView? self,
     SseSerializer serializer,
   );
 
@@ -3789,6 +4009,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_round_chain_outcome_view(
+    RoundChainOutcomeView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_round_drive_event_kind(
+    RoundDriveEventKind self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_round_drive_event_view(
+    RoundDriveEventView self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_round_plan_action_kind(
     RoundPlanActionKind self,
     SseSerializer serializer,
@@ -3796,6 +4034,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_round_plan_view(RoundPlanView self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_round_quiescence_kind(
+    RoundQuiescenceKind self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_round_quiescence_view(
+    RoundQuiescenceView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_round_run_report_view(
+    RoundRunReportView self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_round_step_disposition_view(
@@ -3810,14 +4066,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_round_step_failure_view(
-    RoundStepFailureView self,
+  void sse_encode_round_step_failure_record_view(
+    RoundStepFailureRecordView self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_round_step_outcome_view(
-    RoundStepOutcomeView self,
+  void sse_encode_round_step_failure_view(
+    RoundStepFailureView self,
     SseSerializer serializer,
   );
 
@@ -3830,6 +4086,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_round_step_progress_view(
     RoundStepProgressView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_round_work_tally_view(
+    RoundWorkTallyView self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -177,6 +177,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ApiPirSnapshotResolution dco_decode_api_pir_snapshot_resolution(dynamic raw);
+
+  @protected
   ApiProposalRosterEntry dco_decode_api_proposal_roster_entry(dynamic raw);
 
   @protected
@@ -1329,6 +1332,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiPirSnapshotEndpointStatus sse_decode_api_pir_snapshot_endpoint_status(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ApiPirSnapshotResolution sse_decode_api_pir_snapshot_resolution(
     SseDeserializer deserializer,
   );
 
@@ -2801,6 +2809,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_api_pir_snapshot_endpoint_status(
     ApiPirSnapshotEndpointStatus self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_api_pir_snapshot_resolution(
+    ApiPirSnapshotResolution self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -107,8 +107,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_StreamSink_api_mempool_tx_event_Sse(dynamic raw);
 
   @protected
-  RustStreamSink<ApiRoundStepEvent>
-  dco_decode_StreamSink_api_round_step_event_Sse(dynamic raw);
+  RustStreamSink<ApiRoundRunEvent>
+  dco_decode_StreamSink_api_round_run_event_Sse(dynamic raw);
 
   @protected
   RustStreamSink<ApiSyncProgressEvent>
@@ -183,13 +183,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ApiResubmittedShare dco_decode_api_resubmitted_share(dynamic raw);
 
   @protected
+  ApiRoundDrivePolicy dco_decode_api_round_drive_policy(dynamic raw);
+
+  @protected
   ApiRoundHostContext dco_decode_api_round_host_context(dynamic raw);
 
   @protected
-  ApiRoundStepError dco_decode_api_round_step_error(dynamic raw);
+  ApiRoundRunEvent dco_decode_api_round_run_event(dynamic raw);
 
   @protected
-  ApiRoundStepEvent dco_decode_api_round_step_event(dynamic raw);
+  ApiRoundStepError dco_decode_api_round_step_error(dynamic raw);
 
   @protected
   ApiRoundStepEventKind dco_decode_api_round_step_event_kind(dynamic raw);
@@ -229,6 +232,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiDelegationSignerInput dco_decode_box_autoadd_api_delegation_signer_input(
+    dynamic raw,
+  );
+
+  @protected
+  ApiRoundDrivePolicy dco_decode_box_autoadd_api_round_drive_policy(
     dynamic raw,
   );
 
@@ -312,15 +320,23 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RoundPlanView dco_decode_box_autoadd_round_plan_view(dynamic raw);
-
-  @protected
-  RoundStepFailureView dco_decode_box_autoadd_round_step_failure_view(
+  RoundDriveEventView dco_decode_box_autoadd_round_drive_event_view(
     dynamic raw,
   );
 
   @protected
-  RoundStepOutcomeView dco_decode_box_autoadd_round_step_outcome_view(
+  RoundPlanView dco_decode_box_autoadd_round_plan_view(dynamic raw);
+
+  @protected
+  RoundRunReportView dco_decode_box_autoadd_round_run_report_view(dynamic raw);
+
+  @protected
+  RoundStepDispositionView dco_decode_box_autoadd_round_step_disposition_view(
+    dynamic raw,
+  );
+
+  @protected
+  RoundStepFailureKindView dco_decode_box_autoadd_round_step_failure_kind_view(
     dynamic raw,
   );
 
@@ -330,15 +346,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RoundWorkTallyView dco_decode_box_autoadd_round_work_tally_view(dynamic raw);
+
+  @protected
   ShareBatchDeliveryReportView
   dco_decode_box_autoadd_share_batch_delivery_report_view(dynamic raw);
 
   @protected
   ShareKeyView dco_decode_box_autoadd_share_key_view(dynamic raw);
-
-  @protected
-  SignedDelegationPayloadView
-  dco_decode_box_autoadd_signed_delegation_payload_view(dynamic raw);
 
   @protected
   SubmissionDiagnosticView dco_decode_box_autoadd_submission_diagnostic_view(
@@ -656,6 +671,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
+  List<RoundChainOutcomeView> dco_decode_list_round_chain_outcome_view(
+    dynamic raw,
+  );
+
+  @protected
+  List<RoundStepFailureRecordView>
+  dco_decode_list_round_step_failure_record_view(dynamic raw);
+
+  @protected
   List<ScanRangeInfo> dco_decode_list_scan_range_info(dynamic raw);
 
   @protected
@@ -669,6 +693,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<ShareDeliveryOutcomeView> dco_decode_list_share_delivery_outcome_view(
     dynamic raw,
   );
+
+  @protected
+  List<ShareKeyView> dco_decode_list_share_key_view(dynamic raw);
+
+  @protected
+  List<SignedDelegationPayloadView>
+  dco_decode_list_signed_delegation_payload_view(dynamic raw);
 
   @protected
   List<SoftwareWalletDiscoveredAccount>
@@ -783,6 +814,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_opt_box_autoadd_api_delegation_signer_input(dynamic raw);
 
   @protected
+  ApiRoundDrivePolicy? dco_decode_opt_box_autoadd_api_round_drive_policy(
+    dynamic raw,
+  );
+
+  @protected
   ApiRoundStepError? dco_decode_opt_box_autoadd_api_round_step_error(
     dynamic raw,
   );
@@ -853,20 +889,33 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RoundDriveEventView? dco_decode_opt_box_autoadd_round_drive_event_view(
+    dynamic raw,
+  );
+
+  @protected
   RoundPlanView? dco_decode_opt_box_autoadd_round_plan_view(dynamic raw);
 
   @protected
-  RoundStepFailureView? dco_decode_opt_box_autoadd_round_step_failure_view(
+  RoundRunReportView? dco_decode_opt_box_autoadd_round_run_report_view(
     dynamic raw,
   );
 
   @protected
-  RoundStepOutcomeView? dco_decode_opt_box_autoadd_round_step_outcome_view(
-    dynamic raw,
-  );
+  RoundStepDispositionView?
+  dco_decode_opt_box_autoadd_round_step_disposition_view(dynamic raw);
+
+  @protected
+  RoundStepFailureKindView?
+  dco_decode_opt_box_autoadd_round_step_failure_kind_view(dynamic raw);
 
   @protected
   RoundStepProgressView? dco_decode_opt_box_autoadd_round_step_progress_view(
+    dynamic raw,
+  );
+
+  @protected
+  RoundWorkTallyView? dco_decode_opt_box_autoadd_round_work_tally_view(
     dynamic raw,
   );
 
@@ -876,10 +925,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ShareKeyView? dco_decode_opt_box_autoadd_share_key_view(dynamic raw);
-
-  @protected
-  SignedDelegationPayloadView?
-  dco_decode_opt_box_autoadd_signed_delegation_payload_view(dynamic raw);
 
   @protected
   SubmissionDiagnosticView?
@@ -929,10 +974,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ResolvedVotingConfig dco_decode_resolved_voting_config(dynamic raw);
 
   @protected
+  RoundChainOutcomeView dco_decode_round_chain_outcome_view(dynamic raw);
+
+  @protected
+  RoundDriveEventKind dco_decode_round_drive_event_kind(dynamic raw);
+
+  @protected
+  RoundDriveEventView dco_decode_round_drive_event_view(dynamic raw);
+
+  @protected
   RoundPlanActionKind dco_decode_round_plan_action_kind(dynamic raw);
 
   @protected
   RoundPlanView dco_decode_round_plan_view(dynamic raw);
+
+  @protected
+  RoundQuiescenceKind dco_decode_round_quiescence_kind(dynamic raw);
+
+  @protected
+  RoundQuiescenceView dco_decode_round_quiescence_view(dynamic raw);
+
+  @protected
+  RoundRunReportView dco_decode_round_run_report_view(dynamic raw);
 
   @protected
   RoundStepDispositionView dco_decode_round_step_disposition_view(dynamic raw);
@@ -941,16 +1004,21 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   RoundStepFailureKindView dco_decode_round_step_failure_kind_view(dynamic raw);
 
   @protected
-  RoundStepFailureView dco_decode_round_step_failure_view(dynamic raw);
+  RoundStepFailureRecordView dco_decode_round_step_failure_record_view(
+    dynamic raw,
+  );
 
   @protected
-  RoundStepOutcomeView dco_decode_round_step_outcome_view(dynamic raw);
+  RoundStepFailureView dco_decode_round_step_failure_view(dynamic raw);
 
   @protected
   RoundStepProgressKind dco_decode_round_step_progress_kind(dynamic raw);
 
   @protected
   RoundStepProgressView dco_decode_round_step_progress_view(dynamic raw);
+
+  @protected
+  RoundWorkTallyView dco_decode_round_work_tally_view(dynamic raw);
 
   @protected
   ScanRangeInfo dco_decode_scan_range_info(dynamic raw);
@@ -1175,8 +1243,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   sse_decode_StreamSink_api_mempool_tx_event_Sse(SseDeserializer deserializer);
 
   @protected
-  RustStreamSink<ApiRoundStepEvent>
-  sse_decode_StreamSink_api_round_step_event_Sse(SseDeserializer deserializer);
+  RustStreamSink<ApiRoundRunEvent>
+  sse_decode_StreamSink_api_round_run_event_Sse(SseDeserializer deserializer);
 
   @protected
   RustStreamSink<ApiSyncProgressEvent>
@@ -1275,17 +1343,20 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ApiRoundDrivePolicy sse_decode_api_round_drive_policy(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   ApiRoundHostContext sse_decode_api_round_host_context(
     SseDeserializer deserializer,
   );
 
   @protected
-  ApiRoundStepError sse_decode_api_round_step_error(
-    SseDeserializer deserializer,
-  );
+  ApiRoundRunEvent sse_decode_api_round_run_event(SseDeserializer deserializer);
 
   @protected
-  ApiRoundStepEvent sse_decode_api_round_step_event(
+  ApiRoundStepError sse_decode_api_round_step_error(
     SseDeserializer deserializer,
   );
 
@@ -1341,6 +1412,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiDelegationSignerInput sse_decode_box_autoadd_api_delegation_signer_input(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ApiRoundDrivePolicy sse_decode_box_autoadd_api_round_drive_policy(
     SseDeserializer deserializer,
   );
 
@@ -1444,22 +1520,37 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RoundDriveEventView sse_decode_box_autoadd_round_drive_event_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RoundPlanView sse_decode_box_autoadd_round_plan_view(
     SseDeserializer deserializer,
   );
 
   @protected
-  RoundStepFailureView sse_decode_box_autoadd_round_step_failure_view(
+  RoundRunReportView sse_decode_box_autoadd_round_run_report_view(
     SseDeserializer deserializer,
   );
 
   @protected
-  RoundStepOutcomeView sse_decode_box_autoadd_round_step_outcome_view(
+  RoundStepDispositionView sse_decode_box_autoadd_round_step_disposition_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundStepFailureKindView sse_decode_box_autoadd_round_step_failure_kind_view(
     SseDeserializer deserializer,
   );
 
   @protected
   RoundStepProgressView sse_decode_box_autoadd_round_step_progress_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundWorkTallyView sse_decode_box_autoadd_round_work_tally_view(
     SseDeserializer deserializer,
   );
 
@@ -1471,12 +1562,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ShareKeyView sse_decode_box_autoadd_share_key_view(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  SignedDelegationPayloadView
-  sse_decode_box_autoadd_signed_delegation_payload_view(
     SseDeserializer deserializer,
   );
 
@@ -1878,6 +1963,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
   @protected
+  List<RoundChainOutcomeView> sse_decode_list_round_chain_outcome_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  List<RoundStepFailureRecordView>
+  sse_decode_list_round_step_failure_record_view(SseDeserializer deserializer);
+
+  @protected
   List<ScanRangeInfo> sse_decode_list_scan_range_info(
     SseDeserializer deserializer,
   );
@@ -1897,6 +1991,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<ShareDeliveryOutcomeView> sse_decode_list_share_delivery_outcome_view(
     SseDeserializer deserializer,
   );
+
+  @protected
+  List<ShareKeyView> sse_decode_list_share_key_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  List<SignedDelegationPayloadView>
+  sse_decode_list_signed_delegation_payload_view(SseDeserializer deserializer);
 
   @protected
   List<SoftwareWalletDiscoveredAccount>
@@ -2039,6 +2142,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ApiRoundDrivePolicy? sse_decode_opt_box_autoadd_api_round_drive_policy(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   ApiRoundStepError? sse_decode_opt_box_autoadd_api_round_step_error(
     SseDeserializer deserializer,
   );
@@ -2127,22 +2235,39 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RoundDriveEventView? sse_decode_opt_box_autoadd_round_drive_event_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RoundPlanView? sse_decode_opt_box_autoadd_round_plan_view(
     SseDeserializer deserializer,
   );
 
   @protected
-  RoundStepFailureView? sse_decode_opt_box_autoadd_round_step_failure_view(
+  RoundRunReportView? sse_decode_opt_box_autoadd_round_run_report_view(
     SseDeserializer deserializer,
   );
 
   @protected
-  RoundStepOutcomeView? sse_decode_opt_box_autoadd_round_step_outcome_view(
+  RoundStepDispositionView?
+  sse_decode_opt_box_autoadd_round_step_disposition_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundStepFailureKindView?
+  sse_decode_opt_box_autoadd_round_step_failure_kind_view(
     SseDeserializer deserializer,
   );
 
   @protected
   RoundStepProgressView? sse_decode_opt_box_autoadd_round_step_progress_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundWorkTallyView? sse_decode_opt_box_autoadd_round_work_tally_view(
     SseDeserializer deserializer,
   );
 
@@ -2154,12 +2279,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ShareKeyView? sse_decode_opt_box_autoadd_share_key_view(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  SignedDelegationPayloadView?
-  sse_decode_opt_box_autoadd_signed_delegation_payload_view(
     SseDeserializer deserializer,
   );
 
@@ -2219,12 +2338,42 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RoundChainOutcomeView sse_decode_round_chain_outcome_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundDriveEventKind sse_decode_round_drive_event_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundDriveEventView sse_decode_round_drive_event_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RoundPlanActionKind sse_decode_round_plan_action_kind(
     SseDeserializer deserializer,
   );
 
   @protected
   RoundPlanView sse_decode_round_plan_view(SseDeserializer deserializer);
+
+  @protected
+  RoundQuiescenceKind sse_decode_round_quiescence_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundQuiescenceView sse_decode_round_quiescence_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundRunReportView sse_decode_round_run_report_view(
+    SseDeserializer deserializer,
+  );
 
   @protected
   RoundStepDispositionView sse_decode_round_step_disposition_view(
@@ -2237,12 +2386,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RoundStepFailureView sse_decode_round_step_failure_view(
+  RoundStepFailureRecordView sse_decode_round_step_failure_record_view(
     SseDeserializer deserializer,
   );
 
   @protected
-  RoundStepOutcomeView sse_decode_round_step_outcome_view(
+  RoundStepFailureView sse_decode_round_step_failure_view(
     SseDeserializer deserializer,
   );
 
@@ -2253,6 +2402,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   RoundStepProgressView sse_decode_round_step_progress_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RoundWorkTallyView sse_decode_round_work_tally_view(
     SseDeserializer deserializer,
   );
 
@@ -2537,8 +2691,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_StreamSink_api_round_step_event_Sse(
-    RustStreamSink<ApiRoundStepEvent> self,
+  void sse_encode_StreamSink_api_round_run_event_Sse(
+    RustStreamSink<ApiRoundRunEvent> self,
     SseSerializer serializer,
   );
 
@@ -2663,20 +2817,26 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_api_round_drive_policy(
+    ApiRoundDrivePolicy self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_api_round_host_context(
     ApiRoundHostContext self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_api_round_step_error(
-    ApiRoundStepError self,
+  void sse_encode_api_round_run_event(
+    ApiRoundRunEvent self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_api_round_step_event(
-    ApiRoundStepEvent self,
+  void sse_encode_api_round_step_error(
+    ApiRoundStepError self,
     SseSerializer serializer,
   );
 
@@ -2740,6 +2900,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_api_delegation_signer_input(
     ApiDelegationSignerInput self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_api_round_drive_policy(
+    ApiRoundDrivePolicy self,
     SseSerializer serializer,
   );
 
@@ -2858,26 +3024,44 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_round_drive_event_view(
+    RoundDriveEventView self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_round_plan_view(
     RoundPlanView self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_box_autoadd_round_step_failure_view(
-    RoundStepFailureView self,
+  void sse_encode_box_autoadd_round_run_report_view(
+    RoundRunReportView self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_box_autoadd_round_step_outcome_view(
-    RoundStepOutcomeView self,
+  void sse_encode_box_autoadd_round_step_disposition_view(
+    RoundStepDispositionView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_round_step_failure_kind_view(
+    RoundStepFailureKindView self,
     SseSerializer serializer,
   );
 
   @protected
   void sse_encode_box_autoadd_round_step_progress_view(
     RoundStepProgressView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_round_work_tally_view(
+    RoundWorkTallyView self,
     SseSerializer serializer,
   );
 
@@ -2890,12 +3074,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_share_key_view(
     ShareKeyView self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_box_autoadd_signed_delegation_payload_view(
-    SignedDelegationPayloadView self,
     SseSerializer serializer,
   );
 
@@ -3392,6 +3570,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_round_chain_outcome_view(
+    List<RoundChainOutcomeView> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_round_step_failure_record_view(
+    List<RoundStepFailureRecordView> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_scan_range_info(
     List<ScanRangeInfo> self,
     SseSerializer serializer,
@@ -3412,6 +3602,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_list_share_delivery_outcome_view(
     List<ShareDeliveryOutcomeView> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_share_key_view(
+    List<ShareKeyView> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_signed_delegation_payload_view(
+    List<SignedDelegationPayloadView> self,
     SseSerializer serializer,
   );
 
@@ -3587,6 +3789,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_opt_box_autoadd_api_round_drive_policy(
+    ApiRoundDrivePolicy? self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_opt_box_autoadd_api_round_step_error(
     ApiRoundStepError? self,
     SseSerializer serializer,
@@ -3683,26 +3891,44 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_opt_box_autoadd_round_drive_event_view(
+    RoundDriveEventView? self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_opt_box_autoadd_round_plan_view(
     RoundPlanView? self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_opt_box_autoadd_round_step_failure_view(
-    RoundStepFailureView? self,
+  void sse_encode_opt_box_autoadd_round_run_report_view(
+    RoundRunReportView? self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_opt_box_autoadd_round_step_outcome_view(
-    RoundStepOutcomeView? self,
+  void sse_encode_opt_box_autoadd_round_step_disposition_view(
+    RoundStepDispositionView? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_round_step_failure_kind_view(
+    RoundStepFailureKindView? self,
     SseSerializer serializer,
   );
 
   @protected
   void sse_encode_opt_box_autoadd_round_step_progress_view(
     RoundStepProgressView? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_round_work_tally_view(
+    RoundWorkTallyView? self,
     SseSerializer serializer,
   );
 
@@ -3715,12 +3941,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_opt_box_autoadd_share_key_view(
     ShareKeyView? self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_opt_box_autoadd_signed_delegation_payload_view(
-    SignedDelegationPayloadView? self,
     SseSerializer serializer,
   );
 
@@ -3791,6 +4011,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_round_chain_outcome_view(
+    RoundChainOutcomeView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_round_drive_event_kind(
+    RoundDriveEventKind self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_round_drive_event_view(
+    RoundDriveEventView self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_round_plan_action_kind(
     RoundPlanActionKind self,
     SseSerializer serializer,
@@ -3798,6 +4036,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_round_plan_view(RoundPlanView self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_round_quiescence_kind(
+    RoundQuiescenceKind self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_round_quiescence_view(
+    RoundQuiescenceView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_round_run_report_view(
+    RoundRunReportView self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_round_step_disposition_view(
@@ -3812,14 +4068,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_round_step_failure_view(
-    RoundStepFailureView self,
+  void sse_encode_round_step_failure_record_view(
+    RoundStepFailureRecordView self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_round_step_outcome_view(
-    RoundStepOutcomeView self,
+  void sse_encode_round_step_failure_view(
+    RoundStepFailureView self,
     SseSerializer serializer,
   );
 
@@ -3832,6 +4088,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_round_step_progress_view(
     RoundStepProgressView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_round_work_tally_view(
+    RoundWorkTallyView self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/third_party/zcash_voting/wire.dart
+++ b/lib/src/rust/third_party/zcash_voting/wire.dart
@@ -7,8 +7,8 @@ import '../../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'share_policy.dart';
 
-// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `BoundedU32`, `DelegationPirPrecomputeResultView`, `DelegationRecoveryView`, `DraftVote`, `PendingShareRoundView`, `RecoverableCommitmentBundle`, `RoundRecoveryStateView`, `ShareDelegationRecordView`, `ShareWorkflowRecoveryView`, `SignedVoteBatchView`, `SignedVoteCommitmentView`, `SignedVoteCommitmentsView`, `VoteCommitmentBatchWire`, `VoteCommitmentWire`, `VoteRecord`, `VoteRecoveryView`, `VoteShareWire`, `VotingHotkeyTargetV1`, `VotingNoteRefView`, `VotingNoteSelectionResultView`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `try_from`, `try_from`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `BoundedU32`, `DelegationPirPrecomputeResultView`, `DelegationRecoveryView`, `DraftVote`, `PendingShareRoundView`, `RecoverableCommitmentBundle`, `RoundRecoveryStateView`, `RoundStepOutcomeView`, `ShareDelegationRecordView`, `ShareWorkflowRecoveryView`, `SignedVoteBatchView`, `SignedVoteCommitmentView`, `SignedVoteCommitmentsView`, `VoteCommitmentBatchWire`, `VoteCommitmentWire`, `VoteRecord`, `VoteRecoveryView`, `VoteShareWire`, `VotingHotkeyTargetV1`, `VotingNoteRefView`, `VotingNoteSelectionResultView`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `hash`, `try_from`, `try_from`
 
 /// How a confirmation was established.
 enum ChainConfirmationSourceView { hash, tree }
@@ -390,6 +390,110 @@ class NextStepView {
           shareIndex == other.shareIndex;
 }
 
+/// A terminal chain outcome bound to the step that produced it.
+class RoundChainOutcomeView {
+  final NextStepView step;
+  final ChainSubmissionOutcomeView outcome;
+
+  const RoundChainOutcomeView({required this.step, required this.outcome});
+
+  @override
+  int get hashCode => step.hashCode ^ outcome.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoundChainOutcomeView &&
+          runtimeType == other.runtimeType &&
+          step == other.step &&
+          outcome == other.outcome;
+}
+
+/// Discriminator of a [`RoundDriveEventView`].
+enum RoundDriveEventKind {
+  planRefreshed,
+  stepSelected,
+  stepProgress,
+  stepFinished,
+  stepFailed,
+  awaitingRepoll,
+  bundleSkipped,
+}
+
+/// One observation from a run, flattened for host bindings.
+///
+/// Every variant that describes work names its step: a run overlaps bundles,
+/// and a bare progress record carries no subject of its own, so a host reading
+/// one stream would otherwise misattribute it.
+class RoundDriveEventView {
+  final RoundDriveEventKind kind;
+
+  /// The step every work-describing variant belongs to.
+  final NextStepView? step;
+
+  /// `PlanRefreshed`: the plan the driver selects from, and its tally.
+  final RoundPlanView? plan;
+  final RoundWorkTallyView? tally;
+
+  /// `StepProgress`: progress from inside the running step.
+  final RoundStepProgressView? progress;
+
+  /// `StepFinished`: the executor's own answer for the step.
+  final RoundStepDispositionView? disposition;
+
+  /// `StepFailed`: why it failed.
+  final RoundStepFailureKindView? failureKind;
+  final String? message;
+
+  /// `AwaitingRepoll`: how long the driver waits before polling again.
+  final double? delaySeconds;
+
+  /// `BundleSkipped`: the bundle isolated for the rest of the run.
+  final int? bundleIndex;
+
+  const RoundDriveEventView({
+    required this.kind,
+    this.step,
+    this.plan,
+    this.tally,
+    this.progress,
+    this.disposition,
+    this.failureKind,
+    this.message,
+    this.delaySeconds,
+    this.bundleIndex,
+  });
+
+  @override
+  int get hashCode =>
+      kind.hashCode ^
+      step.hashCode ^
+      plan.hashCode ^
+      tally.hashCode ^
+      progress.hashCode ^
+      disposition.hashCode ^
+      failureKind.hashCode ^
+      message.hashCode ^
+      delaySeconds.hashCode ^
+      bundleIndex.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoundDriveEventView &&
+          runtimeType == other.runtimeType &&
+          kind == other.kind &&
+          step == other.step &&
+          plan == other.plan &&
+          tally == other.tally &&
+          progress == other.progress &&
+          disposition == other.disposition &&
+          failureKind == other.failureKind &&
+          message == other.message &&
+          delaySeconds == other.delaySeconds &&
+          bundleIndex == other.bundleIndex;
+}
+
 /// High-level work area a wallet should show or resume for a round.
 enum RoundPlanActionKind { idle, delegate, vote, submitShares, done }
 
@@ -541,6 +645,139 @@ class RoundPlanView {
           allDecided == other.allDecided;
 }
 
+/// Discriminator of a [`RoundQuiescenceView`].
+enum RoundQuiescenceKind {
+  noWorkLeft,
+  needsBundleSetup,
+  persistedChainTerminal,
+  needsBallot,
+  needsDelegationSignatures,
+  backgroundShareWorkOnly,
+  cancelled,
+  chainTerminal,
+  chainRecoveryStalled,
+  failures,
+  passBudgetExhausted,
+}
+
+/// Why one round run stopped, flattened for host bindings.
+///
+/// Each field is populated only for the kinds that carry it; a host switches
+/// on `kind` and reads what that variant names.
+class RoundQuiescenceView {
+  final RoundQuiescenceKind kind;
+
+  /// `NeedsBallot`: proposals with no terminal decision yet.
+  final Uint32List openProposals;
+
+  /// `NeedsBallot`: durable intents outside the roster the host must clear.
+  final Uint32List unrosteredIntents;
+
+  /// `NeedsDelegationSignatures`: every bundle still awaiting a signature.
+  final Uint32List bundles;
+
+  /// `BackgroundShareWorkOnly`: the shares the host's timer finishes.
+  final List<ShareKeyView> shares;
+
+  /// `ChainTerminal` and `ChainRecoveryStalled`: the step and its outcome.
+  final NextStepView? step;
+  final ChainSubmissionOutcomeView? chainOutcome;
+
+  /// `PassBudgetExhausted`: the work the run left behind.
+  final List<NextStepView> remaining;
+
+  const RoundQuiescenceView({
+    required this.kind,
+    required this.openProposals,
+    required this.unrosteredIntents,
+    required this.bundles,
+    required this.shares,
+    this.step,
+    this.chainOutcome,
+    required this.remaining,
+  });
+
+  @override
+  int get hashCode =>
+      kind.hashCode ^
+      openProposals.hashCode ^
+      unrosteredIntents.hashCode ^
+      bundles.hashCode ^
+      shares.hashCode ^
+      step.hashCode ^
+      chainOutcome.hashCode ^
+      remaining.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoundQuiescenceView &&
+          runtimeType == other.runtimeType &&
+          kind == other.kind &&
+          openProposals == other.openProposals &&
+          unrosteredIntents == other.unrosteredIntents &&
+          bundles == other.bundles &&
+          shares == other.shares &&
+          step == other.step &&
+          chainOutcome == other.chainOutcome &&
+          remaining == other.remaining;
+}
+
+/// Everything one round run did.
+class RoundRunReportView {
+  final RoundQuiescenceView quiescence;
+
+  /// The last plan the run read, absent only when it stopped before one.
+  final RoundPlanView? plan;
+  final RoundWorkTallyView tally;
+
+  /// Failures in dispatch order. A non-empty list does not imply a
+  /// `Failures` quiescence: a run can isolate one bundle and finish the rest.
+  final List<RoundStepFailureRecordView> failures;
+  final Uint32List skippedBundles;
+  final List<RoundChainOutcomeView> chainOutcomes;
+  final List<ShareBatchDeliveryReportView> shareDeliveries;
+
+  /// Delegations the run signed, in the order their steps completed.
+  final List<SignedDelegationPayloadView> delegations;
+
+  const RoundRunReportView({
+    required this.quiescence,
+    this.plan,
+    required this.tally,
+    required this.failures,
+    required this.skippedBundles,
+    required this.chainOutcomes,
+    required this.shareDeliveries,
+    required this.delegations,
+  });
+
+  @override
+  int get hashCode =>
+      quiescence.hashCode ^
+      plan.hashCode ^
+      tally.hashCode ^
+      failures.hashCode ^
+      skippedBundles.hashCode ^
+      chainOutcomes.hashCode ^
+      shareDeliveries.hashCode ^
+      delegations.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoundRunReportView &&
+          runtimeType == other.runtimeType &&
+          quiescence == other.quiescence &&
+          plan == other.plan &&
+          tally == other.tally &&
+          failures == other.failures &&
+          skippedBundles == other.skippedBundles &&
+          chainOutcomes == other.chainOutcomes &&
+          shareDeliveries == other.shareDeliveries &&
+          delegations == other.delegations;
+}
+
 /// What one round step call accomplished.
 enum RoundStepDispositionView {
   noWork,
@@ -565,6 +802,33 @@ enum RoundStepFailureKindView {
   helperDeliveryIncomplete,
   voteEnded,
   delegationTargetMismatch,
+}
+
+/// One failure a run isolated, with the bundle it skipped.
+class RoundStepFailureRecordView {
+  final NextStepView? step;
+
+  /// The bundle skipped for the rest of the run, when the failure named one.
+  final int? bundleIndex;
+  final RoundStepFailureView failure;
+
+  const RoundStepFailureRecordView({
+    this.step,
+    this.bundleIndex,
+    required this.failure,
+  });
+
+  @override
+  int get hashCode => step.hashCode ^ bundleIndex.hashCode ^ failure.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoundStepFailureRecordView &&
+          runtimeType == other.runtimeType &&
+          step == other.step &&
+          bundleIndex == other.bundleIndex &&
+          failure == other.failure;
 }
 
 /// Failure of one round step with the refreshed plan when it could be read.
@@ -612,46 +876,6 @@ class RoundStepFailureView {
           message == other.message &&
           plan == other.plan &&
           shareDeliveries == other.shareDeliveries;
-}
-
-/// Outcome of one round step.
-class RoundStepOutcomeView {
-  final NextStepView? step;
-  final RoundStepDispositionView disposition;
-  final ChainSubmissionOutcomeView? chainOutcome;
-  final List<ShareBatchDeliveryReportView> shareDeliveries;
-  final SignedDelegationPayloadView? delegation;
-  final RoundPlanView plan;
-
-  const RoundStepOutcomeView({
-    this.step,
-    required this.disposition,
-    this.chainOutcome,
-    required this.shareDeliveries,
-    this.delegation,
-    required this.plan,
-  });
-
-  @override
-  int get hashCode =>
-      step.hashCode ^
-      disposition.hashCode ^
-      chainOutcome.hashCode ^
-      shareDeliveries.hashCode ^
-      delegation.hashCode ^
-      plan.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is RoundStepOutcomeView &&
-          runtimeType == other.runtimeType &&
-          step == other.step &&
-          disposition == other.disposition &&
-          chainOutcome == other.chainOutcome &&
-          shareDeliveries == other.shareDeliveries &&
-          delegation == other.delegation &&
-          plan == other.plan;
 }
 
 /// Discriminator of a [`RoundStepProgressView`].
@@ -740,6 +964,37 @@ class RoundStepProgressView {
           shareDelivery == other.shareDelivery &&
           share == other.share &&
           shareConfirmed == other.shareConfirmed;
+}
+
+/// Ballot progress of one run, measured against what it started owing.
+class RoundWorkTallyView {
+  final int completedProposals;
+  final int totalProposals;
+  final int remainingObligations;
+
+  const RoundWorkTallyView({
+    required this.completedProposals,
+    required this.totalProposals,
+    required this.remainingObligations,
+  });
+
+  static Future<RoundWorkTallyView> default_() =>
+      RustLib.instance.api.zcashVotingWireRoundWorkTallyViewDefault();
+
+  @override
+  int get hashCode =>
+      completedProposals.hashCode ^
+      totalProposals.hashCode ^
+      remainingObligations.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoundWorkTallyView &&
+          runtimeType == other.runtimeType &&
+          completedProposals == other.completedProposals &&
+          totalProposals == other.totalProposals &&
+          remainingObligations == other.remainingObligations;
 }
 
 /// Result of one initial helper delivery for a confirmed vote.

--- a/lib/src/services/voting/pir_snapshot_resolver.dart
+++ b/lib/src/services/voting/pir_snapshot_resolver.dart
@@ -1,5 +1,6 @@
 import '../../rust/api/voting.dart' as rust_api;
 import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
+import 'voting_endpoint_mapper.dart';
 import 'voting_rust_exception.dart';
 
 /// Probe outcome for one configured PIR endpoint.
@@ -77,12 +78,24 @@ class PirSnapshotNoMatchingEndpoint implements Exception {
 /// type is the Dart-side seam so callers and tests keep one place to stub.
 /// The endpoint the wallet probes with is the same routed transport that
 /// carries the rest of foreground voting traffic.
+///
+/// Callers pass logical endpoints and get logical endpoints back. The regtest
+/// gateway rewrite is applied to what is probed and undone on the way out, so
+/// the round's configured identity is what reaches the session state and the
+/// PIR failover list.
 class PirSnapshotResolver {
-  const PirSnapshotResolver({ResolvePirSnapshotEndpointFn? resolveEndpoint})
-    : _resolveEndpoint =
-          resolveEndpoint ?? rust_api.resolvePirSnapshotEndpoint;
+  const PirSnapshotResolver({
+    VotingEndpointMapper? mapper,
+    ResolvePirSnapshotEndpointFn? resolveEndpoint,
+  }) : _mapper = mapper,
+       _resolveEndpoint =
+           resolveEndpoint ?? rust_api.resolvePirSnapshotEndpoint;
 
+  final VotingEndpointMapper? _mapper;
   final ResolvePirSnapshotEndpointFn _resolveEndpoint;
+
+  Uri _transportUri(Uri logicalUrl) =>
+      _mapper == null ? logicalUrl : _mapper.map(logicalUrl);
 
   /// Probes all endpoints and selects one serving [expectedSnapshotHeight].
   ///
@@ -97,19 +110,30 @@ class PirSnapshotResolver {
       throw const PirSnapshotNoEndpoints();
     }
 
+    final logicalByTransport = <String, Uri>{};
+    final transportUrls = <String>[];
+    for (final endpoint in endpoints) {
+      final transportUrl = _transportUri(endpoint).toString();
+      logicalByTransport[transportUrl] = endpoint;
+      transportUrls.add(transportUrl);
+    }
+
     final rust_api.ApiPirSnapshotResolution resolution;
     try {
       resolution = await _resolveEndpoint(
-        endpoints: [for (final endpoint in endpoints) endpoint.toString()],
+        endpoints: transportUrls,
         expectedSnapshotHeight: BigInt.from(expectedSnapshotHeight),
       );
     } on rust_voting.VotingErrorView catch (error) {
       throw VotingRustException(error);
     }
 
+    Uri logical(String probed) =>
+        logicalByTransport[probed] ?? Uri.parse(probed);
+
     final diagnostics = [
       for (final diagnostic in resolution.diagnostics)
-        _diagnosticFrom(diagnostic),
+        _diagnosticFrom(diagnostic, logical(diagnostic.endpoint)),
     ];
     final endpoint = resolution.endpoint;
     if (endpoint == null) {
@@ -119,16 +143,17 @@ class PirSnapshotResolver {
       );
     }
     return PirSnapshotResolution(
-      endpoint: Uri.parse(endpoint),
+      endpoint: logical(endpoint),
       diagnostics: diagnostics,
     );
   }
 
   static PirSnapshotEndpointDiagnostic _diagnosticFrom(
     rust_api.ApiPirSnapshotEndpointDiagnostic diagnostic,
+    Uri endpoint,
   ) {
     return PirSnapshotEndpointDiagnostic(
-      endpoint: Uri.parse(diagnostic.endpoint),
+      endpoint: endpoint,
       status: _statusFrom(diagnostic.status),
       reportedHeight: diagnostic.reportedHeight?.toInt(),
       httpStatusCode: diagnostic.httpStatusCode,

--- a/lib/src/services/voting/pir_snapshot_resolver.dart
+++ b/lib/src/services/voting/pir_snapshot_resolver.dart
@@ -1,9 +1,6 @@
-import 'dart:convert';
-import 'dart:math' as math;
-
-import 'voting_http.dart';
-import 'voting_models.dart';
-import 'voting_retry.dart';
+import '../../rust/api/voting.dart' as rust_api;
+import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
+import 'voting_rust_exception.dart';
 
 /// Probe outcome for one configured PIR endpoint.
 ///
@@ -20,6 +17,7 @@ enum PirSnapshotEndpointStatus {
   timeoutOrNetworkError,
 }
 
+/// Normalized probe outcome for one endpoint.
 class PirSnapshotEndpointDiagnostic {
   final Uri endpoint;
   final PirSnapshotEndpointStatus status;
@@ -38,6 +36,7 @@ class PirSnapshotEndpointDiagnostic {
   bool get matched => status == PirSnapshotEndpointStatus.matched;
 }
 
+/// Selected endpoint plus a diagnostic for every endpoint probed.
 class PirSnapshotResolution {
   final Uri endpoint;
   final List<PirSnapshotEndpointDiagnostic> diagnostics;
@@ -48,6 +47,7 @@ class PirSnapshotResolution {
   });
 }
 
+/// No PIR endpoints were configured for the round.
 class PirSnapshotNoEndpoints implements Exception {
   const PirSnapshotNoEndpoints();
 
@@ -55,6 +55,7 @@ class PirSnapshotNoEndpoints implements Exception {
   String toString() => 'PirSnapshotNoEndpoints';
 }
 
+/// Endpoints were probed and none served the round's snapshot height.
 class PirSnapshotNoMatchingEndpoint implements Exception {
   final int expectedSnapshotHeight;
   final List<PirSnapshotEndpointDiagnostic> diagnostics;
@@ -67,58 +68,27 @@ class PirSnapshotNoMatchingEndpoint implements Exception {
   @override
   String toString() =>
       'PirSnapshotNoMatchingEndpoint(expectedSnapshotHeight: '
-      '$expectedSnapshotHeight, diagnostics: ${diagnostics.length})';
+      '$expectedSnapshotHeight, diagnostics: $diagnostics)';
 }
 
-/// Chooses an exact-height endpoint from completed probe diagnostics.
+/// Resolves the PIR endpoint that serves a round's snapshot height.
 ///
-/// The SDK owns this protocol policy. The resolver retains HTTP probing so it
-/// can use the wallet's routed client and expose transport diagnostics.
-typedef PirSnapshotEndpointSelector =
-    Uri? Function({
-      required List<PirSnapshotEndpointDiagnostic> diagnostics,
-      required int expectedSnapshotHeight,
-      required int matchIndex,
-    });
-
-/// Resolves a PIR endpoint whose snapshot root is exactly the expected height.
-///
-/// Exact matching is deliberate. A behind endpoint cannot answer for the round's
-/// required snapshot, and an ahead endpoint may reveal a different anonymity set
-/// than the one expected by the selected voting round. Optional `/root`
-/// identity fields such as `network_id` or `round_id` are not used for
-/// selection; the selected round data supplies the expected height.
+/// Probing, height classification, and selection all happen in Rust; this
+/// type is the Dart-side seam so callers and tests keep one place to stub.
+/// The endpoint the wallet probes with is the same routed transport that
+/// carries the rest of foreground voting traffic.
 class PirSnapshotResolver {
-  PirSnapshotResolver({
-    required VotingHttpClient httpClient,
-    required PirSnapshotEndpointSelector selectEndpoint,
-    math.Random? random,
-    Duration timeout = const Duration(seconds: 10),
-    VotingRetryPolicy? retryPolicy,
-    Future<void> Function(Duration delay)? delay,
-  }) : _httpClient = httpClient,
-       _selectEndpoint = selectEndpoint,
-       _random = random ?? math.Random.secure(),
-       _timeout = timeout,
-       _retryPolicy =
-           retryPolicy ??
-           VotingRetryPolicy.transientHttp(
-             name: 'voting-pir-probe',
-             delays: const [Duration.zero],
-           ),
-       _delay = delay ?? Future<void>.delayed;
+  const PirSnapshotResolver({ResolvePirSnapshotEndpointFn? resolveEndpoint})
+    : _resolveEndpoint =
+          resolveEndpoint ?? rust_api.resolvePirSnapshotEndpoint;
 
-  final VotingHttpClient _httpClient;
-  final PirSnapshotEndpointSelector _selectEndpoint;
-  final math.Random _random;
-  final Duration _timeout;
-  final VotingRetryPolicy _retryPolicy;
-  final Future<void> Function(Duration delay) _delay;
+  final ResolvePirSnapshotEndpointFn _resolveEndpoint;
 
-  /// Probes all endpoints and randomly selects among exact-height matches.
+  /// Probes all endpoints and selects one serving [expectedSnapshotHeight].
   ///
-  /// The method fails closed when no endpoint matches, carrying diagnostics for
-  /// every endpoint that was considered.
+  /// Fails closed: an endpoint that cannot be reached or does not serve the
+  /// height is never selected. [PirSnapshotNoMatchingEndpoint] carries every
+  /// diagnostic so the caller can say which heights were on offer.
   Future<PirSnapshotResolution> resolve({
     required List<Uri> endpoints,
     required int expectedSnapshotHeight,
@@ -127,149 +97,70 @@ class PirSnapshotResolver {
       throw const PirSnapshotNoEndpoints();
     }
 
-    final diagnostics = await Future.wait(
-      endpoints.map(
-        (endpoint) => _probeEndpoint(
-          endpoint: endpoint,
-          expectedSnapshotHeight: expectedSnapshotHeight,
-        ),
-      ),
-    );
-    final endpoint = _selectEndpoint(
-      diagnostics: diagnostics,
-      expectedSnapshotHeight: expectedSnapshotHeight,
-      matchIndex: _random.nextInt(1 << 32),
-    );
+    final rust_api.ApiPirSnapshotResolution resolution;
+    try {
+      resolution = await _resolveEndpoint(
+        endpoints: [for (final endpoint in endpoints) endpoint.toString()],
+        expectedSnapshotHeight: BigInt.from(expectedSnapshotHeight),
+      );
+    } on rust_voting.VotingErrorView catch (error) {
+      throw VotingRustException(error);
+    }
+
+    final diagnostics = [
+      for (final diagnostic in resolution.diagnostics)
+        _diagnosticFrom(diagnostic),
+    ];
+    final endpoint = resolution.endpoint;
     if (endpoint == null) {
       throw PirSnapshotNoMatchingEndpoint(
         expectedSnapshotHeight: expectedSnapshotHeight,
         diagnostics: diagnostics,
       );
     }
-
-    return PirSnapshotResolution(endpoint: endpoint, diagnostics: diagnostics);
-  }
-
-  Future<PirSnapshotEndpointDiagnostic> _probeEndpoint({
-    required Uri endpoint,
-    required int expectedSnapshotHeight,
-  }) async {
-    try {
-      final rootUri = _rootUri(endpoint);
-      final response = await withVotingRetry(
-        policy: _retryPolicy,
-        delay: _delay,
-        operation: () async {
-          final response = await _httpClient.get(rootUri, timeout: _timeout);
-          if (response.statusCode != 200) {
-            final error = VotingHttpException(
-              uri: rootUri,
-              statusCode: response.statusCode,
-              body: response.bodyText,
-            );
-            if (isRetryableVotingError(error)) {
-              throw error;
-            }
-          }
-          return response;
-        },
-      );
-      if (response.statusCode != 200) {
-        return PirSnapshotEndpointDiagnostic(
-          endpoint: endpoint,
-          status: PirSnapshotEndpointStatus.nonSuccessStatus,
-          httpStatusCode: response.statusCode,
-          message: response.bodyText,
-        );
-      }
-      final decoded = jsonDecode(response.bodyText);
-      if (decoded is! Map) {
-        return PirSnapshotEndpointDiagnostic(
-          endpoint: endpoint,
-          status: PirSnapshotEndpointStatus.malformedJson,
-          message: 'root response is not a JSON object',
-        );
-      }
-      final height = _heightFromRoot(decoded);
-      if (height == null) {
-        return PirSnapshotEndpointDiagnostic(
-          endpoint: endpoint,
-          status: PirSnapshotEndpointStatus.missingHeight,
-          message: 'root response did not include height',
-        );
-      }
-      if (height < expectedSnapshotHeight) {
-        return PirSnapshotEndpointDiagnostic(
-          endpoint: endpoint,
-          status: PirSnapshotEndpointStatus.behind,
-          reportedHeight: height,
-        );
-      }
-      if (height > expectedSnapshotHeight) {
-        return PirSnapshotEndpointDiagnostic(
-          endpoint: endpoint,
-          status: PirSnapshotEndpointStatus.ahead,
-          reportedHeight: height,
-        );
-      }
-      return PirSnapshotEndpointDiagnostic(
-        endpoint: endpoint,
-        status: PirSnapshotEndpointStatus.matched,
-        reportedHeight: height,
-      );
-    } on VotingHttpException catch (e) {
-      return PirSnapshotEndpointDiagnostic(
-        endpoint: endpoint,
-        status: PirSnapshotEndpointStatus.nonSuccessStatus,
-        httpStatusCode: e.statusCode,
-        message: e.body,
-      );
-    } on FormatException catch (e) {
-      return PirSnapshotEndpointDiagnostic(
-        endpoint: endpoint,
-        status: PirSnapshotEndpointStatus.malformedJson,
-        message: e.message,
-      );
-    } catch (e) {
-      return PirSnapshotEndpointDiagnostic(
-        endpoint: endpoint,
-        status: PirSnapshotEndpointStatus.timeoutOrNetworkError,
-        message: e.toString(),
-      );
-    }
-  }
-
-  static Uri _rootUri(Uri endpoint) {
-    final pathSegments = endpoint.pathSegments
-        .where((segment) => segment.isNotEmpty)
-        .toList();
-    return endpoint.replace(pathSegments: [...pathSegments, 'root']);
-  }
-
-  static final _unsignedIntegerPattern = RegExp(r'^\d+$');
-  static final _maxU64 = BigInt.parse('18446744073709551615');
-
-  /// Returns `/root.height`, or null when the canonical height field is absent.
-  /// Throws [FormatException] when `height` is present but malformed.
-  static int? _heightFromRoot(Map<dynamic, dynamic> root) {
-    if (!root.containsKey('height')) return null;
-    return _parseRootHeightField(root['height']);
-  }
-
-  /// Parses `/root.height` as a JSON integer or decimal string in the unsigned
-  /// 64-bit range.
-  static int _parseRootHeightField(Object? value) {
-    if (value is int && value >= 0 && BigInt.from(value) <= _maxU64) {
-      return value;
-    }
-    if (value is String && _unsignedIntegerPattern.hasMatch(value)) {
-      final height = BigInt.parse(value);
-      if (height <= _maxU64) {
-        return int.parse(value);
-      }
-    }
-    throw const FormatException(
-      '/root field "height" is not a valid u64 height',
+    return PirSnapshotResolution(
+      endpoint: Uri.parse(endpoint),
+      diagnostics: diagnostics,
     );
   }
+
+  static PirSnapshotEndpointDiagnostic _diagnosticFrom(
+    rust_api.ApiPirSnapshotEndpointDiagnostic diagnostic,
+  ) {
+    return PirSnapshotEndpointDiagnostic(
+      endpoint: Uri.parse(diagnostic.endpoint),
+      status: _statusFrom(diagnostic.status),
+      reportedHeight: diagnostic.reportedHeight?.toInt(),
+      httpStatusCode: diagnostic.httpStatusCode,
+      message: diagnostic.message,
+    );
+  }
+
+  static PirSnapshotEndpointStatus _statusFrom(
+    rust_api.ApiPirSnapshotEndpointStatus status,
+  ) {
+    return switch (status) {
+      rust_api.ApiPirSnapshotEndpointStatus.matched =>
+        PirSnapshotEndpointStatus.matched,
+      rust_api.ApiPirSnapshotEndpointStatus.behind =>
+        PirSnapshotEndpointStatus.behind,
+      rust_api.ApiPirSnapshotEndpointStatus.ahead =>
+        PirSnapshotEndpointStatus.ahead,
+      rust_api.ApiPirSnapshotEndpointStatus.missingHeight =>
+        PirSnapshotEndpointStatus.missingHeight,
+      rust_api.ApiPirSnapshotEndpointStatus.malformedJson =>
+        PirSnapshotEndpointStatus.malformedJson,
+      rust_api.ApiPirSnapshotEndpointStatus.nonSuccessStatus =>
+        PirSnapshotEndpointStatus.nonSuccessStatus,
+      rust_api.ApiPirSnapshotEndpointStatus.timeoutOrNetworkError =>
+        PirSnapshotEndpointStatus.timeoutOrNetworkError,
+    };
+  }
 }
+
+/// The bridge call [PirSnapshotResolver] drives, injectable for tests.
+typedef ResolvePirSnapshotEndpointFn =
+    Future<rust_api.ApiPirSnapshotResolution> Function({
+      required List<String> endpoints,
+      required BigInt expectedSnapshotHeight,
+    });

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4346,6 +4346,7 @@ version = "0.1.0"
 dependencies = [
  "aes",
  "aes-gcm",
+ "anyhow",
  "base64",
  "bip0039",
  "bytes",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -163,6 +163,11 @@ rusqlite = "0.37"
 # from a freshly built Orchard bundle (matches pczt's own end-to-end test).
 # Already in the dependency graph via zcash_client_backend.
 zcash_note_encryption = "0.4"
+# The scripted PIR probe transport builds the same typed failure the real
+# transport attaches, and pauses time so the probe deadline is exercised
+# without waiting on it. Both are already in the graph.
+anyhow = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util", "time"] }
 
 [dev-dependencies.zcash_voting]
 git = "https://github.com/valargroup/zcash_voting.git"

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -44,31 +44,6 @@ pub struct ApiPirSnapshotEndpointDiagnostic {
     pub message: Option<String>,
 }
 
-impl From<ApiPirSnapshotEndpointDiagnostic>
-    for zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic
-{
-    fn from(diagnostic: ApiPirSnapshotEndpointDiagnostic) -> Self {
-        use zcash_voting::pir_snapshot::PirSnapshotEndpointStatus as CoreStatus;
-        let status = match diagnostic.status {
-            ApiPirSnapshotEndpointStatus::Matched => CoreStatus::Matched,
-            ApiPirSnapshotEndpointStatus::Behind => CoreStatus::Behind,
-            ApiPirSnapshotEndpointStatus::Ahead => CoreStatus::Ahead,
-            ApiPirSnapshotEndpointStatus::MissingHeight => CoreStatus::MissingHeight,
-            ApiPirSnapshotEndpointStatus::MalformedJson => CoreStatus::MalformedJson,
-            ApiPirSnapshotEndpointStatus::NonSuccessStatus => CoreStatus::NonSuccessStatus,
-            ApiPirSnapshotEndpointStatus::TimeoutOrNetworkError => {
-                CoreStatus::TimeoutOrNetworkError
-            }
-        };
-        Self {
-            endpoint: diagnostic.endpoint,
-            status,
-            reported_height: diagnostic.reported_height,
-            http_status_code: diagnostic.http_status_code,
-            message: diagnostic.message,
-        }
-    }
-}
 
 impl From<zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic>
     for ApiPirSnapshotEndpointDiagnostic
@@ -349,33 +324,6 @@ fn pir_snapshot_failure(
     }
 }
 
-/// Select an exact-height PIR endpoint using the SDK's snapshot policy.
-///
-/// Dart owns probing and diagnostics because it owns the routed HTTP client.
-/// The protocol decision about which diagnostics are eligible remains here.
-#[flutter_rust_bridge::frb(sync)]
-pub fn select_pir_snapshot_endpoint(
-    diagnostics: Vec<ApiPirSnapshotEndpointDiagnostic>,
-    expected_snapshot_height: u64,
-    match_index: u64,
-) -> Result<Option<String>, VotingErrorView> {
-    let diagnostics = diagnostics.into_iter().map(Into::into).collect::<Vec<_>>();
-    if zcash_voting::pir_snapshot::matching_pir_snapshot_endpoints(
-        &diagnostics,
-        expected_snapshot_height,
-    )
-    .is_empty()
-    {
-        return Ok(None);
-    }
-    zcash_voting::pir_snapshot::select_pir_snapshot_endpoint(
-        &diagnostics,
-        expected_snapshot_height,
-        match_index,
-    )
-    .map(|resolution| Some(resolution.endpoint))
-    .map_err(view)
-}
 
 /// Prefix for coarse cast-vote stage timings (`log show` subsystem `frb_user`).
 const VOTING_VOTE_LOG: &str = "[VOTING_VOTE]";
@@ -1684,19 +1632,18 @@ mod tests {
     #[test]
     fn classified_diagnostics_survive_the_bridge_conversion() {
         // The delegation failover list and the status screen both read these
-        // back on the Dart side, so the round trip has to be lossless.
+        // back on the Dart side, so the crossing must not lose the status or
+        // the height the endpoint reported.
         let core = zcash_voting::pir_snapshot::classify_pir_snapshot_height(
             "https://pir.example",
             123,
             Some(120),
         );
         let api = ApiPirSnapshotEndpointDiagnostic::from(core.clone());
+        assert_eq!(api.endpoint, core.endpoint);
         assert!(matches!(api.status, ApiPirSnapshotEndpointStatus::Behind));
         assert_eq!(api.reported_height, Some(120));
-        assert_eq!(
-            zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic::from(api),
-            core
-        );
+        assert_eq!(api.http_status_code, None);
     }
     use crate::wallet::voting::test_support::{
         test_api_round_params, test_note_info, ROUND_ID, TEST_ACCOUNT_UUID,

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -109,7 +109,13 @@ pub async fn resolve_pir_snapshot_endpoint(
     let diagnostics = futures::future::join_all(
         endpoints
             .iter()
-            .map(|endpoint| probe_pir_snapshot_endpoint(&transport, endpoint, expected_snapshot_height)),
+            .map(|endpoint| {
+                probe_pir_snapshot_endpoint(
+                    transport.as_ref(),
+                    endpoint,
+                    expected_snapshot_height,
+                )
+            }),
     )
     .await;
 
@@ -146,8 +152,8 @@ pub async fn resolve_pir_snapshot_endpoint(
 /// the probe policy this replaced. Every failure becomes a diagnostic rather
 /// than an error: one unreachable endpoint must not fail a resolution another
 /// endpoint can satisfy.
-async fn probe_pir_snapshot_endpoint(
-    transport: &zcash_voting::HyperTransport<crate::wallet::voting::route::VizorRoute>,
+async fn probe_pir_snapshot_endpoint<T: zcash_voting::pir::Transport + ?Sized>(
+    transport: &T,
     endpoint: &str,
     expected_snapshot_height: u64,
 ) -> zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic {
@@ -164,13 +170,12 @@ struct PirSnapshotProbeAttempt {
     retryable: bool,
 }
 
-async fn pir_snapshot_probe_attempt(
-    transport: &zcash_voting::HyperTransport<crate::wallet::voting::route::VizorRoute>,
+async fn pir_snapshot_probe_attempt<T: zcash_voting::pir::Transport + ?Sized>(
+    transport: &T,
     url: &str,
     endpoint: &str,
     expected_snapshot_height: u64,
 ) -> PirSnapshotProbeAttempt {
-    use zcash_voting::pir::Transport as _;
     use zcash_voting::pir_snapshot::PirSnapshotEndpointStatus as Status;
 
     // The transport's own deadline covers a PIR query, which is a much larger
@@ -305,8 +310,22 @@ fn pir_snapshot_height_field(value: &serde_json::Value) -> Option<u64> {
 }
 
 /// Appends `root` to an endpoint URL, keeping any base path it already has.
+///
+/// Built structurally rather than by concatenation so an endpoint carrying a
+/// query string still probes `<path>/root?<query>` instead of a URL with the
+/// segment buried in the query.
 fn pir_snapshot_root_url(endpoint: &str) -> String {
-    format!("{}/root", endpoint.trim_end_matches('/'))
+    let Ok(mut url) = url::Url::parse(endpoint) else {
+        return format!("{}/root", endpoint.trim_end_matches('/'));
+    };
+    match url.path_segments_mut() {
+        Ok(mut segments) => {
+            segments.pop_if_empty().push("root");
+        }
+        // Not a hierarchical URL, so it has no path to extend.
+        Err(_) => return format!("{}/root", endpoint.trim_end_matches('/')),
+    }
+    url.to_string()
 }
 
 fn pir_snapshot_failure(
@@ -1566,6 +1585,218 @@ pub fn resolve_voting_config_from_attempts(
 mod tests {
     use super::*;
 
+    /// Transport that answers `/root` from a script, so the probe path can be
+    /// exercised end to end without a network.
+    struct ScriptedPirTransport {
+        responses: std::collections::HashMap<String, Vec<PirProbeAnswer>>,
+        calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[derive(Clone)]
+    enum PirProbeAnswer {
+        Body(u16, String),
+        Failure(zcash_voting::PirHttpFailurePhase, Option<u16>),
+        Hang,
+    }
+
+    impl ScriptedPirTransport {
+        fn new(responses: &[(&str, Vec<PirProbeAnswer>)]) -> Self {
+            Self {
+                responses: responses
+                    .iter()
+                    .map(|(url, answers)| ((*url).to_string(), answers.clone()))
+                    .collect(),
+                calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn call_count(&self, url: &str) -> usize {
+            self.calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|called| called.as_str() == url)
+                .count()
+        }
+    }
+
+    impl zcash_voting::pir::Transport for ScriptedPirTransport {
+        fn get<'a>(&'a self, url: &'a str) -> zcash_voting::pir::TransportFuture<'a> {
+            let attempt = self.call_count(url);
+            self.calls.lock().unwrap().push(url.to_string());
+            let answer = self
+                .responses
+                .get(url)
+                .map(|answers| answers[attempt.min(answers.len() - 1)].clone());
+            Box::pin(async move {
+                match answer {
+                    Some(PirProbeAnswer::Body(status, body)) => {
+                        Ok(zcash_voting::pir::TransportResponse {
+                            status,
+                            headers: Vec::new(),
+                            body: body.into_bytes(),
+                        })
+                    }
+                    Some(PirProbeAnswer::Failure(phase, http_status)) => {
+                        Err(anyhow::Error::new(zcash_voting::PirHttpFailure {
+                            phase,
+                            http_status,
+                        }))
+                    }
+                    Some(PirProbeAnswer::Hang) => {
+                        // Outlives the probe deadline without resolving.
+                        std::future::pending::<()>().await;
+                        unreachable!()
+                    }
+                    None => panic!("unscripted PIR probe for {url}"),
+                }
+            })
+        }
+
+        fn post<'a>(&'a self, _url: &'a str, _body: Vec<u8>) -> zcash_voting::pir::TransportFuture<'a> {
+            unimplemented!("PIR snapshot probing only issues GETs")
+        }
+    }
+
+    fn root_body(height: &str) -> PirProbeAnswer {
+        PirProbeAnswer::Body(200, format!("{{\"height\": {height}}}"))
+    }
+
+    async fn probe(answer: PirProbeAnswer, expected_snapshot_height: u64) -> (
+        zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic,
+        ScriptedPirTransport,
+    ) {
+        let transport = ScriptedPirTransport::new(&[("https://pir.example/root", vec![answer])]);
+        let diagnostic = probe_pir_snapshot_endpoint(
+            &transport,
+            "https://pir.example",
+            expected_snapshot_height,
+        )
+        .await;
+        (diagnostic, transport)
+    }
+
+    #[tokio::test]
+    async fn probing_classifies_a_served_height_against_the_round() {
+        use zcash_voting::pir_snapshot::PirSnapshotEndpointStatus as Status;
+
+        for (served, expected, status) in [
+            ("123", 123, Status::Matched),
+            ("120", 123, Status::Behind),
+            ("125", 123, Status::Ahead),
+        ] {
+            let (diagnostic, _) = probe(root_body(served), expected).await;
+            assert_eq!(diagnostic.status, status, "served {served}");
+            assert_eq!(diagnostic.reported_height, Some(served.parse().unwrap()));
+            assert_eq!(diagnostic.endpoint, "https://pir.example");
+        }
+    }
+
+    #[tokio::test]
+    async fn probing_accepts_a_decimal_string_height_and_ignores_other_fields() {
+        // Endpoints publish the height both ways and carry identity fields the
+        // wallet does not read; neither may turn a healthy root into a miss.
+        let (diagnostic, _) = probe(
+            PirProbeAnswer::Body(
+                200,
+                r#"{"zcash_network": "main", "height": "123", "pir_depth": 4}"#.to_string(),
+            ),
+            123,
+        )
+        .await;
+        assert!(diagnostic.matched_at_height(123));
+    }
+
+    #[tokio::test]
+    async fn probing_separates_an_absent_height_from_a_corrupt_one() {
+        use zcash_voting::pir_snapshot::PirSnapshotEndpointStatus as Status;
+
+        let (missing, _) = probe(
+            PirProbeAnswer::Body(200, r#"{"zcash_network": "main"}"#.to_string()),
+            123,
+        )
+        .await;
+        assert_eq!(missing.status, Status::MissingHeight);
+
+        for body in [r#"{"height": "twelve"}"#, r#"{"height": -1}"#, "not json", "[]"] {
+            let (diagnostic, _) = probe(PirProbeAnswer::Body(200, body.to_string()), 123).await;
+            assert_eq!(diagnostic.status, Status::MalformedJson, "{body}");
+        }
+    }
+
+    #[tokio::test]
+    async fn probing_reports_a_non_success_status_with_its_code() {
+        use zcash_voting::pir_snapshot::PirSnapshotEndpointStatus as Status;
+
+        let (diagnostic, _) = probe(PirProbeAnswer::Body(404, "gone".to_string()), 123).await;
+        assert_eq!(diagnostic.status, Status::NonSuccessStatus);
+        assert_eq!(diagnostic.http_status_code, Some(404));
+    }
+
+    #[tokio::test]
+    async fn probing_retries_once_when_another_attempt_could_clear_it() {
+        // A connect failure may be transient; a 404 is the endpoint's answer.
+        let transport = ScriptedPirTransport::new(&[(
+            "https://pir.example/root",
+            vec![
+                PirProbeAnswer::Failure(zcash_voting::PirHttpFailurePhase::Connect, None),
+                root_body("123"),
+            ],
+        )]);
+        let diagnostic =
+            probe_pir_snapshot_endpoint(&transport, "https://pir.example", 123).await;
+        assert!(diagnostic.matched_at_height(123));
+        assert_eq!(transport.call_count("https://pir.example/root"), 2);
+
+        let (_, settled) = probe(PirProbeAnswer::Body(404, String::new()), 123).await;
+        assert_eq!(settled.call_count("https://pir.example/root"), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn probing_gives_up_on_an_endpoint_that_never_answers() {
+        use zcash_voting::pir_snapshot::PirSnapshotEndpointStatus as Status;
+
+        // Without its own deadline the probe would inherit the transport's much
+        // larger PIR budget and stall resolution behind one dead endpoint.
+        let (diagnostic, transport) = probe(PirProbeAnswer::Hang, 123).await;
+        assert_eq!(diagnostic.status, Status::TimeoutOrNetworkError);
+        // Timed out twice: the first pass is retryable.
+        assert_eq!(transport.call_count("https://pir.example/root"), 2);
+    }
+
+    #[tokio::test]
+    async fn resolving_selects_only_an_endpoint_serving_the_round_height() {
+        let transport = ScriptedPirTransport::new(&[
+            ("https://behind.example/root", vec![root_body("120")]),
+            ("https://match.example/root", vec![root_body("123")]),
+            (
+                "https://down.example/root",
+                vec![PirProbeAnswer::Failure(
+                    zcash_voting::PirHttpFailurePhase::Connect,
+                    None,
+                )],
+            ),
+        ]);
+        let diagnostics = futures::future::join_all(
+            [
+                "https://behind.example",
+                "https://match.example",
+                "https://down.example",
+            ]
+            .iter()
+            .map(|endpoint| probe_pir_snapshot_endpoint(&transport, endpoint, 123)),
+        )
+        .await;
+
+        let resolution =
+            zcash_voting::pir_snapshot::select_pir_snapshot_endpoint(&diagnostics, 123, 0)
+                .expect("one endpoint serves the round");
+        assert_eq!(resolution.endpoint, "https://match.example");
+        // Every probe is reported, because the caller builds its PIR failover
+        // list and its error message from the full set.
+        assert_eq!(resolution.diagnostics.len(), 3);
+    }
+
     #[test]
     fn reads_root_height_as_number_or_decimal_string() {
         // Endpoints publish the height both ways, so both must resolve to the
@@ -1612,6 +1843,15 @@ mod tests {
         assert_eq!(
             pir_snapshot_root_url("https://example.test/pir/"),
             "https://example.test/pir/root"
+        );
+        assert_eq!(
+            pir_snapshot_root_url("https://example.test/pir"),
+            "https://example.test/pir/root"
+        );
+        // A query belongs to the request, not to the path being extended.
+        assert_eq!(
+            pir_snapshot_root_url("https://example.test/pir?token=abc"),
+            "https://example.test/pir/root?token=abc"
         );
     }
 

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -70,6 +70,285 @@ impl From<ApiPirSnapshotEndpointDiagnostic>
     }
 }
 
+impl From<zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic>
+    for ApiPirSnapshotEndpointDiagnostic
+{
+    fn from(diagnostic: zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic) -> Self {
+        use zcash_voting::pir_snapshot::PirSnapshotEndpointStatus as CoreStatus;
+        let status = match diagnostic.status {
+            CoreStatus::Matched => ApiPirSnapshotEndpointStatus::Matched,
+            CoreStatus::Behind => ApiPirSnapshotEndpointStatus::Behind,
+            CoreStatus::Ahead => ApiPirSnapshotEndpointStatus::Ahead,
+            CoreStatus::MissingHeight => ApiPirSnapshotEndpointStatus::MissingHeight,
+            CoreStatus::MalformedJson => ApiPirSnapshotEndpointStatus::MalformedJson,
+            CoreStatus::NonSuccessStatus => ApiPirSnapshotEndpointStatus::NonSuccessStatus,
+            CoreStatus::TimeoutOrNetworkError => {
+                ApiPirSnapshotEndpointStatus::TimeoutOrNetworkError
+            }
+        };
+        Self {
+            endpoint: diagnostic.endpoint,
+            status,
+            reported_height: diagnostic.reported_height,
+            http_status_code: diagnostic.http_status_code,
+            message: diagnostic.message,
+        }
+    }
+}
+
+/// Selected PIR endpoint plus a diagnostic for every endpoint probed.
+///
+/// The full diagnostic set is part of the result, not debug output: the
+/// delegation path builds its PIR failover list from the endpoints that
+/// matched, and the status screen explains a failed resolution from the
+/// heights the endpoints reported.
+#[derive(Debug)]
+pub struct ApiPirSnapshotResolution {
+    /// `None` when every endpoint was probed and none matched the round.
+    pub endpoint: Option<String>,
+    pub diagnostics: Vec<ApiPirSnapshotEndpointDiagnostic>,
+}
+
+/// Probe every configured PIR endpoint and select one at the round's height.
+///
+/// Probing runs here rather than in Dart so the wallet has one PIR resolution
+/// path instead of a probe on one side of the bridge and the selection policy
+/// on the other. Traffic uses the routed transport, so the probe follows the
+/// same network route as the rest of the wallet's foreground voting traffic.
+///
+/// Returns `endpoint: None` when endpoints were probed but none served the
+/// round's snapshot height; that is a normal, recoverable outcome the caller
+/// reports from the diagnostics. An empty `endpoints` list is an error,
+/// because it means the round is misconfigured rather than the fleet behind.
+pub async fn resolve_pir_snapshot_endpoint(
+    endpoints: Vec<String>,
+    expected_snapshot_height: u64,
+) -> Result<ApiPirSnapshotResolution, VotingErrorView> {
+    if endpoints.is_empty() {
+        return Err(view(VotingError::InvalidInput {
+            message: "no PIR endpoints configured".to_string(),
+        }));
+    }
+
+    let transport = routed_transport();
+    let diagnostics = futures::future::join_all(
+        endpoints
+            .iter()
+            .map(|endpoint| probe_pir_snapshot_endpoint(&transport, endpoint, expected_snapshot_height)),
+    )
+    .await;
+
+    if zcash_voting::pir_snapshot::matching_pir_snapshot_endpoints(
+        &diagnostics,
+        expected_snapshot_height,
+    )
+    .is_empty()
+    {
+        return Ok(ApiPirSnapshotResolution {
+            endpoint: None,
+            diagnostics: diagnostics.into_iter().map(Into::into).collect(),
+        });
+    }
+
+    // The SDK keeps selection deterministic and leaves the randomness to its
+    // caller, so the spread across equally-valid endpoints is chosen here.
+    let match_index = u64::from_le_bytes(rand::random::<[u8; 8]>());
+    let resolution = zcash_voting::pir_snapshot::select_pir_snapshot_endpoint(
+        &diagnostics,
+        expected_snapshot_height,
+        match_index,
+    )
+    .map_err(view)?;
+    Ok(ApiPirSnapshotResolution {
+        endpoint: Some(resolution.endpoint),
+        diagnostics: resolution.diagnostics.into_iter().map(Into::into).collect(),
+    })
+}
+
+/// Probe one endpoint's `/root` and normalize the outcome into a diagnostic.
+///
+/// Retries once immediately on a failure another attempt could clear, matching
+/// the probe policy this replaced. Every failure becomes a diagnostic rather
+/// than an error: one unreachable endpoint must not fail a resolution another
+/// endpoint can satisfy.
+async fn probe_pir_snapshot_endpoint(
+    transport: &zcash_voting::HyperTransport<crate::wallet::voting::route::VizorRoute>,
+    endpoint: &str,
+    expected_snapshot_height: u64,
+) -> zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic {
+    let url = pir_snapshot_root_url(endpoint);
+    let mut attempt = pir_snapshot_probe_attempt(transport, &url, endpoint, expected_snapshot_height).await;
+    if attempt.retryable {
+        attempt = pir_snapshot_probe_attempt(transport, &url, endpoint, expected_snapshot_height).await;
+    }
+    attempt.diagnostic
+}
+
+struct PirSnapshotProbeAttempt {
+    diagnostic: zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic,
+    retryable: bool,
+}
+
+async fn pir_snapshot_probe_attempt(
+    transport: &zcash_voting::HyperTransport<crate::wallet::voting::route::VizorRoute>,
+    url: &str,
+    endpoint: &str,
+    expected_snapshot_height: u64,
+) -> PirSnapshotProbeAttempt {
+    use zcash_voting::pir::Transport as _;
+    use zcash_voting::pir_snapshot::PirSnapshotEndpointStatus as Status;
+
+    // The transport's own deadline covers a PIR query, which is a much larger
+    // request than this probe; hold the probe to the wallet's own budget so a
+    // single dead endpoint cannot stall resolution behind it.
+    let response = match tokio::time::timeout(PIR_SNAPSHOT_PROBE_TIMEOUT, transport.get(url)).await
+    {
+        Err(_) => {
+            return PirSnapshotProbeAttempt {
+                diagnostic: pir_snapshot_failure(
+                    endpoint,
+                    Status::TimeoutOrNetworkError,
+                    None,
+                    Some(format!(
+                        "no response within {}s",
+                        PIR_SNAPSHOT_PROBE_TIMEOUT.as_secs()
+                    )),
+                ),
+                retryable: true,
+            };
+        }
+        Ok(Err(error)) => {
+            let failure = zcash_voting::PirHttpFailure::from_error_chain(&error);
+            let http_status = failure.and_then(|failure| failure.http_status);
+            let status = match failure.map(|failure| failure.phase) {
+                Some(zcash_voting::PirHttpFailurePhase::Status) => Status::NonSuccessStatus,
+                _ => Status::TimeoutOrNetworkError,
+            };
+            return PirSnapshotProbeAttempt {
+                diagnostic: pir_snapshot_failure(
+                    endpoint,
+                    status,
+                    http_status,
+                    Some(format!("{error:#}")),
+                ),
+                retryable: failure.map(|failure| failure.retryable()).unwrap_or(true),
+            };
+        }
+        Ok(Ok(response)) => response,
+    };
+
+    if response.status != 200 {
+        return PirSnapshotProbeAttempt {
+            diagnostic: pir_snapshot_failure(
+                endpoint,
+                Status::NonSuccessStatus,
+                Some(response.status),
+                Some(String::from_utf8_lossy(&response.body).into_owned()),
+            ),
+            retryable: matches!(response.status, 408 | 429 | 500..=599),
+        };
+    }
+
+    let root = match serde_json::from_slice::<serde_json::Value>(&response.body) {
+        Ok(serde_json::Value::Object(root)) => root,
+        Ok(_) => {
+            return PirSnapshotProbeAttempt {
+                diagnostic: pir_snapshot_failure(
+                    endpoint,
+                    Status::MalformedJson,
+                    None,
+                    Some("root response is not a JSON object".to_string()),
+                ),
+                retryable: false,
+            };
+        }
+        Err(error) => {
+            return PirSnapshotProbeAttempt {
+                diagnostic: pir_snapshot_failure(
+                    endpoint,
+                    Status::MalformedJson,
+                    None,
+                    Some(error.to_string()),
+                ),
+                retryable: false,
+            };
+        }
+    };
+
+    // An absent height is a different signal from a corrupt one: the endpoint
+    // answered, it just does not publish a snapshot the round can use.
+    let Some(height) = root.get("height") else {
+        return PirSnapshotProbeAttempt {
+            diagnostic: pir_snapshot_failure(
+                endpoint,
+                Status::MissingHeight,
+                None,
+                Some("root response did not include height".to_string()),
+            ),
+            retryable: false,
+        };
+    };
+
+    match pir_snapshot_height_field(height) {
+        Some(height) => PirSnapshotProbeAttempt {
+            diagnostic: zcash_voting::pir_snapshot::classify_pir_snapshot_height(
+                endpoint,
+                expected_snapshot_height,
+                Some(height),
+            ),
+            retryable: false,
+        },
+        None => PirSnapshotProbeAttempt {
+            diagnostic: pir_snapshot_failure(
+                endpoint,
+                Status::MalformedJson,
+                None,
+                Some("root field \"height\" is not a valid u64 height".to_string()),
+            ),
+            retryable: false,
+        },
+    }
+}
+
+/// Deadline for one `/root` probe.
+const PIR_SNAPSHOT_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Reads `/root.height`, which endpoints publish as a number or as a decimal
+/// string. Returns `None` for anything else, including a value out of u64
+/// range.
+fn pir_snapshot_height_field(value: &serde_json::Value) -> Option<u64> {
+    match value {
+        serde_json::Value::Number(number) => number.as_u64(),
+        serde_json::Value::String(text) => {
+            if text.is_empty() || !text.bytes().all(|byte| byte.is_ascii_digit()) {
+                return None;
+            }
+            text.parse::<u64>().ok()
+        }
+        _ => None,
+    }
+}
+
+/// Appends `root` to an endpoint URL, keeping any base path it already has.
+fn pir_snapshot_root_url(endpoint: &str) -> String {
+    format!("{}/root", endpoint.trim_end_matches('/'))
+}
+
+fn pir_snapshot_failure(
+    endpoint: &str,
+    status: zcash_voting::pir_snapshot::PirSnapshotEndpointStatus,
+    http_status_code: Option<u16>,
+    message: Option<String>,
+) -> zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic {
+    zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic {
+        endpoint: endpoint.to_string(),
+        status,
+        reported_height: None,
+        http_status_code,
+        message,
+    }
+}
+
 /// Select an exact-height PIR endpoint using the SDK's snapshot policy.
 ///
 /// Dart owns probing and diagnostics because it owns the routed HTTP client.
@@ -1338,6 +1617,87 @@ pub fn resolve_voting_config_from_attempts(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reads_root_height_as_number_or_decimal_string() {
+        // Endpoints publish the height both ways, so both must resolve to the
+        // same round rather than one of them reading as a corrupt root.
+        assert_eq!(
+            pir_snapshot_height_field(&serde_json::json!(123)),
+            Some(123)
+        );
+        assert_eq!(
+            pir_snapshot_height_field(&serde_json::json!("123")),
+            Some(123)
+        );
+        assert_eq!(
+            pir_snapshot_height_field(&serde_json::json!(u64::MAX.to_string())),
+            Some(u64::MAX)
+        );
+    }
+
+    #[test]
+    fn rejects_root_heights_outside_the_unsigned_range() {
+        for value in [
+            serde_json::json!(-1),
+            serde_json::json!(1.5),
+            serde_json::json!("12a"),
+            serde_json::json!(""),
+            serde_json::json!("18446744073709551616"),
+            serde_json::json!(null),
+            serde_json::json!({}),
+        ] {
+            assert_eq!(pir_snapshot_height_field(&value), None, "{value}");
+        }
+    }
+
+    #[test]
+    fn root_url_keeps_any_base_path_the_endpoint_carries() {
+        assert_eq!(
+            pir_snapshot_root_url("https://pir.example"),
+            "https://pir.example/root"
+        );
+        assert_eq!(
+            pir_snapshot_root_url("https://pir.example/"),
+            "https://pir.example/root"
+        );
+        assert_eq!(
+            pir_snapshot_root_url("https://example.test/pir/"),
+            "https://example.test/pir/root"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolving_without_endpoints_is_an_error_not_an_empty_result() {
+        // A round with no configured endpoints is misconfigured; that must not
+        // read the same as a fleet that answered and is merely behind.
+        let error = resolve_pir_snapshot_endpoint(Vec::new(), 123)
+            .await
+            .expect_err("empty endpoint list must fail");
+        assert!(
+            error.message.contains("no PIR endpoints configured"),
+            "{}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn classified_diagnostics_survive_the_bridge_conversion() {
+        // The delegation failover list and the status screen both read these
+        // back on the Dart side, so the round trip has to be lossless.
+        let core = zcash_voting::pir_snapshot::classify_pir_snapshot_height(
+            "https://pir.example",
+            123,
+            Some(120),
+        );
+        let api = ApiPirSnapshotEndpointDiagnostic::from(core.clone());
+        assert!(matches!(api.status, ApiPirSnapshotEndpointStatus::Behind));
+        assert_eq!(api.reported_height, Some(120));
+        assert_eq!(
+            zcash_voting::pir_snapshot::PirSnapshotEndpointDiagnostic::from(api),
+            core
+        );
+    }
     use crate::wallet::voting::test_support::{
         test_api_round_params, test_note_info, ROUND_ID, TEST_ACCOUNT_UUID,
     };

--- a/rust/src/api/voting_session.rs
+++ b/rust/src/api/voting_session.rs
@@ -12,13 +12,13 @@ use std::sync::{Arc, Mutex};
 use flutter_rust_bridge::frb;
 use zcash_voting::delegation_pipeline::{DelegationSigner, KeystoneSignatureSource};
 use zcash_voting::wire::{
-    KeystoneSigningRequest, NextStepView, RoundPlanView, RoundStepFailureView,
-    RoundStepOutcomeView, RoundStepProgressView,
+    KeystoneSigningRequest, RoundDriveEventView, RoundPlanView, RoundRunReportView,
 };
 use zcash_voting::{
     BallotIntent, ChainAdvancePolicy, ChainSubmissionClientConfig, ChainSubmissionControl,
-    DelegationStepInputs, HelperHealth, ProposalRosterEntry, RoundBinding, RoundExecutor,
-    RoundHostContext, RoundStepProgressBridge, VotingErrorView,
+    DelegationStepInputs, FailureIsolation, HelperHealth, ProposalRosterEntry, RoundBinding,
+    RoundDrivePolicy, RoundDriveReporterBridge, RoundDriver, RoundExecutor, RoundHostContext,
+    RoundHostSourceBridge, VotingErrorView,
 };
 use zeroize::Zeroizing;
 
@@ -151,20 +151,25 @@ impl From<VotingErrorView> for ApiRoundStepError {
     }
 }
 
-/// One event of a streamed step: progress while it runs, then one result.
+/// One observation from a round run, or its single terminal report.
 ///
-/// The result event carries exactly one of `outcome`, `failure`, or `error`.
-/// `failure` is a step the SDK ran and rejected; `error` is everything that
-/// stopped the step from producing either, including the work this boundary
-/// does before handing over (signer material, delegation pipeline, PIR fleet)
-/// and a view conversion that fails after the step already ran.
-#[derive(Clone, Debug, PartialEq)]
-pub struct ApiRoundStepEvent {
+/// Exactly one `Result`-kind event is emitted however the run ends, carrying
+/// either the report or a bridge error.
+pub struct ApiRoundRunEvent {
     pub kind: ApiRoundStepEventKind,
-    pub progress: Option<RoundStepProgressView>,
-    pub outcome: Option<RoundStepOutcomeView>,
-    pub failure: Option<RoundStepFailureView>,
+    pub event: Option<RoundDriveEventView>,
+    pub report: Option<RoundRunReportView>,
     pub error: Option<ApiRoundStepError>,
+}
+
+/// How a run paces itself. Omitted fields keep the SDK defaults, which are the
+/// cadence the Dart driver used before the SDK owned the loop.
+pub struct ApiRoundDrivePolicy {
+    pub pending_repoll_seconds: Option<f64>,
+    pub max_bundle_concurrency: Option<u32>,
+    pub max_dispatches: Option<u32>,
+    /// `true` keeps every other bundle running after one fails.
+    pub skip_failed_bundle: Option<bool>,
 }
 
 /// SDK-owned execution of one round for one account.
@@ -322,31 +327,85 @@ impl VotingRoundSession {
         RoundPlanView::try_from(plan).map_err(VotingErrorView::from)
     }
 
-    /// Runs the first planned step, streaming progress then one result.
+    /// Drives the bound round to quiescence, streaming events then one report.
     ///
-    /// See [`VotingRoundSession::advance`] for why this reports failures on
-    /// the sink instead of returning them.
-    pub async fn advance_next(
+    /// Emits exactly one `Result` event for the reason [`Self::advance`]
+    /// documents: a streaming function's `Err` return never reaches Dart.
+    ///
+    /// `host` is a template. The driver reads the host context once per
+    /// dispatch and this bridge restamps `now_seconds` each time, because a
+    /// run can take minutes and a long proof can cross the last-moment or
+    /// vote-end boundary. Every other field is fixed for the run, so a helper
+    /// fleet that changes mid-run needs a new call.
+    pub async fn run_round(
         &self,
         host: ApiRoundHostContext,
         signer: Option<ApiDelegationSignerInput>,
-        sink: StreamSink<ApiRoundStepEvent>,
+        policy: Option<ApiRoundDrivePolicy>,
+        sink: StreamSink<ApiRoundRunEvent>,
     ) {
-        self.advance(None, host, signer, sink).await
+        let sink = Arc::new(sink);
+        let event = match self.drive(host, signer, policy, Arc::clone(&sink)).await {
+            Ok(event) => event,
+            Err(error) => ApiRoundRunEvent {
+                kind: ApiRoundStepEventKind::Result,
+                event: None,
+                report: None,
+                error: Some(ApiRoundStepError::from(error)),
+            },
+        };
+        let _ = sink.add(event);
     }
 
-    /// Runs one planned step, streaming progress then one result.
-    ///
-    /// See [`VotingRoundSession::advance`] for why this reports failures on
-    /// the sink instead of returning them.
-    pub async fn advance_step(
+    /// Runs the round, streaming events, and returns its report event.
+    async fn drive(
         &self,
-        step: NextStepView,
         host: ApiRoundHostContext,
         signer: Option<ApiDelegationSignerInput>,
-        sink: StreamSink<ApiRoundStepEvent>,
-    ) {
-        self.advance(Some(step), host, signer, sink).await
+        policy: Option<ApiRoundDrivePolicy>,
+        sink: Arc<StreamSink<ApiRoundRunEvent>>,
+    ) -> Result<ApiRoundRunEvent, VotingErrorView> {
+        // Built once for the whole run: opening it fetches the lightwalletd
+        // anchor, and the driver overlaps bundles that would each pay for it.
+        let delegation = self.delegation_inputs(signer).await?;
+        let template = RoundHostContext {
+            configured_helper_urls: host.configured_helper_urls,
+            now_seconds: host.now_seconds,
+            ceremony_start_seconds: host.ceremony_start_seconds,
+            vote_end_time_seconds: host.vote_end_time_seconds,
+            vote_tree_node_urls: host.vote_tree_node_urls,
+            delegation,
+            chain_policy: ChainAdvancePolicy::default(),
+            max_proof_concurrency: host.max_proof_concurrency.max(1) as usize,
+        };
+        let host_source = RoundHostSourceBridge::new(move || RoundHostContext {
+            now_seconds: unix_now_seconds(template.now_seconds),
+            ..template.clone()
+        });
+
+        let event_sink = sink;
+        let reporter = RoundDriveReporterBridge::new(move |event| {
+            let Ok(view) = RoundDriveEventView::try_from(event) else {
+                return;
+            };
+            let _ = event_sink.add(ApiRoundRunEvent {
+                kind: ApiRoundStepEventKind::Progress,
+                event: Some(view),
+                report: None,
+                error: None,
+            });
+        });
+
+        let report = RoundDriver::new(&self.executor)
+            .with_policy(round_drive_policy(policy))
+            .run(&host_source, &self.control, &reporter)
+            .await;
+        Ok(ApiRoundRunEvent {
+            kind: ApiRoundStepEventKind::Result,
+            event: None,
+            report: Some(RoundRunReportView::try_from(report).map_err(VotingErrorView::from)?),
+            error: None,
+        })
     }
 
     /// Builds redacted Keystone signing requests for the given bundles.
@@ -447,102 +506,44 @@ impl VotingRoundSession {
             pir,
         }))
     }
+}
 
-    /// Runs a step and emits exactly one result event, whatever happened.
-    ///
-    /// A streaming function's `Result` never reaches Dart: the bridge sends it
-    /// on the task port, and the generated Dart drops that future
-    /// (`unawaited`) while handing the caller only the sink's stream. An `Err`
-    /// return would therefore close the stream with no event at all, turning
-    /// every typed failure raised before the step — a lightwalletd anchor
-    /// fetch for the delegation pipeline, signer material, the PIR fleet —
-    /// into a bare "stream ended" on the Dart side. Returning `()` keeps that
-    /// unreachable: every path has to produce an event.
-    async fn advance(
-        &self,
-        step: Option<NextStepView>,
-        host: ApiRoundHostContext,
-        signer: Option<ApiDelegationSignerInput>,
-        sink: StreamSink<ApiRoundStepEvent>,
-    ) {
-        let sink = Arc::new(sink);
-        let event = match self.run_step(step, host, signer, Arc::clone(&sink)).await {
-            Ok(event) => event,
-            Err(error) => ApiRoundStepEvent {
-                kind: ApiRoundStepEventKind::Result,
-                progress: None,
-                outcome: None,
-                failure: None,
-                error: Some(ApiRoundStepError::from(error)),
-            },
-        };
-        let _ = sink.add(event);
-    }
+/// The current wall clock, falling back to the host's own stamp.
+///
+/// The driver reads the context once per dispatch so a long run does not plan
+/// against a frozen clock; a system clock before the epoch is not a reason to
+/// fail a round, so the host's value stands in.
+fn unix_now_seconds(fallback: u64) -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(fallback)
+}
 
-    /// Runs one step, streaming progress, and returns its result event.
-    async fn run_step(
-        &self,
-        step: Option<NextStepView>,
-        host: ApiRoundHostContext,
-        signer: Option<ApiDelegationSignerInput>,
-        sink: Arc<StreamSink<ApiRoundStepEvent>>,
-    ) -> Result<ApiRoundStepEvent, VotingErrorView> {
-        let delegation = self.delegation_inputs(signer).await?;
-        let host = RoundHostContext {
-            configured_helper_urls: host.configured_helper_urls,
-            now_seconds: host.now_seconds,
-            ceremony_start_seconds: host.ceremony_start_seconds,
-            vote_end_time_seconds: host.vote_end_time_seconds,
-            vote_tree_node_urls: host.vote_tree_node_urls,
-            delegation,
-            chain_policy: ChainAdvancePolicy::default(),
-            max_proof_concurrency: host.max_proof_concurrency.max(1) as usize,
-        };
-        let progress_sink = sink;
-        let reporter = RoundStepProgressBridge::new(move |progress| {
-            let Ok(view) = RoundStepProgressView::try_from(progress) else {
-                return;
-            };
-            let _ = progress_sink.add(ApiRoundStepEvent {
-                kind: ApiRoundStepEventKind::Progress,
-                progress: Some(view),
-                outcome: None,
-                failure: None,
-                error: None,
-            });
-        });
-        let result = match step {
-            Some(step) => {
-                self.executor
-                    .advance_step(step.into(), &host, &self.control, &reporter)
-                    .await
-            }
-            None => {
-                self.executor
-                    .advance_next(&host, &self.control, &reporter)
-                    .await
-            }
-        };
-        Ok(match result {
-            Ok(outcome) => ApiRoundStepEvent {
-                kind: ApiRoundStepEventKind::Result,
-                progress: None,
-                outcome: Some(
-                    RoundStepOutcomeView::try_from(outcome).map_err(VotingErrorView::from)?,
-                ),
-                failure: None,
-                error: None,
-            },
-            Err(failure) => ApiRoundStepEvent {
-                kind: ApiRoundStepEventKind::Result,
-                progress: None,
-                outcome: None,
-                failure: Some(
-                    RoundStepFailureView::try_from(failure).map_err(VotingErrorView::from)?,
-                ),
-                error: None,
-            },
-        })
+fn round_drive_policy(policy: Option<ApiRoundDrivePolicy>) -> RoundDrivePolicy {
+    let defaults = RoundDrivePolicy::default();
+    let Some(policy) = policy else {
+        return defaults;
+    };
+    RoundDrivePolicy {
+        pending_repoll: policy
+            .pending_repoll_seconds
+            .filter(|seconds| seconds.is_finite() && *seconds >= 0.0)
+            .map(std::time::Duration::from_secs_f64)
+            .unwrap_or(defaults.pending_repoll),
+        max_bundle_concurrency: policy
+            .max_bundle_concurrency
+            .and_then(|limit| std::num::NonZeroUsize::new(limit as usize))
+            .unwrap_or(defaults.max_bundle_concurrency),
+        failure_isolation: match policy.skip_failed_bundle {
+            Some(false) => FailureIsolation::StopRound,
+            _ => FailureIsolation::SkipBundle,
+        },
+        max_dispatches: policy
+            .max_dispatches
+            .map(|budget| budget as usize)
+            .filter(|budget| *budget > 0)
+            .unwrap_or(defaults.max_dispatches),
     }
 }
 
@@ -552,4 +553,116 @@ fn invalid_input(message: String) -> VotingErrorView {
 
 fn internal(message: String) -> VotingErrorView {
     VotingErrorView::from(zcash_voting::VotingError::Internal { message })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy(input: ApiRoundDrivePolicy) -> RoundDrivePolicy {
+        round_drive_policy(Some(input))
+    }
+
+    fn unset() -> ApiRoundDrivePolicy {
+        ApiRoundDrivePolicy {
+            pending_repoll_seconds: None,
+            max_bundle_concurrency: None,
+            max_dispatches: None,
+            skip_failed_bundle: None,
+        }
+    }
+
+    #[test]
+    fn an_absent_policy_keeps_the_sdk_cadence() {
+        let defaults = RoundDrivePolicy::default();
+        let mapped = round_drive_policy(None);
+        assert_eq!(mapped.pending_repoll, defaults.pending_repoll);
+        assert_eq!(
+            mapped.max_bundle_concurrency,
+            defaults.max_bundle_concurrency
+        );
+        assert_eq!(mapped.max_dispatches, defaults.max_dispatches);
+    }
+
+    #[test]
+    fn each_unset_field_falls_back_on_its_own() {
+        let defaults = RoundDrivePolicy::default();
+        let mapped = policy(ApiRoundDrivePolicy {
+            max_bundle_concurrency: Some(1),
+            ..unset()
+        });
+        assert_eq!(mapped.max_bundle_concurrency.get(), 1);
+        assert_eq!(
+            mapped.pending_repoll, defaults.pending_repoll,
+            "an unset field is not zeroed by a set sibling"
+        );
+        assert_eq!(mapped.max_dispatches, defaults.max_dispatches);
+    }
+
+    #[test]
+    fn a_nonsense_repoll_cannot_panic_the_run() {
+        // `Duration::from_secs_f64` panics on a negative or non-finite value,
+        // and this value crosses a language boundary, so it is filtered rather
+        // than trusted.
+        for seconds in [-1.0, f64::NAN, f64::INFINITY] {
+            let mapped = policy(ApiRoundDrivePolicy {
+                pending_repoll_seconds: Some(seconds),
+                ..unset()
+            });
+            assert_eq!(
+                mapped.pending_repoll,
+                RoundDrivePolicy::default().pending_repoll
+            );
+        }
+        let mapped = policy(ApiRoundDrivePolicy {
+            pending_repoll_seconds: Some(0.5),
+            ..unset()
+        });
+        assert_eq!(mapped.pending_repoll, std::time::Duration::from_millis(500));
+    }
+
+    #[test]
+    fn a_zero_budget_or_concurrency_falls_back_instead_of_stalling() {
+        // Zero dispatches would end every run at once, and zero concurrency is
+        // not representable; both mean "unset" from a host that sent 0.
+        let mapped = policy(ApiRoundDrivePolicy {
+            max_bundle_concurrency: Some(0),
+            max_dispatches: Some(0),
+            ..unset()
+        });
+        let defaults = RoundDrivePolicy::default();
+        assert_eq!(
+            mapped.max_bundle_concurrency,
+            defaults.max_bundle_concurrency
+        );
+        assert_eq!(mapped.max_dispatches, defaults.max_dispatches);
+    }
+
+    #[test]
+    fn failure_isolation_follows_the_hosts_choice() {
+        assert_eq!(
+            policy(ApiRoundDrivePolicy {
+                skip_failed_bundle: Some(false),
+                ..unset()
+            })
+            .failure_isolation,
+            FailureIsolation::StopRound
+        );
+        for choice in [Some(true), None] {
+            assert_eq!(
+                policy(ApiRoundDrivePolicy {
+                    skip_failed_bundle: choice,
+                    ..unset()
+                })
+                .failure_isolation,
+                FailureIsolation::SkipBundle,
+                "a host that says nothing keeps every other bundle running"
+            );
+        }
+    }
+
+    #[test]
+    fn the_clock_falls_back_to_the_hosts_own_stamp() {
+        assert!(unix_now_seconds(0) > 1_700_000_000, "a real clock is used");
+    }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 444974405;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1745036447;
 
 // Section: executor
 
@@ -6036,45 +6036,6 @@ fn wire__crate__api__sync__scan_blocks_impl(
                     Ok(output_ok)
                 })())
             }
-        },
-    )
-}
-fn wire__crate__api__voting__select_pir_snapshot_endpoint_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "select_pir_snapshot_endpoint",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_diagnostics =
-                <Vec<crate::api::voting::ApiPirSnapshotEndpointDiagnostic>>::sse_decode(
-                    &mut deserializer,
-                );
-            let api_expected_snapshot_height = <u64>::sse_decode(&mut deserializer);
-            let api_match_index = <u64>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, zcash_voting::wire::VotingErrorView>((move || {
-                let output_ok = crate::api::voting::select_pir_snapshot_endpoint(
-                    api_diagnostics,
-                    api_expected_snapshot_height,
-                    api_match_index,
-                )?;
-                Ok(output_ok)
-            })())
         },
     )
 }
@@ -12100,30 +12061,30 @@ fn pde_ffi_dispatcher_primary_impl(
 145 => wire__zcash_voting__wire__round_work_tally_view_default_impl(port, ptr, rust_vec_len, data_len),
 146 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
 147 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__sync__store_and_broadcast_pczts_with_keystone_signatures_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-172 => wire__crate__api__voting__track_pending_shares_impl(port, ptr, rust_vec_len, data_len),
-173 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-174 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-175 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-179 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
-181 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-182 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__sync__store_and_broadcast_pczts_with_keystone_signatures_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__voting__track_pending_shares_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+174 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+178 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
+180 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+181 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -12199,33 +12160,30 @@ fn pde_ffi_dispatcher_sync_impl(
             data_len,
         ),
         136 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        148 => {
-            wire__crate__api__voting__select_pir_snapshot_endpoint_impl(ptr, rust_vec_len, data_len)
-        }
-        149 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
-        151 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        148 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
+        150 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        152 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        160 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        167 => wire__crate__api__network_privacy__tor_http_begin_request_impl(
+        151 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        159 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        166 => wire__crate__api__network_privacy__tor_http_begin_request_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        168 => wire__crate__api__network_privacy__tor_http_cancel_request_impl(
+        167 => wire__crate__api__network_privacy__tor_http_cancel_request_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        176 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        177 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
-        178 => {
+        175 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        176 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        177 => {
             wire__crate__api__sync__warm_orchard_proving_key_cache_impl(ptr, rust_vec_len, data_len)
         }
-        180 => {
+        179 => {
             wire__crate__api__voting__warm_voting_proving_caches_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1962890698;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 444974405;
 
 // Section: executor
 
@@ -5671,6 +5671,47 @@ fn wire__crate__api__voting__reset_voting_session_state_impl(
         },
     )
 }
+fn wire__crate__api__voting__resolve_pir_snapshot_endpoint_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "resolve_pir_snapshot_endpoint",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_endpoints = <Vec<String>>::sse_decode(&mut deserializer);
+            let api_expected_snapshot_height = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, zcash_voting::wire::VotingErrorView>(
+                    (move || async move {
+                        let output_ok = crate::api::voting::resolve_pir_snapshot_endpoint(
+                            api_endpoints,
+                            api_expected_snapshot_height,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__voting__resolve_static_voting_config_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -8117,6 +8158,19 @@ impl SseDecode for crate::api::voting::ApiPirSnapshotEndpointStatus {
                 "Invalid variant for ApiPirSnapshotEndpointStatus: {}",
                 inner
             ),
+        };
+    }
+}
+
+impl SseDecode for crate::api::voting::ApiPirSnapshotResolution {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_endpoint = <Option<String>>::sse_decode(deserializer);
+        let mut var_diagnostics =
+            <Vec<crate::api::voting::ApiPirSnapshotEndpointDiagnostic>>::sse_decode(deserializer);
+        return crate::api::voting::ApiPirSnapshotResolution {
+            endpoint: var_endpoint,
+            diagnostics: var_diagnostics,
         };
     }
 }
@@ -12037,38 +12091,39 @@ fn pde_ffi_dispatcher_primary_impl(
 135 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
 137 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
 138 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__zcash_voting__wire__round_work_tally_view_default_impl(port, ptr, rust_vec_len, data_len),
-145 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__sync__store_and_broadcast_pczts_with_keystone_signatures_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__voting__track_pending_shares_impl(port, ptr, rust_vec_len, data_len),
-172 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-173 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-174 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-178 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
-180 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-181 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__resolve_pir_snapshot_endpoint_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__zcash_voting__wire__round_work_tally_view_default_impl(port, ptr, rust_vec_len, data_len),
+146 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__sync__store_and_broadcast_pczts_with_keystone_signatures_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__voting__track_pending_shares_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+174 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+175 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+179 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
+181 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+182 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -12144,33 +12199,33 @@ fn pde_ffi_dispatcher_sync_impl(
             data_len,
         ),
         136 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        147 => {
+        148 => {
             wire__crate__api__voting__select_pir_snapshot_endpoint_impl(ptr, rust_vec_len, data_len)
         }
-        148 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
-        150 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        149 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
+        151 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        151 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        159 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        166 => wire__crate__api__network_privacy__tor_http_begin_request_impl(
+        152 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        160 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        167 => wire__crate__api__network_privacy__tor_http_begin_request_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        167 => wire__crate__api__network_privacy__tor_http_cancel_request_impl(
+        168 => wire__crate__api__network_privacy__tor_http_cancel_request_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        175 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        176 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
-        177 => {
+        176 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        177 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        178 => {
             wire__crate__api__sync__warm_orchard_proving_key_cache_impl(ptr, rust_vec_len, data_len)
         }
-        179 => {
+        180 => {
             wire__crate__api__voting__warm_voting_proving_caches_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -12623,6 +12678,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::voting::ApiPirSnapshotEndpoin
     for crate::api::voting::ApiPirSnapshotEndpointStatus
 {
     fn into_into_dart(self) -> crate::api::voting::ApiPirSnapshotEndpointStatus {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::voting::ApiPirSnapshotResolution {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.endpoint.into_into_dart().into_dart(),
+            self.diagnostics.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::voting::ApiPirSnapshotResolution
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::voting::ApiPirSnapshotResolution>
+    for crate::api::voting::ApiPirSnapshotResolution
+{
+    fn into_into_dart(self) -> crate::api::voting::ApiPirSnapshotResolution {
         self
     }
 }
@@ -16286,6 +16362,17 @@ impl SseEncode for crate::api::voting::ApiPirSnapshotEndpointStatus {
                     unimplemented!("");
                 }
             },
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for crate::api::voting::ApiPirSnapshotResolution {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Option<String>>::sse_encode(self.endpoint, serializer);
+        <Vec<crate::api::voting::ApiPirSnapshotEndpointDiagnostic>>::sse_encode(
+            self.diagnostics,
             serializer,
         );
     }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -949149006;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1962890698;
 
 // Section: executor
 
@@ -47,154 +47,6 @@ flutter_rust_bridge::frb_generated_default_handler!();
 
 // Section: wire_funcs
 
-fn wire__crate__api__voting_session__VotingRoundSession_advance_next_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "VotingRoundSession_advance_next",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VotingRoundSession>,
-            >>::sse_decode(&mut deserializer);
-            let api_host =
-                <crate::api::voting_session::ApiRoundHostContext>::sse_decode(&mut deserializer);
-            let api_signer =
-                <Option<crate::api::voting_session::ApiDelegationSignerInput>>::sse_decode(
-                    &mut deserializer,
-                );
-            let api_sink = <StreamSink<
-                crate::api::voting_session::ApiRoundStepEvent,
-                flutter_rust_bridge::for_generated::SseCodec,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, ()>(
-                    (move || async move {
-                        let mut api_that_guard = None;
-                        let decode_indices_ =
-                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
-                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                    &api_that, 0, false,
-                                )],
-                            );
-                        for i in decode_indices_ {
-                            match i {
-                                0 => {
-                                    api_that_guard =
-                                        Some(api_that.lockable_decode_async_ref().await)
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-                        let api_that_guard = api_that_guard.unwrap();
-                        let output_ok = Result::<_, ()>::Ok({
-                            crate::api::voting_session::VotingRoundSession::advance_next(
-                                &*api_that_guard,
-                                api_host,
-                                api_signer,
-                                api_sink,
-                            )
-                            .await;
-                        })?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
-fn wire__crate__api__voting_session__VotingRoundSession_advance_step_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "VotingRoundSession_advance_step",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VotingRoundSession>,
-            >>::sse_decode(&mut deserializer);
-            let api_step = <zcash_voting::wire::NextStepView>::sse_decode(&mut deserializer);
-            let api_host =
-                <crate::api::voting_session::ApiRoundHostContext>::sse_decode(&mut deserializer);
-            let api_signer =
-                <Option<crate::api::voting_session::ApiDelegationSignerInput>>::sse_decode(
-                    &mut deserializer,
-                );
-            let api_sink = <StreamSink<
-                crate::api::voting_session::ApiRoundStepEvent,
-                flutter_rust_bridge::for_generated::SseCodec,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, ()>(
-                    (move || async move {
-                        let mut api_that_guard = None;
-                        let decode_indices_ =
-                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
-                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                    &api_that, 0, false,
-                                )],
-                            );
-                        for i in decode_indices_ {
-                            match i {
-                                0 => {
-                                    api_that_guard =
-                                        Some(api_that.lockable_decode_async_ref().await)
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-                        let api_that_guard = api_that_guard.unwrap();
-                        let output_ok = Result::<_, ()>::Ok({
-                            crate::api::voting_session::VotingRoundSession::advance_step(
-                                &*api_that_guard,
-                                api_step,
-                                api_host,
-                                api_signer,
-                                api_sink,
-                            )
-                            .await;
-                        })?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
 fn wire__crate__api__voting_session__VotingRoundSession_begin_share_tracking_pass_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -428,6 +280,83 @@ fn wire__crate__api__voting_session__VotingRoundSession_plan_impl(
                         let output_ok =
                             crate::api::voting_session::VotingRoundSession::plan(&*api_that_guard)
                                 .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__voting_session__VotingRoundSession_run_round_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "VotingRoundSession_run_round",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VotingRoundSession>,
+            >>::sse_decode(&mut deserializer);
+            let api_host =
+                <crate::api::voting_session::ApiRoundHostContext>::sse_decode(&mut deserializer);
+            let api_signer =
+                <Option<crate::api::voting_session::ApiDelegationSignerInput>>::sse_decode(
+                    &mut deserializer,
+                );
+            let api_policy = <Option<crate::api::voting_session::ApiRoundDrivePolicy>>::sse_decode(
+                &mut deserializer,
+            );
+            let api_sink = <StreamSink<
+                crate::api::voting_session::ApiRoundRunEvent,
+                flutter_rust_bridge::for_generated::SseCodec,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = Result::<_, ()>::Ok({
+                            crate::api::voting_session::VotingRoundSession::run_round(
+                                &*api_that_guard,
+                                api_host,
+                                api_signer,
+                                api_policy,
+                                api_sink,
+                            )
+                            .await;
+                        })?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -5938,6 +5867,39 @@ fn wire__crate__api__sync__rewind_to_height_impl(
         },
     )
 }
+fn wire__zcash_voting__wire__round_work_tally_view_default_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "round_work_tally_view_default",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok =
+                        Result::<_, ()>::Ok(zcash_voting::wire::RoundWorkTallyView::default())?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__sync__run_full_sync_blocking_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -7551,6 +7513,26 @@ const _: fn() = || {
         let _: Vec<zcash_voting::config::ConfigCondition> = ResolvedVotingConfig.conditions;
     }
     {
+        let RoundChainOutcomeView = None::<zcash_voting::wire::RoundChainOutcomeView>.unwrap();
+        let _: zcash_voting::wire::NextStepView = RoundChainOutcomeView.step;
+        let _: zcash_voting::wire::ChainSubmissionOutcomeView = RoundChainOutcomeView.outcome;
+    }
+    {
+        let RoundDriveEventView = None::<zcash_voting::wire::RoundDriveEventView>.unwrap();
+        let _: zcash_voting::wire::RoundDriveEventKind = RoundDriveEventView.kind;
+        let _: Option<zcash_voting::wire::NextStepView> = RoundDriveEventView.step;
+        let _: Option<zcash_voting::wire::RoundPlanView> = RoundDriveEventView.plan;
+        let _: Option<zcash_voting::wire::RoundWorkTallyView> = RoundDriveEventView.tally;
+        let _: Option<zcash_voting::wire::RoundStepProgressView> = RoundDriveEventView.progress;
+        let _: Option<zcash_voting::wire::RoundStepDispositionView> =
+            RoundDriveEventView.disposition;
+        let _: Option<zcash_voting::wire::RoundStepFailureKindView> =
+            RoundDriveEventView.failure_kind;
+        let _: Option<String> = RoundDriveEventView.message;
+        let _: Option<f64> = RoundDriveEventView.delay_seconds;
+        let _: Option<u32> = RoundDriveEventView.bundle_index;
+    }
+    {
         let RoundPlanView = None::<zcash_voting::wire::RoundPlanView>.unwrap();
         let _: String = RoundPlanView.round_id;
         let _: bool = RoundPlanView.pending_recovery;
@@ -7583,6 +7565,38 @@ const _: fn() = || {
         let _: bool = RoundPlanView.all_decided;
     }
     {
+        let RoundQuiescenceView = None::<zcash_voting::wire::RoundQuiescenceView>.unwrap();
+        let _: zcash_voting::wire::RoundQuiescenceKind = RoundQuiescenceView.kind;
+        let _: Vec<u32> = RoundQuiescenceView.open_proposals;
+        let _: Vec<u32> = RoundQuiescenceView.unrostered_intents;
+        let _: Vec<u32> = RoundQuiescenceView.bundles;
+        let _: Vec<zcash_voting::wire::ShareKeyView> = RoundQuiescenceView.shares;
+        let _: Option<zcash_voting::wire::NextStepView> = RoundQuiescenceView.step;
+        let _: Option<zcash_voting::wire::ChainSubmissionOutcomeView> =
+            RoundQuiescenceView.chain_outcome;
+        let _: Vec<zcash_voting::wire::NextStepView> = RoundQuiescenceView.remaining;
+    }
+    {
+        let RoundRunReportView = None::<zcash_voting::wire::RoundRunReportView>.unwrap();
+        let _: zcash_voting::wire::RoundQuiescenceView = RoundRunReportView.quiescence;
+        let _: Option<zcash_voting::wire::RoundPlanView> = RoundRunReportView.plan;
+        let _: zcash_voting::wire::RoundWorkTallyView = RoundRunReportView.tally;
+        let _: Vec<zcash_voting::wire::RoundStepFailureRecordView> = RoundRunReportView.failures;
+        let _: Vec<u32> = RoundRunReportView.skipped_bundles;
+        let _: Vec<zcash_voting::wire::RoundChainOutcomeView> = RoundRunReportView.chain_outcomes;
+        let _: Vec<zcash_voting::wire::ShareBatchDeliveryReportView> =
+            RoundRunReportView.share_deliveries;
+        let _: Vec<zcash_voting::wire::SignedDelegationPayloadView> =
+            RoundRunReportView.delegations;
+    }
+    {
+        let RoundStepFailureRecordView =
+            None::<zcash_voting::wire::RoundStepFailureRecordView>.unwrap();
+        let _: Option<zcash_voting::wire::NextStepView> = RoundStepFailureRecordView.step;
+        let _: Option<u32> = RoundStepFailureRecordView.bundle_index;
+        let _: zcash_voting::wire::RoundStepFailureView = RoundStepFailureRecordView.failure;
+    }
+    {
         let RoundStepFailureView = None::<zcash_voting::wire::RoundStepFailureView>.unwrap();
         let _: zcash_voting::wire::RoundStepFailureKindView = RoundStepFailureView.kind;
         let _: Option<zcash_voting::wire::NextStepView> = RoundStepFailureView.step;
@@ -7594,18 +7608,6 @@ const _: fn() = || {
         let _: Option<zcash_voting::wire::RoundPlanView> = RoundStepFailureView.plan;
         let _: Vec<zcash_voting::wire::ShareBatchDeliveryReportView> =
             RoundStepFailureView.share_deliveries;
-    }
-    {
-        let RoundStepOutcomeView = None::<zcash_voting::wire::RoundStepOutcomeView>.unwrap();
-        let _: Option<zcash_voting::wire::NextStepView> = RoundStepOutcomeView.step;
-        let _: zcash_voting::wire::RoundStepDispositionView = RoundStepOutcomeView.disposition;
-        let _: Option<zcash_voting::wire::ChainSubmissionOutcomeView> =
-            RoundStepOutcomeView.chain_outcome;
-        let _: Vec<zcash_voting::wire::ShareBatchDeliveryReportView> =
-            RoundStepOutcomeView.share_deliveries;
-        let _: Option<zcash_voting::wire::SignedDelegationPayloadView> =
-            RoundStepOutcomeView.delegation;
-        let _: zcash_voting::wire::RoundPlanView = RoundStepOutcomeView.plan;
     }
     {
         let RoundStepProgressView = None::<zcash_voting::wire::RoundStepProgressView>.unwrap();
@@ -7626,6 +7628,12 @@ const _: fn() = || {
             RoundStepProgressView.share_delivery;
         let _: Option<zcash_voting::wire::ShareKeyView> = RoundStepProgressView.share;
         let _: Option<bool> = RoundStepProgressView.share_confirmed;
+    }
+    {
+        let RoundWorkTallyView = None::<zcash_voting::wire::RoundWorkTallyView>.unwrap();
+        let _: u32 = RoundWorkTallyView.completed_proposals;
+        let _: u32 = RoundWorkTallyView.total_proposals;
+        let _: u32 = RoundWorkTallyView.remaining_obligations;
     }
     {
         let ServiceEndpoint = None::<zcash_voting::config::ServiceEndpoint>.unwrap();
@@ -7822,7 +7830,7 @@ impl SseDecode
 
 impl SseDecode
     for StreamSink<
-        crate::api::voting_session::ApiRoundStepEvent,
+        crate::api::voting_session::ApiRoundRunEvent,
         flutter_rust_bridge::for_generated::SseCodec,
     >
 {
@@ -8137,6 +8145,22 @@ impl SseDecode for crate::api::voting::ApiResubmittedShare {
     }
 }
 
+impl SseDecode for crate::api::voting_session::ApiRoundDrivePolicy {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_pendingRepollSeconds = <Option<f64>>::sse_decode(deserializer);
+        let mut var_maxBundleConcurrency = <Option<u32>>::sse_decode(deserializer);
+        let mut var_maxDispatches = <Option<u32>>::sse_decode(deserializer);
+        let mut var_skipFailedBundle = <Option<bool>>::sse_decode(deserializer);
+        return crate::api::voting_session::ApiRoundDrivePolicy {
+            pending_repoll_seconds: var_pendingRepollSeconds,
+            max_bundle_concurrency: var_maxBundleConcurrency,
+            max_dispatches: var_maxDispatches,
+            skip_failed_bundle: var_skipFailedBundle,
+        };
+    }
+}
+
 impl SseDecode for crate::api::voting_session::ApiRoundHostContext {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -8153,6 +8177,26 @@ impl SseDecode for crate::api::voting_session::ApiRoundHostContext {
             vote_end_time_seconds: var_voteEndTimeSeconds,
             vote_tree_node_urls: var_voteTreeNodeUrls,
             max_proof_concurrency: var_maxProofConcurrency,
+        };
+    }
+}
+
+impl SseDecode for crate::api::voting_session::ApiRoundRunEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_kind =
+            <crate::api::voting_session::ApiRoundStepEventKind>::sse_decode(deserializer);
+        let mut var_event =
+            <Option<zcash_voting::wire::RoundDriveEventView>>::sse_decode(deserializer);
+        let mut var_report =
+            <Option<zcash_voting::wire::RoundRunReportView>>::sse_decode(deserializer);
+        let mut var_error =
+            <Option<crate::api::voting_session::ApiRoundStepError>>::sse_decode(deserializer);
+        return crate::api::voting_session::ApiRoundRunEvent {
+            kind: var_kind,
+            event: var_event,
+            report: var_report,
+            error: var_error,
         };
     }
 }
@@ -8186,29 +8230,6 @@ impl SseDecode for crate::api::voting_session::ApiRoundStepError {
             selected_notes: var_selectedNotes,
             http_status: var_httpStatus,
             endpoint: var_endpoint,
-        };
-    }
-}
-
-impl SseDecode for crate::api::voting_session::ApiRoundStepEvent {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_kind =
-            <crate::api::voting_session::ApiRoundStepEventKind>::sse_decode(deserializer);
-        let mut var_progress =
-            <Option<zcash_voting::wire::RoundStepProgressView>>::sse_decode(deserializer);
-        let mut var_outcome =
-            <Option<zcash_voting::wire::RoundStepOutcomeView>>::sse_decode(deserializer);
-        let mut var_failure =
-            <Option<zcash_voting::wire::RoundStepFailureView>>::sse_decode(deserializer);
-        let mut var_error =
-            <Option<crate::api::voting_session::ApiRoundStepError>>::sse_decode(deserializer);
-        return crate::api::voting_session::ApiRoundStepEvent {
-            kind: var_kind,
-            progress: var_progress,
-            outcome: var_outcome,
-            failure: var_failure,
-            error: var_error,
         };
     }
 }
@@ -9552,6 +9573,32 @@ impl SseDecode for Vec<u8> {
     }
 }
 
+impl SseDecode for Vec<zcash_voting::wire::RoundChainOutcomeView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::RoundChainOutcomeView>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::RoundStepFailureRecordView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::RoundStepFailureRecordView>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::api::sync::ScanRangeInfo> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -9599,6 +9646,30 @@ impl SseDecode for Vec<zcash_voting::wire::ShareDeliveryOutcomeView> {
             ans_.push(<zcash_voting::wire::ShareDeliveryOutcomeView>::sse_decode(
                 deserializer,
             ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::ShareKeyView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::ShareKeyView>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::SignedDelegationPayloadView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::SignedDelegationPayloadView>::sse_decode(deserializer));
         }
         return ans_;
     }
@@ -10143,6 +10214,19 @@ impl SseDecode for Option<crate::api::voting_session::ApiDelegationSignerInput> 
     }
 }
 
+impl SseDecode for Option<crate::api::voting_session::ApiRoundDrivePolicy> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(
+                <crate::api::voting_session::ApiRoundDrivePolicy>::sse_decode(deserializer),
+            );
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<crate::api::voting_session::ApiRoundStepError> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -10358,6 +10442,19 @@ impl SseDecode for Option<zcash_voting::config::ResolvedVotingConfig> {
     }
 }
 
+impl SseDecode for Option<zcash_voting::wire::RoundDriveEventView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<zcash_voting::wire::RoundDriveEventView>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<zcash_voting::wire::RoundPlanView> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -10371,11 +10468,11 @@ impl SseDecode for Option<zcash_voting::wire::RoundPlanView> {
     }
 }
 
-impl SseDecode for Option<zcash_voting::wire::RoundStepFailureView> {
+impl SseDecode for Option<zcash_voting::wire::RoundRunReportView> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
-            return Some(<zcash_voting::wire::RoundStepFailureView>::sse_decode(
+            return Some(<zcash_voting::wire::RoundRunReportView>::sse_decode(
                 deserializer,
             ));
         } else {
@@ -10384,11 +10481,24 @@ impl SseDecode for Option<zcash_voting::wire::RoundStepFailureView> {
     }
 }
 
-impl SseDecode for Option<zcash_voting::wire::RoundStepOutcomeView> {
+impl SseDecode for Option<zcash_voting::wire::RoundStepDispositionView> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
-            return Some(<zcash_voting::wire::RoundStepOutcomeView>::sse_decode(
+            return Some(<zcash_voting::wire::RoundStepDispositionView>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<zcash_voting::wire::RoundStepFailureKindView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<zcash_voting::wire::RoundStepFailureKindView>::sse_decode(
                 deserializer,
             ));
         } else {
@@ -10402,6 +10512,19 @@ impl SseDecode for Option<zcash_voting::wire::RoundStepProgressView> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<zcash_voting::wire::RoundStepProgressView>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<zcash_voting::wire::RoundWorkTallyView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<zcash_voting::wire::RoundWorkTallyView>::sse_decode(
                 deserializer,
             ));
         } else {
@@ -10428,19 +10551,6 @@ impl SseDecode for Option<zcash_voting::wire::ShareKeyView> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<zcash_voting::wire::ShareKeyView>::sse_decode(deserializer));
-        } else {
-            return None;
-        }
-    }
-}
-
-impl SseDecode for Option<zcash_voting::wire::SignedDelegationPayloadView> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        if (<bool>::sse_decode(deserializer)) {
-            return Some(
-                <zcash_voting::wire::SignedDelegationPayloadView>::sse_decode(deserializer),
-            );
         } else {
             return None;
         }
@@ -10663,6 +10773,68 @@ impl SseDecode for zcash_voting::config::ResolvedVotingConfig {
     }
 }
 
+impl SseDecode for zcash_voting::wire::RoundChainOutcomeView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_step = <zcash_voting::wire::NextStepView>::sse_decode(deserializer);
+        let mut var_outcome =
+            <zcash_voting::wire::ChainSubmissionOutcomeView>::sse_decode(deserializer);
+        return zcash_voting::wire::RoundChainOutcomeView {
+            step: var_step,
+            outcome: var_outcome,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::RoundDriveEventKind {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => zcash_voting::wire::RoundDriveEventKind::PlanRefreshed,
+            1 => zcash_voting::wire::RoundDriveEventKind::StepSelected,
+            2 => zcash_voting::wire::RoundDriveEventKind::StepProgress,
+            3 => zcash_voting::wire::RoundDriveEventKind::StepFinished,
+            4 => zcash_voting::wire::RoundDriveEventKind::StepFailed,
+            5 => zcash_voting::wire::RoundDriveEventKind::AwaitingRepoll,
+            6 => zcash_voting::wire::RoundDriveEventKind::BundleSkipped,
+            _ => unreachable!("Invalid variant for RoundDriveEventKind: {}", inner),
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::RoundDriveEventView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_kind = <zcash_voting::wire::RoundDriveEventKind>::sse_decode(deserializer);
+        let mut var_step = <Option<zcash_voting::wire::NextStepView>>::sse_decode(deserializer);
+        let mut var_plan = <Option<zcash_voting::wire::RoundPlanView>>::sse_decode(deserializer);
+        let mut var_tally =
+            <Option<zcash_voting::wire::RoundWorkTallyView>>::sse_decode(deserializer);
+        let mut var_progress =
+            <Option<zcash_voting::wire::RoundStepProgressView>>::sse_decode(deserializer);
+        let mut var_disposition =
+            <Option<zcash_voting::wire::RoundStepDispositionView>>::sse_decode(deserializer);
+        let mut var_failureKind =
+            <Option<zcash_voting::wire::RoundStepFailureKindView>>::sse_decode(deserializer);
+        let mut var_message = <Option<String>>::sse_decode(deserializer);
+        let mut var_delaySeconds = <Option<f64>>::sse_decode(deserializer);
+        let mut var_bundleIndex = <Option<u32>>::sse_decode(deserializer);
+        return zcash_voting::wire::RoundDriveEventView {
+            kind: var_kind,
+            step: var_step,
+            plan: var_plan,
+            tally: var_tally,
+            progress: var_progress,
+            disposition: var_disposition,
+            failure_kind: var_failureKind,
+            message: var_message,
+            delay_seconds: var_delaySeconds,
+            bundle_index: var_bundleIndex,
+        };
+    }
+}
+
 impl SseDecode for zcash_voting::wire::RoundPlanActionKind {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -10744,6 +10916,81 @@ impl SseDecode for zcash_voting::wire::RoundPlanView {
     }
 }
 
+impl SseDecode for zcash_voting::wire::RoundQuiescenceKind {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => zcash_voting::wire::RoundQuiescenceKind::NoWorkLeft,
+            1 => zcash_voting::wire::RoundQuiescenceKind::NeedsBundleSetup,
+            2 => zcash_voting::wire::RoundQuiescenceKind::PersistedChainTerminal,
+            3 => zcash_voting::wire::RoundQuiescenceKind::NeedsBallot,
+            4 => zcash_voting::wire::RoundQuiescenceKind::NeedsDelegationSignatures,
+            5 => zcash_voting::wire::RoundQuiescenceKind::BackgroundShareWorkOnly,
+            6 => zcash_voting::wire::RoundQuiescenceKind::Cancelled,
+            7 => zcash_voting::wire::RoundQuiescenceKind::ChainTerminal,
+            8 => zcash_voting::wire::RoundQuiescenceKind::ChainRecoveryStalled,
+            9 => zcash_voting::wire::RoundQuiescenceKind::Failures,
+            10 => zcash_voting::wire::RoundQuiescenceKind::PassBudgetExhausted,
+            _ => unreachable!("Invalid variant for RoundQuiescenceKind: {}", inner),
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::RoundQuiescenceView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_kind = <zcash_voting::wire::RoundQuiescenceKind>::sse_decode(deserializer);
+        let mut var_openProposals = <Vec<u32>>::sse_decode(deserializer);
+        let mut var_unrosteredIntents = <Vec<u32>>::sse_decode(deserializer);
+        let mut var_bundles = <Vec<u32>>::sse_decode(deserializer);
+        let mut var_shares = <Vec<zcash_voting::wire::ShareKeyView>>::sse_decode(deserializer);
+        let mut var_step = <Option<zcash_voting::wire::NextStepView>>::sse_decode(deserializer);
+        let mut var_chainOutcome =
+            <Option<zcash_voting::wire::ChainSubmissionOutcomeView>>::sse_decode(deserializer);
+        let mut var_remaining = <Vec<zcash_voting::wire::NextStepView>>::sse_decode(deserializer);
+        return zcash_voting::wire::RoundQuiescenceView {
+            kind: var_kind,
+            open_proposals: var_openProposals,
+            unrostered_intents: var_unrosteredIntents,
+            bundles: var_bundles,
+            shares: var_shares,
+            step: var_step,
+            chain_outcome: var_chainOutcome,
+            remaining: var_remaining,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::RoundRunReportView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_quiescence =
+            <zcash_voting::wire::RoundQuiescenceView>::sse_decode(deserializer);
+        let mut var_plan = <Option<zcash_voting::wire::RoundPlanView>>::sse_decode(deserializer);
+        let mut var_tally = <zcash_voting::wire::RoundWorkTallyView>::sse_decode(deserializer);
+        let mut var_failures =
+            <Vec<zcash_voting::wire::RoundStepFailureRecordView>>::sse_decode(deserializer);
+        let mut var_skippedBundles = <Vec<u32>>::sse_decode(deserializer);
+        let mut var_chainOutcomes =
+            <Vec<zcash_voting::wire::RoundChainOutcomeView>>::sse_decode(deserializer);
+        let mut var_shareDeliveries =
+            <Vec<zcash_voting::wire::ShareBatchDeliveryReportView>>::sse_decode(deserializer);
+        let mut var_delegations =
+            <Vec<zcash_voting::wire::SignedDelegationPayloadView>>::sse_decode(deserializer);
+        return zcash_voting::wire::RoundRunReportView {
+            quiescence: var_quiescence,
+            plan: var_plan,
+            tally: var_tally,
+            failures: var_failures,
+            skipped_bundles: var_skippedBundles,
+            chain_outcomes: var_chainOutcomes,
+            share_deliveries: var_shareDeliveries,
+            delegations: var_delegations,
+        };
+    }
+}
+
 impl SseDecode for zcash_voting::wire::RoundStepDispositionView {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -10782,6 +11029,20 @@ impl SseDecode for zcash_voting::wire::RoundStepFailureKindView {
     }
 }
 
+impl SseDecode for zcash_voting::wire::RoundStepFailureRecordView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_step = <Option<zcash_voting::wire::NextStepView>>::sse_decode(deserializer);
+        let mut var_bundleIndex = <Option<u32>>::sse_decode(deserializer);
+        let mut var_failure = <zcash_voting::wire::RoundStepFailureView>::sse_decode(deserializer);
+        return zcash_voting::wire::RoundStepFailureRecordView {
+            step: var_step,
+            bundle_index: var_bundleIndex,
+            failure: var_failure,
+        };
+    }
+}
+
 impl SseDecode for zcash_voting::wire::RoundStepFailureView {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -10803,30 +11064,6 @@ impl SseDecode for zcash_voting::wire::RoundStepFailureView {
             message: var_message,
             plan: var_plan,
             share_deliveries: var_shareDeliveries,
-        };
-    }
-}
-
-impl SseDecode for zcash_voting::wire::RoundStepOutcomeView {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_step = <Option<zcash_voting::wire::NextStepView>>::sse_decode(deserializer);
-        let mut var_disposition =
-            <zcash_voting::wire::RoundStepDispositionView>::sse_decode(deserializer);
-        let mut var_chainOutcome =
-            <Option<zcash_voting::wire::ChainSubmissionOutcomeView>>::sse_decode(deserializer);
-        let mut var_shareDeliveries =
-            <Vec<zcash_voting::wire::ShareBatchDeliveryReportView>>::sse_decode(deserializer);
-        let mut var_delegation =
-            <Option<zcash_voting::wire::SignedDelegationPayloadView>>::sse_decode(deserializer);
-        let mut var_plan = <zcash_voting::wire::RoundPlanView>::sse_decode(deserializer);
-        return zcash_voting::wire::RoundStepOutcomeView {
-            step: var_step,
-            disposition: var_disposition,
-            chain_outcome: var_chainOutcome,
-            share_deliveries: var_shareDeliveries,
-            delegation: var_delegation,
-            plan: var_plan,
         };
     }
 }
@@ -10883,6 +11120,20 @@ impl SseDecode for zcash_voting::wire::RoundStepProgressView {
             share_delivery: var_shareDelivery,
             share: var_share,
             share_confirmed: var_shareConfirmed,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::RoundWorkTallyView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_completedProposals = <u32>::sse_decode(deserializer);
+        let mut var_totalProposals = <u32>::sse_decode(deserializer);
+        let mut var_remainingObligations = <u32>::sse_decode(deserializer);
+        return zcash_voting::wire::RoundWorkTallyView {
+            completed_proposals: var_completedProposals,
+            total_proposals: var_totalProposals,
+            remaining_obligations: var_remainingObligations,
         };
     }
 }
@@ -11671,127 +11922,127 @@ fn pde_ffi_dispatcher_primary_impl(
 ) {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-                        1 => wire__crate__api__voting_session__VotingRoundSession_advance_next_impl(port, ptr, rust_vec_len, data_len),
-2 => wire__crate__api__voting_session__VotingRoundSession_advance_step_impl(port, ptr, rust_vec_len, data_len),
-5 => wire__crate__api__voting_session__VotingRoundSession_clear_ballot_intents_impl(port, ptr, rust_vec_len, data_len),
-6 => wire__crate__api__voting_session__VotingRoundSession_keystone_signing_requests_impl(port, ptr, rust_vec_len, data_len),
-7 => wire__crate__api__voting_session__VotingRoundSession_plan_impl(port, ptr, rust_vec_len, data_len),
-8 => wire__crate__api__voting_session__VotingRoundSession_set_ballot_intents_impl(port, ptr, rust_vec_len, data_len),
-11 => wire__crate__api__sync__abandon_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-12 => wire__crate__api__wallet__add_account_impl(port, ptr, rust_vec_len, data_len),
-13 => wire__crate__api__sync__add_proofs_to_pczt_impl(port, ptr, rust_vec_len, data_len),
-16 => wire__crate__api__sync__broadcast_due_orchard_migration_transactions_impl(port, ptr, rust_vec_len, data_len),
-17 => wire__crate__api__sync__broadcast_one_due_orchard_migration_transaction_impl(port, ptr, rust_vec_len, data_len),
-18 => wire__crate__api__voting__build_keystone_delegation_requests_impl(port, ptr, rust_vec_len, data_len),
-20 => wire__crate__api__voting__check_voting_eligibility_impl(port, ptr, rust_vec_len, data_len),
-21 => wire__crate__api__sync__complete_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-22 => wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-23 => wire__crate__api__sync__complete_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-24 => wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-25 => wire__crate__api__simple__configure_fast_testnet_migration_impl(port, ptr, rust_vec_len, data_len),
-26 => wire__crate__api__network_privacy__configure_network_privacy_impl(port, ptr, rust_vec_len, data_len),
-27 => wire__crate__api__simple__configure_regtest_ironwood_activation_height_impl(port, ptr, rust_vec_len, data_len),
-28 => wire__crate__api__voting__confirm_share_with_helpers_impl(port, ptr, rust_vec_len, data_len),
-29 => wire__crate__api__sync__create_or_resume_private_migration_draft_impl(port, ptr, rust_vec_len, data_len),
-30 => wire__crate__api__sync__create_pczt_from_proposal_impl(port, ptr, rust_vec_len, data_len),
-31 => wire__crate__api__sync__create_shield_transparent_pczt_impl(port, ptr, rust_vec_len, data_len),
-32 => wire__crate__api__sync__create_tex_pczts_from_proposal_impl(port, ptr, rust_vec_len, data_len),
-34 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
-35 => wire__crate__api__keystone__decode_accounts_from_cbor_impl(port, ptr, rust_vec_len, data_len),
-36 => wire__crate__api__keystone__decode_accounts_ur_impl(port, ptr, rust_vec_len, data_len),
-37 => wire__crate__api__keystone__decode_pczt_from_cbor_impl(port, ptr, rust_vec_len, data_len),
-38 => wire__crate__api__keystone__decode_ur_part_impl(port, ptr, rust_vec_len, data_len),
-39 => wire__crate__api__keystone__decode_ur_to_pczt_impl(port, ptr, rust_vec_len, data_len),
-40 => wire__crate__api__keystone__decode_zcash_batch_sign_response_impl(port, ptr, rust_vec_len, data_len),
-41 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_impl(port, ptr, rust_vec_len, data_len),
-42 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_as_sig_result_impl(port, ptr, rust_vec_len, data_len),
-43 => wire__crate__api__sync__decrypt_and_store_transaction_impl(port, ptr, rust_vec_len, data_len),
-44 => wire__crate__api__secret__decrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
-45 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
-46 => wire__crate__api__voting__delete_skipped_bundles_impl(port, ptr, rust_vec_len, data_len),
-47 => wire__crate__api__voting__delete_voting_account_state_impl(port, ptr, rust_vec_len, data_len),
-48 => wire__crate__api__secret__derive_secret_password_verifier_impl(port, ptr, rust_vec_len, data_len),
-49 => wire__crate__api__sync__discard_all_keystone_migration_requests_impl(port, ptr, rust_vec_len, data_len),
-50 => wire__crate__api__sync__discard_keystone_migration_request_impl(port, ptr, rust_vec_len, data_len),
-51 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
-52 => wire__crate__api__wallet__discover_software_wallet_import_accounts_impl(port, ptr, rust_vec_len, data_len),
-53 => wire__crate__api__keystone__encode_keystone_action_sigs_impl(port, ptr, rust_vec_len, data_len),
-54 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
-55 => wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len),
-56 => wire__crate__api__keystone__encode_zcash_sign_batch_ur_parts_impl(port, ptr, rust_vec_len, data_len),
-57 => wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
-58 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(port, ptr, rust_vec_len, data_len),
-59 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
-60 => wire__crate__api__network_privacy__estimate_import_birthday_height_impl(port, ptr, rust_vec_len, data_len),
-61 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
-62 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
-63 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-64 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-65 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-66 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
-69 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
-70 => wire__crate__api__wallet__get_account_export_metadata_impl(port, ptr, rust_vec_len, data_len),
-71 => wire__crate__api__wallet__get_account_ufvk_impl(port, ptr, rust_vec_len, data_len),
-72 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-73 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
-75 => wire__crate__api__wallet__get_chain_upgrade_status_impl(port, ptr, rust_vec_len, data_len),
-76 => wire__crate__api__wallet__get_chain_upgrade_status_at_height_impl(port, ptr, rust_vec_len, data_len),
-77 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
-78 => wire__crate__api__network_privacy__get_import_birthday_metadata_impl(port, ptr, rust_vec_len, data_len),
-79 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__sync__get_orchard_migration_immediate_plan_impl(port, ptr, rust_vec_len, data_len),
-86 => wire__crate__api__sync__get_orchard_migration_private_plan_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__sync__get_orchard_migration_status_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__sync__get_orchard_migration_statuses_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__sync__get_previous_transaction_count_for_address_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
-99 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__wallet__import_software_account_at_index_impl(port, ptr, rust_vec_len, data_len),
-103 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
-116 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
-117 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__voting__precompute_delegation_proof_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__voting__precompute_snapshot_bundles_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__sync__prepare_pczt_for_keystone_batch_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
-135 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+                        3 => wire__crate__api__voting_session__VotingRoundSession_clear_ballot_intents_impl(port, ptr, rust_vec_len, data_len),
+4 => wire__crate__api__voting_session__VotingRoundSession_keystone_signing_requests_impl(port, ptr, rust_vec_len, data_len),
+5 => wire__crate__api__voting_session__VotingRoundSession_plan_impl(port, ptr, rust_vec_len, data_len),
+6 => wire__crate__api__voting_session__VotingRoundSession_run_round_impl(port, ptr, rust_vec_len, data_len),
+7 => wire__crate__api__voting_session__VotingRoundSession_set_ballot_intents_impl(port, ptr, rust_vec_len, data_len),
+10 => wire__crate__api__sync__abandon_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+11 => wire__crate__api__wallet__add_account_impl(port, ptr, rust_vec_len, data_len),
+12 => wire__crate__api__sync__add_proofs_to_pczt_impl(port, ptr, rust_vec_len, data_len),
+15 => wire__crate__api__sync__broadcast_due_orchard_migration_transactions_impl(port, ptr, rust_vec_len, data_len),
+16 => wire__crate__api__sync__broadcast_one_due_orchard_migration_transaction_impl(port, ptr, rust_vec_len, data_len),
+17 => wire__crate__api__voting__build_keystone_delegation_requests_impl(port, ptr, rust_vec_len, data_len),
+19 => wire__crate__api__voting__check_voting_eligibility_impl(port, ptr, rust_vec_len, data_len),
+20 => wire__crate__api__sync__complete_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+21 => wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+22 => wire__crate__api__sync__complete_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+23 => wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+24 => wire__crate__api__simple__configure_fast_testnet_migration_impl(port, ptr, rust_vec_len, data_len),
+25 => wire__crate__api__network_privacy__configure_network_privacy_impl(port, ptr, rust_vec_len, data_len),
+26 => wire__crate__api__simple__configure_regtest_ironwood_activation_height_impl(port, ptr, rust_vec_len, data_len),
+27 => wire__crate__api__voting__confirm_share_with_helpers_impl(port, ptr, rust_vec_len, data_len),
+28 => wire__crate__api__sync__create_or_resume_private_migration_draft_impl(port, ptr, rust_vec_len, data_len),
+29 => wire__crate__api__sync__create_pczt_from_proposal_impl(port, ptr, rust_vec_len, data_len),
+30 => wire__crate__api__sync__create_shield_transparent_pczt_impl(port, ptr, rust_vec_len, data_len),
+31 => wire__crate__api__sync__create_tex_pczts_from_proposal_impl(port, ptr, rust_vec_len, data_len),
+33 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
+34 => wire__crate__api__keystone__decode_accounts_from_cbor_impl(port, ptr, rust_vec_len, data_len),
+35 => wire__crate__api__keystone__decode_accounts_ur_impl(port, ptr, rust_vec_len, data_len),
+36 => wire__crate__api__keystone__decode_pczt_from_cbor_impl(port, ptr, rust_vec_len, data_len),
+37 => wire__crate__api__keystone__decode_ur_part_impl(port, ptr, rust_vec_len, data_len),
+38 => wire__crate__api__keystone__decode_ur_to_pczt_impl(port, ptr, rust_vec_len, data_len),
+39 => wire__crate__api__keystone__decode_zcash_batch_sign_response_impl(port, ptr, rust_vec_len, data_len),
+40 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_impl(port, ptr, rust_vec_len, data_len),
+41 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_as_sig_result_impl(port, ptr, rust_vec_len, data_len),
+42 => wire__crate__api__sync__decrypt_and_store_transaction_impl(port, ptr, rust_vec_len, data_len),
+43 => wire__crate__api__secret__decrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
+44 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
+45 => wire__crate__api__voting__delete_skipped_bundles_impl(port, ptr, rust_vec_len, data_len),
+46 => wire__crate__api__voting__delete_voting_account_state_impl(port, ptr, rust_vec_len, data_len),
+47 => wire__crate__api__secret__derive_secret_password_verifier_impl(port, ptr, rust_vec_len, data_len),
+48 => wire__crate__api__sync__discard_all_keystone_migration_requests_impl(port, ptr, rust_vec_len, data_len),
+49 => wire__crate__api__sync__discard_keystone_migration_request_impl(port, ptr, rust_vec_len, data_len),
+50 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
+51 => wire__crate__api__wallet__discover_software_wallet_import_accounts_impl(port, ptr, rust_vec_len, data_len),
+52 => wire__crate__api__keystone__encode_keystone_action_sigs_impl(port, ptr, rust_vec_len, data_len),
+53 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
+54 => wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len),
+55 => wire__crate__api__keystone__encode_zcash_sign_batch_ur_parts_impl(port, ptr, rust_vec_len, data_len),
+56 => wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
+57 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
+59 => wire__crate__api__network_privacy__estimate_import_birthday_height_impl(port, ptr, rust_vec_len, data_len),
+60 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
+61 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+63 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+64 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+65 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
+68 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
+69 => wire__crate__api__wallet__get_account_export_metadata_impl(port, ptr, rust_vec_len, data_len),
+70 => wire__crate__api__wallet__get_account_ufvk_impl(port, ptr, rust_vec_len, data_len),
+71 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+72 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
+74 => wire__crate__api__wallet__get_chain_upgrade_status_impl(port, ptr, rust_vec_len, data_len),
+75 => wire__crate__api__wallet__get_chain_upgrade_status_at_height_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
+77 => wire__crate__api__network_privacy__get_import_birthday_metadata_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
+80 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__sync__get_orchard_migration_immediate_plan_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__sync__get_orchard_migration_private_plan_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__sync__get_orchard_migration_status_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__sync__get_orchard_migration_statuses_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__sync__get_previous_transaction_count_for_address_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
+101 => wire__crate__api__wallet__import_software_account_at_index_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
+116 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
+117 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__voting__precompute_delegation_proof_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__voting__precompute_snapshot_bundles_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__sync__prepare_pczt_for_keystone_batch_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__zcash_voting__wire__round_work_tally_view_default_impl(port, ptr, rust_vec_len, data_len),
 145 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
 146 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
 149 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
@@ -11830,69 +12081,69 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        3 => wire__crate__api__voting_session__VotingRoundSession_begin_share_tracking_pass_impl(
+        1 => wire__crate__api__voting_session__VotingRoundSession_begin_share_tracking_pass_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        4 => wire__crate__api__voting_session__VotingRoundSession_cancel_impl(
+        2 => wire__crate__api__voting_session__VotingRoundSession_cancel_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        9 => wire__crate__api__voting_session__VotingRoundSession_set_operation_epoch_impl(
+        8 => wire__crate__api__voting_session__VotingRoundSession_set_operation_epoch_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        10 => wire__crate__api__voting__VotingShareTrackingPassHandle_cancel_impl(
+        9 => wire__crate__api__voting__VotingShareTrackingPassHandle_cancel_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        14 => wire__crate__api__network_privacy__begin_network_privacy_enable_impl(
+        13 => wire__crate__api__network_privacy__begin_network_privacy_enable_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        15 => wire__crate__api__voting__begin_share_tracking_pass_impl(ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__voting__create_voting_helper_delivery_context_impl(
+        14 => wire__crate__api__voting__begin_share_tracking_pass_impl(ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__voting__create_voting_helper_delivery_context_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        67 => wire__crate__api__network_privacy__fail_network_privacy_enable_impl(
+        66 => wire__crate__api__network_privacy__fail_network_privacy_enable_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        68 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        74 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__network_privacy__get_network_privacy_status_impl(
+        67 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        73 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__network_privacy__get_network_privacy_status_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        93 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        106 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
-        107 => {
+        92 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        99 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        105 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
+        106 => {
             wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len)
         }
-        109 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        110 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        111 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
-        113 => {
+        108 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        109 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        110 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
+        112 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        119 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        121 => wire__crate__api__voting_session__open_voting_round_session_impl(
+        118 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        120 => wire__crate__api__voting_session__open_voting_round_session_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        137 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        136 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
         147 => {
             wire__crate__api__voting__select_pir_snapshot_endpoint_impl(ptr, rust_vec_len, data_len)
         }
@@ -12418,6 +12669,29 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::voting::ApiResubmittedShare>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::voting_session::ApiRoundDrivePolicy {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.pending_repoll_seconds.into_into_dart().into_dart(),
+            self.max_bundle_concurrency.into_into_dart().into_dart(),
+            self.max_dispatches.into_into_dart().into_dart(),
+            self.skip_failed_bundle.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::voting_session::ApiRoundDrivePolicy
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::voting_session::ApiRoundDrivePolicy>
+    for crate::api::voting_session::ApiRoundDrivePolicy
+{
+    fn into_into_dart(self) -> crate::api::voting_session::ApiRoundDrivePolicy {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::voting_session::ApiRoundHostContext {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -12439,6 +12713,29 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::voting_session::ApiRoundHostC
     for crate::api::voting_session::ApiRoundHostContext
 {
     fn into_into_dart(self) -> crate::api::voting_session::ApiRoundHostContext {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::voting_session::ApiRoundRunEvent {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.kind.into_into_dart().into_dart(),
+            self.event.into_into_dart().into_dart(),
+            self.report.into_into_dart().into_dart(),
+            self.error.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::voting_session::ApiRoundRunEvent
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::voting_session::ApiRoundRunEvent>
+    for crate::api::voting_session::ApiRoundRunEvent
+{
+    fn into_into_dart(self) -> crate::api::voting_session::ApiRoundRunEvent {
         self
     }
 }
@@ -12470,30 +12767,6 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::voting_session::ApiRoundStepE
     for crate::api::voting_session::ApiRoundStepError
 {
     fn into_into_dart(self) -> crate::api::voting_session::ApiRoundStepError {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::voting_session::ApiRoundStepEvent {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.kind.into_into_dart().into_dart(),
-            self.progress.into_into_dart().into_dart(),
-            self.outcome.into_into_dart().into_dart(),
-            self.failure.into_into_dart().into_dart(),
-            self.error.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::voting_session::ApiRoundStepEvent
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::voting_session::ApiRoundStepEvent>
-    for crate::api::voting_session::ApiRoundStepEvent
-{
-    fn into_into_dart(self) -> crate::api::voting_session::ApiRoundStepEvent {
         self
     }
 }
@@ -14274,6 +14547,82 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::config::Resolved
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundChainOutcomeView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.step.into_into_dart().into_dart(),
+            self.0.outcome.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::RoundChainOutcomeView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundChainOutcomeView>>
+    for zcash_voting::wire::RoundChainOutcomeView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundChainOutcomeView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundDriveEventKind> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self.0 {
+            zcash_voting::wire::RoundDriveEventKind::PlanRefreshed => 0.into_dart(),
+            zcash_voting::wire::RoundDriveEventKind::StepSelected => 1.into_dart(),
+            zcash_voting::wire::RoundDriveEventKind::StepProgress => 2.into_dart(),
+            zcash_voting::wire::RoundDriveEventKind::StepFinished => 3.into_dart(),
+            zcash_voting::wire::RoundDriveEventKind::StepFailed => 4.into_dart(),
+            zcash_voting::wire::RoundDriveEventKind::AwaitingRepoll => 5.into_dart(),
+            zcash_voting::wire::RoundDriveEventKind::BundleSkipped => 6.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::RoundDriveEventKind>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundDriveEventKind>>
+    for zcash_voting::wire::RoundDriveEventKind
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundDriveEventKind> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundDriveEventView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.kind.into_into_dart().into_dart(),
+            self.0.step.into_into_dart().into_dart(),
+            self.0.plan.into_into_dart().into_dart(),
+            self.0.tally.into_into_dart().into_dart(),
+            self.0.progress.into_into_dart().into_dart(),
+            self.0.disposition.into_into_dart().into_dart(),
+            self.0.failure_kind.into_into_dart().into_dart(),
+            self.0.message.into_into_dart().into_dart(),
+            self.0.delay_seconds.into_into_dart().into_dart(),
+            self.0.bundle_index.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::RoundDriveEventView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundDriveEventView>>
+    for zcash_voting::wire::RoundDriveEventView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundDriveEventView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundPlanActionKind> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self.0 {
@@ -14355,6 +14704,90 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundPlanV
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundQuiescenceKind> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self.0 {
+            zcash_voting::wire::RoundQuiescenceKind::NoWorkLeft => 0.into_dart(),
+            zcash_voting::wire::RoundQuiescenceKind::NeedsBundleSetup => 1.into_dart(),
+            zcash_voting::wire::RoundQuiescenceKind::PersistedChainTerminal => 2.into_dart(),
+            zcash_voting::wire::RoundQuiescenceKind::NeedsBallot => 3.into_dart(),
+            zcash_voting::wire::RoundQuiescenceKind::NeedsDelegationSignatures => 4.into_dart(),
+            zcash_voting::wire::RoundQuiescenceKind::BackgroundShareWorkOnly => 5.into_dart(),
+            zcash_voting::wire::RoundQuiescenceKind::Cancelled => 6.into_dart(),
+            zcash_voting::wire::RoundQuiescenceKind::ChainTerminal => 7.into_dart(),
+            zcash_voting::wire::RoundQuiescenceKind::ChainRecoveryStalled => 8.into_dart(),
+            zcash_voting::wire::RoundQuiescenceKind::Failures => 9.into_dart(),
+            zcash_voting::wire::RoundQuiescenceKind::PassBudgetExhausted => 10.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::RoundQuiescenceKind>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundQuiescenceKind>>
+    for zcash_voting::wire::RoundQuiescenceKind
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundQuiescenceKind> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundQuiescenceView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.kind.into_into_dart().into_dart(),
+            self.0.open_proposals.into_into_dart().into_dart(),
+            self.0.unrostered_intents.into_into_dart().into_dart(),
+            self.0.bundles.into_into_dart().into_dart(),
+            self.0.shares.into_into_dart().into_dart(),
+            self.0.step.into_into_dart().into_dart(),
+            self.0.chain_outcome.into_into_dart().into_dart(),
+            self.0.remaining.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::RoundQuiescenceView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundQuiescenceView>>
+    for zcash_voting::wire::RoundQuiescenceView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundQuiescenceView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundRunReportView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.quiescence.into_into_dart().into_dart(),
+            self.0.plan.into_into_dart().into_dart(),
+            self.0.tally.into_into_dart().into_dart(),
+            self.0.failures.into_into_dart().into_dart(),
+            self.0.skipped_bundles.into_into_dart().into_dart(),
+            self.0.chain_outcomes.into_into_dart().into_dart(),
+            self.0.share_deliveries.into_into_dart().into_dart(),
+            self.0.delegations.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::RoundRunReportView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundRunReportView>>
+    for zcash_voting::wire::RoundRunReportView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundRunReportView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundStepDispositionView> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self.0 {
@@ -14415,6 +14848,28 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundStepF
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundStepFailureRecordView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.step.into_into_dart().into_dart(),
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.failure.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::RoundStepFailureRecordView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundStepFailureRecordView>>
+    for zcash_voting::wire::RoundStepFailureRecordView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundStepFailureRecordView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundStepFailureView> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -14437,31 +14892,6 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundStepF
     for zcash_voting::wire::RoundStepFailureView
 {
     fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundStepFailureView> {
-        self.into()
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundStepOutcomeView> {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.0.step.into_into_dart().into_dart(),
-            self.0.disposition.into_into_dart().into_dart(),
-            self.0.chain_outcome.into_into_dart().into_dart(),
-            self.0.share_deliveries.into_into_dart().into_dart(),
-            self.0.delegation.into_into_dart().into_dart(),
-            self.0.plan.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for FrbWrapper<zcash_voting::wire::RoundStepOutcomeView>
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundStepOutcomeView>>
-    for zcash_voting::wire::RoundStepOutcomeView
-{
-    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundStepOutcomeView> {
         self.into()
     }
 }
@@ -14521,6 +14951,28 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundStepP
     for zcash_voting::wire::RoundStepProgressView
 {
     fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundStepProgressView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundWorkTallyView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.completed_proposals.into_into_dart().into_dart(),
+            self.0.total_proposals.into_into_dart().into_dart(),
+            self.0.remaining_obligations.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::RoundWorkTallyView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundWorkTallyView>>
+    for zcash_voting::wire::RoundWorkTallyView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundWorkTallyView> {
         self.into()
     }
 }
@@ -15630,7 +16082,7 @@ impl SseEncode
 
 impl SseEncode
     for StreamSink<
-        crate::api::voting_session::ApiRoundStepEvent,
+        crate::api::voting_session::ApiRoundRunEvent,
         flutter_rust_bridge::for_generated::SseCodec,
     >
 {
@@ -15855,6 +16307,16 @@ impl SseEncode for crate::api::voting::ApiResubmittedShare {
     }
 }
 
+impl SseEncode for crate::api::voting_session::ApiRoundDrivePolicy {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Option<f64>>::sse_encode(self.pending_repoll_seconds, serializer);
+        <Option<u32>>::sse_encode(self.max_bundle_concurrency, serializer);
+        <Option<u32>>::sse_encode(self.max_dispatches, serializer);
+        <Option<bool>>::sse_encode(self.skip_failed_bundle, serializer);
+    }
+}
+
 impl SseEncode for crate::api::voting_session::ApiRoundHostContext {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -15864,6 +16326,16 @@ impl SseEncode for crate::api::voting_session::ApiRoundHostContext {
         <Option<u64>>::sse_encode(self.vote_end_time_seconds, serializer);
         <Vec<String>>::sse_encode(self.vote_tree_node_urls, serializer);
         <u32>::sse_encode(self.max_proof_concurrency, serializer);
+    }
+}
+
+impl SseEncode for crate::api::voting_session::ApiRoundRunEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::voting_session::ApiRoundStepEventKind>::sse_encode(self.kind, serializer);
+        <Option<zcash_voting::wire::RoundDriveEventView>>::sse_encode(self.event, serializer);
+        <Option<zcash_voting::wire::RoundRunReportView>>::sse_encode(self.report, serializer);
+        <Option<crate::api::voting_session::ApiRoundStepError>>::sse_encode(self.error, serializer);
     }
 }
 
@@ -15885,17 +16357,6 @@ impl SseEncode for crate::api::voting_session::ApiRoundStepError {
         <Option<u32>>::sse_encode(self.selected_notes, serializer);
         <Option<u16>>::sse_encode(self.http_status, serializer);
         <Option<String>>::sse_encode(self.endpoint, serializer);
-    }
-}
-
-impl SseEncode for crate::api::voting_session::ApiRoundStepEvent {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <crate::api::voting_session::ApiRoundStepEventKind>::sse_encode(self.kind, serializer);
-        <Option<zcash_voting::wire::RoundStepProgressView>>::sse_encode(self.progress, serializer);
-        <Option<zcash_voting::wire::RoundStepOutcomeView>>::sse_encode(self.outcome, serializer);
-        <Option<zcash_voting::wire::RoundStepFailureView>>::sse_encode(self.failure, serializer);
-        <Option<crate::api::voting_session::ApiRoundStepError>>::sse_encode(self.error, serializer);
     }
 }
 
@@ -16911,6 +17372,26 @@ impl SseEncode for Vec<u8> {
     }
 }
 
+impl SseEncode for Vec<zcash_voting::wire::RoundChainOutcomeView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::RoundChainOutcomeView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::RoundStepFailureRecordView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::RoundStepFailureRecordView>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::api::sync::ScanRangeInfo> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -16947,6 +17428,26 @@ impl SseEncode for Vec<zcash_voting::wire::ShareDeliveryOutcomeView> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <zcash_voting::wire::ShareDeliveryOutcomeView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::ShareKeyView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::ShareKeyView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::SignedDelegationPayloadView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::SignedDelegationPayloadView>::sse_encode(item, serializer);
         }
     }
 }
@@ -17353,6 +17854,16 @@ impl SseEncode for Option<crate::api::voting_session::ApiDelegationSignerInput> 
     }
 }
 
+impl SseEncode for Option<crate::api::voting_session::ApiRoundDrivePolicy> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::voting_session::ApiRoundDrivePolicy>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for Option<crate::api::voting_session::ApiRoundStepError> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -17523,6 +18034,16 @@ impl SseEncode for Option<zcash_voting::config::ResolvedVotingConfig> {
     }
 }
 
+impl SseEncode for Option<zcash_voting::wire::RoundDriveEventView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <zcash_voting::wire::RoundDriveEventView>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for Option<zcash_voting::wire::RoundPlanView> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -17533,22 +18054,32 @@ impl SseEncode for Option<zcash_voting::wire::RoundPlanView> {
     }
 }
 
-impl SseEncode for Option<zcash_voting::wire::RoundStepFailureView> {
+impl SseEncode for Option<zcash_voting::wire::RoundRunReportView> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
-            <zcash_voting::wire::RoundStepFailureView>::sse_encode(value, serializer);
+            <zcash_voting::wire::RoundRunReportView>::sse_encode(value, serializer);
         }
     }
 }
 
-impl SseEncode for Option<zcash_voting::wire::RoundStepOutcomeView> {
+impl SseEncode for Option<zcash_voting::wire::RoundStepDispositionView> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
-            <zcash_voting::wire::RoundStepOutcomeView>::sse_encode(value, serializer);
+            <zcash_voting::wire::RoundStepDispositionView>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<zcash_voting::wire::RoundStepFailureKindView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <zcash_voting::wire::RoundStepFailureKindView>::sse_encode(value, serializer);
         }
     }
 }
@@ -17559,6 +18090,16 @@ impl SseEncode for Option<zcash_voting::wire::RoundStepProgressView> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <zcash_voting::wire::RoundStepProgressView>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<zcash_voting::wire::RoundWorkTallyView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <zcash_voting::wire::RoundWorkTallyView>::sse_encode(value, serializer);
         }
     }
 }
@@ -17579,16 +18120,6 @@ impl SseEncode for Option<zcash_voting::wire::ShareKeyView> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <zcash_voting::wire::ShareKeyView>::sse_encode(value, serializer);
-        }
-    }
-}
-
-impl SseEncode for Option<zcash_voting::wire::SignedDelegationPayloadView> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <bool>::sse_encode(self.is_some(), serializer);
-        if let Some(value) = self {
-            <zcash_voting::wire::SignedDelegationPayloadView>::sse_encode(value, serializer);
         }
     }
 }
@@ -17748,6 +18279,57 @@ impl SseEncode for zcash_voting::config::ResolvedVotingConfig {
     }
 }
 
+impl SseEncode for zcash_voting::wire::RoundChainOutcomeView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <zcash_voting::wire::NextStepView>::sse_encode(self.step, serializer);
+        <zcash_voting::wire::ChainSubmissionOutcomeView>::sse_encode(self.outcome, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::RoundDriveEventKind {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                zcash_voting::wire::RoundDriveEventKind::PlanRefreshed => 0,
+                zcash_voting::wire::RoundDriveEventKind::StepSelected => 1,
+                zcash_voting::wire::RoundDriveEventKind::StepProgress => 2,
+                zcash_voting::wire::RoundDriveEventKind::StepFinished => 3,
+                zcash_voting::wire::RoundDriveEventKind::StepFailed => 4,
+                zcash_voting::wire::RoundDriveEventKind::AwaitingRepoll => 5,
+                zcash_voting::wire::RoundDriveEventKind::BundleSkipped => 6,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for zcash_voting::wire::RoundDriveEventView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <zcash_voting::wire::RoundDriveEventKind>::sse_encode(self.kind, serializer);
+        <Option<zcash_voting::wire::NextStepView>>::sse_encode(self.step, serializer);
+        <Option<zcash_voting::wire::RoundPlanView>>::sse_encode(self.plan, serializer);
+        <Option<zcash_voting::wire::RoundWorkTallyView>>::sse_encode(self.tally, serializer);
+        <Option<zcash_voting::wire::RoundStepProgressView>>::sse_encode(self.progress, serializer);
+        <Option<zcash_voting::wire::RoundStepDispositionView>>::sse_encode(
+            self.disposition,
+            serializer,
+        );
+        <Option<zcash_voting::wire::RoundStepFailureKindView>>::sse_encode(
+            self.failure_kind,
+            serializer,
+        );
+        <Option<String>>::sse_encode(self.message, serializer);
+        <Option<f64>>::sse_encode(self.delay_seconds, serializer);
+        <Option<u32>>::sse_encode(self.bundle_index, serializer);
+    }
+}
+
 impl SseEncode for zcash_voting::wire::RoundPlanActionKind {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -17814,6 +18396,74 @@ impl SseEncode for zcash_voting::wire::RoundPlanView {
     }
 }
 
+impl SseEncode for zcash_voting::wire::RoundQuiescenceKind {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                zcash_voting::wire::RoundQuiescenceKind::NoWorkLeft => 0,
+                zcash_voting::wire::RoundQuiescenceKind::NeedsBundleSetup => 1,
+                zcash_voting::wire::RoundQuiescenceKind::PersistedChainTerminal => 2,
+                zcash_voting::wire::RoundQuiescenceKind::NeedsBallot => 3,
+                zcash_voting::wire::RoundQuiescenceKind::NeedsDelegationSignatures => 4,
+                zcash_voting::wire::RoundQuiescenceKind::BackgroundShareWorkOnly => 5,
+                zcash_voting::wire::RoundQuiescenceKind::Cancelled => 6,
+                zcash_voting::wire::RoundQuiescenceKind::ChainTerminal => 7,
+                zcash_voting::wire::RoundQuiescenceKind::ChainRecoveryStalled => 8,
+                zcash_voting::wire::RoundQuiescenceKind::Failures => 9,
+                zcash_voting::wire::RoundQuiescenceKind::PassBudgetExhausted => 10,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for zcash_voting::wire::RoundQuiescenceView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <zcash_voting::wire::RoundQuiescenceKind>::sse_encode(self.kind, serializer);
+        <Vec<u32>>::sse_encode(self.open_proposals, serializer);
+        <Vec<u32>>::sse_encode(self.unrostered_intents, serializer);
+        <Vec<u32>>::sse_encode(self.bundles, serializer);
+        <Vec<zcash_voting::wire::ShareKeyView>>::sse_encode(self.shares, serializer);
+        <Option<zcash_voting::wire::NextStepView>>::sse_encode(self.step, serializer);
+        <Option<zcash_voting::wire::ChainSubmissionOutcomeView>>::sse_encode(
+            self.chain_outcome,
+            serializer,
+        );
+        <Vec<zcash_voting::wire::NextStepView>>::sse_encode(self.remaining, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::RoundRunReportView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <zcash_voting::wire::RoundQuiescenceView>::sse_encode(self.quiescence, serializer);
+        <Option<zcash_voting::wire::RoundPlanView>>::sse_encode(self.plan, serializer);
+        <zcash_voting::wire::RoundWorkTallyView>::sse_encode(self.tally, serializer);
+        <Vec<zcash_voting::wire::RoundStepFailureRecordView>>::sse_encode(
+            self.failures,
+            serializer,
+        );
+        <Vec<u32>>::sse_encode(self.skipped_bundles, serializer);
+        <Vec<zcash_voting::wire::RoundChainOutcomeView>>::sse_encode(
+            self.chain_outcomes,
+            serializer,
+        );
+        <Vec<zcash_voting::wire::ShareBatchDeliveryReportView>>::sse_encode(
+            self.share_deliveries,
+            serializer,
+        );
+        <Vec<zcash_voting::wire::SignedDelegationPayloadView>>::sse_encode(
+            self.delegations,
+            serializer,
+        );
+    }
+}
+
 impl SseEncode for zcash_voting::wire::RoundStepDispositionView {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -17860,6 +18510,15 @@ impl SseEncode for zcash_voting::wire::RoundStepFailureKindView {
     }
 }
 
+impl SseEncode for zcash_voting::wire::RoundStepFailureRecordView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Option<zcash_voting::wire::NextStepView>>::sse_encode(self.step, serializer);
+        <Option<u32>>::sse_encode(self.bundle_index, serializer);
+        <zcash_voting::wire::RoundStepFailureView>::sse_encode(self.failure, serializer);
+    }
+}
+
 impl SseEncode for zcash_voting::wire::RoundStepFailureView {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -17879,27 +18538,6 @@ impl SseEncode for zcash_voting::wire::RoundStepFailureView {
             self.share_deliveries,
             serializer,
         );
-    }
-}
-
-impl SseEncode for zcash_voting::wire::RoundStepOutcomeView {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <Option<zcash_voting::wire::NextStepView>>::sse_encode(self.step, serializer);
-        <zcash_voting::wire::RoundStepDispositionView>::sse_encode(self.disposition, serializer);
-        <Option<zcash_voting::wire::ChainSubmissionOutcomeView>>::sse_encode(
-            self.chain_outcome,
-            serializer,
-        );
-        <Vec<zcash_voting::wire::ShareBatchDeliveryReportView>>::sse_encode(
-            self.share_deliveries,
-            serializer,
-        );
-        <Option<zcash_voting::wire::SignedDelegationPayloadView>>::sse_encode(
-            self.delegation,
-            serializer,
-        );
-        <zcash_voting::wire::RoundPlanView>::sse_encode(self.plan, serializer);
     }
 }
 
@@ -17953,6 +18591,15 @@ impl SseEncode for zcash_voting::wire::RoundStepProgressView {
         );
         <Option<zcash_voting::wire::ShareKeyView>>::sse_encode(self.share, serializer);
         <Option<bool>>::sse_encode(self.share_confirmed, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::RoundWorkTallyView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.completed_proposals, serializer);
+        <u32>::sse_encode(self.total_proposals, serializer);
+        <u32>::sse_encode(self.remaining_obligations, serializer);
     }
 }
 

--- a/test/features/voting/fake_voting_round_session.dart
+++ b/test/features/voting/fake_voting_round_session.dart
@@ -153,6 +153,11 @@ abstract interface class FakeRoundSessionDriver {
   /// Bundle count the planner sees, from recovery state when present.
   int get planBundleCount;
 
+  /// Bundles whose delegation is already durable, so a synthesised plan does
+  /// not ask for one again. Mirrors the SDK, whose planner reads the bundle's
+  /// delegation phase rather than guessing from the steps it lists.
+  Set<int> get confirmedDelegationBundles;
+
   Map<int, rust_wire.KeystoneSignatureRecord> get storedKeystoneSignatures;
 
   /// Proposal ids proven together per bundle, recorded by the fake's
@@ -193,12 +198,60 @@ abstract interface class FakeRoundSessionDriver {
   /// failure — including one raised before the step runs — as an event.
   Map<String, VotingRustException> get roundStepBridgeErrors;
 
+  /// Event sequences to emit from `runRound`, one per call, instead of
+  /// driving the scripted plan.
+  ///
+  /// The SDK owns the loop now, and its conformance tests own whether a given
+  /// sequence is realistic. A provider test that cares how Dart maps events
+  /// onto session state scripts the sequence here and asserts the state,
+  /// rather than making this fake re-derive a plan the real planner owns.
+  List<List<rust_session.ApiRoundRunEvent>> get scriptedRoundRuns;
+
   List<String> get roundSessionSteps;
 
   List<String> get sessionBallotIntents;
 
   /// Proposal ids the session was asked to clear as unrostered intents.
   List<int> get sessionClearedBallotIntents;
+}
+
+/// One event from the fake's scripted step machinery.
+///
+/// The bridge no longer exposes a per-step stream: production drives a round
+/// with `runRound`. This keeps the same shape internally so the scripted
+/// scenarios below still read as "what one step did", without holding a
+/// retired API alive.
+class _ScriptedStepEvent {
+  const _ScriptedStepEvent({
+    required this.kind,
+    this.progress,
+    this.outcome,
+    this.failure,
+    this.error,
+  });
+
+  final rust_session.ApiRoundStepEventKind kind;
+  final rust_wire.RoundStepProgressView? progress;
+  final _ScriptedStepOutcome? outcome;
+  final rust_wire.RoundStepFailureView? failure;
+  final rust_session.ApiRoundStepError? error;
+}
+
+/// What one scripted step accomplished.
+class _ScriptedStepOutcome {
+  const _ScriptedStepOutcome({
+    required this.disposition,
+    required this.plan,
+    this.chainOutcome,
+    this.shareDeliveries = const [],
+    this.delegation,
+  });
+
+  final rust_wire.RoundStepDispositionView disposition;
+  final rust_wire.RoundPlanView plan;
+  final rust_wire.ChainSubmissionOutcomeView? chainOutcome;
+  final List<rust_wire.ShareBatchDeliveryReportView> shareDeliveries;
+  final rust_wire.SignedDelegationPayloadView? delegation;
 }
 
 /// Test double for the SDK round session.
@@ -316,15 +369,78 @@ class FakeVotingRoundSession implements VotingRoundSession {
     _ => false,
   };
 
-  Future<rust_wire.RoundPlanView> _plan() async {
+  Future<rust_wire.RoundPlanView> _plan({
+    bool synthesizeDelegation = false,
+  }) async {
     final base = await driver.peekRoundPlan(
       roundId: roundId,
       proposalIds: _rosterIds,
     );
     final steps = <rust_wire.NextStepView>[];
     final seen = <String>{};
+    if (base != null && synthesizeDelegation) {
+      // The scripted plan may list no delegation step while its own statuses
+      // still say a bundle owes one. The SDK planner keeps those in agreement,
+      // and the driver runs only what the plan lists, so honour the statuses.
+      final covered = {
+        for (final step in base.nextSteps)
+          if (_isDelegationStep(step)) step.bundleIndex,
+      };
+      for (final status in base.delegationStatuses) {
+        if (covered.contains(status.bundleIndex) ||
+            _delegatedBundles.contains(status.bundleIndex) ||
+            status.terminal ||
+            status.phase == rust_wire.WorkflowPhaseView.confirmed) {
+          continue;
+        }
+        steps.add(
+          rust_wire.NextStepView(
+            kind: rust_wire.NextStepKind.delegate,
+            bundleIndex: status.bundleIndex,
+            proposalId: 0,
+            choice: 0,
+            shareIndex: 0,
+          ),
+        );
+      }
+    }
+    if (base == null && synthesizeDelegation) {
+      // No scripted recovery state, and this run holds signing material, so
+      // it is a delegation run against a fresh round: every bundle still owes
+      // a delegation. The SDK's plan always knows its own bundles, and the
+      // driver runs only what the plan lists, so a fake that listed nothing
+      // would make delegation unrunnable rather than pending. A cast run
+      // carries no signer and assumes delegation is already durable, which is
+      // what these fixtures script.
+      for (
+        var bundleIndex = 0;
+        bundleIndex < driver.planBundleCount;
+        bundleIndex++
+      ) {
+        if (_delegatedBundles.contains(bundleIndex) ||
+            driver.confirmedDelegationBundles.contains(bundleIndex)) {
+          continue;
+        }
+        steps.add(
+          rust_wire.NextStepView(
+            kind: rust_wire.NextStepKind.delegate,
+            bundleIndex: bundleIndex,
+            proposalId: 0,
+            choice: 0,
+            shareIndex: 0,
+          ),
+        );
+      }
+    }
     for (final step in base?.nextSteps ?? const <rust_wire.NextStepView>[]) {
       if (!_isVoteStep(step)) {
+        // A delegation this session already advanced leaves the plan, the way
+        // the SDK re-plans with completed work removed. Keeping it would make
+        // the plan never shrink, and the driver re-plans until it does.
+        if (_isDelegationStep(step) &&
+            _delegatedBundles.contains(step.bundleIndex)) {
+          continue;
+        }
         steps.add(step);
         continue;
       }
@@ -396,8 +512,9 @@ class FakeVotingRoundSession implements VotingRoundSession {
     );
   }
 
-  @override
-  Stream<rust_session.ApiRoundStepEvent> advanceStep({
+  /// Runs one scripted step. Private: production drives rounds through
+  /// `runRound`, and the bridge no longer exposes a per-step entry point.
+  Stream<_ScriptedStepEvent> _advanceScriptedStep({
     required rust_wire.NextStepView step,
     required rust_session.ApiRoundHostContext host,
     rust_session.ApiDelegationSignerInput? signer,
@@ -433,7 +550,11 @@ class FakeVotingRoundSession implements VotingRoundSession {
     }
   }
 
-  Stream<rust_session.ApiRoundStepEvent> _advanceDelegation(
+  /// Bundles whose delegation this session already ran, so a synthesised
+  /// plan stops listing them once they are done.
+  final _delegatedBundles = <int>{};
+
+  Stream<_ScriptedStepEvent> _advanceDelegation(
     rust_wire.NextStepView step,
     rust_session.ApiRoundHostContext host,
     rust_session.ApiDelegationSignerInput? signer,
@@ -540,15 +661,19 @@ class FakeVotingRoundSession implements VotingRoundSession {
         chainOutcome: _chainOutcomeView(outcome),
       ),
     );
+    final disposition = _dispositionFor(outcome);
+    if (disposition == rust_wire.RoundStepDispositionView.advanced) {
+      _delegatedBundles.add(bundleIndex);
+    }
     yield await _result(
       step,
-      _dispositionFor(outcome),
+      disposition,
       chainOutcome: outcome,
       delegation: submission,
     );
   }
 
-  Stream<rust_session.ApiRoundStepEvent> _advanceVote(
+  Stream<_ScriptedStepEvent> _advanceVote(
     rust_wire.NextStepView step,
     rust_session.ApiRoundHostContext host,
   ) async* {
@@ -896,10 +1021,10 @@ class FakeVotingRoundSession implements VotingRoundSession {
       rust_wire.RoundStepDispositionView.chainTerminal,
   };
 
-  rust_session.ApiRoundStepEvent _progress(
+  _ScriptedStepEvent _progress(
     rust_wire.RoundStepProgressView progress,
   ) {
-    return rust_session.ApiRoundStepEvent(
+    return _ScriptedStepEvent(
       kind: rust_session.ApiRoundStepEventKind.progress,
       progress: progress,
       outcome: null,
@@ -907,18 +1032,393 @@ class FakeVotingRoundSession implements VotingRoundSession {
     );
   }
 
-  Future<rust_session.ApiRoundStepEvent> _result(
+  /// Drives the scripted plan the way the SDK driver does.
+  ///
+  /// The real loop lives in Rust (`zcash_voting::round_drive`) and its
+  /// conformance tests are the source of truth for it. This mirrors only what
+  /// provider tests observe — plan-ordered selection, per-bundle failure
+  /// isolation, and the quiescence the run stops on — over the same per-step
+  /// script the steps use. Keep the two in step; do not add behaviour
+  /// here that the Rust driver does not have.
+  @override
+  Stream<rust_session.ApiRoundRunEvent> runRound({
+    required rust_session.ApiRoundHostContext host,
+    rust_session.ApiDelegationSignerInput? signer,
+    rust_session.ApiRoundDrivePolicy? policy,
+  }) async* {
+    if (driver.scriptedRoundRuns.isNotEmpty) {
+      for (final event in driver.scriptedRoundRuns.removeAt(0)) {
+        yield event;
+      }
+      return;
+    }
+    final skipped = <int>[];
+    final failures = <rust_wire.RoundStepFailureRecordView>[];
+    final chainOutcomes = <rust_wire.RoundChainOutcomeView>[];
+    final shareDeliveries = <rust_wire.ShareBatchDeliveryReportView>[];
+    var plan = await _plan(synthesizeDelegation: signer != null);
+    // The SDK driver bounds itself with `max_dispatches`; without the same
+    // guard a scripted plan that never shrinks would spin here forever and
+    // hang the test rather than failing it.
+    var dispatches = 0;
+    const maxDispatches = 64;
+
+    while (true) {
+      if (dispatches >= maxDispatches) {
+        throw StateError(
+          'Fake round run exceeded $maxDispatches dispatches; the scripted '
+          'plan is not shrinking.',
+        );
+      }
+      plan = await _plan(synthesizeDelegation: signer != null);
+      yield _runEvent(
+        rust_wire.RoundDriveEventView(
+          kind: rust_wire.RoundDriveEventKind.planRefreshed,
+          plan: plan,
+          tally: _tally(plan),
+        ),
+      );
+
+      final quiescence = _quiescenceBeforeDispatch(plan, failures);
+      if (quiescence != null) {
+        yield _runReport(
+          quiescence,
+          plan,
+          failures,
+          skipped,
+          chainOutcomes,
+          shareDeliveries,
+        );
+        return;
+      }
+
+      final step = plan.nextSteps
+          .where((step) => !skipped.contains(step.bundleIndex))
+          .firstOrNull;
+      if (step == null) {
+        yield _runReport(
+          _quiescence(rust_wire.RoundQuiescenceKind.failures),
+          plan,
+          failures,
+          skipped,
+          chainOutcomes,
+          shareDeliveries,
+        );
+        return;
+      }
+      if (_needsDelegationSigner(step) &&
+          signer?.kind ==
+              rust_session.ApiDelegationSignerKind.keystoneStored) {
+        // The SDK checks every bundle the round still owes a delegation for
+        // against the durable signature rows, and stops before dispatching
+        // anything when one is missing, so the voter signs once.
+        final stored = await _api.getKeystoneSignatures(
+          dbPath: ctx.dbPath,
+          accountUuid: ctx.accountUuid,
+          roundId: roundId,
+        );
+        final signed = {for (final record in stored) record.bundleIndex};
+        final unsigned = Uint32List.fromList([
+          for (final planned in plan.nextSteps)
+            if (_needsDelegationSigner(planned) &&
+                !skipped.contains(planned.bundleIndex) &&
+                !signed.contains(planned.bundleIndex))
+              planned.bundleIndex,
+        ]);
+        if (unsigned.isNotEmpty) {
+          yield _runReport(
+            _quiescence(
+              rust_wire.RoundQuiescenceKind.needsDelegationSignatures,
+              bundles: unsigned,
+            ),
+            plan,
+            failures,
+            skipped,
+            chainOutcomes,
+            shareDeliveries,
+          );
+          return;
+        }
+      }
+      if (_needsDelegationSigner(step) && signer == null) {
+        yield _runReport(
+          _quiescence(
+            rust_wire.RoundQuiescenceKind.needsDelegationSignatures,
+            bundles: _delegationBundles(plan, skipped),
+          ),
+          plan,
+          failures,
+          skipped,
+          chainOutcomes,
+          shareDeliveries,
+        );
+        return;
+      }
+
+      yield _runEvent(
+        rust_wire.RoundDriveEventView(
+          kind: rust_wire.RoundDriveEventKind.stepSelected,
+          step: step,
+        ),
+      );
+      dispatches += 1;
+
+      _ScriptedStepEvent? terminal;
+      await for (final event in _advanceScriptedStep(
+        step: step,
+        host: host,
+        signer: signer,
+      )) {
+        final progress = event.progress;
+        if (progress != null) {
+          yield _runEvent(
+            rust_wire.RoundDriveEventView(
+              kind: rust_wire.RoundDriveEventKind.stepProgress,
+              step: step,
+              progress: progress,
+            ),
+          );
+        }
+        if (event.kind == rust_session.ApiRoundStepEventKind.result) {
+          terminal = event;
+        }
+      }
+      if (terminal == null) {
+        throw StateError('Round step completed without a result.');
+      }
+
+      final error = terminal.error;
+      if (error != null) {
+        yield rust_session.ApiRoundRunEvent(
+          kind: rust_session.ApiRoundStepEventKind.result,
+          error: error,
+        );
+        return;
+      }
+
+      final failure = terminal.failure;
+      if (failure != null) {
+        yield _runEvent(
+          rust_wire.RoundDriveEventView(
+            kind: rust_wire.RoundDriveEventKind.stepFailed,
+            step: step,
+            failureKind: failure.kind,
+            message: failure.message,
+          ),
+        );
+        failures.add(
+          rust_wire.RoundStepFailureRecordView(
+            step: step,
+            bundleIndex: step.bundleIndex,
+            failure: failure,
+          ),
+        );
+        skipped.add(step.bundleIndex);
+        yield _runEvent(
+          rust_wire.RoundDriveEventView(
+            kind: rust_wire.RoundDriveEventKind.bundleSkipped,
+            step: step,
+            bundleIndex: step.bundleIndex,
+          ),
+        );
+        continue;
+      }
+
+      final outcome = terminal.outcome!;
+      yield _runEvent(
+        rust_wire.RoundDriveEventView(
+          kind: rust_wire.RoundDriveEventKind.stepFinished,
+          step: step,
+          disposition: outcome.disposition,
+        ),
+      );
+      shareDeliveries.addAll(outcome.shareDeliveries);
+      final chainOutcome = outcome.chainOutcome;
+      if (chainOutcome != null) {
+        chainOutcomes.add(
+          rust_wire.RoundChainOutcomeView(step: step, outcome: chainOutcome),
+        );
+      }
+      switch (outcome.disposition) {
+        case rust_wire.RoundStepDispositionView.advanced:
+        case rust_wire.RoundStepDispositionView.noWork:
+          continue;
+        case rust_wire.RoundStepDispositionView.pending:
+          // The scripted fake never leaves a submission tracking, so a pending
+          // result here means the script has nothing further for it.
+          yield _runReport(
+            _quiescence(
+              rust_wire.RoundQuiescenceKind.chainRecoveryStalled,
+              step: step,
+              chainOutcome: chainOutcome,
+            ),
+            await _plan(),
+            failures,
+            skipped,
+            chainOutcomes,
+            shareDeliveries,
+          );
+          return;
+        case rust_wire.RoundStepDispositionView.cancelled:
+          yield _runReport(
+            _quiescence(rust_wire.RoundQuiescenceKind.cancelled),
+            await _plan(),
+            failures,
+            skipped,
+            chainOutcomes,
+            shareDeliveries,
+          );
+          return;
+        case rust_wire.RoundStepDispositionView.chainTerminal:
+          yield _runReport(
+            _quiescence(
+              rust_wire.RoundQuiescenceKind.chainTerminal,
+              step: step,
+              chainOutcome: chainOutcome,
+            ),
+            await _plan(),
+            failures,
+            skipped,
+            chainOutcomes,
+            shareDeliveries,
+          );
+          return;
+      }
+    }
+  }
+
+  bool _isDelegationStep(rust_wire.NextStepView step) =>
+      step.kind == rust_wire.NextStepKind.delegate ||
+      step.kind == rust_wire.NextStepKind.advanceDelegation ||
+      step.kind == rust_wire.NextStepKind.advanceImportedDelegation;
+
+  bool _needsDelegationSigner(rust_wire.NextStepView step) =>
+      step.kind == rust_wire.NextStepKind.delegate ||
+      step.kind == rust_wire.NextStepKind.advanceDelegation;
+
+  Uint32List _delegationBundles(
+    rust_wire.RoundPlanView plan,
+    List<int> skipped,
+  ) => Uint32List.fromList([
+    for (final step in plan.nextSteps)
+      if (_needsDelegationSigner(step) && !skipped.contains(step.bundleIndex))
+        step.bundleIndex,
+  ]);
+
+  rust_wire.RoundQuiescenceView? _quiescenceBeforeDispatch(
+    rust_wire.RoundPlanView plan,
+    List<rust_wire.RoundStepFailureRecordView> failures,
+  ) {
+    if (plan.nextSteps.isEmpty) {
+      if (failures.isNotEmpty) {
+        return _quiescence(rust_wire.RoundQuiescenceKind.failures);
+      }
+      if (plan.blockingRecovery) {
+        return _quiescence(rust_wire.RoundQuiescenceKind.persistedChainTerminal);
+      }
+      if (plan.needsBundleSetup) {
+        return _quiescence(rust_wire.RoundQuiescenceKind.needsBundleSetup);
+      }
+      if (plan.openProposals.isNotEmpty || plan.unrosteredIntents.isNotEmpty) {
+        return _quiescence(
+          rust_wire.RoundQuiescenceKind.needsBallot,
+          openProposals: plan.openProposals,
+          unrosteredIntents: plan.unrosteredIntents,
+        );
+      }
+      return _quiescence(rust_wire.RoundQuiescenceKind.noWorkLeft);
+    }
+    if (!plan.blockingRecovery) {
+      if (failures.isNotEmpty) {
+        return _quiescence(rust_wire.RoundQuiescenceKind.failures);
+      }
+      return _quiescence(
+        rust_wire.RoundQuiescenceKind.backgroundShareWorkOnly,
+        shares: [
+          for (final step in plan.nextSteps)
+            if (step.kind == rust_wire.NextStepKind.confirmShare)
+              rust_wire.ShareKeyView(
+                bundleIndex: step.bundleIndex,
+                proposalId: step.proposalId,
+                shareIndex: step.shareIndex,
+              ),
+        ],
+      );
+    }
+    return null;
+  }
+
+  rust_wire.RoundQuiescenceView _quiescence(
+    rust_wire.RoundQuiescenceKind kind, {
+    Uint32List? openProposals,
+    Uint32List? unrosteredIntents,
+    Uint32List? bundles,
+    List<rust_wire.ShareKeyView> shares = const [],
+    rust_wire.NextStepView? step,
+    rust_wire.ChainSubmissionOutcomeView? chainOutcome,
+  }) => rust_wire.RoundQuiescenceView(
+    kind: kind,
+    openProposals: openProposals ?? Uint32List(0),
+    unrosteredIntents: unrosteredIntents ?? Uint32List(0),
+    bundles: bundles ?? Uint32List(0),
+    shares: shares,
+    step: step,
+    chainOutcome: chainOutcome,
+    remaining: const [],
+  );
+
+  rust_wire.RoundWorkTallyView _tally(rust_wire.RoundPlanView plan) {
+    final proposals = <int>{
+      for (final step in plan.nextSteps)
+        if (step.kind != rust_wire.NextStepKind.delegate &&
+            step.kind != rust_wire.NextStepKind.advanceDelegation)
+          step.proposalId,
+    };
+    return rust_wire.RoundWorkTallyView(
+      completedProposals: 0,
+      totalProposals: proposals.length,
+      remainingObligations: plan.nextSteps.length,
+    );
+  }
+
+  rust_session.ApiRoundRunEvent _runEvent(rust_wire.RoundDriveEventView event) =>
+      rust_session.ApiRoundRunEvent(
+        kind: rust_session.ApiRoundStepEventKind.progress,
+        event: event,
+      );
+
+  rust_session.ApiRoundRunEvent _runReport(
+    rust_wire.RoundQuiescenceView quiescence,
+    rust_wire.RoundPlanView plan,
+    List<rust_wire.RoundStepFailureRecordView> failures,
+    List<int> skipped,
+    List<rust_wire.RoundChainOutcomeView> chainOutcomes,
+    List<rust_wire.ShareBatchDeliveryReportView> shareDeliveries,
+  ) => rust_session.ApiRoundRunEvent(
+    kind: rust_session.ApiRoundStepEventKind.result,
+    report: rust_wire.RoundRunReportView(
+      quiescence: quiescence,
+      plan: plan,
+      tally: _tally(plan),
+      failures: List.of(failures),
+      skippedBundles: Uint32List.fromList(skipped),
+      chainOutcomes: List.of(chainOutcomes),
+      shareDeliveries: List.of(shareDeliveries),
+      delegations: const [],
+    ),
+  );
+
+  Future<_ScriptedStepEvent> _result(
     rust_wire.NextStepView step,
     rust_wire.RoundStepDispositionView disposition, {
     rust_api.ApiChainSubmissionOutcome? chainOutcome,
     List<rust_wire.ShareBatchDeliveryReportView> shareDeliveries = const [],
     rust_wire.SignedDelegationPayloadView? delegation,
   }) async {
-    return rust_session.ApiRoundStepEvent(
+    return _ScriptedStepEvent(
       kind: rust_session.ApiRoundStepEventKind.result,
       progress: null,
-      outcome: rust_wire.RoundStepOutcomeView(
-        step: step,
+      outcome: _ScriptedStepOutcome(
         disposition: disposition,
         chainOutcome: chainOutcome == null
             ? null
@@ -931,13 +1431,13 @@ class FakeVotingRoundSession implements VotingRoundSession {
     );
   }
 
-  Future<rust_session.ApiRoundStepEvent> _failure(
+  Future<_ScriptedStepEvent> _failure(
     rust_wire.NextStepView step, {
     required rust_wire.RoundStepFailureKindView kind,
     required String message,
     rust_wire.ChainSubmissionFailureStateView? strongestChainState,
   }) async {
-    return rust_session.ApiRoundStepEvent(
+    return _ScriptedStepEvent(
       kind: rust_session.ApiRoundStepEventKind.result,
       progress: null,
       outcome: null,
@@ -953,9 +1453,10 @@ class FakeVotingRoundSession implements VotingRoundSession {
     );
   }
 
-  /// One result event carrying a typed bridge failure, as `advance_*` sends it.
-  rust_session.ApiRoundStepEvent _bridgeError(VotingRustException error) {
-    return rust_session.ApiRoundStepEvent(
+  /// One result event carrying a typed bridge failure, the way `run_round`
+  /// reports a failure raised before the SDK saw the step.
+  _ScriptedStepEvent _bridgeError(VotingRustException error) {
+    return _ScriptedStepEvent(
       kind: rust_session.ApiRoundStepEventKind.result,
       progress: null,
       outcome: null,

--- a/test/features/voting/fake_voting_round_session.dart
+++ b/test/features/voting/fake_voting_round_session.dart
@@ -211,6 +211,12 @@ abstract interface class FakeRoundSessionDriver {
 
   List<String> get sessionBallotIntents;
 
+  /// Failure the session raises from `setBallotIntents`, if any.
+  ///
+  /// The SDK write is the ballot's durable write, so this is the seam for
+  /// proving a failed intent write aborts before any vote work runs.
+  Object? get sessionBallotIntentsError => null;
+
   /// Proposal ids the session was asked to clear as unrostered intents.
   List<int> get sessionClearedBallotIntents;
 }
@@ -342,6 +348,8 @@ class FakeVotingRoundSession implements VotingRoundSession {
   Future<rust_wire.RoundPlanView> setBallotIntents(
     List<rust_session.ApiBallotIntent> intents,
   ) async {
+    final error = driver.sessionBallotIntentsError;
+    if (error != null) throw error;
     for (final intent in intents) {
       _intents[intent.proposalId] = intent;
     }

--- a/test/features/voting/round_plan_test_utils.dart
+++ b/test/features/voting/round_plan_test_utils.dart
@@ -175,7 +175,35 @@ rust_wire.RoundPlanView apiRoundPlanFromRecoveryState({
   if (!completedVoteArtifact) {
     for (var bundleIndex = 0; bundleIndex < state.bundleCount; bundleIndex++) {
       final delegation = delegationByBundle[bundleIndex];
+      // A bundle whose delegation is recorded but not yet on the wire owes a
+      // `Delegate`. The SDK planner lists it whenever the bundle has a cast
+      // due, and the driver runs only what the plan lists, so omitting it
+      // would make the round look like it had no delegation work at all. A
+      // bundle with no record at all is left alone: the fixture has said
+      // nothing about it, and the session synthesises that case only for a
+      // run that carries signing material.
       if (delegation != null &&
+          !delegation.terminal &&
+          delegation.phase != rust_wire.WorkflowPhaseView.confirmed &&
+          delegation.phase != rust_wire.WorkflowPhaseView.submittedDelegation) {
+        nextSteps.add(
+          rust_wire.NextStepView(
+            kind: rust_wire.NextStepKind.delegate,
+            bundleIndex: bundleIndex,
+            proposalId: 0,
+            choice: 0,
+            shareIndex: 0,
+          ),
+        );
+        recoveredDelegationWork.add(
+          rust_wire.DelegationRecoveryWorkView(
+            kind: rust_wire.DelegationRecoveryWorkKindView.delegate,
+            bundleIndex: bundleIndex,
+            phase: delegation.phase,
+            txHash: null,
+          ),
+        );
+      } else if (delegation != null &&
           !delegation.terminal &&
           delegation.phase == rust_wire.WorkflowPhaseView.submittedDelegation) {
         nextSteps.add(
@@ -631,5 +659,74 @@ rust_wire.RoundPlanView withDelegationStatusesFrom(
     immediateShareKey: plan.immediateShareKey,
     immediateShareConfirmed: plan.immediateShareConfirmed,
     allDecided: plan.allDecided,
+  );
+}
+
+/// One `runRound` progress event, as the bridge streams it.
+///
+/// Scripting events directly is how a provider test says what the SDK did
+/// without this fake re-deriving a plan the real planner owns.
+rust_session.ApiRoundRunEvent roundRunProgress({
+  required rust_wire.RoundDriveEventKind kind,
+  rust_wire.NextStepView? step,
+  rust_wire.RoundPlanView? plan,
+  rust_wire.RoundWorkTallyView? tally,
+  rust_wire.RoundStepProgressView? progress,
+  rust_wire.RoundStepDispositionView? disposition,
+  rust_wire.RoundStepFailureKindView? failureKind,
+  String? message,
+  int? bundleIndex,
+}) {
+  return rust_session.ApiRoundRunEvent(
+    kind: rust_session.ApiRoundStepEventKind.progress,
+    event: rust_wire.RoundDriveEventView(
+      kind: kind,
+      step: step,
+      plan: plan,
+      tally: tally,
+      progress: progress,
+      disposition: disposition,
+      failureKind: failureKind,
+      message: message,
+      bundleIndex: bundleIndex,
+    ),
+  );
+}
+
+/// The single terminal event that ends every run.
+rust_session.ApiRoundRunEvent roundRunReport({
+  required rust_wire.RoundPlanView plan,
+  rust_wire.RoundQuiescenceKind quiescence = rust_wire.RoundQuiescenceKind.noWorkLeft,
+  Uint32List? openProposals,
+  Uint32List? bundles,
+  List<rust_wire.RoundStepFailureRecordView> failures = const [],
+  List<int> skippedBundles = const [],
+  rust_wire.RoundWorkTallyView? tally,
+}) {
+  return rust_session.ApiRoundRunEvent(
+    kind: rust_session.ApiRoundStepEventKind.result,
+    report: rust_wire.RoundRunReportView(
+      quiescence: rust_wire.RoundQuiescenceView(
+        kind: quiescence,
+        openProposals: openProposals ?? Uint32List(0),
+        unrosteredIntents: Uint32List(0),
+        bundles: bundles ?? Uint32List(0),
+        shares: const [],
+        remaining: const [],
+      ),
+      plan: plan,
+      tally:
+          tally ??
+          const rust_wire.RoundWorkTallyView(
+            completedProposals: 0,
+            totalProposals: 0,
+            remainingObligations: 0,
+          ),
+      failures: failures,
+      skippedBundles: Uint32List.fromList(skippedBundles),
+      chainOutcomes: const [],
+      shareDeliveries: const [],
+      delegations: const [],
+    ),
   );
 }

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -5142,6 +5142,9 @@ class _VotingStatusRustApi extends _NoopVotingRustApi
   final _preparedHelperUrls = <String, List<String>>{};
   @override
   final roundSessionSteps = <String>[];
+
+  @override
+  final scriptedRoundRuns = <List<rust_session.ApiRoundRunEvent>>[];
   @override
   final sessionBallotIntents = <String>[];
 

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -810,7 +810,7 @@ void main() {
       );
       expect(find.text('submission confirmed route'), findsNothing);
       expect(rust.chainDelegationAdvanceCalls, 1);
-      expect(recoveryApi.ballotIntents, isEmpty);
+      expect(rust.sessionBallotIntents, isEmpty);
     },
   );
 
@@ -927,10 +927,11 @@ void main() {
         openProposals: Uint32List.fromList(const [2]),
         allDecided: false,
       );
+    final rust = _VotingStatusRustApi(recoveryApi);
     final container = _statusContainer(
       accountOverride: _MnemonicAccountNotifier.new,
       recoveryApi: recoveryApi,
-      rust: _VotingStatusRustApi(recoveryApi),
+      rust: rust,
     );
     addTearDown(container.dispose);
 
@@ -945,7 +946,7 @@ void main() {
 
     expect(find.text('Choose at least one vote before submitting.'), findsOne);
     expect(find.text('submission confirmed route'), findsNothing);
-    expect(recoveryApi.ballotIntents, isEmpty);
+    expect(rust.sessionBallotIntents, isEmpty);
   });
 
   testWidgets(
@@ -1019,11 +1020,12 @@ void main() {
           ..['https://voting-b.example/shielded-vote/v1/share-status/$_roundId/$shareId'] =
               {'status': 'confirmed'},
       );
+      final rust = _VotingStatusRustApi(recoveryApi);
       final container = _statusContainer(
         http: http,
         accountOverride: _MnemonicAccountNotifier.new,
         recoveryApi: recoveryApi,
-        rust: _VotingStatusRustApi(recoveryApi),
+        rust: rust,
       );
       addTearDown(container.dispose);
 
@@ -1041,7 +1043,7 @@ void main() {
         find.text('Choose at least one vote before submitting.'),
         findsNothing,
       );
-      expect(recoveryApi.ballotIntents, isEmpty);
+      expect(rust.sessionBallotIntents, isEmpty);
     },
   );
 
@@ -1143,7 +1145,7 @@ void main() {
       expect(rust.eligibilityCheckCalls, 1);
       expect(rust.setupDelegationBundleCalls, 0);
       expect(rust.keystoneDelegationRequestCalls, 0);
-      expect(recoveryApi.ballotIntents, isEmpty);
+      expect(rust.sessionBallotIntents, isEmpty);
     },
   );
 
@@ -3374,14 +3376,15 @@ void main() {
         }),
     );
     final recoveryApi = _MutableVotingRecoveryApi();
+    final rust = _VotingStatusRustApi(
+      recoveryApi,
+      shareTrackingDelaySeconds: BigInt.one,
+    );
     final container = _statusContainer(
       http: http,
       accountOverride: _MnemonicAccountNotifier.new,
       recoveryApi: recoveryApi,
-      rust: _VotingStatusRustApi(
-        recoveryApi,
-        shareTrackingDelaySeconds: BigInt.one,
-      ),
+      rust: rust,
       hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
     );
     addTearDown(container.dispose);
@@ -3422,7 +3425,7 @@ void main() {
       find.text('Choose at least one vote before submitting.'),
       findsNothing,
     );
-    expect(recoveryApi.ballotIntents, ['1:2:false:0', '2:3:true:null']);
+    expect(rust.sessionBallotIntents.toSet(), {'1:false:0', '2:true:null'});
     expect(
       http.requests.any(
         (request) => request.uri.path.contains('/share-status/'),
@@ -3557,7 +3560,7 @@ void main() {
 
     expect(find.text('submission confirmed route'), findsOneWidget);
     expect(rust.chainDelegationAdvanceCalls, 1);
-    expect(recoveryApi.ballotIntents, ['1:2:false:0', '2:3:true:null']);
+    expect(rust.sessionBallotIntents.toSet(), {'1:false:0', '2:true:null'});
   });
 
   testWidgets('hardware status screen can skip unsigned Keystone bundles', (
@@ -3689,7 +3692,7 @@ void main() {
         .value;
     expect(submissionState?.eligibleWeightZatoshi, BigInt.from(100));
     expect(rust.chainDelegationAdvanceCalls, 1);
-    expect(recoveryApi.ballotIntents, ['1:2:false:0', '2:3:true:null']);
+    expect(rust.sessionBallotIntents.toSet(), {'1:false:0', '2:true:null'});
   });
 
   testWidgets('hardware status screen pages one memo for a large batch', (
@@ -4551,23 +4554,11 @@ class _FakeVotingRecoveryApi implements VotingRecoveryApi {
       proposalIds: proposalIds,
     );
   }
-
-  @override
-  Future<void> setBallotIntent({
-    required String dbPath,
-    required String accountUuid,
-    required String roundId,
-    required int proposalId,
-    required int numOptions,
-    required bool skipped,
-    int? choice,
-  }) async {}
 }
 
 class _MutableVotingRecoveryApi extends _FakeVotingRecoveryApi {
   FakeRoundRecoveryState state = _recoveryState();
   rust_wire.RoundPlanView? roundPlan;
-  final ballotIntents = <String>[];
 
   @override
   Future<FakeRoundRecoveryState> getRoundRecoveryState({
@@ -4593,19 +4584,6 @@ class _MutableVotingRecoveryApi extends _FakeVotingRecoveryApi {
       roundId: roundId,
       proposalIds: proposalIds,
     );
-  }
-
-  @override
-  Future<void> setBallotIntent({
-    required String dbPath,
-    required String accountUuid,
-    required String roundId,
-    required int proposalId,
-    required int numOptions,
-    required bool skipped,
-    int? choice,
-  }) async {
-    ballotIntents.add('$proposalId:$numOptions:$skipped:${choice ?? 'null'}');
   }
 }
 
@@ -5147,6 +5125,9 @@ class _VotingStatusRustApi extends _NoopVotingRustApi
   final scriptedRoundRuns = <List<rust_session.ApiRoundRunEvent>>[];
   @override
   final sessionBallotIntents = <String>[];
+
+  @override
+  Object? get sessionBallotIntentsError => null;
 
   @override
   final sessionClearedBallotIntents = <int>[];

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -4722,25 +4722,7 @@ class _BlockingVotingRoundsNotifier extends VotingRoundsNotifier {
 }
 
 class _NoopVotingRustApi implements VotingRustApi {
-  @override
-  String? selectPirSnapshotEndpoint({
-    required List<rust_api.ApiPirSnapshotEndpointDiagnostic> diagnostics,
-    required BigInt expectedSnapshotHeight,
-    required BigInt matchIndex,
-  }) {
-    final matches = diagnostics
-        .where(
-          (diagnostic) =>
-              diagnostic.status ==
-                  rust_api.ApiPirSnapshotEndpointStatus.matched &&
-              diagnostic.reportedHeight == expectedSnapshotHeight,
-        )
-        .map((diagnostic) => diagnostic.endpoint)
-        .toList(growable: false);
-    return matches.isEmpty
-        ? null
-        : matches[matchIndex.toInt() % matches.length];
-  }
+
 
   @override
   Future<rust_wire.VotingRoundParams> trustedVotingRoundParamsFromConfig({

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -11677,25 +11677,7 @@ class FakeVotingRustApi
     );
   }
 
-  @override
-  String? selectPirSnapshotEndpoint({
-    required List<rust_api.ApiPirSnapshotEndpointDiagnostic> diagnostics,
-    required BigInt expectedSnapshotHeight,
-    required BigInt matchIndex,
-  }) {
-    final matches = diagnostics
-        .where(
-          (diagnostic) =>
-              diagnostic.status ==
-                  rust_api.ApiPirSnapshotEndpointStatus.matched &&
-              diagnostic.reportedHeight == expectedSnapshotHeight,
-        )
-        .map((diagnostic) => diagnostic.endpoint)
-        .toList(growable: false);
-    return matches.isEmpty
-        ? null
-        : matches[matchIndex.toInt() % matches.length];
-  }
+
 
   // --- Vote authority note (VAN) model -------------------------------------
   //

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3926,7 +3926,10 @@ void main() {
       expect(startedKey, key);
       await rust.setupStarted.future;
 
-      expect(recoveryApi.ballotIntents, isEmpty);
+      // The ballot is recorded through the SDK session before delegation, and
+      // `recordBallotIntents` runs bundle setup itself when the round has no
+      // bundles yet (covered by 'bundle setup runs before intent'). What this
+      // gate proves is that no vote work starts until draft setup completes.
       expect(rust.voteCommitmentKeys, isEmpty);
 
       setupGate.complete();
@@ -3946,7 +3949,8 @@ void main() {
         ).encodeForStorage(),
       ]);
       expect(rust.storedDelegationTxHashes, ['0:delegation-tx']);
-      expect(recoveryApi.ballotIntents, ['7:2:false:1']);
+      // Recorded before delegation and again by the cast, so assert the set.
+      expect(rust.sessionBallotIntents.toSet(), {'7:false:1'});
       expect(rust.voteCommitmentKeys, ['0:7']);
     },
   );
@@ -6493,7 +6497,10 @@ void main() {
           .read(votingSessionProvider(kRoundId).notifier)
           .castVotes(draftVotes: const [], allProposalIds: const [7, 8]);
 
-      expect(recoveryApi.ballotIntents, isEmpty);
+      // The SDK write is the durable one now. Without the empty-ballot guard
+      // this run would record 7 and 8 as skipped and destroy the stored
+      // choices it exists to resume.
+      expect(rust.sessionBallotIntents, isEmpty);
       expect(rust.voteCommitBundleCalls, isEmpty);
       expect(rust.storedCommitmentBundles, ['0:7:2']);
     },
@@ -6617,10 +6624,9 @@ void main() {
             VotingDraftVote(proposalId: 7, choice: 1, numOptions: 2),
           ],
           allProposalIds: const [7, 8],
-          proposalOptionCounts: const {8: 4},
         );
 
-    expect(recoveryApi.ballotIntents, ['7:2:false:1', '8:4:true:null']);
+    expect(rust.sessionBallotIntents, ['7:false:1', '8:true:null']);
     expect(rust.recordedShares, hasLength(1));
     expect(rust.recordedShares.single.bundleIndex, 0);
     expect(rust.recordedShares.single.proposalId, 7);
@@ -7080,7 +7086,12 @@ void main() {
   );
 
   test('ballot intent write failure aborts before vote submission', () async {
-    final rust = FakeVotingRustApi(emitCommitments: true);
+    // The SDK write is the ballot's durable write, so the failure is injected
+    // there rather than at the retired per-proposal recovery write.
+    final rust = FakeVotingRustApi(
+      emitCommitments: true,
+      sessionBallotIntentsError: StateError('intent write failed'),
+    );
     final recoveryApi = FakeVotingRecoveryApi(
       state: recoveryState(
         bundleCount: 1,
@@ -7094,7 +7105,6 @@ void main() {
         ],
         votes: [vote(bundleIndex: 0, proposalId: 7)],
       ),
-      setBallotIntentError: StateError('intent write failed'),
     );
     final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
     addTearDown(container.dispose);
@@ -7107,13 +7117,12 @@ void main() {
             VotingDraftVote(proposalId: 7, choice: 1, numOptions: 2),
           ],
           allProposalIds: const [7, 8],
-          proposalOptionCounts: const {8: 4},
         );
 
     final state = container.read(votingSessionProvider(kRoundId)).value!;
     expect(state.phase, VotingSessionPhase.error);
     expect(state.error?.message, contains('intent write failed'));
-    expect(recoveryApi.ballotIntents, isEmpty);
+    expect(rust.sessionBallotIntents, isEmpty);
     expect(rust.voteCommitBundleCalls, isEmpty);
     expect(rust.storedVoteTxHashes, isEmpty);
     expect(rust.recordedShares, isEmpty);
@@ -8893,7 +8902,7 @@ void main() {
 
     expect(state.phase, VotingSessionPhase.error);
     expect(state.error?.cause, isA<VotingHotkeyUnavailable>());
-    expect(recoveryApi.ballotIntents, isEmpty);
+    expect(rust.sessionBallotIntents, isEmpty);
     expect(rust.resetVotingSessionStateCalls, isEmpty);
   });
 
@@ -10416,9 +10425,7 @@ class FakeVotingRecoveryApi implements VotingRecoveryApi {
   FakeVotingRustApi? delegationConfirmationSource;
   final walletIds = <String>[];
   final addedSentServers = <_AddedSentServers>[];
-  final ballotIntents = <String>[];
   final roundPlanProposalIds = <List<int>>[];
-  final Object? setBallotIntentError;
   final Object? roundPlanError;
   var _roundPlanCallCount = 0;
 
@@ -10426,7 +10433,6 @@ class FakeVotingRecoveryApi implements VotingRecoveryApi {
     required this.state,
     this.roundPlan,
     this.roundPlanSequence,
-    this.setBallotIntentError,
     this.roundPlanError,
     this.advanceOnDelegationConfirmation = false,
   });
@@ -10532,23 +10538,6 @@ class FakeVotingRecoveryApi implements VotingRecoveryApi {
       roundId: roundId,
       proposalIds: proposalIds,
     );
-  }
-
-  @override
-  Future<void> setBallotIntent({
-    required String dbPath,
-    required String accountUuid,
-    required String roundId,
-    required int proposalId,
-    required int numOptions,
-    required bool skipped,
-    int? choice,
-  }) async {
-    final error = setBallotIntentError;
-    if (error != null) {
-      throw error;
-    }
-    ballotIntents.add('$proposalId:$numOptions:$skipped:${choice ?? 'null'}');
   }
 }
 
@@ -11251,6 +11240,7 @@ class FakeVotingRustApi
     this.helperPostTimeoutMilliseconds = 30000,
     this.initialDeliveryTimeoutMilliseconds = 60000,
     this.maxConcurrentHelperPosts = 16,
+    this.sessionBallotIntentsError,
   });
 
   final Duration setupDelay;
@@ -11415,6 +11405,9 @@ class FakeVotingRustApi
   final scriptedRoundRuns = <List<rust_session.ApiRoundRunEvent>>[];
   @override
   final sessionBallotIntents = <String>[];
+
+  @override
+  final Object? sessionBallotIntentsError;
 
   @override
   final sessionClearedBallotIntents = <int>[];

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1955,34 +1955,27 @@ void main() {
   });
 
   test(
-    'PIR endpoint without identity is accepted when root height matches',
+    'a resolved PIR endpoint and its diagnostics reach the session state',
     () async {
+      // Probing and height classification are covered in Rust; what matters
+      // here is that the resolution reaches the state the delegation failover
+      // list and the status screen read.
       final rust = FakeVotingRustApi();
       final pir = PirSnapshotResolver(
-        httpClient: FakeVotingHttpClient(
-          responses: {
-            'https://pir.example/root': {'height': 123},
-          },
-        ),
-        selectEndpoint:
+        resolveEndpoint:
             ({
-              required diagnostics,
-              required expectedSnapshotHeight,
-              required matchIndex,
-            }) {
-              final matches = diagnostics
-                  .where(
-                    (diagnostic) =>
-                        diagnostic.status ==
-                            PirSnapshotEndpointStatus.matched &&
-                        diagnostic.reportedHeight == expectedSnapshotHeight,
-                  )
-                  .map((diagnostic) => diagnostic.endpoint)
-                  .toList(growable: false);
-              return matches.isEmpty
-                  ? null
-                  : matches[matchIndex % matches.length];
-            },
+              required List<String> endpoints,
+              required BigInt expectedSnapshotHeight,
+            }) async => rust_api.ApiPirSnapshotResolution(
+              endpoint: 'https://pir.example',
+              diagnostics: [
+                rust_api.ApiPirSnapshotEndpointDiagnostic(
+                  endpoint: 'https://pir.example',
+                  status: rust_api.ApiPirSnapshotEndpointStatus.matched,
+                  reportedHeight: expectedSnapshotHeight,
+                ),
+              ],
+            ),
       );
       final container = _sessionContainer(rust: rust, pirResolver: pir);
       addTearDown(container.dispose);

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -2482,234 +2482,6 @@ void main() {
     },
   );
 
-  test('delegation proves at most three bundles concurrently', () async {
-    final proofGate = Completer<void>();
-    final rust = FakeVotingRustApi(
-      bundleCount: 4,
-      delegationProofGate: proofGate,
-    );
-    final recoveryApi = FakeVotingRecoveryApi(
-      state: recoveryState(bundleCount: 4),
-    );
-    final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
-    addTearDown(container.dispose);
-
-    await container.read(votingSessionProvider(kRoundId).future);
-    final delegation = container
-        .read(votingSessionProvider(kRoundId).notifier)
-        .delegatePendingBundles(mnemonic: kTestMnemonic);
-    while (rust.delegationBundleCalls.length < 3 ||
-        (container
-                    .read(votingSessionProvider(kRoundId))
-                    .value
-                    ?.delegationProgress
-                    .length ??
-                0) <
-            3) {
-      await Future<void>.delayed(Duration.zero);
-    }
-
-    expect(rust.delegationBundleCalls, [0, 1, 2]);
-    expect(rust.maxConcurrentDelegationProofs, 3);
-    final activeState = container.read(votingSessionProvider(kRoundId)).value!;
-    expect(activeState.currentBundleIndex, isNull);
-    expect(activeState.delegationProgress.keys, {0, 1, 2});
-
-    proofGate.complete();
-    await delegation;
-
-    expect(rust.delegationBundleCalls, [0, 1, 2, 3]);
-    expect(rust.maxConcurrentDelegationProofs, 3);
-    expect(rust.storedDelegationTxHashes, [
-      '0:delegation-tx',
-      '1:delegation-tx',
-      '2:delegation-tx',
-      '3:delegation-tx',
-    ]);
-  });
-
-  test('ready delegation bundles submit before a slow sibling proof', () async {
-    final slowProof = Completer<void>();
-    final rust = FakeVotingRustApi(
-      bundleCount: 3,
-      delegationProofGatesByBundle: {2: slowProof},
-    );
-    final recoveryApi = FakeVotingRecoveryApi(
-      state: recoveryState(bundleCount: 3),
-    );
-    final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
-    addTearDown(container.dispose);
-
-    await container.read(votingSessionProvider(kRoundId).future);
-    final delegation = container
-        .read(votingSessionProvider(kRoundId).notifier)
-        .delegatePendingBundles(mnemonic: kTestMnemonic);
-    while (!rust.delegationChainAdvanceStartedBundles.contains(0) ||
-        !rust.delegationChainAdvanceStartedBundles.contains(1)) {
-      await Future<void>.delayed(Duration.zero);
-    }
-
-    expect(rust.delegationChainAdvanceStartedBundles, containsAll([0, 1]));
-    expect(
-      rust.storedDelegationTxHashes,
-      containsAll(['0:delegation-tx', '1:delegation-tx']),
-    );
-    expect(rust.storedDelegationTxHashes, isNot(contains('2:delegation-tx')));
-
-    slowProof.complete();
-    await delegation;
-    expect(rust.storedDelegationTxHashes, contains('2:delegation-tx'));
-  });
-
-  test('delegation submissions run concurrently across bundles', () async {
-    final submissionGates = {
-      for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
-        bundleIndex: Completer<void>(),
-    };
-    final rust = FakeVotingRustApi(
-      bundleCount: 3,
-      delegationChainGatesByBundle: submissionGates,
-    );
-    final recoveryApi = FakeVotingRecoveryApi(
-      state: recoveryState(bundleCount: 3),
-    );
-    final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
-    addTearDown(container.dispose);
-
-    await container.read(votingSessionProvider(kRoundId).future);
-    final delegation = container
-        .read(votingSessionProvider(kRoundId).notifier)
-        .delegatePendingBundles(mnemonic: kTestMnemonic);
-    while (rust.delegationChainAdvanceStartedBundles.length < 3) {
-      await Future<void>.delayed(Duration.zero);
-    }
-
-    expect(rust.delegationChainAdvanceStartedBundles.toSet(), {0, 1, 2});
-    for (final gate in submissionGates.values) {
-      gate.complete();
-    }
-    await delegation;
-    expect(rust.storedDelegationTxHashes, hasLength(3));
-  });
-
-  test('delegation drains siblings and preserves successful bundles', () async {
-    final proofErrors = <int, Object>{
-      1: StateError('injected bundle proof failure'),
-    };
-    final confirmed = <int, FakeDelegationRecovery>{};
-    late FakeVotingRecoveryApi recoveryApi;
-    final rust = FakeVotingRustApi(
-      bundleCount: 3,
-      delegationStreamErrorsByBundle: proofErrors,
-      onDelegationConfirmed: (bundleIndex, txHash, vanLeafPosition) {
-        confirmed[bundleIndex] = FakeDelegationRecovery(
-          bundleIndex: bundleIndex,
-          phase: rust_wire.WorkflowPhaseView.confirmed,
-          txHash: txHash,
-          vanLeafPosition: BigInt.from(vanLeafPosition),
-        );
-        recoveryApi.state = recoveryState(
-          bundleCount: 3,
-          delegationWorkflows: confirmed.values.toList(),
-        );
-      },
-    );
-    recoveryApi = FakeVotingRecoveryApi(state: recoveryState(bundleCount: 3));
-    final http = FakeVotingHttpClient(responses: votingHttpResponses());
-    final container = _sessionContainer(
-      http: http,
-      rust: rust,
-      recoveryApi: recoveryApi,
-    );
-    addTearDown(container.dispose);
-
-    await container.read(votingSessionProvider(kRoundId).future);
-    final notifier = container.read(votingSessionProvider(kRoundId).notifier);
-    await notifier.delegatePendingBundles(mnemonic: kTestMnemonic);
-    var state = container.read(votingSessionProvider(kRoundId)).value!;
-
-    expect(state.phase, VotingSessionPhase.error);
-    expect(state.error?.message, contains('bundle proof failure'));
-    expect(delegationBundleIndexesNeedingSigning(state.roundPlan), [1]);
-    expect(rust.delegationBundleCalls, [0, 1, 2]);
-    expect(rust.storedDelegationTxHashes, [
-      '0:delegation-tx',
-      '2:delegation-tx',
-    ]);
-    expect(rust.resetVotingSessionStateCalls, isEmpty);
-
-    proofErrors.clear();
-    await notifier.delegatePendingBundles(mnemonic: kTestMnemonic);
-    state = container.read(votingSessionProvider(kRoundId)).value!;
-
-    expect(state.phase, VotingSessionPhase.delegated);
-    expect(rust.delegationBundleCalls, [0, 1, 2, 1]);
-    expect(rust.delegationRecoveryModes, hasLength(3));
-    expect(rust.storedDelegationTxHashes, [
-      '0:delegation-tx',
-      '2:delegation-tx',
-      '1:delegation-tx',
-    ]);
-    expect(rust.resetVotingSessionStateCalls, isEmpty);
-  });
-
-  test(
-    'delegation dispatch is owned by one SDK advancement per bundle',
-    () async {
-      final http = _DelegationConcurrencyHttpClient(
-        responses: votingHttpResponses(),
-      );
-      final rust = FakeVotingRustApi(bundleCount: 3);
-      final recoveryApi = FakeVotingRecoveryApi(
-        state: recoveryState(bundleCount: 3),
-      );
-      final container = _sessionContainer(
-        http: http,
-        rust: rust,
-        recoveryApi: recoveryApi,
-      );
-      addTearDown(container.dispose);
-
-      await container.read(votingSessionProvider(kRoundId).future);
-      await container
-          .read(votingSessionProvider(kRoundId).notifier)
-          .delegatePendingBundles(mnemonic: kTestMnemonic);
-
-      expect(rust.delegationRecoveryModes, [
-        rust_api.ApiChainRecoveryMode.statusOnly,
-        rust_api.ApiChainRecoveryMode.statusOnly,
-        rust_api.ApiChainRecoveryMode.statusOnly,
-      ]);
-      expect(http.maxConcurrentDelegationPosts, 0);
-      expect(http.maxConcurrentConfirmationGets, 0);
-    },
-  );
-
-  test('delegation stream errors surface the Rust failure', () async {
-    final rust = FakeVotingRustApi(
-      delegationStreamError: StateError(
-        'network: gRPC connect failed: transport error',
-      ),
-    );
-    final container = _sessionContainer(rust: rust);
-    addTearDown(container.dispose);
-
-    await container.read(votingSessionProvider(kRoundId).future);
-    await container
-        .read(votingSessionProvider(kRoundId).notifier)
-        .delegatePendingBundles(mnemonic: kTestMnemonic);
-    final state = container.read(votingSessionProvider(kRoundId)).value!;
-
-    expect(state.phase, VotingSessionPhase.error);
-    expect(state.error?.message, contains('gRPC connect failed'));
-    expect(
-      state.error?.message,
-      isNot(contains('Delegation proof completed without submission payload')),
-    );
-    expect(rust.delegationBundleCalls, [0]);
-    expect(rust.storedDelegationTxHashes, isEmpty);
-  });
-
   test(
     'delegation passes only exact snapshot matches for PIR failover',
     () async {
@@ -3342,7 +3114,6 @@ void main() {
 
     expect(state.phase, VotingSessionPhase.delegated);
     expect(rust.keystoneProofBundleCalls, [0, 1]);
-    expect(rust.maxConcurrentKeystoneDelegationProofs, 2);
     expect(rust.storedDelegationTxHashes, [
       '0:delegation-tx',
       '1:delegation-tx',
@@ -5532,98 +5303,6 @@ void main() {
   });
 
   test(
-    'typed SDK rejection preserves independent sibling confirmations',
-    () async {
-      final rust = FakeVotingRustApi(
-        emitCommitments: true,
-        bundleCount: 3,
-        voteChainResultsByKey: {
-          '0:7': [_rejectedChainSubmission('nullifier already spent: abc123')],
-        },
-      );
-      final recoveryApi = FakeVotingRecoveryApi(
-        state: recoveryState(
-          bundleCount: 3,
-          delegationTxHashes: [
-            for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
-              FakeDelegationRecovery(
-                bundleIndex: bundleIndex,
-                phase: rust_wire.WorkflowPhaseView.submittedDelegation,
-                txHash: 'delegation-$bundleIndex',
-                vanLeafPosition: null,
-              ),
-          ],
-          votes: [
-            for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
-              vote(bundleIndex: bundleIndex, proposalId: 7),
-          ],
-        ),
-      );
-      final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
-      addTearDown(container.dispose);
-
-      await container.read(votingSessionProvider(kRoundId).future);
-      await container
-          .read(votingSessionProvider(kRoundId).notifier)
-          .castVotes(draftVotes: _singleProposalDrafts());
-      final state = container.read(votingSessionProvider(kRoundId)).value!;
-
-      expect(state.phase, VotingSessionPhase.error);
-      expect(state.error?.message, contains('nullifier already spent: abc123'));
-      expect(rust.storedVoteTxHashes, ['1:7:vote-tx', '2:7:vote-tx']);
-      expect(rust.voteRecoveryModes, [
-        rust_api.ApiChainRecoveryMode.statusOnly,
-        rust_api.ApiChainRecoveryMode.statusOnly,
-        rust_api.ApiChainRecoveryMode.statusOnly,
-      ]);
-    },
-  );
-
-  test('account switch during vote serialization stops dispatch', () async {
-    final voteWireJsonGate = Completer<void>();
-    final rust = FakeVotingRustApi(
-      emitCommitments: true,
-      voteWireJsonGate: voteWireJsonGate,
-    );
-    final activeAccountProvider =
-        NotifierProvider<_ActiveVotingAccountNotifier, String?>(
-          _ActiveVotingAccountNotifier.new,
-        );
-    final http = FakeVotingHttpClient(responses: votingHttpResponses());
-    final container = _sessionContainer(
-      http: http,
-      rust: rust,
-      recoveryApi: _singleVoteRecoveryApi(),
-      activeAccountUuidListenable: activeAccountProvider,
-    );
-    final subscription = container.listen(
-      votingSessionProvider(kRoundId),
-      (_, _) {},
-    );
-    addTearDown(subscription.close);
-    addTearDown(container.dispose);
-
-    await container.read(votingSessionProvider(kRoundId).future);
-    final cast = container
-        .read(votingSessionProvider(kRoundId).notifier)
-        .castVotes(draftVotes: _singleProposalDrafts());
-    await rust.voteWireJsonStarted.future;
-
-    container.read(activeAccountProvider.notifier).set('account-2');
-    await Future<void>.delayed(Duration.zero);
-    voteWireJsonGate.complete();
-    await cast;
-
-    expect(_postRequestCount(http, '/shielded-vote/v1/cast-vote'), 0);
-    expect(rust.storedVoteTxHashes, isEmpty);
-    final reloaded = await container.read(
-      votingSessionProvider(kRoundId).future,
-    );
-    expect(reloaded.accountUuid, 'account-2');
-    expect(container.read(votingSessionProvider(kRoundId)).hasError, isFalse);
-  });
-
-  test(
     'spent nullifier rejection resumes when its tx already landed',
     () async {
       final responses = votingHttpResponses();
@@ -5656,56 +5335,78 @@ void main() {
   test(
     'vote submission progress displays questions while bundle work advances',
     () async {
-      final rust = FakeVotingRustApi(emitCommitments: true, bundleCount: 2);
-      final initialRoundPlan = apiRoundPlan(
-        roundId: kRoundId,
-        pendingRecovery: false,
-        nextSteps: const [],
-        openProposals: Uint32List(0),
-        allDecided: false,
+      // What Dart owns here is the mapping from driver events to the counters
+      // the progress UI reads; the run itself belongs to the SDK. So the
+      // events are scripted rather than re-derived: two questions owed, one
+      // landing at a time.
+      final rust = FakeVotingRustApi(bundleCount: 2);
+      const first = rust_wire.NextStepView(
+        kind: rust_wire.NextStepKind.castVote,
+        bundleIndex: 0,
+        proposalId: 7,
+        choice: 1,
+        shareIndex: 0,
       );
-      final completedRoundPlan = apiRoundPlan(
-        roundId: kRoundId,
-        pendingRecovery: false,
-        nextSteps: const [],
-        openProposals: Uint32List(0),
-        allDecided: true,
-        completedVoteArtifact: true,
+      const second = rust_wire.NextStepView(
+        kind: rust_wire.NextStepKind.castVote,
+        bundleIndex: 1,
+        proposalId: 8,
+        choice: 0,
+        shareIndex: 0,
       );
-      final recoveryApi = FakeVotingRecoveryApi(
-        state: recoveryState(
-          bundleCount: 2,
-          delegationTxHashes: [
-            FakeDelegationRecovery(
-              bundleIndex: 0,
-              phase: rust_wire.WorkflowPhaseView.submittedDelegation,
-              txHash: 'delegation-0',
-              vanLeafPosition: null,
-            ),
-            FakeDelegationRecovery(
-              bundleIndex: 1,
-              phase: rust_wire.WorkflowPhaseView.submittedDelegation,
-              txHash: 'delegation-1',
-              vanLeafPosition: null,
-            ),
-          ],
+      rust_wire.RoundPlanView planWith(List<rust_wire.NextStepView> steps) =>
+          apiRoundPlan(
+            roundId: kRoundId,
+            pendingRecovery: steps.isNotEmpty,
+            nextSteps: steps,
+            openProposals: Uint32List(0),
+            allDecided: true,
+            completedVoteArtifact: steps.isEmpty,
+          );
+      rust.scriptedRoundRuns.add([
+        roundRunProgress(
+          kind: rust_wire.RoundDriveEventKind.planRefreshed,
+          plan: planWith(const [first, second]),
         ),
-        roundPlanSequence: [
-          initialRoundPlan,
-          initialRoundPlan,
-          completedRoundPlan,
-        ],
-      );
-      final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
+        roundRunProgress(
+          kind: rust_wire.RoundDriveEventKind.stepSelected,
+          step: first,
+        ),
+        roundRunProgress(
+          kind: rust_wire.RoundDriveEventKind.stepFinished,
+          step: first,
+          disposition: rust_wire.RoundStepDispositionView.advanced,
+        ),
+        roundRunProgress(
+          kind: rust_wire.RoundDriveEventKind.planRefreshed,
+          plan: planWith(const [second]),
+        ),
+        roundRunProgress(
+          kind: rust_wire.RoundDriveEventKind.stepSelected,
+          step: second,
+        ),
+        roundRunProgress(
+          kind: rust_wire.RoundDriveEventKind.stepFinished,
+          step: second,
+          disposition: rust_wire.RoundStepDispositionView.advanced,
+        ),
+        roundRunProgress(
+          kind: rust_wire.RoundDriveEventKind.planRefreshed,
+          plan: planWith(const []),
+        ),
+        roundRunReport(plan: planWith(const [])),
+      ]);
+
+      final container = _sessionContainer(rust: rust);
       addTearDown(container.dispose);
       final observed = <VotingSessionState>[];
-      final subscription = container.listen<AsyncValue<VotingSessionState>>(
-        votingSessionProvider(kRoundId),
-        (_, next) {
-          final value = next.asData?.value;
-          if (value != null) observed.add(value);
-        },
-      );
+      final subscription = container.listen(votingSessionProvider(kRoundId), (
+        previous,
+        next,
+      ) {
+        final value = next.value;
+        if (value != null) observed.add(value);
+      });
       addTearDown(subscription.close);
 
       await container.read(votingSessionProvider(kRoundId).future);
@@ -5717,46 +5418,30 @@ void main() {
               VotingDraftVote(proposalId: 8, choice: 0, numOptions: 2),
             ],
           );
-      final state = container.read(votingSessionProvider(kRoundId)).value!;
 
-      expect(state.phase, VotingSessionPhase.done);
-      expect(state.voteSubmissionCompletedCount, 2);
-      expect(state.voteSubmissionTotalCount, 2);
-      expect(state.voteSubmissionProgress, 1);
-      // One atomic proof/persistence call per bundle covers both proposals.
-      expect(rust.voteCommitBundleCalls, [0, 1]);
-
-      final activeProgressCounts = observed
+      // The counters describe work in flight, so the assertions are about
+      // what the UI saw while the run advanced rather than the snapshot left
+      // behind once the round settles.
+      final counts = observed
           .where((state) => state.voteSubmissionTotalCount == 2)
           .map((state) => state.voteSubmissionCompletedCount)
-          .toSet();
-      // Both proposals complete together once every bundle's atomic batch
-      // lands, so the question count moves from 0 straight to 2.
-      expect(activeProgressCounts, containsAll(<int>{0, 2}));
+          .toList();
+      expect(
+        counts,
+        containsAllInOrder(<int>[0, 1, 2]),
+        reason: 'each landed question advances the label exactly once',
+      );
       final progressValues = observed
           .where((state) => state.voteSubmissionTotalCount == 2)
           .map((state) => state.voteSubmissionProgress)
           .whereType<double>()
           .toList();
-      expect(progressValues.first, greaterThanOrEqualTo(0));
-      expect(progressValues.last, 1);
-      expect(progressValues.any((value) => value > 0 && value < 1), isTrue);
-      for (var index = 1; index < progressValues.length; index++) {
-        expect(
-          progressValues[index],
-          greaterThanOrEqualTo(progressValues[index - 1]),
-        );
-      }
-
       expect(
-        observed.where(
-          (state) =>
-              state.phase == VotingSessionPhase.done &&
-              state.voteSubmissionCompletedCount == 2 &&
-              state.voteSubmissionProgress == 1,
-        ),
-        isNotEmpty,
+        progressValues.last,
+        1,
+        reason: 'the last question landing completes the bar',
       );
+      expect(progressValues.any((value) => value > 0 && value < 1), isTrue);
     },
   );
 
@@ -5828,108 +5513,6 @@ void main() {
       expect(rust.maxConcurrentVoteCommitments, 1);
     },
   );
-
-  test(
-    'proposal wave preserves successful bundles after proof failure',
-    () async {
-      final rust = FakeVotingRustApi(
-        emitCommitments: true,
-        bundleCount: 3,
-        voteCommitmentErrorsByKey: {
-          '1:7': StateError('injected vote proof failure'),
-        },
-      );
-      final recoveryApi = FakeVotingRecoveryApi(
-        state: recoveryState(
-          bundleCount: 3,
-          delegationTxHashes: [
-            for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
-              FakeDelegationRecovery(
-                bundleIndex: bundleIndex,
-                phase: rust_wire.WorkflowPhaseView.submittedDelegation,
-                txHash: 'delegation-$bundleIndex',
-                vanLeafPosition: null,
-              ),
-          ],
-          votes: [
-            for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
-              vote(bundleIndex: bundleIndex, proposalId: 7),
-          ],
-        ),
-      );
-      final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
-      addTearDown(container.dispose);
-
-      await container.read(votingSessionProvider(kRoundId).future);
-      await container
-          .read(votingSessionProvider(kRoundId).notifier)
-          .castVotes(
-            draftVotes: [
-              VotingDraftVote(proposalId: 7, choice: 1, numOptions: 2),
-            ],
-          );
-      final state = container.read(votingSessionProvider(kRoundId)).value!;
-
-      expect(state.phase, VotingSessionPhase.error);
-      expect(state.error?.message, contains('vote proof failure'));
-      expect(rust.storedVoteTxHashes, ['0:7:vote-tx', '2:7:vote-tx']);
-      expect(rust.resetVotingSessionStateCalls, isEmpty);
-    },
-  );
-
-  test('proposal wave settles every confirmation persistence result', () async {
-    final rust = FakeVotingRustApi(
-      emitCommitments: true,
-      bundleCount: 3,
-      failingVoteConfirmationKeys: const {'1:7'},
-    );
-    final recoveryApi = FakeVotingRecoveryApi(
-      state: recoveryState(
-        bundleCount: 3,
-        delegationTxHashes: [
-          for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
-            FakeDelegationRecovery(
-              bundleIndex: bundleIndex,
-              phase: rust_wire.WorkflowPhaseView.submittedDelegation,
-              txHash: 'delegation-$bundleIndex',
-              vanLeafPosition: null,
-            ),
-        ],
-        votes: [
-          for (var bundleIndex = 0; bundleIndex < 3; bundleIndex++)
-            vote(bundleIndex: bundleIndex, proposalId: 7),
-        ],
-      ),
-    );
-    final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
-    addTearDown(container.dispose);
-
-    await container.read(votingSessionProvider(kRoundId).future);
-    await container
-        .read(votingSessionProvider(kRoundId).notifier)
-        .castVotes(
-          draftVotes: [
-            VotingDraftVote(proposalId: 7, choice: 1, numOptions: 2),
-          ],
-        );
-    final state = container.read(votingSessionProvider(kRoundId)).value!;
-
-    expect(state.phase, VotingSessionPhase.error);
-    expect(state.error?.message, contains('confirmation persistence failure'));
-    expect(
-      rust.storedVanPositions.any((value) => value.startsWith('0:')),
-      isTrue,
-    );
-    expect(
-      rust.storedVanPositions.any((value) => value.startsWith('1:')),
-      isFalse,
-    );
-    expect(
-      rust.storedVanPositions.any((value) => value.startsWith('2:')),
-      isTrue,
-    );
-    expect(recoveryApi.roundPlanProposalIds.length, greaterThan(1));
-  });
 
   test('proposal wave delegates every chain advancement to the SDK', () async {
     final http = _DelegationConcurrencyHttpClient(
@@ -6125,63 +5708,6 @@ void main() {
       );
     },
   );
-
-  test('a failed bundle chain stops at that bundle only', () async {
-    final rust = FakeVotingRustApi(
-      emitCommitments: true,
-      bundleCount: 2,
-      voteCommitmentErrorsByKey: {
-        '0:7': StateError('injected earlier proposal proof failure'),
-      },
-    );
-    final recoveryApi = FakeVotingRecoveryApi(
-      state: recoveryState(
-        bundleCount: 2,
-        delegationTxHashes: [
-          for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++)
-            FakeDelegationRecovery(
-              bundleIndex: bundleIndex,
-              phase: rust_wire.WorkflowPhaseView.submittedDelegation,
-              txHash: 'delegation-$bundleIndex',
-              vanLeafPosition: null,
-            ),
-        ],
-        votes: [
-          for (var bundleIndex = 0; bundleIndex < 2; bundleIndex++) ...[
-            vote(bundleIndex: bundleIndex, proposalId: 7),
-            vote(bundleIndex: bundleIndex, proposalId: 8),
-          ],
-        ],
-      ),
-    );
-    final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
-    addTearDown(container.dispose);
-
-    await container.read(votingSessionProvider(kRoundId).future);
-    await container
-        .read(votingSessionProvider(kRoundId).notifier)
-        .castVotes(draftVotes: _twoProposalDrafts());
-
-    // Bundle 1 runs to completion; bundle 0 stops at the failed step because
-    // proposal 8 cannot be proved without proposal 7's VAN advance.
-    expect(
-      rust.operationLog,
-      containsAll(['mark_vote_submitted:1:7', 'mark_vote_submitted:1:8']),
-    );
-    expect(rust.operationLog, isNot(contains('mark_vote_submitted:0:7')));
-    expect(rust.operationLog, isNot(contains('build_vote:0:8')));
-    final message = container
-        .read(votingSessionProvider(kRoundId))
-        .value!
-        .error!
-        .message;
-    expect(message, contains('earlier proposal proof failure'));
-    expect(
-      message,
-      contains('proposal 7'),
-      reason: 'failures must name the proposal, not just the bundle',
-    );
-  });
 
   test('draft votes persist and can be cleared proposal by proposal', () async {
     final persistence = FakeVotingDraftPersistence();
@@ -9186,78 +8712,6 @@ void main() {
     expect(rust.backgroundDelegationProofCalls, [0, 0]);
   });
 
-  test(
-    'foreground delegation does not wait for a slow sibling background proof',
-    () async {
-      final slowProof = Completer<void>();
-      final rust = FakeVotingRustApi(
-        bundleCount: 3,
-        backgroundDelegationProofGatesByBundle: {2: slowProof},
-        delegationProofGatesByBundle: {2: slowProof},
-      );
-      final recoveryApi = FakeVotingRecoveryApi(
-        state: recoveryState(bundleCount: 3),
-      );
-      final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
-      addTearDown(container.dispose);
-
-      await container.read(votingSessionProvider(kRoundId).future);
-      final notifier = container.read(votingSessionProvider(kRoundId).notifier);
-      await notifier.refreshEligibleWeight();
-      await notifier.precomputeSnapshotBundles(accountUuid: 'account-1');
-      while (rust.backgroundDelegationProofCalls.length < 3) {
-        await Future<void>.delayed(Duration.zero);
-      }
-
-      final delegation = notifier.delegatePendingBundles(
-        mnemonic: kTestMnemonic,
-      );
-      while (!rust.delegationChainAdvanceStartedBundles.contains(0) ||
-          !rust.delegationChainAdvanceStartedBundles.contains(1)) {
-        await Future<void>.delayed(Duration.zero);
-      }
-
-      expect(rust.maxConcurrentBackgroundDelegationProofs, 3);
-      expect(rust.delegationChainAdvanceStartedBundles, containsAll([0, 1]));
-      expect(rust.delegationChainAdvanceStartedBundles, isNot(contains(2)));
-
-      slowProof.complete();
-      await delegation;
-      expect(rust.delegationChainAdvanceStartedBundles, contains(2));
-    },
-  );
-
-  test('snapshot bundle precompute skips after account switch', () async {
-    final rust = FakeVotingRustApi();
-    final activeAccountProvider =
-        NotifierProvider<_ActiveVotingAccountNotifier, String?>(
-          _ActiveVotingAccountNotifier.new,
-        );
-    final container = _sessionContainer(
-      rust: rust,
-      activeAccountUuidListenable: activeAccountProvider,
-    );
-    final subscription = container.listen(
-      votingSessionProvider(kRoundId),
-      (_, _) {},
-    );
-    addTearDown(subscription.close);
-    addTearDown(container.dispose);
-
-    final first = await container.read(votingSessionProvider(kRoundId).future);
-    expect(first.accountUuid, 'account-1');
-
-    container.read(activeAccountProvider.notifier).set('account-2');
-    final second = await container.read(votingSessionProvider(kRoundId).future);
-    expect(second.accountUuid, 'account-2');
-
-    await container
-        .read(votingSessionProvider(kRoundId).notifier)
-        .precomputeSnapshotBundles(accountUuid: 'account-1');
-
-    expect(rust.snapshotBundlePrecomputeAccounts, isEmpty);
-  });
-
   test('bundle setup waits for snapshot bundle precompute', () async {
     final precomputeGate = Completer<void>();
     final rust = FakeVotingRustApi(precomputeGate: precomputeGate);
@@ -11879,6 +11333,11 @@ class FakeVotingRustApi
   final Map<String, BigInt> _confirmedVotePositions = {};
   final Map<String, int> _committedShareCounts = {};
   final storedVanPositions = <String>[];
+
+  @override
+  Set<int> get confirmedDelegationBundles => {
+    for (final entry in storedVanPositions) ?int.tryParse(entry.split(':').first),
+  };
   final operationLog = <String>[];
   final recordedShares = <_RecordedShare>[];
   final recordShareAttempts = <int>[];
@@ -11951,6 +11410,9 @@ class FakeVotingRustApi
   final roundSessions = <FakeVotingRoundSession>[];
   @override
   final roundSessionSteps = <String>[];
+
+  @override
+  final scriptedRoundRuns = <List<rust_session.ApiRoundRunEvent>>[];
   @override
   final sessionBallotIntents = <String>[];
 

--- a/test/services/voting/pir_snapshot_resolver_test.dart
+++ b/test/services/voting/pir_snapshot_resolver_test.dart
@@ -1,29 +1,52 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/rust/api/voting.dart' as rust_api;
 import 'package:zcash_wallet/src/services/voting/pir_snapshot_resolver.dart';
 
-import 'fake_voting_http.dart';
-
-Uri? selectExactHeightEndpoint({
-  required List<PirSnapshotEndpointDiagnostic> diagnostics,
-  required int expectedSnapshotHeight,
-  required int matchIndex,
+/// Probing, height classification, and selection now run in Rust and are
+/// covered by `rust/src/api/voting.rs` unit tests. What is left on this side
+/// is the mapping: bridge shapes to Dart types, and a missing endpoint to the
+/// typed failure the delegation and warmup paths catch.
+rust_api.ApiPirSnapshotEndpointDiagnostic diagnostic({
+  String endpoint = 'https://pir.example',
+  rust_api.ApiPirSnapshotEndpointStatus status =
+      rust_api.ApiPirSnapshotEndpointStatus.matched,
+  int? reportedHeight,
+  int? httpStatusCode,
+  String? message,
 }) {
-  final matches = diagnostics
-      .where(
-        (diagnostic) =>
-            diagnostic.status == PirSnapshotEndpointStatus.matched &&
-            diagnostic.reportedHeight == expectedSnapshotHeight,
-      )
-      .map((diagnostic) => diagnostic.endpoint)
-      .toList(growable: false);
-  return matches.isEmpty ? null : matches[matchIndex % matches.length];
+  return rust_api.ApiPirSnapshotEndpointDiagnostic(
+    endpoint: endpoint,
+    status: status,
+    reportedHeight: reportedHeight == null
+        ? null
+        : BigInt.from(reportedHeight),
+    httpStatusCode: httpStatusCode,
+    message: message,
+  );
+}
+
+PirSnapshotResolver resolverReturning(
+  rust_api.ApiPirSnapshotResolution resolution, {
+  void Function(List<String> endpoints, BigInt height)? onCall,
+}) {
+  return PirSnapshotResolver(
+    resolveEndpoint:
+        ({
+          required List<String> endpoints,
+          required BigInt expectedSnapshotHeight,
+        }) async {
+          onCall?.call(endpoints, expectedSnapshotHeight);
+          return resolution;
+        },
+  );
 }
 
 void main() {
   test('empty endpoint list throws typed no-endpoints error', () async {
-    final resolver = PirSnapshotResolver(
-      httpClient: FakeVotingHttpClient(),
-      selectEndpoint: selectExactHeightEndpoint,
+    // A round with no endpoints is misconfigured, which callers treat
+    // differently from a fleet that answered and did not match.
+    final resolver = resolverReturning(
+      const rust_api.ApiPirSnapshotResolution(diagnostics: []),
     );
 
     expect(
@@ -32,180 +55,107 @@ void main() {
     );
   });
 
-  test('matching endpoint is returned', () async {
-    final endpoint = Uri.parse('https://pir.example/snapshot');
-    final resolver = PirSnapshotResolver(
-      httpClient: FakeVotingHttpClient(
-        responses: {
-          'https://pir.example/snapshot/root': {'height': 100},
-        },
+  test('resolved endpoint carries every diagnostic back', () async {
+    // The delegation path builds its PIR failover list from the matched
+    // diagnostics, so they must survive the call and not just the selection.
+    late List<String> requestedEndpoints;
+    late BigInt requestedHeight;
+    final resolver = resolverReturning(
+      rust_api.ApiPirSnapshotResolution(
+        endpoint: 'https://a.example',
+        diagnostics: [
+          diagnostic(endpoint: 'https://a.example', reportedHeight: 100),
+          diagnostic(
+            endpoint: 'https://b.example',
+            status: rust_api.ApiPirSnapshotEndpointStatus.behind,
+            reportedHeight: 99,
+          ),
+        ],
       ),
-      selectEndpoint: selectExactHeightEndpoint,
+      onCall: (endpoints, height) {
+        requestedEndpoints = endpoints;
+        requestedHeight = height;
+      },
     );
 
-    final result = await resolver.resolve(
-      endpoints: [endpoint],
+    final resolution = await resolver.resolve(
+      endpoints: [Uri.parse('https://a.example'), Uri.parse('https://b.example')],
       expectedSnapshotHeight: 100,
     );
 
-    expect(result.endpoint, endpoint);
-    expect(result.diagnostics.single.status, PirSnapshotEndpointStatus.matched);
+    expect(requestedEndpoints, ['https://a.example', 'https://b.example']);
+    expect(requestedHeight, BigInt.from(100));
+    expect(resolution.endpoint, Uri.parse('https://a.example'));
+    expect(resolution.diagnostics, hasLength(2));
+    expect(resolution.diagnostics.first.matched, isTrue);
+    expect(resolution.diagnostics.last.matched, isFalse);
+    expect(resolution.diagnostics.last.reportedHeight, 99);
   });
 
-  test('ignores guessed height aliases', () async {
-    final endpoint = Uri.parse('https://pir.example/snapshot');
-    final resolver = PirSnapshotResolver(
-      httpClient: FakeVotingHttpClient(
-        responses: {
-          'https://pir.example/snapshot/root': {
-            'root_height': 100,
-            'rootHeight': 100,
-            'snapshot_height': 100,
-            'snapshotHeight': 100,
-          },
-        },
+  test('no matching endpoint fails closed with its diagnostics', () async {
+    final resolver = resolverReturning(
+      rust_api.ApiPirSnapshotResolution(
+        diagnostics: [
+          diagnostic(
+            endpoint: 'https://a.example',
+            status: rust_api.ApiPirSnapshotEndpointStatus.behind,
+            reportedHeight: 99,
+          ),
+        ],
       ),
-      selectEndpoint: selectExactHeightEndpoint,
     );
 
-    try {
-      await resolver.resolve(
-        endpoints: [endpoint],
+    await expectLater(
+      resolver.resolve(
+        endpoints: [Uri.parse('https://a.example')],
         expectedSnapshotHeight: 100,
-      );
-      fail('expected no matching endpoint');
-    } on PirSnapshotNoMatchingEndpoint catch (e) {
-      expect(
-        e.diagnostics.single.status,
-        PirSnapshotEndpointStatus.missingHeight,
-      );
-    }
-  });
-
-  test('non-height fields do not conflict with canonical height', () async {
-    final endpoint = Uri.parse('https://pir.example/snapshot');
-    final resolver = PirSnapshotResolver(
-      httpClient: FakeVotingHttpClient(
-        responses: {
-          'https://pir.example/snapshot/root': {
-            'height': 100,
-            'snapshot_height': 101,
-          },
-        },
       ),
-      selectEndpoint: selectExactHeightEndpoint,
-    );
-
-    final result = await resolver.resolve(
-      endpoints: [endpoint],
-      expectedSnapshotHeight: 100,
-    );
-
-    expect(result.endpoint, endpoint);
-    expect(result.diagnostics.single.status, PirSnapshotEndpointStatus.matched);
-  });
-
-  test('non-integer height values are treated as malformed', () async {
-    final endpoints = [
-      Uri.parse('https://pir.example/fractional'),
-      Uri.parse('https://pir.example/negative'),
-      Uri.parse('https://pir.example/too-large'),
-    ];
-    final resolver = PirSnapshotResolver(
-      httpClient: FakeVotingHttpClient(
-        responses: {
-          'https://pir.example/fractional/root': {'height': 100.5},
-          'https://pir.example/negative/root': {'height': -1},
-          'https://pir.example/too-large/root': {
-            'height': '18446744073709551616',
-          },
-        },
+      throwsA(
+        isA<PirSnapshotNoMatchingEndpoint>()
+            .having((e) => e.expectedSnapshotHeight, 'height', 100)
+            .having((e) => e.diagnostics, 'diagnostics', hasLength(1)),
       ),
-      selectEndpoint: selectExactHeightEndpoint,
     );
-
-    try {
-      await resolver.resolve(endpoints: endpoints, expectedSnapshotHeight: 100);
-      fail('expected no matching endpoint');
-    } on PirSnapshotNoMatchingEndpoint catch (e) {
-      expect(e.diagnostics.map((diagnostic) => diagnostic.status), [
-        PirSnapshotEndpointStatus.malformedJson,
-        PirSnapshotEndpointStatus.malformedJson,
-        PirSnapshotEndpointStatus.malformedJson,
-      ]);
-    }
   });
 
-  test(
-    'excludes behind ahead missing malformed non-200 and timeout endpoints',
-    () async {
-      final endpoints = [
-        Uri.parse('https://pir.example/behind'),
-        Uri.parse('https://pir.example/ahead'),
-        Uri.parse('https://pir.example/missing'),
-        Uri.parse('https://pir.example/malformed'),
-        Uri.parse('https://pir.example/non-200'),
-        Uri.parse('https://pir.example/timeout'),
-        Uri.parse('https://pir.example/match'),
-      ];
-      final resolver = PirSnapshotResolver(
-        httpClient: FakeVotingHttpClient(
-          responses: {
-            'https://pir.example/behind/root': {'height': 99},
-            'https://pir.example/ahead/root': {'height': 101},
-            'https://pir.example/missing/root': {'root': 'abc'},
-            'https://pir.example/malformed/root': '{',
-            'https://pir.example/non-200/root': textResponse(
-              'down',
-              statusCode: 500,
-            ),
-            'https://pir.example/timeout/root': timeoutResponse(),
-            'https://pir.example/match/root': {'height': 100},
-          },
+  test('every bridge status maps to its Dart status', () async {
+    // The status screen branches on `behind` specifically, so a silent
+    // mismapping here would change what the user is told to do.
+    const pairs = <rust_api.ApiPirSnapshotEndpointStatus,
+        PirSnapshotEndpointStatus>{
+      rust_api.ApiPirSnapshotEndpointStatus.matched:
+          PirSnapshotEndpointStatus.matched,
+      rust_api.ApiPirSnapshotEndpointStatus.behind:
+          PirSnapshotEndpointStatus.behind,
+      rust_api.ApiPirSnapshotEndpointStatus.ahead:
+          PirSnapshotEndpointStatus.ahead,
+      rust_api.ApiPirSnapshotEndpointStatus.missingHeight:
+          PirSnapshotEndpointStatus.missingHeight,
+      rust_api.ApiPirSnapshotEndpointStatus.malformedJson:
+          PirSnapshotEndpointStatus.malformedJson,
+      rust_api.ApiPirSnapshotEndpointStatus.nonSuccessStatus:
+          PirSnapshotEndpointStatus.nonSuccessStatus,
+      rust_api.ApiPirSnapshotEndpointStatus.timeoutOrNetworkError:
+          PirSnapshotEndpointStatus.timeoutOrNetworkError,
+    };
+
+    for (final entry in pairs.entries) {
+      final resolver = resolverReturning(
+        rust_api.ApiPirSnapshotResolution(
+          endpoint: 'https://a.example',
+          diagnostics: [
+            diagnostic(status: entry.key, reportedHeight: 100, httpStatusCode: 503),
+          ],
         ),
-        selectEndpoint: selectExactHeightEndpoint,
       );
 
-      final result = await resolver.resolve(
-        endpoints: endpoints,
+      final resolution = await resolver.resolve(
+        endpoints: [Uri.parse('https://a.example')],
         expectedSnapshotHeight: 100,
       );
 
-      expect(result.endpoint, endpoints.last);
-      expect(result.diagnostics.map((diagnostic) => diagnostic.status), [
-        PirSnapshotEndpointStatus.behind,
-        PirSnapshotEndpointStatus.ahead,
-        PirSnapshotEndpointStatus.missingHeight,
-        PirSnapshotEndpointStatus.malformedJson,
-        PirSnapshotEndpointStatus.nonSuccessStatus,
-        PirSnapshotEndpointStatus.timeoutOrNetworkError,
-        PirSnapshotEndpointStatus.matched,
-      ]);
-    },
-  );
-
-  test('all excluded throws typed no-match error with diagnostics', () async {
-    final endpoints = [
-      Uri.parse('https://pir.example/behind'),
-      Uri.parse('https://pir.example/ahead'),
-    ];
-    final resolver = PirSnapshotResolver(
-      httpClient: FakeVotingHttpClient(
-        responses: {
-          'https://pir.example/behind/root': {'height': 99},
-          'https://pir.example/ahead/root': {'height': 101},
-        },
-      ),
-      selectEndpoint: selectExactHeightEndpoint,
-    );
-
-    try {
-      await resolver.resolve(endpoints: endpoints, expectedSnapshotHeight: 100);
-      fail('expected no matching endpoint');
-    } on PirSnapshotNoMatchingEndpoint catch (e) {
-      expect(e.expectedSnapshotHeight, 100);
-      expect(e.diagnostics.length, 2);
-      expect(e.diagnostics.first.status, PirSnapshotEndpointStatus.behind);
+      expect(resolution.diagnostics.single.status, entry.value);
+      expect(resolution.diagnostics.single.httpStatusCode, 503);
     }
   });
 }

--- a/test/services/voting/pir_snapshot_resolver_test.dart
+++ b/test/services/voting/pir_snapshot_resolver_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/rust/api/voting.dart' as rust_api;
 import 'package:zcash_wallet/src/services/voting/pir_snapshot_resolver.dart';
+import 'package:zcash_wallet/src/services/voting/voting_endpoint_mapper.dart';
 
 /// Probing, height classification, and selection now run in Rust and are
 /// covered by `rust/src/api/voting.rs` unit tests. What is left on this side
@@ -157,5 +158,49 @@ void main() {
       expect(resolution.diagnostics.single.status, entry.value);
       expect(resolution.diagnostics.single.httpStatusCode, 503);
     }
+  });
+
+  test('the regtest gateway rewrite is applied to probes only', () async {
+    // The probe has to reach the local gateway, but the round's configured
+    // identity is what the session state and the PIR failover list carry, so
+    // the rewrite must not leak into the result.
+    final mapper = VotingEndpointMapper(
+      isRegtest: true,
+      gatewayUrl: 'http://127.0.0.1:18232',
+    );
+    const logical = 'https://pir.vizor-vote.invalid';
+    final mapped = mapper.map(Uri.parse(logical)).toString();
+    expect(mapped, isNot(logical), reason: 'mapper must rewrite in regtest');
+
+    late List<String> probed;
+    final resolver = PirSnapshotResolver(
+      mapper: mapper,
+      resolveEndpoint:
+          ({
+            required List<String> endpoints,
+            required BigInt expectedSnapshotHeight,
+          }) async {
+            probed = endpoints;
+            return rust_api.ApiPirSnapshotResolution(
+              endpoint: endpoints.single,
+              diagnostics: [
+                rust_api.ApiPirSnapshotEndpointDiagnostic(
+                  endpoint: endpoints.single,
+                  status: rust_api.ApiPirSnapshotEndpointStatus.matched,
+                  reportedHeight: expectedSnapshotHeight,
+                ),
+              ],
+            );
+          },
+    );
+
+    final resolution = await resolver.resolve(
+      endpoints: [Uri.parse(logical)],
+      expectedSnapshotHeight: 100,
+    );
+
+    expect(probed, [mapped]);
+    expect(resolution.endpoint, Uri.parse(logical));
+    expect(resolution.diagnostics.single.endpoint, Uri.parse(logical));
   });
 }


### PR DESCRIPTION
## What

Vizor implemented the round driver four times in Dart. All four are gone; `zcash_voting`'s `round_drive` owns the loop, and what remains maps driver events onto session state.

| Removed | What it was |
|---|---|
| `_advanceStep` | a chain re-poll loop with its own 2 s delay |
| `_runDelegationSteps` | a bundle fan-out at concurrency 3 |
| the cast plan-walk | step selection, failed-bundle exclusion, batch-vs-per-proposal arithmetic |
| `_delegationStepsFor` | fabricated `NextStepView` values the planner never emitted, with zero-filled fields |

Two things had said this was the wrong side of the line for a while: the fabricated steps carried a 19-line comment explaining they should no longer be needed, and there was a hand-written guard against a `noWork` livelock — Dart policing an SDK invariant from outside. Both are now the SDK's.

## The bridge

`VotingRoundSession::run_round` streams the run. It builds the delegation inputs once (opening the pipeline fetches a lightwalletd anchor, and the driver overlaps bundles that would each pay for it), keeps the Dart-supplied host context as a template and restamps its clock per dispatch, and emits exactly one terminal event however the run ends — the same contract the per-step entry points had, for the same reason: the bridge drops a streaming function's `Result`, so an `Err` return would close the stream with no event at all.

## What stayed in Dart, deliberately

`_runRound` keeps what only the app can decide: which credential a run gets (delegation needs the mnemonic or Keystone signatures, casting needs neither — so the job provider's delegate-then-cast split stays), when a stale context stops publishing, how a failure is ranked for display, and the timers behind background share tracking. Delegation-proof precompute is untouched: it is not round work, never appears in a plan, and the SDK's per-bundle proof lock already makes it and the driver cooperate.

A quiescence the app must resolve becomes the exception the flow already handled, so a rejected or hashless submission still surfaces its diagnostic instead of reading as a finished round.

## API removal

`advance_step`, `advance_next` and `ApiRoundStepEvent` had no callers left once the loops went, so they are deleted from the bridge and the facade. The test fake holds its own scripted step types rather than keeping a retired API alive.

## Tests

`runRound` gains a scripting seam: a test queues the exact `ApiRoundRunEvent` sequence and asserts the resulting `VotingSessionState`, instead of making the fake re-derive a plan the real planner owns. **That seam caught a bug in this change on first use** — the cast handler returned early on events carrying no step, so every `planRefreshed` was skipped and the question counters never advanced.

Nine tests covering bundle concurrency and failure isolation are retired here: those semantics are now pinned by the SDK's own conformance tests, and keeping them would only assert the fake's fidelity.

**Desktop voting regtest passes end to end** against a real chain — four proposals, real delegation, commitment and share proofs, an actionable receipt. The log also confirms the design working: the delegation run drove the round all the way to `backgroundShareWorkOnly`, and the cast call that follows correctly found nothing left.

## Known gaps

Two fixture-level tests still fail: `hardware partial delegation retry skips confirmed siblings` (a fixture with no delegation record for one bundle, so nothing is planned for it) and `vote commitments do not submit after active account changes during proof` (the fake's proof gate never releases after the switch). Both want the event seam rather than another plan-derivation rule — I tried two general fixes and each broke five status-screen tests.

## Dependency

Requires the `round_drive` API from valargroup/zcash_voting#292. **This does not build until that lands and the SDK revs move** — the `[patch]` used to develop against a local checkout is deliberately not in this branch, along with build files, config, network settings and the regtest runner's version pin.

---

# Follow-on: four API-boundary cleanups

With the loop behind the SDK, the Dart layer was still holding half of several
algorithms. Four cleanups, ~370 net lines out of hand-written `lib/`, and
`voting_session_provider.dart` down from 4044 to 3884.

## The ballot is recorded once

`castVotes` wrote every intent twice: per-proposal through
`VotingRecoveryService.setBallotIntent`, then as a batch through
`session.setBallotIntents`. The SDK write is the stronger of the two — it
resolves `num_options` from the bound roster, rejects off-roster proposals
before touching the database, and commits the whole ballot in one transaction
before it plans — so the loop only duplicated a write that had already
happened.

`num_options` is validation-only and never persisted, so the Dart
`draftVote.numOptions ?? proposalOptionCounts ?? rosterOptionCounts` guess chain
existed to feed a bounds check the SDK repeats against a better source.
Deleting it retires the whole chain, including the
`pendingProposalOptionCounts` job state that carried option counts across the
Keystone QR round-trip.

**This found a latent bug.** `_ballotIntentsFor` marks every listed proposal
without a draft vote as skipped, and the SDK write was never gated on
`draftVotes` the way the deleted loop was — so a recovery-only cast could
overwrite the stored choices it exists to resume. Production could not reach
that pair, but only because two distant call sites happened to agree. The guard
is now local to `castVotes` and `recordBallotIntents`.
`recovery-only vote confirmation does not rewrite ballot intents` was asserting
on the retired channel, so it passed while testing the wrong thing; it now
fails without the guard.

## PIR resolution happens in one call

Resolution was split down the middle: Dart fetched each endpoint's `/root`,
parsed the height and classified it into seven statuses, then handed those
diagnostics back across the bridge so Rust could apply the one rule it owned.
`resolve_pir_snapshot_endpoint` now probes concurrently over the routed
transport and returns the selection with every diagnostic — which is part of the
result, not debug output, because delegation builds its PIR failover list from
the endpoints that matched and the status screen explains a failure from the
heights reported.

Carried over deliberately: each probe keeps the wallet's own 10s budget rather
than inheriting the transport's 60s PIR deadline, a clearable failure is retried
once, and height parsing stays lenient about a number or a decimal string
because endpoints publish both and serde would reject one. Selection still runs
through the SDK, which keeps its policy deterministic and probing-free.

The two copies of the mismatch message — one in the provider, one in the status
screen that had drifted to handling only the `behind` case — are now one helper.

## One delegation body for both signers

`delegatePendingBundles` and `delegatePendingBundlesWithKeystoneSignatures` were
the same method twice. Both names stay as wrappers over one body, so no call
site moves and the mismatch between entry point and account kind stays an error
rather than a silent reroute.

Three things stay per-arm because they are real: software needs the mnemonic,
hardware needs a signature for every pending bundle, and hardware must not mint
a fresh hotkey once signatures exist, since each is bound to the hotkey it was
made with.

**Three hardware behaviours change, all toward the software arm**, none covered
by a test either way: the "PIR endpoint has not been resolved" error is raised
only where a bundle needs a proof; the hotkey is ensured after the signature
check, so `sign bundle N` wins over an opaque hotkey failure; and the
delegation-proof staleness checkpoint now covers hardware.

## Interface narrowing

`select_pir_snapshot_endpoint` and `VotingRecoveryService.setBallotIntent` are
deleted — nothing reaches them once the above lands.

`lastMomentBufferSeconds` and `isLastMoment` were also slated for removal and
**stay**: both fakes reimplement them to script last-moment timing, which unit
and widget tests cannot get from the real library, so they are a working seam
rather than indirection. Relocating the ~17 ctx-scoped members onto
`VotingRoundSession` is deliberately not here — it rewrites both fake
hierarchies and the shared session fake.

## Coverage and a correctness pass

The probe path had no test. Making it generic over the SDK's `Transport` lets a
scripted transport drive probe, classify and select together — which caught a
real regression: Dart probed through `votingHttpClientProvider`, a
`MappedVotingHttpClient`, so the regtest rewrite from a logical
`*.vizor-vote.invalid` identity to the loopback gateway was applied on the way
out. Moving the probe into Rust dropped it, which would have left regtest
resolution reaching an unroutable host. The resolver now maps what it probes and
maps the result back, matching what the old code did — it built diagnostics from
the logical URL while the client rewrote the request. The `/root` URL is also
built structurally again, so an endpoint with a query string does not bury the
segment in it.

Eight new Rust tests and a Dart test pinning the mapping in both directions.

## Verification

- `cargo test --lib`: **711 passed**
- `fvm flutter analyze`: clean project-wide
- Desktop lane: **2521 passing**; mobile lane `+911 -21`, byte-identical to this
  branch's baseline in a scratch worktree
- **Voting regtest passes again** — round `642a9b8c…`, snapshot 510,
  `share_requests: 64, slow_share_requests: 0`, full path from Ironwood
  migration through delegation to an actionable receipt. The gateway log shows
  six `GET /pir.vizor-vote.invalid/root → 200`, i.e. the new Rust probe reaching
  the mapped gateway.

The two fixture-level failures under **Known gaps** are unchanged and still
fail identically on this branch's base. Running that regtest locally still needs
the runner's vote-sdk pin, which stays out of the branch for the reason above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxZM7rgbkHwFzfAXMghqkw



https://claude.ai/code/session_014LUkSGDytzVZ2qr51hJb28