### PR TITLE
Accept every proposal id the SDK allows, and pin the mirror

### DIFF
--- a/lib/src/features/voting/voting_flow_models.dart
+++ b/lib/src/features/voting/voting_flow_models.dart
@@ -6,8 +6,20 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/storage/app_secure_store.dart';
 import '../../providers/voting/voting_state.dart';
 
-const int _minProposalId = 1;
-const int _maxProposalId = 15;
+/// Inclusive bounds on an on-chain proposal id, mirroring the SDK's
+/// `MIN_PROPOSAL_ID` and `MAX_PROPOSAL_ID`.
+///
+/// Mirrored rather than read at parse time because this parser is synchronous
+/// and runs per proposal; a round trip into Rust to re-learn two constants
+/// would cost more than it is worth. The mirror is what makes them wrong when
+/// the SDK moves, so `voting_proposal_id_range_test.dart` asserts these equal
+/// the values the SDK actually enforces and fails the build when they drift.
+///
+/// They drifted once already: this held 15 while the SDK allowed 50, so a
+/// 37-question round failed to parse at proposal 16 with a `FormatException`
+/// the user could do nothing about.
+const int kMinProposalId = 1;
+const int kMaxProposalId = 50;
 const List<String> _forumUrlKeys = [
   'discussion_url',
   'discussionUrl',
@@ -523,9 +535,9 @@ int _proposalIdFromJson(Map<String, dynamic> json) {
   if (id == null) {
     throw const FormatException('Missing required int: id');
   }
-  if (id < _minProposalId || id > _maxProposalId) {
+  if (id < kMinProposalId || id > kMaxProposalId) {
     throw FormatException(
-      'id must be $_minProposalId..$_maxProposalId, got $id',
+      'id must be $kMinProposalId..$kMaxProposalId, got $id',
     );
   }
   return id;

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -53,6 +53,10 @@ bool isLastMoment({
   voteEndTimeSeconds: voteEndTimeSeconds,
 );
 
+/// Returns the proposal id range the pinned SDK enforces.
+Future<ApiProposalIdRange> votingProposalIdRange() =>
+    RustLib.instance.api.crateApiVotingVotingProposalIdRange();
+
 /// Build round params from server metadata while binding trusted `ea_pk`.
 ///
 /// Trust model for the per-round parameters:
@@ -692,6 +696,29 @@ class ApiPirSnapshotResolution {
           runtimeType == other.runtimeType &&
           endpoint == other.endpoint &&
           diagnostics == other.diagnostics;
+}
+
+/// Inclusive bounds the vote circuit enforces on an on-chain proposal id.
+///
+/// Exposed so hosts can check their own copy against the SDK rather than
+/// discover a mismatch as a parse failure in front of a voter. Read from
+/// `zcash_voting` directly, so bumping the pinned SDK moves this with it.
+class ApiProposalIdRange {
+  final int min;
+  final int max;
+
+  const ApiProposalIdRange({required this.min, required this.max});
+
+  @override
+  int get hashCode => min.hashCode ^ max.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ApiProposalIdRange &&
+          runtimeType == other.runtimeType &&
+          min == other.min &&
+          max == other.max;
 }
 
 /// PIR cache result for one snapshot-precomputed delegation bundle.

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -610038420;
+  int get rustContentHash => -889021001;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -1146,6 +1146,8 @@ abstract class RustLibApi extends BaseApi {
   });
 
   bool crateApiWalletValidateMnemonic({required String mnemonic});
+
+  Future<ApiProposalIdRange> crateApiVotingVotingProposalIdRange();
 
   bool crateApiWalletWalletExists({required String dbPath});
 
@@ -8343,6 +8345,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<ApiProposalIdRange> crateApiVotingVotingProposalIdRange() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 175,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_api_proposal_id_range,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiVotingVotingProposalIdRangeConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVotingVotingProposalIdRangeConstMeta =>
+      const TaskConstMeta(debugName: "voting_proposal_id_range", argNames: []);
+
+  @override
   bool crateApiWalletWalletExists({required String dbPath}) {
     return handler.executeSync(
       SyncTask(
@@ -8352,7 +8381,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 176,
           )!;
         },
         codec: SseCodec(
@@ -8378,7 +8407,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 177,
           )!;
         },
         codec: SseCodec(
@@ -8424,7 +8453,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 178,
             port: port_,
           );
         },
@@ -8472,7 +8501,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 178,
+            funcId: 179,
           )!;
         },
         codec: SseCodec(
@@ -8506,7 +8535,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 179,
+            funcId: 180,
             port: port_,
           );
         },
