### PR TITLE
feat(migration): add mobile schedule management

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -16,8 +16,10 @@
 		OUTBOX010000000000000001 /* BackgroundMigrationOutbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OUTBOX000000000000000001 /* BackgroundMigrationOutbox.swift */; };
 		OUTBOX010000000000000002 /* BackgroundMigrationOutboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = OUTBOX000000000000000002 /* BackgroundMigrationOutboxStore.swift */; };
 		OUTBOX010000000000000004 /* BackgroundMigrationOutboxRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = OUTBOX000000000000000004 /* BackgroundMigrationOutboxRunner.swift */; };
+		OUTBOX010000000000000007 /* BackgroundMigrationOutboxExecutionGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OUTBOX000000000000000007 /* BackgroundMigrationOutboxExecutionGate.swift */; };
 		OUTBOX010000000000000005 /* BackgroundMigrationOutboxChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = OUTBOX000000000000000005 /* BackgroundMigrationOutboxChannel.swift */; };
 		OUTBOX010000000000000003 /* BackgroundMigrationOutboxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OUTBOX000000000000000003 /* BackgroundMigrationOutboxTests.swift */; };
+		OUTBOX010000000000000008 /* BackgroundMigrationOutboxExecutionGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OUTBOX000000000000000008 /* BackgroundMigrationOutboxExecutionGateTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		42257B77B623F2ABAD2A1912 /* DynamicIslandManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4D4F9C0A149C751B796E19 /* DynamicIslandManager.swift */; };
 		5736417E0A4E184E8572693A /* WalletPathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5736417D0A4E184E8572693A /* WalletPathResolver.swift */; };
@@ -93,8 +95,10 @@
 		OUTBOX000000000000000001 /* BackgroundMigrationOutbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundMigrationOutbox.swift; sourceTree = "<group>"; };
 		OUTBOX000000000000000002 /* BackgroundMigrationOutboxStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundMigrationOutboxStore.swift; sourceTree = "<group>"; };
 		OUTBOX000000000000000004 /* BackgroundMigrationOutboxRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundMigrationOutboxRunner.swift; sourceTree = "<group>"; };
+		OUTBOX000000000000000007 /* BackgroundMigrationOutboxExecutionGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundMigrationOutboxExecutionGate.swift; sourceTree = "<group>"; };
 		OUTBOX000000000000000005 /* BackgroundMigrationOutboxChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundMigrationOutboxChannel.swift; sourceTree = "<group>"; };
 		OUTBOX000000000000000003 /* BackgroundMigrationOutboxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundMigrationOutboxTests.swift; sourceTree = "<group>"; };
+		OUTBOX000000000000000008 /* BackgroundMigrationOutboxExecutionGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundMigrationOutboxExecutionGateTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		363BC99CD33184F9C3C7E797 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
@@ -199,6 +203,7 @@
 			children = (
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 				OUTBOX000000000000000003 /* BackgroundMigrationOutboxTests.swift */,
+				OUTBOX000000000000000008 /* BackgroundMigrationOutboxExecutionGateTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -267,6 +272,7 @@
 				OUTBOX000000000000000001 /* BackgroundMigrationOutbox.swift */,
 				OUTBOX000000000000000002 /* BackgroundMigrationOutboxStore.swift */,
 				OUTBOX000000000000000004 /* BackgroundMigrationOutboxRunner.swift */,
+				OUTBOX000000000000000007 /* BackgroundMigrationOutboxExecutionGate.swift */,
 				OUTBOX000000000000000005 /* BackgroundMigrationOutboxChannel.swift */,
 				NATIVELW0ED2DC5600515810 /* NativeLightwalletdClient.swift */,
 				BGPREP000ED2DC5600515810 /* BackgroundMigrationPreparationManager.swift */,
@@ -533,6 +539,7 @@
 			files = (
 				331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */,
 				OUTBOX010000000000000003 /* BackgroundMigrationOutboxTests.swift in Sources */,
+				OUTBOX010000000000000008 /* BackgroundMigrationOutboxExecutionGateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -544,6 +551,7 @@
 				OUTBOX010000000000000001 /* BackgroundMigrationOutbox.swift in Sources */,
 				OUTBOX010000000000000002 /* BackgroundMigrationOutboxStore.swift in Sources */,
 				OUTBOX010000000000000004 /* BackgroundMigrationOutboxRunner.swift in Sources */,
+				OUTBOX010000000000000007 /* BackgroundMigrationOutboxExecutionGate.swift in Sources */,
 				OUTBOX010000000000000005 /* BackgroundMigrationOutboxChannel.swift in Sources */,
 				NATIVELW1ED2DC5600515810 /* NativeLightwalletdClient.swift in Sources */,
 				BGPREP001ED2DC5600515810 /* BackgroundMigrationPreparationManager.swift in Sources */,

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -271,24 +271,48 @@ import UIKit
         }
         result(true)
       case "quiesce":
