### PR TITLE
Explain why funds are ineligible for voting

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -748,7 +748,8 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
   ),
   FigmaCompareScenario(
     id: 'mobile-voting-ineligible-modal',
-    description: 'Mobile voting eligibility dialog matching Figma 8048:71300',
+    description:
+        'Variation B: structured sheet with snapshot date and exclusion reason',
     builder: buildMobileVotingIneligibleModalUseCase,
     desktop: false,
     mobile: true,
@@ -777,7 +778,8 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
   ),
   FigmaCompareScenario(
     id: 'mobile-voting-ineligible',
-    description: 'Mobile ineligible voting detail matching Figma 8048:35024',
+    description:
+        'Variation A: inline snapshot date and exclusion reason on the poll page',
     builder: buildMobileVotingIneligibleUseCase,
     desktop: false,
     mobile: true,

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -20,12 +20,14 @@ import '../../../providers/voting/voting_tree_sync_provider.dart';
 import '../../../providers/voting/voting_state.dart';
 import '../../../rust/third_party/zcash_voting/wire.dart' as rust_wire;
 import '../../accounts/widgets/mobile/mobile_accounts_sheet.dart';
+import '../voting_eligibility_explanation.dart';
 import '../voting_error_messages.dart';
 import '../voting_flow_models.dart';
 import '../voting_formatters.dart';
 import '../voting_poll_ordering.dart';
 import '../voting_resume_plan.dart';
 import '../voting_routes.dart';
+import '../widgets/voting_eligibility_notice.dart';
 import '../widgets/voting_metadata_widgets.dart';
 import '../widgets/voting_pane_scroll_area.dart';
 import '../widgets/voting_share_status_card.dart';
@@ -337,6 +339,7 @@ class _VotingProposalDetailViewState
           roundId: roundId,
           title: round.title.isEmpty ? 'Token holder voting' : round.title,
           snapshotHeight: round.snapshotHeight,
+          snapshotDate: round.snapshotTime,
           description: _roundDescription(round.rawJson),
           forumUri: forumUri,
           endDate: _roundEndDate(round.rawJson),
@@ -574,6 +577,8 @@ class VotingActivePollContent extends StatefulWidget {
     required this.roundId,
     required this.title,
     required this.snapshotHeight,
+    this.snapshotDate,
+    this.showInlineEligibilityExplanation = true,
     required this.description,
     required this.forumUri,
     required this.endDate,
@@ -593,6 +598,11 @@ class VotingActivePollContent extends StatefulWidget {
   final String roundId;
   final String title;
   final int snapshotHeight;
+  final DateTime? snapshotDate;
+
+  /// Variation A. When false, the page stays compact and the reason lives
+  /// in the ineligible sheet (Variation B).
+  final bool showInlineEligibilityExplanation;
   final String description;
   final Uri? forumUri;
   final DateTime? endDate;
@@ -618,6 +628,16 @@ class VotingActivePollContent extends StatefulWidget {
 class _ActivePollContentState extends State<VotingActivePollContent> {
   bool _showingIneligibleDialog = false;
 
+  VotingEligibilityExplanation? get _ineligibleExplanation {
+    final message = widget.votingEligibilityErrorMessage;
+    if (message == null) return null;
+    return VotingEligibilityExplanation.fromMessage(
+      message,
+      snapshotDate: widget.snapshotDate,
+      snapshotHeight: widget.snapshotHeight,
+    );
+  }
+
   Future<void> _showIneligibleDialog() async {
     final message = widget.votingEligibilityErrorMessage;
     if (message == null || _showingIneligibleDialog) return;
@@ -631,7 +651,11 @@ class _ActivePollContentState extends State<VotingActivePollContent> {
           barrierColor: context.colors.background.neutralScrim,
           builder: (_) => AppTheme(
             data: appTheme,
-            child: VotingIneligibleDialog(message: message),
+            child: VotingIneligibleDialog(
+              message: message,
+              snapshotDate: widget.snapshotDate,
+              snapshotHeight: widget.snapshotHeight,
+            ),
           ),
         );
         final switchAccount = await Navigator.of(
@@ -650,7 +674,11 @@ class _ActivePollContentState extends State<VotingActivePollContent> {
     }
     await showDialog<void>(
       context: context,
-      builder: (_) => VotingIneligibleDialog(message: message),
+      builder: (_) => VotingIneligibleDialog(
+        message: message,
+        snapshotDate: widget.snapshotDate,
+        snapshotHeight: widget.snapshotHeight,
+      ),
     );
   }
 
@@ -709,6 +737,9 @@ class _ActivePollContentState extends State<VotingActivePollContent> {
         votingPowerZatoshi: widget.votingPowerZatoshi,
         votingPowerPreparing: widget.votingPowerPreparing,
         votingEligibilityMessage: votingEligibilityMessage,
+        inlineExplanation: widget.showInlineEligibilityExplanation
+            ? _ineligibleExplanation
+            : null,
       );
     }
     return _PollSummary(
@@ -720,6 +751,9 @@ class _ActivePollContentState extends State<VotingActivePollContent> {
       votingPowerZatoshi: widget.votingPowerZatoshi,
       votingPowerPreparing: widget.votingPowerPreparing,
       votingEligibilityMessage: widget.votingEligibilityMessage,
+      inlineExplanation: widget.showInlineEligibilityExplanation
+          ? _ineligibleExplanation
+          : null,
     );
   }
 
@@ -1004,9 +1038,24 @@ class _SkippedQuestionsDialog extends StatelessWidget {
 
 /// Shared by the live dialog route and deterministic visual previews.
 class VotingIneligibleDialog extends StatelessWidget {
-  const VotingIneligibleDialog({super.key, required this.message});
+  const VotingIneligibleDialog({
+    super.key,
+    required this.message,
+    this.snapshotDate,
+    this.snapshotHeight,
+  });
 
   final String message;
+  final DateTime? snapshotDate;
+  final int? snapshotHeight;
+
+  VotingEligibilityExplanation get explanation {
+    return VotingEligibilityExplanation.fromMessage(
+      message,
+      snapshotDate: snapshotDate,
+      snapshotHeight: snapshotHeight,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -1040,7 +1089,7 @@ class VotingIneligibleDialog extends StatelessWidget {
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    _MobileVotingEligibilityMessage(message: message),
+                    VotingEligibilitySheetBody(explanation: explanation),
                     const SizedBox(height: AppSpacing.md),
                     AppButton(
                       key: const ValueKey('voting_ineligible_switch_account'),
@@ -1114,12 +1163,7 @@ class VotingIneligibleDialog extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: AppSpacing.sm),
-              Text(
-                message,
-                style: AppTypography.bodyMedium.copyWith(
-                  color: colors.text.secondary,
-                ),
-              ),
+              VotingEligibilitySheetBody(explanation: explanation),
               const SizedBox(height: AppSpacing.md),
               AppButton(
                 onPressed: () => Navigator.of(context).pop(),
@@ -1129,52 +1173,6 @@ class VotingIneligibleDialog extends StatelessWidget {
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-class _MobileVotingEligibilityMessage extends StatelessWidget {
-  const _MobileVotingEligibilityMessage({required this.message});
-
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    const guidance = 'Switch to an eligible account to vote.';
-    final text = message.trim();
-    final hasGuidance = text.endsWith(guidance);
-    var reason = hasGuidance
-        ? text.substring(0, text.length - guidance.length).trimRight()
-        : text;
-    if (hasGuidance && reason.endsWith('.')) {
-      reason = reason.substring(0, reason.length - 1);
-    }
-    final spans = <TextSpan>[];
-    var offset = 0;
-    for (final match in RegExp(r'\b\d+(?:\.\d+)? ZEC\b').allMatches(reason)) {
-      spans.add(TextSpan(text: reason.substring(offset, match.start)));
-      spans.add(
-        TextSpan(
-          text: match.group(0),
-          style: TextStyle(color: context.colors.text.destructive),
-        ),
-      );
-      offset = match.end;
-    }
-    spans.add(TextSpan(text: reason.substring(offset)));
-    if (hasGuidance) {
-      spans.add(
-        TextSpan(
-          text: '\n\n$guidance',
-          style: TextStyle(color: context.colors.text.accent),
-        ),
-      );
-    }
-    return Text.rich(
-      TextSpan(children: spans),
-      style: AppTypography.bodyMedium.copyWith(
-        color: context.colors.text.primary,
       ),
     );
   }
@@ -1191,6 +1189,7 @@ class _MobilePollSummary extends StatelessWidget {
     required this.votingPowerZatoshi,
     required this.votingPowerPreparing,
     required this.votingEligibilityMessage,
+    this.inlineExplanation,
   });
 
   final String title;
@@ -1202,6 +1201,7 @@ class _MobilePollSummary extends StatelessWidget {
   final BigInt? votingPowerZatoshi;
   final bool votingPowerPreparing;
   final String? votingEligibilityMessage;
+  final VotingEligibilityExplanation? inlineExplanation;
 
   @override
   Widget build(BuildContext context) {
@@ -1275,7 +1275,10 @@ class _MobilePollSummary extends StatelessWidget {
             ],
           ],
         ),
-        if (!isIneligible && votingEligibilityMessage != null) ...[
+        if (inlineExplanation != null) ...[
+          const SizedBox(height: AppSpacing.sm),
+          VotingEligibilityInlineNotice(explanation: inlineExplanation!),
+        ] else if (!isIneligible && votingEligibilityMessage != null) ...[
           const SizedBox(height: AppSpacing.xxs),
           Text(
             votingEligibilityMessage!,
@@ -1345,6 +1348,7 @@ class _PollSummary extends StatelessWidget {
     required this.votingPowerZatoshi,
     required this.votingPowerPreparing,
     required this.votingEligibilityMessage,
+    this.inlineExplanation,
   });
 
   final String title;
@@ -1355,6 +1359,7 @@ class _PollSummary extends StatelessWidget {
   final BigInt? votingPowerZatoshi;
   final bool votingPowerPreparing;
   final String? votingEligibilityMessage;
+  final VotingEligibilityExplanation? inlineExplanation;
 
   @override
   Widget build(BuildContext context) {
@@ -1425,7 +1430,10 @@ class _PollSummary extends StatelessWidget {
             ],
           ],
         ),
-        if (votingEligibilityMessage != null) ...[
+        if (inlineExplanation != null) ...[
+          const SizedBox(height: AppSpacing.sm),
+          VotingEligibilityInlineNotice(explanation: inlineExplanation!),
+        ] else if (votingEligibilityMessage != null) ...[
           const SizedBox(height: AppSpacing.xxs),
           Text(
             votingEligibilityMessage!,

--- a/lib/src/features/voting/voting_eligibility_explanation.dart
+++ b/lib/src/features/voting/voting_eligibility_explanation.dart
@@ -1,0 +1,191 @@
+import '../../core/formatting/date_format.dart';
+import 'voting_formatters.dart';
+
+/// Shared closing line for account-level voting ineligibility.
+const kVotingEligibilityGuidance = 'Switch to an eligible account to vote.';
+
+/// Why this account's funds were left out of a voting round.
+///
+/// Mapped from the Rust eligibility check, which selects
+/// `get_unspent_ironwood_notes_at_historical_height` and then applies the
+/// 0.125 ZEC bundle minimum. Spending a snapshot note *after* the snapshot
+/// does not remove it; notes received or created later do not count.
+enum VotingEligibilityExclusionReason {
+  /// No Ironwood notes were unspent at the snapshot height.
+  noNotesAtSnapshot,
+
+  /// Snapshot notes existed but did not form a 0.125 ZEC voting bundle.
+  belowMinimum,
+
+  /// Eligible overall, with a privacy-trim tail left out.
+  privacyTrim,
+
+  /// A voting-eligibility failure that is not one of the known reasons.
+  unknown,
+}
+
+/// Snapshot cutoff plus the plain-language exclusion reason.
+class VotingEligibilityExplanation {
+  const VotingEligibilityExplanation({
+    required this.reason,
+    this.snapshotHeight,
+    this.snapshotDate,
+    this.customBody,
+  });
+
+  final VotingEligibilityExclusionReason reason;
+  final int? snapshotHeight;
+  final DateTime? snapshotDate;
+  final String? customBody;
+
+  /// Calendar date when the round JSON includes one; otherwise the block.
+  String get snapshotValue {
+    final date = snapshotDate;
+    if (date != null) return formatMonthDayYear(date);
+    final height = snapshotHeight;
+    if (height != null) return 'Block ${formatBlockHeight(height)}';
+    return 'This voting round snapshot';
+  }
+
+  /// Block line shown under a calendar snapshot date.
+  String? get snapshotBlockLabel {
+    final height = snapshotHeight;
+    if (height == null || snapshotDate == null) return null;
+    return 'Block ${formatBlockHeight(height)}';
+  }
+
+  String get snapshotSentenceFragment {
+    final date = snapshotDate;
+    final height = snapshotHeight;
+    if (date != null && height != null) {
+      return 'snapshot ${formatMonthDayYear(date)} (block ${formatBlockHeight(height)})';
+    }
+    if (date != null) return 'snapshot ${formatMonthDayYear(date)}';
+    if (height != null) {
+      return 'snapshot block ${formatBlockHeight(height)}';
+    }
+    return 'the voting round snapshot';
+  }
+
+  String get reasonTitle => switch (reason) {
+    VotingEligibilityExclusionReason.noNotesAtSnapshot =>
+      'No Ironwood notes at the snapshot',
+    VotingEligibilityExclusionReason.belowMinimum =>
+      'Below the 0.125 ZEC minimum',
+    VotingEligibilityExclusionReason.privacyTrim =>
+      'Some funds were left out',
+    VotingEligibilityExclusionReason.unknown => 'Not eligible for this round',
+  };
+
+  String get reasonBody {
+    final customBody = this.customBody;
+    if (customBody != null && customBody.isNotEmpty) return customBody;
+    return switch (reason) {
+      VotingEligibilityExclusionReason.noNotesAtSnapshot =>
+        'Only Ironwood notes this account held at the snapshot can vote. '
+            'Notes you received or created after that point do not count, '
+            'even if you later moved funds or finished Ironwood.',
+      VotingEligibilityExclusionReason.belowMinimum =>
+        'Voting needs at least 0.125 ZEC in eligible Ironwood notes at the '
+            'snapshot. This account was below that minimum.',
+      VotingEligibilityExclusionReason.privacyTrim =>
+        'A small amount is left out of this vote to keep your submission '
+            'less identifiable.',
+      VotingEligibilityExclusionReason.unknown =>
+        'This account is not eligible for this voting round.',
+    };
+  }
+
+  /// Single paragraph used by status screens and existing string matchers.
+  String get combinedMessage {
+    if (reason == VotingEligibilityExclusionReason.privacyTrim) {
+      return reasonBody;
+    }
+    return '$reasonBody Eligibility is measured at $snapshotSentenceFragment. '
+        '$kVotingEligibilityGuidance';
+  }
+
+  static VotingEligibilityExplanation? fromPrivacyTrimNotice(String? message) {
+    if (message == null || message.isEmpty) return null;
+    if (!message.contains('is left out of this vote')) return null;
+    return VotingEligibilityExplanation(
+      reason: VotingEligibilityExclusionReason.privacyTrim,
+      customBody: message,
+    );
+  }
+
+  factory VotingEligibilityExplanation.fromMessage(
+    String message, {
+    DateTime? snapshotDate,
+    int? snapshotHeight,
+  }) {
+    final normalized = _normalizedEligibilityMessage(message);
+    final height = snapshotHeight ?? snapshotHeightFromEligibilityText(message);
+    if (_noNotesPattern.hasMatch(normalized) ||
+        normalized.contains('only ironwood notes this account held') ||
+        normalized.contains('no eligible ironwood notes') ||
+        normalized.contains('no eligible shielded funds') ||
+        normalized.contains('no spendable voting notes')) {
+      return VotingEligibilityExplanation(
+        reason: VotingEligibilityExclusionReason.noNotesAtSnapshot,
+        snapshotHeight: height,
+        snapshotDate: snapshotDate,
+      );
+    }
+    if (_minimumPattern.hasMatch(normalized) ||
+        normalized.contains('below the 0.125 zec minimum') ||
+        normalized.contains('0.125 zec in eligible ironwood') ||
+        normalized.contains('0.125 zec') ||
+        normalized.contains('12500000 zatoshi')) {
+      return VotingEligibilityExplanation(
+        reason: VotingEligibilityExclusionReason.belowMinimum,
+        snapshotHeight: height,
+        snapshotDate: snapshotDate,
+      );
+    }
+    return VotingEligibilityExplanation(
+      reason: VotingEligibilityExclusionReason.unknown,
+      snapshotHeight: height,
+      snapshotDate: snapshotDate,
+      customBody: _bodyWithoutGuidance(message),
+    );
+  }
+}
+
+int? snapshotHeightFromEligibilityText(String text) {
+  final match = _snapshotHeightPattern.firstMatch(text);
+  if (match == null) return null;
+  return int.tryParse(match.group(1)!.replaceAll(',', ''));
+}
+
+String _normalizedEligibilityMessage(String message) {
+  return _bodyWithoutGuidance(message).toLowerCase();
+}
+
+String _bodyWithoutGuidance(String message) {
+  var text = message.trim();
+  if (text.endsWith(kVotingEligibilityGuidance)) {
+    text = text
+        .substring(0, text.length - kVotingEligibilityGuidance.length)
+        .trimRight();
+  }
+  if (text.endsWith('.')) {
+    text = text.substring(0, text.length - 1);
+  }
+  return text;
+}
+
+final _snapshotHeightPattern = RegExp(
+  r'snapshot(?: block| height)?\s+([\d,]+)',
+  caseSensitive: false,
+);
+
+final _noNotesPattern = RegExp(
+  r'no (?:eligible|spendable) (?:ironwood |shielded )?notes',
+  caseSensitive: false,
+);
+
+final _minimumPattern = RegExp(
+  r'(?:minimum voting eligibility|at least (?:one eligible|0\.125))',
+  caseSensitive: false,
+);

--- a/lib/src/features/voting/voting_error_messages.dart
+++ b/lib/src/features/voting/voting_error_messages.dart
@@ -1,4 +1,4 @@
-import 'voting_formatters.dart';
+import 'voting_eligibility_explanation.dart';
 
 String friendlyVotingErrorMessage(Object error) {
   return friendlyVotingErrorText(error.toString());
@@ -9,7 +9,11 @@ bool isVotingEligibilityErrorText(String text) {
   final lowerMessage = message.toLowerCase();
   return _noSpendableNotesPattern.firstMatch(message) != null ||
       _minimumVotingEligibilityPattern.firstMatch(message) != null ||
+      lowerMessage.contains('no eligible ironwood notes') ||
+      lowerMessage.contains('no eligible shielded funds') ||
       lowerMessage.startsWith('this account is not eligible for this ') ||
+      lowerMessage.startsWith('only ironwood notes this account held') ||
+      lowerMessage.startsWith('voting needs at least 0.125 zec') ||
       lowerMessage.startsWith(
         'voting requires at least one eligible shielded note bundle with 0.125 zec',
       ) ||
@@ -25,25 +29,20 @@ String friendlyVotingErrorText(String text) {
   final message = _normalizedVotingErrorText(text);
   final noSpendableNotes = _noSpendableNotesPattern.firstMatch(message);
   if (noSpendableNotes != null) {
-    final heightText = noSpendableNotes.group(1);
-    final snapshot = heightText == null
-        ? 'the voting round snapshot block'
-        : 'snapshot block ${formatBlockHeight(int.parse(heightText))}';
-    return 'This account is not eligible for this voting round. It had no eligible '
-        'shielded funds at $snapshot. Switch to an eligible account to vote.';
+    return VotingEligibilityExplanation(
+      reason: VotingEligibilityExclusionReason.noNotesAtSnapshot,
+      snapshotHeight: int.tryParse(noSpendableNotes.group(1) ?? ''),
+    ).combinedMessage;
   }
 
   final minimumVotingEligibility = _minimumVotingEligibilityPattern.firstMatch(
     message,
   );
   if (minimumVotingEligibility != null) {
-    final heightText = minimumVotingEligibility.group(1);
-    final snapshot = heightText == null
-        ? 'the voting round snapshot block'
-        : 'snapshot block ${formatBlockHeight(int.parse(heightText))}';
-    return 'Voting requires at least one eligible shielded note bundle with '
-        '0.125 ZEC '
-        'at $snapshot. Switch to an eligible account to vote.';
+    return VotingEligibilityExplanation(
+      reason: VotingEligibilityExclusionReason.belowMinimum,
+      snapshotHeight: int.tryParse(minimumVotingEligibility.group(1) ?? ''),
+    ).combinedMessage;
   }
 
   return message.isEmpty ? 'Voting session action failed.' : message;

--- a/lib/src/features/voting/widgets/voting_eligibility_notice.dart
+++ b/lib/src/features/voting/widgets/voting_eligibility_notice.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../voting_eligibility_explanation.dart';
+
+/// Variation A: a persistent on-page explainer for ineligible funds.
+///
+/// Shows the snapshot cutoff first, then the exclusion reason, so the
+/// reported "I moved after the snapshot but I was in Ironwood" case is
+/// visible without opening a dialog.
+class VotingEligibilityInlineNotice extends StatelessWidget {
+  const VotingEligibilityInlineNotice({
+    required this.explanation,
+    super.key,
+  });
+
+  final VotingEligibilityExplanation explanation;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final blockLabel = explanation.snapshotBlockLabel;
+    return DecoratedBox(
+      key: const ValueKey('voting_eligibility_inline_notice'),
+      decoration: BoxDecoration(
+        color: colors.background.utilityDestructiveSubtle,
+        borderRadius: BorderRadius.circular(AppRadii.medium),
+        border: Border.all(color: colors.border.subtle),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.sm),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                AppIcon(
+                  AppIcons.warning,
+                  size: 20,
+                  color: colors.text.destructive,
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                Expanded(
+                  child: Text(
+                    explanation.reasonTitle,
+                    style: AppTypography.bodyMediumStrong.copyWith(
+                      color: colors.text.destructive,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.s),
+            Text(
+              'Snapshot',
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xxs),
+            Text(
+              explanation.snapshotValue,
+              key: const ValueKey('voting_eligibility_snapshot_value'),
+              style: AppTypography.bodyLarge.copyWith(
+                color: colors.text.accent,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            if (blockLabel != null) ...[
+              const SizedBox(height: 2),
+              Text(
+                blockLabel,
+                style: AppTypography.bodyMedium.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+            ],
+            const SizedBox(height: AppSpacing.s),
+            Text(
+              explanation.reasonBody,
+              style: AppTypography.bodyMedium.copyWith(
+                color: colors.text.primary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Variation B: labeled snapshot + reason rows inside the ineligible sheet.
+class VotingEligibilitySheetBody extends StatelessWidget {
+  const VotingEligibilitySheetBody({
+    required this.explanation,
+    super.key,
+  });
+
+  final VotingEligibilityExplanation explanation;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final blockLabel = explanation.snapshotBlockLabel;
+    return Column(
+      key: const ValueKey('voting_eligibility_sheet_body'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _SheetFact(
+          label: 'Snapshot',
+          value: explanation.snapshotValue,
+          detail: blockLabel,
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Divider(height: 1, color: colors.border.subtle),
+        const SizedBox(height: AppSpacing.sm),
+        _SheetFact(
+          label: 'Why these funds do not count',
+          value: explanation.reasonTitle,
+          detail: explanation.reasonBody,
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Text(
+          kVotingEligibilityGuidance,
+          style: AppTypography.bodyMedium.copyWith(color: colors.text.accent),
+        ),
+      ],
+    );
+  }
+}
+
+class _SheetFact extends StatelessWidget {
+  const _SheetFact({
+    required this.label,
+    required this.value,
+    this.detail,
+  });
+
+  final String label;
+  final String value;
+  final String? detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final detail = this.detail;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          label,
+          style: AppTypography.labelLarge.copyWith(
+            color: colors.text.secondary,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xxs),
+        Text(
+          value,
+          style: AppTypography.bodyLarge.copyWith(
+            color: colors.text.accent,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        if (detail != null) ...[
+          const SizedBox(height: AppSpacing.xxs),
+          Text(
+            detail,
+            style: AppTypography.bodyMedium.copyWith(
+              color: colors.text.primary,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/src/providers/voting/voting_state.dart
+++ b/lib/src/providers/voting/voting_state.dart
@@ -165,6 +165,22 @@ class VotingRoundDetails {
   DateTime? get voteEndTime => _dateFromJson(rawJson, 'vote_end_time');
 
   DateTime? get ceremonyStart => _dateFromJson(rawJson, 'ceremony_phase_start');
+
+  /// Optional calendar time for the snapshot cutoff.
+  ///
+  /// Voting eligibility is defined at [snapshotHeight]. When the round JSON
+  /// also carries a timestamp, the UI can show that date next to the block.
+  DateTime? get snapshotTime {
+    for (final key in const [
+      'snapshot_time',
+      'snapshot_date',
+      'snapshot_timestamp',
+    ]) {
+      final value = _dateFromJson(rawJson, key);
+      if (value != null) return value;
+    }
+    return null;
+  }
 }
 
 DateTime? votingSessionVoteEndTime(String? sessionJson) {

--- a/lib/widgetbook/voting_use_cases.dart
+++ b/lib/widgetbook/voting_use_cases.dart
@@ -243,8 +243,14 @@ Widget buildMobileVotingProposalDefaultUseCase(BuildContext context) {
 Widget buildMobileVotingEligibleUseCase(BuildContext context) =>
     _buildMobileVotingActiveUseCase(context, eligible: true);
 
+/// Variation A: snapshot date and exclusion reason stay on the poll page.
 Widget buildMobileVotingIneligibleUseCase(BuildContext context) =>
-    _buildMobileVotingActiveUseCase(context, eligible: false);
+    _buildMobileVotingActiveUseCase(
+      context,
+      eligible: false,
+      snapshotDate: _previewVotingSnapshotDate,
+      votingEligibilityErrorMessage: _previewMovedAfterSnapshotMessage,
+    );
 
 Widget buildMobileVotingPrivacyTrimUseCase(BuildContext context) =>
     _buildMobileVotingActiveUseCase(
@@ -267,7 +273,10 @@ Widget _buildMobileVotingActiveUseCase(
   BuildContext context, {
   required bool eligible,
   bool eligibilityUnknown = false,
+  bool showInlineEligibilityExplanation = true,
+  DateTime? snapshotDate,
   String? votingEligibilityMessage,
+  String? votingEligibilityErrorMessage,
 }) {
   return _mobileVotingFullPagePreview(
     context,
@@ -278,6 +287,8 @@ Widget _buildMobileVotingActiveUseCase(
         roundId: 'preview-nsm',
         title: '[TEST] Very Serious Snack Governance 3',
         snapshotHeight: 3543600,
+        snapshotDate: snapshotDate,
+        showInlineEligibilityExplanation: showInlineEligibilityExplanation,
         description:
             'A silly sample round for testing the shielded vote builder '
             'without using real governance content.',
@@ -294,8 +305,8 @@ Widget _buildMobileVotingActiveUseCase(
         votingEligibilityMessage: votingEligibilityMessage,
         votingEligibilityErrorMessage: eligible || eligibilityUnknown
             ? null
-            : 'This account did not have enough eligible '
-                  'shielded funds at snapshot block 3,543,600. Switch to an eligible account to vote.',
+            : votingEligibilityErrorMessage ??
+                  _previewMovedAfterSnapshotMessage,
         onVotingEligibilityRetry: _previewNoop,
         proposals: const [_previewNsmProposal],
         draft: const VotingDraftState(),
@@ -306,21 +317,33 @@ Widget _buildMobileVotingActiveUseCase(
   );
 }
 
+/// Variation B: compact page plus a structured reason sheet.
 Widget buildMobileVotingIneligibleModalUseCase(BuildContext context) {
   return Stack(
     fit: StackFit.expand,
     children: [
-      buildMobileVotingIneligibleUseCase(context),
+      _buildMobileVotingActiveUseCase(
+        context,
+        eligible: false,
+        showInlineEligibilityExplanation: false,
+        snapshotDate: _previewVotingSnapshotDate,
+        votingEligibilityErrorMessage: _previewMovedAfterSnapshotMessage,
+      ),
       ColoredBox(color: context.colors.background.neutralScrim),
-      const VotingIneligibleDialog(
-        message:
-            'Voting requires at least one eligible shielded note bundle '
-            'with 0.125 ZEC at snapshot block 3,459,350. '
-            'Switch to an eligible account to vote.',
+      VotingIneligibleDialog(
+        message: _previewMovedAfterSnapshotMessage,
+        snapshotDate: _previewVotingSnapshotDate,
+        snapshotHeight: 3543600,
       ),
     ],
   );
 }
+
+final _previewVotingSnapshotDate = DateTime.utc(2026, 8, 1);
+
+const _previewMovedAfterSnapshotMessage =
+    'This account had no eligible Ironwood notes at snapshot block 3,543,600. '
+    'Switch to an eligible account to vote.';
 
 const _previewNsmProposal = VotingProposalView(
   id: 1,

--- a/test/features/voting/mobile_voting_design_test.dart
+++ b/test/features/voting/mobile_voting_design_test.dart
@@ -10,6 +10,7 @@ import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/voting/screens/mobile/mobile_voting_screens.dart';
 import 'package:zcash_wallet/src/features/voting/screens/voting_proposal_detail_screen.dart';
 import 'package:zcash_wallet/src/features/voting/screens/voting_results_screen.dart';
+import 'package:zcash_wallet/src/features/voting/voting_eligibility_explanation.dart';
 import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
 import 'package:zcash_wallet/src/features/voting/widgets/voting_metadata_widgets.dart';
 import 'package:zcash_wallet/src/features/voting/widgets/voting_pane_scroll_area.dart';
@@ -239,11 +240,29 @@ void main() {
     expect(badge, findsOneWidget);
     expect(tester.getTopLeft(badge).dy, 140.5);
     expect(
-      tester.getTopLeft(find.byType(VotingProposalCard)),
-      const Offset(16, 406),
+      tester.getTopLeft(find.byType(VotingProposalCard)).dy,
+      greaterThan(
+        tester
+            .getBottomLeft(
+              find.byKey(const ValueKey('voting_eligibility_inline_notice')),
+            )
+            .dy,
+      ),
     );
     expect(find.textContaining('Voting power'), findsNothing);
     expect(find.text('Ends Aug 24, 2026'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('voting_eligibility_inline_notice')),
+      findsOneWidget,
+    );
+    expect(find.text('Snapshot'), findsOneWidget);
+    expect(find.text('Aug 1, 2026'), findsOneWidget);
+    expect(find.text('Block 3,543,600'), findsOneWidget);
+    expect(find.text('No Ironwood notes at the snapshot'), findsOneWidget);
+    expect(
+      find.textContaining('moved funds or finished Ironwood'),
+      findsOneWidget,
+    );
     expect(
       find.textContaining(RegExp(r'^(Ends today|1 day left|\d+ days left)$')),
       findsNothing,
@@ -251,8 +270,8 @@ void main() {
     expect(find.text('·'), findsNothing);
     expect(tester.getTopLeft(find.text('Show description')).dx, 36);
     final option = find.byKey(const ValueKey('voting_proposal_1_option_1'));
-    expect(tester.getTopLeft(option), const Offset(32, 713));
-    expect(tester.getSize(option), const Size(329, 115));
+    expect(option, findsOneWidget);
+    expect(tester.getSize(option).width, 329);
     expect(
       tester
           .widget<Opacity>(
@@ -269,8 +288,8 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Hide description'), findsOneWidget);
     expect(
-      tester.getTopLeft(find.byType(VotingProposalCard)),
-      const Offset(16, 406),
+      find.byKey(const ValueKey('voting_eligibility_inline_notice')),
+      findsOneWidget,
     );
     await tester.tap(find.text('Hide description'));
     await tester.pumpAndSettle();
@@ -297,37 +316,34 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('ineligible modal matches Figma geometry and styled live values', (
+  testWidgets('ineligible modal shows snapshot date and exclusion reason', (
     tester,
   ) async {
     await _pumpMobileFixture(tester, buildMobileVotingIneligibleModalUseCase);
+    expect(find.byType(MobileModalCard), findsOneWidget);
     expect(
-      tester.getRect(find.byType(MobileModalCard)),
-      const Rect.fromLTWH(16, 238.5, 361, 375),
+      find.byKey(const ValueKey('voting_eligibility_sheet_body')),
+      findsOneWidget,
     );
+    expect(find.text('Snapshot'), findsWidgets);
+    expect(find.text('Aug 1, 2026'), findsOneWidget);
+    expect(find.text('Block 3,543,600'), findsOneWidget);
+    expect(find.text('Why these funds do not count'), findsOneWidget);
+    expect(find.text('No Ironwood notes at the snapshot'), findsOneWidget);
+    expect(
+      find.textContaining('moved funds or finished Ironwood'),
+      findsOneWidget,
+    );
+    expect(find.text(kVotingEligibilityGuidance), findsOneWidget);
     final switchButton = find.byKey(
       const ValueKey('voting_ineligible_switch_account'),
     );
     final closeButton = find.byKey(const ValueKey('voting_ineligible_close'));
     expect(tester.getSize(switchButton), const Size(329, 50));
-    expect(tester.getTopLeft(switchButton).dy, 469.5);
     expect(
       tester.getTopLeft(closeButton).dy - tester.getBottomLeft(switchButton).dy,
       12,
     );
-    final text = tester.widget<Text>(find.textContaining('Voting requires'));
-    expect(text.style?.fontSize, 16);
-    expect(text.style?.height, 25 / 16);
-    final span = text.textSpan! as TextSpan;
-    expect(
-      span.toPlainText(),
-      'Voting requires at least one eligible shielded note bundle '
-      'with 0.125 ZEC at snapshot block 3,459,350\n\nSwitch to an eligible account to vote.',
-    );
-    final amount = span.children!.cast<TextSpan>().singleWhere(
-      (s) => s.text == '0.125 ZEC',
-    );
-    expect(amount.style?.color, AppThemeData.dark.colors.text.destructive);
     expect(tester.takeException(), isNull);
   });
 
@@ -342,12 +358,9 @@ void main() {
             'shielded funds at snapshot block 123,456. Switch to an eligible account to vote.',
       ),
     );
-    final text = tester.widget<Text>(find.textContaining('It had no eligible'));
-    expect(
-      text.textSpan!.toPlainText(),
-      contains('snapshot block 123,456\n\nSwitch'),
-    );
-    expect(text.textSpan!.toPlainText(), isNot(contains('0.125')));
+    expect(find.text('Block 123,456'), findsOneWidget);
+    expect(find.text('No Ironwood notes at the snapshot'), findsOneWidget);
+    expect(find.textContaining('0.125'), findsNothing);
     expect(tester.takeException(), isNull);
   });
 

--- a/test/features/voting/mobile_voting_design_test.dart
+++ b/test/features/voting/mobile_voting_design_test.dart
@@ -293,6 +293,8 @@ void main() {
     );
     await tester.tap(find.text('Hide description'));
     await tester.pumpAndSettle();
+    await tester.ensureVisible(option);
+    await tester.pumpAndSettle();
     await tester.tap(option);
     await tester.pumpAndSettle();
     expect(find.text('Not eligible for this voting round'), findsOneWidget);
@@ -404,11 +406,15 @@ void main() {
   ) async {
     await _pumpMobileFixture(tester, buildMobileVotingIneligibleUseCase);
     final option = find.byKey(const ValueKey('voting_proposal_1_option_1'));
+    await tester.ensureVisible(option);
+    await tester.pumpAndSettle();
     await tester.tap(option);
     await tester.pumpAndSettle();
     await tester.tap(find.bySemanticsLabel('Close').first);
     await tester.pumpAndSettle();
     expect(find.byType(VotingIneligibleDialog), findsNothing);
+    await tester.ensureVisible(option);
+    await tester.pumpAndSettle();
     await tester.tap(option);
     await tester.pumpAndSettle();
     await tester.tapAt(const Offset(5, 200));
@@ -428,14 +434,15 @@ void main() {
           textScaler: TextScaler.linear(scale),
         );
         final card = find.byType(VotingProposalCard);
+        await tester.ensureVisible(find.text('Show description'));
+        await tester.pumpAndSettle();
         final collapsedTop = tester.getTopLeft(card).dy;
         await tester.tap(find.text('Show description'));
         await tester.pumpAndSettle();
         expect(tester.getTopLeft(card).dy, greaterThan(collapsedTop));
         expect(find.byType(VotingForumLinkButton), findsOneWidget);
-        await tester.drag(
-          find.byType(VotingPaneScrollView),
-          const Offset(0, -1600),
+        await tester.ensureVisible(
+          find.byKey(const ValueKey('voting_review_answers_button')),
         );
         await tester.pumpAndSettle();
         await tester.tap(

--- a/test/features/voting/voting_eligibility_explanation_test.dart
+++ b/test/features/voting/voting_eligibility_explanation_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/voting/voting_eligibility_explanation.dart';
+import 'package:zcash_wallet/src/features/voting/voting_error_messages.dart';
+
+void main() {
+  test('no spendable notes maps to the snapshot Ironwood exclusion', () {
+    final explanation = VotingEligibilityExplanation.fromMessage(
+      friendlyVotingErrorText(
+        'Invalid input: no spendable voting notes at snapshot height 3359740',
+      ),
+      snapshotDate: DateTime.utc(2026, 8, 1),
+    );
+
+    expect(
+      explanation.reason,
+      VotingEligibilityExclusionReason.noNotesAtSnapshot,
+    );
+    expect(explanation.snapshotHeight, 3359740);
+    expect(explanation.snapshotValue, 'Aug 1, 2026');
+    expect(explanation.snapshotBlockLabel, 'Block 3,359,740');
+    expect(
+      explanation.reasonBody,
+      contains('Only Ironwood notes this account held at the snapshot'),
+    );
+    expect(explanation.reasonBody, contains('moved funds or finished Ironwood'));
+    expect(explanation.reasonBody, isNot(contains('sending after')));
+  });
+
+  test('minimum eligibility keeps the 0.125 ZEC bundle rule', () {
+    final explanation = VotingEligibilityExplanation.fromMessage(
+      friendlyVotingErrorText(
+        'Invalid input: minimum voting eligibility requires at least one '
+        'eligible voting bundle with 12500000 zatoshi voting weight; selected '
+        '0 persisted bundles with 0 zatoshi eligible bundle weight at '
+        'snapshot height 123',
+      ),
+    );
+
+    expect(explanation.reason, VotingEligibilityExclusionReason.belowMinimum);
+    expect(explanation.snapshotHeight, 123);
+    expect(explanation.snapshotValue, 'Block 123');
+    expect(explanation.reasonBody, contains('0.125 ZEC'));
+    expect(explanation.combinedMessage, contains('snapshot block 123'));
+    expect(
+      explanation.combinedMessage,
+      contains(kVotingEligibilityGuidance),
+    );
+  });
+
+  test('spending after the snapshot is not described as disqualifying', () {
+    // zcash_voting selects unspent-at-historical-height Ironwood notes.
+    // A later spend of those notes still counts; later receipts do not.
+    final body = const VotingEligibilityExplanation(
+      reason: VotingEligibilityExclusionReason.noNotesAtSnapshot,
+    ).reasonBody;
+    expect(body, contains('received or created after'));
+    expect(body.toLowerCase(), isNot(contains('spent after')));
+    expect(body.toLowerCase(), isNot(contains('sending after')));
+  });
+
+  test('friendly text is recognized as an eligibility failure', () {
+    final message = friendlyVotingErrorText(
+      'no spendable voting notes at snapshot height 10',
+    );
+    expect(isVotingEligibilityErrorText(message), isTrue);
+    expect(message, contains('Ironwood notes'));
+    expect(message, contains('snapshot block 10'));
+  });
+}

--- a/test/features/voting/voting_state_test.dart
+++ b/test/features/voting/voting_state_test.dart
@@ -108,6 +108,26 @@ void main() {
     );
   });
 
+  test('round details expose an optional snapshot calendar date', () {
+    final withDate = VotingRoundDetails.fromStatus(
+      VotingRoundStatus(
+        roundId: 'round-1',
+        status: 'active',
+        rawJson: _roundJson()..['snapshot_time'] = '2026-08-01T00:00:00Z',
+      ),
+    );
+    expect(withDate.snapshotTime, DateTime.utc(2026, 8, 1));
+
+    final withoutDate = VotingRoundDetails.fromStatus(
+      VotingRoundStatus(
+        roundId: 'round-1',
+        status: 'active',
+        rawJson: _roundJson(),
+      ),
+    );
+    expect(withoutDate.snapshotTime, isNull);
+  });
+
   test('round details require 32-byte round parameter fields', () {
     for (final entry in const {
       'ea_pk': 31,

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -212,9 +212,10 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'This account is not eligible for this voting round. It had no eligible '
-        'shielded funds at snapshot block 3,359,740. Switch to an eligible '
-        'account to vote.';
+        'Only Ironwood notes this account held at the snapshot can vote. '
+        'Notes you received or created after that point do not count, '
+        'even if you later moved funds or finished Ironwood. Eligibility is '
+        'measured at snapshot block 3,359,740. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
 
     expect(find.text(message), findsOneWidget);
@@ -244,9 +245,9 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least one eligible shielded note bundle with '
-        '0.125 ZEC '
-        'at snapshot block 123. Switch to an eligible account to vote.';
+        'Voting needs at least 0.125 ZEC in eligible Ironwood notes at the '
+        'snapshot. This account was below that minimum. Eligibility is measured at '
+        'snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
 
     expect(find.text(message), findsOneWidget);
@@ -304,9 +305,9 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least one eligible shielded note bundle with '
-        '0.125 ZEC '
-        'at snapshot block 123. Switch to an eligible account to vote.';
+        'Voting needs at least 0.125 ZEC in eligible Ironwood notes at the '
+        'snapshot. This account was below that minimum. Eligibility is measured at '
+        'snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
 
     expect(find.text(message), findsOneWidget);
@@ -347,9 +348,9 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least one eligible shielded note bundle with '
-        '0.125 ZEC '
-        'at snapshot block 123. Switch to an eligible account to vote.';
+        'Voting needs at least 0.125 ZEC in eligible Ironwood notes at the '
+        'snapshot. This account was below that minimum. Eligibility is measured at '
+        'snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
 
     expect(find.text(message), findsOneWidget);
@@ -379,9 +380,10 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'This account is not eligible for this voting round. It had no eligible '
-        'shielded funds at snapshot block 3,359,740. Switch to an eligible '
-        'account to vote.';
+        'Only Ironwood notes this account held at the snapshot can vote. '
+        'Notes you received or created after that point do not count, '
+        'even if you later moved funds or finished Ironwood. Eligibility is '
+        'measured at snapshot block 3,359,740. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
     await tester.tap(find.text('Retry'));
     await tester.pumpAndSettle();
@@ -557,9 +559,9 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least one eligible shielded note bundle with '
-        '0.125 ZEC '
-        'at snapshot block 3,359,740. Switch to an eligible account to vote.';
+        'Voting needs at least 0.125 ZEC in eligible Ironwood notes at the '
+        'snapshot. This account was below that minimum. Eligibility is measured at '
+        'snapshot block 3,359,740. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
 
     expect(find.text(message), findsOneWidget);
@@ -2919,9 +2921,9 @@ void main() {
       await tester.pumpAndSettle();
 
       const message =
-          'Voting requires at least one eligible shielded note bundle with '
-          '0.125 ZEC '
-          'at snapshot block 123. Switch to an eligible account to vote.';
+          'Voting needs at least 0.125 ZEC in eligible Ironwood notes at the '
+          'snapshot. This account was below that minimum. Eligibility is measured at '
+          'snapshot block 123. Switch to an eligible account to vote.';
       await _pumpUntilFound(tester, find.text('Not eligible'));
 
       expect(find.text(message), findsNothing);
@@ -2991,9 +2993,9 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least one eligible shielded note bundle with '
-        '0.125 ZEC '
-        'at snapshot block 123. Switch to an eligible account to vote.';
+        'Voting needs at least 0.125 ZEC in eligible Ironwood notes at the '
+        'snapshot. This account was below that minimum. Eligibility is measured at '
+        'snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text('Not eligible'));
 
     expect(find.text(message), findsNothing);
@@ -3046,9 +3048,9 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least one eligible shielded note bundle with '
-        '0.125 ZEC '
-        'at snapshot block 123. Switch to an eligible account to vote.';
+        'Voting needs at least 0.125 ZEC in eligible Ironwood notes at the '
+        'snapshot. This account was below that minimum. Eligibility is measured at '
+        'snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text('Not eligible'));
 
     expect(find.text(message), findsNothing);
@@ -3088,9 +3090,9 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least one eligible shielded note bundle with '
-        '0.125 ZEC '
-        'at snapshot block 123. Switch to an eligible account to vote.';
+        'Voting needs at least 0.125 ZEC in eligible Ironwood notes at the '
+        'snapshot. This account was below that minimum. Eligibility is measured at '
+        'snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
 
     expect(find.text(message), findsOneWidget);

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -2920,13 +2920,13 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      const message =
+      const reasonBody =
           'Voting needs at least 0.125 ZEC in eligible Ironwood notes at the '
-          'snapshot. This account was below that minimum. Eligibility is measured at '
-          'snapshot block 123. Switch to an eligible account to vote.';
+          'snapshot. This account was below that minimum.';
       await _pumpUntilFound(tester, find.text('Not eligible'));
 
-      expect(find.text(message), findsNothing);
+      expect(find.text('Below the 0.125 ZEC minimum'), findsOneWidget);
+      expect(find.text(reasonBody), findsOneWidget);
       expect(find.text('First proposal'), findsOneWidget);
       expect(find.text('Voting power 0 ZEC'), findsOneWidget);
       expect(find.text('Yes'), findsOneWidget);
@@ -2939,7 +2939,8 @@ void main() {
 
       expect(container.read(votingDraftProvider(_draftKey)).isEmpty, true);
       expect(find.text('Not eligible for this voting round'), findsOneWidget);
-      expect(find.text(message), findsOneWidget);
+      expect(find.text('Why these funds do not count'), findsOneWidget);
+      expect(find.text(reasonBody), findsWidgets);
 
       await tester.tap(find.text('Done'));
       await tester.pumpAndSettle();
@@ -2948,7 +2949,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Not eligible for this voting round'), findsOneWidget);
-      expect(find.text(message), findsOneWidget);
+      expect(find.text('Why these funds do not count'), findsOneWidget);
+      expect(find.text(reasonBody), findsWidgets);
     },
   );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [VZR-151](https://linear.app/vizor-wallet/issue/VZR-151/explain-why-funds-are-ineligible-for-voting).

## Problem

A mining-pool operator reported that a user did not understand why their funds were ineligible: they were in Ironwood, but had moved funds after the snapshot. The poll page only showed a generic “Not eligible” state.

## Eligibility check (before copy)

Rust selects notes with `get_unspent_ironwood_notes_at_historical_height`:

- Only Ironwood notes that were unspent **at the snapshot** count.
- Notes received or created **after** the snapshot do not count.
- Notes spent **after** the snapshot still count if they were Ironwood and unspent at the snapshot.
- Minimum: one eligible bundle with **0.125 ZEC**.

The reported case is therefore “no Ironwood notes at the snapshot,” not “sending after the snapshot removes eligibility.” Copy does not say the latter.

## Two design directions

Both are implemented and isolated as Widgetbook / figma-compare scenarios.

### Variation A — inline explainer (proactive)

A persistent destructive-subtle card on the poll page. Snapshot date and exclusion reason are visible without a tap.

- Scenario: `mobile-voting-ineligible`
- Shows: reason title, **Snapshot** `Aug 1, 2026`, **Block 3,543,600**, and the Ironwood / moved-after copy.

[Variation A: inline explainer on the poll page](https://cursor.com/agents/bc-07430014-dd99-413c-8232-a8eea4317859/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvariation_a_inline_explainer.png)

### Variation B — structured reason sheet (on demand)

Labeled rows replace the old paragraph dialog: Snapshot, Why these funds do not count, and switch-account guidance.

- Scenario: `mobile-voting-ineligible-modal`
- Shown when the user taps an option or “Not eligible.”

[Variation B: structured reason sheet](https://cursor.com/agents/bc-07430014-dd99-413c-8232-a8eea4317859/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvariation_b_reason_sheet.png)

Production uses both: A is always visible when ineligible; B opens on tap. Isolate B with `VotingActivePollContent.showInlineEligibilityExplanation = false`.

## Copy

Sentence case throughout.

- No notes: “Only Ironwood notes this account held at the snapshot can vote. Notes you received or created after that point do not count, even if you later moved funds or finished Ironwood.”
- Minimum: “Voting needs at least 0.125 ZEC in eligible Ironwood notes at the snapshot. This account was below that minimum.”
- Guidance: “Switch to an eligible account to vote.”

Calendar date is shown only when the round JSON includes `snapshot_time` / `snapshot_date` / `snapshot_timestamp`. Block height is always available.

## Tests

- `voting_eligibility_explanation_test.dart`
- `voting_status_screen_test.dart` eligibility cases (12)
- `mobile_voting_design_test.dart` (42, mobile lane)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [VZR-151](https://linear.app/keplrwallet/issue/VZR-151/explain-why-funds-are-ineligible-for-voting)

<div><a href="https://cursor.com/agents/bc-07430014-dd99-413c-8232-a8eea4317859?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07430014-dd99-413c-8232-a8eea4317859&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

