### PR TITLE
Surface SDK voting observability in os_log and Dart

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -103,15 +103,51 @@ import 'src/providers/voting/voting_share_tracking_restorer_provider.dart';
 import 'src/providers/wallet_provider.dart';
 import 'src/providers/windows_update_provider.dart';
 import 'src/rust/api/sync.dart' as rust_sync;
+import 'src/rust/api/voting.dart' as rust_voting;
 import 'src/rust/frb_generated.dart';
 import 'src/rust/api/simple.dart' as rust_simple;
 
 void log(String message) => debugPrint('[zcash] $message');
 
+StreamSubscription<rust_voting.ApiVotingObservability>?
+_votingObservabilitySubscription;
+
+/// Mirrors Rust voting observability into the Flutter console.
+///
+/// Rust `log` records reach os_log (subsystem `frb_user`) and never the
+/// `flutter run` console, so without this stream these reports are invisible
+/// exactly where a developer is already looking. os_log still receives every
+/// line: this is a second sink, not a replacement.
+///
+/// Registered unconditionally on purpose. Collection is governed on the Rust
+/// side by `VOTING_OBSERVABILITY_ENABLED`, so a build with it off simply
+/// yields a silent stream — keeping the enable decision in one place instead
+/// of splitting it across two languages.
+void _startVotingObservabilityLogging() {
+  unawaited(_votingObservabilitySubscription?.cancel());
+  _votingObservabilitySubscription = rust_voting
+      .setVotingObservabilitySink()
+      .listen(
+        (snapshot) {
+          log('voting-obs ${snapshot.context}: ${snapshot.rendered}');
+          // Failures are logged separately because the rendered report shows
+          // per-stage outcomes without an error category; these carry the
+          // SDK's stable `error_kind`, which is the reason a stage failed.
+          for (final failure in snapshot.failures) {
+            log('voting-obs ${snapshot.context}: FAILED $failure');
+          }
+        },
+        // The stream ending is normal at shutdown; a failure in a debugging
+        // aid must never take down the wallet runtime with it.
+        onError: (Object error) => log('voting-obs: stream failed: $error'),
+      );
+}
+
 Future<void> initializeZcashWalletRuntime() async {
   WidgetsFlutterBinding.ensureInitialized();
   log('runtime: initializing RustLib');
   await RustLib.init();
+  _startVotingObservabilityLogging();
   log('runtime: applying network privacy policy');
   await initializeNetworkPrivacyRuntime();
   await rust_simple.configureFastTestnetMigration(

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -559,17 +559,18 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
     final bundleIndexes = _delegationProgressBundleIndexes(state);
     if (bundleIndexes.isEmpty) return null;
 
-    var completedProgress = 0.0;
-    for (final bundleIndex in bundleIndexes) {
-      final progress = state.delegationProgress[bundleIndex];
-      if (_isDelegationBundleComplete(progress)) {
-        completedProgress += 1;
-      } else {
-        completedProgress +=
-            progress?.proofProgress?.clamp(0.0, 1.0).toDouble() ?? 0;
-      }
-    }
-    return (completedProgress / bundleIndexes.length).clamp(0.0, 1.0);
+    final completed = bundleIndexes
+        .where(
+          (index) =>
+              _isDelegationBundleComplete(state.delegationProgress[index]),
+        )
+        .length;
+    // Use the same unit as the bundle counter. A finished proof still owes
+    // signing, submission, and confirmation. Once every bundle confirms, keep
+    // animating while the round driver finishes and its plan is refreshed.
+    return completed == bundleIndexes.length
+        ? null
+        : completed / bundleIndexes.length;
   }
 
   String? _delegationDetail(VotingSessionState state) {
@@ -588,12 +589,28 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
           progress.phase == VotingProgressPhase.waitingForExistingProof,
     );
     final count = '$completed of ${bundleIndexes.length} bundles complete';
-    return waiting ? 'Reusing an in-progress proof — $count' : count;
+    if (completed == bundleIndexes.length) {
+      return 'Finalizing delegation — $count';
+    }
+    if (waiting) return 'Reusing an in-progress proof — $count';
+    final awaitingChain = bundleIndexes
+        .where(
+          (index) =>
+              !_isDelegationBundleComplete(state.delegationProgress[index]),
+        )
+        .every((index) {
+          final phase = state.delegationProgress[index]?.phase;
+          return phase == VotingProgressPhase.payloadReady ||
+              phase == VotingProgressPhase.submitted;
+        });
+    return awaitingChain
+        ? 'Waiting for submission and confirmation — $count'
+        : count;
   }
 
   List<int> _delegationProgressBundleIndexes(VotingSessionState state) {
     final indexes = <int>{
-      ...delegationBundleIndexesNeedingSigning(state.roundPlan),
+      ...delegationBundleIndexesNeedingWork(state.roundPlan),
       ...state.delegationProgress.keys,
       ?state.currentBundleIndex,
     }.toList()..sort();
@@ -601,8 +618,7 @@ class _VotingStatusViewState extends ConsumerState<VotingStatusView> {
   }
 
   bool _isDelegationBundleComplete(VotingSessionProgress? progress) {
-    return progress?.phase == VotingProgressPhase.submitted ||
-        progress?.phase == VotingProgressPhase.confirmed;
+    return progress?.phase == VotingProgressPhase.confirmed;
   }
 
   void _retry() {

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -431,6 +431,23 @@ Future<VotingConfigResolution> resolveVotingConfigFromAttempts({
   previous: previous,
 );
 
+/// Streams voting observability snapshots to Dart until the sink is closed.
+///
+/// Rust `log` records reach os_log, never the Flutter console, so a debugging
+/// aid that lives only in `log stream` is invisible where developers actually
+/// look. This is the second sink, not a replacement: os_log still receives
+/// every line whether or not Dart ever registers.
+///
+/// Registering twice replaces the previous sink and closes it. Collection
+/// itself stays governed by `VOTING_OBSERVABILITY_ENABLED`, so on a build with
+/// observability off this stream is simply silent.
+Stream<ApiVotingObservability> setVotingObservabilitySink() =>
+    RustLib.instance.api.crateApiVotingSetVotingObservabilitySink();
+
+/// Stops streaming snapshots to Dart, closing any registered sink.
+Future<void> clearVotingObservabilitySink() =>
+    RustLib.instance.api.crateApiVotingClearVotingObservabilitySink();
+
 /// FRB-facing bundle layout for [`setup_delegation_bundles`].
 ///
 /// Keeps the SDK's flat privacy-trim totals on the existing layout boundary so
@@ -778,6 +795,66 @@ class ApiVotingEligibility {
           eligibleWeightZatoshi == other.eligibleWeightZatoshi &&
           privacyTrimDroppedValueZatoshi ==
               other.privacyTrimDroppedValueZatoshi;
+}
+
+/// One SDK observability snapshot, flattened for codegen.
+///
+/// Mirrors [`crate::wallet::voting::observability::VotingObservabilitySnapshot`]
+/// rather than re-exporting the SDK's types: those are `#[non_exhaustive]` and
+/// nest `Vec`s of further structs, neither of which suits this surface.
+/// `rendered` is the SDK's own `Display`, so a Dart line and its os_log
+/// counterpart always say the same thing.
+class ApiVotingObservability {
+  /// The Vizor call site that asked, not the SDK operation.
+  final String context;
+  final String operation;
+  final String? roundId;
+  final String outcome;
+  final BigInt elapsedUs;
+  final BigInt startedAtUnixUs;
+  final String rendered;
+
+  /// One entry per record that failed, was rejected, or may have been
+  /// dispatched, each carrying the SDK's stable `error_kind`. Empty on a
+  /// clean run. `rendered` cannot show these: it prints summaries, and a
+  /// summary has an outcome but no error category.
+  final List<String> failures;
+
+  const ApiVotingObservability({
+    required this.context,
+    required this.operation,
+    this.roundId,
+    required this.outcome,
+    required this.elapsedUs,
+    required this.startedAtUnixUs,
+    required this.rendered,
+    required this.failures,
+  });
+
+  @override
+  int get hashCode =>
+      context.hashCode ^
+      operation.hashCode ^
+      roundId.hashCode ^
+      outcome.hashCode ^
+      elapsedUs.hashCode ^
+      startedAtUnixUs.hashCode ^
+      rendered.hashCode ^
+      failures.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ApiVotingObservability &&
+          runtimeType == other.runtimeType &&
+          context == other.context &&
+          operation == other.operation &&
+          roundId == other.roundId &&
+          outcome == other.outcome &&
+          elapsedUs == other.elapsedUs &&
+          startedAtUnixUs == other.startedAtUnixUs &&
+          rendered == other.rendered &&
+          failures == other.failures;
 }
 
 /// Shared delegation/voting round context passed across the FRB boundary.

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 278247269;
+  int get rustContentHash => -610038420;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -203,6 +203,8 @@ abstract class RustLibApi extends BaseApi {
   Future<ApiVotingEligibility> crateApiVotingCheckVotingEligibility({
     required ApiVotingRoundContext ctx,
   });
+
+  Future<void> crateApiVotingClearVotingObservabilitySink();
 
   Future<IronwoodMigrationResult>
   crateApiSyncCompleteOrchardMigrationBatchPczt({
@@ -1008,6 +1010,8 @@ abstract class RustLibApi extends BaseApi {
     required String txidHex,
     required PlatformInt64 status,
   });
+
+  Stream<ApiVotingObservability> crateApiVotingSetVotingObservabilitySink();
 
   Future<ApiBundleLayout> crateApiVotingSetupDelegationBundles({
     required ApiVotingRoundContext ctx,
@@ -1986,6 +1990,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void> crateApiVotingClearVotingObservabilitySink() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 20,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiVotingClearVotingObservabilitySinkConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVotingClearVotingObservabilitySinkConstMeta =>
+      const TaskConstMeta(
+        debugName: "clear_voting_observability_sink",
+        argNames: [],
+      );
+
+  @override
   Future<IronwoodMigrationResult>
   crateApiSyncCompleteOrchardMigrationBatchPczt({
     required String dbPath,
@@ -2013,7 +2047,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 21,
             port: port_,
           );
         },
@@ -2085,7 +2119,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 22,
             port: port_,
           );
         },
@@ -2154,7 +2188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 23,
             port: port_,
           );
         },
@@ -2220,7 +2254,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 24,
             port: port_,
           );
         },
@@ -2272,7 +2306,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -2307,7 +2341,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -2340,7 +2374,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -2386,7 +2420,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 28,
             port: port_,
           );
         },
