### PR TITLE
[desktop] Prevent concurrent Linux wallet instances

### DIFF
--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -9,6 +9,7 @@ project(runner LANGUAGES CXX)
 add_executable(${BINARY_NAME}
   "main.cc"
   "my_application.cc"
+  "single_instance.cc"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
 )
 

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -8,6 +8,7 @@
 #include <cstring>
 
 #include "flutter/generated_plugin_registrant.h"
+#include "single_instance.h"
 
 struct _MyApplication {
   GtkApplication parent_instance;
@@ -16,9 +17,23 @@ struct _MyApplication {
   FlMethodChannel* payment_uri_channel;
   GPtrArray* pending_payment_uris;
   gboolean payment_uri_dart_ready;
+  SingleInstanceGuard* instance_guard;
+  gboolean is_primary;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+static void show_startup_error(const gchar* message) {
+  g_printerr("%s\n", message);
+  if (gtk_init_check(nullptr, nullptr)) {
+    GtkWidget* dialog = gtk_message_dialog_new(
+        nullptr, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
+        "%s", message);
+    gtk_window_set_title(GTK_WINDOW(dialog), APP_DISPLAY_NAME);
+    gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+  }
+}
 
 // Called when first Flutter frame received.
 static void first_frame_cb(MyApplication* self, FlView* view) {
@@ -129,11 +144,17 @@ static void register_payment_uri_channel(MyApplication* self, FlView* view) {
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
+  if (!self->is_primary) {
+    return;
+  }
   register_icon_theme_paths();
   gtk_window_set_default_icon_name(APP_ICON_NAME);
 
   if (self->main_window != nullptr) {
-    gtk_window_present(self->main_window);
+    // Reactivation must not expose the window before Flutter's first frame.
+    if (gtk_widget_get_visible(GTK_WIDGET(self->main_window))) {
+      gtk_window_present(self->main_window);
+    }
     return;
   }
 
@@ -222,18 +243,9 @@ static gboolean my_application_local_command_line(GApplication* application,
 
   g_autoptr(GError) error = nullptr;
   if (!g_application_register(application, nullptr, &error)) {
-    // Unique mode needs a session bus to negotiate ownership of the
-    // application ID, and a session without a usable D-Bus -- a minimal window
-    // manager, a container -- has none. Treating that as fatal exited before a
-    // window was ever created, so the app simply would not launch where it
-    // used to.
-    //
-    // Single-instance behaviour is a nicety; starting at all is not. Retry as
-    // a non-unique application, which skips the negotiation entirely. Nothing
-    // about the launch is lost: the local branch below still collects the
-    // zcash: arguments this process was started with and hands them to Dart.
-    // Only forwarding a link to an already-running instance is given up, and
-    // without a session bus there was no way to reach one anyway.
+    // A minimal desktop may have no usable session bus. Preserve its local
+    // launch and payment URI arguments; the OS lock below still excludes
+    // another wallet process when D-Bus cannot negotiate ownership.
     g_warning("Failed to register on the session bus (%s); continuing as a "
               "non-unique instance.",
               error->message);
@@ -264,6 +276,31 @@ static gboolean my_application_local_command_line(GApplication* application,
       g_application_activate(application);
     }
     *exit_status = 0;
+    return TRUE;
+  }
+
+  // Negotiate the D-Bus owner before taking the OS lock. Otherwise a secondary
+  // process could claim the bus name while the lock owner is still registering.
+  const SingleInstanceAcquireResult instance_result =
+      self->instance_guard->Acquire(APPLICATION_ID);
+  if (instance_result == SingleInstanceAcquireResult::kError) {
+    g_autofree gchar* message = g_strdup_printf(
+        "%s could not safely open wallet storage.\n\n%s",
+        APP_DISPLAY_NAME, g_strerror(self->instance_guard->last_error()));
+    show_startup_error(message);
+    *exit_status = 1;
+    return TRUE;
+  }
+  self->is_primary = instance_result == SingleInstanceAcquireResult::kPrimary;
+
+  if (!self->is_primary) {
+    // The owner may be on another D-Bus session. Do not start Flutter or touch
+    // the keyring when that owner cannot be activated through this session.
+    g_autofree gchar* message = g_strdup_printf(
+        "%s is already running in another session.\n\n"
+        "Close the other window before opening this one.", APP_DISPLAY_NAME);
+    show_startup_error(message);
+    *exit_status = 1;
     return TRUE;
   }
 
@@ -302,6 +339,8 @@ static void my_application_dispose(GObject* object) {
   g_clear_pointer(&self->pending_payment_uris, g_ptr_array_unref);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+  delete self->instance_guard;
+  self->instance_guard = nullptr;
 }
 
 static void my_application_class_init(MyApplicationClass* klass) {
@@ -316,6 +355,8 @@ static void my_application_class_init(MyApplicationClass* klass) {
 
 static void my_application_init(MyApplication* self) {
   self->main_window = nullptr;
+  self->instance_guard = new SingleInstanceGuard();
+  self->is_primary = FALSE;
   self->pending_payment_uris = g_ptr_array_new_with_free_func(g_free);
   self->payment_uri_dart_ready = FALSE;
 }

--- a/linux/runner/single_instance.cc
+++ b/linux/runner/single_instance.cc
@@ -1,0 +1,82 @@
+#include "single_instance.h"
+
+#include <gio/gio.h>
+#include <glib/gstdio.h>
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+
+SingleInstanceGuard::~SingleInstanceGuard() {
+  if (lock_file_ >= 0) {
+    close(lock_file_);
+  }
+}
+
+SingleInstanceAcquireResult SingleInstanceGuard::Acquire(
+    const char* application_id) {
+  if (acquire_attempted_) {
+    last_error_ = EALREADY;
+    return SingleInstanceAcquireResult::kError;
+  }
+  acquire_attempted_ = true;
+  if (application_id == nullptr || !g_application_id_is_valid(application_id)) {
+    last_error_ = EINVAL;
+    return SingleInstanceAcquireResult::kError;
+  }
+
+  // XDG_RUNTIME_DIR is shared by the user's login sessions. Unlike a D-Bus
+  // name, this lock also excludes a process on a different session bus.
+  g_autofree gchar* directory = g_build_filename(
+      g_get_user_runtime_dir(), "vizor-instance-locks", nullptr);
+  if (g_mkdir_with_parents(directory, 0700) != 0) {
+    last_error_ = errno;
+    return SingleInstanceAcquireResult::kError;
+  }
+  const int directory_fd =
+      open(directory, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+  if (directory_fd < 0) {
+    last_error_ = errno;
+    return SingleInstanceAcquireResult::kError;
+  }
+  struct stat directory_stat {};
+  if (fstat(directory_fd, &directory_stat) != 0) {
+    last_error_ = errno;
+    close(directory_fd);
+    return SingleInstanceAcquireResult::kError;
+  }
+  if (directory_stat.st_uid != geteuid() ||
+      (directory_stat.st_mode & 0022) != 0) {
+    last_error_ = EACCES;
+    close(directory_fd);
+    return SingleInstanceAcquireResult::kError;
+  }
+
+  g_autofree gchar* filename = g_strconcat(application_id, ".lock", nullptr);
+  lock_file_ = openat(directory_fd, filename,
+                      O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW, 0600);
+  last_error_ = lock_file_ < 0 ? errno : 0;
+  close(directory_fd);
+  if (lock_file_ < 0) {
+    return SingleInstanceAcquireResult::kError;
+  }
+  struct stat file_stat {};
+  if (fstat(lock_file_, &file_stat) != 0) {
+    last_error_ = errno;
+  } else if (!S_ISREG(file_stat.st_mode) || file_stat.st_uid != geteuid()) {
+    last_error_ = EACCES;
+  } else if (flock(lock_file_, LOCK_EX | LOCK_NB) == 0) {
+    return SingleInstanceAcquireResult::kPrimary;
+  } else {
+    last_error_ = errno;
+  }
+
+  close(lock_file_);
+  lock_file_ = -1;
+  if (last_error_ == EWOULDBLOCK || last_error_ == EAGAIN) {
+    return SingleInstanceAcquireResult::kSecondary;
+  }
+  return SingleInstanceAcquireResult::kError;
+}

--- a/linux/runner/single_instance.h
+++ b/linux/runner/single_instance.h
@@ -1,0 +1,30 @@
+#ifndef RUNNER_SINGLE_INSTANCE_H_
+#define RUNNER_SINGLE_INSTANCE_H_
+
+enum class SingleInstanceAcquireResult {
+  kPrimary,
+  kSecondary,
+  kError,
+};
+
+// Protects the Linux keyring namespace, which is keyed by APPLICATION_ID.
+// Keep this guard alive until the Flutter application has been disposed.
+// The OS releases the lock on process exit; the lock file must not be deleted.
+class SingleInstanceGuard {
+ public:
+  SingleInstanceGuard() = default;
+  ~SingleInstanceGuard();
+
+  SingleInstanceGuard(const SingleInstanceGuard&) = delete;
+  SingleInstanceGuard& operator=(const SingleInstanceGuard&) = delete;
+
+  SingleInstanceAcquireResult Acquire(const char* application_id);
+  int last_error() const { return last_error_; }
+
+ private:
+  int lock_file_ = -1;
+  int last_error_ = 0;
+  bool acquire_attempted_ = false;
+};
+
+#endif  // RUNNER_SINGLE_INSTANCE_H_

--- a/linux/runner/tests/flutter_stub.cc
+++ b/linux/runner/tests/flutter_stub.cc
@@ -1,0 +1,200 @@
+#include <flutter_linux/flutter_linux.h>
+
+#include <glib/gstdio.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+FlMethodChannel* payment_channel = nullptr;
+FlMethodCallHandler payment_handler = nullptr;
+gpointer payment_handler_data = nullptr;
+
+void Record(const char* event, gchar** arguments = nullptr) {
+  FILE* file = fopen(g_getenv("VIZOR_TEST_EVENTS"), "a");
+  g_assert_nonnull(file);
+  fprintf(file, "%s\t%d", event, getpid());
+  for (int i = 0; arguments != nullptr && arguments[i] != nullptr; ++i) {
+    fprintf(file, "\t%s", arguments[i]);
+  }
+  fprintf(file, "\n");
+  fclose(file);
+}
+
+gboolean Draw(GtkWidget* widget, cairo_t* cr, gpointer data) {
+  cairo_set_source_rgb(cr, 0.055, 0.075, 0.075);
+  cairo_paint(cr);
+  cairo_set_source_rgb(cr, 0.9, 0.94, 0.9);
+  cairo_select_font_face(cr, "Sans", CAIRO_FONT_SLANT_NORMAL,
+                        CAIRO_FONT_WEIGHT_NORMAL);
+  cairo_set_font_size(cr, 28);
+  cairo_move_to(cr, 48, 80);
+  cairo_show_text(cr, "Vizor native runner test");
+  cairo_set_font_size(cr, 18);
+  cairo_move_to(cr, 48, 120);
+  cairo_show_text(cr, "Flutter content is substituted; GTK lifecycle is real.");
+  return FALSE;
+}
+
+gboolean FirstFrame(gpointer data) {
+  g_signal_emit_by_name(data, "first-frame");
+  Record("first-frame");
+  return G_SOURCE_REMOVE;
+}
+
+gboolean Control(gpointer data) {
+  GtkWidget* view = GTK_WIDGET(data);
+  GtkWindow* window = GTK_WINDOW(gtk_widget_get_toplevel(view));
+  const gchar* path = g_getenv("VIZOR_TEST_CONTROL");
+  g_autofree gchar* command = nullptr;
+  if (!g_file_get_contents(path, &command, nullptr, nullptr)) {
+    return G_SOURCE_CONTINUE;
+  }
+  g_unlink(path);
+  g_strstrip(command);
+  if (strcmp(command, "payment-ready") == 0) {
+    g_assert_nonnull(payment_channel);
+    FlMethodCall take{"takePendingUris"};
+    payment_handler(payment_channel, &take, payment_handler_data);
+    FlMethodCall ready{"ready"};
+    payment_handler(payment_channel, &ready, payment_handler_data);
+    Record("payment-ready");
+  }
+  if (strcmp(command, "close") == 0) {
+    gtk_window_close(window);
+    return G_SOURCE_REMOVE;
+  }
+  if (strcmp(command, "state") == 0) {
+    const auto state = gdk_window_get_state(gtk_widget_get_window(
+        GTK_WIDGET(window)));
+    g_autofree gchar* value = g_strdup_printf(
+        "{\"visible\":%s,\"iconified\":%s,\"active\":%s,\"windows\":%u}",
+        gtk_widget_get_visible(GTK_WIDGET(window)) ? "true" : "false",
+        state & GDK_WINDOW_STATE_ICONIFIED ? "true" : "false",
+        gtk_window_is_active(window) ? "true" : "false",
+        g_list_length(gtk_application_get_windows(
+            gtk_window_get_application(window))));
+    g_autofree gchar* output = g_strconcat(path, ".state", nullptr);
+    g_file_set_contents(output, value, -1, nullptr);
+  }
+  if (strcmp(command, "capture") == 0) {
+    GdkWindow* surface = gtk_widget_get_window(GTK_WIDGET(window));
+    g_autoptr(GdkPixbuf) capture = gdk_pixbuf_get_from_window(
+        surface, 0, 0, gdk_window_get_width(surface),
+        gdk_window_get_height(surface));
+    g_autoptr(GdkPixbuf) small =
+        gdk_pixbuf_scale_simple(capture, 640, 360, GDK_INTERP_BILINEAR);
+    g_autofree gchar* output = g_strconcat(path, ".png", nullptr);
+    gdk_pixbuf_save(small, output, "png", nullptr, nullptr);
+  }
+  return G_SOURCE_CONTINUE;
+}
+
+gboolean CloseAfterDeadline(gpointer data) {
+  // Bound a failed test through a normal window close, never a process signal.
+  GtkWidget* top = gtk_widget_get_toplevel(GTK_WIDGET(data));
+  if (GTK_IS_WINDOW(top)) gtk_window_close(GTK_WINDOW(top));
+  return G_SOURCE_REMOVE;
+}
+
+}  // namespace
+
+FlDartProject* fl_dart_project_new() { return g_new0(FlDartProject, 1); }
+
+void fl_dart_project_free(FlDartProject* project) {
+  g_strfreev(project->arguments);
+  g_free(project);
+}
+
+void fl_dart_project_set_dart_entrypoint_arguments(FlDartProject* project,
+                                                 gchar** arguments) {
+  project->arguments = g_strdupv(arguments);
+}
+
+FlView* fl_view_new(FlDartProject* project) {
+  GtkWidget* view = gtk_drawing_area_new();
+  g_signal_new("first-frame", GTK_TYPE_DRAWING_AREA, G_SIGNAL_RUN_LAST, 0,
+               nullptr, nullptr, nullptr, G_TYPE_NONE, 0);
+  Record("engine", project->arguments);
+  g_signal_connect(view, "draw", G_CALLBACK(Draw), nullptr);
+  const gchar* delay = g_getenv("VIZOR_TEST_FRAME_DELAY_MS");
+  g_timeout_add_full(G_PRIORITY_DEFAULT, delay == nullptr ? 30 : atoi(delay),
+                     FirstFrame, g_object_ref(view), g_object_unref);
+  g_timeout_add_full(G_PRIORITY_DEFAULT, 20, Control, g_object_ref(view),
+                     g_object_unref);
+  g_timeout_add_seconds_full(G_PRIORITY_DEFAULT, 45, CloseAfterDeadline,
+                             g_object_ref(view), g_object_unref);
+  return view;
+}
+
+void fl_view_set_background_color(FlView* view, const GdkRGBA* color) {}
+
+void fl_register_plugins(FlPluginRegistry* registry) { Record("plugins"); }
+
+void fl_value_unref(FlValue* value) { delete value; }
+void fl_method_response_free(FlMethodResponse* response) {
+  delete response->value;
+  delete response;
+}
+FlValue* fl_value_new_list() { return new FlValue(); }
+FlValue* fl_value_new_string(const gchar* value) {
+  return new FlValue{{value}};
+}
+void fl_value_append_take(FlValue* list, FlValue* value) {
+  list->strings.insert(list->strings.end(), value->strings.begin(),
+                       value->strings.end());
+  delete value;
+}
+const gchar* fl_method_call_get_name(FlMethodCall* call) { return call->name; }
+FlMethodResponse* fl_method_success_response_new(FlValue* value) {
+  return new FlMethodResponse{value == nullptr ? nullptr : new FlValue(*value)};
+}
+FlMethodResponse* fl_method_not_implemented_response_new() {
+  return new FlMethodResponse{nullptr};
+}
+static void RecordUris(FlValue* value) {
+  if (value == nullptr) return;
+  for (const auto& uri : value->strings) {
+    gchar* arguments[] = {const_cast<gchar*>(uri.c_str()), nullptr};
+    Record("payment-uri", arguments);
+  }
+}
+void fl_method_call_respond(FlMethodCall* call, FlMethodResponse* response,
+                            GError**) {
+  if (strcmp(call->name, "takePendingUris") == 0) RecordUris(response->value);
+}
+FlStandardMethodCodec* fl_standard_method_codec_new() {
+  return G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+}
+FlEngine* fl_view_get_engine(FlView* view) { return G_OBJECT(view); }
+GObject* fl_engine_get_binary_messenger(FlEngine* engine) { return engine; }
+FlMethodChannel* fl_method_channel_new(GObject*, const gchar*, GObject*) {
+  payment_channel = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+  g_object_add_weak_pointer(payment_channel,
+                             reinterpret_cast<gpointer*>(&payment_channel));
+  return payment_channel;
+}
+void fl_method_channel_set_method_call_handler(
+    FlMethodChannel*, FlMethodCallHandler handler, gpointer data, GDestroyNotify) {
+  payment_handler = handler;
+  payment_handler_data = data;
+}
+void fl_method_channel_invoke_method(FlMethodChannel*, const gchar* method,
+                                      FlValue* value, GCancellable*,
+                                      GAsyncReadyCallback, gpointer) {
+  g_assert_cmpstr(method, ==, "onUris");
+  RecordUris(value);
+}
+
+extern "C" gint __real_gtk_dialog_run(GtkDialog* dialog);
+
+extern "C" gint __wrap_gtk_dialog_run(GtkDialog* dialog) {
+  Record("dialog");
+  g_timeout_add(150, [](gpointer data) -> gboolean {
+    gtk_dialog_response(GTK_DIALOG(data), GTK_RESPONSE_CLOSE);
+    return G_SOURCE_REMOVE;
+  }, dialog);
+  return __real_gtk_dialog_run(dialog);
+}

--- a/linux/runner/tests/guard_probe.cc
+++ b/linux/runner/tests/guard_probe.cc
@@ -1,0 +1,30 @@
+#include "single_instance.h"
+
+#include <unistd.h>
+
+#include <iostream>
+#include <string>
+
+int main(int argc, char** argv) {
+  if (argc != 3) return 2;
+  SingleInstanceGuard guard;
+  const auto result = guard.Acquire(argv[1]);
+  if (result == SingleInstanceAcquireResult::kSecondary) return 3;
+  if (result == SingleInstanceAcquireResult::kError) {
+    std::cerr << guard.last_error() << std::endl;
+    return 1;
+  }
+  std::cout << "primary" << std::endl;
+  if (std::string(argv[2]) == "hold") {
+    std::string command;
+    std::getline(std::cin, command);
+    if (command == "exit-without-dispose") {
+      // Exercise kernel cleanup without sending a signal to any process.
+      _exit(0);
+    }
+  } else if (std::string(argv[2]) == "exec-child") {
+    execl("/bin/sleep", "sleep", "2", nullptr);
+    return 2;
+  }
+  return 0;
+}

--- a/linux/runner/tests/stubs/flutter/generated_plugin_registrant.h
+++ b/linux/runner/tests/stubs/flutter/generated_plugin_registrant.h
@@ -1,0 +1,8 @@
+#ifndef VIZOR_TEST_PLUGIN_REGISTRANT_H_
+#define VIZOR_TEST_PLUGIN_REGISTRANT_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+void fl_register_plugins(FlPluginRegistry* registry);
+
+#endif

--- a/linux/runner/tests/stubs/flutter_linux/flutter_linux.h
+++ b/linux/runner/tests/stubs/flutter_linux/flutter_linux.h
@@ -1,0 +1,59 @@
+#ifndef VIZOR_TEST_FLUTTER_LINUX_H_
+#define VIZOR_TEST_FLUTTER_LINUX_H_
+
+#include <gtk/gtk.h>
+#include <string>
+#include <vector>
+
+// Only Flutter is substituted: the production runner, GTK, GApplication,
+// D-Bus, native window manager, and OS lock all run normally in this test.
+struct FlDartProject {
+  gchar** arguments;
+};
+using FlView = GtkWidget;
+using FlPluginRegistry = GtkWidget;
+
+FlDartProject* fl_dart_project_new();
+void fl_dart_project_free(FlDartProject* project);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FlDartProject, fl_dart_project_free)
+void fl_dart_project_set_dart_entrypoint_arguments(FlDartProject* project,
+                                                 gchar** arguments);
+FlView* fl_view_new(FlDartProject* project);
+void fl_view_set_background_color(FlView* view, const GdkRGBA* color);
+#define FL_PLUGIN_REGISTRY(view) (view)
+
+// Substitute only the Flutter channel boundary; URI dispatch and buffering
+// continue to execute in the production runner.
+using FlEngine = GObject;
+using FlStandardMethodCodec = GObject;
+using FlMethodChannel = GObject;
+struct FlValue { std::vector<std::string> strings; };
+struct FlMethodCall { const gchar* name; };
+struct FlMethodResponse { FlValue* value; };
+using FlMethodCallHandler = void (*)(FlMethodChannel*, FlMethodCall*, gpointer);
+
+void fl_value_unref(FlValue* value);
+void fl_method_response_free(FlMethodResponse* response);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FlValue, fl_value_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FlMethodResponse, fl_method_response_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FlStandardMethodCodec, g_object_unref)
+FlValue* fl_value_new_list();
+FlValue* fl_value_new_string(const gchar* value);
+void fl_value_append_take(FlValue* list, FlValue* value);
+const gchar* fl_method_call_get_name(FlMethodCall* call);
+FlMethodResponse* fl_method_success_response_new(FlValue* value);
+FlMethodResponse* fl_method_not_implemented_response_new();
+void fl_method_call_respond(FlMethodCall*, FlMethodResponse*, GError**);
+FlStandardMethodCodec* fl_standard_method_codec_new();
+FlEngine* fl_view_get_engine(FlView* view);
+GObject* fl_engine_get_binary_messenger(FlEngine* engine);
+FlMethodChannel* fl_method_channel_new(GObject*, const gchar*, GObject*);
+void fl_method_channel_set_method_call_handler(
+    FlMethodChannel*, FlMethodCallHandler, gpointer, GDestroyNotify);
+void fl_method_channel_invoke_method(
+    FlMethodChannel*, const gchar*, FlValue*, GCancellable*, GAsyncReadyCallback,
+    gpointer);
+#define FL_METHOD_RESPONSE(value) (value)
+#define FL_METHOD_CODEC(value) (value)
+
+#endif

--- a/linux/runner/tests/test_single_instance.py
+++ b/linux/runner/tests/test_single_instance.py
@@ -1,0 +1,255 @@
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+
+OUTPUT = Path(sys.argv[1])
+APP_ID = 'app.keplr.vizor'
+EVENTS = OUTPUT / 'events.tsv'
+ENV = dict(os.environ, XDG_RUNTIME_DIR=str(OUTPUT / 'runtime'),
+           VIZOR_TEST_EVENTS=str(EVENTS))
+Path(ENV['XDG_RUNTIME_DIR']).mkdir(mode=0o700, exist_ok=True)
+RESULTS = []
+RUNNERS = []
+
+
+def passed(name):
+    RESULTS.append(name)
+    print(f'PASS {name}', flush=True)
+
+
+def wait_for(callback, description, timeout=8):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = callback()
+        if result:
+            return result
+        time.sleep(0.02)
+    raise AssertionError(f'Timed out: {description}')
+
+
+def events(name, pid=None):
+    rows = [line.split('\t') for line in EVENTS.read_text().splitlines()]
+    return [row for row in rows if row[0] == name and
+            (pid is None or row[1] == str(pid))]
+
+
+def probe(mode='once', identity=APP_ID, env=ENV):
+    return subprocess.Popen([str(OUTPUT / 'guard-probe'), identity, mode],
+                            env=env, text=True, stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def once(expected, **kwargs):
+    process = probe(**kwargs)
+    stdout, stderr = process.communicate(timeout=8)
+    assert process.returncode == expected, (stdout, stderr)
+
+
+def guard_tests():
+    owner = probe('hold')
+    assert owner.stdout.readline().strip() == 'primary'
+    try:
+        once(3)
+        once(0, identity=APP_ID + '.testnet')
+        passed('OS lock excludes same identity; testnet remains independent')
+    finally:
+        owner.communicate('close\n', timeout=8)
+    path = Path(ENV['XDG_RUNTIME_DIR']) / 'vizor-instance-locks' / (APP_ID + '.lock')
+    inode = path.stat().st_ino
+    once(0)
+    assert path.stat().st_ino == inode
+    passed('normal exit releases lock without deleting its file')
+
+    owner = probe('hold')
+    assert owner.stdout.readline().strip() == 'primary'
+    owner.communicate('exit-without-dispose\n', timeout=8)
+    once(0)
+    passed('process exit releases lock without destructor cleanup')
+
+    owner = probe('exec-child')
+    assert owner.stdout.readline().strip() == 'primary'
+    def acquired_after_exec():
+        candidate = probe()
+        candidate.communicate(timeout=3)
+        return candidate.returncode == 0
+    try:
+        wait_for(acquired_after_exec, 'close-on-exec lock release', timeout=1)
+        assert owner.poll() is None
+    finally:
+        owner.wait(timeout=5)
+    passed('executed helper cannot retain the wallet process lock')
+
+    other = path.with_name(APP_ID + '.symlink.lock')
+    sentinel = OUTPUT / 'sentinel'
+    sentinel.write_text('preserve me')
+    other.symlink_to(sentinel)
+    once(1, identity=APP_ID + '.symlink')
+    assert sentinel.read_text() == 'preserve me'
+    passed('symlink lock rejected without changing its target')
+
+
+class Runner:
+    def __init__(self, name, binary='runner', args=(), fresh_bus=False, extra=None):
+        self.control = OUTPUT / (name + '.control')
+        self.log = OUTPUT / (name + '.log')
+        env = dict(ENV, VIZOR_TEST_CONTROL=str(self.control))
+        env.update(extra or {})
+        command = [str(OUTPUT / binary), *args]
+        if fresh_bus:
+            command = ['dbus-run-session', '--', *command]
+        with self.log.open('w') as log:
+            self.process = subprocess.Popen(command, env=env, stdout=log, stderr=log)
+        RUNNERS.append(self)
+
+    def wait(self, code=0):
+        actual = self.process.wait(timeout=10)
+        assert actual == code, (actual, self.log.read_text())
+
+    def send(self, command):
+        self.control.write_text(command)
+
+    def state(self):
+        output = Path(str(self.control) + '.state')
+        output.unlink(missing_ok=True)
+        self.send('state')
+        wait_for(output.exists, 'window state')
+        return json.loads(output.read_text())
+
+    def ready(self):
+        wait_for(lambda: events('first-frame', self.process.pid), 'first frame')
+
+    def close(self):
+        if self.process.poll() is None:
+            self.send('close')
+            self.wait()
+
+
+def runner_tests():
+    primary = Runner('primary', args=('zcash:test-fixture', 'argument with spaces'),
+                     extra={'VIZOR_TEST_FRAME_DELAY_MS': '1800'})
+    wait_for(lambda: events('plugins', primary.process.pid), 'plugin registration')
+    secondary = Runner('during-startup', args=('zcash:queued-fixture',))
+    secondary.wait()
+    assert len(events('engine')) == 1
+    assert not events('first-frame')
+    assert primary.state()['visible'] is False
+    primary.ready()
+    assert events('engine', primary.process.pid)[0][2:] == [
+        'zcash:test-fixture', 'argument with spaces']
+    passed('startup reactivation creates one engine and waits for first frame')
+    passed('cold-start Dart arguments remain intact')
+
+    primary.send('payment-ready')
+    wait_for(lambda: events('payment-ready', primary.process.pid),
+             'Dart payment URI readiness')
+    assert [row[2] for row in events('payment-uri', primary.process.pid)] == [
+        'zcash:test-fixture', 'zcash:queued-fixture']
+    passed('cold and forwarded links survive the wait for Dart readiness')
+
+    secondary = Runner('warm-payment-link', args=('zcash:warm-fixture',))
+    secondary.wait()
+    wait_for(lambda: any(row[2] == 'zcash:warm-fixture'
+                         for row in events('payment-uri', primary.process.pid)),
+             'warm link forwarding')
+    assert len(events('engine')) == 1
+    assert len(events('payment-uri', primary.process.pid)) == 3
+    passed('warm payment link reaches the primary without another engine')
+
+    # A different executable path models another extracted AppImage directory.
+    shutil.copy2(OUTPUT / 'runner', OUTPUT / 'runner-copy')
+    secondary = Runner('copied-executable', binary='runner-copy')
+    secondary.wait()
+    assert not events('engine', secondary.process.pid)
+    assert primary.state()['windows'] == 1
+    passed('another executable path activates the same window')
+
+    window_ids = subprocess.check_output(
+        ['xdotool', 'search', '--pid', str(primary.process.pid)], text=True).split()
+    window_id = window_ids[-1]
+    subprocess.check_call(['xdotool', 'windowminimize', window_id])
+    wait_for(lambda: primary.state()['iconified'], 'minimized window')
+    secondary = Runner('minimized-reactivation')
+    secondary.wait()
+    wait_for(lambda: not primary.state()['iconified'], 'restored window')
+    wait_for(lambda: primary.state()['active'], 'focused window')
+    assert primary.state()['windows'] == 1
+    assert len(events('engine')) == 1
+    primary.send('capture')
+    wait_for(lambda: Path(str(primary.control) + '.png').exists(), 'capture')
+    passed('second launch restores and focuses the minimized original window')
+
+    secondary = Runner('different-session', fresh_bus=True)
+    secondary.wait(1)
+    assert len(events('engine')) == 1
+    assert 'already running in another session' in secondary.log.read_text()
+    assert events('dialog')
+    passed('another D-Bus session is blocked before engine or plugins start')
+
+    testnet = Runner('testnet', binary='runner-testnet')
+    testnet.ready()
+    assert len(events('engine')) == 2
+    assert testnet.state()['windows'] == 1
+    testnet.close()
+    primary.close()
+    passed('mainnet and testnet windows coexist and close normally')
+
+    reopened = Runner('reopened')
+    reopened.ready()
+    assert len(events('engine', reopened.process.pid)) == 1
+    reopened.close()
+    passed('closing the primary allows a fresh launch')
+
+    count = len(events('engine'))
+    racers = [Runner(f'race-{i}') for i in range(6)]
+    wait_for(lambda: len(events('first-frame')) == count + 1, 'raced primary')
+    wait_for(lambda: sum(r.process.poll() is None for r in racers) == 1,
+             'secondary launchers to exit')
+    assert len(events('engine')) == count + 1
+    for runner in racers:
+        runner.close()
+        runner.wait()
+    passed('six simultaneous launches leave exactly one live engine')
+
+    count = len(events('engine'))
+    bad_runtime = OUTPUT / 'runtime-is-file'
+    bad_runtime.write_text('not a directory')
+    denied = Runner('lock-error', extra={'XDG_RUNTIME_DIR': str(bad_runtime)})
+    denied.wait(1)
+    assert len(events('engine')) == count
+    assert 'could not safely open wallet storage' in denied.log.read_text()
+    passed('unavailable lock directory shows an error without starting Flutter')
+
+    # A session-bus outage must never allow two independent wallet engines.
+    disconnected = Runner('no-bus', extra={
+        'DBUS_SESSION_BUS_ADDRESS': 'unix:path=' + str(OUTPUT / 'missing-bus')})
+    wait_for(lambda: disconnected.process.poll() is not None or
+             events('first-frame', disconnected.process.pid), 'no-bus outcome')
+    if disconnected.process.poll() is None:
+        second = Runner('no-bus-second', extra={
+            'DBUS_SESSION_BUS_ADDRESS': 'unix:path=' + str(OUTPUT / 'missing-bus')})
+        second.wait(1)
+        assert not events('engine', second.process.pid)
+        disconnected.close()
+    else:
+        disconnected.wait(1)
+        assert not events('engine', disconnected.process.pid)
+    passed('missing D-Bus cannot bypass process exclusion')
+
+
+EVENTS.write_text('')
+try:
+    guard_tests()
+    runner_tests()
+finally:
+    for runner in RUNNERS:
+        runner.close()
+
+(OUTPUT / 'result.json').write_text(json.dumps(
+    {'passed': len(RESULTS), 'checks': RESULTS,
+     'scope': 'Production native runner, real GTK/D-Bus/flock; Flutter content substituted'},
+    indent=2) + '\n')
+print(f'{len(RESULTS)} checks passed', flush=True)

--- a/scripts/test-linux-single-instance.sh
+++ b/scripts/test-linux-single-instance.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Native Linux dependencies: a C++14 compiler, pkg-config, libgtk-3-dev,
+# dbus-run-session, Xvfb/xvfb-run, xauth, openbox, xdotool, and Python 3.
+if [[ "$(uname -s)" != Linux ]]; then
+  echo 'Run this native test on Linux or inside a Linux container.' >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+runner_dir="$repo_root/linux/runner"
+output_parent="${VIZOR_SINGLE_INSTANCE_TEST_OUTPUT:-/tmp}"
+mkdir -p "$output_parent"
+test_output="$(mktemp -d "$output_parent/vizor-instance-test.XXXXXX")"
+read -r -a gtk_flags <<< "$(pkg-config --cflags --libs gtk+-3.0)"
+
+"${CXX:-c++}" -std=c++14 -Wall -Werror \
+  -I"$runner_dir" "$runner_dir/single_instance.cc" \
+  "$runner_dir/tests/guard_probe.cc" "${gtk_flags[@]}" \
+  -o "$test_output/guard-probe"
+
+for flavor in main testnet; do
+  app_id=app.keplr.vizor
+  binary=runner
+  if [[ "$flavor" == testnet ]]; then
+    app_id=app.keplr.vizor.testnet
+    binary=runner-testnet
+  fi
+  "${CXX:-c++}" -std=c++14 -Wall -Werror \
+    -I"$runner_dir/tests/stubs" -I"$runner_dir" \
+    "-DAPPLICATION_ID=\"$app_id\"" '-DAPP_DISPLAY_NAME="Vizor"' \
+    "-DAPP_ICON_NAME=\"$app_id\"" '-DAPP_ICON_THEME_PATH="/nonexistent"' \
+    "$runner_dir/main.cc" "$runner_dir/my_application.cc" \
+    "$runner_dir/single_instance.cc" "$runner_dir/tests/flutter_stub.cc" \
+    -Wl,--wrap=gtk_dialog_run "${gtk_flags[@]}" -o "$test_output/$binary"
+done
+
+# Each run owns a display and D-Bus session, and opens no production wallet.
+# Error dialogs are closed through GtkDialog responses in the test fixture.
+# Xvfb/dbus-run-session clean up their own private session on completion.
+xvfb-run -a -s '-screen 0 1280x800x24' dbus-run-session -- \
+  bash -c 'openbox > "$1/openbox.log" 2>&1 &
+    python3 "$2/tests/test_single_instance.py" "$1"' \
+  bash "$test_output" "$runner_dir"
+echo "Evidence: $test_output"


### PR DESCRIPTION
Linux launches on different D-Bus sessions, or without a usable session bus, could start separate Flutter engines against the same wallet. Acquire an application-scoped OS lock in the user runtime directory before Flutter or plugins initialize, and show a startup error when another process owns it or the lock cannot be acquired.

Same-session launches continue to focus the existing window and forward `zcash:` links. Keep the existing no-bus startup path under the same lock, preserve mainnet/testnet separation, and avoid revealing the window before Flutter renders its first frame.

### Validation

- `scripts/test-linux-single-instance.sh`: **17 checks passed** in an isolated Linux container, using the production runner with real GTK, D-Bus, Openbox, and `flock`; Flutter rendering and channel endpoints are substituted by the test fixture.
- Covers simultaneous launches, cross-session exclusion, copied executable paths, minimized-window activation, normal/process-exit lock release, lock-path failures, missing D-Bus, and payment links received before and after Dart readiness.
- Native fixtures compile with C++14, `-Wall`, and `-Werror`; `git diff --check` passes.

This PR contains only the Linux single-instance change. Wallet recovery and the Linux secure-storage backend changes are separate.