-        BackgroundMigrationManager.shared.quiesce {
-          outboxSuccess in
-          guard outboxSuccess else {
-            result(false)
-            return
-          }
-          if #available(iOS 26.0, *) {
-            BackgroundMigrationPreparationManager.shared.quiesce {
-              preparationSuccess in result(preparationSuccess)
+        guard let arguments = call.arguments as? [String: Any],
+          let leaseId = arguments["leaseId"] as? String, !leaseId.isEmpty
+        else {
+          result(FlutterError(code: "invalid_arguments", message: "Missing migration mutation lease.", details: nil))
+          return
+        }
+        let gate = BackgroundMigrationOutboxExecutionGate.shared
+        gate.pause(leaseId: leaseId)
+        DispatchQueue.global(qos: .utility).async {
+          // Includes runOutboxOnceNow, not just BGProcessingTask's queue.
+          gate.waitUntilIdle()
+          DispatchQueue.main.async {
+            BackgroundMigrationManager.shared.quiesce { outboxSuccess in
+              guard outboxSuccess else {
+                result(false)
+                return
+              }
+              if #available(iOS 26.0, *) {
+                BackgroundMigrationPreparationManager.shared.quiesce {
+                  preparationSuccess in result(preparationSuccess)
+                }
+              } else {
+                result(true)
+              }
             }
-          } else {
-            result(true)
           }
         }
       case "resume":
+        guard let arguments = call.arguments as? [String: Any],
+          let leaseId = arguments["leaseId"] as? String, !leaseId.isEmpty
+        else {
+          result(FlutterError(code: "invalid_arguments", message: "Missing migration mutation lease.", details: nil))
+          return
+        }
+        let gate = BackgroundMigrationOutboxExecutionGate.shared
+        guard gate.resume(leaseId: leaseId) else {
+          result(true)
+          return
+        }
         BackgroundMigrationManager.shared.resumeAfterFailedMutation {
           resumed in
-          if #available(iOS 26.0, *) {
+          if #available(iOS 26.0, *), !gate.isPaused {
             BackgroundMigrationPreparationManager.shared.resumeAfterMutation()
           }
           DispatchQueue.main.async { result(resumed) }

--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -448,7 +448,8 @@ final class BackgroundMigrationManager {
   }
 
   private var isMutationQuiesced: Bool {
-    stateLock.vizorWithLock { mutationQuiesced }
+    BackgroundMigrationOutboxExecutionGate.shared.isPaused
+      || stateLock.vizorWithLock { mutationQuiesced }
   }
 
   private var isNotificationWorkDisabled: Bool {
@@ -517,7 +518,8 @@ final class BackgroundMigrationManager {
 
   private func submitAuthorized(earliestBeginDate: Date) -> Bool {
     stateLock.vizorWithLock {
-      guard !mutationQuiesced && !notificationAuthorization.isDisabled else {
+      guard !mutationQuiesced && !notificationAuthorization.isDisabled
+        && !BackgroundMigrationOutboxExecutionGate.shared.isPaused else {
         return false
       }
       BGTaskScheduler.shared.cancel(
@@ -607,14 +609,35 @@ final class BackgroundMigrationManager {
     }
   }
 
+  /// Revocation may also be called directly by account removal. Hold a local
+  /// lease in addition to the caller's lease so no foreground sender can race
+  /// record deletion, even when no BGProcessingTask is active.
+  private func revokeAfterDrainingOutbox(
+    _ operation: @escaping () -> Bool,
+    completion: @escaping (Bool) -> Void
+  ) {
+    let gate = BackgroundMigrationOutboxExecutionGate.shared
+    let leaseId = "revoke:" + UUID().uuidString
+    gate.pause(leaseId: leaseId)
+    DispatchQueue.global(qos: .utility).async {
+      gate.waitUntilIdle()
+      self.queue.async {
+        self.stopActiveWork(quiesceForMutation: true)
+        let success = operation()
+        gate.resume(leaseId: leaseId)
+        self.scheduleRemainingWork()
+        DispatchQueue.main.async { completion(success) }
+      }
+    }
+  }
+
   func revokeAccount(
     network: String,
     accountUuid: String,
     completion: @escaping (Bool) -> Void
   ) {
-    stopActiveWork(quiesceForMutation: true)
-    queue.async { [weak self] in
-      let batchIds = self?.batchIds(network: network, accountUuid: accountUuid) ?? []
+    revokeAfterDrainingOutbox {
+      let batchIds = self.batchIds(network: network, accountUuid: accountUuid)
       let revoked =
         (try? BackgroundMigrationOutboxChannel.revoke(
           network: network,
@@ -625,34 +648,35 @@ final class BackgroundMigrationManager {
           network: network,
           accountUuid: accountUuid
         )
+        BackgroundMigrationOutboxExecutionGate.shared.discardStopLeases(
+          network: network, accountUuid: accountUuid
+        )
       }
-      let hasRemainingWork = self?.hasRunnableOutboxWork() ?? false
+      let hasRemainingWork = self.hasRunnableOutboxWork()
       BackgroundMigrationNotification.remove(
         batchIds: batchIds,
         includeNeedsAction: !hasRemainingWork
       )
-      self?.scheduleRemainingWork()
-      DispatchQueue.main.async { completion(revoked) }
-    }
+      return revoked
+    } completion: { completion($0) }
   }
 
   func revokeAll(completion: @escaping (Bool) -> Void) {
-    stopActiveWork(quiesceForMutation: true)
-    queue.async { [weak self] in
+    revokeAfterDrainingOutbox {
       let batchIds =
         (try? BackgroundMigrationOutboxStore.shared.read().batches.map(\.batchId))
         ?? []
       let removed = (try? BackgroundMigrationOutboxChannel.removeAll()) != nil
       if removed {
         IronwoodMigrationBackgroundCredentialStore.deleteAll()
+        BackgroundMigrationOutboxExecutionGate.shared.discardStopLeases()
       }
       BackgroundMigrationNotification.remove(
         batchIds: batchIds,
         includeNeedsAction: true
       )
-      self?.endMutationQuiescence()
-      DispatchQueue.main.async { completion(removed) }
-    }
+      return removed
+    } completion: { completion($0) }
   }
 
   #if DEBUG || targetEnvironment(simulator)
@@ -876,7 +900,8 @@ final class BackgroundMigrationManager {
 
   private func prepareForBackgroundWake() -> Bool {
     stateLock.vizorWithLock {
-      guard !mutationQuiesced && !notificationAuthorization.isDisabled else {
+      guard !mutationQuiesced && !notificationAuthorization.isDisabled
+        && !BackgroundMigrationOutboxExecutionGate.shared.isPaused else {
         return false
       }
       expired = false

--- a/ios/Runner/BackgroundMigrationOutboxExecutionGate.swift
+++ b/ios/Runner/BackgroundMigrationOutboxExecutionGate.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// One wallet-wide admission gate for both foreground and background outbox
+/// runners. A mutation blocks new runs immediately, then waits for the admitted
+/// run to persist its response. It never cancels an in-flight SendTransaction.
+final class BackgroundMigrationOutboxExecutionGate: @unchecked Sendable {
+  static let shared = BackgroundMigrationOutboxExecutionGate()
+
+  private let condition = NSCondition()
+  private var running = false
+  private var mutationLeases = Set<String>()
+
+  var isPaused: Bool {
+    condition.lock()
+    defer { condition.unlock() }
+    return !mutationLeases.isEmpty
+  }
+
+  func tryBeginRun() -> Bool {
+    condition.lock()
+    defer { condition.unlock() }
+    guard !running && mutationLeases.isEmpty else { return false }
+    running = true
+    return true
+  }
+
+  func finishRun() {
+    condition.lock()
+    running = false
+    condition.broadcast()
+    condition.unlock()
+  }
+
+  /// Register on the calling thread before dispatching the blocking wait.
+  /// Reusing a lease makes retries after a lost channel response idempotent.
+  func pause(leaseId: String) {
+    condition.lock()
+    mutationLeases.insert(leaseId)
+    condition.unlock()
+  }
+
+  /// Must run off the main thread and outside the runner's execution queue.
+  func waitUntilIdle() {
+    condition.lock()
+    defer { condition.unlock() }
+    while running { condition.wait() }
+  }
+
+  /// Successful account removal/reset also retires safety holds left by a
+  /// failed stop. Call while holding a separate mutation lease, after revoking
+  /// the corresponding outbox records. Other live mutation leases stay intact.
+  func discardStopLeases(network: String? = nil, accountUuid: String? = nil) {
+    let prefix: String
+    if let network, let accountUuid {
+      prefix = "stop:\(network):\(accountUuid):"
+    } else {
+      prefix = "stop:"
+    }
+    condition.lock()
+    mutationLeases = mutationLeases.filter { !$0.hasPrefix(prefix) }
+    condition.unlock()
+  }
+
+  /// Only the caller's lease is released; duplicate replies cannot release a
+  /// different mutation. Returns whether all callers have finished.
+  @discardableResult
+  func resume(leaseId: String) -> Bool {
+    condition.lock()
+    defer { condition.unlock() }
+    mutationLeases.remove(leaseId)
+    return mutationLeases.isEmpty
+  }
+}

--- a/ios/Runner/BackgroundMigrationOutboxRunner.swift
+++ b/ios/Runner/BackgroundMigrationOutboxRunner.swift
@@ -31,7 +31,6 @@ struct BackgroundMigrationOutboxRunnerDependencies {
 }
 
 enum BackgroundMigrationOutboxRunner {
-  private static let runLock = NSLock()
 
   static func runOnce(
     store: BackgroundMigrationOutboxStore = .shared,
@@ -40,13 +39,14 @@ enum BackgroundMigrationOutboxRunner {
     requiresPreparationProofVerification: Bool = false,
     dependencies: BackgroundMigrationOutboxRunnerDependencies = .live
   ) -> BackgroundMigrationOutboxRunResult {
-    guard runLock.try() else {
+    let gate = BackgroundMigrationOutboxExecutionGate.shared
+    guard gate.tryBeginRun() else {
       return BackgroundMigrationOutboxRunResult(
         transport: .temporarilyUnavailable,
         proofReady: nil
       )
     }
-    defer { runLock.unlock() }
+    defer { gate.finishRun() }
 
     if cancellation.isCancelled {
       return BackgroundMigrationOutboxRunResult(

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -1456,6 +1456,7 @@ final class BackgroundMigrationPreparationManager {
   }
 
   func resumeAfterMutation() {
+    guard !BackgroundMigrationOutboxExecutionGate.shared.isPaused else { return }
     stateLock.withPreparationLock {
       expired = false
       mutationQuiesced = false

--- a/ios/RunnerTests/BackgroundMigrationOutboxExecutionGateTests.swift
+++ b/ios/RunnerTests/BackgroundMigrationOutboxExecutionGateTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import XCTest
+#if canImport(Runner)
+@testable import Runner
+#endif
+
+final class BackgroundMigrationOutboxExecutionGateTests: XCTestCase {
+  func testIdlePauseBlocksAdmissionUntilResume() {
+    let gate = BackgroundMigrationOutboxExecutionGate()
+    gate.pause(leaseId: "a")
+    gate.waitUntilIdle()
+    XCTAssertFalse(gate.tryBeginRun())
+    XCTAssertTrue(gate.resume(leaseId: "a"))
+    XCTAssertTrue(gate.tryBeginRun())
+    gate.finishRun()
+  }
+
+  func testOverlappingAndRepeatedLeasesCannotResumeAnotherMutation() {
+    let gate = BackgroundMigrationOutboxExecutionGate()
+    gate.pause(leaseId: "a")
+    gate.pause(leaseId: "a") // lost quiesce response, same retry
+    gate.pause(leaseId: "b")
+    XCTAssertFalse(gate.resume(leaseId: "a"))
+    XCTAssertFalse(gate.resume(leaseId: "a")) // lost resume response
+    XCTAssertFalse(gate.tryBeginRun())
+    XCTAssertTrue(gate.resume(leaseId: "b"))
+    XCTAssertTrue(gate.tryBeginRun())
+    gate.finishRun()
+  }
+
+  func testAccountRemovalRetiresOnlyItsFailedStopLeases() {
+    let gate = BackgroundMigrationOutboxExecutionGate()
+    gate.pause(leaseId: "stop:test:a:run-a")
+    gate.pause(leaseId: "stop:test:b:run-b")
+    gate.pause(leaseId: "remove-a")
+    gate.discardStopLeases(network: "test", accountUuid: "a")
+    XCTAssertFalse(gate.resume(leaseId: "remove-a"))
+    XCTAssertFalse(gate.tryBeginRun())
+    XCTAssertTrue(gate.resume(leaseId: "stop:test:b:run-b"))
+  }
+
+  func testWalletResetPreservesOtherLiveMutationLeases() {
+    let gate = BackgroundMigrationOutboxExecutionGate()
+    gate.pause(leaseId: "stop:test:a:run-a")
+    gate.pause(leaseId: "reset")
+    gate.discardStopLeases()
+    XCTAssertFalse(gate.tryBeginRun())
+    XCTAssertTrue(gate.resume(leaseId: "reset"))
+  }
+
+  func testDrainWaitsForSuccessfulBroadcastAndReceipt() throws {
+    try verifyDrain(accepted: true)
+  }
+
+  func testDrainWaitsForUncertainBroadcastAndAttemptRecord() throws {
+    try verifyDrain(accepted: false)
+  }
+
+  private func verifyDrain(accepted: Bool) throws {
+    let gate = BackgroundMigrationOutboxExecutionGate.shared
+    let leaseId = "stop:test:a:" + UUID().uuidString
+    let sendStarted = DispatchSemaphore(value: 0)
+    let releaseSend = DispatchSemaphore(value: 0)
+    let drained = DispatchSemaphore(value: 0)
+    let runnerDone = DispatchSemaphore(value: 0)
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let store = BackgroundMigrationOutboxStore(
+      fileURL: directory.appendingPathComponent("outbox.bin"),
+      keyProvider: { Data(repeating: 0xCD, count: 32) }
+    )
+    defer {
+      releaseSend.signal()
+      gate.resume(leaseId: leaseId)
+      try? FileManager.default.removeItem(at: directory)
+    }
+    let item = BackgroundMigrationOutboxItem(
+      itemId: "item-a", partIndex: 0, txidHex: String(repeating: "a", count: 64),
+      rawTransaction: Data([1, 2]), anchorBoundaryHeight: 0,
+      scheduledHeight: 100, scheduleStartHeight: 99, expiryHeight: 69_120
+    )
+    let batch = BackgroundMigrationOutboxBatch(
+      batchId: "batch-a", network: "test", accountUuid: "a", runId: "run-a",
+      lightwalletdUrl: "https://example.invalid", timingMeanBlocks: 144,
+      timingMaxBlocks: 576, createdAt: Date(), armedAt: nil,
+      nextProofHeight: nil, proofReadyNotificationPendingAt: nil,
+      proofReadyNotifiedAt: nil, items: [item]
+    )
+    _ = try store.update {
+      try $0.stage(batch)
+      try $0.armBatch(batchId: batch.batchId,
+        expectedDigests: [item.itemId: item.payloadDigestHex], at: Date())
+    }
+    // Foreground recovery for any account enters this same wallet-wide runner.
+    DispatchQueue.global().async {
+      _ = BackgroundMigrationOutboxRunner.runOnce(
+        store: store, cancellation: BackgroundMigrationCancellation(),
+        dependencies: BackgroundMigrationOutboxRunnerDependencies(
+          latestBlockHeight: { _, _ in .success(100) },
+          sendTransaction: { _, _, cancellation in
+            sendStarted.signal()
+            guard releaseSend.wait(timeout: .now() + 5) == .success else {
+              XCTFail("Test did not release the broadcast")
+              return .failure(.timedOut)
+            }
+            XCTAssertFalse(cancellation.isCancelled)
+            return accepted
+              ? .success(NativeLightwalletdSendResponse(errorCode: 0, errorMessage: ""))
+              : .failure(.timedOut)
+          }
+        )
+      )
+      runnerDone.signal()
+    }
+    XCTAssertEqual(sendStarted.wait(timeout: .now() + 5), .success)
+    gate.pause(leaseId: leaseId)
+    DispatchQueue.global().async {
+      gate.waitUntilIdle()
+      drained.signal()
+    }
+    XCTAssertEqual(drained.wait(timeout: .now() + 0.05), .timedOut)
+    let blocked = BackgroundMigrationOutboxRunner.runOnce(
+      store: store, cancellation: BackgroundMigrationCancellation(),
+      dependencies: BackgroundMigrationOutboxRunnerDependencies(
+        latestBlockHeight: { _, _ in XCTFail("A paused runner contacted the network"); return .success(100) },
+        sendTransaction: { _, _, _ in XCTFail("A paused runner broadcast"); return .failure(.timedOut) }
+      )
+    )
+    XCTAssertEqual(blocked.transport, .temporarilyUnavailable)
+    releaseSend.signal()
+    XCTAssertEqual(drained.wait(timeout: .now() + 5), .success)
+    XCTAssertEqual(runnerDone.wait(timeout: .now() + 5), .success)
+    let snapshot = try store.read()
+    XCTAssertEqual(snapshot.batches.first?.items.first?.attemptCount, accepted ? 0 : 1)
+    if accepted {
+      XCTAssertEqual(snapshot.receipts.count, 1)
+      XCTAssertEqual(snapshot.receipts.first?.outcome, .accepted)
+    } else {
+      // A timeout is not evidence that no submission happened. Rust stop must
+      // reconcile this attempt rather than treating the input as unspent.
+      XCTAssertEqual(snapshot.batches.first?.items.first?.status, .armed)
+    }
+    XCTAssertFalse(gate.tryBeginRun())
+    gate.resume(leaseId: leaseId)
+    XCTAssertTrue(gate.tryBeginRun())
+    gate.finishRun()
+  }
+}

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_flow_screen.dart
@@ -45,6 +45,7 @@ part 'mobile_ironwood_migration_back_scope.dart';
 part 'mobile_ironwood_migration_routes.dart';
 part 'mobile_ironwood_migration_start.dart';
 part 'mobile_ironwood_migration_schedule.dart';
+part 'mobile_ironwood_migration_manage.dart';
 part 'mobile_ironwood_migration_intro_options.dart';
 part 'mobile_ironwood_migration_review.dart';
 part 'mobile_ironwood_migration_live_states.dart';

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_manage.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_manage.dart
@@ -157,6 +157,16 @@ class _MobileMigrationManageDialogState
                       child: Text(_submitting ? 'Stopping...' : 'Confirm'),
                     ),
                   ],
+                  if (_submitting) ...[
+                    const SizedBox(height: AppSpacing.sm),
+                    Text(
+                      'Waiting for any active broadcast to finish before '
+                      'stopping the remaining migration.',
+                      style: AppTypography.bodyMedium.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                  ],
                   if (_error != null || (!canStop && !_submitting)) ...[
                     const SizedBox(height: AppSpacing.sm),
                     Text(

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_manage.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_manage.dart
@@ -1,0 +1,200 @@
+part of 'mobile_ironwood_migration_flow_screen.dart';
+
+enum _MobileMigrationManageChoice { fast, stop }
+
+/// Keeps the confirmation mounted until native cleanup has finished, even when
+/// the durable Rust stop clears activeRunId before the service returns.
+class _MobileMigrationManageDialog extends ConsumerStatefulWidget {
+  const _MobileMigrationManageDialog({
+    required this.request,
+    required this.runId,
+  });
+
+  final IronwoodMigrationStatusRequest request;
+  final String runId;
+
+  @override
+  ConsumerState<_MobileMigrationManageDialog> createState() =>
+      _MobileMigrationManageDialogState();
+}
+
+class _MobileMigrationManageDialogState
+    extends ConsumerState<_MobileMigrationManageDialog> {
+  _MobileMigrationManageChoice? _choice;
+  bool _submitting = false;
+  bool _stopAttempted = false;
+  String? _error;
+
+  bool _canStop(rust_sync.MigrationStatus? status) {
+    if (ref.read(ironwoodMigrationInputsProvider).statusRequest !=
+        widget.request) {
+      return false;
+    }
+    if (status == null) return false;
+    // A failed native cleanup can follow a committed Rust stop. Retry the same
+    // run's idempotent cleanup, but never authorize stopping a newer run.
+    if (_stopAttempted && status.activeRunId == null) return true;
+    return status.activeRunId == widget.runId && status.canAbandon;
+  }
+
+  Future<void> _confirm() async {
+    final choice = _choice;
+    if (_submitting || choice == null) return;
+    final status = ref
+        .read(ironwoodMigrationStatusProvider(widget.request))
+        .asData
+        ?.value;
+    if (!_canStop(status)) return;
+    setState(() {
+      _submitting = true;
+      _stopAttempted = true;
+      _error = null;
+    });
+    try {
+      await ref
+          .read(ironwoodMigrationCoordinatorProvider.notifier)
+          .stop(accountUuid: widget.request.accountUuid, runId: widget.runId);
+      if (!mounted) return;
+      Navigator.of(context).pop(choice);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _submitting = false;
+        _error = 'The migration could not be updated. Please try again.';
+      });
+      ref.invalidate(ironwoodMigrationStatusProvider(widget.request));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.watch(ironwoodMigrationInputsProvider);
+    final status = ref.watch(ironwoodMigrationStatusProvider(widget.request));
+    final canStop = _canStop(status.asData?.value);
+    final statusMessage = status.isLoading
+        ? 'Checking migration status...'
+        : status.hasError
+        ? "Couldn't check the migration status. Please try again."
+        : 'This migration is no longer available to manage.';
+    final colors = context.colors;
+    final choice = _choice;
+    final fast = choice == _MobileMigrationManageChoice.fast;
+    return PopScope(
+      canPop: !_submitting,
+      child: Dialog(
+        key: const ValueKey('mobile_ironwood_manage_dialog'),
+        backgroundColor: colors.background.ground,
+        insetPadding: const EdgeInsets.all(AppSpacing.md),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 360),
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    choice == null
+                        ? 'Manage migration'
+                        : fast
+                        ? 'Switch to Fast?'
+                        : 'Stop migration?',
+                    style: AppTypography.bodyLarge.copyWith(
+                      color: colors.text.accent,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  if (choice == null) ...[
+                    AppButton(
+                      key: const ValueKey('mobile_ironwood_manage_fast'),
+                      expand: true,
+                      onPressed: canStop
+                          ? () => setState(() {
+                              _choice = _MobileMigrationManageChoice.fast;
+                            })
+                          : null,
+                      child: const Text('Switch to Fast'),
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                    AppButton(
+                      key: const ValueKey('mobile_ironwood_manage_stop'),
+                      expand: true,
+                      variant: AppButtonVariant.ghost,
+                      onPressed: canStop
+                          ? () => setState(() {
+                              _choice = _MobileMigrationManageChoice.stop;
+                            })
+                          : null,
+                      child: const Text('Stop migration'),
+                    ),
+                  ] else ...[
+                    Text(
+                      fast
+                          ? 'Stop the private schedule and review a Fast '
+                                'migration for your remaining balance. Fast '
+                                'migration increases traceability and cannot '
+                                'be reversed once submitted.'
+                          : 'Stop the remaining migration. Funds already '
+                                'migrated will stay in Ironwood.',
+                      style: AppTypography.bodyMedium.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.sm),
+                    Text(
+                      'Transactions already broadcast will not be reverted.',
+                      style: AppTypography.bodyMedium.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.md),
+                    AppButton(
+                      key: const ValueKey('mobile_ironwood_manage_confirm'),
+                      expand: true,
+                      onPressed: !_submitting && canStop ? _confirm : null,
+                      child: Text(_submitting ? 'Stopping...' : 'Confirm'),
+                    ),
+                  ],
+                  if (_error != null || (!canStop && !_submitting)) ...[
+                    const SizedBox(height: AppSpacing.sm),
+                    Text(
+                      _error ?? statusMessage,
+                      style: AppTypography.bodyMedium.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                  ],
+                  if (status.hasError && !_submitting) ...[
+                    const SizedBox(height: AppSpacing.xs),
+                    AppButton(
+                      key: const ValueKey(
+                        'mobile_ironwood_manage_retry_status',
+                      ),
+                      expand: true,
+                      onPressed: () => ref.invalidate(
+                        ironwoodMigrationStatusProvider(widget.request),
+                      ),
+                      child: const Text('Retry status check'),
+                    ),
+                  ],
+                  const SizedBox(height: AppSpacing.xs),
+                  AppButton(
+                    key: const ValueKey('mobile_ironwood_manage_cancel'),
+                    expand: true,
+                    variant: AppButtonVariant.ghost,
+                    onPressed: _submitting
+                        ? null
+                        : () => Navigator.of(context).pop(),
+                    child: const Text('Cancel'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_schedule.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_schedule.dart
@@ -31,7 +31,7 @@ class MobileIronwoodMigrationPreparationScheduleScreen extends ConsumerWidget {
   }
 }
 
-class _MobileMigrationScheduleLoader extends ConsumerWidget {
+class _MobileMigrationScheduleLoader extends ConsumerStatefulWidget {
   const _MobileMigrationScheduleLoader({
     required this.previewStatus,
     required this.preparation,
@@ -41,8 +41,49 @@ class _MobileMigrationScheduleLoader extends ConsumerWidget {
   final bool preparation;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final preview = previewStatus;
+  ConsumerState<_MobileMigrationScheduleLoader> createState() =>
+      _MobileMigrationScheduleLoaderState();
+}
+
+class _MobileMigrationScheduleLoaderState
+    extends ConsumerState<_MobileMigrationScheduleLoader> {
+  bool _managing = false;
+
+  Future<void> _manage(
+    IronwoodMigrationStatusRequest request,
+    String runId,
+  ) async {
+    if (_managing) return;
+    setState(() => _managing = true);
+    final appTheme = AppTheme.of(context);
+    try {
+      final choice = await showDialog<_MobileMigrationManageChoice>(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => AppTheme(
+          data: appTheme,
+          child: _MobileMigrationManageDialog(request: request, runId: runId),
+        ),
+      );
+      if (!mounted || choice == null) return;
+      // A lock or account switch must not send a different wallet into Fast.
+      if (ref.read(ironwoodMigrationInputsProvider).statusRequest != request) {
+        return;
+      }
+      if (choice == _MobileMigrationManageChoice.fast) {
+        ref.invalidate(ironwoodMigrationImmediatePlanProvider);
+        context.go('/migration/fast/review');
+      } else {
+        context.go('/home');
+      }
+    } finally {
+      if (mounted) setState(() => _managing = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final preview = widget.previewStatus;
     final syncState = ref.watch(syncProvider).asData?.value;
     if (preview != null) {
       return _screen(
@@ -71,6 +112,7 @@ class _MobileMigrationScheduleLoader extends ConsumerWidget {
             return _screen(
               context,
               status: cached,
+              request: request,
               currentHeight: _mobileMigrationHeight(syncState),
               unavailable: cached == null,
               onRetry: () =>
@@ -80,6 +122,7 @@ class _MobileMigrationScheduleLoader extends ConsumerWidget {
           data: (status) => _screen(
             context,
             status: status,
+            request: request,
             currentHeight: _mobileMigrationHeight(syncState),
           ),
         );
@@ -89,9 +132,18 @@ class _MobileMigrationScheduleLoader extends ConsumerWidget {
     BuildContext context, {
     rust_sync.MigrationStatus? status,
     required int currentHeight,
+    IronwoodMigrationStatusRequest? request,
     bool unavailable = false,
     VoidCallback? onRetry,
   }) {
+    final canManage =
+        request != null &&
+        status?.activeRunId != null &&
+        status?.canAbandon == true &&
+        supportsPrivateMobileIronwoodMigration();
+    final VoidCallback? onManage = canManage && !_managing
+        ? () => _manage(request, status!.activeRunId!)
+        : null;
     void returnToStatus() {
       if (context.canPop()) {
         context.pop();
@@ -110,7 +162,7 @@ class _MobileMigrationScheduleLoader extends ConsumerWidget {
           child: Column(
             children: [
               MobileTopNav.back(
-                title: preparation
+                title: widget.preparation
                     ? 'Preparation Schedule'
                     : 'Migration Schedule',
                 titleStyle: AppTypography.headlineSmall.copyWith(
@@ -129,16 +181,18 @@ class _MobileMigrationScheduleLoader extends ConsumerWidget {
                           semanticLabel: 'Loading migration schedule',
                         ),
                       )
-                    : preparation
+                    : widget.preparation
                     ? _MobilePreparationScheduleContent(
                         status: status,
                         currentHeight: currentHeight,
                         onReturn: returnToStatus,
+                        onManage: onManage,
                       )
                     : _MobileMigrationScheduleContent(
                         status: status,
                         currentHeight: currentHeight,
                         onReturn: returnToStatus,
+                        onManage: onManage,
                       ),
               ),
             ],
@@ -154,11 +208,13 @@ class _MobileMigrationScheduleContent extends StatelessWidget {
     required this.status,
     required this.currentHeight,
     required this.onReturn,
+    this.onManage,
   });
 
   final rust_sync.MigrationStatus status;
   final int currentHeight;
   final VoidCallback onReturn;
+  final VoidCallback? onManage;
 
   @override
   Widget build(BuildContext context) {
@@ -246,6 +302,7 @@ class _MobileMigrationScheduleContent extends StatelessWidget {
             secondaryLabel: 'Duration',
             secondaryValue: duration,
             onReturn: onReturn,
+            onManage: onManage,
           ),
         ],
       ),
@@ -356,11 +413,13 @@ class _MobilePreparationScheduleContent extends StatelessWidget {
     required this.status,
     required this.currentHeight,
     required this.onReturn,
+    this.onManage,
   });
 
   final rust_sync.MigrationStatus status;
   final int currentHeight;
   final VoidCallback onReturn;
+  final VoidCallback? onManage;
 
   @override
   Widget build(BuildContext context) {
@@ -431,6 +490,7 @@ class _MobilePreparationScheduleContent extends StatelessWidget {
             secondaryLabel: 'Ready in',
             secondaryValue: duration,
             onReturn: onReturn,
+            onManage: onManage,
           ),
         ],
       ),
@@ -749,6 +809,7 @@ class _MobileMigrationScheduleFooter extends StatelessWidget {
     required this.secondaryLabel,
     required this.secondaryValue,
     required this.onReturn,
+    this.onManage,
   });
 
   final String primaryIcon;
@@ -758,6 +819,7 @@ class _MobileMigrationScheduleFooter extends StatelessWidget {
   final String secondaryLabel;
   final String secondaryValue;
   final VoidCallback onReturn;
+  final VoidCallback? onManage;
 
   @override
   Widget build(BuildContext context) {
@@ -798,6 +860,16 @@ class _MobileMigrationScheduleFooter extends StatelessWidget {
                 ],
               ),
             ),
+            if (onManage != null) ...[
+              AppButton(
+                key: const ValueKey('mobile_ironwood_schedule_manage_button'),
+                variant: AppButtonVariant.ghost,
+                expand: true,
+                leading: const AppIcon(AppIcons.wrench, size: 20),
+                onPressed: onManage,
+                child: const Text('Manage'),
+              ),
+            ],
             const SizedBox(height: AppSpacing.s),
             SizedBox(
               width: double.infinity,

--- a/lib/src/features/migration/services/ironwood_migration_background_credential_store.dart
+++ b/lib/src/features/migration/services/ironwood_migration_background_credential_store.dart
@@ -479,13 +479,26 @@ class IronwoodMigrationBackgroundLifecycle {
 
   static final instance = IronwoodMigrationBackgroundLifecycle();
   static final Object _callerManagedQuiescenceZoneKey = Object();
+  static final Object _quiescenceLeaseZoneKey = Object();
 
   final IronwoodMigrationBackgroundCredentialStore _credentialStore;
   final MethodChannel _channel;
   final bool _isIOS;
   final bool _isAndroid;
   final List<Duration> _resumeRetryDelays;
-  final Queue<String> _androidQuiescenceLeaseIds = Queue<String>();
+  final Queue<String> _quiescenceLeaseIds = Queue<String>();
+  final Set<String> _pendingResumeLeaseIds = <String>{};
+
+  /// A stop retry must release the same native lease left by failed cleanup.
+  /// Async-local binding also prevents overlapping accounts from releasing one
+  /// another's leases when they finish in a different order.
+  static Future<T> runWithQuiescenceLease<T>(
+    String leaseId,
+    Future<T> Function() action,
+  ) => runZoned(action, zoneValues: {_quiescenceLeaseZoneKey: leaseId});
+
+  String? get _scopedLeaseId =>
+      Zone.current[_quiescenceLeaseZoneKey] as String?;
 
   bool get isQuiescenceManagedByCaller =>
       Zone.current[_callerManagedQuiescenceZoneKey] == true;
@@ -499,12 +512,11 @@ class IronwoodMigrationBackgroundLifecycle {
 
   Future<void> quiesce() async {
     if (!_isIOS && !_isAndroid) return;
-    final leaseId = _isAndroid ? _newAndroidQuiescenceLeaseId() : null;
-    if (leaseId != null) _androidQuiescenceLeaseIds.addLast(leaseId);
-    final quiesced = await _channel.invokeMethod<bool>(
-      'quiesce',
-      leaseId == null ? null : {'leaseId': leaseId},
-    );
+    final leaseId = _scopedLeaseId ?? _newQuiescenceLeaseId();
+    if (_scopedLeaseId == null) _quiescenceLeaseIds.addLast(leaseId);
+    final quiesced = await _channel.invokeMethod<bool>('quiesce', {
+      'leaseId': leaseId,
+    });
     if (quiesced != true) {
       throw StateError(
         'Failed to pause Ironwood migration before wallet data changed.',
@@ -514,39 +526,53 @@ class IronwoodMigrationBackgroundLifecycle {
 
   Future<void> resumeAfterMutation() async {
     if (!_isIOS && !_isAndroid) return;
-    final leaseId = _isAndroid && _androidQuiescenceLeaseIds.isNotEmpty
-        ? _androidQuiescenceLeaseIds.first
-        : null;
+    final scopedLeaseId = _scopedLeaseId;
+    // Reserve before awaiting the channel so concurrent resumes cannot select
+    // the same lease. Retries within this call keep using the reserved ID.
+    final leaseId =
+        scopedLeaseId ??
+        (_quiescenceLeaseIds.isNotEmpty
+            ? _quiescenceLeaseIds.removeFirst()
+            : _newQuiescenceLeaseId());
+    // Failed releases belong to completed mutations, not the pause queue.
+    // Try them separately and always release this mutation's own lease too.
+    final pendingLeaseIds = _pendingResumeLeaseIds.toList();
+    _pendingResumeLeaseIds.clear();
     Object? lastError;
-    for (final delay in _resumeRetryDelays) {
-      if (delay != Duration.zero) await Future<void>.delayed(delay);
-      try {
-        final resumed = await _channel.invokeMethod<bool>(
-          'resume',
-          leaseId == null ? null : {'leaseId': leaseId},
-        );
-        if (resumed == true) {
-          if (leaseId != null &&
-              _androidQuiescenceLeaseIds.isNotEmpty &&
-              _androidQuiescenceLeaseIds.first == leaseId) {
-            _androidQuiescenceLeaseIds.removeFirst();
+    for (final id in {...pendingLeaseIds, leaseId}) {
+      Object? releaseError;
+      var released = false;
+      for (final delay in _resumeRetryDelays) {
+        if (delay != Duration.zero) await Future<void>.delayed(delay);
+        try {
+          final resumed = await _channel.invokeMethod<bool>('resume', {
+            'leaseId': id,
+          });
+          if (resumed == true) {
+            released = true;
+            break;
           }
-          return;
+          releaseError = StateError('Native migration resume returned false.');
+        } catch (error) {
+          releaseError = error;
         }
-        lastError = StateError('Native migration resume returned false.');
-      } catch (error) {
-        lastError = error;
+      }
+      if (!released) {
+        if (id != scopedLeaseId) _pendingResumeLeaseIds.add(id);
+        lastError =
+            releaseError ?? StateError('Native resume was not attempted.');
       }
     }
+    if (lastError == null) return;
     throw StateError(
       'Failed to resume Ironwood migration after wallet data changed'
-      '${lastError == null ? '.' : ': $lastError'}',
+      ': $lastError',
     );
   }
 
   Future<void> resumeAfterFailedMutation() => resumeAfterMutation();
 
-  static String _newAndroidQuiescenceLeaseId() {
+  static String _newQuiescenceLeaseId() {
     final bytes = Uint8List(16);
     final random = Random.secure();
     for (var index = 0; index < bytes.length; index++) {

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -1144,126 +1144,129 @@ class IronwoodMigrationService {
           accountUuid: accountUuid,
           lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
         );
-        await _serializeCredentialState(context, () async {
-          var quiesceAttempted = false;
-          var mayResumeBackgroundWork = true;
-          try {
-            // Native may already have acquired its mutation lease even if the
-            // MethodChannel reply is lost, so every attempt gets a matching
-            // best-effort resume.
-            if (_usesNativeMigrationLifecycle) {
-              quiesceAttempted = true;
-              await quiesceBackgroundMigration();
-            }
-            final currentStatus = await _getStatusForContext(context);
-            if (currentStatus.activeRunId == null) {
-              // This is a cleanup retry after the durable run became
-              // terminal. Revoke the stale native batch before retrying
-              // idempotent Rust cleanup, so a cleanup error can never resume
-              // abandoned work.
+        await IronwoodMigrationBackgroundLifecycle.runWithQuiescenceLease(
+          'stop:${context.network}:${context.accountUuid}:$expectedRunId',
+          () => _serializeCredentialState(context, () async {
+            var quiesceAttempted = false;
+            var mayResumeBackgroundWork = true;
+            try {
+              // Native may already have acquired its mutation lease even if the
+              // MethodChannel reply is lost, so every attempt gets a matching
+              // best-effort resume.
               if (_usesNativeMigrationLifecycle) {
-                mayResumeBackgroundWork = false;
-                await revokeMigrationAccount(
+                quiesceAttempted = true;
+                await quiesceBackgroundMigration();
+              }
+              final currentStatus = await _getStatusForContext(context);
+              if (currentStatus.activeRunId == null) {
+                // This is a cleanup retry after the durable run became
+                // terminal. Revoke the stale native batch before retrying
+                // idempotent Rust cleanup, so a cleanup error can never resume
+                // abandoned work.
+                if (_usesNativeMigrationLifecycle) {
+                  mayResumeBackgroundWork = false;
+                  await revokeMigrationAccount(
+                    network: context.network,
+                    accountUuid: context.accountUuid,
+                  );
+                  mayResumeBackgroundWork = true;
+                }
+                await stopMigrationRun(
+                  dbPath: context.dbPath,
+                  lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
                   network: context.network,
                   accountUuid: context.accountUuid,
+                  expectedRunId: expectedRunId,
+                  nativeAttemptedTxids: const [],
                 );
-                mayResumeBackgroundWork = true;
+                return;
               }
-              await stopMigrationRun(
-                dbPath: context.dbPath,
-                lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-                network: context.network,
-                accountUuid: context.accountUuid,
-                expectedRunId: expectedRunId,
-                nativeAttemptedTxids: const [],
-              );
-              return;
-            }
 
-            var nativeAttemptedTxids = const <String>[];
-            if (_usesNativeMigrationOutbox) {
-              final receipts = await _reconcileMigrationOutboxReceipts(
-                context: context,
-              );
-              if (receipts.unreconciledCount > 0) {
-                throw StateError(
-                  'Migration cannot stop until submitted transactions are '
-                  'reconciled.',
+              var nativeAttemptedTxids = const <String>[];
+              if (_usesNativeMigrationOutbox) {
+                final receipts = await _reconcileMigrationOutboxReceipts(
+                  context: context,
+                );
+                if (receipts.unreconciledCount > 0) {
+                  throw StateError(
+                    'Migration cannot stop until submitted transactions are '
+                    'reconciled.',
+                  );
+                }
+                nativeAttemptedTxids = await listMigrationOutboxAttemptedTxids(
+                  network: context.network,
+                  accountUuid: context.accountUuid,
+                  runId: expectedRunId,
                 );
               }
-              nativeAttemptedTxids = await listMigrationOutboxAttemptedTxids(
-                network: context.network,
-                accountUuid: context.accountUuid,
-                runId: expectedRunId,
-              );
-            }
-            if (currentStatus.activeRunId != expectedRunId) {
-              // A retry after the Rust transaction committed must still finish
-              // wallet-lock reconciliation, but a stale UI must never revoke
-              // the native credential/outbox belonging to a newer run.
-              await stopMigrationRun(
-                dbPath: context.dbPath,
-                lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-                network: context.network,
-                accountUuid: context.accountUuid,
-                expectedRunId: expectedRunId,
-                nativeAttemptedTxids: nativeAttemptedTxids,
-              );
-              return;
-            }
+              if (currentStatus.activeRunId != expectedRunId) {
+                // A retry after the Rust transaction committed must still finish
+                // wallet-lock reconciliation, but a stale UI must never revoke
+                // the native credential/outbox belonging to a newer run.
+                await stopMigrationRun(
+                  dbPath: context.dbPath,
+                  lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+                  network: context.network,
+                  accountUuid: context.accountUuid,
+                  expectedRunId: expectedRunId,
+                  nativeAttemptedTxids: nativeAttemptedTxids,
+                );
+                return;
+              }
 
-            try {
-              await stopMigrationRun(
-                dbPath: context.dbPath,
-                lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-                network: context.network,
-                accountUuid: context.accountUuid,
-                expectedRunId: expectedRunId,
-                nativeAttemptedTxids: nativeAttemptedTxids,
-              );
-            } catch (stopError, stopStackTrace) {
-              // A local FFI response can be lost after Rust committed. Re-read
-              // the durable projection before deciding whether native work may
-              // resume or still needs to be revoked.
               try {
-                final afterFailure = await _getStatusForContext(context);
-                if (afterFailure.activeRunId == expectedRunId ||
-                    afterFailure.activeRunId != null) {
+                await stopMigrationRun(
+                  dbPath: context.dbPath,
+                  lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+                  network: context.network,
+                  accountUuid: context.accountUuid,
+                  expectedRunId: expectedRunId,
+                  nativeAttemptedTxids: nativeAttemptedTxids,
+                );
+              } catch (stopError, stopStackTrace) {
+                // A local FFI response can be lost after Rust committed. Re-read
+                // the durable projection before deciding whether native work may
+                // resume or still needs to be revoked.
+                try {
+                  final afterFailure = await _getStatusForContext(context);
+                  if (afterFailure.activeRunId == expectedRunId ||
+                      afterFailure.activeRunId != null) {
+                    Error.throwWithStackTrace(stopError, stopStackTrace);
+                  }
+                } catch (statusError) {
+                  if (identical(statusError, stopError)) rethrow;
                   Error.throwWithStackTrace(stopError, stopStackTrace);
                 }
-              } catch (statusError) {
-                if (identical(statusError, stopError)) rethrow;
-                Error.throwWithStackTrace(stopError, stopStackTrace);
               }
-            }
 
-            if (_usesNativeMigrationLifecycle) {
-              try {
-                // Rust has already made the run terminal. If this reply is
-                // lost, leave native quiesced; a later idempotent stop retries
-                // only this cleanup and cannot submit the abandoned batch.
-                await revokeMigrationAccount(
-                  network: context.network,
-                  accountUuid: context.accountUuid,
-                );
-              } catch (error, stackTrace) {
-                mayResumeBackgroundWork = false;
-                Error.throwWithStackTrace(error, stackTrace);
+              if (_usesNativeMigrationLifecycle) {
+                try {
+                  // Rust has already made the run terminal. If this reply is
+                  // lost, leave native quiesced; a later idempotent stop retries
+                  // only this cleanup and cannot submit the abandoned batch.
+                  await revokeMigrationAccount(
+                    network: context.network,
+                    accountUuid: context.accountUuid,
+                  );
+                } catch (error, stackTrace) {
+                  mayResumeBackgroundWork = false;
+                  Error.throwWithStackTrace(error, stackTrace);
+                }
+              }
+            } finally {
+              if (quiesceAttempted && mayResumeBackgroundWork) {
+                try {
+                  await resumeBackgroundMigration();
+                } catch (error) {
+                  debugPrint(
+                    'Failed to resume Ironwood background work after stop: '
+                    '$error',
+                  );
+                }
               }
             }
-          } finally {
-            if (quiesceAttempted && mayResumeBackgroundWork) {
-              try {
-                await resumeBackgroundMigration();
-              } catch (error) {
-                debugPrint(
-                  'Failed to resume Ironwood background work after stop: '
-                  '$error',
-                );
-              }
-            }
-          }
-        });
+          }),
+        );
       },
     );
   }

--- a/scripts/test-ios-migration-outbox-gate.sh
+++ b/scripts/test-ios-migration-outbox-gate.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Run the production Swift outbox/gate/store with injected transport on macOS.
+# No simulator, wallet DB, Keychain reads, or network access is needed.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+test_dir="$(mktemp -d "${TMPDIR:-/tmp}/vizor-outbox-tests.XXXXXX")"
+trap 'rm -rf "$test_dir"' EXIT
+cat > "$test_dir/TransportStub.swift" <<'SWIFT'
+import Foundation
+final class BackgroundMigrationCancellation: @unchecked Sendable {
+  private let lock = NSLock()
+  private var cancelled = false
+  var isCancelled: Bool { lock.lock(); defer { lock.unlock() }; return cancelled }
+  func cancel() { lock.lock(); cancelled = true; lock.unlock() }
+}
+enum NativeLightwalletdError: Error, Equatable { case cancelled, timedOut }
+struct NativeLightwalletdSendResponse { let errorCode: Int32; let errorMessage: String }
+enum NativeLightwalletdClient {
+  static func latestBlockHeight(endpoint: String, cancellation: BackgroundMigrationCancellation) -> Result<UInt64, NativeLightwalletdError> { fatalError("Inject transport in tests") }
+  static func sendTransaction(endpoint: String, rawTransaction: Data, cancellation: BackgroundMigrationCancellation) -> Result<NativeLightwalletdSendResponse, NativeLightwalletdError> { fatalError("Inject transport in tests") }
+}
+SWIFT
+cat > "$test_dir/main.swift" <<'SWIFT'
+import XCTest
+import Darwin
+let suite = BackgroundMigrationOutboxExecutionGateTests.defaultTestSuite
+suite.run()
+exit(suite.testRun?.hasSucceeded == true && suite.testCaseCount == 6 ? 0 : 1)
+SWIFT
+test_frameworks="$(xcrun --show-sdk-platform-path)/Developer/Library/Frameworks"
+test_libraries="$(xcrun --show-sdk-platform-path)/Developer/usr/lib"
+test_private_frameworks="$(xcrun --show-sdk-platform-path)/Developer/Library/PrivateFrameworks"
+xcrun swiftc -swift-version 5 -Xlinker -rpath -Xlinker "$test_private_frameworks" -I "$test_libraries" -L "$test_libraries" -Xlinker -rpath -Xlinker "$test_libraries" -F "$test_frameworks" -Xlinker -rpath -Xlinker "$test_frameworks" \
+  ios/Runner/BackgroundMigrationOutboxExecutionGate.swift \
+  ios/Runner/BackgroundMigrationOutbox.swift \
+  ios/Runner/BackgroundMigrationOutboxStore.swift \
+  ios/Runner/BackgroundMigrationOutboxRunner.swift \
+  "$test_dir/TransportStub.swift" \
+  ios/RunnerTests/BackgroundMigrationOutboxExecutionGateTests.swift \
+  "$test_dir/main.swift" -o "$test_dir/tests"
+"$test_dir/tests"

--- a/test/features/migration/ironwood_migration_background_credential_store_test.dart
+++ b/test/features/migration/ironwood_migration_background_credential_store_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/services.dart';
@@ -10,6 +11,39 @@ void main() {
 
   setUp(() {
     FlutterSecureStorage.setMockInitialValues({});
+  });
+
+  test('failed resume does not displace the next mutation lease', () async {
+    const channel = MethodChannel('test/background_migration/failed_release');
+    final active = <String>{};
+    var failResume = true;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          final id = (call.arguments as Map)['leaseId'] as String;
+          if (call.method == 'quiesce') active.add(id);
+          if (call.method == 'resume') {
+            if (failResume) throw PlatformException(code: 'unavailable');
+            active.remove(id);
+          }
+          return true;
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null),
+    );
+    final lifecycle = IronwoodMigrationBackgroundLifecycle(
+      channel: channel,
+      isIOS: true,
+      isAndroid: false,
+      resumeRetryDelays: const [Duration.zero, Duration.zero],
+    );
+    await lifecycle.quiesce();
+    await expectLater(lifecycle.resumeAfterMutation(), throwsStateError);
+    await lifecycle.quiesce();
+    expect(active, hasLength(2));
+    failResume = false;
+    await lifecycle.resumeAfterMutation();
+    expect(active, isEmpty);
   });
 
   test('manifest round-trips through scoped secure storage', () async {
@@ -305,6 +339,137 @@ void main() {
         'network': 'test',
         'accountUuid': 'account-1',
       });
+    },
+  );
+
+  test(
+    'iOS scoped leases resume the matching account when completion order reverses',
+    () async {
+      const channel = MethodChannel('test/background_migration/scoped_leases');
+      final calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            calls.add(call);
+            return true;
+          });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null),
+      );
+      final lifecycle = IronwoodMigrationBackgroundLifecycle(
+        channel: channel,
+        isIOS: true,
+      );
+      final aPaused = Completer<void>();
+      final releaseA = Completer<void>();
+      final a = IronwoodMigrationBackgroundLifecycle.runWithQuiescenceLease(
+        'stop:test:a:run-a',
+        () async {
+          await lifecycle.quiesce();
+          aPaused.complete();
+          await releaseA.future;
+          await lifecycle.resumeAfterMutation();
+        },
+      );
+      await aPaused.future;
+      await IronwoodMigrationBackgroundLifecycle.runWithQuiescenceLease(
+        'stop:test:b:run-b',
+        () async {
+          await lifecycle.quiesce();
+          await lifecycle.resumeAfterMutation();
+        },
+      );
+      releaseA.complete();
+      await a;
+      expect(calls.map((call) => (call.arguments as Map)['leaseId']), [
+        'stop:test:a:run-a',
+        'stop:test:b:run-b',
+        'stop:test:b:run-b',
+        'stop:test:a:run-a',
+      ]);
+    },
+  );
+
+  test(
+    'iOS cleanup retry reuses its retained lease without consuming another mutation',
+    () async {
+      const channel = MethodChannel('test/background_migration/retained_lease');
+      final active = <String>{};
+      var loseResumeReply = true;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            final lease = (call.arguments as Map)['leaseId'] as String;
+            if (call.method == 'quiesce') active.add(lease);
+            if (call.method == 'resume') {
+              active.remove(lease);
+              if (loseResumeReply) {
+                loseResumeReply = false;
+                throw PlatformException(code: 'lost_reply');
+              }
+            }
+            return true;
+          });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null),
+      );
+      final lifecycle = IronwoodMigrationBackgroundLifecycle(
+        channel: channel,
+        isIOS: true,
+        resumeRetryDelays: const [Duration.zero, Duration.zero],
+      );
+      await IronwoodMigrationBackgroundLifecycle.runWithQuiescenceLease(
+        'stop:test:a:run-a',
+        lifecycle.quiesce,
+      );
+      await IronwoodMigrationBackgroundLifecycle.runWithQuiescenceLease(
+        'other-mutation',
+        lifecycle.quiesce,
+      );
+      await IronwoodMigrationBackgroundLifecycle.runWithQuiescenceLease(
+        'stop:test:a:run-a',
+        () async {
+          await lifecycle.quiesce();
+          expect(active, {'stop:test:a:run-a', 'other-mutation'});
+          await lifecycle.resumeAfterMutation();
+        },
+      );
+      expect(active, {'other-mutation'});
+    },
+  );
+
+  test(
+    'overlapping unscoped iOS resumes reserve different leases before awaiting',
+    () async {
+      const channel = MethodChannel(
+        'test/background_migration/concurrent_resume',
+      );
+      final resumed = <String>[];
+      final release = Completer<void>();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            if (call.method == 'resume') {
+              resumed.add((call.arguments as Map)['leaseId'] as String);
+              if (resumed.length == 2) release.complete();
+              await release.future;
+            }
+            return true;
+          });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null),
+      );
+      final lifecycle = IronwoodMigrationBackgroundLifecycle(
+        channel: channel,
+        isIOS: true,
+      );
+      await lifecycle.quiesce();
+      await lifecycle.quiesce();
+      await Future.wait([
+        lifecycle.resumeAfterMutation(),
+        lifecycle.resumeAfterMutation(),
+      ]);
+      expect(resumed.toSet(), hasLength(2));
     },
   );
 

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -218,6 +218,81 @@ void main() {
     },
   );
 
+  test(
+    'iOS stop keeps the same native lease across failed cleanup and retry',
+    () async {
+      const channel = MethodChannel('test/background_migration/stop_lease');
+      final calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            calls.add(call);
+            return true;
+          });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null),
+      );
+      final lifecycle = IronwoodMigrationBackgroundLifecycle(
+        channel: channel,
+        isIOS: true,
+      );
+      var terminal = false;
+      var revokeCalls = 0;
+      final service = IronwoodMigrationService(
+        operationRegistry: IronwoodMigrationOperationRegistry(),
+        getWalletDbPath: () async => '/tmp/wallet.db',
+        getStatus:
+            ({required dbPath, required network, required accountUuid}) async =>
+                _migrationStatus(activeRunId: terminal ? null : 'run-a'),
+        getPrivatePlan:
+            ({required dbPath, required network, required accountUuid}) async =>
+                null,
+        secureStore: AppSecureStore.testing(
+          storage: const FlutterSecureStorage(),
+        ),
+        getEndpoint: _testEndpoint,
+        isMobile: () => true,
+        isIOS: () => true,
+        isAndroid: () => false,
+        quiesceBackgroundMigration: lifecycle.quiesce,
+        resumeBackgroundMigration: lifecycle.resumeAfterMutation,
+        listMigrationOutboxReceipts: () async => const [],
+        listMigrationOutboxAttemptedTxids:
+            ({required network, required accountUuid, required runId}) async =>
+                const [],
+        revokeMigrationAccount:
+            ({required network, required accountUuid}) async {
+              if (++revokeCalls == 1) throw StateError('Native revoke failed');
+            },
+        stopMigrationRun:
+            ({
+              required dbPath,
+              required lightwalletdUrl,
+              required network,
+              required accountUuid,
+              required expectedRunId,
+              required nativeAttemptedTxids,
+            }) async {
+              terminal = true;
+            },
+      );
+      await expectLater(
+        service.stop(accountUuid: 'account-a', expectedRunId: 'run-a'),
+        throwsStateError,
+      );
+      expect(calls.map((call) => call.method), ['quiesce']);
+      await service.stop(accountUuid: 'account-a', expectedRunId: 'run-a');
+      expect(calls.map((call) => call.method), [
+        'quiesce',
+        'quiesce',
+        'resume',
+      ]);
+      expect(calls.map((call) => (call.arguments as Map)['leaseId']).toSet(), {
+        'stop:test:account-a:run-a',
+      });
+    },
+  );
+
   test('stop drains native work before abandoning the durable run', () async {
     final events = <String>[];
     final service = IronwoodMigrationService(

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -49,6 +49,7 @@ import 'package:zcash_wallet/src/rust/wallet/keystone.dart'
 import 'package:zcash_wallet/src/services/qr_scanner.dart';
 
 import '../../fakes/fake_sync_notifier.dart';
+import '../../figma_compare/figma_compare_font_loader.dart';
 
 final _rustApiFake = _RustApiFake();
 
@@ -188,6 +189,23 @@ class _HardwareAccountNotifier extends AccountNotifier {
   @override
   Future<AccountState> build() async =>
       _bootstrap(hardware: true).initialAccountState;
+}
+
+class _ManageTestMigrationCoordinator extends IronwoodMigrationCoordinator {
+  _ManageTestMigrationCoordinator(this.onStop);
+
+  final Future<void> Function(String accountUuid, String runId) onStop;
+
+  @override
+  IronwoodMigrationCoordinatorState build() =>
+      const IronwoodMigrationCoordinatorState();
+
+  @override
+  Future<void> stop({required String accountUuid, required String runId}) =>
+      onStop(accountUuid, runId);
+
+  @override
+  Future<void> refreshNow({bool forceAdvance = false}) async {}
 }
 
 class _StartScreenTestMigrationCoordinator
@@ -533,6 +551,7 @@ final _immediatePlan = rust_sync.OrchardMigrationImmediatePlan(
 rust_sync.MigrationStatus _status({
   required String phase,
   String? activeRunId = 'run-1',
+  bool canAbandon = false,
   List<String>? broadcastStatuses,
   List<rust_sync.MigrationPartStatus> parts = const [],
   List<int> targetValues = const [412_000_000, 412_000_000, 412_000_000],
@@ -572,7 +591,7 @@ rust_sync.MigrationStatus _status({
     totalCount: 3,
     signedChildPcztCount: signedChildPcztCount,
     pendingSplitStageCount: pendingSplitStageCount,
-    canAbandon: false,
+    canAbandon: canAbandon,
     signingBatchLimit: signingBatchLimit,
     scheduleMeanDelayBlocks: 144,
     scheduleMaxDelayBlocks: 576,
@@ -828,6 +847,7 @@ Widget _productionApp({
   SyncState? syncState,
   FakeSyncNotifier? syncNotifier,
   IronwoodMigrationCoordinator Function()? migrationCoordinator,
+  bool liveSchedule = false,
   bool realKeystoneCombinedRoute = false,
   bool realKeystoneDenominationRoute = false,
   bool realKeystoneBatchRoute = false,
@@ -908,13 +928,14 @@ Widget _productionApp({
       ),
       GoRoute(
         path: '/migration/private/schedule',
-        builder: (_, _) =>
-            MobileIronwoodMigrationScheduleScreen(previewStatus: status),
+        builder: (_, _) => MobileIronwoodMigrationScheduleScreen(
+          previewStatus: liveSchedule ? null : status,
+        ),
       ),
       GoRoute(
         path: '/migration/private/preparation-schedule',
         builder: (_, _) => MobileIronwoodMigrationPreparationScheduleScreen(
-          previewStatus: status,
+          previewStatus: liveSchedule ? null : status,
         ),
       ),
       GoRoute(
@@ -1359,7 +1380,9 @@ void main() {
     expect(supportsPrivateMobileIronwoodMigration(isAndroid: true), isFalse);
   });
 
-  setUpAll(() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await loadFigmaCompareFonts();
     RustLib.initMock(api: _rustApiFake);
   });
 
@@ -1369,6 +1392,309 @@ void main() {
     _rustApiFake.reset();
     FlutterSecureStorage.setMockInitialValues({});
   });
+
+  for (final preparation in [false, true]) {
+    for (final fast in [false, true]) {
+      testWidgets(
+        'mobile schedule manage ${preparation ? 'preparation' : 'migration'} '
+        '${fast ? 'Fast' : 'stop'} waits for cleanup before navigating',
+        (tester) async {
+          _useMobileViewport(tester, size: const Size(375, 667));
+          final release = Completer<void>();
+          var calls = 0;
+          var planCalls = 0;
+          var status = _status(
+            phase: kIronwoodMigrationBroadcastScheduledPhase,
+            canAbandon: true,
+          );
+          late ProviderContainer container;
+          final coordinator = _ManageTestMigrationCoordinator((
+            account,
+            run,
+          ) async {
+            expect(account, 'account-1');
+            expect(run, 'run-1');
+            calls++;
+            // Rust can commit before native credential/outbox cleanup returns.
+            status = _status(
+              phase: kIronwoodMigrationCompletePhase,
+              activeRunId: null,
+            );
+            container.invalidate(ironwoodMigrationStatusProvider);
+            await release.future;
+          });
+          await tester.pumpWidget(
+            _productionApp(
+              initialLocation: preparation
+                  ? '/migration/private/preparation-schedule'
+                  : '/migration/private/schedule',
+              migrationService: _migrationService(),
+              liveSchedule: true,
+              statusLoader: () async => status,
+              migrationCoordinator: () => coordinator,
+              immediatePlanLoader: () async {
+                planCalls++;
+                return _immediatePlan;
+              },
+            ),
+          );
+          await tester.pumpAndSettle();
+          container = ProviderScope.containerOf(
+            tester.element(
+              find
+                      .byType(MobileIronwoodMigrationScheduleScreen)
+                      .evaluate()
+                      .isNotEmpty
+                  ? find.byType(MobileIronwoodMigrationScheduleScreen)
+                  : find.byType(
+                      MobileIronwoodMigrationPreparationScheduleScreen,
+                    ),
+            ),
+          );
+          final planSubscription = container.listen(
+            ironwoodMigrationImmediatePlanProvider,
+            (_, _) {},
+          );
+          addTearDown(planSubscription.close);
+          await container.read(ironwoodMigrationImmediatePlanProvider.future);
+          expect(planCalls, 1);
+          await tester.tap(
+            find.byKey(
+              const ValueKey('mobile_ironwood_schedule_manage_button'),
+            ),
+          );
+          await tester.pumpAndSettle();
+          await tester.tap(
+            find.byKey(
+              ValueKey(
+                fast
+                    ? 'mobile_ironwood_manage_fast'
+                    : 'mobile_ironwood_manage_stop',
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+          expect(
+            find.text('Transactions already broadcast will not be reverted.'),
+            findsOneWidget,
+          );
+          final confirm = find.byKey(
+            const ValueKey('mobile_ironwood_manage_confirm'),
+          );
+          await tester.tap(confirm);
+          await tester.pumpAndSettle();
+          expect(calls, 1);
+          expect(planCalls, 1);
+          expect(
+            find.byKey(const ValueKey('mobile_ironwood_manage_dialog')),
+            findsOneWidget,
+          );
+          expect(tester.widget<AppButton>(confirm).onPressed, isNull);
+          expect(
+            tester
+                .widget<AppButton>(
+                  find.byKey(const ValueKey('mobile_ironwood_manage_cancel')),
+                )
+                .onPressed,
+            isNull,
+          );
+          await tester.binding.handlePopRoute();
+          await tester.tapAt(const Offset(4, 4));
+          await tester.pumpAndSettle();
+          expect(
+            find.byKey(const ValueKey('mobile_ironwood_manage_dialog')),
+            findsOneWidget,
+          );
+          release.complete();
+          await tester.pumpAndSettle();
+          expect(
+            find.byKey(const ValueKey('mobile_ironwood_manage_dialog')),
+            findsNothing,
+          );
+          expect(
+            find.text(fast ? 'Fast Migration' : 'home route'),
+            findsOneWidget,
+          );
+          expect(planCalls, fast ? 2 : 1);
+          expect(calls, 1);
+          expect(tester.takeException(), isNull);
+        },
+      );
+    }
+  }
+
+  testWidgets(
+    'mobile schedule manage hides actions for a non-abandonable run',
+    (tester) async {
+      _useMobileViewport(tester);
+      await tester.pumpWidget(
+        _productionApp(
+          initialLocation: '/migration/private/schedule',
+          migrationService: _migrationService(),
+          liveSchedule: true,
+          status: _status(phase: kIronwoodMigrationWaitingConfirmationsPhase),
+          migrationCoordinator: () =>
+              _ManageTestMigrationCoordinator((_, _) async {
+                fail('A non-abandonable migration cannot be stopped');
+              }),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('mobile_ironwood_schedule_manage_button')),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
+    'mobile schedule manage cancels without stopping and rejects a changed run',
+    (tester) async {
+      _useMobileViewport(tester);
+      var status = _status(
+        phase: kIronwoodMigrationBroadcastScheduledPhase,
+        canAbandon: true,
+      );
+      await tester.pumpWidget(
+        _productionApp(
+          initialLocation: '/migration/private/schedule',
+          migrationService: _migrationService(),
+          liveSchedule: true,
+          statusLoader: () async => status,
+          migrationCoordinator: () => _ManageTestMigrationCoordinator((
+            _,
+            _,
+          ) async {
+            fail('Cancelled or stale confirmation must not stop a migration');
+          }),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(MobileIronwoodMigrationScheduleScreen)),
+      );
+      await tester.tap(
+        find.byKey(const ValueKey('mobile_ironwood_schedule_manage_button')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('mobile_ironwood_manage_cancel')),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('mobile_ironwood_manage_dialog')),
+        findsNothing,
+      );
+      await tester.tap(
+        find.byKey(const ValueKey('mobile_ironwood_schedule_manage_button')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('mobile_ironwood_manage_fast')),
+      );
+      await tester.pumpAndSettle();
+      status = _status(
+        phase: kIronwoodMigrationBroadcastScheduledPhase,
+        activeRunId: 'run-2',
+        canAbandon: true,
+      );
+      container.invalidate(ironwoodMigrationStatusProvider);
+      await tester.pumpAndSettle();
+      expect(
+        tester
+            .widget<AppButton>(
+              find.byKey(const ValueKey('mobile_ironwood_manage_confirm')),
+            )
+            .onPressed,
+        isNull,
+      );
+      expect(
+        find.text('This migration is no longer available to manage.'),
+        findsOneWidget,
+      );
+    },
+  );
+
+  for (final failStatusRead in [false, true]) {
+    testWidgets(
+      'mobile schedule manage retries native cleanup after a terminal stop failure '
+      '(status read fails: $failStatusRead)',
+      (tester) async {
+        _useMobileViewport(tester);
+        var calls = 0;
+        var statusUnavailable = false;
+        var status = _status(
+          phase: kIronwoodMigrationBroadcastScheduledPhase,
+          canAbandon: true,
+        );
+        await tester.pumpWidget(
+          _productionApp(
+            initialLocation: '/migration/private/schedule',
+            migrationService: _migrationService(),
+            liveSchedule: true,
+            statusLoader: () async {
+              if (statusUnavailable) throw StateError('Status read failed');
+              return status;
+            },
+            migrationCoordinator: () => _ManageTestMigrationCoordinator((
+              account,
+              run,
+            ) async {
+              expect(run, 'run-1');
+              calls++;
+              if (calls == 1) {
+                statusUnavailable = failStatusRead;
+                status = _status(
+                  phase: kIronwoodMigrationCompletePhase,
+                  activeRunId: null,
+                );
+                throw StateError('Native cleanup failed after Rust committed');
+              }
+            }),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('mobile_ironwood_schedule_manage_button')),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('mobile_ironwood_manage_fast')),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('mobile_ironwood_manage_confirm')),
+        );
+        await tester.pumpAndSettle();
+        expect(
+          find.text('The migration could not be updated. Please try again.'),
+          findsOneWidget,
+        );
+        expect(find.text('Fast Migration'), findsNothing);
+        if (failStatusRead) {
+          expect(
+            tester
+                .widget<AppButton>(
+                  find.byKey(const ValueKey('mobile_ironwood_manage_confirm')),
+                )
+                .onPressed,
+            isNull,
+          );
+          statusUnavailable = false;
+          await tester.tap(
+            find.byKey(const ValueKey('mobile_ironwood_manage_retry_status')),
+          );
+          await tester.pumpAndSettle();
+        }
+        await tester.tap(
+          find.byKey(const ValueKey('mobile_ironwood_manage_confirm')),
+        );
+        await tester.pumpAndSettle();
+        expect(calls, 2);
+        expect(find.text('Fast Migration'), findsOneWidget);
+      },
+    );
+  }
 
   testWidgets('connects the About and migration-steps screens', (tester) async {
     await tester.pumpWidget(_app(step: MobileIronwoodMigrationStep.intro));
@@ -4352,7 +4678,10 @@ void main() {
     expect(painter.highlightedSegmentOffset, 3.5);
     expect(painter.highlightedOuterOutlineWidth, 18);
     expect(painter.highlightedOutlineWidth, 16);
-    expect(tester.getCenter(find.text('1 ZEC (2%)')).dx, greaterThan(250));
+    expect(
+      tester.getCenter(find.text('1 ZEC (2%)')).dx,
+      greaterThan(tester.getCenter(find.byWidget(ring)).dx),
+    );
     expect(
       mobileIronwoodMigrationAttention(
         _status(


### PR DESCRIPTION
Mobile users can view a private Ironwood migration schedule but cannot stop it or switch its remaining balance to Fast. Add Manage to both Preparation Schedule and Migration Schedule, with confirmation flows for Stop migration and Switch to Fast.

Confirmation stays open until stop and native cleanup finish, blocks duplicate submission and back navigation while working, rejects stale runs, and offers retries for failed cleanup or status reads. Fast conversion refreshes the Immediate plan and opens the existing mobile Fast review; it does not automatically broadcast. Already-broadcast transactions are not reverted.

On iOS, stopping first prevents new wallet-wide outbox broadcasts and waits for any admitted foreground or background runner to finish recording its network result. The existing stop path then reconciles submitted transactions and removes the remaining schedule. This covers foreground recovery triggered by another account. An uncertain network response retains its attempt record for reconciliation; this wait does not wait for block confirmations. The confirmation displays an explanation while stopping.

Mutation leases keep concurrent operations and retries from resuming one another's work. Account removal and wallet reset also drain the shared sender before deleting native records, and safely retire retained stop leases. Failed resume retries are tracked separately from active mutations.

Validation:
- Mobile migration screen suite: 167 passed.
- Migration lifecycle/service, coordinator, desktop screen, and wallet mutation guard suites: 229 passed, 1 existing skip.
- Six native Swift tests passed using the production outbox runner and encrypted store with injected transport, including successful and uncertain broadcasts, overlapping leases, and account/reset cleanup.
- Focused Flutter analysis, Swift syntax parsing, Xcode project validation, and diff checks passed.
- Repeated full-diff review/fix cycles completed; the follow-up changes are consolidated into one commit after the existing feature commit.
- iOS full-app build and device/regtest E2E were not run. The native host tests do not exercise the iOS scheduler or MethodChannel end to end. Full-repository Flutter analysis previously reported an unrelated missing ReceiveAddressService.reserveOrchardAddress implementation in the Widgetbook preview service.