@@ -2439,7 +2473,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 29,
             port: port_,
           );
         },
@@ -2484,7 +2518,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -2525,7 +2559,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -2570,7 +2604,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -2602,7 +2636,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -2635,7 +2669,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -2668,7 +2702,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -2703,7 +2737,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -2734,7 +2768,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -2771,7 +2805,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -2804,7 +2838,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 39,
             port: port_,
           );
         },
@@ -2838,7 +2872,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -2879,7 +2913,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -2916,7 +2950,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -2953,7 +2987,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -2992,7 +3026,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -3027,7 +3061,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -3062,7 +3096,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -3092,7 +3126,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -3125,7 +3159,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -3160,7 +3194,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -3206,7 +3240,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -3256,7 +3290,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -3289,7 +3323,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -3324,7 +3358,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -3361,7 +3395,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -3398,7 +3432,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -3433,7 +3467,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -3476,7 +3510,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 57,
             port: port_,
           );
         },
@@ -3530,7 +3564,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -3584,7 +3618,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -3615,7 +3649,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -3660,7 +3694,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 61,
             port: port_,
           );
         },
@@ -3722,7 +3756,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 62,
             port: port_,
           );
         },
@@ -3780,7 +3814,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 63,
             port: port_,
           );
         },
@@ -3831,7 +3865,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 64,
             port: port_,
           );
         },
@@ -3874,7 +3908,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3899,7 +3933,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3927,7 +3961,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 67,
             port: port_,
           );
         },
@@ -3964,7 +3998,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 68,
             port: port_,
           );
         },
@@ -4001,7 +4035,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 69,
             port: port_,
           );
         },
@@ -4038,7 +4072,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 70,
             port: port_,
           );
         },
@@ -4072,7 +4106,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 71,
             port: port_,
           );
         },
@@ -4099,7 +4133,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4129,7 +4163,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 73,
             port: port_,
           );
         },
@@ -4165,7 +4199,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 74,
             port: port_,
           );
         },
@@ -4202,7 +4236,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 75,
             port: port_,
           );
         },
@@ -4238,7 +4272,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 76,
             port: port_,
           );
         },
@@ -4275,7 +4309,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 77,
             port: port_,
           );
         },
@@ -4308,7 +4342,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 78,
             port: port_,
           );
         },
@@ -4341,7 +4375,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 79,
             port: port_,
           );
         },
@@ -4368,7 +4402,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_network_privacy_status,
@@ -4405,7 +4439,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 81,
             port: port_,
           );
         },
@@ -4440,7 +4474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 82,
             port: port_,
           );
         },
@@ -4478,7 +4512,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 83,
             port: port_,
           );
         },
@@ -4519,7 +4553,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 84,
             port: port_,
           );
         },
@@ -4562,7 +4596,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4599,7 +4633,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 86,
             port: port_,
           );
         },
@@ -4638,7 +4672,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 87,
             port: port_,
           );
         },
@@ -4678,7 +4712,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4718,7 +4752,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 89,
             port: port_,
           );
         },
@@ -4754,7 +4788,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4781,7 +4815,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -4811,7 +4845,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 92,
             port: port_,
           );
         },
@@ -4845,7 +4879,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -4886,7 +4920,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 94,
             port: port_,
           );
         },
@@ -4925,7 +4959,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 95,
             port: port_,
           );
         },
@@ -4962,7 +4996,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -4999,7 +5033,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -5027,7 +5061,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 97)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 98)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -5067,7 +5101,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 99,
             port: port_,
           );
         },
@@ -5131,7 +5165,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 100,
             port: port_,
           );
         },
@@ -5199,7 +5233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
             port: port_,
           );
         },
@@ -5265,7 +5299,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 102,
             port: port_,
           );
         },
@@ -5308,7 +5342,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 103,
             port: port_,
           );
         },
@@ -5342,7 +5376,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 104,
           )!;
         },
         codec: SseCodec(
@@ -5370,7 +5404,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 105,
           )!;
         },
         codec: SseCodec(
@@ -5410,7 +5444,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 106,
             port: port_,
           );
         },
@@ -5453,7 +5487,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 107,
           )!;
         },
         codec: SseCodec(
@@ -5479,7 +5513,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 108,
           )!;
         },
         codec: SseCodec(
@@ -5505,7 +5539,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 109,
           )!;
         },
         codec: SseCodec(
@@ -5533,7 +5567,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5568,7 +5602,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
           )!;
         },
         codec: SseCodec(
@@ -5602,7 +5636,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5636,7 +5670,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5688,7 +5722,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
             port: port_,
           );
         },
@@ -5758,7 +5792,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -5829,7 +5863,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
             port: port_,
           );
         },
@@ -5879,7 +5913,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
           )!;
         },
         codec: SseCodec(
@@ -5914,7 +5948,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
           )!;
         },
         codec: SseCodec(
@@ -5947,7 +5981,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 119,
             port: port_,
           );
         },
@@ -5986,7 +6020,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 120,
             port: port_,
           );
         },
@@ -6022,7 +6056,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 121,
             port: port_,
           );
         },
@@ -6060,7 +6094,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 122,
             port: port_,
           );
         },
@@ -6105,7 +6139,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 123,
             port: port_,
           );
         },
@@ -6165,7 +6199,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 124,
             port: port_,
           );
         },
@@ -6225,7 +6259,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 125,
             port: port_,
           );
         },
@@ -6284,7 +6318,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6329,7 +6363,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6370,7 +6404,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6429,7 +6463,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6491,7 +6525,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6539,7 +6573,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6598,7 +6632,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6654,7 +6688,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6684,7 +6718,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 134,
           )!;
         },
         codec: SseCodec(
@@ -6717,7 +6751,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 135,
             port: port_,
           );
         },
@@ -6754,7 +6788,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 136,
             port: port_,
           );
         },
@@ -6789,7 +6823,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 137,
             port: port_,
           );
         },
@@ -6824,7 +6858,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 138,
             port: port_,
           );
         },
@@ -6866,7 +6900,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 139,
             port: port_,
           );
         },
@@ -6901,7 +6935,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 140,
             port: port_,
           );
         },
@@ -6942,7 +6976,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 141,
             port: port_,
           );
         },
@@ -6991,7 +7025,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7020,7 +7054,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7059,7 +7093,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 144,
             port: port_,
           );
         },
@@ -7114,7 +7148,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7170,7 +7204,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
           )!;
         },
         codec: SseCodec(
@@ -7214,7 +7248,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7261,7 +7295,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
           )!;
         },
         codec: SseCodec(
@@ -7291,7 +7325,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
           )!;
         },
         codec: SseCodec(
@@ -7326,7 +7360,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
             port: port_,
           );
         },
