### PR TITLE
Improve Tor HTTP timeout resilience

### DIFF
--- a/lib/src/core/network/network_http_client.dart
+++ b/lib/src/core/network/network_http_client.dart
@@ -176,7 +176,7 @@ class RustTorHttpBridge implements TorHttpBridge {
     try {
       return networkHttpResponseFromRust(await send(requestId));
     } catch (error, stackTrace) {
-      if (timeout != null && error.toString().contains(_requestTimeoutError)) {
+      if (error.toString().contains(_requestTimeoutError)) {
         throw TimeoutException(_requestTimeoutError, timeout);
       }
       Error.throwWithStackTrace(error, stackTrace);
@@ -280,9 +280,10 @@ class NetworkHttpClient {
     Future<void>? cancelSignal,
   }) {
     _requirePositiveTimeout(timeout);
+    final normalizedMethod = method.toUpperCase();
     return _torDesired()
-        ? _requestViaTorWithRedirects(
-            method.toUpperCase(),
+        ? _requestViaTorWithTimeoutRetry(
+            normalizedMethod,
             uri,
             headers: headers,
             bodyBytes: bodyBytes,
@@ -291,7 +292,7 @@ class NetworkHttpClient {
           )
         : _runDirectRequest(
             () => _requestDirect(
-              method.toUpperCase(),
+              normalizedMethod,
               uri,
               headers: headers,
               bodyBytes: bodyBytes,
@@ -299,6 +300,38 @@ class NetworkHttpClient {
               cancelSignal: cancelSignal,
             ),
           );
+  }
+
+  Future<NetworkHttpResponse> _requestViaTorWithTimeoutRetry(
+    String method,
+    Uri uri, {
+    required Map<String, String> headers,
+    required List<int> bodyBytes,
+    required Duration? timeout,
+    required Future<void>? cancelSignal,
+  }) async {
+    try {
+      return await _requestViaTorWithRedirects(
+        method,
+        uri,
+        headers: headers,
+        bodyBytes: bodyBytes,
+        timeout: timeout,
+        cancelSignal: cancelSignal,
+      );
+    } on TimeoutException {
+      if (method != 'GET') rethrow;
+      // Each bridge GET resolves another isolated Tor client. Restarting the
+      // redirect chain therefore avoids the circuit that timed out.
+      return _requestViaTorWithRedirects(
+        method,
+        uri,
+        headers: headers,
+        bodyBytes: bodyBytes,
+        timeout: timeout,
+        cancelSignal: cancelSignal,
+      );
+    }
   }
 
   /// Streams a GET response to [destination] without retaining the response

--- a/lib/src/features/wallet_link/services/wallet_link_api_client.dart
+++ b/lib/src/features/wallet_link/services/wallet_link_api_client.dart
@@ -21,7 +21,7 @@ class WalletLinkApiClient {
     HttpClient? client,
     NetworkHttpClient? networkClient,
     Uri? baseUri,
-    this.timeout = const Duration(seconds: 12),
+    this.timeout = const Duration(seconds: 20),
   }) : _client = networkClient ?? NetworkHttpClient(directClient: client),
        _baseUri = baseUri ?? walletLinkBackendBaseUri();
 

--- a/lib/src/features/wallet_link/services/wallet_link_completion.dart
+++ b/lib/src/features/wallet_link/services/wallet_link_completion.dart
@@ -4,6 +4,8 @@ import '../models/wallet_link_models.dart';
 import 'wallet_link_api_client.dart';
 import 'wallet_link_completion_crypto.dart';
 
+const _bestEffortCompletionTimeout = Duration(seconds: 10);
+
 Future<void> completeWalletLinkPackageBestEffort({
   required String packageId,
   required String completionToken,
@@ -11,7 +13,7 @@ Future<void> completeWalletLinkPackageBestEffort({
   required int importedAccountCount,
   required int importedContactCount,
 }) async {
-  final client = WalletLinkApiClient(timeout: const Duration(seconds: 4));
+  final client = WalletLinkApiClient(timeout: _bestEffortCompletionTimeout);
   try {
     final completionEnvelope = await encryptWalletLinkImportSummary(
       summary: WalletLinkImportSummary(

--- a/lib/src/providers/zec_price_change_provider.dart
+++ b/lib/src/providers/zec_price_change_provider.dart
@@ -115,7 +115,7 @@ class CoinGeckoZecMarketDataSource implements ZecMarketDataSource {
     HttpClient? client,
     NetworkHttpClient? networkClient,
     Uri? baseUri,
-    this.timeout = const Duration(seconds: 12),
+    this.timeout = const Duration(seconds: 20),
   }) : _client = networkClient ?? NetworkHttpClient(directClient: client),
        _baseUri = baseUri ?? Uri.parse(kVizorCoinGeckoPriceBaseUrl);
 

--- a/rust/src/api/network_privacy.rs
+++ b/rust/src/api/network_privacy.rs
@@ -16,7 +16,10 @@ use zcash_client_backend::proto::{
     compact_formats::CompactBlock,
     service::{compact_tx_streamer_client::CompactTxStreamerClient, BlockId, ChainSpec, Empty},
 };
-use zcash_client_backend::tor::http::{HttpError, TimeoutPhase};
+use zcash_client_backend::tor::{
+    http::{HttpError, TimeoutPhase},
+    Error as TorError,
+};
 
 pub use crate::network_privacy::NetworkPrivacyStatus;
 
@@ -327,13 +330,10 @@ pub async fn tor_http_download(
     network_http_response(response.map(|_| Vec::new()))
 }
 
-async fn with_tor_http_request_timeout<T, E>(
+async fn with_tor_http_request_timeout<T>(
     timeout_milliseconds: Option<u64>,
-    future: impl std::future::Future<Output = Result<T, E>>,
-) -> Result<T, String>
-where
-    E: std::fmt::Display,
-{
+    future: impl std::future::Future<Output = Result<T, TorError>>,
+) -> Result<T, String> {
     let result = match timeout_milliseconds {
         Some(0) => return Err("Tor HTTP request timeout must be positive".to_string()),
         Some(timeout_milliseconds) => {
@@ -345,7 +345,18 @@ where
         }
         None => future.await,
     };
-    result.map_err(|error| error.to_string())
+    result.map_err(normalize_tor_http_error)
+}
+
+/// Gives Arti's phase-specific HTTP timeouts the stable marker consumed by
+/// Dart, without relying on Arti's human-readable error wording across FFI.
+fn normalize_tor_http_error(error: TorError) -> String {
+    match &error {
+        TorError::Http(HttpError::Timeout(phase)) => {
+            format!("{TOR_HTTP_REQUEST_TIMEOUT_ERROR} while {phase}")
+        }
+        _ => error.to_string(),
+    }
 }
 
 fn apply_headers(
@@ -714,9 +725,10 @@ mod tests {
 
     use super::{
         correct_estimated_height, interpolate_height, mainnet_anchor_segment,
-        tor_http_begin_request, tor_http_cancel_request, with_api_response_body_timeout,
-        with_tor_http_request_cancellation, with_tor_http_request_timeout, BirthdayAnchor,
-        MAINNET_BIRTHDAY_ANCHORS,
+        normalize_tor_http_error, tor_http_begin_request, tor_http_cancel_request,
+        with_api_response_body_timeout, with_tor_http_request_cancellation,
+        with_tor_http_request_timeout, BirthdayAnchor, MAINNET_BIRTHDAY_ANCHORS,
+        TOR_HTTP_REQUEST_TIMEOUT_ERROR,
     };
 
     #[test]
@@ -793,6 +805,26 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn arti_http_timeout_phases_receive_the_stable_timeout_marker() {
+        for phase in [
+            TimeoutPhase::Connect,
+            TimeoutPhase::Request,
+            TimeoutPhase::ResponseBody,
+        ] {
+            let error = normalize_tor_http_error(Error::Http(HttpError::Timeout(phase)));
+            assert!(
+                error.starts_with(TOR_HTTP_REQUEST_TIMEOUT_ERROR),
+                "unrecognized timeout: {error}"
+            );
+        }
+
+        assert_eq!(
+            normalize_tor_http_error(Error::Http(HttpError::NonHttpUrl)),
+            "HTTP-over-Tor error: Only HTTP or HTTPS URLs are supported"
+        );
+    }
+
     #[tokio::test]
     async fn whole_http_deadline_drops_the_in_flight_tor_request() {
         struct DropSignal(Arc<AtomicBool>);
@@ -807,7 +839,7 @@ mod tests {
         let request_drop = Arc::clone(&dropped);
         let result = with_tor_http_request_timeout(Some(1), async move {
             let _drop_signal = DropSignal(request_drop);
-            std::future::pending::<Result<(), &'static str>>().await
+            std::future::pending::<Result<(), Error>>().await
         })
         .await;
 

--- a/test/core/network/network_http_client_test.dart
+++ b/test/core/network/network_http_client_test.dart
@@ -102,6 +102,127 @@ void main() {
     );
   });
 
+  test('Tor GET retries one timeout on a fresh bridge request', () async {
+    const timeout = Duration(seconds: 12);
+    final bridge = _RecordingTorBridge([
+      TimeoutException('Tor HTTP request timed out', timeout),
+      NetworkHttpResponse(
+        statusCode: 200,
+        bodyBytes: utf8.encode('second circuit'),
+      ),
+    ]);
+    final client = NetworkHttpClient(
+      torDesired: () => true,
+      torBootstrapping: () => false,
+      torBridge: bridge,
+    );
+    addTearDown(() => client.close());
+
+    final response = await client.request(
+      'GET',
+      Uri.parse('https://example.com/data'),
+      timeout: timeout,
+    );
+
+    expect(utf8.decode(response.bodyBytes), 'second circuit');
+    expect(bridge.requests, hasLength(2));
+    expect(bridge.timeouts, hasLength(2));
+    for (final attemptTimeout in bridge.timeouts) {
+      expect(
+        attemptTimeout!.inMilliseconds,
+        inInclusiveRange(11_900, timeout.inMilliseconds),
+      );
+    }
+  });
+
+  test('Tor GET stops after the second timeout', () async {
+    const timeout = Duration(seconds: 12);
+    final bridge = _RecordingTorBridge([
+      TimeoutException('first timeout', timeout),
+      TimeoutException('second timeout', timeout),
+    ]);
+    final client = NetworkHttpClient(
+      torDesired: () => true,
+      torBootstrapping: () => false,
+      torBridge: bridge,
+    );
+    addTearDown(() => client.close());
+
+    await expectLater(
+      client.request(
+        'GET',
+        Uri.parse('https://example.com/data'),
+        timeout: timeout,
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+    expect(bridge.requests, hasLength(2));
+  });
+
+  test('Tor POST does not retry a timeout', () async {
+    const timeout = Duration(seconds: 12);
+    final bridge = _RecordingTorBridge([
+      TimeoutException('Tor HTTP request timed out', timeout),
+    ]);
+    final client = NetworkHttpClient(
+      torDesired: () => true,
+      torBootstrapping: () => false,
+      torBridge: bridge,
+    );
+    addTearDown(() => client.close());
+
+    await expectLater(
+      client.request(
+        'POST',
+        Uri.parse('https://example.com/data'),
+        timeout: timeout,
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+    expect(bridge.requests, hasLength(1));
+  });
+
+  test('Tor GET does not retry an HTTP error response', () async {
+    final bridge = _RecordingTorBridge([
+      NetworkHttpResponse(
+        statusCode: HttpStatus.serviceUnavailable,
+        bodyBytes: Uint8List(0),
+      ),
+    ]);
+    final client = NetworkHttpClient(
+      torDesired: () => true,
+      torBootstrapping: () => false,
+      torBridge: bridge,
+    );
+    addTearDown(() => client.close());
+
+    final response = await client.request(
+      'GET',
+      Uri.parse('https://example.com/data'),
+    );
+
+    expect(response.statusCode, HttpStatus.serviceUnavailable);
+    expect(bridge.requests, hasLength(1));
+  });
+
+  test('Tor GET does not retry explicit cancellation', () async {
+    final bridge = _RecordingTorBridge([
+      const NetworkHttpRequestCancelledException(),
+    ]);
+    final client = NetworkHttpClient(
+      torDesired: () => true,
+      torBootstrapping: () => false,
+      torBridge: bridge,
+    );
+    addTearDown(() => client.close());
+
+    await expectLater(
+      client.request('GET', Uri.parse('https://example.com/data')),
+      throwsA(isA<NetworkHttpRequestCancelledException>()),
+    );
+    expect(bridge.requests, hasLength(1));
+  });
+
   test('unsupported methods are blocked while Tor is desired', () async {
     final client = NetworkHttpClient(
       torDesired: () => true,
@@ -223,6 +344,44 @@ void main() {
       expect(bridge.timeouts[1]!.inMilliseconds, lessThanOrEqualTo(110));
     },
   );
+
+  test('a timed-out redirected GET retries from the original URI', () async {
+    const timeout = Duration(seconds: 12);
+    final bridge = _RecordingTorBridge([
+      NetworkHttpResponse(
+        statusCode: HttpStatus.found,
+        bodyBytes: Uint8List(0),
+        headers: const {
+          HttpHeaders.locationHeader: ['/final'],
+        },
+      ),
+      TimeoutException('Tor HTTP request timed out', timeout),
+      NetworkHttpResponse(statusCode: 200, bodyBytes: utf8.encode('done')),
+    ]);
+    final client = NetworkHttpClient(
+      torDesired: () => true,
+      torBootstrapping: () => false,
+      torBridge: bridge,
+    );
+    addTearDown(() => client.close());
+
+    final response = await client.request(
+      'GET',
+      Uri.parse('https://example.com/start'),
+      timeout: timeout,
+    );
+
+    expect(utf8.decode(response.bodyBytes), 'done');
+    expect(bridge.requests.map((request) => request.url), [
+      'https://example.com/start',
+      'https://example.com/final',
+      'https://example.com/start',
+    ]);
+    expect(
+      bridge.timeouts.last!.inMilliseconds,
+      inInclusiveRange(11_900, timeout.inMilliseconds),
+    );
+  });
 
   test('cross-origin redirects strip credentials', () async {
     final bridge = _RecordingTorBridge([
@@ -508,7 +667,7 @@ class _StallingHttpClient implements HttpClient {
 class _RecordingTorBridge implements TorHttpBridge {
   _RecordingTorBridge(this.responses);
 
-  final List<NetworkHttpResponse> responses;
+  final List<Object> responses;
   final requests = <_RecordedRequest>[];
   final timeouts = <Duration?>[];
 
@@ -518,7 +677,7 @@ class _RecordingTorBridge implements TorHttpBridge {
     required Map<String, String> headers,
     required String destinationPath,
   }) async {
-    final response = responses[requests.length];
+    final response = responses[requests.length] as NetworkHttpResponse;
     requests.add(
       _RecordedRequest(
         method: 'GET',
@@ -549,7 +708,7 @@ class _RecordingTorBridge implements TorHttpBridge {
         headers: Map.of(headers),
       ),
     );
-    return responses[requests.length - 1];
+    return _responseOrThrow(responses[requests.length - 1]);
   }
 
   @override
@@ -569,7 +728,12 @@ class _RecordingTorBridge implements TorHttpBridge {
         bodyBytes: List.of(bodyBytes),
       ),
     );
-    return responses[requests.length - 1];
+    return _responseOrThrow(responses[requests.length - 1]);
+  }
+
+  static NetworkHttpResponse _responseOrThrow(Object outcome) {
+    if (outcome is NetworkHttpResponse) return outcome;
+    throw outcome;
   }
 }
 

--- a/test/features/wallet_link/wallet_link_api_client_test.dart
+++ b/test/features/wallet_link/wallet_link_api_client_test.dart
@@ -26,6 +26,10 @@ void main() {
 
     expect(bridge.posts, hasLength(1));
     expect(
+      bridge.posts.single.timeout!.inMilliseconds,
+      inInclusiveRange(19_900, 20_000),
+    );
+    expect(
       bridge.posts.single.uri.toString(),
       'https://functions.example.test/api/wallet-link/v1/packages/'
       '$packageId/revoke',
@@ -117,14 +121,21 @@ class _RecordingTorBridge implements TorHttpBridge {
     required Duration? timeout,
     Future<void>? cancelSignal,
   }) async {
-    posts.add(_RecordedPost(uri: uri, bodyBytes: List.of(bodyBytes)));
+    posts.add(
+      _RecordedPost(uri: uri, bodyBytes: List.of(bodyBytes), timeout: timeout),
+    );
     return responses[posts.length - 1];
   }
 }
 
 class _RecordedPost {
-  const _RecordedPost({required this.uri, required this.bodyBytes});
+  const _RecordedPost({
+    required this.uri,
+    required this.bodyBytes,
+    required this.timeout,
+  });
 
   final Uri uri;
   final List<int> bodyBytes;
+  final Duration? timeout;
 }

--- a/test/providers/linux_update_provider_test.dart
+++ b/test/providers/linux_update_provider_test.dart
@@ -131,7 +131,7 @@ void main() {
   );
 
   test(
-    'a slow Linux release feed times out without blocking startup',
+    'a slow Linux release feed retries once without blocking startup',
     () async {
       final bridge = _LinuxUpdateTorBridge(waitForever: true);
 
@@ -149,7 +149,7 @@ void main() {
       );
 
       expect(update, isNull);
-      expect(bridge.requests, hasLength(1));
+      expect(bridge.requests, hasLength(2));
     },
   );
 

--- a/test/providers/zec_price_change_provider_test.dart
+++ b/test/providers/zec_price_change_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
+import 'package:zcash_wallet/src/core/network/network_http_client.dart';
 import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 
 class _FakeSource implements ZecMarketDataSource {
@@ -56,6 +57,15 @@ class _FakeCache implements ZecMarketDataCache {
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('CoinGecko source uses a 20 second request timeout by default', () {
+    final networkClient = NetworkHttpClient(torDesired: () => false);
+    addTearDown(() => networkClient.close(force: true));
+
+    final source = CoinGeckoZecMarketDataSource(networkClient: networkClient);
+
+    expect(source.timeout, const Duration(seconds: 20));
+  });
 
   group('parseZecMarketData', () {
     test('reads ZEC price and 24h change from a CoinGecko response', () {


### PR DESCRIPTION
## Summary

- normalize Arti connect, request, and response-body timeouts into Dart `TimeoutException`
- retry timed-out Tor GET requests once on a fresh isolated circuit while leaving POST, cancellation, HTTP errors, and downloads unchanged
- increase CoinGecko and Wallet Link request timeouts for realistic Tor latency

## Validation

- `fvm flutter analyze`
- `fvm flutter test` (2,586 tests passed; mobile-tagged tests skipped by the desktop lane)
- `cargo test` (733 passed, 4 ignored)
- focused network and Wallet Link tests under the mobile form-factor define
- 48 sequential production price requests over Tor: 48/48 succeeded; one 12-second first-attempt timeout recovered on a fresh circuit in 3.566 seconds

## Notes

- Tor bootstrap remains outside the per-request HTTP timeout and requests arriving during bootstrap continue after the route becomes ready.
- No retry was added for POST requests, status-code responses, cancellation, or proving-parameter downloads.