### PR TITLE
Simplify the full-address viewer and add copying

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -18,6 +18,7 @@ import '../widgetbook/carousel_use_cases.dart';
 import '../widgetbook/screen_use_cases.dart';
 import '../widgetbook/swap_use_cases.dart';
 import '../widgetbook/voting_use_cases.dart';
+import '../widgetbook/address_verify_use_cases.dart';
 import 'zip321_prefill_use_cases.dart';
 
 typedef FigmaCompareScenarioBuilder = Widget Function(BuildContext context);
@@ -1617,6 +1618,34 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     id: 'activity-gift-card-redeemed-detail-mobile',
     description: 'Mobile redeemed card with saved fiat',
     builder: buildGiftCardRedeemedDetailPreview,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'verify-address-code-block',
+    description:
+        'Desktop full-address viewer: recessed code block with inline Copy',
+    builder: buildVerifyAddressCodeBlockUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'verify-address-action-footer',
+    description:
+        'Desktop full-address viewer: wrapping address with Copy address CTA',
+    builder: buildVerifyAddressActionFooterUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-verify-address-code-block',
+    description:
+        'Mobile full-address sheet: recessed code block with inline Copy',
+    builder: buildMobileVerifyAddressCodeBlockUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-verify-address-action-footer',
+    description:
+        'Mobile full-address sheet: wrapping address with Copy address CTA',
+    builder: buildMobileVerifyAddressActionFooterUseCase,
     desktop: false,
     mobile: true,
   ),

--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -1624,8 +1624,20 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
   FigmaCompareScenario(
     id: 'verify-address-action-footer',
     description:
-        'Desktop full-address viewer: wrapping address with Copy address CTA',
+        'Desktop full-address viewer: wrapping address with Copy action',
     builder: buildVerifyAddressActionFooterUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'verify-address-transparent',
+    description:
+        'Desktop full-address viewer with a wrapping transparent header',
+    builder: buildVerifyAddressUnknownTransparentUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'verify-address-contact',
+    description:
+        'Desktop full-address viewer with contact and transaction history',
+    builder: buildVerifyAddressKnownContactUseCase,
   ),
   FigmaCompareScenario(
     id: 'mobile-verify-address-action-footer',

--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -1622,24 +1622,10 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     mobile: true,
   ),
   FigmaCompareScenario(
-    id: 'verify-address-code-block',
-    description:
-        'Desktop full-address viewer: recessed code block with inline Copy',
-    builder: buildVerifyAddressCodeBlockUseCase,
-  ),
-  FigmaCompareScenario(
     id: 'verify-address-action-footer',
     description:
         'Desktop full-address viewer: wrapping address with Copy address CTA',
     builder: buildVerifyAddressActionFooterUseCase,
-  ),
-  FigmaCompareScenario(
-    id: 'mobile-verify-address-code-block',
-    description:
-        'Mobile full-address sheet: recessed code block with inline Copy',
-    builder: buildMobileVerifyAddressCodeBlockUseCase,
-    desktop: false,
-    mobile: true,
   ),
   FigmaCompareScenario(
     id: 'mobile-verify-address-action-footer',

--- a/lib/src/core/formatting/address_display.dart
+++ b/lib/src/core/formatting/address_display.dart
@@ -1,9 +1,10 @@
 /// Canonical display formatting for Zcash addresses.
 ///
 /// Single source of truth for the send review/status screens, the received
-/// receipt, and the verify-address modal. The redesign removed the old
-/// per-screen address chunking rules; new surfaces must format through
-/// [truncatedAddress] / [addressVerifyGrid].
+/// receipt, and the verify-address modal. Truncated one-line forms go
+/// through [truncatedAddress]. The full-address viewer renders the raw
+/// string in Geist Mono and wraps naturally — [addressVerifyGrid] remains
+/// for any caller that still needs the legacy 5-character grouping.
 library;
 
 /// Head/tail lengths for the single-line truncated form.

--- a/lib/src/core/widgets/full_address_viewer.dart
+++ b/lib/src/core/widgets/full_address_viewer.dart
@@ -5,22 +5,6 @@ import 'app_button.dart';
 import 'app_copy_feedback.dart';
 import 'app_icon.dart';
 
-/// How the full-address viewer presents the copy control.
-///
-/// Two design directions for VZR-152:
-///
-/// * [codeBlock] — recessed monospace surface with an inline Copy chip.
-///   Copy sits on the address itself, like a code snippet.
-/// * [actionFooter] — wrapping monospace body with Copy address as the
-///   primary modal action. Copy is the reason the sheet is open.
-enum FullAddressViewerLayout {
-  /// Recessed monospace block with an inline Copy chip on the address surface.
-  codeBlock,
-
-  /// Wrapping monospace body with Copy address as a primary footer action.
-  actionFooter,
-}
-
 /// Exact string placed on the clipboard: trimmed, with no display spaces
 /// or line breaks introduced for wrapping.
 String fullAddressCopyText(String address) => address.trim();
@@ -57,18 +41,15 @@ class FullAddressText extends StatelessWidget {
   }
 }
 
-/// Visible copy control used by both layouts. [compact] is the inline chip
-/// on a code block; the default is the labeled modal/sheet action.
+/// Primary Copy address action used by the full-address viewer.
 class FullAddressCopyButton extends StatelessWidget {
   const FullAddressCopyButton({
     required this.address,
-    this.compact = false,
     this.expand = false,
     super.key,
   });
 
   final String address;
-  final bool compact;
   final bool expand;
 
   @override
@@ -76,12 +57,12 @@ class FullAddressCopyButton extends StatelessWidget {
     return AppButton(
       key: const ValueKey('full_address_copy_button'),
       onPressed: () => copyFullAddress(context, address),
-      variant: compact ? AppButtonVariant.ghost : AppButtonVariant.primary,
-      size: compact ? AppButtonSize.small : AppButtonSize.mediumLarge,
+      variant: AppButtonVariant.primary,
+      size: AppButtonSize.mediumLarge,
       expand: expand,
-      minWidth: compact ? null : kFullAddressCopyActionMinWidth,
+      minWidth: kFullAddressCopyActionMinWidth,
       leading: const AppIcon(AppIcons.copy),
-      child: Text(compact ? 'Copy' : 'Copy address'),
+      child: const Text('Copy address'),
     );
   }
 }