@@ -7348,6 +7382,44 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Stream<ApiVotingObservability> crateApiVotingSetVotingObservabilitySink() {
+    final sink = RustStreamSink<ApiVotingObservability>();
+    unawaited(
+      handler.executeNormal(
+        NormalTask(
+          callFfi: (port_) {
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            sse_encode_StreamSink_api_voting_observability_Sse(
+              sink,
+              serializer,
+            );
+            pdeCallFfi(
+              generalizedFrbRustBinding,
+              serializer,
+              funcId: 151,
+              port: port_,
+            );
+          },
+          codec: SseCodec(
+            decodeSuccessData: sse_decode_unit,
+            decodeErrorData: null,
+          ),
+          constMeta: kCrateApiVotingSetVotingObservabilitySinkConstMeta,
+          argValues: [sink],
+          apiImpl: this,
+        ),
+      ),
+    );
+    return sink.stream;
+  }
+
+  TaskConstMeta get kCrateApiVotingSetVotingObservabilitySinkConstMeta =>
+      const TaskConstMeta(
+        debugName: "set_voting_observability_sink",
+        argNames: ["sink"],
+      );
+
+  @override
   Future<ApiBundleLayout> crateApiVotingSetupDelegationBundles({
     required ApiVotingRoundContext ctx,
   }) {
@@ -7359,7 +7431,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7390,7 +7462,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7432,7 +7504,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7486,7 +7558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 155,
             port: port_,
           );
         },
@@ -7536,7 +7608,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 154,
+              funcId: 156,
               port: port_,
             );
           },
@@ -7577,7 +7649,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 155,
+              funcId: 157,
               port: port_,
             );
           },
@@ -7609,7 +7681,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7636,7 +7708,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 159,
           )!;
         },
         codec: SseCodec(
@@ -7662,7 +7734,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 160,
             port: port_,
           );
         },
@@ -7709,7 +7781,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 161,
             port: port_,
           );
         },
@@ -7782,7 +7854,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 162,
             port: port_,
           );
         },
@@ -7844,7 +7916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 163,
             port: port_,
           );
         },
@@ -7879,7 +7951,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 164,
             port: port_,
           );
         },
@@ -7918,7 +7990,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 165,
             port: port_,
           );
         },
@@ -7947,7 +8019,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 166,
           )!;
         },
         codec: SseCodec(
@@ -7974,7 +8046,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 167,
           )!;
         },
         codec: SseCodec(
@@ -8010,7 +8082,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8049,7 +8121,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8090,7 +8162,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 170,
             port: port_,
           );
         },
@@ -8140,7 +8212,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 171,
             port: port_,
           );
         },
@@ -8190,7 +8262,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8222,7 +8294,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 173,
             port: port_,
           );
         },
@@ -8250,7 +8322,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 174,
           )!;
         },
         codec: SseCodec(
@@ -8280,7 +8352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 175,
           )!;
         },
         codec: SseCodec(
@@ -8306,7 +8378,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 176,
           )!;
         },
         codec: SseCodec(
@@ -8352,7 +8424,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 177,
             port: port_,
           );
         },
@@ -8400,7 +8472,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 178,
           )!;
         },
         codec: SseCodec(
@@ -8434,7 +8506,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 179,
             port: port_,
           );
         },
@@ -8471,7 +8543,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 178,
+            funcId: 180,
             port: port_,
           );
         },
@@ -8558,6 +8630,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   RustStreamSink<ApiSyncProgressEvent>
   dco_decode_StreamSink_api_sync_progress_event_Sse(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError();
+  }
+
+  @protected
+  RustStreamSink<ApiVotingObservability>
+  dco_decode_StreamSink_api_voting_observability_Sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     throw UnimplementedError();
   }
@@ -8965,6 +9044,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       distinctNoteCount: dco_decode_u_32(arr[1]),
       eligibleWeightZatoshi: dco_decode_u_64(arr[2]),
       privacyTrimDroppedValueZatoshi: dco_decode_u_64(arr[3]),
+    );
+  }
+
+  @protected
+  ApiVotingObservability dco_decode_api_voting_observability(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 8)
+      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    return ApiVotingObservability(
+      context: dco_decode_String(arr[0]),
+      operation: dco_decode_String(arr[1]),
+      roundId: dco_decode_opt_String(arr[2]),
+      outcome: dco_decode_String(arr[3]),
+      elapsedUs: dco_decode_u_64(arr[4]),
+      startedAtUnixUs: dco_decode_u_64(arr[5]),
+      rendered: dco_decode_String(arr[6]),
+      failures: dco_decode_list_String(arr[7]),
     );
   }
 
@@ -12049,6 +12146,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RustStreamSink<ApiVotingObservability>
+  sse_decode_StreamSink_api_voting_observability_Sse(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    throw UnimplementedError('Unreachable ()');
+  }
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_list_prim_u_8_strict(deserializer);
@@ -12553,6 +12659,31 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       distinctNoteCount: var_distinctNoteCount,
       eligibleWeightZatoshi: var_eligibleWeightZatoshi,
       privacyTrimDroppedValueZatoshi: var_privacyTrimDroppedValueZatoshi,
+    );
+  }
+
+  @protected
+  ApiVotingObservability sse_decode_api_voting_observability(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_context = sse_decode_String(deserializer);
+    var var_operation = sse_decode_String(deserializer);
+    var var_roundId = sse_decode_opt_String(deserializer);
+    var var_outcome = sse_decode_String(deserializer);
+    var var_elapsedUs = sse_decode_u_64(deserializer);
+    var var_startedAtUnixUs = sse_decode_u_64(deserializer);
+    var var_rendered = sse_decode_String(deserializer);
+    var var_failures = sse_decode_list_String(deserializer);
+    return ApiVotingObservability(
+      context: var_context,
+      operation: var_operation,
+      roundId: var_roundId,
+      outcome: var_outcome,
+      elapsedUs: var_elapsedUs,
+      startedAtUnixUs: var_startedAtUnixUs,
+      rendered: var_rendered,
+      failures: var_failures,
     );
   }
 
@@ -16701,6 +16832,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_StreamSink_api_voting_observability_Sse(
+    RustStreamSink<ApiVotingObservability> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(
+      self.setupAndSerialize(
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_api_voting_observability,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+      ),
+      serializer,
+    );
+  }
+
+  @protected
   void sse_encode_String(String self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer);
@@ -17054,6 +17202,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_u_32(self.distinctNoteCount, serializer);
     sse_encode_u_64(self.eligibleWeightZatoshi, serializer);
     sse_encode_u_64(self.privacyTrimDroppedValueZatoshi, serializer);