@@ -8543,7 +8572,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 180,
+            funcId: 181,
             port: port_,
           );
         },
@@ -8856,6 +8885,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       diagnostics: dco_decode_list_pir_snapshot_endpoint_diagnostic_view(
         arr[1],
       ),
+    );
+  }
+
+  @protected
+  ApiProposalIdRange dco_decode_api_proposal_id_range(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return ApiProposalIdRange(
+      min: dco_decode_u_32(arr[0]),
+      max: dco_decode_u_32(arr[1]),
     );
   }
 
@@ -12393,6 +12434,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       endpoint: var_endpoint,
       diagnostics: var_diagnostics,
     );
+  }
+
+  @protected
+  ApiProposalIdRange sse_decode_api_proposal_id_range(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_min = sse_decode_u_32(deserializer);
+    var var_max = sse_decode_u_32(deserializer);
+    return ApiProposalIdRange(min: var_min, max: var_max);
   }
 
   @protected
@@ -17030,6 +17081,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       self.diagnostics,
       serializer,
     );
+  }
+
+  @protected
+  void sse_encode_api_proposal_id_range(
+    ApiProposalIdRange self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_32(self.min, serializer);
+    sse_encode_u_32(self.max, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -133,6 +133,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ApiPirSnapshotResolution dco_decode_api_pir_snapshot_resolution(dynamic raw);
 
   @protected
+  ApiProposalIdRange dco_decode_api_proposal_id_range(dynamic raw);
+
+  @protected
   ApiProposalRosterEntry dco_decode_api_proposal_roster_entry(dynamic raw);
 
   @protected
@@ -1338,6 +1341,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiPirSnapshotResolution sse_decode_api_pir_snapshot_resolution(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ApiProposalIdRange sse_decode_api_proposal_id_range(
     SseDeserializer deserializer,
   );
 
@@ -2877,6 +2885,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_api_pir_snapshot_resolution(
     ApiPirSnapshotResolution self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_api_proposal_id_range(
+    ApiProposalIdRange self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -135,6 +135,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ApiPirSnapshotResolution dco_decode_api_pir_snapshot_resolution(dynamic raw);
 
   @protected
+  ApiProposalIdRange dco_decode_api_proposal_id_range(dynamic raw);
+
+  @protected
   ApiProposalRosterEntry dco_decode_api_proposal_roster_entry(dynamic raw);
 
   @protected
@@ -1340,6 +1343,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ApiPirSnapshotResolution sse_decode_api_pir_snapshot_resolution(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ApiProposalIdRange sse_decode_api_proposal_id_range(
     SseDeserializer deserializer,
   );
 
@@ -2879,6 +2887,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_api_pir_snapshot_resolution(
     ApiPirSnapshotResolution self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_api_proposal_id_range(
+    ApiProposalIdRange self,
     SseSerializer serializer,
   );
 

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -314,6 +314,25 @@ pub fn is_last_moment(
 }
 
 // Fixed-width Keystone payload fields used by adapter regression tests.
+/// Inclusive bounds the vote circuit enforces on an on-chain proposal id.
+///
+/// Exposed so hosts can check their own copy against the SDK rather than
+/// discover a mismatch as a parse failure in front of a voter. Read from
+/// `zcash_voting` directly, so bumping the pinned SDK moves this with it.
+pub struct ApiProposalIdRange {
+    pub min: u32,
+    pub max: u32,
+}
+
+/// Returns the proposal id range the pinned SDK enforces.
+pub fn voting_proposal_id_range() -> ApiProposalIdRange {
+    ApiProposalIdRange {
+        min: zcash_voting::MIN_PROPOSAL_ID,
+        max: zcash_voting::MAX_PROPOSAL_ID,
+    }
+}
+
+
 #[cfg(test)]
 const KEYSTONE_SIG_LEN: usize = 64;
 #[cfg(test)]
@@ -1257,6 +1276,26 @@ pub fn clear_voting_observability_sink() {
 
 #[cfg(test)]
 mod tests {
+    /// Pins the SDK half of the proposal-id mirror.
+    ///
+    /// `kMinProposalId` / `kMaxProposalId` in
+    /// `lib/src/features/voting/voting_flow_models.dart` carry the same two
+    /// numbers, because the Dart parser is synchronous and cannot ask the SDK
+    /// per proposal. Dart unit tests fake the Rust API rather than loading the
+    /// native library, so they cannot read these constants either — this test
+    /// is what makes an SDK bump fail the build instead of surfacing as a
+    /// `FormatException` in front of a voter. Update both together.
+    #[test]
+    fn voting_proposal_id_range_matches_the_dart_mirror() {
+        let range = super::voting_proposal_id_range();
+        assert_eq!(
+            (range.min, range.max),
+            (1, 50),
+            "proposal id range moved; update kMinProposalId/kMaxProposalId in \
+             lib/src/features/voting/voting_flow_models.dart to match"
+        );
+    }
+
     use std::sync::Mutex;
 
     use super::*;

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -610038420;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -889021001;
 
 // Section: executor
 
@@ -7024,6 +7024,39 @@ fn wire__crate__api__wallet__validate_mnemonic_impl(
         },
     )
 }
+fn wire__crate__api__voting__voting_proposal_id_range_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "voting_proposal_id_range",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok =
+                        Result::<_, ()>::Ok(crate::api::voting::voting_proposal_id_range())?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet__wallet_exists_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -8000,6 +8033,18 @@ impl SseDecode for crate::api::voting::ApiPirSnapshotResolution {
         return crate::api::voting::ApiPirSnapshotResolution {
             endpoint: var_endpoint,
             diagnostics: var_diagnostics,
+        };
+    }
+}
+
+impl SseDecode for crate::api::voting::ApiProposalIdRange {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_min = <u32>::sse_decode(deserializer);
+        let mut var_max = <u32>::sse_decode(deserializer);
+        return crate::api::voting::ApiProposalIdRange {
+            min: var_min,
+            max: var_max,
         };
     }
 }
@@ -12201,9 +12246,10 @@ fn pde_ffi_dispatcher_primary_impl(
 171 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
 172 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
 173 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-177 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
-179 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-180 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+175 => wire__crate__api__voting__voting_proposal_id_range_impl(port, ptr, rust_vec_len, data_len),
+178 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
+180 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+181 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -12287,11 +12333,11 @@ fn pde_ffi_dispatcher_sync_impl(
             data_len,
         ),
         174 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        175 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
-        176 => {
+        176 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        177 => {
             wire__crate__api__sync__warm_orchard_proving_key_cache_impl(ptr, rust_vec_len, data_len)
         }
-        178 => {
+        179 => {
             wire__crate__api__voting__warm_voting_proving_caches_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -12675,6 +12721,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::voting::ApiPirSnapshotResolut
     for crate::api::voting::ApiPirSnapshotResolution
 {
     fn into_into_dart(self) -> crate::api::voting::ApiPirSnapshotResolution {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::voting::ApiProposalIdRange {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.min.into_into_dart().into_dart(),
+            self.max.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::voting::ApiProposalIdRange
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::voting::ApiProposalIdRange>
+    for crate::api::voting::ApiProposalIdRange
+{
+    fn into_into_dart(self) -> crate::api::voting::ApiProposalIdRange {
         self
     }
 }
@@ -16542,6 +16609,14 @@ impl SseEncode for crate::api::voting::ApiPirSnapshotResolution {
             self.diagnostics,
             serializer,
         );
+    }
+}
+
+impl SseEncode for crate::api::voting::ApiProposalIdRange {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.min, serializer);
+        <u32>::sse_encode(self.max, serializer);
     }
 }
 

--- a/test/features/voting/voting_flow_models_test.dart
+++ b/test/features/voting/voting_flow_models_test.dart
@@ -236,7 +236,7 @@ void main() {
         isA<FormatException>().having(
           (error) => error.message,
           'message',
-          'id must be 1..15, got 0',
+          'id must be $kMinProposalId..$kMaxProposalId, got 0',
         ),
       ),
     );

--- a/test/features/voting/voting_proposal_id_range_test.dart
+++ b/test/features/voting/voting_proposal_id_range_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
+
+/// The Dart bounds mirror the SDK's `MIN_PROPOSAL_ID` / `MAX_PROPOSAL_ID`.
+///
+/// Unit tests fake the Rust API rather than loading the native library, so
+/// they cannot read the SDK's constants directly. The mirror is pinned on both
+/// sides instead: `voting_proposal_id_range_matches_the_sdk` in
+/// `rust/src/api/voting.rs` pins the SDK half against these same literals and
+/// fails the build if the SDK moves.
+Map<String, dynamic> _round(List<int> proposalIds) => {
+  'proposals': [
+    for (final id in proposalIds)
+      {'id': id, 'title': 'Question $id', 'options': <dynamic>[]},
+  ],
+};
+
+void main() {
+  test('the mirrored bounds are the values the SDK enforces', () {
+    expect(kMinProposalId, 1);
+    expect(kMaxProposalId, 50);
+  });
+
+  test('a proposal at either bound parses', () {
+    final parsed = proposalsFromJson(_round([kMinProposalId, kMaxProposalId]));
+    expect(parsed.map((proposal) => proposal.id), [
+      kMinProposalId,
+      kMaxProposalId,
+    ]);
+  });
+
+  test('a proposal outside the bounds is refused with its id named', () {
+    for (final id in [kMinProposalId - 1, kMaxProposalId + 1]) {
+      expect(
+        () => proposalsFromJson(_round([id])),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('got $id'),
+          ),
+        ),
+      );
+    }
+  });
+
+  /// The regression: this parser held a maximum of 15 while the SDK allowed
+  /// 50, so a 37-question round died at proposal 16 with a `FormatException`
+  /// no voter could act on.
+  test('a 37-question round parses end to end', () {
+    final ids = [for (var id = 1; id <= 37; id++) id];
+    final parsed = proposalsFromJson(_round(ids));
+    expect(parsed.map((proposal) => proposal.id), ids);
+  });
+}


### PR DESCRIPTION
Fixes a 37-question round failing to open with:

```
id must be 1..15, got 16
```

## Cause

`voting_flow_models.dart` capped proposal ids at 15:

```dart
const int _maxProposalId = 15;
if (id < _minProposalId || id > _maxProposalId) throw FormatException(...);
```

The SDK enforces `MIN_PROPOSAL_ID = 1` / `MAX_PROPOSAL_ID = 50`. The Dart cap
was a stale copy of a constant that had already moved, so every round with more
than 15 questions failed to parse at proposal 16 — a hard `FormatException` in
front of the voter, with nothing they could do about it.

Nothing was wrong in the SDK or the circuit. The bounds are already exported
(`zcash_voting::{MIN_PROPOSAL_ID, MAX_PROPOSAL_ID}`) and are present at the rev
this branch pins, so the fix needs no SDK change.

## Fix

Correct the bounds, and make the next drift a build failure rather than a
parse error.

The parser stays synchronous and keeps mirroring the constants — it runs once
per proposal, and a round trip into Rust to re-learn two integers would cost
more than it is worth. What changes is that the mirror is now checked:

- `voting_proposal_id_range()` exposes what the pinned SDK actually enforces
- a Rust test pins that against the same two literals the Dart constants carry,
  and names the Dart file to update
- a Dart test pins the parser's boundaries and the 37-question case that failed

Dart unit tests fake the Rust API rather than loading the native library, so
neither side can read the other's constant at test time. Pinning both is what
makes an SDK bump fail CI instead of reaching a voter.

The constants are renamed `kMinProposalId` / `kMaxProposalId` so a test can see
them.

## Verification

- `cargo test` — 712 passed, 0 failed
- `fvm flutter analyze` — no issues
- new Dart test — 4 passed, including the 37-question regression

Independent of #636; both target this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LUkSGDytzVZ2qr51hJb28