@@ -89,53 +70,3 @@ class FullAddressCopyButton extends StatelessWidget {
 /// Minimum width for the labeled Copy address action, matching the
 /// shared modal button floor.
 const kFullAddressCopyActionMinWidth = 96.0;
-
-/// Address body for [FullAddressViewerLayout]: a recessed code block with
-/// an inline Copy chip, or plain wrapping monospace text.
-class FullAddressBody extends StatelessWidget {
-  const FullAddressBody({
-    required this.address,
-    required this.layout,
-    super.key,
-  });
-
-  final String address;
-  final FullAddressViewerLayout layout;
-
-  @override
-  Widget build(BuildContext context) {
-    final text = FullAddressText(address: address);
-    if (layout == FullAddressViewerLayout.actionFooter) {
-      return text;
-    }
-
-    final colors = context.colors;
-    return DecoratedBox(
-      key: const ValueKey('full_address_code_block'),
-      decoration: BoxDecoration(
-        color: colors.background.raised,
-        borderRadius: BorderRadius.circular(AppRadii.small),
-        border: Border.all(color: colors.border.subtle),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(
-          AppSpacing.s,
-          AppSpacing.s,
-          AppSpacing.s,
-          AppSpacing.xs,
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            text,
-            const SizedBox(height: AppSpacing.xs),
-            Align(
-              alignment: AlignmentDirectional.centerEnd,
-              child: FullAddressCopyButton(address: address, compact: true),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}

--- a/lib/src/core/widgets/full_address_viewer.dart
+++ b/lib/src/core/widgets/full_address_viewer.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/widgets.dart';
+
+import '../theme/app_theme.dart';
+import 'app_button.dart';
+import 'app_copy_feedback.dart';
+import 'app_icon.dart';
+
+/// How the full-address viewer presents the copy control.
+///
+/// Two design directions for VZR-152:
+///
+/// * [codeBlock] — recessed monospace surface with an inline Copy chip.
+///   Copy sits on the address itself, like a code snippet.
+/// * [actionFooter] — wrapping monospace body with Copy address as the
+///   primary modal action. Copy is the reason the sheet is open.
+enum FullAddressViewerLayout {
+  /// Recessed monospace block with an inline Copy chip on the address surface.
+  codeBlock,
+
+  /// Wrapping monospace body with Copy address as a primary footer action.
+  actionFooter,
+}
+
+/// Exact string placed on the clipboard: trimmed, with no display spaces
+/// or line breaks introduced for wrapping.
+String fullAddressCopyText(String address) => address.trim();
+
+/// Copies [address] without formatting spaces or line breaks and toasts
+/// `Address copied`.
+void copyFullAddress(BuildContext context, String address) {
+  copyTextWithToast(
+    context,
+    text: fullAddressCopyText(address),
+    toastMessage: 'Address copied',
+  );
+}
+
+/// Continuous, wrapping Geist Mono address. Soft-wrap only — the string
+/// itself stays unspaced so `O` / `0` sit in a fixed-width grid the eye
+/// can scan, and a copy action can take the exact value.
+class FullAddressText extends StatelessWidget {
+  const FullAddressText({required this.address, this.color, super.key});
+
+  final String address;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      fullAddressCopyText(address),
+      key: const ValueKey('full_address_text'),
+      softWrap: true,
+      style: AppTypography.codeMedium.copyWith(
+        color: color ?? context.colors.text.primary,
+      ),
+    );
+  }
+}
+
+/// Visible copy control used by both layouts. [compact] is the inline chip
+/// on a code block; the default is the labeled modal/sheet action.
+class FullAddressCopyButton extends StatelessWidget {
+  const FullAddressCopyButton({
+    required this.address,
+    this.compact = false,
+    this.expand = false,
+    super.key,
+  });
+
+  final String address;
+  final bool compact;
+  final bool expand;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppButton(
+      key: const ValueKey('full_address_copy_button'),
+      onPressed: () => copyFullAddress(context, address),
+      variant: compact ? AppButtonVariant.ghost : AppButtonVariant.primary,
+      size: compact ? AppButtonSize.small : AppButtonSize.mediumLarge,
+      expand: expand,
+      minWidth: compact ? null : kFullAddressCopyActionMinWidth,
+      leading: const AppIcon(AppIcons.copy),
+      child: Text(compact ? 'Copy' : 'Copy address'),
+    );
+  }
+}
+
+/// Minimum width for the labeled Copy address action, matching the
+/// shared modal button floor.
+const kFullAddressCopyActionMinWidth = 96.0;
+
+/// Address body for [FullAddressViewerLayout]: a recessed code block with
+/// an inline Copy chip, or plain wrapping monospace text.
+class FullAddressBody extends StatelessWidget {
+  const FullAddressBody({
+    required this.address,
+    required this.layout,
+    super.key,
+  });
+
+  final String address;
+  final FullAddressViewerLayout layout;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = FullAddressText(address: address);
+    if (layout == FullAddressViewerLayout.actionFooter) {
+      return text;
+    }
+
+    final colors = context.colors;
+    return DecoratedBox(
+      key: const ValueKey('full_address_code_block'),
+      decoration: BoxDecoration(
+        color: colors.background.raised,
+        borderRadius: BorderRadius.circular(AppRadii.small),
+        border: Border.all(color: colors.border.subtle),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.s,
+          AppSpacing.s,
+          AppSpacing.s,
+          AppSpacing.xs,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            text,
+            const SizedBox(height: AppSpacing.xs),
+            Align(
+              alignment: AlignmentDirectional.centerEnd,
+              child: FullAddressCopyButton(address: address, compact: true),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/core/widgets/full_address_viewer.dart
+++ b/lib/src/core/widgets/full_address_viewer.dart
@@ -62,9 +62,13 @@ class FullAddressCopyButton extends StatelessWidget {
       variant: AppButtonVariant.primary,
       size: size,
       expand: expand,
+      constrainContent: expand,
       minWidth: kFullAddressCopyActionMinWidth,
       leading: const AppIcon(AppIcons.copy),
-      child: const Text('Copy address'),
+      child: const FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Text('Copy address', maxLines: 1),
+      ),
     );
   }
 }

--- a/lib/src/core/widgets/full_address_viewer.dart
+++ b/lib/src/core/widgets/full_address_viewer.dart
@@ -46,11 +46,13 @@ class FullAddressCopyButton extends StatelessWidget {
   const FullAddressCopyButton({
     required this.address,
     this.expand = false,
+    this.size = AppButtonSize.mediumLarge,
     super.key,
   });
 
   final String address;
   final bool expand;
+  final AppButtonSize size;
 
   @override
   Widget build(BuildContext context) {
@@ -58,7 +60,7 @@ class FullAddressCopyButton extends StatelessWidget {
       key: const ValueKey('full_address_copy_button'),
       onPressed: () => copyFullAddress(context, address),
       variant: AppButtonVariant.primary,
-      size: AppButtonSize.mediumLarge,
+      size: size,
       expand: expand,
       minWidth: kFullAddressCopyActionMinWidth,
       leading: const AppIcon(AppIcons.copy),

--- a/lib/src/core/widgets/full_address_viewer.dart
+++ b/lib/src/core/widgets/full_address_viewer.dart
@@ -47,12 +47,14 @@ class FullAddressCopyButton extends StatelessWidget {
     required this.address,
     this.expand = false,
     this.size = AppButtonSize.mediumLarge,
+    this.label = 'Copy address',
     super.key,
   });
 
   final String address;
   final bool expand;
   final AppButtonSize size;
+  final String label;
 
   @override
   Widget build(BuildContext context) {
@@ -65,10 +67,7 @@ class FullAddressCopyButton extends StatelessWidget {
       constrainContent: expand,
       minWidth: kFullAddressCopyActionMinWidth,
       leading: const AppIcon(AppIcons.copy),
-      child: const FittedBox(
-        fit: BoxFit.scaleDown,
-        child: Text('Copy address', maxLines: 1),
-      ),
+      child: FittedBox(fit: BoxFit.scaleDown, child: Text(label, maxLines: 1)),
     );
   }
 }

--- a/lib/src/core/widgets/mobile/mobile_address_verify_sheet.dart
+++ b/lib/src/core/widgets/mobile/mobile_address_verify_sheet.dart
@@ -54,14 +54,20 @@ class MobileAddressVerifySheet extends StatelessWidget {
       ),
       bodyGap: AppSpacing.sm,
       bottomPadding: AppSpacing.md,
+      constrainBody: true,
       onClose: onClose,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          SizedBox(
-            key: const ValueKey('mobile_address_verify_chunks'),
-            child: FullAddressText(address: address),
+          Flexible(
+            child: SingleChildScrollView(
+              key: const ValueKey('mobile_address_verify_chunks'),
+              child: SizedBox(
+                width: double.infinity,
+                child: FullAddressText(address: address),
+              ),
+            ),
           ),
           const SizedBox(height: AppSpacing.md),
           FullAddressCopyButton(

--- a/lib/src/core/widgets/mobile/mobile_address_verify_sheet.dart
+++ b/lib/src/core/widgets/mobile/mobile_address_verify_sheet.dart
@@ -5,15 +5,12 @@ import '../../theme/app_theme.dart';
 import '../full_address_viewer.dart';
 
 /// Full-address verification sheet — identity title on top, a continuous
-/// wrapping Geist Mono address, a visible copy control, and a Cancel
-/// action. [layout] selects the recessed code-block treatment or the
-/// primary Copy address footer.
+/// wrapping Geist Mono address, a primary Copy address action, and Cancel.
 Future<void> showMobileAddressVerifySheet(
   BuildContext context, {
   required String title,
   required String address,
   Widget? leading,
-  FullAddressViewerLayout layout = FullAddressViewerLayout.codeBlock,
 }) {
   return showAppMobileSheet<void>(
     context: context,
@@ -22,29 +19,26 @@ Future<void> showMobileAddressVerifySheet(
         title: title,
         address: address,
         leading: leading,
-        layout: layout,
         onClose: () => Navigator.of(sheetContext).pop(),
       );
     },
   );
 }
 
-/// Sheet body extracted so Widgetbook / figma-compare can render either
-/// layout without opening a route.
+/// Sheet body extracted so Widgetbook / figma-compare can render the
+/// viewer without opening a route.
 class MobileAddressVerifySheet extends StatelessWidget {
   const MobileAddressVerifySheet({
     required this.title,
     required this.address,
     required this.onClose,
     this.leading,
-    this.layout = FullAddressViewerLayout.codeBlock,
     super.key,
   });
 
   final String title;
   final String address;
   final Widget? leading;
-  final FullAddressViewerLayout layout;
   final VoidCallback onClose;
 
   @override
@@ -67,13 +61,11 @@ class MobileAddressVerifySheet extends StatelessWidget {
           Padding(
             key: const ValueKey('mobile_address_verify_chunks'),
             padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
-            child: FullAddressBody(address: address, layout: layout),
+            child: FullAddressText(address: address),
           ),
           const SizedBox(height: AppSpacing.md),
-          if (layout == FullAddressViewerLayout.actionFooter) ...[
-            FullAddressCopyButton(address: address, expand: true),
-            const SizedBox(height: AppSpacing.xs),
-          ],
+          FullAddressCopyButton(address: address, expand: true),
+          const SizedBox(height: AppSpacing.xs),
           _MobileAddressVerifyCancel(onTap: onClose),
         ],
       ),

--- a/lib/src/core/widgets/mobile/mobile_address_verify_sheet.dart
+++ b/lib/src/core/widgets/mobile/mobile_address_verify_sheet.dart
@@ -6,7 +6,7 @@ import '../app_button.dart';
 import '../full_address_viewer.dart';
 
 /// Full-address verification sheet — identity title on top, a continuous
-/// wrapping Geist Mono address, a primary Copy address action, and Cancel.
+/// wrapping Geist Mono address, a primary Copy address action, and header close.
 Future<void> showMobileAddressVerifySheet(
   BuildContext context, {
   required String title,
@@ -44,14 +44,9 @@ class MobileAddressVerifySheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = context.colors;
     return MobileModalScaffold(
       title: title,
       leading: leading,
-      titleStyle: AppTypography.labelLarge.copyWith(
-        fontWeight: FontWeight.w600,
-        color: colors.text.accent,
-      ),
       bodyGap: AppSpacing.sm,
       bottomPadding: AppSpacing.md,
       constrainBody: true,
@@ -75,37 +70,7 @@ class MobileAddressVerifySheet extends StatelessWidget {
             expand: true,
             size: AppButtonSize.large,
           ),
-          const SizedBox(height: AppSpacing.xs),
-          _MobileAddressVerifyCancel(onTap: onClose),
         ],
-      ),
-    );
-  }
-}
-
-class _MobileAddressVerifyCancel extends StatelessWidget {
-  const _MobileAddressVerifyCancel({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: SizedBox(
-          height: AppButtonSizing.largeHeight,
-          child: Center(
-            child: Text(
-              'Cancel',
-              style: AppTypography.labelLarge.copyWith(
-                color: context.colors.text.primary,
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/lib/src/core/widgets/mobile/mobile_address_verify_sheet.dart
+++ b/lib/src/core/widgets/mobile/mobile_address_verify_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 
 import '../../layout/mobile/app_mobile_sheet.dart';
 import '../../theme/app_theme.dart';
+import '../app_button.dart';
 import '../full_address_viewer.dart';
 
 /// Full-address verification sheet — identity title on top, a continuous
@@ -51,20 +52,23 @@ class MobileAddressVerifySheet extends StatelessWidget {
         fontWeight: FontWeight.w600,
         color: colors.text.accent,
       ),
-      bodyGap: AppSpacing.md,
-      bottomPadding: AppSpacing.base,
+      bodyGap: AppSpacing.sm,
+      bottomPadding: AppSpacing.md,
       onClose: onClose,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Padding(
+          SizedBox(
             key: const ValueKey('mobile_address_verify_chunks'),
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
             child: FullAddressText(address: address),
           ),
           const SizedBox(height: AppSpacing.md),
-          FullAddressCopyButton(address: address, expand: true),
+          FullAddressCopyButton(
+            address: address,
+            expand: true,
+            size: AppButtonSize.large,
+          ),
           const SizedBox(height: AppSpacing.xs),
           _MobileAddressVerifyCancel(onTap: onClose),
         ],

--- a/lib/src/core/widgets/mobile/mobile_address_verify_sheet.dart
+++ b/lib/src/core/widgets/mobile/mobile_address_verify_sheet.dart
@@ -2,167 +2,80 @@ import 'package:flutter/widgets.dart';
 
 import '../../layout/mobile/app_mobile_sheet.dart';
 import '../../theme/app_theme.dart';
+import '../full_address_viewer.dart';
 
-const _addressVerifyChunkTextStyle = TextStyle(
-  fontFamily: 'Geist',
-  fontWeight: FontWeight.w500,
-  fontSize: 14,
-  height: 16 / 14,
-  letterSpacing: -0.06,
-);
-const _addressVerifyChunksPerLine = 5;
-const _addressVerifyChunkGap = 12.0;
-const _addressVerifyLineHorizontalInset = 10.0;
-
-/// Chunked mobile address verification sheet — Figma `Verify Address`
-/// (4731:96657): identity title on top, the address split into 5-character
-/// chunks, and a Cancel action.
+/// Full-address verification sheet — identity title on top, a continuous
+/// wrapping Geist Mono address, a visible copy control, and a Cancel
+/// action. [layout] selects the recessed code-block treatment or the
+/// primary Copy address footer.
 Future<void> showMobileAddressVerifySheet(
   BuildContext context, {
   required String title,
   required String address,
   Widget? leading,
+  FullAddressViewerLayout layout = FullAddressViewerLayout.codeBlock,
 }) {
   return showAppMobileSheet<void>(
     context: context,
     builder: (sheetContext) {
-      final colors = sheetContext.colors;
-      final chunks = _chunkAddress(address);
-      final chunkLines = _chunkAddressLines(chunks);
-      return MobileModalScaffold(
+      return MobileAddressVerifySheet(
         title: title,
+        address: address,
         leading: leading,
-        titleStyle: AppTypography.labelLarge.copyWith(
-          fontWeight: FontWeight.w600,
-          color: colors.text.accent,
-        ),
-        bodyGap: AppSpacing.md,
-        bottomPadding: AppSpacing.base,
+        layout: layout,
         onClose: () => Navigator.of(sheetContext).pop(),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              key: const ValueKey('mobile_address_verify_chunks'),
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
-              child: _MobileAddressVerifyChunkGrid(
-                chunks: chunks,
-                chunkLines: chunkLines,
-                dividerColor: colors.border.regular,
-              ),
-            ),
-            const SizedBox(height: AppSpacing.md),
-            _MobileAddressVerifyCancel(
-              onTap: () => Navigator.of(sheetContext).pop(),
-            ),
-          ],
-        ),
       );
     },
   );
 }
 
-class _MobileAddressVerifyChunkGrid extends StatelessWidget {
-  const _MobileAddressVerifyChunkGrid({
-    required this.chunks,
-    required this.chunkLines,
-    required this.dividerColor,
-  });
-
-  final List<String> chunks;
-  final List<List<int>> chunkLines;
-  final Color dividerColor;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        for (var lineIndex = 0; lineIndex < chunkLines.length; lineIndex++) ...[
-          _MobileAddressVerifyChunkLine(
-            key: ValueKey('mobile_address_verify_line_$lineIndex'),
-            chunks: chunks,
-            chunkIndexes: chunkLines[lineIndex],
-          ),
-          if (lineIndex < chunkLines.length - 1) ...[
-            const SizedBox(height: _addressVerifyChunkGap),
-            Container(
-              key: ValueKey('mobile_address_verify_divider_$lineIndex'),
-              height: 1,
-              color: dividerColor,
-            ),
-            const SizedBox(height: _addressVerifyChunkGap),
-          ],
-        ],
-      ],
-    );
-  }
-}
-
-class _MobileAddressVerifyChunkLine extends StatelessWidget {
-  const _MobileAddressVerifyChunkLine({
-    required this.chunks,
-    required this.chunkIndexes,
+/// Sheet body extracted so Widgetbook / figma-compare can render either
+/// layout without opening a route.
+class MobileAddressVerifySheet extends StatelessWidget {
+  const MobileAddressVerifySheet({
+    required this.title,
+    required this.address,
+    required this.onClose,
+    this.leading,
+    this.layout = FullAddressViewerLayout.codeBlock,
     super.key,
   });
 
-  final List<String> chunks;
-  final List<int> chunkIndexes;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: _addressVerifyLineHorizontalInset,
-      ),
-      child: Row(
-        children: [
-          for (
-            var position = 0;
-            position < _addressVerifyChunksPerLine;
-            position++
-          ) ...[
-            if (position > 0) const SizedBox(width: _addressVerifyChunkGap),
-            Expanded(
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: position < chunkIndexes.length
-                    ? _MobileAddressVerifyChunkText(
-                        text: chunks[chunkIndexes[position]],
-                        highlighted: _isAddressVerifyChunkHighlighted(
-                          chunkIndexes[position],
-                          chunks.length,
-                        ),
-                      )
-                    : const SizedBox.shrink(),
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _MobileAddressVerifyChunkText extends StatelessWidget {
-  const _MobileAddressVerifyChunkText({
-    required this.text,
-    required this.highlighted,
-  });
-
-  final String text;
-  final bool highlighted;
+  final String title;
+  final String address;
+  final Widget? leading;
+  final FullAddressViewerLayout layout;
+  final VoidCallback onClose;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return Text(
-      text,
-      style: _addressVerifyChunkTextStyle.copyWith(
-        fontWeight: highlighted ? FontWeight.w600 : FontWeight.w500,
-        color: highlighted ? colors.text.brandCrimson : colors.text.primary,
+    return MobileModalScaffold(
+      title: title,
+      leading: leading,
+      titleStyle: AppTypography.labelLarge.copyWith(
+        fontWeight: FontWeight.w600,
+        color: colors.text.accent,
+      ),
+      bodyGap: AppSpacing.md,
+      bottomPadding: AppSpacing.base,
+      onClose: onClose,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            key: const ValueKey('mobile_address_verify_chunks'),
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
+            child: FullAddressBody(address: address, layout: layout),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          if (layout == FullAddressViewerLayout.actionFooter) ...[
+            FullAddressCopyButton(address: address, expand: true),
+            const SizedBox(height: AppSpacing.xs),
+          ],
+          _MobileAddressVerifyCancel(onTap: onClose),
+        ],
       ),
     );
   }
@@ -194,29 +107,4 @@ class _MobileAddressVerifyCancel extends StatelessWidget {
       ),
     );
   }
-}
-
-bool _isAddressVerifyChunkHighlighted(int index, int totalChunks) {
-  return index == 0 ||
-      index == 2 ||
-      index == totalChunks - 3 ||
-      index == totalChunks - 1;
-}
-
-List<String> _chunkAddress(String address) {
-  final trimmed = address.trim();
-  return [
-    for (var i = 0; i < trimmed.length; i += 5)
-      trimmed.substring(i, i + 5 > trimmed.length ? trimmed.length : i + 5),
-  ];
-}
-
-List<List<int>> _chunkAddressLines(List<String> chunks) {
-  return [
-    for (var i = 0; i < chunks.length; i += 5)
-      [
-        for (var index = i; index < chunks.length && index < i + 5; index++)
-          index,
-      ],
-  ];
 }

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -8,6 +8,7 @@ import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_icon_hover_button.dart';
 import '../../../core/widgets/app_profile_picture.dart';
+import '../../../core/widgets/full_address_viewer.dart';
 import '../../../core/widgets/app_tooltip.dart';
 import '../../../core/widgets/pool_badge.dart';
 import '../../../core/widgets/review_list_row.dart'
@@ -1004,10 +1005,8 @@ class _TransactionContentFrame extends StatelessWidget {
 /// makes the privacy status and address action easier to scan.
 ///
 /// The full address never leaves this card. "Show full address" swaps the
-/// one-line truncation for the canonical verify grouping — 5-character
-/// groups with the same head/tail emphasis the verify-address modal uses —
-/// so the user can compare characters without losing the request behind a
-/// second modal.
+/// one-line truncation for a continuous Geist Mono string that wraps
+/// naturally, matching the dedicated verify-address viewer.
 ///
 /// When the wallet can put a name to the address ([identity]) the block leads
 /// with that name and an avatar instead, the way the pay and send reviews
@@ -1235,13 +1234,11 @@ class _RecipientIdentityBlock extends StatelessWidget {
   }
 }
 
-/// The full address in 5-character groups, five groups to a row.
+/// The full address as a continuous wrapping Geist Mono string.
 ///
-/// Chunking and the head/tail crimson emphasis come from
-/// [addressVerifyGrid], the same source the verify-address modal renders,
-/// so a user who has compared an address in one place reads the other
-/// identically. The glyphs stay monospace here because the collapsed form
-/// directly above them is monospace too.
+/// Same typeface as the collapsed truncation above it so expanding the
+/// row does not change the glyph language — only the amount of address
+/// that is visible.
 class _AddressChunks extends StatelessWidget {
   const _AddressChunks({required this.address, super.key});
 
@@ -1249,45 +1246,7 @@ class _AddressChunks extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = context.colors;
-    final rows = addressVerifyGrid(address);
-    final normalStyle = AppTypography.codeMedium.copyWith(
-      color: colors.text.accent,
-    );
-    final highlightedStyle = AppTypography.codeMedium.copyWith(
-      color: colors.text.brandCrimson,
-      fontWeight: FontWeight.w600,
-    );
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        for (var row = 0; row < rows.length; row++) ...[
-          if (row > 0) const SizedBox(height: AppSpacing.xxs),
-          // scaleDown keeps wide glyph metrics (and the test environment's
-          // square Ahem font) from overflowing the card column; with the
-          // production Geist Mono metrics the row fits and renders 1:1.
-          FittedBox(
-            fit: BoxFit.scaleDown,
-            alignment: AlignmentDirectional.centerStart,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                for (var i = 0; i < rows[row].length; i++) ...[
-                  if (i > 0) const SizedBox(width: AppSpacing.xs),
-                  Text(
-                    rows[row][i].text,
-                    style: rows[row][i].highlighted
-                        ? highlightedStyle
-                        : normalStyle,
-                  ),
-                ],
-              ],
-            ),
-          ),
-        ],
-      ],
-    );
+    return FullAddressText(address: address, color: context.colors.text.accent);
   }
 }
 

--- a/lib/src/features/send/widgets/verify_address_modal.dart
+++ b/lib/src/features/send/widgets/verify_address_modal.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/widgets.dart';
 
-import '../../../core/formatting/address_display.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_profile_picture.dart';
+import '../../../core/widgets/full_address_viewer.dart';
 import '../../../core/widgets/review_info_row.dart';
-import '../../../core/widgets/review_wrap_card.dart';
 import '../../accounts/widgets/account_modal_card.dart';
 
 /// Recipient flavor shown by [VerifyAddressModal].
@@ -24,9 +23,9 @@ enum VerifyAddressModalAddressKind { shielded, transparent, external }
 /// The address verification modal opened from "Show full address" on the
 /// send review screen (and later the received receipt).
 ///
-/// Renders the full unified address through the canonical verify grid
-/// ([addressVerifyGrid]): 5-character groups, 5 groups per row, with the
-/// fixed head/tail groups emphasized in the brand crimson.
+/// Renders the full address as a continuous Geist Mono string that wraps
+/// naturally, plus a visible copy control. [layout] selects between the
+/// recessed code-block treatment and the primary Copy address footer.
 ///
 /// Static only — no provider wiring. The caller hosts this card inside an
 /// `AppPaneModalOverlay` and supplies the callbacks.
@@ -39,6 +38,7 @@ class VerifyAddressModal extends StatelessWidget {
     this.contactProfilePictureId,
     this.previousTransactionCount,
     this.unknownAddressKind = VerifyAddressModalAddressKind.shielded,
+    this.layout = FullAddressViewerLayout.codeBlock,
     super.key,
   }) : assert(
          variant == VerifyAddressModalVariant.unknown ||
@@ -46,8 +46,11 @@ class VerifyAddressModal extends StatelessWidget {
          'knownContact requires contactName and contactProfilePictureId.',
        );
 
-  /// Full unified address rendered as the verify grid.
+  /// Full unified address rendered as wrapping monospace text.
   final String address;
+
+  /// Copy-control placement. Defaults to the recessed code-block layout.
+  final FullAddressViewerLayout layout;
 
   final VerifyAddressModalVariant variant;
 
@@ -91,8 +94,12 @@ class VerifyAddressModal extends StatelessWidget {
         children: [
           SizedBox(height: _titleRowHeight, child: _header(context)),
           const SizedBox(height: AppSpacing.md),
-          _AddressVerifyGrid(address: address),
+          FullAddressBody(address: address, layout: layout),
           const SizedBox(height: AppSpacing.md),
+          if (layout == FullAddressViewerLayout.actionFooter) ...[
+            FullAddressCopyButton(address: address, expand: true),
+            const SizedBox(height: AppSpacing.xs),
+          ],
           Center(
             child: AppButton(
               key: const ValueKey('verify_address_close_button'),
@@ -194,69 +201,5 @@ class VerifyAddressModal extends StatelessWidget {
           ],
         );
     }
-  }
-}
-
-/// The full-address grid body: centered rows of 5-character groups with
-/// row dividers between address lines. Highlighted groups
-/// render Label M
-/// SemiBold in the brand crimson; normal groups render Label M in the
-/// primary text color, per the Figma address-color pattern.
-class _AddressVerifyGrid extends StatelessWidget {
-  const _AddressVerifyGrid({required this.address});
-
-  final String address;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    final rows = addressVerifyGrid(address);
-    final normalStyle = AppTypography.labelLarge.copyWith(
-      color: colors.text.primary,
-    );
-    final highlightedStyle = AppTypography.labelLarge.copyWith(
-      color: colors.text.brandCrimson,
-      fontWeight: FontWeight.w600,
-    );
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          // Each address line except the last carries a hairline divider
-          // 12px below its digits; lines are separated by a further 8px,
-          // per the Figma "Address Line" column structure.
-          for (var row = 0; row < rows.length; row++) ...[
-            if (row > 0) const SizedBox(height: AppSpacing.xs),
-            // scaleDown keeps wide glyph metrics (and the test environment's
-            // square Ahem font) from overflowing the 256px column; with the
-            // production Geist metrics the row fits and renders 1:1.
-            FittedBox(
-              fit: BoxFit.scaleDown,
-              alignment: Alignment.centerLeft,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  for (var i = 0; i < rows[row].length; i++) ...[
-                    if (i > 0) const SizedBox(width: AppSpacing.s),
-                    Text(
-                      rows[row][i].text,
-                      style: rows[row][i].highlighted
-                          ? highlightedStyle
-                          : normalStyle,
-                    ),
-                  ],
-                ],
-              ),
-            ),
-            if (row < rows.length - 1) ...[
-              const SizedBox(height: AppSpacing.s),
-              const ReviewWrapDivider(),
-            ],
-          ],
-        ],
-      ),
-    );
   }
 }