+  }
+
+  @protected
+  void sse_encode_api_voting_observability(
+    ApiVotingObservability self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.context, serializer);
+    sse_encode_String(self.operation, serializer);
+    sse_encode_opt_String(self.roundId, serializer);
+    sse_encode_String(self.outcome, serializer);
+    sse_encode_u_64(self.elapsedUs, serializer);
+    sse_encode_u_64(self.startedAtUnixUs, serializer);
+    sse_encode_String(self.rendered, serializer);
+    sse_encode_list_String(self.failures, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -73,6 +73,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_StreamSink_api_sync_progress_event_Sse(dynamic raw);
 
   @protected
+  RustStreamSink<ApiVotingObservability>
+  dco_decode_StreamSink_api_voting_observability_Sse(dynamic raw);
+
+  @protected
   String dco_decode_String(dynamic raw);
 
   @protected
@@ -168,6 +172,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiVotingEligibility dco_decode_api_voting_eligibility(dynamic raw);
+
+  @protected
+  ApiVotingObservability dco_decode_api_voting_observability(dynamic raw);
 
   @protected
   ApiVotingRoundContext dco_decode_api_voting_round_context(dynamic raw);
@@ -1253,6 +1260,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<ApiVotingObservability>
+  sse_decode_StreamSink_api_voting_observability_Sse(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
@@ -1384,6 +1397,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiVotingEligibility sse_decode_api_voting_eligibility(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ApiVotingObservability sse_decode_api_voting_observability(
     SseDeserializer deserializer,
   );
 
@@ -2761,6 +2779,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_StreamSink_api_voting_observability_Sse(
+    RustStreamSink<ApiVotingObservability> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
@@ -2925,6 +2949,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_api_voting_eligibility(
     ApiVotingEligibility self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_api_voting_observability(
+    ApiVotingObservability self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -75,6 +75,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_StreamSink_api_sync_progress_event_Sse(dynamic raw);
 
   @protected
+  RustStreamSink<ApiVotingObservability>
+  dco_decode_StreamSink_api_voting_observability_Sse(dynamic raw);
+
+  @protected
   String dco_decode_String(dynamic raw);
 
   @protected
@@ -170,6 +174,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiVotingEligibility dco_decode_api_voting_eligibility(dynamic raw);
+
+  @protected
+  ApiVotingObservability dco_decode_api_voting_observability(dynamic raw);
 
   @protected
   ApiVotingRoundContext dco_decode_api_voting_round_context(dynamic raw);
@@ -1255,6 +1262,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<ApiVotingObservability>
+  sse_decode_StreamSink_api_voting_observability_Sse(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
@@ -1386,6 +1399,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiVotingEligibility sse_decode_api_voting_eligibility(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ApiVotingObservability sse_decode_api_voting_observability(
     SseDeserializer deserializer,
   );
 
@@ -2763,6 +2781,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_StreamSink_api_voting_observability_Sse(
+    RustStreamSink<ApiVotingObservability> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
@@ -2927,6 +2951,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_api_voting_eligibility(
     ApiVotingEligibility self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_api_voting_observability(
+    ApiVotingObservability self,
     SseSerializer serializer,
   );
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6813,7 +6813,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.6.0"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=2aedde466b59bc7114d7fac60f30db4924604787#2aedde466b59bc7114d7fac60f30db4924604787"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=20e0b600ab0b68ae34e50cf32413b89b57147dfe#20e0b600ab0b68ae34e50cf32413b89b57147dfe"
 dependencies = [
  "anyhow",
  "imt-tree",
@@ -6827,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.8.0"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=2aedde466b59bc7114d7fac60f30db4924604787#2aedde466b59bc7114d7fac60f30db4924604787"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=20e0b600ab0b68ae34e50cf32413b89b57147dfe#20e0b600ab0b68ae34e50cf32413b89b57147dfe"
 dependencies = [
  "base64",
  "hex",
@@ -8028,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "4.0.0"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=2aedde466b59bc7114d7fac60f30db4924604787#2aedde466b59bc7114d7fac60f30db4924604787"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=20e0b600ab0b68ae34e50cf32413b89b57147dfe#20e0b600ab0b68ae34e50cf32413b89b57147dfe"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -118,7 +118,7 @@ features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 [dependencies.zcash_voting]
 git = "https://github.com/valargroup/zcash_voting.git"
-rev = "2aedde466b59bc7114d7fac60f30db4924604787"
+rev = "20e0b600ab0b68ae34e50cf32413b89b57147dfe"
 
 [dependencies.orchard]
 package = "zakura-orchard"
@@ -171,13 +171,13 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util", "
 
 [dev-dependencies.zcash_voting]
 git = "https://github.com/valargroup/zcash_voting.git"
-rev = "2aedde466b59bc7114d7fac60f30db4924604787"
+rev = "20e0b600ab0b68ae34e50cf32413b89b57147dfe"
 features = ["test-fixtures"]
 
 [dev-dependencies.vote-commitment-tree]
 version = "=0.6.0"
 git = "https://github.com/valargroup/zcash_voting.git"
-rev = "2aedde466b59bc7114d7fac60f30db4924604787"
+rev = "20e0b600ab0b68ae34e50cf32413b89b57147dfe"
 default-features = false
 features = ["zakura"]
 

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1,11 +1,13 @@
 use std::{panic, path::Path, sync::Arc, time::Instant};
 
+use crate::frb_generated::StreamSink;
+
 #[cfg(test)]
 use super::voting_helpers::bundle_policy;
 use super::voting_helpers::delegation_static_inputs;
 use crate::wallet::{
     keys,
-    voting::{db, delegation, hotkey, network::voting_network},
+    voting::{db, delegation, hotkey, network::voting_network, observability},
 };
 use zcash_voting::config;
 use zcash_voting::wire::{
@@ -1197,6 +1199,62 @@ pub fn resolve_voting_config_from_attempts(
             .collect(),
     })
 }
+
+/// One SDK observability snapshot, flattened for codegen.
+///
+/// Mirrors [`crate::wallet::voting::observability::VotingObservabilitySnapshot`]
+/// rather than re-exporting the SDK's types: those are `#[non_exhaustive]` and
+/// nest `Vec`s of further structs, neither of which suits this surface.
+/// `rendered` is the SDK's own `Display`, so a Dart line and its os_log
+/// counterpart always say the same thing.
+pub struct ApiVotingObservability {
+    /// The Vizor call site that asked, not the SDK operation.
+    pub context: String,
+    pub operation: String,
+    pub round_id: Option<String>,
+    pub outcome: String,
+    pub elapsed_us: u64,
+    pub started_at_unix_us: u64,
+    pub rendered: String,
+    /// One entry per record that failed, was rejected, or may have been
+    /// dispatched, each carrying the SDK's stable `error_kind`. Empty on a
+    /// clean run. `rendered` cannot show these: it prints summaries, and a
+    /// summary has an outcome but no error category.
+    pub failures: Vec<String>,
+}
+
+/// Streams voting observability snapshots to Dart until the sink is closed.
+///
+/// Rust `log` records reach os_log, never the Flutter console, so a debugging
+/// aid that lives only in `log stream` is invisible where developers actually
+/// look. This is the second sink, not a replacement: os_log still receives
+/// every line whether or not Dart ever registers.
+///
+/// Registering twice replaces the previous sink and closes it. Collection
+/// itself stays governed by `VOTING_OBSERVABILITY_ENABLED`, so on a build with
+/// observability off this stream is simply silent.
+pub fn set_voting_observability_sink(sink: StreamSink<ApiVotingObservability>) {
+    observability::set_observer(Some(Box::new(move |context, observability| {
+        // A closed sink is the normal end of the stream, not an error worth
+        // failing voting work over.
+        let _ = sink.add(ApiVotingObservability {
+            context: context.to_string(),
+            operation: observability.operation.clone(),
+            round_id: observability.round_id.clone(),
+            outcome: observability.outcome.to_string(),
+            elapsed_us: observability.elapsed_us,
+            started_at_unix_us: observability.started_at_unix_us,
+            rendered: observability.to_string(),
+            failures: observability::failure_lines(observability),
+        });
+    })));
+}
+
+/// Stops streaming snapshots to Dart, closing any registered sink.
+pub fn clear_voting_observability_sink() {
+    observability::set_observer(None);
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/api/voting_session.rs
+++ b/rust/src/api/voting_session.rs
@@ -28,7 +28,7 @@ use zeroize::Zeroizing;
 use crate::frb_generated::StreamSink;
 use crate::wallet::voting::delegation::{self, RoundInputs, VizorDelegationPipeline};
 use crate::wallet::voting::signer::SeedSpendAuthSigner;
-use crate::wallet::voting::{db, hotkey};
+use crate::wallet::voting::{db, hotkey, observability};
 
 use super::voting::{
     delegation_static_inputs_for, helper_client, routed_transport, ApiVotingRoundContext,
@@ -470,10 +470,18 @@ impl VotingRoundSession {
             });
         });
 
-        let report = RoundDriver::new(&self.executor)
-            .with_policy(round_drive_policy(policy))
-            .run(&host_source, &self.control, &reporter)
-            .await;
+        let report = observability::report(
+            "round_driver.run",
+            RoundDriver::new(&self.executor)
+                .with_policy(round_drive_policy(policy))
+                .run_with_report(
+                    &host_source,
+                    &self.control,
+                    &reporter,
+                    observability::options(),
+                )
+                .await,
+        );
         Ok(ApiRoundRunEvent {
             kind: ApiRoundStepEventKind::Result,
             event: None,
@@ -557,11 +565,18 @@ impl VotingRoundSession {
         });
 
         let client = helper_client(&self.health);
-        let report =
+        let report = observability::report(
+            "share_tracking_driver.run",
             ShareTrackingDriver::new(&database, &client, &self.inputs.round_params.vote_round_id)
                 .with_policy(share_tracking_drive_policy(policy))
-                .run(&host_source, &self.control, &reporter)
-                .await;
+                .run_with_report(
+                    &host_source,
+                    &self.control,
+                    &reporter,
+                    observability::options(),
+                )
+                .await,
+        );
         Ok(ApiShareTrackingRunEvent {
             kind: ApiRoundStepEventKind::Result,
             event: None,
@@ -589,7 +604,9 @@ impl VotingRoundSession {
         let entry_epoch = self.control.operation_epoch();
         let cancel =
             || self.control.is_cancelled() || self.control.operation_epoch() != entry_epoch;
-        let report = zcash_voting::share_tracking::confirm_pending_share(
+        let report = observability::report(
+            "confirm_pending_share",
+            zcash_voting::share_tracking::confirm_pending_share_with_report(
             &database,
             &zcash_voting::share_tracking::ShareConfirmationParams {
                 round_id: &self.inputs.round_params.vote_round_id,
@@ -603,8 +620,10 @@ impl VotingRoundSession {
             },
             &client,
             &cancel,
+            observability::options(),
+            )
+            .await,
         )
-        .await
         .map_err(VotingErrorView::from)?;
         Ok(report.confirmed)
     }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 278247269;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -610038420;
 
 // Section: executor
 
@@ -932,6 +932,40 @@ fn wire__crate__api__voting__check_voting_eligibility_impl(
                     })()
                     .await,
                 )
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__clear_voting_observability_sink_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "clear_voting_observability_sink",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::voting::clear_voting_observability_sink();
+                    })?;
+                    Ok(output_ok)
+                })())
             }
         },
     )
@@ -6055,6 +6089,44 @@ fn wire__crate__api__sync__set_transaction_status_impl(
         },
     )
 }
+fn wire__crate__api__voting__set_voting_observability_sink_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "set_voting_observability_sink",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_sink = <StreamSink<
+                crate::api::voting::ApiVotingObservability,
+                flutter_rust_bridge::for_generated::SseCodec,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::voting::set_voting_observability_sink(api_sink);
+                    })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__voting__setup_delegation_bundles_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -7678,6 +7750,19 @@ impl SseDecode
     }
 }
 
