### PR TITLE
perf(wallet): reuse recent lightwalletd tips

### DIFF
--- a/integration_test/regtest_mobile_slow_height_fallback_test.dart
+++ b/integration_test/regtest_mobile_slow_height_fallback_test.dart
@@ -73,6 +73,7 @@ void main() {
 
       final baselineHeight = await rust_wallet.getLatestBlockHeight(
         lightwalletdUrl: mobileE2eLightwalletdUrl,
+        network: 'regtest',
       );
       proxy.setSlowHeight(baselineHeight.toInt() + 1);
       await _pumpFor(tester, const Duration(seconds: 4));

--- a/integration_test/regtest_multi_account_send_test.dart
+++ b/integration_test/regtest_multi_account_send_test.dart
@@ -310,6 +310,7 @@ Future<void> _mineRegtestBlocks(int blocks) async {
   while (DateTime.now().isBefore(deadline)) {
     final lightwalletdHeight = await rust_wallet.getLatestBlockHeight(
       lightwalletdUrl: _lightwalletdUrl,
+      network: 'regtest',
     );
     if (lightwalletdHeight.toInt() >= targetHeight) {
       _log('lightwalletd reached mined height $targetHeight');

--- a/integration_test/regtest_slow_height_fallback_test.dart
+++ b/integration_test/regtest_slow_height_fallback_test.dart
@@ -81,6 +81,7 @@ void main() {
 
       final baselineHeight = await rust_wallet.getLatestBlockHeight(
         lightwalletdUrl: _realLightwalletdUrl,
+        network: 'regtest',
       );
       proxy.setSlowHeight(baselineHeight.toInt() + 1);
       await _pumpFor(tester, const Duration(seconds: 4));

--- a/integration_test/regtest_tex_send_test.dart
+++ b/integration_test/regtest_tex_send_test.dart
@@ -256,6 +256,7 @@ Future<void> _mineRegtestBlocks(int blocks) async {
   while (DateTime.now().isBefore(deadline)) {
     final lightwalletdHeight = await rust_wallet.getLatestBlockHeight(
       lightwalletdUrl: _lightwalletdUrl,
+      network: 'regtest',
     );
     if (lightwalletdHeight.toInt() >= targetHeight) {
       _log('lightwalletd reached mined height $targetHeight');

--- a/integration_test/support/mobile_regtest_flow.dart
+++ b/integration_test/support/mobile_regtest_flow.dart
@@ -1011,6 +1011,7 @@ Future<void> mineRegtestBlocks(int blocks) async {
   while (DateTime.now().isBefore(deadline)) {
     final lightwalletdHeight = await rust_wallet.getLatestBlockHeight(
       lightwalletdUrl: mobileE2eLightwalletdUrl,
+      network: 'regtest',
     );
     if (lightwalletdHeight.toInt() >= targetHeight) {
       logE2e('lightwalletd reached mined height $targetHeight');

--- a/lib/src/providers/rpc_endpoint_failover_provider.dart
+++ b/lib/src/providers/rpc_endpoint_failover_provider.dart
@@ -8,7 +8,7 @@ import 'rpc_endpoint_provider.dart';
 typedef RpcEndpointChainNameGetter =
     Future<String> Function(String lightwalletdUrl);
 typedef RpcEndpointLatestBlockHeightGetter =
-    Future<BigInt> Function(String lightwalletdUrl);
+    Future<BigInt> Function(String lightwalletdUrl, String network);
 
 enum RpcEndpointFailoverEventKind { switchedToFallback, switchedToPrimary }
 
@@ -163,7 +163,10 @@ Future<RpcEndpointHealth> checkRpcEndpointHealth({
       'Endpoint is for $chainName, but this wallet uses ${endpoint.networkName}.',
     );
   }
-  final height = await getLatestBlockHeight(endpoint.normalizedLightwalletdUrl);
+  final height = await getLatestBlockHeight(
+    endpoint.normalizedLightwalletdUrl,
+    endpoint.networkName,
+  );
   return RpcEndpointHealth(chainName: chainName, height: height);
 }
 
@@ -219,8 +222,9 @@ final rpcEndpointFailoverChainNameGetterProvider =
 final rpcEndpointFailoverLatestBlockHeightGetterProvider =
     Provider<RpcEndpointLatestBlockHeightGetter>(
       (_) =>
-          (lightwalletdUrl) => rust_wallet.getLatestBlockHeight(
+          (lightwalletdUrl, network) => rust_wallet.getLatestBlockHeight(
             lightwalletdUrl: lightwalletdUrl,
+            network: network,
           ),
     );
 
@@ -252,6 +256,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
     try {
       final height = await getLatestBlockHeight(
         endpoint.normalizedLightwalletdUrl,
+        endpoint.networkName,
       );
       _recordEndpointSuccess(endpoint);
       final slowFallback = await _maybeSwitchFromSlowHeight(
@@ -274,6 +279,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       try {
         final fallbackHeight = await getLatestBlockHeight(
           fallbackEndpoint.normalizedLightwalletdUrl,
+          fallbackEndpoint.networkName,
         );
         _recordEndpointSuccess(fallbackEndpoint);
         _resetHeightWindow(fallbackEndpoint, fallbackHeight);

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -9,10 +9,13 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 // These functions are ignored because they are not marked as `pub`: `block_height_from_u64`, `catch`, `discover_software_account_at_index`, `discover_used_software_accounts`, `discovery_start_height`, `import_discovered_software_wallet_accounts`, `is_ironwood_active_at_height`, `network_name`, `nu6_3_activation_height`, `parse_network_and_migrate`, `preview_transparent_balance_for_addresses`
 
 /// Get the latest block height from lightwalletd.
-Future<BigInt> getLatestBlockHeight({required String lightwalletdUrl}) =>
-    RustLib.instance.api.crateApiWalletGetLatestBlockHeight(
-      lightwalletdUrl: lightwalletdUrl,
-    );
+Future<BigInt> getLatestBlockHeight({
+  required String lightwalletdUrl,
+  required String network,
+}) => RustLib.instance.api.crateApiWalletGetLatestBlockHeight(
+  lightwalletdUrl: lightwalletdUrl,
+  network: network,
+);
 
 /// Get the lightwalletd chain name ("main" or "test") for endpoint validation.
 Future<String> getLightwalletdChainName({required String lightwalletdUrl}) =>

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -581,6 +581,7 @@ abstract class RustLibApi extends BaseApi {
 
   Future<BigInt> crateApiWalletGetLatestBlockHeight({
     required String lightwalletdUrl,
+    required String network,
   });
 
   Future<String> crateApiWalletGetLightwalletdChainName({
@@ -4580,12 +4581,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @override
   Future<BigInt> crateApiWalletGetLatestBlockHeight({
     required String lightwalletdUrl,
+    required String network,
   }) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_String(network, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -4598,7 +4601,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiWalletGetLatestBlockHeightConstMeta,
-        argValues: [lightwalletdUrl],
+        argValues: [lightwalletdUrl, network],
         apiImpl: this,
       ),
     );
@@ -4607,7 +4610,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiWalletGetLatestBlockHeightConstMeta =>
       const TaskConstMeta(
         debugName: "get_latest_block_height",
-        argNames: ["lightwalletdUrl"],
+        argNames: ["lightwalletdUrl", "network"],
       );
 
   @override

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -144,16 +144,21 @@ fn nu6_3_activation_height(network: WalletNetwork) -> Option<u64> {
 }
 
 /// Get the latest block height from lightwalletd.
-pub fn get_latest_block_height(lightwalletd_url: String) -> Result<u64, String> {
+pub fn get_latest_block_height(lightwalletd_url: String, network: String) -> Result<u64, String> {
     catch(|| {
+        let network = keys::parse_network(&network)?;
         let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
         rt.block_on(async {
             let mut client = crate::wallet::sync_engine::open_lwd_channel(&lightwalletd_url)
                 .await
                 .map_err(|e| e.to_string())?;
-            let tip = crate::wallet::sync_engine::get_latest_block(&mut client)
-                .await
-                .map_err(|e| e.to_string())?;
+            let tip = crate::wallet::sync_engine::get_latest_block_recorded(
+                &mut client,
+                &lightwalletd_url,
+                network,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
 
             Ok(tip.height)
         })
@@ -198,9 +203,13 @@ pub fn get_chain_upgrade_status(
             let mut client = crate::wallet::sync_engine::open_lwd_channel(&lightwalletd_url)
                 .await
                 .map_err(|e| e.to_string())?;
-            let tip = crate::wallet::sync_engine::get_latest_block(&mut client)
-                .await
-                .map_err(|e| e.to_string())?;
+            let tip = crate::wallet::sync_engine::get_latest_block_recorded(
+                &mut client,
+                &lightwalletd_url,
+                network,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
             let info = tokio::time::timeout(
                 std::time::Duration::from_secs(10),
                 client.get_lightd_info(Empty {}),
@@ -701,7 +710,13 @@ async fn discover_used_software_accounts(
             return Vec::new();
         }
     };
-    let tip = match crate::wallet::sync_engine::get_latest_block(&mut client).await {
+    let tip = match crate::wallet::sync_engine::get_latest_block_recorded(
+        &mut client,
+        lightwalletd_url,
+        network,
+    )
+    .await
+    {
         Ok(tip) => tip.height,
         Err(e) => {
             log::warn!("software account discovery: could not get chain tip: {e}");

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -3162,11 +3162,14 @@ fn wire__crate__api__wallet__get_latest_block_height_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
-                    let output_ok =
-                        crate::api::wallet::get_latest_block_height(api_lightwalletd_url)?;
+                    let output_ok = crate::api::wallet::get_latest_block_height(
+                        api_lightwalletd_url,
+                        api_network,
+                    )?;
                     Ok(output_ok)
                 })())
             }

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -439,6 +439,7 @@ pub async fn create_pczt_from_proposal(
     }
     let live_expiry_height = match super::send::live_send_expiry_height(
         lightwalletd_url,
+        network,
         zcash_protocol::consensus::BlockHeight::from(stored.proposal.min_target_height()),
     )
     .await
@@ -554,6 +555,7 @@ pub async fn create_tex_pczts_from_proposal(
     }
     let live_expiry_height = match super::send::live_send_expiry_height(
         lightwalletd_url,
+        network,
         zcash_protocol::consensus::BlockHeight::from(stored.proposal.min_target_height()),
     )
     .await
@@ -1483,7 +1485,7 @@ async fn store_and_broadcast_pczts_for_proposal(
     let txids_joined = txids.join(",");
     let total_count = prepared.len() as u32;
 
-    // Resolve a live tip before touching either the DB or the network. An
+    // Resolve a recent tip before touching either the DB or the network. An
     // already-expired set is terminal and must not be persisted as pending.
     let mut expiry_client =
         match crate::wallet::sync_engine::open_isolated_lwd_channel(lightwalletd_url).await {
@@ -1496,7 +1498,13 @@ async fn store_and_broadcast_pczts_for_proposal(
                 );
             }
         };
-    let latest = match crate::wallet::sync_engine::get_latest_block(&mut expiry_client).await {
+    let latest = match crate::wallet::sync_engine::latest_block_for_transaction_with_client(
+        &mut expiry_client,
+        lightwalletd_url,
+        network,
+    )
+    .await
+    {
         Ok(latest) => latest,
         Err(error) => {
             return release_pczt_proposal_after_failure(
@@ -2005,9 +2013,13 @@ pub async fn extract_and_broadcast_pczt(
     let mut client = crate::wallet::sync_engine::open_isolated_lwd_channel(lightwalletd_url)
         .await
         .map_err(|e| e.to_string())?;
-    let latest = crate::wallet::sync_engine::get_latest_block(&mut client)
-        .await
-        .map_err(|e| e.to_string())?;
+    let latest = crate::wallet::sync_engine::latest_block_for_transaction_with_client(
+        &mut client,
+        lightwalletd_url,
+        network,
+    )
+    .await
+    .map_err(|e| e.to_string())?;
     if let Some(error) =
         pczt_broadcast_expiry_error(&txid, u32::from(tx.expiry_height()), latest.height)
     {

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -129,12 +129,10 @@ fn send_proposal_is_expired(
 
 pub(super) async fn live_send_expiry_height(
     lightwalletd_url: &str,
+    network: WalletNetwork,
     min_target_height: BlockHeight,
 ) -> Result<BlockHeight, String> {
-    let mut client = sync_engine::open_lwd_channel(lightwalletd_url)
-        .await
-        .map_err(|e| format!("Connect to lightwalletd before transaction construction: {e}"))?;
-    let tip = sync_engine::get_latest_block(&mut client)
+    let tip = sync_engine::latest_block_for_transaction(lightwalletd_url, network)
         .await
         .map_err(|e| format!("Read live chain tip before transaction construction: {e}"))?;
     let tip = u32::try_from(tip.height).map_err(|_| "Live chain tip exceeds u32")?;
@@ -1013,10 +1011,7 @@ pub(crate) async fn create_shield_transparent_pczt(
     account_uuid: &str,
 ) -> Result<ShieldTransparentPcztResult, String> {
     let live_expiry_height = {
-        let mut client = sync_engine::open_lwd_channel(lightwalletd_url)
-            .await
-            .map_err(|e| format!("Connect to lightwalletd before shielding PCZT: {e}"))?;
-        let tip = sync_engine::get_latest_block(&mut client)
+        let tip = sync_engine::latest_block_for_transaction(lightwalletd_url, network)
             .await
             .map_err(|e| format!("Read live chain tip before shielding PCZT: {e}"))?;
         let tip = u32::try_from(tip.height).map_err(|_| "Shielding PCZT chain tip exceeds u32")?;
@@ -1108,10 +1103,7 @@ pub(crate) async fn shield_transparent_balance(
 ) -> Result<ShieldTransparentResult, String> {
     let shielding_threshold = shielding_threshold()?;
     let live_expiry_height = {
-        let mut client = sync_engine::open_lwd_channel(lightwalletd_url)
-            .await
-            .map_err(|e| format!("Connect to lightwalletd before shielding: {e}"))?;
-        let tip = sync_engine::get_latest_block(&mut client)
+        let tip = sync_engine::latest_block_for_transaction(lightwalletd_url, network)
             .await
             .map_err(|e| format!("Read live chain tip before shielding: {e}"))?;
         let tip = u32::try_from(tip.height).map_err(|_| "Shielding chain tip exceeds u32")?;
@@ -1278,7 +1270,7 @@ async fn execute_stored_proposal(
 
     let min_target_height = BlockHeight::from(stored.proposal.min_target_height());
     let live_expiry_height =
-        match live_send_expiry_height(lightwalletd_url, min_target_height).await {
+        match live_send_expiry_height(lightwalletd_url, network, min_target_height).await {
             Ok(height) => height,
             Err(error) => {
                 return match finish_stored_proposal(proposal_id, &send_flow_id, true) {
@@ -2024,7 +2016,7 @@ pub(crate) async fn retire_unbroadcast_orchard_migration(
     let mut client = sync_engine::open_lwd_channel(lightwalletd_url)
         .await
         .map_err(|e| format!("Open migration recovery endpoint: {e}"))?;
-    let chain_tip = sync_engine::get_latest_block(&mut client)
+    let chain_tip = sync_engine::get_latest_block_recorded(&mut client, lightwalletd_url, network)
         .await
         .map_err(|e| format!("Read migration recovery chain tip: {e}"))?;
     let chain_tip_height =
@@ -2091,7 +2083,7 @@ async fn reconcile_scheduled_migration_txs_before_abandon(
     let mut client = sync_engine::open_lwd_channel(lightwalletd_url)
         .await
         .map_err(|e| format!("Open migration stop reconciliation endpoint: {e}"))?;
-    let chain_tip = sync_engine::get_latest_block(&mut client)
+    let chain_tip = sync_engine::get_latest_block_recorded(&mut client, lightwalletd_url, network)
         .await
         .map_err(|e| format!("Read migration stop reconciliation chain tip: {e}"))?;
     let chain_tip_height = u32::try_from(chain_tip.height)

--- a/rust/src/wallet/sync_engine/mempool.rs
+++ b/rust/src/wallet/sync_engine/mempool.rs
@@ -57,7 +57,7 @@ use zcash_protocol::consensus::{BlockHeight, BranchId};
 
 use crate::wallet::network::WalletNetwork;
 
-use super::lwd::{get_latest_block, start_mempool_stream};
+use super::lwd::start_mempool_stream;
 use super::open_lwd_channel;
 
 /// Event emitted by [`run_mempool_observer`] for every wallet-relevant
@@ -467,7 +467,11 @@ where
                 log::info!("mempool: observer cancelled during tip refresh");
                 return Ok(());
             }
-            r = get_latest_block(&mut client) => r,
+            r = super::get_latest_block_recorded(
+                &mut client,
+                &lightwalletd_url,
+                network,
+            ) => r,
         };
         let tip = match tip_result {
             Ok(tip) => tip,

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -49,6 +49,7 @@ mod enhance;
 mod error;
 mod lwd;
 pub(crate) mod mempool;
+mod tip_cache;
 
 use enhance::run_enhancement;
 pub(crate) use error::SyncError;
@@ -61,6 +62,10 @@ pub(crate) use lwd::{
     get_latest_block, get_taddress_txids, get_transaction, next_stream_message,
     open_background_direct_lwd_channel, open_isolated_lwd_channel, open_lwd_channel,
     open_lwd_channel_with_cancel, send_transaction, send_transaction_with_status,
+};
+pub(crate) use tip_cache::{
+    get_latest_block_recorded, latest_block_for_transaction,
+    latest_block_for_transaction_with_client,
 };
 
 /// Progress event sent to caller (Dart or Swift).
@@ -2318,7 +2323,7 @@ async fn run_sync_impl(
     // authoritative: `WalletDb::update_chain_tip` deliberately ignores a
     // height below the maximum scanned block, so assigning the server height
     // first could later report completion above a lagging endpoint.
-    let tip_result = get_latest_block(&mut client).await;
+    let tip_result = get_latest_block_recorded(&mut client, lightwalletd_url, network).await;
     let Some(tip_result) = tip_rpc_result_unless_exiting(tip_result, should_exit()) else {
         log::info!("[{}] sync: exiting after initial tip fetch", elapsed());
         return Ok(());
@@ -2668,7 +2673,8 @@ async fn run_sync_impl(
         // empty range from a lagging replica.
         if last_periodic_tip_refresh_attempt.elapsed() >= TIP_REFRESH_INTERVAL {
             last_periodic_tip_refresh_attempt = std::time::Instant::now();
-            let fresh_tip_result = get_latest_block(&mut client).await;
+            let fresh_tip_result =
+                get_latest_block_recorded(&mut client, lightwalletd_url, network).await;
             let Some(fresh_tip_result) =
                 tip_rpc_result_unless_exiting(fresh_tip_result, should_exit())
             else {
@@ -2793,7 +2799,8 @@ async fn run_sync_impl(
                     completion_tip_validation_required,
                     last_completion_tip_validation.elapsed(),
                 ) {
-                    let fresh_tip_result = get_latest_block(&mut client).await;
+                    let fresh_tip_result =
+                        get_latest_block_recorded(&mut client, lightwalletd_url, network).await;
                     let Some(fresh_tip_result) =
                         tip_rpc_result_unless_exiting(fresh_tip_result, should_exit())
                     else {
@@ -3420,7 +3427,8 @@ async fn run_sync_impl(
             );
             return Ok(());
         }
-        let fresh_tip_result = get_latest_block(&mut client).await;
+        let fresh_tip_result =
+            get_latest_block_recorded(&mut client, lightwalletd_url, network).await;
         let Some(fresh_tip_result) = tip_rpc_result_unless_exiting(fresh_tip_result, should_exit())
         else {
             log::info!("[{}] sync: exiting after post-batch tip fetch", elapsed());

--- a/rust/src/wallet/sync_engine/tip_cache.rs
+++ b/rust/src/wallet/sync_engine/tip_cache.rs
@@ -1,0 +1,221 @@
+use std::{
+    collections::HashMap,
+    sync::{LazyLock, Mutex},
+    time::{Duration, Instant},
+};
+
+use tonic::transport::Channel;
+use zcash_client_backend::proto::service::{
+    compact_tx_streamer_client::CompactTxStreamerClient, BlockId,
+};
+
+use crate::wallet::network::WalletNetwork;
+
+use super::{get_latest_block, open_lwd_channel, SyncError};
+
+const TRANSACTION_TIP_MAX_AGE: Duration = Duration::from_secs(15);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct CacheKey {
+    lightwalletd_url: String,
+    network: WalletNetwork,
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    tip: BlockId,
+    observed_at: Instant,
+}
+
+#[derive(Default)]
+struct LatestBlockCache {
+    entries: HashMap<CacheKey, CacheEntry>,
+}
+
+impl LatestBlockCache {
+    fn key(lightwalletd_url: &str, network: WalletNetwork) -> CacheKey {
+        CacheKey {
+            lightwalletd_url: lightwalletd_url.to_string(),
+            network,
+        }
+    }
+
+    fn record(
+        &mut self,
+        lightwalletd_url: &str,
+        network: WalletNetwork,
+        tip: BlockId,
+        observed_at: Instant,
+    ) {
+        self.entries.insert(
+            Self::key(lightwalletd_url, network),
+            CacheEntry { tip, observed_at },
+        );
+    }
+
+    fn recent(
+        &mut self,
+        lightwalletd_url: &str,
+        network: WalletNetwork,
+        now: Instant,
+        max_age: Duration,
+    ) -> Option<BlockId> {
+        let key = Self::key(lightwalletd_url, network);
+        let entry = self.entries.get(&key)?;
+        if now.duration_since(entry.observed_at) <= max_age {
+            Some(entry.tip.clone())
+        } else {
+            self.entries.remove(&key);
+            None
+        }
+    }
+}
+
+static LATEST_BLOCK_CACHE: LazyLock<Mutex<LatestBlockCache>> =
+    LazyLock::new(|| Mutex::new(LatestBlockCache::default()));
+
+fn with_cache<T>(f: impl FnOnce(&mut LatestBlockCache) -> T) -> T {
+    let mut cache = LATEST_BLOCK_CACHE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    f(&mut cache)
+}
+
+/// Fetches the latest block and records the successful response for later
+/// transaction operations.
+pub(crate) async fn get_latest_block_recorded(
+    client: &mut CompactTxStreamerClient<Channel>,
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+) -> Result<BlockId, SyncError> {
+    let tip = get_latest_block(client).await?;
+    with_cache(|cache| cache.record(lightwalletd_url, network, tip.clone(), Instant::now()));
+    Ok(tip)
+}
+
+/// Returns a recently observed tip, or refreshes it from lightwalletd when no
+/// successful observation is available from the last 15 seconds.
+pub(crate) async fn latest_block_for_transaction(
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+) -> Result<BlockId, SyncError> {
+    if let Some(tip) = recent_transaction_tip(lightwalletd_url, network) {
+        return Ok(tip);
+    }
+
+    let mut client = open_lwd_channel(lightwalletd_url).await?;
+    get_latest_block_recorded(&mut client, lightwalletd_url, network).await
+}
+
+/// Uses a recent observation when possible, otherwise refreshing through the
+/// caller's existing channel.
+pub(crate) async fn latest_block_for_transaction_with_client(
+    client: &mut CompactTxStreamerClient<Channel>,
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+) -> Result<BlockId, SyncError> {
+    if let Some(tip) = recent_transaction_tip(lightwalletd_url, network) {
+        return Ok(tip);
+    }
+
+    get_latest_block_recorded(client, lightwalletd_url, network).await
+}
+
+fn recent_transaction_tip(lightwalletd_url: &str, network: WalletNetwork) -> Option<BlockId> {
+    with_cache(|cache| {
+        cache.recent(
+            lightwalletd_url,
+            network,
+            Instant::now(),
+            TRANSACTION_TIP_MAX_AGE,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tip(height: u64) -> BlockId {
+        BlockId {
+            height,
+            hash: vec![height as u8],
+        }
+    }
+
+    #[test]
+    fn recent_tip_is_scoped_to_endpoint_and_network() {
+        let now = Instant::now();
+        let mut cache = LatestBlockCache::default();
+        cache.record("https://one.example", WalletNetwork::Main, tip(42), now);
+
+        assert_eq!(
+            cache
+                .recent(
+                    "https://one.example",
+                    WalletNetwork::Main,
+                    now + Duration::from_secs(15),
+                    TRANSACTION_TIP_MAX_AGE,
+                )
+                .map(|tip| tip.height),
+            Some(42)
+        );
+        assert!(cache
+            .recent(
+                "https://two.example",
+                WalletNetwork::Main,
+                now,
+                TRANSACTION_TIP_MAX_AGE,
+            )
+            .is_none());
+        assert!(cache
+            .recent(
+                "https://one.example",
+                WalletNetwork::Test,
+                now,
+                TRANSACTION_TIP_MAX_AGE,
+            )
+            .is_none());
+    }
+
+    #[test]
+    fn tip_older_than_max_age_is_not_reused() {
+        let now = Instant::now();
+        let mut cache = LatestBlockCache::default();
+        cache.record("https://one.example", WalletNetwork::Main, tip(42), now);
+
+        assert!(cache
+            .recent(
+                "https://one.example",
+                WalletNetwork::Main,
+                now + Duration::from_secs(16),
+                TRANSACTION_TIP_MAX_AGE,
+            )
+            .is_none());
+    }
+
+    #[test]
+    fn recording_again_replaces_height_and_recency() {
+        let now = Instant::now();
+        let mut cache = LatestBlockCache::default();
+        cache.record("https://one.example", WalletNetwork::Main, tip(41), now);
+        cache.record(
+            "https://one.example",
+            WalletNetwork::Main,
+            tip(42),
+            now + Duration::from_secs(10),
+        );
+
+        assert_eq!(
+            cache
+                .recent(
+                    "https://one.example",
+                    WalletNetwork::Main,
+                    now + Duration::from_secs(24),
+                    TRANSACTION_TIP_MAX_AGE,
+                )
+                .map(|tip| tip.height),
+            Some(42)
+        );
+    }
+}

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -53,7 +53,7 @@ pub fn run_script(name: &str, args: &[&str]) -> String {
 }
 
 pub fn ensure_regtest_up() {
-    if wallet_api::get_latest_block_height(LIGHTWALLETD_URL.into())
+    if wallet_api::get_latest_block_height(LIGHTWALLETD_URL.into(), "regtest".into())
         .map(|height| height > 0)
         .unwrap_or(false)
     {
@@ -72,7 +72,7 @@ pub fn fund_wallet(unified_address: &str, amount_zec: &str) -> String {
 }
 
 pub fn current_tip_height() -> u64 {
-    wallet_api::get_latest_block_height(LIGHTWALLETD_URL.into())
+    wallet_api::get_latest_block_height(LIGHTWALLETD_URL.into(), "regtest".into())
         .expect("failed to fetch regtest chain tip")
 }
 

--- a/rust/tests/ironwood_regtest_migration.rs
+++ b/rust/tests/ironwood_regtest_migration.rs
@@ -168,7 +168,8 @@ fn ensure_stack_up() {
 }
 
 fn latest_height() -> u64 {
-    wallet_api::get_latest_block_height(lightwalletd_url()).expect("read Ironwood regtest tip")
+    wallet_api::get_latest_block_height(lightwalletd_url(), "regtest".into())
+        .expect("read Ironwood regtest tip")
 }
 
 fn lightwalletd_url() -> String {

--- a/test/features/migration/desktop_migration_epoch_coordinator_test.dart
+++ b/test/features/migration/desktop_migration_epoch_coordinator_test.dart
@@ -131,6 +131,7 @@ Future<_EpochHarness> _startCoordinator({
       ironwoodMigrationServiceProvider.overrideWithValue(service),
       rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue((
         _,
+        _,
       ) async {
         // Each epoch's entry read observes a fresh tip (1_000, 1_001, ...) so
         // tests can prove which epoch's height flowed into a broadcast.

--- a/test/features/migration/ironwood_migration_desktop_advance_trigger_test.dart
+++ b/test/features/migration/ironwood_migration_desktop_advance_trigger_test.dart
@@ -254,7 +254,7 @@ class _Harness {
         appBootstrapProvider.overrideWithValue(_bootstrap()),
         syncProvider.overrideWith(() => _sync),
         rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue(
-          (_) async => BigInt.from(_tipHeight),
+          (_, _) async => BigInt.from(_tipHeight),
         ),
         ironwoodMigrationServiceProvider.overrideWithValue(service),
       ],

--- a/test/features/migration/ironwood_migration_desktop_stop_latency_test.dart
+++ b/test/features/migration/ironwood_migration_desktop_stop_latency_test.dart
@@ -176,7 +176,7 @@ class _Harness {
         appBootstrapProvider.overrideWithValue(_bootstrap()),
         syncProvider.overrideWith(() => _SlowSyncNotifier(this)),
         rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue(
-          (_) async => BigInt.from(1000),
+          (_, _) async => BigInt.from(1000),
         ),
         ironwoodMigrationServiceProvider.overrideWithValue(service),
       ],

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -8475,7 +8475,7 @@ void main() {
         depositSender: depositSender,
         sessionStore: sessionStore,
         failoverChainNameGetter: (url) async => 'main',
-        failoverHeightGetter: (url) async =>
+        failoverHeightGetter: (url, _) async =>
             url == fallback.normalizedLightwalletdUrl
             ? BigInt.from(100)
             : BigInt.from(100),
@@ -9151,7 +9151,7 @@ void main() {
           hardwareSigningService: hardwareSigningService,
           sessionStore: sessionStore,
           failoverChainNameGetter: (_) async => 'main',
-          failoverHeightGetter: (_) async => BigInt.from(100),
+          failoverHeightGetter: (_, _) async => BigInt.from(100),
         ),
       );
       await tester.pumpAndSettle();
@@ -9461,7 +9461,7 @@ Widget _routerHarness(
         failoverChainNameGetter ?? (_) async => 'inert-no-failover',
       ),
       rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue(
-        failoverHeightGetter ?? (_) async => BigInt.zero,
+        failoverHeightGetter ?? (_, _) async => BigInt.zero,
       ),
     ],
     child: MaterialApp.router(

--- a/test/providers/rpc_endpoint_failover_provider_test.dart
+++ b/test/providers/rpc_endpoint_failover_provider_test.dart
@@ -42,11 +42,31 @@ void main() {
       checkRpcEndpointHealth(
         endpoint: defaultRpcEndpointConfig('main'),
         getChainName: (_) async => 'test',
-        getLatestBlockHeight: (_) async => BigInt.from(10),
+        getLatestBlockHeight: (_, _) async => BigInt.from(10),
       ),
       throwsA(isA<FormatException>()),
     );
   });
+
+  test(
+    'checkRpcEndpointHealth scopes the height read to the network',
+    () async {
+      final endpoint = defaultRpcEndpointConfig('main');
+      String? requestedNetwork;
+
+      final health = await checkRpcEndpointHealth(
+        endpoint: endpoint,
+        getChainName: (_) async => 'main',
+        getLatestBlockHeight: (_, network) async {
+          requestedNetwork = network;
+          return BigInt.from(10);
+        },
+      );
+
+      expect(requestedNetwork, 'main');
+      expect(health.height, BigInt.from(10));
+    },
+  );
 
   test('runWithEndpointFallback switches to a healthy fallback', () async {
     final primary = defaultRpcEndpointConfig('main');
@@ -574,7 +594,7 @@ void main() {
           }
           return 'main';
         },
-        getLatestBlockHeight: (_) async => BigInt.from(10),
+        getLatestBlockHeight: (_, _) async => BigInt.from(10),
       );
       addTearDown(harness.container.dispose);
 
@@ -629,7 +649,7 @@ void main() {
           }
           return 'main';
         },
-        getLatestBlockHeight: (url) async =>
+        getLatestBlockHeight: (url, _) async =>
             heightByUrl[url] ?? (throw Exception('no height $url')),
       );
       addTearDown(harness.container.dispose);
@@ -687,7 +707,7 @@ void main() {
           }
           return 'main';
         },
-        getLatestBlockHeight: (url) async =>
+        getLatestBlockHeight: (url, _) async =>
             heightByUrl[url] ?? (throw Exception('no height $url')),
       );
       addTearDown(harness.container.dispose);
@@ -740,7 +760,8 @@ ProviderContainer _container({
             chainNameByUrl[url] ?? (throw Exception('no chain $url')),
       ),
       rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue(
-        (url) async => heightByUrl[url] ?? (throw Exception('no height $url')),
+        (url, _) async =>
+            heightByUrl[url] ?? (throw Exception('no height $url')),
       ),
     ],
   );


### PR DESCRIPTION
## Summary

- cache successful lightwalletd tip observations for 15 seconds, scoped by endpoint and wallet network
- populate the shared cache from foreground sync, mempool observation, endpoint polling, account discovery, and transaction expiry checks
- reuse recent tips for software transaction construction, Keystone/PCZT construction, transparent shielding, and Keystone pre-broadcast expiry checks
- preserve the isolated Keystone broadcast channel; on a cache miss, refresh through that channel before broadcasting

## API surface

- changes the public Rust/FRB `get_latest_block_height` signature to require `network` so endpoint polling can safely populate the endpoint-and-network-keyed cache
- adds only `pub(crate)` cache helpers inside the Rust sync engine; no new downstream-public Rust items

## Tests

- `cd rust && cargo test` (737 passed, 4 ignored; service-backed regtest tests remain ignored)
- `fvm flutter test test/providers/rpc_endpoint_failover_provider_test.dart test/features/migration/desktop_migration_epoch_coordinator_test.dart test/features/migration/ironwood_migration_desktop_advance_trigger_test.dart test/features/migration/ironwood_migration_desktop_stop_latency_test.dart`
- `fvm flutter analyze` reaches one pre-existing `origin/main` error: `_PreviewReceiveAddressService` in `lib/widgetbook/screen_use_cases.dart` does not implement `reserveOrchardAddress`
- `cargo clippy --lib -- -D warnings` reaches six pre-existing warnings outside this change