--- a/lib/src/features/send/widgets/verify_address_modal.dart
+++ b/lib/src/features/send/widgets/verify_address_modal.dart
@@ -24,8 +24,7 @@ enum VerifyAddressModalAddressKind { shielded, transparent, external }
 /// send review screen (and later the received receipt).
 ///
 /// Renders the full address as a continuous Geist Mono string that wraps
-/// naturally, plus a visible copy control. [layout] selects between the
-/// recessed code-block treatment and the primary Copy address footer.
+/// naturally, with Copy address as the primary action.
 ///
 /// Static only — no provider wiring. The caller hosts this card inside an
 /// `AppPaneModalOverlay` and supplies the callbacks.
@@ -38,7 +37,6 @@ class VerifyAddressModal extends StatelessWidget {
     this.contactProfilePictureId,
     this.previousTransactionCount,
     this.unknownAddressKind = VerifyAddressModalAddressKind.shielded,
-    this.layout = FullAddressViewerLayout.codeBlock,
     super.key,
   }) : assert(
          variant == VerifyAddressModalVariant.unknown ||
@@ -48,9 +46,6 @@ class VerifyAddressModal extends StatelessWidget {
 
   /// Full unified address rendered as wrapping monospace text.
   final String address;
-
-  /// Copy-control placement. Defaults to the recessed code-block layout.
-  final FullAddressViewerLayout layout;
 
   final VerifyAddressModalVariant variant;
 
@@ -94,12 +89,10 @@ class VerifyAddressModal extends StatelessWidget {
         children: [
           SizedBox(height: _titleRowHeight, child: _header(context)),
           const SizedBox(height: AppSpacing.md),
-          FullAddressBody(address: address, layout: layout),
+          FullAddressText(address: address),
           const SizedBox(height: AppSpacing.md),
-          if (layout == FullAddressViewerLayout.actionFooter) ...[
-            FullAddressCopyButton(address: address, expand: true),
-            const SizedBox(height: AppSpacing.xs),
-          ],
+          FullAddressCopyButton(address: address, expand: true),
+          const SizedBox(height: AppSpacing.xs),
           Center(
             child: AppButton(
               key: const ValueKey('verify_address_close_button'),

--- a/lib/src/features/send/widgets/verify_address_modal.dart
+++ b/lib/src/features/send/widgets/verify_address_modal.dart
@@ -24,7 +24,7 @@ enum VerifyAddressModalAddressKind { shielded, transparent, external }
 /// send review screen (and later the received receipt).
 ///
 /// Renders the full address as a continuous Geist Mono string that wraps
-/// naturally, with Copy address as the primary action.
+/// naturally, with Copy as the primary action.
 ///
 /// Static only — no provider wiring. The caller hosts this card inside an
 /// `AppPaneModalOverlay` and supplies the callbacks.
@@ -66,14 +66,6 @@ class VerifyAddressModal extends StatelessWidget {
   /// count.
   final int? previousTransactionCount;
 
-  /// Title-row height pinned by the Figma `Title` node. (Its 12px-radius
-  /// hover fill equals the card background in the spec, so no fill is
-  /// painted here.)
-  static const _titleRowHeight = 44.0;
-
-  /// Figma min-width for the ghost Close button.
-  static const _closeMinWidth = 196.0;
-
   bool get _hasPreviousTransactions => (previousTransactionCount ?? 0) > 0;
 
   String get _previousTransactionsLabel => previousTransactionCount == 1
@@ -87,20 +79,35 @@ class VerifyAddressModal extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          SizedBox(height: _titleRowHeight, child: _header(context)),
-          const SizedBox(height: AppSpacing.md),
+          _header(context),
+          const SizedBox(height: AppSpacing.sm),
           FullAddressText(address: address),
           const SizedBox(height: AppSpacing.md),
-          FullAddressCopyButton(address: address, expand: true),
-          const SizedBox(height: AppSpacing.xs),
-          Center(
-            child: AppButton(
-              key: const ValueKey('verify_address_close_button'),
-              onPressed: onClose,
-              variant: AppButtonVariant.ghost,
-              minWidth: _closeMinWidth,
-              child: const Text('Close'),
-            ),
+          Row(
+            children: [
+              Expanded(
+                child: AppButton(
+                  key: const ValueKey('verify_address_close_button'),
+                  onPressed: onClose,
+                  variant: AppButtonVariant.ghost,
+                  size: AppButtonSize.mediumLarge,
+                  expand: true,
+                  constrainContent: true,
+                  child: const FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text('Close', maxLines: 1),
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.s),
+              Expanded(
+                child: FullAddressCopyButton(
+                  address: address,
+                  expand: true,
+                  label: 'Copy',
+                ),
+              ),
+            ],
           ),
         ],
       ),
@@ -109,7 +116,7 @@ class VerifyAddressModal extends StatelessWidget {
 
   Widget _header(BuildContext context) {
     final colors = context.colors;
-    final titleStyle = AppTypography.labelLarge.copyWith(
+    final titleStyle = AppTypography.bodyLarge.copyWith(
       color: colors.text.accent,
       fontWeight: FontWeight.w600,
     );
@@ -137,7 +144,7 @@ class VerifyAddressModal extends StatelessWidget {
             Flexible(
               child: Text(
                 title,
-                maxLines: 1,
+                maxLines: 2,
                 overflow: TextOverflow.ellipsis,
                 style: titleStyle,
               ),
@@ -156,12 +163,13 @@ class VerifyAddressModal extends StatelessWidget {
             const SizedBox(width: AppSpacing.xs),
             Flexible(
               child: Column(
+                mainAxisSize: MainAxisSize.min,
                 mainAxisAlignment: MainAxisAlignment.center,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
                     contactName!,
-                    maxLines: 1,
+                    maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                     style: titleStyle,
                   ),

--- a/lib/widgetbook/address_verify_use_cases.dart
+++ b/lib/widgetbook/address_verify_use_cases.dart
@@ -141,12 +141,12 @@ class _MobileAddressVerifyFrame extends StatelessWidget {
           color: colors.background.neutralScrim,
           child: SafeArea(
             bottom: false,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                const Spacer(),
-                MobileModalCard(child: child),
-              ],
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: SizedBox(
+                width: double.infinity,
+                child: MobileModalCard(child: child),
+              ),
             ),
           ),
         ),

--- a/lib/widgetbook/address_verify_use_cases.dart
+++ b/lib/widgetbook/address_verify_use_cases.dart
@@ -3,13 +3,15 @@
 
 import 'package:flutter/widgets.dart';
 
+import '../src/core/layout/mobile/app_mobile_sheet.dart';
 import '../src/core/theme/app_theme.dart';
 import '../src/core/widgets/app_pane_modal_overlay.dart';
+import '../src/core/widgets/full_address_viewer.dart';
+import '../src/core/widgets/mobile/mobile_address_verify_sheet.dart';
 import '../src/features/send/widgets/verify_address_modal.dart';
 
-/// 200-character Figma-shaped placeholder address: 8 lines × 5 groups, with
-/// the mock's repeated group content so Widgetbook screenshots can compare
-/// against the design without fixture noise.
+/// 200-character placeholder address used by the existing unknown/contact
+/// cases so Widgetbook screenshots stay stable.
 const _sampleFullAddress =
     'u17dc12345123451234512345'
     'u17dc12345123451234512345'
@@ -22,45 +24,99 @@ const _sampleFullAddress =
 
 const _sampleTransparentAddress = 't1PV7nyJ3J6pZBh6sCrd5dSDd6uhXGVSpEX';
 
-/// Verify-address modal, unknown recipient: shield header, full-UA grid,
-/// Close only. (Toggle the Widgetbook theme for the light variant.)
+/// Showcase address that mixes letter `O` and digit `0` so the two
+/// viewer layouts can be compared for glyph ambiguity.
+const kAddressViewerShowcaseAddress =
+    'u10O0qrstuvwxyzO0O0abcdefghijklO0O0mnopqrstuvwxO0O001234567890O0O0'
+    'yzABCDEFGHJKO0O0LMNPQRSTUVWXO0O0';
+
+/// Verify-address modal, unknown recipient: shield header, wrapping
+/// address, copy control. (Toggle the Widgetbook theme for the light variant.)
 Widget buildVerifyAddressUnknownUseCase(BuildContext context) {
-  return _AddressVerifyModalFrame(
+  return const _AddressVerifyModalFrame(
     child: VerifyAddressModal(
       address: _sampleFullAddress,
       variant: VerifyAddressModalVariant.unknown,
-      onClose: () {},
+      onClose: _noop,
     ),
   );
 }
 
-/// Verify-address modal, unknown transparent recipient: transparent-address
-/// header, full-address grid, Close only.
+/// Verify-address modal, unknown transparent recipient.
 Widget buildVerifyAddressUnknownTransparentUseCase(BuildContext context) {
-  return _AddressVerifyModalFrame(
+  return const _AddressVerifyModalFrame(
     child: VerifyAddressModal(
       address: _sampleTransparentAddress,
       variant: VerifyAddressModalVariant.unknown,
       unknownAddressKind: VerifyAddressModalAddressKind.transparent,
-      onClose: () {},
+      onClose: _noop,
     ),
   );
 }
 
-/// Verify-address modal, known contact: avatar + name header with the
-/// previous-transactions sub-line, full-UA grid, Close only.
+/// Verify-address modal, known contact.
 Widget buildVerifyAddressKnownContactUseCase(BuildContext context) {
-  return _AddressVerifyModalFrame(
+  return const _AddressVerifyModalFrame(
     child: VerifyAddressModal(
       address: _sampleFullAddress,
       variant: VerifyAddressModalVariant.knownContact,
       contactName: 'Mike',
       contactProfilePictureId: 'pfp-02',
       previousTransactionCount: 12,
-      onClose: () {},
+      onClose: _noop,
     ),
   );
 }
+
+/// Direction A: recessed code block with an inline Copy chip.
+Widget buildVerifyAddressCodeBlockUseCase(BuildContext context) {
+  return const _AddressVerifyModalFrame(
+    child: VerifyAddressModal(
+      address: kAddressViewerShowcaseAddress,
+      variant: VerifyAddressModalVariant.unknown,
+      layout: FullAddressViewerLayout.codeBlock,
+      onClose: _noop,
+    ),
+  );
+}
+
+/// Direction B: wrapping body with Copy address as the primary action.
+Widget buildVerifyAddressActionFooterUseCase(BuildContext context) {
+  return const _AddressVerifyModalFrame(
+    child: VerifyAddressModal(
+      address: kAddressViewerShowcaseAddress,
+      variant: VerifyAddressModalVariant.unknown,
+      layout: FullAddressViewerLayout.actionFooter,
+      onClose: _noop,
+    ),
+  );
+}
+
+/// Mobile direction A: code-block sheet.
+Widget buildMobileVerifyAddressCodeBlockUseCase(BuildContext context) {
+  return const _MobileAddressVerifyFrame(
+    child: MobileAddressVerifySheet(
+      title: 'Unknown shielded address',
+      address: kAddressViewerShowcaseAddress,
+      layout: FullAddressViewerLayout.codeBlock,
+      onClose: _noop,
+    ),
+  );
+}
+
+/// Mobile direction B: primary Copy address footer.
+Widget buildMobileVerifyAddressActionFooterUseCase(BuildContext context) {
+  return const _MobileAddressVerifyFrame(
+    child: MobileAddressVerifySheet(
+      title: 'Unknown shielded address',
+      address: kAddressViewerShowcaseAddress,
+      layout: FullAddressViewerLayout.actionFooter,
+      onClose: _noop,
+    ),
+  );
+}
+
+void _noop() {}
 
 /// Trailing-pane stand-in on the window background: a pane-radius surface
 /// hosting the real [AppPaneModalOverlay] scrim with the modal centered,
@@ -84,7 +140,41 @@ class _AddressVerifyModalFrame extends StatelessWidget {
             borderRadius: BorderRadius.circular(AppWindowSizing.paneRadius),
           ),
           child: Stack(
-            children: [AppPaneModalOverlay(onDismiss: () {}, child: child)],
+            children: [AppPaneModalOverlay(onDismiss: _noop, child: child)],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MobileAddressVerifyFrame extends StatelessWidget {
+  const _MobileAddressVerifyFrame({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return SizedBox(
+      width: 393,
+      height: 852,
+      child: MediaQuery(
+        data: const MediaQueryData(
+          size: Size(393, 852),
+          viewPadding: EdgeInsets.only(top: 55, bottom: 34),
+        ),
+        child: ColoredBox(
+          color: colors.background.neutralScrim,
+          child: SafeArea(
+            bottom: false,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const Spacer(),
+                MobileModalCard(child: child),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/widgetbook/address_verify_use_cases.dart
+++ b/lib/widgetbook/address_verify_use_cases.dart
@@ -6,7 +6,6 @@ import 'package:flutter/widgets.dart';
 import '../src/core/layout/mobile/app_mobile_sheet.dart';
 import '../src/core/theme/app_theme.dart';
 import '../src/core/widgets/app_pane_modal_overlay.dart';
-import '../src/core/widgets/full_address_viewer.dart';
 import '../src/core/widgets/mobile/mobile_address_verify_sheet.dart';
 import '../src/features/send/widgets/verify_address_modal.dart';
 
@@ -24,8 +23,8 @@ const _sampleFullAddress =
 
 const _sampleTransparentAddress = 't1PV7nyJ3J6pZBh6sCrd5dSDd6uhXGVSpEX';
 
-/// Showcase address that mixes letter `O` and digit `0` so the two
-/// viewer layouts can be compared for glyph ambiguity.
+/// Showcase address that mixes letter `O` and digit `0` so Geist Mono's
+/// glyph distinction is visible in Widgetbook / figma-compare.
 const kAddressViewerShowcaseAddress =
     'u10O0qrstuvwxyzO0O0abcdefghijklO0O0mnopqrstuvwxO0O001234567890O0O0'
     'yzABCDEFGHJKO0O0LMNPQRSTUVWXO0O0';
@@ -68,49 +67,23 @@ Widget buildVerifyAddressKnownContactUseCase(BuildContext context) {
   );
 }
 
-/// Direction A: recessed code block with an inline Copy chip.
-Widget buildVerifyAddressCodeBlockUseCase(BuildContext context) {
-  return const _AddressVerifyModalFrame(
-    child: VerifyAddressModal(
-      address: kAddressViewerShowcaseAddress,
-      variant: VerifyAddressModalVariant.unknown,
-      layout: FullAddressViewerLayout.codeBlock,
-      onClose: _noop,
-    ),
-  );
-}
-
-/// Direction B: wrapping body with Copy address as the primary action.
+/// Desktop viewer with a mixed `O`/`0` address for glyph comparison.
 Widget buildVerifyAddressActionFooterUseCase(BuildContext context) {
   return const _AddressVerifyModalFrame(
     child: VerifyAddressModal(
       address: kAddressViewerShowcaseAddress,
       variant: VerifyAddressModalVariant.unknown,
-      layout: FullAddressViewerLayout.actionFooter,
       onClose: _noop,
     ),
   );
 }
 
-/// Mobile direction A: code-block sheet.
-Widget buildMobileVerifyAddressCodeBlockUseCase(BuildContext context) {
-  return const _MobileAddressVerifyFrame(
-    child: MobileAddressVerifySheet(
-      title: 'Unknown shielded address',
-      address: kAddressViewerShowcaseAddress,
-      layout: FullAddressViewerLayout.codeBlock,
-      onClose: _noop,
-    ),
-  );
-}
-
-/// Mobile direction B: primary Copy address footer.
+/// Mobile viewer with a mixed `O`/`0` address for glyph comparison.
 Widget buildMobileVerifyAddressActionFooterUseCase(BuildContext context) {
   return const _MobileAddressVerifyFrame(
     child: MobileAddressVerifySheet(
       title: 'Unknown shielded address',
       address: kAddressViewerShowcaseAddress,
-      layout: FullAddressViewerLayout.actionFooter,
       onClose: _noop,
     ),
   );

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -1593,19 +1593,11 @@ class WidgetbookApp extends StatelessWidget {
                       builder: buildVerifyAddressKnownContactUseCase,
                     ),
                     WidgetbookUseCase(
-                      name: 'Code block copy',
-                      builder: buildVerifyAddressCodeBlockUseCase,
-                    ),
-                    WidgetbookUseCase(
-                      name: 'Action footer copy',
+                      name: 'O / 0 showcase',
                       builder: buildVerifyAddressActionFooterUseCase,
                     ),
                     WidgetbookUseCase(
-                      name: 'Mobile code block copy',
-                      builder: buildMobileVerifyAddressCodeBlockUseCase,
-                    ),
-                    WidgetbookUseCase(
-                      name: 'Mobile action footer copy',
+                      name: 'Mobile O / 0 showcase',
                       builder: buildMobileVerifyAddressActionFooterUseCase,
                     ),
                   ],

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -1592,6 +1592,22 @@ class WidgetbookApp extends StatelessWidget {
                       name: 'Known contact',
                       builder: buildVerifyAddressKnownContactUseCase,
                     ),
+                    WidgetbookUseCase(
+                      name: 'Code block copy',
+                      builder: buildVerifyAddressCodeBlockUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Action footer copy',
+                      builder: buildVerifyAddressActionFooterUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Mobile code block copy',
+                      builder: buildMobileVerifyAddressCodeBlockUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Mobile action footer copy',
+                      builder: buildMobileVerifyAddressActionFooterUseCase,
+                    ),
                   ],
                 ),
                 WidgetbookComponent(

--- a/test/core/widgets/full_address_viewer_test.dart
+++ b/test/core/widgets/full_address_viewer_test.dart
@@ -15,16 +15,10 @@ void main() {
     expect(fullAddressCopyText(_address).contains('\n'), isFalse);
   });
 
-  testWidgets('code block wraps the exact address in Geist Mono', (
+  testWidgets('address text wraps the exact string in Geist Mono', (
     tester,
   ) async {
-    await _pump(
-      tester,
-      const FullAddressBody(
-        address: _address,
-        layout: FullAddressViewerLayout.codeBlock,
-      ),
-    );
+    await _pump(tester, const FullAddressText(address: _address));
 
     final text = tester.widget<Text>(
       find.byKey(const ValueKey('full_address_text')),
@@ -32,28 +26,6 @@ void main() {
     expect(text.data, _address);
     expect(text.softWrap, isTrue);
     expect(text.style?.fontFamily, 'Geist Mono');
-    expect(
-      find.byKey(const ValueKey('full_address_code_block')),
-      findsOneWidget,
-    );
-    expect(find.text('Copy'), findsOneWidget);
-    expect(find.text('Copy address'), findsNothing);
-  });
-
-  testWidgets('action footer is wrapping text without the recessed block', (
-    tester,
-  ) async {
-    await _pump(
-      tester,
-      const FullAddressBody(
-        address: _address,
-        layout: FullAddressViewerLayout.actionFooter,
-      ),
-    );
-
-    expect(find.byKey(const ValueKey('full_address_code_block')), findsNothing);
-    expect(find.text(_address), findsOneWidget);
-    expect(find.text('Copy'), findsNothing);
   });
 
   testWidgets('copy button writes the exact address without spaces', (

--- a/test/core/widgets/full_address_viewer_test.dart
+++ b/test/core/widgets/full_address_viewer_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart' show MaterialApp, Overlay;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/full_address_viewer.dart';
+
+const _address =
+    'u10O0qrstuvwxyzO0O0abcdefghijklO0O0mnopqrstuvwxO0O001234567890O0O0';
+
+void main() {
+  test('fullAddressCopyText trims without inserting spaces', () {
+    expect(fullAddressCopyText('  $_address\n'), _address);
+    expect(fullAddressCopyText(_address).contains(' '), isFalse);
+    expect(fullAddressCopyText(_address).contains('\n'), isFalse);
+  });
+
+  testWidgets('code block wraps the exact address in Geist Mono', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      const FullAddressBody(
+        address: _address,
+        layout: FullAddressViewerLayout.codeBlock,
+      ),
+    );
+
+    final text = tester.widget<Text>(
+      find.byKey(const ValueKey('full_address_text')),
+    );
+    expect(text.data, _address);
+    expect(text.softWrap, isTrue);
+    expect(text.style?.fontFamily, 'Geist Mono');
+    expect(
+      find.byKey(const ValueKey('full_address_code_block')),
+      findsOneWidget,
+    );
+    expect(find.text('Copy'), findsOneWidget);
+    expect(find.text('Copy address'), findsNothing);
+  });
+
+  testWidgets('action footer is wrapping text without the recessed block', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      const FullAddressBody(
+        address: _address,
+        layout: FullAddressViewerLayout.actionFooter,
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('full_address_code_block')), findsNothing);
+    expect(find.text(_address), findsOneWidget);
+    expect(find.text('Copy'), findsNothing);
+  });
+
+  testWidgets('copy button writes the exact address without spaces', (
+    tester,
+  ) async {
+    final copied = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied.add(
+            (call.arguments as Map<Object?, Object?>)['text']! as String,
+          );
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+
+    await _pump(tester, const FullAddressCopyButton(address: '  $_address  '));
+
+    await tester.tap(find.byKey(const ValueKey('full_address_copy_button')));
+    await tester.pump();
+
+    expect(copied, [_address]);
+  });
+}
+
+Future<void> _pump(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: Overlay(
+          initialEntries: [
+            OverlayEntry(
+              builder: (context) =>
+                  Center(child: SizedBox(width: 312, child: child)),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}

--- a/test/core/widgets/mobile/mobile_address_verify_sheet_test.dart
+++ b/test/core/widgets/mobile/mobile_address_verify_sheet_test.dart
@@ -1,0 +1,102 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/mobile/mobile_address_verify_sheet.dart';
+
+import '../../../figma_compare/figma_compare_font_loader.dart';
+
+void main() {
+  for (final dark in [false, true]) {
+    for (final compact in [false, true]) {
+      testWidgets(
+        'address sheet keeps actions reachable: dark=$dark compact=$compact',
+        (tester) async {
+          tester.view.devicePixelRatio = 1;
+          tester.view.physicalSize = compact
+              ? const Size(320, 568)
+              : const Size(393, 852);
+          addTearDown(tester.view.resetDevicePixelRatio);
+          addTearDown(tester.view.resetPhysicalSize);
+          await loadFigmaCompareFonts();
+          final address = compact
+              ? 'u1${List.filled(211, 'q').join()}'
+              : 't1PV7nyJ3J6pZBh6sCrd5dSDd6uhXGVSpEX';
+          final copied = <String>[];
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            SystemChannels.platform,
+            (call) async {
+              if (call.method == 'Clipboard.setData') {
+                copied.add((call.arguments as Map)['text'] as String);
+              }
+              return null;
+            },
+          );
+          addTearDown(
+            () => tester.binding.defaultBinaryMessenger
+                .setMockMethodCallHandler(SystemChannels.platform, null),
+          );
+          await tester.pumpWidget(
+            MaterialApp(
+              builder: (context, child) => AppTheme(
+                data: dark ? AppThemeData.dark : AppThemeData.light,
+                child: MediaQuery(
+                  data: MediaQuery.of(
+                    context,
+                  ).copyWith(textScaler: TextScaler.linear(compact ? 2 : 1)),
+                  child: child!,
+                ),
+              ),
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => TextButton(
+                    onPressed: () => showMobileAddressVerifySheet(
+                      context,
+                      title: 'A long saved contact name for the address',
+                      address: '  $address\n',
+                    ),
+                    child: const Text('Open'),
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.tap(find.text('Open'));
+          await tester.pumpAndSettle();
+          expect(tester.takeException(), isNull);
+          expect(find.text(address), findsOneWidget);
+          final copy = find.byKey(const ValueKey('full_address_copy_button'));
+          expect(copy.hitTestable(), findsOneWidget);
+          expect(find.text('Cancel').hitTestable(), findsOneWidget);
+          if (compact) {
+            final scrollable = find.descendant(
+              of: find.byType(MobileAddressVerifySheet),
+              matching: find.byType(Scrollable),
+            );
+            final state = tester.state<ScrollableState>(scrollable);
+            expect(state.position.maxScrollExtent, greaterThan(0));
+            await tester.drag(scrollable, const Offset(0, -200));
+            await tester.pumpAndSettle();
+            expect(state.position.pixels, greaterThan(0));
+          }
+          await tester.tap(copy);
+          await tester.pump();
+          expect(copied, [address]);
+          expect(find.byType(MobileAddressVerifySheet), findsOneWidget);
+          await tester.tap(find.text('Cancel'));
+          await tester.pumpAndSettle();
+          expect(find.byType(MobileAddressVerifySheet), findsNothing);
+          await tester.tap(find.text('Open'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.bySemanticsLabel('Close'));
+          await tester.pumpAndSettle();
+          expect(find.byType(MobileAddressVerifySheet), findsNothing);
+          expect(tester.takeException(), isNull);
+        },
+      );
+    }
+  }
+}

--- a/test/core/widgets/mobile/mobile_address_verify_sheet_test.dart
+++ b/test/core/widgets/mobile/mobile_address_verify_sheet_test.dart
@@ -70,7 +70,8 @@ void main() {
           expect(find.text(address), findsOneWidget);
           final copy = find.byKey(const ValueKey('full_address_copy_button'));
           expect(copy.hitTestable(), findsOneWidget);
-          expect(find.text('Cancel').hitTestable(), findsOneWidget);
+          expect(find.text('Cancel'), findsNothing);
+          expect(find.bySemanticsLabel('Close').hitTestable(), findsOneWidget);
           if (compact) {
             final scrollable = find.descendant(
               of: find.byType(MobileAddressVerifySheet),
@@ -86,11 +87,6 @@ void main() {
           await tester.pump();
           expect(copied, [address]);
           expect(find.byType(MobileAddressVerifySheet), findsOneWidget);
-          await tester.tap(find.text('Cancel'));
-          await tester.pumpAndSettle();
-          expect(find.byType(MobileAddressVerifySheet), findsNothing);
-          await tester.tap(find.text('Open'));
-          await tester.pumpAndSettle();
           await tester.tap(find.bySemanticsLabel('Close'));
           await tester.pumpAndSettle();
           expect(find.byType(MobileAddressVerifySheet), findsNothing);

--- a/test/features/activity/mobile_transaction_status_screen_test.dart
+++ b/test/features/activity/mobile_transaction_status_screen_test.dart
@@ -664,8 +664,8 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Unified address'), findsOneWidget);
-    expect(find.text('u1l8x'), findsOneWidget);
-    expect(find.text(_address), findsNothing);
+    expect(find.text(_address), findsOneWidget);
+    expect(find.text('Copy'), findsOneWidget);
   });
 
   testWidgets('show full address action label fits on mobile width', (

--- a/test/features/activity/mobile_transaction_status_screen_test.dart
+++ b/test/features/activity/mobile_transaction_status_screen_test.dart
@@ -665,7 +665,7 @@ void main() {
     );
     expect(find.text('Unified address'), findsOneWidget);
     expect(find.text(_address), findsOneWidget);
-    expect(find.text('Copy'), findsOneWidget);
+    expect(find.text('Copy address'), findsOneWidget);
   });
 
   testWidgets('show full address action label fits on mobile width', (

--- a/test/features/pay/mobile_pay_review_content_test.dart
+++ b/test/features/pay/mobile_pay_review_content_test.dart
@@ -125,7 +125,7 @@ void main() {
     );
     expect(find.text('Ethereum address'), findsOneWidget);
     expect(find.text(_recipientAddress), findsOneWidget);
-    expect(find.text('Copy'), findsOneWidget);
+    expect(find.text('Copy address'), findsOneWidget);
     expect(find.text('Hide address'), findsNothing);
 
     await tester.tapAt(const Offset(8, 8));

--- a/test/features/pay/mobile_pay_review_content_test.dart
+++ b/test/features/pay/mobile_pay_review_content_test.dart
@@ -124,7 +124,8 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Ethereum address'), findsOneWidget);
-    expect(find.text('0x529'), findsOneWidget);
+    expect(find.text(_recipientAddress), findsOneWidget);
+    expect(find.text('Copy'), findsOneWidget);
     expect(find.text('Hide address'), findsNothing);
 
     await tester.tapAt(const Offset(8, 8));

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -3353,8 +3353,7 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Copy address'), findsOneWidget);
-    expect(find.text('Cancel'), findsWidgets);
-    await tester.tap(find.text('Cancel').last);
+    await tester.tap(find.bySemanticsLabel('Close').last);
     await tester.pumpAndSettle();
 
     // Memo round-trip through the sheet.

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -3352,7 +3352,7 @@ void main() {
       ),
       findsOneWidget,
     );
-    expect(find.text('Copy'), findsOneWidget);
+    expect(find.text('Copy address'), findsOneWidget);
     expect(find.text('Cancel'), findsWidgets);
     await tester.tap(find.text('Cancel').last);
     await tester.pumpAndSettle();

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -3346,7 +3346,13 @@ void main() {
       find.byKey(const ValueKey('mobile_address_verify_chunks')),
       findsOneWidget,
     );
-    expect(find.text('u1tes'), findsOneWidget);
+    expect(
+      find.text(
+        'u1testshieldedaddress00000000000000000000000000000000000000000000000',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Copy'), findsOneWidget);
     expect(find.text('Cancel'), findsWidgets);
     await tester.tap(find.text('Cancel').last);
     await tester.pumpAndSettle();

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -416,7 +416,7 @@ void main() {
     },
   );
 
-  testWidgets('verify modal shows the full address grid for unknown address', (
+  testWidgets('verify modal shows the wrapping address for unknown address', (
     tester,
   ) async {
     await _setDesktopViewport(tester);

--- a/test/features/send/verify_address_modal_test.dart
+++ b/test/features/send/verify_address_modal_test.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:zcash_wallet/src/core/formatting/address_display.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_profile_picture.dart';
+import 'package:zcash_wallet/src/core/widgets/full_address_viewer.dart';
 import 'package:zcash_wallet/src/core/widgets/review_info_row.dart';
 import 'package:zcash_wallet/src/features/accounts/widgets/account_modal_card.dart';
 import 'package:zcash_wallet/src/features/send/widgets/verify_address_modal.dart';
@@ -15,7 +16,7 @@ const _address =
 
 void main() {
   group('VerifyAddressModal unknown variant', () {
-    testWidgets('renders header copy, grid, and the Close action', (
+    testWidgets('renders header copy, wrapping address, and the Close action', (
       tester,
     ) async {
       var closed = 0;
@@ -30,10 +31,16 @@ void main() {
 
       expect(find.text('Unknown shielded address'), findsOneWidget);
       expect(find.byType(ReviewInfoIconCircle), findsOneWidget);
+      expect(find.text(_address), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('full_address_code_block')),
+        findsOneWidget,
+      );
+      expect(find.text('Copy'), findsOneWidget);
 
-      // The add-to-contacts flow is deferred: Close is the only action.
+      // The add-to-contacts flow is deferred: Close plus the inline copy.
       expect(find.text('Add to contacts'), findsNothing);
-      expect(find.byType(AppButton), findsOneWidget);
+      expect(find.byType(AppButton), findsNWidgets(2));
 
       await tester.tap(find.text('Close'));
       await tester.pump();
@@ -73,9 +80,28 @@ void main() {
       expect(find.text('Unknown shielded address'), findsNothing);
     });
 
-    testWidgets('highlights the fixed head/tail groups in crimson', (
+    testWidgets('copies the exact address from the inline Copy chip', (
       tester,
     ) async {
+      final copied = <String>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied.add(
+              (call.arguments as Map<Object?, Object?>)['text']! as String,
+            );
+          }
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+
       await _pump(
         tester,
         VerifyAddressModal(
@@ -85,28 +111,35 @@ void main() {
         ),
       );
 
-      final colors = AppThemeData.light.colors;
-      final rows = addressVerifyGrid(_address);
+      await tester.tap(find.byKey(const ValueKey('full_address_copy_button')));
+      await tester.pump();
+      expect(copied, [_address]);
+    });
 
-      final firstGroup = rows.first.first;
-      expect(firstGroup.highlighted, isTrue);
-      final firstText = tester.widget<Text>(find.text(firstGroup.text).first);
-      expect(firstText.style?.color, colors.text.brandCrimson);
-      expect(firstText.style?.fontWeight, FontWeight.w600);
+    testWidgets('action footer uses Copy address as the primary action', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        VerifyAddressModal(
+          address: _address,
+          variant: VerifyAddressModalVariant.unknown,
+          layout: FullAddressViewerLayout.actionFooter,
+          onClose: () {},
+        ),
+      );
 
-      final lastGroup = rows.last.last;
-      expect(lastGroup.highlighted, isTrue);
-      final lastText = tester.widget<Text>(find.text(lastGroup.text).last);
-      expect(lastText.style?.color, colors.text.brandCrimson);
-      expect(lastText.style?.fontWeight, FontWeight.w600);
-
-      // Second group of the first row sits outside the mock's
-      // non-consecutive emphasis pattern (0, 2, N-3, N-1).
-      final middleGroup = rows.first[1];
-      expect(middleGroup.highlighted, isFalse);
-      final middleText = tester.widget<Text>(find.text(middleGroup.text).first);
-      expect(middleText.style?.color, colors.text.primary);
-      expect(middleText.style?.fontWeight, FontWeight.w500);
+      expect(
+        find.byKey(const ValueKey('full_address_code_block')),
+        findsNothing,
+      );
+      expect(find.text('Copy address'), findsOneWidget);
+      expect(find.text('Close'), findsOneWidget);
+      expect(find.text(_address), findsOneWidget);
+      final addressText = tester.widget<Text>(
+        find.byKey(const ValueKey('full_address_text')),
+      );
+      expect(addressText.style?.fontFamily, 'Geist Mono');
     });
   });
 
@@ -130,7 +163,8 @@ void main() {
       expect(find.text('12 previous transactions'), findsOneWidget);
       expect(find.text('Unknown shielded address'), findsNothing);
       expect(find.text('Add to contacts'), findsNothing);
-      expect(find.byType(AppButton), findsOneWidget);
+      expect(find.text('Copy'), findsOneWidget);
+      expect(find.text('Close'), findsOneWidget);
 
       await tester.tap(find.text('Close'));
       await tester.pump();

--- a/test/features/send/verify_address_modal_test.dart
+++ b/test/features/send/verify_address_modal_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart' show MaterialApp;
 import 'package:flutter/services.dart';
+import 'package:flutter/rendering.dart' show RenderParagraph;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
@@ -8,6 +9,8 @@ import 'package:zcash_wallet/src/core/widgets/app_profile_picture.dart';
 import 'package:zcash_wallet/src/core/widgets/review_info_row.dart';
 import 'package:zcash_wallet/src/features/accounts/widgets/account_modal_card.dart';
 import 'package:zcash_wallet/src/features/send/widgets/verify_address_modal.dart';
+
+import '../../figma_compare/figma_compare_font_loader.dart';
 
 const _address =
     'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
@@ -31,9 +34,9 @@ void main() {
       expect(find.text('Unknown shielded address'), findsOneWidget);
       expect(find.byType(ReviewInfoIconCircle), findsOneWidget);
       expect(find.text(_address), findsOneWidget);
-      expect(find.text('Copy address'), findsOneWidget);
+      expect(find.text('Copy'), findsOneWidget);
 
-      // The add-to-contacts flow is deferred: Copy address plus Close.
+      // The add-to-contacts flow is deferred: Copy plus Close.
       expect(find.text('Add to contacts'), findsNothing);
       expect(find.byType(AppButton), findsNWidgets(2));
 
@@ -75,7 +78,7 @@ void main() {
       expect(find.text('Unknown shielded address'), findsNothing);
     });
 
-    testWidgets('copies the exact address from Copy address', (tester) async {
+    testWidgets('copies the exact address from Copy', (tester) async {
       final copied = <String>[];
       tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
         SystemChannels.platform,
@@ -109,7 +112,7 @@ void main() {
       expect(copied, [_address]);
     });
 
-    testWidgets('uses Copy address as the primary action', (tester) async {
+    testWidgets('uses Copy as the primary action', (tester) async {
       await _pump(
         tester,
         VerifyAddressModal(
@@ -119,7 +122,7 @@ void main() {
         ),
       );
 
-      expect(find.text('Copy address'), findsOneWidget);
+      expect(find.text('Copy'), findsOneWidget);
       expect(find.text('Close'), findsOneWidget);
       expect(find.text(_address), findsOneWidget);
       final addressText = tester.widget<Text>(
@@ -129,8 +132,47 @@ void main() {
     });
   });
 
+  testWidgets(
+    'wrapped contact header clears the address and horizontal actions',
+    (tester) async {
+      await loadFigmaCompareFonts();
+      const name = 'Treasury operating account';
+      await _pump(
+        tester,
+        VerifyAddressModal(
+          address: _address,
+          variant: VerifyAddressModalVariant.knownContact,
+          contactName: name,
+          contactProfilePictureId: 'pfp-02',
+          previousTransactionCount: 12,
+          onClose: () {},
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      final titleParagraph = tester.renderObject<RenderParagraph>(
+        find.descendant(of: find.text(name), matching: find.byType(RichText)),
+      );
+      expect(titleParagraph.didExceedMaxLines, isFalse);
+      final title = tester.getRect(find.text(name));
+      final subtitle = tester.getRect(find.text('12 previous transactions'));
+      final address = tester.getRect(find.text(_address));
+      expect(title.bottom, lessThanOrEqualTo(subtitle.top));
+      expect(subtitle.bottom, lessThan(address.top));
+      final close = tester.getRect(
+        find.byKey(const ValueKey('verify_address_close_button')),
+      );
+      final copy = tester.getRect(
+        find.byKey(const ValueKey('full_address_copy_button')),
+      );
+      expect(close.top, moreOrLessEquals(copy.top));
+      expect(close.height, moreOrLessEquals(copy.height));
+      expect(close.right, lessThan(copy.left));
+      expect(find.text('Copy').hitTestable(), findsOneWidget);
+    },
+  );
+
   group('VerifyAddressModal knownContact variant', () {
-    testWidgets('shows the contact identity and Close only', (tester) async {
+    testWidgets('shows the contact identity and actions', (tester) async {
       var closed = 0;
       await _pump(
         tester,
@@ -149,7 +191,7 @@ void main() {
       expect(find.text('12 previous transactions'), findsOneWidget);
       expect(find.text('Unknown shielded address'), findsNothing);
       expect(find.text('Add to contacts'), findsNothing);
-      expect(find.text('Copy address'), findsOneWidget);
+      expect(find.text('Copy'), findsOneWidget);
       expect(find.text('Close'), findsOneWidget);
 
       await tester.tap(find.text('Close'));

--- a/test/features/send/verify_address_modal_test.dart
+++ b/test/features/send/verify_address_modal_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_profile_picture.dart';
-import 'package:zcash_wallet/src/core/widgets/full_address_viewer.dart';
 import 'package:zcash_wallet/src/core/widgets/review_info_row.dart';
 import 'package:zcash_wallet/src/features/accounts/widgets/account_modal_card.dart';
 import 'package:zcash_wallet/src/features/send/widgets/verify_address_modal.dart';
@@ -32,13 +31,9 @@ void main() {
       expect(find.text('Unknown shielded address'), findsOneWidget);
       expect(find.byType(ReviewInfoIconCircle), findsOneWidget);
       expect(find.text(_address), findsOneWidget);
-      expect(
-        find.byKey(const ValueKey('full_address_code_block')),
-        findsOneWidget,
-      );
-      expect(find.text('Copy'), findsOneWidget);
+      expect(find.text('Copy address'), findsOneWidget);
 
-      // The add-to-contacts flow is deferred: Close plus the inline copy.
+      // The add-to-contacts flow is deferred: Copy address plus Close.
       expect(find.text('Add to contacts'), findsNothing);
       expect(find.byType(AppButton), findsNWidgets(2));
 
@@ -80,9 +75,7 @@ void main() {
       expect(find.text('Unknown shielded address'), findsNothing);
     });
 
-    testWidgets('copies the exact address from the inline Copy chip', (
-      tester,
-    ) async {
+    testWidgets('copies the exact address from Copy address', (tester) async {
       final copied = <String>[];
       tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
         SystemChannels.platform,
@@ -116,23 +109,16 @@ void main() {
       expect(copied, [_address]);
     });
 
-    testWidgets('action footer uses Copy address as the primary action', (
-      tester,
-    ) async {
+    testWidgets('uses Copy address as the primary action', (tester) async {
       await _pump(
         tester,
         VerifyAddressModal(
           address: _address,
           variant: VerifyAddressModalVariant.unknown,
-          layout: FullAddressViewerLayout.actionFooter,
           onClose: () {},
         ),
       );
 
-      expect(
-        find.byKey(const ValueKey('full_address_code_block')),
-        findsNothing,
-      );
       expect(find.text('Copy address'), findsOneWidget);
       expect(find.text('Close'), findsOneWidget);
       expect(find.text(_address), findsOneWidget);
@@ -163,7 +149,7 @@ void main() {
       expect(find.text('12 previous transactions'), findsOneWidget);
       expect(find.text('Unknown shielded address'), findsNothing);
       expect(find.text('Add to contacts'), findsNothing);
-      expect(find.text('Copy'), findsOneWidget);
+      expect(find.text('Copy address'), findsOneWidget);
       expect(find.text('Close'), findsOneWidget);
 
       await tester.tap(find.text('Close'));

--- a/test/features/swap/mobile_swap_review_content_test.dart
+++ b/test/features/swap/mobile_swap_review_content_test.dart
@@ -211,7 +211,7 @@ void main() {
     expect(find.text('Full address'), findsNothing);
   });
 
-  testWidgets('full address sheet uses shared modal chunk layout', (
+  testWidgets('full address sheet uses wrapping monospace and a copy control', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(393, 852));
@@ -250,61 +250,20 @@ void main() {
     expect(title.style?.fontSize, AppTypography.labelLarge.fontSize);
     expect(title.style?.fontWeight, FontWeight.w600);
 
-    final chunkScope = find.byKey(
+    final addressScope = find.byKey(
       const ValueKey('mobile_address_verify_chunks'),
     );
-    expect(chunkScope, findsOneWidget);
-    final chunkScopeRect = tester.getRect(chunkScope);
-    expect(chunkScopeRect.width, moreOrLessEquals(329));
+    expect(addressScope, findsOneWidget);
     expect(
-      find.descendant(of: chunkScope, matching: find.text('11111')),
+      find.descendant(of: addressScope, matching: find.text(address)),
       findsOneWidget,
     );
-    expect(
-      find.descendant(of: chunkScope, matching: find.text('22222')),
-      findsOneWidget,
+    final addressText = tester.widget<Text>(
+      find.byKey(const ValueKey('full_address_text')),
     );
-    expect(
-      find.descendant(of: chunkScope, matching: find.text('CCCCC')),
-      findsOneWidget,
-    );
-    final firstChunk = tester.widget<Text>(find.text('11111'));
-    expect(firstChunk.style?.fontSize, 14);
-    expect(firstChunk.style?.height, 16 / 14);
-    final firstLineScope = find.byKey(
-      const ValueKey('mobile_address_verify_line_0'),
-    );
-    final lastLineScope = find.byKey(
-      const ValueKey('mobile_address_verify_line_2'),
-    );
-    final firstLine = tester.widget<Row>(
-      find.descendant(of: firstLineScope, matching: find.byType(Row)),
-    );
-    final lastLine = tester.widget<Row>(
-      find.descendant(of: lastLineScope, matching: find.byType(Row)),
-    );
-    expect(firstLine.mainAxisAlignment, MainAxisAlignment.start);
-    expect(lastLine.mainAxisAlignment, MainAxisAlignment.start);
-    final firstDivider = find.byKey(
-      const ValueKey('mobile_address_verify_divider_0'),
-    );
-    expect(tester.getSize(firstDivider).width, moreOrLessEquals(305));
-    expect(
-      tester.getRect(find.text('11111')).left,
-      moreOrLessEquals(chunkScopeRect.left + 22, epsilon: 1),
-    );
-    final thirdChunk = tester.widget<Text>(find.text('33333'));
-    expect(
-      thirdChunk.style?.color,
-      AppThemeData.light.colors.text.brandCrimson,
-    );
-    final secondChunk = tester.widget<Text>(find.text('22222'));
-    expect(secondChunk.style?.color, AppThemeData.light.colors.text.primary);
-    expect(
-      tester.getRect(find.text('BBBBB')).left,
-      moreOrLessEquals(tester.getRect(find.text('66666')).left, epsilon: 1),
-    );
-    expect(find.text('DDDDD'), findsNothing);
+    expect(addressText.softWrap, isTrue);
+    expect(addressText.style?.fontFamily, 'Geist Mono');
+    expect(find.text('Copy'), findsOneWidget);
     expect(find.text('Cancel'), findsOneWidget);
   });
 }

--- a/test/features/swap/mobile_swap_review_content_test.dart
+++ b/test/features/swap/mobile_swap_review_content_test.dart
@@ -247,7 +247,7 @@ void main() {
 
     expect(find.text('Solana address'), findsOneWidget);
     final title = tester.widget<Text>(find.text('Solana address'));
-    expect(title.style?.fontSize, AppTypography.labelLarge.fontSize);
+    expect(title.style?.fontSize, AppTypography.bodyLarge.fontSize);
     expect(title.style?.fontWeight, FontWeight.w600);
 
     final addressScope = find.byKey(
@@ -264,7 +264,8 @@ void main() {
     expect(addressText.softWrap, isTrue);
     expect(addressText.style?.fontFamily, 'Geist Mono');
     expect(find.text('Copy address'), findsOneWidget);
-    expect(find.text('Cancel'), findsOneWidget);
+    expect(find.text('Cancel'), findsNothing);
+    expect(find.bySemanticsLabel('Close'), findsOneWidget);
   });
 }
 

--- a/test/features/swap/mobile_swap_review_content_test.dart
+++ b/test/features/swap/mobile_swap_review_content_test.dart
@@ -263,7 +263,7 @@ void main() {
     );
     expect(addressText.softWrap, isTrue);
     expect(addressText.style?.fontFamily, 'Geist Mono');
-    expect(find.text('Copy'), findsOneWidget);
+    expect(find.text('Copy address'), findsOneWidget);
     expect(find.text('Cancel'), findsOneWidget);
   });
 }

--- a/test/widgetbook/address_verify_use_cases_test.dart
+++ b/test/widgetbook/address_verify_use_cases_test.dart
@@ -38,6 +38,34 @@ void main() {
     expect(find.text('Unknown shielded address'), findsNothing);
     expect(find.text('Close'), findsOneWidget);
   });
+
+  testWidgets('code-block variation shows inline Copy on a recessed block', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildVerifyAddressCodeBlockUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(kAddressViewerShowcaseAddress), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('full_address_code_block')),
+      findsOneWidget,
+    );
+    expect(find.text('Copy'), findsOneWidget);
+    expect(find.text('Copy address'), findsNothing);
+    expect(find.text('Close'), findsOneWidget);
+  });
+
+  testWidgets('action-footer variation shows Copy address as the primary CTA', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildVerifyAddressActionFooterUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(kAddressViewerShowcaseAddress), findsOneWidget);
+    expect(find.byKey(const ValueKey('full_address_code_block')), findsNothing);
+    expect(find.text('Copy address'), findsOneWidget);
+    expect(find.text('Close'), findsOneWidget);
+  });
 }
 
 Future<void> _pumpUseCase(WidgetTester tester, WidgetBuilder builder) async {

--- a/test/widgetbook/address_verify_use_cases_test.dart
+++ b/test/widgetbook/address_verify_use_cases_test.dart
@@ -39,14 +39,12 @@ void main() {
     expect(find.text('Close'), findsOneWidget);
   });
 
-  testWidgets('O / 0 showcase shows Copy address as the primary CTA', (
-    tester,
-  ) async {
+  testWidgets('O / 0 showcase shows Copy as the primary CTA', (tester) async {
     await _pumpUseCase(tester, buildVerifyAddressActionFooterUseCase);
 
     expect(tester.takeException(), isNull);
     expect(find.text(kAddressViewerShowcaseAddress), findsOneWidget);
-    expect(find.text('Copy address'), findsOneWidget);
+    expect(find.text('Copy'), findsOneWidget);
     expect(find.text('Close'), findsOneWidget);
   });
 }

--- a/test/widgetbook/address_verify_use_cases_test.dart
+++ b/test/widgetbook/address_verify_use_cases_test.dart
@@ -39,30 +39,13 @@ void main() {
     expect(find.text('Close'), findsOneWidget);
   });
 
-  testWidgets('code-block variation shows inline Copy on a recessed block', (
-    tester,
-  ) async {
-    await _pumpUseCase(tester, buildVerifyAddressCodeBlockUseCase);
-
-    expect(tester.takeException(), isNull);
-    expect(find.text(kAddressViewerShowcaseAddress), findsOneWidget);
-    expect(
-      find.byKey(const ValueKey('full_address_code_block')),
-      findsOneWidget,
-    );
-    expect(find.text('Copy'), findsOneWidget);
-    expect(find.text('Copy address'), findsNothing);
-    expect(find.text('Close'), findsOneWidget);
-  });
-
-  testWidgets('action-footer variation shows Copy address as the primary CTA', (
+  testWidgets('O / 0 showcase shows Copy address as the primary CTA', (
     tester,
   ) async {
     await _pumpUseCase(tester, buildVerifyAddressActionFooterUseCase);
 
     expect(tester.takeException(), isNull);
     expect(find.text(kAddressViewerShowcaseAddress), findsOneWidget);
-    expect(find.byKey(const ValueKey('full_address_code_block')), findsNothing);
     expect(find.text('Copy address'), findsOneWidget);
     expect(find.text('Close'), findsOneWidget);
   });

--- a/test/widgetbook/payment_request_use_cases_test.dart
+++ b/test/widgetbook/payment_request_use_cases_test.dart
@@ -338,9 +338,13 @@ void main() {
       find.byKey(const ValueKey('payment_request_address_chunks')),
       findsOneWidget,
     );
-    // 5-character groups, taken from the verify-address grid.
-    expect(find.text('u1950'), findsOneWidget);
-    expect(find.text('591'), findsOneWidget);
+    expect(
+      find.text(
+        'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+        '73d57f73c6dc05121591a83861cd190591',
+      ),
+      findsOneWidget,
+    );
     // Nothing left the card: the actions are still on screen.
     expect(find.text('Review'), findsOneWidget);
 
@@ -360,7 +364,13 @@ void main() {
       await _pumpUseCase(tester, builder, size: size);
       expect(tester.takeException(), isNull);
       expect(find.text('Hide full address'), findsOneWidget);
-      expect(find.text('u1950'), findsOneWidget);
+      expect(
+        find.text(
+          'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+          '73d57f73c6dc05121591a83861cd190591',
+        ),
+        findsOneWidget,
+      );
     }
   });
 
@@ -1042,7 +1052,13 @@ void main() {
 
       expect(tester.takeException(), isNull);
       expect(_key('payment_request_address_chunks'), findsOneWidget);
-      expect(find.text('u1950'), findsOneWidget);
+      expect(
+        find.text(
+          'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+          '73d57f73c6dc05121591a83861cd190591',
+        ),
+        findsOneWidget,
+      );
       // The name and its sub-label stay; the truncated sub-line does not
       // repeat the address the grid is already showing.
       expect(_key('payment_request_recipient_name'), findsOneWidget);
@@ -1068,7 +1084,13 @@ void main() {
       await _pumpUseCase(tester, builder, size: size);
       expect(tester.takeException(), isNull);
       expect(find.text('Hide full address'), findsOneWidget);
-      expect(find.text('u1950'), findsOneWidget);
+      expect(
+        find.text(
+          'u1950915183f0fed838d6d2dd92d6f4111ed3c6dd4e3eb19a3702b'
+          '73d57f73c6dc05121591a83861cd190591',
+        ),
+        findsOneWidget,
+      );
       expect(find.text('Your account'), findsOneWidget);
     }
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves [VZR-152](https://linear.app/vizor/issue/VZR-152). Ships **Variation B**: a continuous wrapping Geist Mono address with **Copy address** as the primary action.

The 4–5-character grid is gone. Copy writes the exact trimmed address — no inserted spaces or line breaks. Address-book matches still change only the header (contact/account name), not the address string. Address reuse is out of scope.

[Desktop dark: wrapping address with Copy address CTA](https://cursor.com/agents/bc-fbd2c098-fbb5-485c-9fae-ea953375c73d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvariation_b_action_footer_desktop_dark.png)
[Mobile dark: wrapping address with Copy address CTA](https://cursor.com/agents/bc-fbd2c098-fbb5-485c-9fae-ea953375c73d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvariation_b_action_footer_mobile_dark.png)
[Desktop light: wrapping address with Copy address CTA](https://cursor.com/agents/bc-fbd2c098-fbb5-485c-9fae-ea953375c73d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvariation_b_action_footer_desktop_light.png)

## What changed

- Desktop verify modal and mobile verify sheet: wrapping `FullAddressText` + primary `Copy address` + Close/Cancel.
- Payment-request in-card expansion uses the same wrapping Geist Mono.
- The unused recessed code-block layout was removed after the design choice.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [VZR-152](https://linear.app/keplrwallet/issue/VZR-152/simplify-the-full-address-viewer-and-add-copying)

<div><a href="https://cursor.com/agents/bc-fbd2c098-fbb5-485c-9fae-ea953375c73d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbd2c098-fbb5-485c-9fae-ea953375c73d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