+impl SseDecode
+    for StreamSink<
+        crate::api::voting::ApiVotingObservability,
+        flutter_rust_bridge::for_generated::SseCodec,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <String>::sse_decode(deserializer);
+        return StreamSink::deserialize(inner);
+    }
+}
+
 impl SseDecode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -8152,6 +8237,30 @@ impl SseDecode for crate::api::voting::ApiVotingEligibility {
             distinct_note_count: var_distinctNoteCount,
             eligible_weight_zatoshi: var_eligibleWeightZatoshi,
             privacy_trim_dropped_value_zatoshi: var_privacyTrimDroppedValueZatoshi,
+        };
+    }
+}
+
+impl SseDecode for crate::api::voting::ApiVotingObservability {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_context = <String>::sse_decode(deserializer);
+        let mut var_operation = <String>::sse_decode(deserializer);
+        let mut var_roundId = <Option<String>>::sse_decode(deserializer);
+        let mut var_outcome = <String>::sse_decode(deserializer);
+        let mut var_elapsedUs = <u64>::sse_decode(deserializer);
+        let mut var_startedAtUnixUs = <u64>::sse_decode(deserializer);
+        let mut var_rendered = <String>::sse_decode(deserializer);
+        let mut var_failures = <Vec<String>>::sse_decode(deserializer);
+        return crate::api::voting::ApiVotingObservability {
+            context: var_context,
+            operation: var_operation,
+            round_id: var_roundId,
+            outcome: var_outcome,
+            elapsed_us: var_elapsedUs,
+            started_at_unix_us: var_startedAtUnixUs,
+            rendered: var_rendered,
+            failures: var_failures,
         };
     }
 }
@@ -11956,140 +12065,142 @@ fn pde_ffi_dispatcher_primary_impl(
 16 => wire__crate__api__sync__broadcast_one_due_orchard_migration_transaction_impl(port, ptr, rust_vec_len, data_len),
 17 => wire__crate__api__voting__build_keystone_delegation_requests_impl(port, ptr, rust_vec_len, data_len),
 19 => wire__crate__api__voting__check_voting_eligibility_impl(port, ptr, rust_vec_len, data_len),
-20 => wire__crate__api__sync__complete_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-21 => wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-22 => wire__crate__api__sync__complete_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-23 => wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-24 => wire__crate__api__simple__configure_fast_testnet_migration_impl(port, ptr, rust_vec_len, data_len),
-25 => wire__crate__api__network_privacy__configure_network_privacy_impl(port, ptr, rust_vec_len, data_len),
-26 => wire__crate__api__simple__configure_regtest_ironwood_activation_height_impl(port, ptr, rust_vec_len, data_len),
-27 => wire__crate__api__sync__create_or_resume_private_migration_draft_impl(port, ptr, rust_vec_len, data_len),
-28 => wire__crate__api__sync__create_pczt_from_proposal_impl(port, ptr, rust_vec_len, data_len),
-29 => wire__crate__api__sync__create_shield_transparent_pczt_impl(port, ptr, rust_vec_len, data_len),
-30 => wire__crate__api__sync__create_tex_pczts_from_proposal_impl(port, ptr, rust_vec_len, data_len),
-31 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
-32 => wire__crate__api__keystone__decode_accounts_from_cbor_impl(port, ptr, rust_vec_len, data_len),
-33 => wire__crate__api__keystone__decode_accounts_ur_impl(port, ptr, rust_vec_len, data_len),
-34 => wire__crate__api__keystone__decode_pczt_from_cbor_impl(port, ptr, rust_vec_len, data_len),
-35 => wire__crate__api__keystone__decode_ur_part_impl(port, ptr, rust_vec_len, data_len),
-36 => wire__crate__api__keystone__decode_ur_to_pczt_impl(port, ptr, rust_vec_len, data_len),
-37 => wire__crate__api__keystone__decode_zcash_batch_sign_response_impl(port, ptr, rust_vec_len, data_len),
-38 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_impl(port, ptr, rust_vec_len, data_len),
-39 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_as_sig_result_impl(port, ptr, rust_vec_len, data_len),
-40 => wire__crate__api__sync__decrypt_and_store_transaction_impl(port, ptr, rust_vec_len, data_len),
-41 => wire__crate__api__secret__decrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
-42 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
-43 => wire__crate__api__voting__delete_skipped_bundles_impl(port, ptr, rust_vec_len, data_len),
-44 => wire__crate__api__voting__delete_voting_account_state_impl(port, ptr, rust_vec_len, data_len),
-45 => wire__crate__api__secret__derive_secret_password_verifier_impl(port, ptr, rust_vec_len, data_len),
-46 => wire__crate__api__sync__discard_all_keystone_migration_requests_impl(port, ptr, rust_vec_len, data_len),
-47 => wire__crate__api__sync__discard_keystone_migration_request_impl(port, ptr, rust_vec_len, data_len),
-48 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
-49 => wire__crate__api__wallet__discover_software_wallet_import_accounts_impl(port, ptr, rust_vec_len, data_len),
-50 => wire__crate__api__keystone__encode_keystone_action_sigs_impl(port, ptr, rust_vec_len, data_len),
-51 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
-52 => wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len),
-53 => wire__crate__api__keystone__encode_zcash_sign_batch_ur_parts_impl(port, ptr, rust_vec_len, data_len),
-54 => wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
-55 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(port, ptr, rust_vec_len, data_len),
-56 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
-57 => wire__crate__api__network_privacy__estimate_import_birthday_height_impl(port, ptr, rust_vec_len, data_len),
-58 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
-59 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
-60 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-61 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-62 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-63 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
-66 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
-67 => wire__crate__api__wallet__get_account_export_metadata_impl(port, ptr, rust_vec_len, data_len),
-68 => wire__crate__api__wallet__get_account_ufvk_impl(port, ptr, rust_vec_len, data_len),
-69 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-70 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
-72 => wire__crate__api__wallet__get_chain_upgrade_status_impl(port, ptr, rust_vec_len, data_len),
-73 => wire__crate__api__wallet__get_chain_upgrade_status_at_height_impl(port, ptr, rust_vec_len, data_len),
-74 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
-75 => wire__crate__api__network_privacy__get_import_birthday_metadata_impl(port, ptr, rust_vec_len, data_len),
-76 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
-77 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
-78 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
-82 => wire__crate__api__sync__get_orchard_migration_immediate_plan_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__sync__get_orchard_migration_private_plan_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__sync__get_orchard_migration_status_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__sync__get_orchard_migration_statuses_impl(port, ptr, rust_vec_len, data_len),
-86 => wire__crate__api__sync__get_previous_transaction_count_for_address_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
-93 => wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
-99 => wire__crate__api__wallet__import_software_account_at_index_impl(port, ptr, rust_vec_len, data_len),
-100 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
-119 => wire__crate__api__voting__precompute_delegation_proof_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__voting__precompute_snapshot_bundles_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__sync__prepare_pczt_for_keystone_batch_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-135 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__voting__resolve_pir_snapshot_endpoint_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__zcash_voting__wire__round_work_tally_view_default_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__zcash_voting__wire__share_tracking_pass_report_view_default_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__sync__store_and_broadcast_pczts_with_keystone_signatures_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-175 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
-177 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-178 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+20 => wire__crate__api__voting__clear_voting_observability_sink_impl(port, ptr, rust_vec_len, data_len),
+21 => wire__crate__api__sync__complete_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+22 => wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+23 => wire__crate__api__sync__complete_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+24 => wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+25 => wire__crate__api__simple__configure_fast_testnet_migration_impl(port, ptr, rust_vec_len, data_len),
+26 => wire__crate__api__network_privacy__configure_network_privacy_impl(port, ptr, rust_vec_len, data_len),
+27 => wire__crate__api__simple__configure_regtest_ironwood_activation_height_impl(port, ptr, rust_vec_len, data_len),
+28 => wire__crate__api__sync__create_or_resume_private_migration_draft_impl(port, ptr, rust_vec_len, data_len),
+29 => wire__crate__api__sync__create_pczt_from_proposal_impl(port, ptr, rust_vec_len, data_len),
+30 => wire__crate__api__sync__create_shield_transparent_pczt_impl(port, ptr, rust_vec_len, data_len),
+31 => wire__crate__api__sync__create_tex_pczts_from_proposal_impl(port, ptr, rust_vec_len, data_len),
+32 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
+33 => wire__crate__api__keystone__decode_accounts_from_cbor_impl(port, ptr, rust_vec_len, data_len),
+34 => wire__crate__api__keystone__decode_accounts_ur_impl(port, ptr, rust_vec_len, data_len),
+35 => wire__crate__api__keystone__decode_pczt_from_cbor_impl(port, ptr, rust_vec_len, data_len),
+36 => wire__crate__api__keystone__decode_ur_part_impl(port, ptr, rust_vec_len, data_len),
+37 => wire__crate__api__keystone__decode_ur_to_pczt_impl(port, ptr, rust_vec_len, data_len),
+38 => wire__crate__api__keystone__decode_zcash_batch_sign_response_impl(port, ptr, rust_vec_len, data_len),
+39 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_impl(port, ptr, rust_vec_len, data_len),
+40 => wire__crate__api__keystone__decode_zcash_sign_result_cbor_as_sig_result_impl(port, ptr, rust_vec_len, data_len),
+41 => wire__crate__api__sync__decrypt_and_store_transaction_impl(port, ptr, rust_vec_len, data_len),
+42 => wire__crate__api__secret__decrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
+43 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
+44 => wire__crate__api__voting__delete_skipped_bundles_impl(port, ptr, rust_vec_len, data_len),
+45 => wire__crate__api__voting__delete_voting_account_state_impl(port, ptr, rust_vec_len, data_len),
+46 => wire__crate__api__secret__derive_secret_password_verifier_impl(port, ptr, rust_vec_len, data_len),
+47 => wire__crate__api__sync__discard_all_keystone_migration_requests_impl(port, ptr, rust_vec_len, data_len),
+48 => wire__crate__api__sync__discard_keystone_migration_request_impl(port, ptr, rust_vec_len, data_len),
+49 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
+50 => wire__crate__api__wallet__discover_software_wallet_import_accounts_impl(port, ptr, rust_vec_len, data_len),
+51 => wire__crate__api__keystone__encode_keystone_action_sigs_impl(port, ptr, rust_vec_len, data_len),
+52 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
+53 => wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len),
+54 => wire__crate__api__keystone__encode_zcash_sign_batch_ur_parts_impl(port, ptr, rust_vec_len, data_len),
+55 => wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
+56 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(port, ptr, rust_vec_len, data_len),
+57 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crate__api__network_privacy__estimate_import_birthday_height_impl(port, ptr, rust_vec_len, data_len),
+59 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
+60 => wire__crate__api__wallet__evict_wallet_summary_cache_impl(port, ptr, rust_vec_len, data_len),
+61 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+63 => wire__crate__api__sync__export_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+64 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
+67 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
+68 => wire__crate__api__wallet__get_account_export_metadata_impl(port, ptr, rust_vec_len, data_len),
+69 => wire__crate__api__wallet__get_account_ufvk_impl(port, ptr, rust_vec_len, data_len),
+70 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+71 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
+73 => wire__crate__api__wallet__get_chain_upgrade_status_impl(port, ptr, rust_vec_len, data_len),
+74 => wire__crate__api__wallet__get_chain_upgrade_status_at_height_impl(port, ptr, rust_vec_len, data_len),
+75 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__network_privacy__get_import_birthday_metadata_impl(port, ptr, rust_vec_len, data_len),
+77 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__sync__get_orchard_migration_immediate_plan_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__sync__get_orchard_migration_private_plan_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__sync__get_orchard_migration_status_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__sync__get_orchard_migration_statuses_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__sync__get_previous_transaction_count_for_address_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__wallet__import_software_account_at_index_impl(port, ptr, rust_vec_len, data_len),
+101 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+106 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
+116 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__voting__precompute_delegation_proof_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__voting__precompute_snapshot_bundles_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__sync__prepare_pczt_for_keystone_batch_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+136 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__voting__resolve_pir_snapshot_endpoint_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__zcash_voting__wire__round_work_tally_view_default_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__voting__set_voting_observability_sink_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__zcash_voting__wire__share_tracking_pass_report_view_default_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__sync__store_and_broadcast_pczts_with_keystone_signatures_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+177 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
+179 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+180 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -12123,61 +12234,61 @@ fn pde_ffi_dispatcher_sync_impl(
             data_len,
         ),
         18 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        64 => wire__crate__api__network_privacy__fail_network_privacy_enable_impl(
+        65 => wire__crate__api__network_privacy__fail_network_privacy_enable_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        65 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        71 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        79 => wire__crate__api__network_privacy__get_network_privacy_status_impl(
+        66 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        72 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        80 => wire__crate__api__network_privacy__get_network_privacy_status_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        90 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        97 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        103 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
-        104 => {
+        91 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        98 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        104 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
+        105 => {
             wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len)
         }
-        106 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        107 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        108 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
-        110 => {
+        107 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        108 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        109 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
+        111 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        116 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        117 => wire__crate__api__voting_session__open_voting_round_session_impl(
+        117 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        118 => wire__crate__api__voting_session__open_voting_round_session_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        133 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        145 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
-        147 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        134 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        146 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
+        148 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        148 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        157 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        164 => wire__crate__api__network_privacy__tor_http_begin_request_impl(
+        149 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        159 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        166 => wire__crate__api__network_privacy__tor_http_begin_request_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        165 => wire__crate__api__network_privacy__tor_http_cancel_request_impl(
+        167 => wire__crate__api__network_privacy__tor_http_cancel_request_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        172 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        173 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
-        174 => {
+        174 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        175 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        176 => {
             wire__crate__api__sync__warm_orchard_proving_key_cache_impl(ptr, rust_vec_len, data_len)
         }
-        176 => {
+        178 => {
             wire__crate__api__voting__warm_voting_proving_caches_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -12862,6 +12973,33 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::voting::ApiVotingEligibility>
     for crate::api::voting::ApiVotingEligibility
 {
     fn into_into_dart(self) -> crate::api::voting::ApiVotingEligibility {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::voting::ApiVotingObservability {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.context.into_into_dart().into_dart(),
+            self.operation.into_into_dart().into_dart(),
+            self.round_id.into_into_dart().into_dart(),
+            self.outcome.into_into_dart().into_dart(),
+            self.elapsed_us.into_into_dart().into_dart(),
+            self.started_at_unix_us.into_into_dart().into_dart(),
+            self.rendered.into_into_dart().into_dart(),
+            self.failures.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::voting::ApiVotingObservability
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::voting::ApiVotingObservability>
+    for crate::api::voting::ApiVotingObservability
+{
+    fn into_into_dart(self) -> crate::api::voting::ApiVotingObservability {
         self
     }
 }
@@ -16223,6 +16361,18 @@ impl SseEncode
     }
 }
 
+impl SseEncode
+    for StreamSink<
+        crate::api::voting::ApiVotingObservability,
+        flutter_rust_bridge::for_generated::SseCodec,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        unimplemented!("")
+    }
+}
+
 impl SseEncode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -16540,6 +16690,20 @@ impl SseEncode for crate::api::voting::ApiVotingEligibility {
         <u32>::sse_encode(self.distinct_note_count, serializer);
         <u64>::sse_encode(self.eligible_weight_zatoshi, serializer);
         <u64>::sse_encode(self.privacy_trim_dropped_value_zatoshi, serializer);
+    }
+}
+
+impl SseEncode for crate::api::voting::ApiVotingObservability {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.context, serializer);
+        <String>::sse_encode(self.operation, serializer);
+        <Option<String>>::sse_encode(self.round_id, serializer);
+        <String>::sse_encode(self.outcome, serializer);
+        <u64>::sse_encode(self.elapsed_us, serializer);
+        <u64>::sse_encode(self.started_at_unix_us, serializer);
+        <String>::sse_encode(self.rendered, serializer);
+        <Vec<String>>::sse_encode(self.failures, serializer);
     }
 }
 

--- a/rust/src/wallet/voting.rs
+++ b/rust/src/wallet/voting.rs
@@ -2,6 +2,7 @@ pub mod db;
 pub mod delegation;
 pub mod hotkey;
 pub mod network;
+pub mod observability;
 pub(crate) mod route;
 pub mod signer;
 pub(crate) mod transport;

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -29,6 +29,7 @@ use crate::wallet::sync::open_wallet_db_for_read;
 use crate::wallet::voting::network::wallet_network;
 
 use super::db::open_voting_db;
+use super::observability;
 use super::transport::fetch_snapshot_tree_state;
 
 fn invalid_input(message: impl Into<String>) -> VotingError {
@@ -156,7 +157,13 @@ pub fn start_proving_cache_warmup() {
 /// Select notes and create/reuse delegation bundle rows for a round.
 pub async fn setup_delegation_bundles(inputs: RoundInputs) -> Result<BundleLayout, VotingError> {
     let pipeline = open_pipeline(&inputs, None).await?;
-    blocking("bundle setup", move || pipeline.setup_bundles()).await
+    blocking("bundle setup", move || {
+        observability::report(
+            "setup_delegation_bundles",
+            pipeline.setup_bundles_with_report(observability::options()),
+        )
+    })
+    .await
 }
 
 /// Select notes and check whether a wallet can vote without persisting bundles.
@@ -192,13 +199,17 @@ pub async fn precompute_snapshot_bundles(
         let notes = pipeline.select_notes()?;
         let round_id = pipeline.round_id().to_string();
         fleet.with_failover(|session| {
-            zcash_voting::precompute::precompute_snapshot_bundles(
-                &pipeline.voting_db(),
-                &round_id,
-                &notes,
-                bundle_policy,
-                session,
-                network,
+            observability::report(
+                "precompute_snapshot_bundles",
+                zcash_voting::precompute::precompute_snapshot_bundles_with_report(
+                    &pipeline.voting_db(),
+                    &round_id,
+                    &notes,
+                    bundle_policy,
+                    session,
+                    network,
+                    observability::options(),
+                ),
             )
         })
     })
@@ -219,7 +230,15 @@ pub async fn precompute_delegation_proof(
     let fleet = pir_fleet(pir_server_urls, pir_layout)?;
     let pipeline = open_pipeline(&inputs, Some(hotkey)).await?;
     let status = proving("delegation-proof", move || {
-        pipeline.ensure_proof(bundle_index, &fleet, &NoopProgressReporter)
+        observability::report(
+            "precompute_delegation_proof",
+            pipeline.ensure_proof_with_report(
+                bundle_index,
+                &fleet,
+                &NoopProgressReporter,
+                observability::options(),
+            ),
+        )
     })
     .await?;
     Ok(matches!(status, DelegationProofStatus::Generated))

--- a/rust/src/wallet/voting/observability.rs
+++ b/rust/src/wallet/voting/observability.rs
@@ -1,0 +1,178 @@
+//! One switch for SDK voting observability, and the debug logging it feeds.
+//!
+//! The SDK collects per-stage timings and outcomes only for callers that opt in
+//! through a `*_with_report` entry point and hand it
+//! [`zcash_voting::ObservabilityOptions`]; `None` disables collection at the
+//! source, so a disabled build starts no timers and retains no records.
+//!
+//! Every Vizor call site reads [`VOTING_OBSERVABILITY_ENABLED`] through
+//! [`options`] rather than deciding for itself, so collection cannot end up on
+//! for one entry point and off for the next — a half-instrumented run is worse
+//! than an uninstrumented one, because the gaps read as fast stages.
+//!
+//! Rendering is the SDK's own [`std::fmt::Display`], not a local printer: stage
+//! names are SDK-authored, errors are reduced to a stable category, endpoints
+//! appear as a configured ordinal, and detailed records and free-form error
+//! text are omitted. No URL, address, or error message reaches these lines.
+
+use std::sync::Mutex;
+
+use zcash_voting::{
+    ObservabilityOptions, ObservationOutcome, OperationObservability, OperationReport,
+};
+
+/// The single switch for SDK voting observability.
+///
+/// Debug builds collect; release builds do not. Collection costs a timer and a
+/// bounded record buffer per invocation — noise next to proving, but not free —
+/// and the reports are a debugging aid rather than a product feature. Flip this
+/// one constant to change every voting call site at once.
+pub const VOTING_OBSERVABILITY_ENABLED: bool = cfg!(debug_assertions);
+
+/// Options for a `*_with_report` entry point, or `None` when collection is off.
+pub fn options() -> Option<ObservabilityOptions> {
+    VOTING_OBSERVABILITY_ENABLED.then(ObservabilityOptions::default)
+}
+
+/// The transport `api` installs so snapshots can also reach Dart.
+///
+/// A callback rather than a type because `wallet` does not depend on `api`:
+/// the FRB-facing struct lives up there, and flattening the SDK snapshot into
+/// it is that layer's job. Borrowing the SDK type here keeps exactly one
+/// definition of these fields in the crate.
+type Observer = Box<dyn Fn(&str, &OperationObservability) + Send + Sync>;
+
+static OBSERVER: Mutex<Option<Observer>> = Mutex::new(None);
+
+/// Installs, or with `None` removes, the transport for snapshots.
+///
+/// Replacing an observer drops the previous one, closing whatever stream it
+/// held: a second registration is a deliberate hand-over, not a duplicate.
+pub fn set_observer(observer: Option<Observer>) {
+    *OBSERVER.lock().unwrap_or_else(|poison| poison.into_inner()) = observer;
+}
+
+/// Hands one snapshot to the installed transport, if there is one.
+fn emit(context: &str, observability: &OperationObservability) {
+    let observer = OBSERVER.lock().unwrap_or_else(|poison| poison.into_inner());
+    if let Some(observer) = observer.as_ref() {
+        observer(context, observability);
+    }
+}
+
+/// Renders the error category of every record that did not succeed.
+///
+/// The SDK's `Display` prints summaries, and `ObservationSummary` carries an
+/// outcome but no `error_kind` — so a failed stage renders with no reason
+/// attached, which is exactly the case worth reading. `error_kind` lives on
+/// `ObservationRecord`, is collected already, and is a stable category rather
+/// than free-form error text, so surfacing it leaks nothing.
+///
+/// Restricted to outcomes that denote a problem. `Unfinished` is excluded: it
+/// is the normal state of work still in flight when the snapshot was taken,
+/// and including it would bury real failures. `PossiblyDispatched` is kept
+/// because an ambiguous submission is precisely what an operator must see.
+pub fn failure_lines(observability: &OperationObservability) -> Vec<String> {
+    observability
+        .records
+        .iter()
+        .filter(|record| {
+            matches!(
+                record.outcome,
+                ObservationOutcome::Failed
+                    | ObservationOutcome::Rejected
+                    | ObservationOutcome::PossiblyDispatched
+            )
+        })
+        .map(|record| {
+            let mut line = record.stage.to_string();
+            if let Some(bundle) = record.attribution.bundle_index {
+                line.push_str(&format!(" bundle={bundle}"));
+            }
+            if let Some(proposal) = record.attribution.proposal_id {
+                line.push_str(&format!(" proposal={proposal}"));
+            }
+            if let Some(share) = record.attribution.share_index {
+                line.push_str(&format!(" share={share}"));
+            }
+            line.push_str(&format!(
+                ": {} error_kind={}",
+                record.outcome,
+                record.error_kind.as_deref().unwrap_or("-")
+            ));
+            if let Some(status) = record.http_status {
+                line.push_str(&format!(" http_status={status}"));
+            }
+            if let Some(endpoint) = record.endpoint_index {
+                line.push_str(&format!(" endpoint={endpoint}"));
+            }
+            if let Some(attempt) = record.attempt {
+                line.push_str(&format!(" attempt={attempt}"));
+            }
+            line.push_str(&format!(" elapsed_us={}", record.elapsed_us));
+            line
+        })
+        .collect()
+}
+
+/// Unwraps an SDK [`OperationReport`], reporting its snapshot when one came back.
+///
+/// `context` names the Vizor path that asked; the SDK's own operation name is
+/// already inside the snapshot. Reporting happens before the caller applies
+/// `?`, so a failed operation still describes the stages that preceded the
+/// failure — the case these reports exist for.
+pub fn report<T>(context: &str, report: OperationReport<T>) -> T {
+    let (result, observability) = report.into_parts();
+    if let Some(observability) = observability {
+        // One record per rendered line, not one record for the whole report.
+        // os_log truncates a single message at ~1018 characters with a `<…>`
+        // marker, and the renderer sorts summaries by stage name, so a long
+        // report loses whichever stages sort last — `vote::*` before anything
+        // else. Per-line records keep every stage. The Dart stream has no such
+        // limit and still receives the report as one block.
+        for line in observability.to_string().lines() {
+            log::info!("[VOTING_OBS] {context}: {line}");
+        }
+        // Warn level so a failure stands out against the summary rows, and
+        // survives any future tightening of the log filter above Info.
+        for line in failure_lines(&observability) {
+            log::warn!("[VOTING_OBS] {context}: FAILED {line}");
+        }
+        emit(context, &observability);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Options are what every call site passes, so they must follow the switch
+    /// rather than being decided independently anywhere.
+    #[test]
+    fn options_follow_the_single_switch() {
+        assert_eq!(options().is_some(), VOTING_OBSERVABILITY_ENABLED);
+    }
+
+    /// The result must survive the unwrap untouched, including on the error
+    /// path — the one these reports exist to explain.
+    ///
+    /// The observer hand-over is deliberately not covered: the SDK's
+    /// `OperationObservability` is `#[non_exhaustive]` with no constructor, so
+    /// a host cannot build one to emit. Restoring that test needs a fixture
+    /// constructor from the SDK's `test-fixtures` feature.
+    #[test]
+    fn report_returns_the_result_unchanged() {
+        let ok = OperationReport {
+            result: Ok::<u32, &str>(7),
+            observability: None,
+        };
+        assert_eq!(report("test", ok), Ok(7));
+
+        let failed = OperationReport {
+            result: Err::<u32, &str>("boom"),
+            observability: None,
+        };
+        assert_eq!(report("test", failed), Err("boom"));
+    }
+}

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -71,6 +71,159 @@ void main() {
 
   tearDownAll(RustLib.dispose);
 
+  testWidgets('delegation ring follows confirmations through finalization', (
+    tester,
+  ) async {
+    const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+    final updates = StreamController<VotingSessionState>();
+    addTearDown(updates.close);
+    final sessionProvider = StreamProvider((ref) => updates.stream);
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      overrides: [
+        votingSubmissionJobsProvider.overrideWith(
+          () => _StaticVotingSubmissionJobsNotifier(
+            const VotingSubmissionJobsState(jobKeys: [key]),
+          ),
+        ),
+        votingSubmissionJobProvider(key).overrideWith(
+          () => _StaticVotingSubmissionJobNotifier(
+            key,
+            const VotingSubmissionJobState(
+              key: key,
+              status: VotingSubmissionJobStatus.running,
+              generation: 1,
+            ),
+          ),
+        ),
+        votingSubmissionJobSessionProvider(
+          key,
+        ).overrideWith((ref) => ref.watch(sessionProvider)),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _statusHarness(
+          initialLocation: votingStatusRoute(
+            _roundId,
+            accountUuid: 'account-1',
+          ),
+        ),
+      ),
+    );
+    final plan = apiRoundPlan(
+      roundId: _roundId,
+      pendingRecovery: true,
+      nextSteps: [
+        for (var index = 0; index < 3; index++)
+          rust_wire.NextStepView(
+            // Bundle 2 already has a submission. It must be counted before
+            // its first progress event, even though it needs no signature.
+            kind: index == 2
+                ? rust_frb_types.NextStepKind.advanceDelegation
+                : rust_frb_types.NextStepKind.delegate,
+            bundleIndex: index,
+            proposalId: 0,
+            choice: 0,
+            shareIndex: 0,
+          ),
+      ],
+      openProposals: Uint32List.fromList([1]),
+      allDecided: false,
+    );
+    final progress = <int, VotingSessionProgress>{};
+    Future<void> check(String detail, double? value) async {
+      updates.add(
+        VotingSessionState(
+          roundId: _roundId,
+          accountUuid: 'account-1',
+          phase: VotingSessionPhase.delegating,
+          roundPlan: plan,
+          delegationProgress: progress,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text(detail), findsOneWidget);
+      expect(
+        tester
+            .widget<CircularProgressIndicator>(
+              find.byType(CircularProgressIndicator),
+            )
+            .value,
+        value == null ? isNull : closeTo(value, 0.0001),
+      );
+      expect(find.text('submission confirmed route'), findsNothing);
+    }
+
+    await check('0 of 3 bundles complete', 0);
+    progress[0] = const VotingSessionProgress(
+      phase: VotingProgressPhase.proofProgress,
+      proofProgress: 1,
+    );
+    progress[1] = const VotingSessionProgress(
+      phase: VotingProgressPhase.proofProgress,
+      proofProgress: 0.7,
+    );
+    await check('0 of 3 bundles complete', 0);
+    progress[1] = const VotingSessionProgress(
+      phase: VotingProgressPhase.waitingForExistingProof,
+    );
+    await check('Reusing an in-progress proof — 0 of 3 bundles complete', 0);
+    for (var index = 0; index < 3; index++) {
+      progress[index] = const VotingSessionProgress(
+        phase: VotingProgressPhase.payloadReady,
+        proofProgress: 1,
+      );
+    }
+    await check(
+      'Waiting for submission and confirmation — 0 of 3 bundles complete',
+      0,
+    );
+    progress[2] = const VotingSessionProgress(
+      phase: VotingProgressPhase.submitted,
+    );
+    await check(
+      'Waiting for submission and confirmation — 0 of 3 bundles complete',
+      0,
+    );
+    // Confirm out of order: proof completion must never pre-fill the ring.
+    progress[2] = const VotingSessionProgress(
+      phase: VotingProgressPhase.confirmed,
+    );
+    await check(
+      'Waiting for submission and confirmation — 1 of 3 bundles complete',
+      1 / 3,
+    );
+    progress[0] = const VotingSessionProgress(
+      phase: VotingProgressPhase.confirmed,
+    );
+    await check(
+      'Waiting for submission and confirmation — 2 of 3 bundles complete',
+      2 / 3,
+    );
+    progress[1] = const VotingSessionProgress(
+      phase: VotingProgressPhase.confirmed,
+    );
+    await check('Finalizing delegation — 3 of 3 bundles complete', null);
+    updates.add(
+      VotingSessionState(
+        roundId: _roundId,
+        accountUuid: 'account-1',
+        phase: VotingSessionPhase.castingVotes,
+        roundPlan: plan,
+        delegationProgress: progress,
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.textContaining('bundles complete'), findsNothing);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+
   testWidgets('status screen requires software account without mnemonic', (
     tester,
   ) async {


### PR DESCRIPTION
Stacked on #625. Requires valargroup/zcash_voting#308, which this pins (`20e0b600`).

## Why

A vote that ran slowly or failed left almost nothing behind to read. The SDK
collects per-stage timings and outcomes, but emits **no log records of its own** —
no `log`, no `tracing`, zero macro invocations anywhere in its source. That was
not a routing failure; there was nothing to route.

Separately, Rust `log` records reach os_log (subsystem `frb_user`) and **never**
the Flutter console, so a report written only one way is invisible wherever the
developer happens to be looking.

## What this does

Opts into the SDK's `*_with_report` entry points behind one switch,
`VOTING_OBSERVABILITY_ENABLED` (debug builds only), read by every call site
through `observability::options()`. A half-instrumented run is worse than an
uninstrumented one, because the gaps read as fast stages.

Reports go to **both** sinks, which are not equivalent:

| | os_log | Dart stream |
|---|---|---|
| visible in `flutter run` | no | yes |
| visible in a detached `.app` | yes | no |
| survives the session | yes (`log show --last 30m`) | no |

os_log is retrospective — it is how a failure from hours ago gets reconstructed.
Dart is where you are already looking. Neither replaces the other.

Two details that are load-bearing rather than cosmetic:

- **One os_log record per rendered line.** A single message is truncated at
  ~1018 characters, and the renderer sorts stages by name — so a long report
  loses whichever sort last, which is `vote::*` before anything else. Exactly
  the stages you would be reading it for.
- **Failed records carry `error_kind`.** The SDK's `Display` renders summaries,
  and a summary has an outcome but no reason. `error_kind` is collected on
  `ObservationRecord` and was being dropped before any sink.

## Reading it

```bash
/usr/bin/log stream --predicate 'subsystem == "frb_user"' --level info | grep VOTING_OBS
```

(`log` is a zsh builtin that shadows `/usr/bin/log`; the bare form fails with
`too many arguments`.)

## What it already found

Per-phase breakdown of a real round, which was not previously measurable:

| Phase | Calls | Cumulative |
|---|---|---|
| `helper.http.post_json` | 288 | **72.2 s** |
| `chain::advance_until_terminal_in_epoch` | 6 | 17.5 s |
| `delegation::driver_prove_and_sign` | 3 | 9.4 s |
| `zkp2.prove` | 18 | 4.2 s |
| `vote::prepare_atomic_vote_batch` | 3 | **1.6 s** |

Batch cast is ~0.53 s per call and stable across runs — not the slow part.
Share delivery is ~70% of measured time, which is what valargroup/zcash_voting#308
addresses.

## Also included

``Track the delegation ring by confirmations, not proof progress`` — a separate
commit, not observability work. A finished proof still owes signing,
submission, and confirmation, so a ring driven by proof progress filled while
the bundle still had work left. It now counts confirmed bundles, the same unit
as the counter beside it, and the detail line names the two states that were
previously indistinguishable from "not done": finalizing, and waiting on
submission and confirmation.

Carried here rather than on #625 at the author'''s request, though it continues
that branch'''s progress-bar work.

## Scope

Deliberately excluded: network/build config, build scripts, and local scratch
files. Generated FRB bindings are included because the Dart sink needs them.

## Verification

- `cargo test` — 713 passed, 0 failed
- `cargo check --all-targets` — 0 errors
- `fvm flutter test` — 2534 passed, 0 failed
- `fvm flutter analyze` — no issues
- Builds against the pinned rev fetched from GitHub, not a local path override

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LUkSGDytzVZ2qr51hJb28
