### PR TITLE
[desktop][mobile] Fix stale balances after signing cancellation and align return flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -645,6 +645,15 @@ while an executed denomination preparation waits for confirmations.
 - Post-send: `refreshAfterSend()` for immediate pending TX display
 - Friendly error messages via `_friendlyError()` pattern matching
 
+### Signing Cancellation
+
+Keep desktop and mobile consistent when cancelling signing, not merely closing the QR scanner:
+
+- Send / Gift Card: preserve inputs, return to Review, and refresh balance and fees before retry.
+- Swap / Pay: return to the composer without preserving inputs; obtain a new quote on the next Review.
+- Vote: preserve saved partial signatures and resume unsigned bundles.
+- For transaction proposals, finish input-lock release and balance refresh before allowing retry.
+
 ### Hardware Wallet (Keystone) Send Flow
 
 Normal hardware sends use Keystone's signatures-only batch protocol, even for

--- a/integration_test/payment_uri_prefill_test.dart
+++ b/integration_test/payment_uri_prefill_test.dart
@@ -211,6 +211,7 @@ PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async => true,
 );
 

--- a/lib/src/features/donation/screens/donation_screen.dart
+++ b/lib/src/features/donation/screens/donation_screen.dart
@@ -238,6 +238,7 @@ class _DonationScreenState extends ConsumerState<DonationScreen> {
       _globalError = null;
     });
     final flowId = newSendFlowId();
+    final syncNotifier = ref.read(syncProvider.notifier);
     BigInt? proposalId;
     var openedReview = false;
     try {
@@ -268,6 +269,8 @@ class _DonationScreenState extends ConsumerState<DonationScreen> {
           proposalId: proposalId,
           sendFlowId: flowId,
           logContext: 'Donation(review not opened)',
+          syncNotifier: syncNotifier,
+          accountUuid: accountUuid,
         );
       }
     }

--- a/lib/src/features/payment_links/screens/payment_links_mobile_body.dart
+++ b/lib/src/features/payment_links/screens/payment_links_mobile_body.dart
@@ -381,7 +381,9 @@ class PaymentLinksMobileBody extends StatelessWidget {
       cardAmountText: '${formatZecAmount(quote.recipientAmountZatoshi)} ZEC',
       cardFeeText: '${formatZecAmount(quote.cardFeeZatoshi)} ZEC',
       totalAmountText: '${formatZecAmount(quote.totalDeductedZatoshi)} ZEC',
-      onContinue: operationInProgress
+      onContinue:
+          operationInProgress ||
+              (!hasPendingFundingMetadata && !canContinueAmount)
           ? null
           : !hasPendingFundingMetadata
           ? onCreateFundedLink

--- a/lib/src/features/payment_links/screens/payment_links_screen.dart
+++ b/lib/src/features/payment_links/screens/payment_links_screen.dart
@@ -1089,11 +1089,45 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     }
   }
 
-  void _cancelKeystoneFunding() {
+  Future<void> _cancelKeystoneFunding() async {
+    final request = _keystoneFundingRequest;
+    if (request == null) return;
+    // The signing surface has released its input lock and refreshed balance.
+    // Recheck fees before making the preserved review actionable again.
+    PaymentLinkFundingQuote? quote;
+    try {
+      quote = await ref
+          .read(paymentLinkOperationsProvider)
+          .quoteFunding(
+            amountZatoshi: request.amountZatoshi,
+            sourceAccountUuid: request.sourceAccountUuid,
+          );
+    } catch (error) {
+      log('PaymentLinks: cancelled funding review refresh failed: $error');
+    }
+    if (!mounted || _keystoneFundingRequest != request) return;
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    if (accountUuid != request.sourceAccountUuid ||
+        (quote != null &&
+            quote.sourceAccountUuid != request.sourceAccountUuid)) {
+      throw StateError('Gift Card account changed. Review the amount again.');
+    }
     setState(() {
+      // Preserve the card for inspection even if a fresh fee is unavailable,
+      // but require returning to Amount before this old quote can be used.
+      if (quote != null) _fundingQuote = quote;
+      _amountSupportingText = quote == null
+          ? 'Card fee could not be updated. Return to the amount step and try again.'
+          : null;
+      _amountSupportingTextIsError = quote == null;
+      _maxFundingQuote = null;
+      _maxFundingQuoteGeneration++;
+      _maxFundingQuoteInProgress = false;
       _keystoneFundingRequest = null;
       _operationInProgress = false;
     });
+    if (quote == null) _showError(_amountSupportingText!);
+    unawaited(_loadMaxFundingQuote());
     unawaited(_loadRecoveries(showError: false));
   }
 
@@ -2395,7 +2429,9 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       cardFeeText: '${formatZecAmount(_fundingQuote!.cardFeeZatoshi)} ZEC',
       totalAmountText:
           '${formatZecAmount(_fundingQuote!.totalDeductedZatoshi)} ZEC',
-      onConfirm: _operationInProgress
+      onConfirm:
+          _operationInProgress ||
+              (_pendingFundingMetadata == null && !_canContinueAmount)
           ? null
           : _pendingFundingMetadata == null
           ? _createFundedLink

--- a/lib/src/features/payment_links/services/payment_link_hardware_signing_service.dart
+++ b/lib/src/features/payment_links/services/payment_link_hardware_signing_service.dart
@@ -286,6 +286,7 @@ class RustPaymentLinkHardwareSigningService
       'PaymentLinkHardwareSigning: proposal cleanup remains pending '
       'flow=${draft.sendFlowId} proposal=${draft.proposalId} error=$lastError',
     );
+    throw StateError('Could not finish cancelling. Please try again.');
   }
 
   @override

--- a/lib/src/features/payment_links/widgets/payment_link_keystone_signing_overlay.dart
+++ b/lib/src/features/payment_links/widgets/payment_link_keystone_signing_overlay.dart
@@ -9,6 +9,9 @@ import '../../../../main.dart' show log;
 import '../../../core/layout/app_form_factor.dart';
 import '../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
+import '../../../core/widgets/app_toast.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../providers/sync_provider.dart';
 import '../../keystone/widgets/keystone_signing_modal.dart';
 import '../../keystone/widgets/mobile_keystone_pczt_signing_flow.dart';
 import '../../send/services/sapling_params.dart';
@@ -31,7 +34,7 @@ class PaymentLinkKeystoneSigningOverlay extends ConsumerStatefulWidget {
   final BigInt amountZatoshi;
   final String sourceAccountUuid;
   final PaymentLinkPresentation? presentation;
-  final VoidCallback onCancel;
+  final FutureOr<void> Function() onCancel;
   final Future<void> Function(
     VizorPaymentLink link,
     PaymentLinkHardwareFundingResult result,
@@ -53,6 +56,11 @@ class _PaymentLinkKeystoneSigningOverlayState
   String? _error;
   PaymentLinkHardwareSigningService? _signingService;
   PaymentLinkHardwarePcztDraft? _draft;
+  Future<PaymentLinkHardwarePcztDraft>? _draftCreation;
+  Future<void>? _discardFuture;
+  late final SyncNotifier _syncNotifier;
+  bool _cancelling = false;
+  bool _cancelled = false;
   List<String> _urParts = const [];
   List<int>? _pcztWithProofs;
   SaplingParamsStatus? _saplingParams;
@@ -60,6 +68,7 @@ class _PaymentLinkKeystoneSigningOverlayState
   @override
   void initState() {
     super.initState();
+    _syncNotifier = ref.read(syncProvider.notifier);
     // The mobile surface is driven by MobileKeystonePcztSigningFlow, which
     // calls its own `preparePczt` once it is mounted.
     if (kAppFormFactor == AppFormFactor.mobile) return;
@@ -75,7 +84,11 @@ class _PaymentLinkKeystoneSigningOverlayState
     if (completer != null && !completer.isCompleted) {
       completer.complete(false);
     }
-    unawaited(_discardDraft());
+    unawaited(
+      _discardDraft().catchError((Object error) {
+        log('PaymentLinkKeystoneSigning: cleanup failed: $error');
+      }),
+    );
     super.dispose();
   }
 
@@ -83,17 +96,18 @@ class _PaymentLinkKeystoneSigningOverlayState
     try {
       final service = ref.read(paymentLinkHardwareSigningServiceProvider);
       _signingService = service;
-      final draft = await service.createFundingPczt(
+      final creation = service.createFundingPczt(
         amountZatoshi: widget.amountZatoshi,
         sourceAccountUuid: widget.sourceAccountUuid,
         presentation: widget.presentation,
       );
-      if (!mounted) {
-        await service.discardPcztDraft(draft: draft);
+      _draftCreation = creation;
+      final draft = await creation;
+      _draft = draft;
+      if (!mounted || _cancelled) {
+        await _discardDraft();
         return;
       }
-      _draft = draft;
-
       SaplingParamsStatus? saplingParams;
       if (draft.needsSaplingParams) {
         saplingParams = await loadSaplingParamsStatus();
@@ -101,7 +115,7 @@ class _PaymentLinkKeystoneSigningOverlayState
           final confirmed = await _showDownloadPrompt();
           if (!confirmed) {
             await _discardDraft();
-            if (!mounted) return;
+            if (!mounted || _cancelled) return;
             setState(() {
               _phase = _PaymentLinkKeystonePhase.failed;
               _error =
@@ -127,7 +141,7 @@ class _PaymentLinkKeystoneSigningOverlayState
             ? saplingParams!.outputPath
             : null,
       );
-      if (!mounted) return;
+      if (!mounted || _cancelled) return;
       setState(() {
         _phase = _PaymentLinkKeystonePhase.ready;
         _urParts = urParts;
@@ -136,8 +150,13 @@ class _PaymentLinkKeystoneSigningOverlayState
       });
     } catch (error, stackTrace) {
       log('PaymentLinkKeystoneSigning._preparePczt: $error\n$stackTrace');
-      await _discardDraft();
-      if (!mounted) return;
+      if (_cancelled) return;
+      try {
+        await _discardDraft();
+      } catch (cleanupError) {
+        log('PaymentLinkKeystoneSigning: cleanup failed: $cleanupError');
+      }
+      if (!mounted || _cancelled) return;
       setState(() {
         _phase = _PaymentLinkKeystonePhase.failed;
         _error = _friendlyError(error);
@@ -176,7 +195,7 @@ class _PaymentLinkKeystoneSigningOverlayState
       '/send/keystone/scan',
       extra: const KeystoneSendScanArgs.batch(),
     );
-    if (responseCbor == null || !mounted) return;
+    if (responseCbor == null || !mounted || _cancelled) return;
     final service = _signingService;
     final draft = _draft;
     if (service == null || draft == null) return;
@@ -185,7 +204,7 @@ class _PaymentLinkKeystoneSigningOverlayState
         draft: draft,
         responseCbor: responseCbor,
       );
-      if (!mounted) return;
+      if (!mounted || _cancelled) return;
       await _broadcast(signatures);
     } catch (error, stackTrace) {
       log('PaymentLinkKeystoneSigning._getSignature: $error\n$stackTrace');
@@ -197,6 +216,7 @@ class _PaymentLinkKeystoneSigningOverlayState
   }
 
   Future<void> _broadcast(List<int> signatures) async {
+    if (_cancelled) return;
     setState(() {
       _phase = _PaymentLinkKeystonePhase.broadcasting;
       _error = null;
@@ -289,16 +309,18 @@ class _PaymentLinkKeystoneSigningOverlayState
   ) async {
     final service = ref.read(paymentLinkHardwareSigningServiceProvider);
     _signingService = service;
-    final draft = await service.createFundingPczt(
+    final creation = service.createFundingPczt(
       amountZatoshi: widget.amountZatoshi,
       sourceAccountUuid: widget.sourceAccountUuid,
       presentation: widget.presentation,
     );
-    if (!mounted) {
-      await service.discardPcztDraft(draft: draft);
+    _draftCreation = creation;
+    final draft = await creation;
+    _draft = draft;
+    if (!mounted || _cancelled) {
+      await _discardDraft();
       throw const MobileKeystonePcztSigningAborted();
     }
-    _draft = draft;
 
     SaplingParamsStatus? saplingParams;
     if (draft.needsSaplingParams) {
@@ -319,6 +341,7 @@ class _PaymentLinkKeystoneSigningOverlayState
     _saplingParams = saplingParams;
 
     final urParts = await service.encodeSigningUrParts(draft: draft);
+    if (!mounted || _cancelled) throw const MobileKeystonePcztSigningAborted();
     return MobileKeystonePcztSigningPayload(
       urParts: urParts,
       pcztWithProofs: service.addProofsForSigning(
@@ -334,6 +357,11 @@ class _PaymentLinkKeystoneSigningOverlayState
   }
 
   Future<Uint8List> _decodeMobileSigningResponse(List<int> responseCbor) async {
+    if (_cancelled) {
+      throw StateError(
+        'Signing was cancelled. Return to the review to try again.',
+      );
+    }
     final draft = _draft;
     final service = _signingService;
     if (draft == null || service == null) {
@@ -353,21 +381,57 @@ class _PaymentLinkKeystoneSigningOverlayState
     List<int> pcztWithProofs,
     Uint8List signatures,
   ) async {
+    if (_cancelled) {
+      throw StateError(
+        'Signing was cancelled. Return to the review to try again.',
+      );
+    }
     _pcztWithProofs = pcztWithProofs;
     await _completeFunding(signatures);
   }
 
-  void _cancel() {
-    if (_phase == _PaymentLinkKeystonePhase.broadcasting) return;
-    unawaited(_discardDraft());
-    widget.onCancel();
+  Future<void> _cancel() async {
+    if (_cancelling || _phase == _PaymentLinkKeystonePhase.broadcasting) return;
+    setState(() {
+      _cancelling = true;
+      _cancelled = true;
+    });
+    try {
+      await _discardDraft();
+      if (mounted) await widget.onCancel();
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _cancelling = false;
+        _phase = _PaymentLinkKeystonePhase.failed;
+        _error = 'Could not finish cancelling. Please try again.';
+      });
+      showAppToast(
+        context,
+        _error!,
+        iconName: AppIcons.warningCircle,
+        tone: AppToastTone.destructive,
+      );
+    }
   }
 
-  Future<void> _discardDraft() async {
+  Future<void> _discardDraft() =>
+      _discardFuture ??= _releaseDraft().catchError((Object error) {
+        _discardFuture = null;
+        throw error;
+      });
+
+  Future<void> _releaseDraft() async {
+    try {
+      await _draftCreation;
+    } catch (_) {
+      // Creation owns cleanup if it could not return a draft.
+    }
     final draft = _draft;
-    _draft = null;
     if (draft == null) return;
     await _signingService?.discardPcztDraft(draft: draft);
+    await _syncNotifier.refreshAfterProposalRelease(widget.sourceAccountUuid);
+    _draft = null;
   }
 
   @override
@@ -415,11 +479,14 @@ class _PaymentLinkKeystoneSigningOverlayState
                   ? null
                   : 'Get signature',
               onPrimary:
-                  _phase == _PaymentLinkKeystonePhase.ready &&
+                  !_cancelled &&
+                      _phase == _PaymentLinkKeystonePhase.ready &&
                       _pcztWithProofs != null
                   ? () => unawaited(_getSignature())
                   : null,
-              secondaryLabel: isBroadcasting
+              secondaryLabel: _cancelling
+                  ? 'Cancelling…'
+                  : isBroadcasting
                   ? null
                   : _phase == _PaymentLinkKeystonePhase.failed
                   ? 'Back to gift card'
@@ -448,22 +515,26 @@ class _PaymentLinkKeystoneSigningOverlayState
         // animated PCZT QR while `/payment-links` stays put behind it, so an
         // arriving `zcash:` link must stay parked until the round ends.
         PaymentUriBusySurfaceHold(
-          child: MobileKeystonePcztSigningFlow(
-            title: 'Confirm Gift Card',
-            description:
-                'Use your Keystone wallet to scan this transaction QR code. '
-                'Follow the steps on your device.',
-            scanCaption: 'Scan the QR code on your Keystone to finish creating',
-            readingSignatureLabel: 'Reading signature...',
-            finalizingSignatureLabel: 'Creating your gift card...',
-            keyPrefix: 'payment_link_keystone_sign',
-            logTag: 'PaymentLinkKeystoneSigning',
-            expectedSignedUrType: 'zcash-batch-sig-result',
-            preparePczt: _prepareMobilePczt,
-            signedPcztDecoder: _decodeMobileSigningResponse,
-            onSigned: _handleMobileSigned,
-            friendlyError: _friendlyError,
-            onCancel: _cancel,
+          child: AbsorbPointer(
+            absorbing: _cancelling,
+            child: MobileKeystonePcztSigningFlow(
+              title: _cancelling ? 'Cancelling…' : 'Confirm Gift Card',
+              description:
+                  'Use your Keystone wallet to scan this transaction QR code. '
+                  'Follow the steps on your device.',
+              scanCaption:
+                  'Scan the QR code on your Keystone to finish creating',
+              readingSignatureLabel: 'Reading signature...',
+              finalizingSignatureLabel: 'Creating your gift card...',
+              keyPrefix: 'payment_link_keystone_sign',
+              logTag: 'PaymentLinkKeystoneSigning',
+              expectedSignedUrType: 'zcash-batch-sig-result',
+              preparePczt: _prepareMobilePczt,
+              signedPcztDecoder: _decodeMobileSigningResponse,
+              onSigned: _handleMobileSigned,
+              friendlyError: _friendlyError,
+              onCancel: _cancel,
+            ),
           ),
         ),
         if (_showSaplingParamsPrompt)

--- a/lib/src/features/send/screens/mobile/mobile_keystone_sign_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_keystone_sign_screen.dart
@@ -10,6 +10,7 @@ import '../../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/storage/wallet_paths.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
+import '../../../../providers/sync_provider.dart';
 import '../../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../keystone/services/keystone_batch_signing.dart';
@@ -22,9 +23,14 @@ import 'mobile_send_screen.dart' show MobileSaplingParamsSheet;
 /// preparation and the result payload; the QR display and signed-PCZT scan are
 /// shared by every mobile Keystone signing surface.
 class MobileKeystoneSignScreen extends ConsumerStatefulWidget {
-  const MobileKeystoneSignScreen({required this.args, super.key});
+  const MobileKeystoneSignScreen({
+    required this.args,
+    this.loadWalletDbPath = getWalletDbPath,
+    super.key,
+  });
 
   final SendReviewArgs args;
+  final Future<String> Function() loadWalletDbPath;
 
   @override
   ConsumerState<MobileKeystoneSignScreen> createState() =>
@@ -69,6 +75,9 @@ class _MobileKeystoneSignScreenState
     extends ConsumerState<MobileKeystoneSignScreen>
     with PaymentUriBusySurfaceHoldMixin {
   bool _proposalOwnershipTransferred = false;
+  bool _cancelRequested = false;
+  Future<Object?>? _proposalConsumption;
+  late final SyncNotifier _syncNotifier;
   late final MobileKeystoneSigningRounds _rounds;
   List<MobileKeystonePcztSigningPayload>? _payloads;
   List<KeystoneBatchSigningRequest?>? _batchRequests;
@@ -76,6 +85,7 @@ class _MobileKeystoneSignScreenState
   @override
   void initState() {
     super.initState();
+    _syncNotifier = ref.read(syncProvider.notifier);
     _rounds = MobileKeystoneSigningRounds(args: widget.args);
   }
 
@@ -84,6 +94,8 @@ class _MobileKeystoneSignScreenState
     if (!_proposalOwnershipTransferred) {
       unawaited(
         discardSendProposal(
+          syncNotifier: _syncNotifier,
+          accountUuid: widget.args.proposalAccountUuid,
           proposalId: widget.args.proposalId,
           sendFlowId: widget.args.sendFlowId,
           logContext: 'MobileKeystoneSign(dispose)',
@@ -95,35 +107,48 @@ class _MobileKeystoneSignScreenState
 
   @override
   Widget build(BuildContext context) {
-    return MobileKeystonePcztSigningFlow(
-      key: ValueKey('mobile_keystone_sign_round_${_rounds.index}'),
-      title: _rounds.title,
-      description: widget.args.addressType == 'tex'
-          ? 'This TEX send requires two Keystone approvals. Scan transaction ${_rounds.index + 1} of 2.'
-          : 'Use your Keystone wallet to scan this transaction QR code. '
-                'Follow the steps on your device.',
-      preparePczt: _preparePczt,
-      onSigned: _handleSignedPczt,
-      signedPcztDecoder: _decodeKeystoneResponse,
-      expectedSignedUrType: widget.args.addressType == 'tex'
-          ? 'zcash-pczt'
-          : 'zcash-batch-sig-result',
-      friendlyError: _friendlyError,
-      keyPrefix: 'mobile_keystone_sign',
-      scanCaption: 'Scan the QR code on your Keystone to finish sending',
-      logTag: 'MobileKeystoneSign',
-      onCancel: () {
-        _proposalOwnershipTransferred = true;
-        unawaited(
-          discardSendProposal(
-            proposalId: widget.args.proposalId,
-            sendFlowId: widget.args.sendFlowId,
-            logContext: 'MobileKeystoneSign(cancel)',
-          ),
-        );
-        context.pop();
+    return PopScope<void>(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) _proposalOwnershipTransferred = true;
       },
+      child: AbsorbPointer(
+        absorbing: _cancelRequested,
+        child: MobileKeystonePcztSigningFlow(
+          key: ValueKey('mobile_keystone_sign_round_${_rounds.index}'),
+          title: _cancelRequested ? 'Cancelling…' : _rounds.title,
+          description: widget.args.addressType == 'tex'
+              ? 'This TEX send requires two Keystone approvals. Scan transaction ${_rounds.index + 1} of 2.'
+              : 'Use your Keystone wallet to scan this transaction QR code. '
+                    'Follow the steps on your device.',
+          preparePczt: _preparePczt,
+          onSigned: _handleSignedPczt,
+          signedPcztDecoder: _decodeKeystoneResponse,
+          expectedSignedUrType: widget.args.addressType == 'tex'
+              ? 'zcash-pczt'
+              : 'zcash-batch-sig-result',
+          friendlyError: _friendlyError,
+          keyPrefix: 'mobile_keystone_sign',
+          scanCaption: 'Scan the QR code on your Keystone to finish sending',
+          logTag: 'MobileKeystoneSign',
+          onCancel: _cancelSigning,
+        ),
+      ),
     );
+  }
+
+  Future<void> _cancelSigning() async {
+    if (_cancelRequested || _proposalOwnershipTransferred) return;
+    setState(() => _cancelRequested = true);
+    // Finish an in-flight creator before the review releases its input lock.
+    try {
+      await _proposalConsumption;
+    } catch (_) {
+      // The review handles idempotent cleanup of failed creation as well.
+    }
+    if (!mounted) return;
+    _proposalOwnershipTransferred = true;
+    context.pop();
   }
 
   Future<MobileKeystonePcztSigningPayload> _preparePczt(
@@ -132,9 +157,15 @@ class _MobileKeystoneSignScreenState
   ) async {
     final cached = _payloads;
     if (cached != null) return cached[_rounds.index];
-    final dbPath = await getWalletDbPath();
+    final dbPath = await widget.loadWalletDbPath();
+    if (!mounted || _cancelRequested || _proposalOwnershipTransferred) {
+      throw const MobileKeystonePcztSigningAborted();
+    }
     final endpoint = ref.read(rpcEndpointProvider);
     var saplingParams = await loadSaplingParamsStatus();
+    if (!mounted || _cancelRequested || _proposalOwnershipTransferred) {
+      throw const MobileKeystonePcztSigningAborted();
+    }
 
     if (widget.args.needsSaplingParams && !saplingParams.complete) {
       if (!context.mounted) {
@@ -151,8 +182,11 @@ class _MobileKeystoneSignScreenState
       saplingParams = await loadSaplingParamsStatus();
     }
 
-    final texPczts = widget.args.addressType == 'tex'
-        ? await rust_sync.createTexPcztsFromProposal(
+    if (!mounted || _cancelRequested || _proposalOwnershipTransferred) {
+      throw const MobileKeystonePcztSigningAborted();
+    }
+    final texFuture = widget.args.addressType == 'tex'
+        ? rust_sync.createTexPcztsFromProposal(
             dbPath: dbPath,
             lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
             network: endpoint.networkName,
@@ -160,17 +194,25 @@ class _MobileKeystoneSignScreenState
             sendFlowId: widget.args.sendFlowId,
           )
         : null;
-    final pczts =
-        texPczts?.pczts ??
-        [
-          await rust_sync.createPcztFromProposal(
+    _proposalConsumption = texFuture;
+    final texPczts = await texFuture;
+    if (!mounted || _cancelRequested || _proposalOwnershipTransferred) {
+      throw const MobileKeystonePcztSigningAborted();
+    }
+    final pcztFuture = texPczts == null
+        ? rust_sync.createPcztFromProposal(
             dbPath: dbPath,
             lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
             network: endpoint.networkName,
             proposalId: widget.args.proposalId,
             sendFlowId: widget.args.sendFlowId,
-          ),
-        ];
+          )
+        : null;
+    if (pcztFuture != null) _proposalConsumption = pcztFuture;
+    final pczts = texPczts?.pczts ?? [await pcztFuture!];
+    if (!mounted || _cancelRequested || _proposalOwnershipTransferred) {
+      throw const MobileKeystonePcztSigningAborted();
+    }
     final payloads = <MobileKeystonePcztSigningPayload>[];
     final batchRequests = <KeystoneBatchSigningRequest?>[];
     final signerPczts = texPczts?.signerPczts;
@@ -247,6 +289,7 @@ class _MobileKeystoneSignScreenState
     List<int> pcztWithProofs,
     Uint8List signedPczt,
   ) async {
+    if (_cancelRequested || _proposalOwnershipTransferred) return;
     if (!_rounds.add(pcztWithProofs, signedPczt)) {
       if (mounted) setState(() {});
       return;

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -1886,25 +1886,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
           )) {
         return;
       }
-      if (amountZatoshi + args.feeZatoshi > _spendable) {
-        setState(() {
-          _invalidateReviewFeeQuote();
-          _amountError = _notEnoughZecText;
-          _reviewFeeNotice = _notEnoughZecText;
-        });
-        return;
-      }
       setState(() {
-        _isConfirmingSend = false;
-        _feeZatoshi = args.feeZatoshi;
-        _reviewFeeQuote = _MobileSendFeeQuote(
-          accountUuid: accountUuid,
-          address: address,
-          memo: memo,
-          amountZatoshi: amountZatoshi,
-          feeZatoshi: args.feeZatoshi,
-        );
-        _reviewFeeRetryAvailable = false;
         _reviewFeeNotice = 'Fee updated after sync. Review and confirm again.';
       });
       return;

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -719,7 +719,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   // into `onPopInvokedWithResult` → [_handleBack] instead.
   bool get _routePopAllowed {
     if (_phase != _SendPhase.compose) return false;
-    if (_isConfirmingSend) return false;
+    if (_isConfirmingSend || _pendingCancellation != null) return false;
     if (!widget.useRouteSteps && _step != _SendStep.recipient) return false;
     // Without an enclosing route (bare widgetbook renders) there is no way to
     // tell whether a pop would go anywhere, so keep the framework default.
@@ -1971,6 +1971,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   // ── Navigation ─────────────────────────────────────────────────────
 
   void _cancelSend() {
+    if (_isConfirmingSend || _pendingCancellation != null) return;
     if (widget.useRouteSteps) {
       context.go('/home');
       return;
@@ -1979,7 +1980,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   }
 
   void _handleBack() {
-    if (_isConfirmingSend) return;
+    if (_isConfirmingSend || _pendingCancellation != null) return;
     switch (_phase) {
       case _SendPhase.failed:
         setState(() => _phase = _SendPhase.compose);
@@ -2200,7 +2201,9 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                   children: [
                     MobileTopNav.back(
                       title: title,
-                      onBack: _isConfirmingSend ? null : _handleBack,
+                      onBack: _isConfirmingSend || _pendingCancellation != null
+                          ? null
+                          : _handleBack,
                     ),
                     Expanded(child: body),
                   ],
@@ -3267,7 +3270,9 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                   key: const ValueKey('mobile_send_cancel'),
                   expand: true,
                   variant: AppButtonVariant.ghost,
-                  onPressed: _isConfirmingSend ? null : _cancelSend,
+                  onPressed: _isConfirmingSend || _pendingCancellation != null
+                      ? null
+                      : _cancelSend,
                   child: const Text('Cancel'),
                 ),
               ],

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -520,6 +520,8 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   var _paymentRequestDetached = false;
   var _phase = _SendPhase.compose;
   var _isConfirmingSend = false;
+  SendReviewArgs? _pendingCancellation;
+  late final SyncNotifier _syncNotifier;
 
   /// Captured in [initState] so the hold can be given back from [dispose]
   /// and from an async continuation that outlives the element.
@@ -568,6 +570,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   @override
   void initState() {
     super.initState();
+    _syncNotifier = ref.read(syncProvider.notifier);
     _paymentUriBusySurface = ref.read(paymentUriBusySurfaceProvider.notifier);
     try {
       ref.read(sendProvingKeyWarmupProvider).call();
@@ -1668,6 +1671,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       }
       setState(() {
         _feeZatoshi = fee;
+        _amountError = null;
         _reviewFeeQuote = _MobileSendFeeQuote(
           accountUuid: accountUuid,
           address: address,
@@ -1780,7 +1784,11 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   /// window; when it lifts, the app re-runs the drain against `/send/status`,
   /// which waits for the receipt.
   Future<void> _confirmAndSend() async {
-    if (_phase != _SendPhase.compose || _isConfirmingSend) return;
+    if (_phase != _SendPhase.compose ||
+        _isConfirmingSend ||
+        _pendingCancellation != null) {
+      return;
+    }
     _acquireConfirmBusySurface();
     try {
       await _confirmAndSendHeld();
@@ -1853,6 +1861,8 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       // this returns, and a link parked behind it would otherwise be
       // pre-checked against inputs this proposal still holds.
       await discardSendProposal(
+        syncNotifier: _syncNotifier,
+        accountUuid: args.proposalAccountUuid,
         proposalId: args.proposalId,
         sendFlowId: _sendFlowId,
         logContext: 'MobileSend(unmounted)',
@@ -1860,12 +1870,30 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       return;
     }
     if (args.feeZatoshi != reviewedFeeZatoshi) {
-      await discardSendProposal(
-        proposalId: args.proposalId,
-        sendFlowId: _sendFlowId,
-        logContext: 'MobileSend(fee changed after review)',
-      );
+      await _recoverCancelledProposal(args);
       if (!mounted) return;
+      // Recovery may have failed, switched accounts, or recomputed Max. Keep
+      // that result instead of replacing it with the discarded proposal's fee.
+      if (_pendingCancellation != null ||
+          !_hasCurrentReviewFeeQuote ||
+          _isMaxMode ||
+          !_reviewFeeQuote!.matches(
+            accountUuid: accountUuid,
+            address: address,
+            memo: memo,
+            amountZatoshi: amountZatoshi,
+            feeZatoshi: _feeZatoshi,
+          )) {
+        return;
+      }
+      if (amountZatoshi + args.feeZatoshi > _spendable) {
+        setState(() {
+          _invalidateReviewFeeQuote();
+          _amountError = _notEnoughZecText;
+          _reviewFeeNotice = _notEnoughZecText;
+        });
+        return;
+      }
       setState(() {
         _isConfirmingSend = false;
         _feeZatoshi = args.feeZatoshi;
@@ -1896,20 +1924,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         extra: args,
       );
       if (keystone == null) {
-        // Cancelled (or failed before signing); discard is idempotent. Released
-        // before the review is re-enabled so neither Back nor a second Confirm
-        // can run while the proposal still holds its inputs.
-        await discardSendProposal(
-          proposalId: args.proposalId,
-          sendFlowId: _sendFlowId,
-          logContext: 'MobileSend(keystone cancelled)',
-        );
-        if (mounted) {
-          setState(() {
-            _isConfirmingSend = false;
-            _phase = _SendPhase.compose;
-          });
-        }
+        await _recoverCancelledProposal(args);
         return;
       }
       if (!mounted) return;
@@ -1919,6 +1934,56 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
 
     if (!mounted) return;
     _openStatusRoute(args);
+  }
+
+  Future<void> _recoverCancelledProposal(SendReviewArgs args) async {
+    if (mounted) {
+      setState(() {
+        _pendingCancellation = args;
+        _isConfirmingSend = true;
+        _invalidateReviewFeeQuote();
+        _validateSeq++;
+        _maxSeq++;
+        _maxQuote = null;
+        _isResolvingMax = false;
+      });
+    }
+    final released = await discardSendProposal(
+      syncNotifier: _syncNotifier,
+      accountUuid: args.proposalAccountUuid,
+      proposalId: args.proposalId,
+      sendFlowId: args.sendFlowId,
+      logContext: 'MobileSend(cancelled proposal)',
+    );
+    if (!mounted) return;
+    if (!released) {
+      setState(() {
+        _isConfirmingSend = false;
+        _reviewFeeNotice = 'Could not finish cancellation. Try again.';
+      });
+      return;
+    }
+    setState(() {
+      _pendingCancellation = null;
+      _amountError = '';
+      _phase = _SendPhase.compose;
+    });
+    // Re-read the current account and amount through the normal quote path.
+    // Nothing may re-enable Confirm using the balance cached while inputs
+    // were reserved, including a Max quote from the first signing attempt.
+    await _refreshReviewQuote();
+    if (mounted) setState(() => _isConfirmingSend = false);
+  }
+
+  Future<void> _retryCancelledProposal() async {
+    final args = _pendingCancellation;
+    if (args == null || _isConfirmingSend) return;
+    _acquireConfirmBusySurface();
+    try {
+      await _recoverCancelledProposal(args);
+    } finally {
+      _releaseConfirmBusySurface();
+    }
   }
 
   // ── Navigation ─────────────────────────────────────────────────────
@@ -2086,9 +2151,15 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       previous,
       next,
     ) {
-      if (previous == next) return;
+      if (previous == next ||
+          _isConfirmingSend ||
+          _pendingCancellation != null) {
+        return;
+      }
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
+        if (!mounted || _isConfirmingSend || _pendingCancellation != null) {
+          return;
+        }
         if (_isMaxMode) {
           if (next.freshness == SpendableBalanceFreshness.lastCompletedSync) {
             _invalidateMaxQuoteForSync();
@@ -3143,7 +3214,9 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                     isShielded: _isShieldedAddress,
                     memo: _effectiveMemo,
                     feeText: feeText,
-                    onMemoTap: () => unawaited(_editMemo()),
+                    onMemoTap: _isConfirmingSend || _pendingCancellation != null
+                        ? null
+                        : () => unawaited(_editMemo()),
                     onFeeInfoTap: () => unawaited(_showFeeInfo()),
                   ),
                   if (_reviewFeeNotice != null) ...[
@@ -3173,13 +3246,16 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                   expand: true,
                   onPressed:
                       _isConfirmingSend ||
-                          _isResolvingMax ||
-                          (_isMaxMode && !_hasCurrentMaxQuote) ||
-                          (!_hasCurrentReviewFeeQuote &&
-                              !_reviewFeeRetryAvailable)
+                          (_pendingCancellation == null &&
+                              (_isResolvingMax ||
+                                  (_isMaxMode && !_hasCurrentMaxQuote) ||
+                                  (!_hasCurrentReviewFeeQuote &&
+                                      !_reviewFeeRetryAvailable)))
                       ? null
                       : () => unawaited(
-                          _reviewFeeRetryAvailable
+                          _pendingCancellation != null
+                              ? _retryCancelledProposal()
+                              : _reviewFeeRetryAvailable
                               ? _refreshReviewQuote()
                               : _confirmAndSend(),
                         ),
@@ -3190,7 +3266,8 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                   child: Text(
                     _isConfirmingSend
                         ? 'Preparing...'
-                        : _reviewFeeRetryAvailable
+                        : _pendingCancellation != null ||
+                              _reviewFeeRetryAvailable
                         ? 'Try again'
                         : _isUsingCompletedSpendableSnapshot
                         ? 'Finishing wallet sync...'
@@ -3208,7 +3285,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                   key: const ValueKey('mobile_send_cancel'),
                   expand: true,
                   variant: AppButtonVariant.ghost,
-                  onPressed: _cancelSend,
+                  onPressed: _isConfirmingSend ? null : _cancelSend,
                   child: const Text('Cancel'),
                 ),
               ],
@@ -3784,7 +3861,7 @@ class _ReviewWrap extends StatelessWidget {
   final bool isShielded;
   final String memo;
   final String feeText;
-  final VoidCallback onMemoTap;
+  final VoidCallback? onMemoTap;
   final VoidCallback onFeeInfoTap;
 
   @override

--- a/lib/src/features/send/screens/mobile/mobile_send_status_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_status_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../../providers/sync_provider.dart';
 
 import '../../../../core/feedback/app_haptics.dart';
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
@@ -61,11 +62,13 @@ class _MobileSendStatusScreenState
   /// Captured in [initState] so [dispose] can release the flag without reading
   /// from `ref` after the element is gone.
   late final SendStatusTerminalNotifier _sendStatusTerminal;
+  late final SyncNotifier _syncNotifier;
 
   @override
   void initState() {
     super.initState();
     _sendStatusTerminal = ref.read(sendStatusTerminalProvider.notifier);
+    _syncNotifier = ref.read(syncProvider.notifier);
     _proposalConsumed = widget.keystone != null;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) unawaited(_startBroadcast());
@@ -89,6 +92,8 @@ class _MobileSendStatusScreenState
           : _proposalRelease,
       // Idempotent in Rust, so no gate on the (optimistic) consumed flag.
       retryRelease: () => discardSendProposal(
+        syncNotifier: _syncNotifier,
+        accountUuid: widget.args.proposalAccountUuid,
         proposalId: widget.args.proposalId,
         sendFlowId: widget.args.sendFlowId,
         logContext: 'MobileSendStatus(retry)',
@@ -106,6 +111,8 @@ class _MobileSendStatusScreenState
   Future<bool> _discardProposalIfNeeded(String logContext) {
     if (_proposalConsumed) return Future<bool>.value(true);
     return _proposalRelease ??= discardSendProposal(
+      syncNotifier: _syncNotifier,
+      accountUuid: widget.args.proposalAccountUuid,
       proposalId: widget.args.proposalId,
       sendFlowId: widget.args.sendFlowId,
       logContext: logContext,

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -564,10 +564,13 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     final backTarget = AppBackResolver.resolve(context);
 
     return PopScope<Object?>(
-      canPop: keystonePhase == null && !_cancelling,
+      canPop: keystonePhase == null && !_cancelling && !_proposalAbandoned,
       onPopInvokedWithResult: (didPop, _) {
-        if (!didPop && keystonePhase != null) {
+        if (didPop) return;
+        if (keystonePhase != null) {
           unawaited(_cancelKeystoneSigning());
+        } else if (_proposalAbandoned) {
+          unawaited(_leaveReview(() => backTarget.navigate(context)));
         }
       },
       child: AppDesktopShell(

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -273,6 +273,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
 
       if (args.needsSaplingParams && !saplingParams.complete) {
         final confirmed = await _showDownloadPrompt();
+        if (!isCurrent()) return;
         if (!confirmed) {
           unawaited(_scheduleDiscard());
           if (!mounted) return;
@@ -408,6 +409,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
       _reviewRecoveryFailed = false;
       _signingGeneration++;
     });
+    _resolveSaplingParamsDialog(false);
     final released = await _scheduleDiscard();
     if (!mounted) return;
     if (!released) {

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -20,6 +20,9 @@ import '../../../providers/zec_price_change_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../core/navigation/payment_uri_busy_surface_hold.dart';
 import '../../../core/navigation/payment_uri_busy_surface_provider.dart';
+import '../../../core/navigation/app_back_resolver.dart';
+import '../../../core/widgets/app_toast.dart';
+import '../../../providers/sync_provider.dart';
 import '../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../address_book/models/address_book_contact.dart';
@@ -49,7 +52,14 @@ class SendReviewScreen extends ConsumerStatefulWidget {
 class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   late final PaymentUriBusySurfaceNotifier _paymentUriBusySurface;
   bool _holdsPaymentUriBusySurface = false;
-  Future<void>? _discardFuture;
+  late final SyncNotifier _syncNotifier;
+  Future<bool>? _discardFuture;
+  bool _cancelling = false;
+  bool _proposalAbandoned = false;
+  late SendReviewArgs _reviewArgs;
+  int _signingGeneration = 0;
+  Future<Object?>? _proposalConsumption;
+  bool _reviewRecoveryFailed = false;
   bool _handoffToKeystone = false;
   bool _showSaplingParamsPrompt = false;
   bool _messageExpanded = false;
@@ -68,7 +78,9 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   @override
   void initState() {
     super.initState();
+    _reviewArgs = widget.args;
     _paymentUriBusySurface = ref.read(paymentUriBusySurfaceProvider.notifier);
+    _syncNotifier = ref.read(syncProvider.notifier);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       if (!_holdsPaymentUriBusySurface) {
@@ -91,12 +103,27 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     super.dispose();
   }
 
-  Future<void> _scheduleDiscard() {
-    return _discardFuture ??= discardSendProposal(
-      proposalId: widget.args.proposalId,
-      sendFlowId: widget.args.sendFlowId,
-      logContext: 'SendReview',
-    );
+  Future<bool> _scheduleDiscard() {
+    _proposalAbandoned = true;
+    final args = _reviewArgs;
+    return _discardFuture ??=
+        () async {
+          try {
+            await _proposalConsumption;
+          } catch (_) {
+            // A failed creator still needs idempotent proposal cleanup.
+          }
+          return discardSendProposal(
+            proposalId: args.proposalId,
+            sendFlowId: args.sendFlowId,
+            logContext: 'SendReview',
+            syncNotifier: _syncNotifier,
+            accountUuid: args.proposalAccountUuid,
+          );
+        }().then((released) {
+          if (!released) _discardFuture = null;
+          return released;
+        });
   }
 
   void _releasePaymentUriBusySurface({Future<void>? after}) {
@@ -126,42 +153,72 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   }
 
   Future<void> _handleSend() async {
+    if (_reviewRecoveryFailed) {
+      await _cancelKeystoneSigning();
+      return;
+    }
+    if (_cancelling || _proposalAbandoned) return;
     final isHardware = ref
         .read(accountProvider.notifier)
-        .isHardwareAccount(widget.args.proposalAccountUuid);
+        .isHardwareAccount(_reviewArgs.proposalAccountUuid);
     if (isHardware) {
       _showKeystoneSigningModal();
       return;
     }
 
-    ref.read(sendStatusRoutePayloadProvider.notifier).retain(widget.args);
+    ref.read(sendStatusRoutePayloadProvider.notifier).retain(_reviewArgs);
     _releasePaymentUriBusySurface();
     await context.push(
-      sendStatusRouteLocation(widget.args.sendFlowId),
-      extra: widget.args,
+      sendStatusRouteLocation(_reviewArgs.sendFlowId),
+      extra: _reviewArgs,
     );
   }
 
-  void _handleCancel() {
-    unawaited(_scheduleDiscard());
+  Future<void> _leaveReview(VoidCallback navigate) async {
+    if (_cancelling) return;
+    setState(() => _cancelling = true);
+    final released = await _scheduleDiscard();
     if (!mounted) return;
-    context.go(
-      widget.args.flowKind == SendFlowKind.donation ? '/donation' : '/send',
-    );
-  }
-
-  void _handleDonationBack() {
-    _scheduleDiscard();
-    if (!mounted) return;
-    if (context.canPop()) {
-      context.pop();
-    } else {
-      context.go('/donation');
+    if (released) {
+      navigate();
+      return;
     }
+    const error = 'Could not finish cancelling. Please try again.';
+    setState(() {
+      _cancelling = false;
+      if (_keystonePhase != null) {
+        _keystonePhase = KeystoneSigningModalPhase.failed;
+        _keystoneError = error;
+      }
+    });
+    showAppToast(
+      context,
+      error,
+      iconName: AppIcons.warningCircle,
+      tone: AppToastTone.destructive,
+    );
   }
+
+  void _handleCancel() => unawaited(
+    _leaveReview(
+      () => context.go(
+        _reviewArgs.flowKind == SendFlowKind.donation ? '/donation' : '/send',
+      ),
+    ),
+  );
+
+  Future<void> _handleDonationBack() => _keystonePhase != null
+      ? _cancelKeystoneSigning()
+      : _leaveReview(() {
+          if (context.canPop()) {
+            context.pop();
+          } else {
+            context.go('/donation');
+          }
+        });
 
   void _showKeystoneSigningModal() {
-    if (_keystonePhase != null) return;
+    if (_keystonePhase != null || _proposalAbandoned) return;
     setState(() {
       _keystonePhase = KeystoneSigningModalPhase.preparing;
       _keystoneError = null;
@@ -173,7 +230,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
       _keystoneRound = 0;
       _keystoneSaplingParams = null;
     });
-    unawaited(_prepareKeystonePczt());
+    unawaited(_prepareKeystonePczt(++_signingGeneration));
   }
 
   Future<bool> _showDownloadPrompt() {
@@ -203,13 +260,18 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     completer.complete(confirmed);
   }
 
-  Future<void> _prepareKeystonePczt() async {
+  Future<void> _prepareKeystonePczt(int generation) async {
+    bool isCurrent() =>
+        mounted && !_proposalAbandoned && generation == _signingGeneration;
+    final args = _reviewArgs;
     try {
       final dbPath = await getWalletDbPath();
+      if (!isCurrent()) return;
       final endpoint = ref.read(rpcEndpointProvider);
       final saplingParams = await loadSaplingParamsStatus();
+      if (!isCurrent()) return;
 
-      if (widget.args.needsSaplingParams && !saplingParams.complete) {
+      if (args.needsSaplingParams && !saplingParams.complete) {
         final confirmed = await _showDownloadPrompt();
         if (!confirmed) {
           unawaited(_scheduleDiscard());
@@ -228,35 +290,40 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
         );
       }
 
-      if (!mounted) return;
+      if (!isCurrent()) return;
       final currentSaplingParams = await loadSaplingParamsStatus();
+      if (!isCurrent()) return;
       _keystoneSaplingParams = currentSaplingParams;
 
-      final texPczts = widget.args.addressType == 'tex'
-          ? await rust_sync.createTexPcztsFromProposal(
+      final texFuture = args.addressType == 'tex'
+          ? rust_sync.createTexPcztsFromProposal(
               dbPath: dbPath,
               lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
               network: endpoint.networkName,
-              proposalId: widget.args.proposalId,
-              sendFlowId: widget.args.sendFlowId,
+              proposalId: args.proposalId,
+              sendFlowId: args.sendFlowId,
             )
           : null;
-      final pczts =
-          texPczts?.pczts ??
-          [
-            await rust_sync.createPcztFromProposal(
+      _proposalConsumption = texFuture;
+      final texPczts = await texFuture;
+      if (!isCurrent()) return;
+      final pcztFuture = texPczts == null
+          ? rust_sync.createPcztFromProposal(
               dbPath: dbPath,
               lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
               network: endpoint.networkName,
-              proposalId: widget.args.proposalId,
-              sendFlowId: widget.args.sendFlowId,
-            ),
-          ];
+              proposalId: args.proposalId,
+              sendFlowId: args.sendFlowId,
+            )
+          : null;
+      if (pcztFuture != null) _proposalConsumption = pcztFuture;
+      final pczts = texPczts?.pczts ?? [await pcztFuture!];
+      if (!isCurrent()) return;
       final urPartsByRound = <List<String>>[];
       final batchRequestsByRound = <KeystoneBatchSigningRequest?>[];
       final signerPczts = texPczts?.signerPczts;
       for (var index = 0; index < pczts.length; index++) {
-        if (widget.args.addressType == 'tex') {
+        if (args.addressType == 'tex') {
           final redacted = signerPczts![index];
           urPartsByRound.add(
             await rust_keystone.encodePcztUrParts(
@@ -267,8 +334,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
           batchRequestsByRound.add(null);
         } else {
           final request = await buildKeystoneBatchSigningRequest(
-            requestId:
-                'vizor-send-${widget.args.sendFlowId}-transaction-${index + 1}',
+            requestId: 'vizor-send-${args.sendFlowId}-transaction-${index + 1}',
             pczts: [
               KeystoneBatchPcztSource(
                 id: 'send-transaction-${index + 1}',
@@ -281,7 +347,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
         }
       }
 
-      if (!mounted) return;
+      if (!isCurrent()) return;
       setState(() {
         _keystonePhase = KeystoneSigningModalPhase.ready;
         _keystoneUrPartsByRound = urPartsByRound;
@@ -294,22 +360,23 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
         proofs.add(
           await rust_sync.addProofsToPczt(
             pcztBytes: pczt,
-            spendParamsPath: widget.args.needsSaplingParams
+            spendParamsPath: args.needsSaplingParams
                 ? currentSaplingParams.spendPath
                 : null,
-            outputParamsPath: widget.args.needsSaplingParams
+            outputParamsPath: args.needsSaplingParams
                 ? currentSaplingParams.outputPath
                 : null,
           ),
         );
       }
 
-      if (!mounted) return;
+      if (!isCurrent()) return;
       setState(() {
         _keystonePcztsWithProofs = proofs;
       });
     } catch (e, st) {
       log('SendReview._prepareKeystonePczt: ERROR: $e\n$st');
+      if (!isCurrent()) return;
       unawaited(_scheduleDiscard());
       if (!mounted) return;
       setState(() {
@@ -334,16 +401,76 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   }
 
   Future<void> _cancelKeystoneSigning() async {
-    unawaited(_scheduleDiscard());
+    if (_cancelling) return;
+    setState(() {
+      _cancelling = true;
+      _proposalAbandoned = true;
+      _reviewRecoveryFailed = false;
+      _signingGeneration++;
+    });
+    final released = await _scheduleDiscard();
     if (!mounted) return;
-    context.go(
-      widget.args.flowKind == SendFlowKind.donation ? '/donation' : '/send',
-    );
+    if (!released) {
+      setState(() {
+        _cancelling = false;
+        _keystonePhase = KeystoneSigningModalPhase.failed;
+        _keystoneError = 'Could not finish cancelling. Please try again.';
+      });
+      return;
+    }
+    setState(() => _keystonePhase = null);
+    final previous = _reviewArgs;
+    try {
+      final refreshed = await proposeSendTransfer(
+        ref: ref,
+        accountUuid: previous.proposalAccountUuid,
+        sendFlowId: previous.sendFlowId,
+        address: previous.address,
+        addressType: previous.addressType,
+        amountZatoshi: previous.amountZatoshi,
+        memo: previous.memo,
+        isPaymentRequest: previous.isPaymentRequest,
+        requestedBy: previous.requestedBy,
+        requestedAmountZatoshi: previous.requestedAmountZatoshi,
+        flowKind: previous.flowKind,
+      );
+      if (!mounted) {
+        await discardSendProposal(
+          proposalId: refreshed.proposalId,
+          sendFlowId: refreshed.sendFlowId,
+          accountUuid: refreshed.proposalAccountUuid,
+          syncNotifier: _syncNotifier,
+          logContext: 'SendReview(cancelled recovery)',
+        );
+        return;
+      }
+      setState(() {
+        _reviewArgs = refreshed;
+        _discardFuture = null;
+        _proposalConsumption = null;
+        _proposalAbandoned = false;
+        _cancelling = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _cancelling = false;
+        _reviewRecoveryFailed = true;
+      });
+      showAppToast(
+        context,
+        friendlyProposeSendError(error.toString()),
+        iconName: AppIcons.warningCircle,
+        tone: AppToastTone.destructive,
+      );
+    }
   }
 
   Future<void> _getKeystoneSignature() async {
+    final generation = _signingGeneration;
     final saplingParams = _keystoneSaplingParams;
-    if (_keystonePhase != KeystoneSigningModalPhase.ready ||
+    if (_proposalAbandoned ||
+        _keystonePhase != KeystoneSigningModalPhase.ready ||
         _keystonePcztsWithProofs.isEmpty ||
         saplingParams == null) {
       return;
@@ -354,14 +481,19 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
       extra: _keystoneBatchRequestsByRound[_keystoneRound] == null
           ? KeystoneSendScanArgs(
               suppressSidebarSelection:
-                  widget.args.flowKind == SendFlowKind.donation,
+                  _reviewArgs.flowKind == SendFlowKind.donation,
             )
           : KeystoneSendScanArgs.batch(
               suppressSidebarSelection:
-                  widget.args.flowKind == SendFlowKind.donation,
+                  _reviewArgs.flowKind == SendFlowKind.donation,
             ),
     );
-    if (response == null || !mounted) return;
+    if (response == null ||
+        !mounted ||
+        _proposalAbandoned ||
+        generation != _signingGeneration) {
+      return;
+    }
     try {
       final batchRequest = _keystoneBatchRequestsByRound[_keystoneRound];
       if (batchRequest == null) {
@@ -369,10 +501,13 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
       } else {
         _keystoneSignatures.addAll(await batchRequest.decodeResponse(response));
       }
-      if (mounted) setState(() => _keystoneError = null);
+      if (!mounted || _proposalAbandoned || generation != _signingGeneration) {
+        return;
+      }
+      setState(() => _keystoneError = null);
     } catch (e, st) {
       log('SendReview._getKeystoneSignature: ERROR: $e\n$st');
-      if (!mounted) return;
+      if (!mounted || generation != _signingGeneration) return;
       setState(() {
         _keystoneError =
             'This QR code does not match the current Keystone signing request.';
@@ -391,13 +526,13 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     _handoffToKeystone = true;
     _releasePaymentUriBusySurface();
     final statusArgs = KeystoneBroadcastArgs(
-      reviewArgs: widget.args,
+      reviewArgs: _reviewArgs,
       pcztWithProofs: _keystonePcztsWithProofs,
       pcztWithSignatures: List<List<int>>.of(_keystoneSignatures),
     );
     ref.read(sendStatusRoutePayloadProvider.notifier).retain(statusArgs);
     context.go(
-      sendStatusRouteLocation(widget.args.sendFlowId),
+      sendStatusRouteLocation(_reviewArgs.sendFlowId),
       extra: statusArgs,
     );
   }
@@ -406,7 +541,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   Widget build(BuildContext context) {
     final isHardware = ref
         .read(accountProvider.notifier)
-        .isHardwareAccount(widget.args.proposalAccountUuid);
+        .isHardwareAccount(_reviewArgs.proposalAccountUuid);
     final keystonePhase = _keystonePhase;
     final addressBookContacts =
         ref.watch(addressBookProvider).value?.contacts ??
@@ -416,130 +551,169 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
         const <String, AccountInfo>{};
     final recipient = sendReviewRecipientFor(
       contacts: addressBookContacts,
-      address: widget.args.address,
+      address: _reviewArgs.address,
       ownAccounts: ownAccounts,
     );
     final zecUsdUnitPrice = ref.watch(zecHomeUsdUnitPriceProvider);
-    final memo = widget.args.memo;
+    final memo = _reviewArgs.memo;
     // Present means non-empty, not non-blank: an edited request whose memo is
     // only whitespace still sends that memo, so the row has to say so rather
     // than omit a memo the transaction carries.
     final hasMemo = memo != null && memo.isNotEmpty;
-    final requestedAmountZatoshi = widget.args.differingRequestedAmountZatoshi;
+    final requestedAmountZatoshi = _reviewArgs.differingRequestedAmountZatoshi;
+    final backTarget = AppBackResolver.resolve(context);
 
-    return AppDesktopShell(
-      sidebar: AppMainSidebar(
-        suppressActiveSelection: widget.args.flowKind == SendFlowKind.donation,
-      ),
-      pane: AppDesktopPane(
-        padding: EdgeInsets.zero,
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            AppPaneScrollScaffold(
-              toolbar: AppPaneToolbar(
-                leading: widget.args.flowKind == SendFlowKind.donation
-                    ? AppBackLink(
-                        label: 'Support Vizor',
-                        minWidth: 60,
-                        onTap: _handleDonationBack,
+    return PopScope<Object?>(
+      canPop: keystonePhase == null && !_cancelling,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop && keystonePhase != null) {
+          unawaited(_cancelKeystoneSigning());
+        }
+      },
+      child: AppDesktopShell(
+        sidebar: AppMainSidebar(
+          suppressActiveSelection:
+              _reviewArgs.flowKind == SendFlowKind.donation,
+        ),
+        pane: AppDesktopPane(
+          padding: EdgeInsets.zero,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              AppPaneScrollScaffold(
+                toolbar: AppPaneToolbar(
+                  leading: _reviewArgs.flowKind == SendFlowKind.donation
+                      ? AppBackLink(
+                          label: 'Support Vizor',
+                          minWidth: 60,
+                          onTap: _handleDonationBack,
+                        )
+                      : AppBackLink(
+                          label: backTarget.label,
+                          minWidth: 60,
+                          onTap: () => keystonePhase != null
+                              ? _cancelKeystoneSigning()
+                              : _leaveReview(
+                                  () => backTarget.navigate(context),
+                                ),
+                        ),
+                  backLinkMinWidth: 60,
+                ),
+                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+                child: _reviewArgs.flowKind == SendFlowKind.donation
+                    ? DonationReviewContentView(
+                        amountText: _formatAmount(_reviewArgs.amountZatoshi),
+                        fiatText: fiatTextForZatoshi(
+                          _reviewArgs.amountZatoshi,
+                          zecUsdUnitPrice: zecUsdUnitPrice,
+                        ),
+                        feeText: _formatFee(_reviewArgs.feeZatoshi),
+                        confirmLabel: _reviewRecoveryFailed
+                            ? 'Retry'
+                            : _cancelling
+                            ? 'Cancelling…'
+                            : isHardware
+                            ? 'Confirm with Keystone'
+                            : 'Confirm donation',
+                        confirmIcon: isHardware
+                            ? AppIcons.qr
+                            : AppIcons.donation,
+                        onConfirm:
+                            _cancelling ||
+                                (_proposalAbandoned && !_reviewRecoveryFailed)
+                            ? null
+                            : () => unawaited(_handleSend()),
                       )
-                    : null,
-                onBeforeNavigate: _scheduleDiscard,
-                backLinkMinWidth: 60,
-              ),
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
-              child: widget.args.flowKind == SendFlowKind.donation
-                  ? DonationReviewContentView(
-                      amountText: _formatAmount(widget.args.amountZatoshi),
-                      fiatText: fiatTextForZatoshi(
-                        widget.args.amountZatoshi,
-                        zecUsdUnitPrice: zecUsdUnitPrice,
+                    : SendReviewContentView(
+                        isPaymentRequest: _reviewArgs.isPaymentRequest,
+                        requestedAmountText: requestedAmountZatoshi == null
+                            ? null
+                            : _formatAmount(requestedAmountZatoshi),
+                        amountText: _formatAmount(_reviewArgs.amountZatoshi),
+                        fiatText: fiatTextForZatoshi(
+                          _reviewArgs.amountZatoshi,
+                          zecUsdUnitPrice: zecUsdUnitPrice,
+                        ),
+                        recipient: recipient,
+                        feeText: _formatFee(_reviewArgs.feeZatoshi),
+                        isShieldedRecipient: _reviewArgs.isShielded,
+                        recipientAddressType: _reviewArgs.addressType,
+                        memoText: hasMemo ? memo : null,
+                        memoExpanded: _messageExpanded,
+                        confirmLabel: _reviewRecoveryFailed
+                            ? 'Retry'
+                            : _cancelling
+                            ? 'Cancelling…'
+                            : isHardware
+                            ? 'Confirm with Keystone'
+                            : 'Confirm & send',
+                        confirmLeadingIconName: isHardware
+                            ? AppIcons.qr
+                            : AppIcons.plane,
+                        onConfirm:
+                            _cancelling ||
+                                (_proposalAbandoned && !_reviewRecoveryFailed)
+                            ? null
+                            : () => unawaited(_handleSend()),
+                        onCancel: _cancelling ? null : _handleCancel,
+                        onShowFullAddress: () =>
+                            setState(() => _showVerifyAddress = true),
+                        onExpandMemo: _toggleMessageExpanded,
                       ),
-                      feeText: _formatFee(widget.args.feeZatoshi),
-                      confirmLabel: isHardware
-                          ? 'Confirm with Keystone'
-                          : 'Confirm donation',
-                      confirmIcon: isHardware ? AppIcons.qr : AppIcons.donation,
-                      onConfirm: () => unawaited(_handleSend()),
-                    )
-                  : SendReviewContentView(
-                      isPaymentRequest: widget.args.isPaymentRequest,
-                      requestedAmountText: requestedAmountZatoshi == null
+              ),
+              if (_showVerifyAddress && keystonePhase == null)
+                SendVerifyAddressOverlay(
+                  accountUuid: _reviewArgs.proposalAccountUuid,
+                  address: _reviewArgs.address.trim(),
+                  isShieldedAddress: _reviewArgs.isShielded,
+                  onClose: () => setState(() => _showVerifyAddress = false),
+                ),
+              // The review's outer hold protects its proposal inputs. This
+              // nested hold protects the live QR as well, so the latch cannot
+              // briefly open while signing subtrees change.
+              if (keystonePhase != null)
+                PaymentUriBusySurfaceHold(
+                  child: AppPaneModalOverlay(
+                    onDismiss: () => unawaited(_cancelKeystoneSigning()),
+                    child: KeystoneSigningModal(
+                      phase: keystonePhase,
+                      urParts: _keystoneUrParts,
+                      error: _keystoneError,
+                      title: 'Confirm with Keystone',
+                      subtitle: _keystoneUrPartsByRound.length == 2
+                          ? 'Transaction ${_keystoneRound + 1} of 2'
+                          : 'Scan with your Keystone',
+                      instruction:
+                          _keystoneError ??
+                          (_keystonePcztsWithProofs.isEmpty
+                              ? 'Scan now. Signature import unlocks after proofs are ready.'
+                              : 'After you scanned, click Get signature.'),
+                      primaryLabel: _keystonePcztsWithProofs.isEmpty
+                          ? 'Preparing'
+                          : 'Get signature',
+                      onPrimary:
+                          !_proposalAbandoned &&
+                              keystonePhase ==
+                                  KeystoneSigningModalPhase.ready &&
+                              _keystonePcztsWithProofs.isNotEmpty
+                          ? () => unawaited(_getKeystoneSignature())
+                          : null,
+                      secondaryLabel: _cancelling ? 'Cancelling…' : 'Cancel',
+                      onSecondary: _cancelling
                           ? null
-                          : _formatAmount(requestedAmountZatoshi),
-                      amountText: _formatAmount(widget.args.amountZatoshi),
-                      fiatText: fiatTextForZatoshi(
-                        widget.args.amountZatoshi,
-                        zecUsdUnitPrice: zecUsdUnitPrice,
-                      ),
-                      recipient: recipient,
-                      feeText: _formatFee(widget.args.feeZatoshi),
-                      isShieldedRecipient: widget.args.isShielded,
-                      recipientAddressType: widget.args.addressType,
-                      memoText: hasMemo ? memo : null,
-                      memoExpanded: _messageExpanded,
-                      confirmLabel: isHardware
-                          ? 'Confirm with Keystone'
-                          : 'Confirm & send',
-                      confirmLeadingIconName: isHardware
-                          ? AppIcons.qr
-                          : AppIcons.plane,
-                      onConfirm: () => unawaited(_handleSend()),
-                      onCancel: _handleCancel,
-                      onShowFullAddress: () =>
-                          setState(() => _showVerifyAddress = true),
-                      onExpandMemo: _toggleMessageExpanded,
+                          : () => unawaited(_cancelKeystoneSigning()),
                     ),
-            ),
-            if (_showVerifyAddress && keystonePhase == null)
-              SendVerifyAddressOverlay(
-                accountUuid: widget.args.proposalAccountUuid,
-                address: widget.args.address.trim(),
-                isShieldedAddress: widget.args.isShielded,
-                onClose: () => setState(() => _showVerifyAddress = false),
-              ),
-            // The review's outer hold protects its proposal inputs. This
-            // nested hold protects the live QR as well, so the latch cannot
-            // briefly open while signing subtrees change.
-            if (keystonePhase != null)
-              PaymentUriBusySurfaceHold(
-                child: AppPaneModalOverlay(
-                  onDismiss: () => unawaited(_cancelKeystoneSigning()),
-                  child: KeystoneSigningModal(
-                    phase: keystonePhase,
-                    urParts: _keystoneUrParts,
-                    error: _keystoneError,
-                    title: 'Confirm with Keystone',
-                    subtitle: _keystoneUrPartsByRound.length == 2
-                        ? 'Transaction ${_keystoneRound + 1} of 2'
-                        : 'Scan with your Keystone',
-                    instruction:
-                        _keystoneError ??
-                        (_keystonePcztsWithProofs.isEmpty
-                            ? 'Scan now. Signature import unlocks after proofs are ready.'
-                            : 'After you scanned, click Get signature.'),
-                    primaryLabel: _keystonePcztsWithProofs.isEmpty
-                        ? 'Preparing'
-                        : 'Get signature',
-                    onPrimary:
-                        keystonePhase == KeystoneSigningModalPhase.ready &&
-                            _keystonePcztsWithProofs.isNotEmpty
-                        ? () => unawaited(_getKeystoneSignature())
-                        : null,
-                    secondaryLabel: 'Cancel',
-                    onSecondary: () => unawaited(_cancelKeystoneSigning()),
                   ),
                 ),
-              ),
-            if (_showSaplingParamsPrompt)
-              Positioned.fill(
-                child: SaplingParamsPrompt(
-                  onDownload: () => _resolveSaplingParamsDialog(true),
-                  onCancel: () => _resolveSaplingParamsDialog(false),
+              if (_showSaplingParamsPrompt)
+                Positioned.fill(
+                  child: SaplingParamsPrompt(
+                    onDownload: () => _resolveSaplingParamsDialog(true),
+                    onCancel: () => _resolveSaplingParamsDialog(false),
+                  ),
                 ),
-              ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -934,6 +934,8 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   }
 
   Future<void> _openReview() async {
+    final syncNotifier = ref.read(syncProvider.notifier);
+    final proposalAccountUuid = widget.activeAccountUuid;
     setState(() {
       _isSending = true;
       _error = null;
@@ -1038,6 +1040,8 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
           proposalId: activeProposalId,
           sendFlowId: _sendFlowId,
           logContext: 'Send(review not opened)',
+          syncNotifier: syncNotifier,
+          accountUuid: proposalAccountUuid!,
         );
       }
     }

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../providers/sync_provider.dart';
 
 import '../../../core/config/zcash_explorer.dart';
 import '../../../core/formatting/address_display.dart';
@@ -86,6 +87,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   /// Captured in [initState] so [dispose] can release the flag without reading
   /// from `ref` after the element is gone.
   late final SendStatusTerminalNotifier _sendStatusTerminal;
+  late final SyncNotifier _syncNotifier;
   bool get _suppressSidebarSelection =>
       widget.args.flowKind == SendFlowKind.donation;
 
@@ -93,6 +95,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   void initState() {
     super.initState();
     _sendStatusTerminal = ref.read(sendStatusTerminalProvider.notifier);
+    _syncNotifier = ref.read(syncProvider.notifier);
     _proposalConsumed = widget.keystone != null;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -123,6 +126,8 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
           : _proposalRelease,
       // Idempotent in Rust, so no gate on the (optimistic) consumed flag.
       retryRelease: () => discardSendProposal(
+        syncNotifier: _syncNotifier,
+        accountUuid: widget.args.proposalAccountUuid,
         proposalId: widget.args.proposalId,
         sendFlowId: widget.args.sendFlowId,
         logContext: 'SendStatus(retry)',
@@ -140,6 +145,8 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   Future<bool> _discardProposalIfNeeded(String logContext) {
     if (_proposalConsumed) return Future<bool>.value(true);
     return _proposalRelease ??= discardSendProposal(
+      syncNotifier: _syncNotifier,
+      accountUuid: widget.args.proposalAccountUuid,
       proposalId: widget.args.proposalId,
       sendFlowId: widget.args.sendFlowId,
       logContext: logContext,

--- a/lib/src/features/send/services/payment_request_precheck.dart
+++ b/lib/src/features/send/services/payment_request_precheck.dart
@@ -79,12 +79,13 @@ typedef PaymentRequestSpendableIsAuthoritativeNow = bool Function();
 typedef PaymentRequestSpendableBalanceNow = BigInt Function();
 
 /// Releases a proposal. Matches [discardSendProposal].
-/// Returns whether Rust confirmed the release (`discardSendProposal`).
+/// Returns whether release and the owning account's balance refresh completed.
 typedef PaymentRequestDiscardProposal =
     Future<bool> Function({
       required BigInt proposalId,
       required String sendFlowId,
       required String logContext,
+      required String accountUuid,
     });
 
 /// A proposal the card is holding on the user's behalf.
@@ -129,6 +130,7 @@ class PaymentRequestProposalHandle {
         proposalId: reviewArgs.proposalId,
         sendFlowId: reviewArgs.sendFlowId,
         logContext: logContext,
+        accountUuid: reviewArgs.proposalAccountUuid,
       );
       _discardConfirmed = released;
       _discardInFlight = null;
@@ -429,12 +431,25 @@ BigInt paymentRequestSpendableOf(
 
 /// The live pre-check, wired to Rust and the send pipeline.
 final paymentRequestPrecheckProvider = Provider<PaymentRequestPrecheck>((ref) {
+  final syncNotifier = ref.read(syncProvider.notifier);
   return PaymentRequestPrecheck(
     validateAddress: rust_sync.validateAddress,
     // The same endpoint the proposal below is made against, so a link can
     // never be refused for a network the wallet is not on.
     readNetworkName: () => ref.read(rpcEndpointProvider).networkName,
-    discardProposal: discardSendProposal,
+    discardProposal:
+        ({
+          required BigInt proposalId,
+          required String sendFlowId,
+          required String logContext,
+          required String accountUuid,
+        }) => discardSendProposal(
+          proposalId: proposalId,
+          sendFlowId: sendFlowId,
+          logContext: logContext,
+          accountUuid: accountUuid,
+          syncNotifier: syncNotifier,
+        ),
     // The same predicate the card's own read and its sync watch use, scoped
     // to the active account: an unscoped read answers with the wallet-wide
     // sync fields of a state that may hold no balance for this account.

--- a/lib/src/features/send/services/send_flow.dart
+++ b/lib/src/features/send/services/send_flow.dart
@@ -411,16 +411,19 @@ Duration debugUnconfirmedReleaseGrace = const Duration(seconds: 3);
 
 /// Idempotent proposal release for every non-consuming exit path.
 ///
-/// Returns whether Rust confirmed the release. Never throws: a release that
-/// still fails after its retries is logged and left to height-based expiry,
-/// and the caller that needs to know (the terminal flag's departure edge) reads
-/// the result instead of catching.
+/// Returns true only after Rust confirmed release and the account's balance
+/// was reconciled. Never throws. A false result can be retried idempotently;
+/// it must not enable signing the old proposal or proposing a replacement.
+/// Capture [syncNotifier] before leaving a widget so disposal never reads ref.
 Future<bool> discardSendProposal({
   required BigInt proposalId,
   required String sendFlowId,
   required String logContext,
+  required SyncNotifier syncNotifier,
+  required String accountUuid,
 }) async {
   Object? lastError;
+  var released = false;
   for (var attempt = 1; attempt <= 3; attempt++) {
     try {
       await rust_sync.discardProposal(
@@ -428,13 +431,23 @@ Future<bool> discardSendProposal({
         sendFlowId: sendFlowId,
       );
       log('$logContext: released proposal $proposalId');
-      return true;
+      released = true;
+      break;
     } catch (e) {
       lastError = e;
       log('$logContext: discardProposal cleanup attempt $attempt failed: $e');
       if (attempt < 3) {
         await Future<void>.delayed(Duration(milliseconds: attempt * 100));
       }
+    }
+  }
+  if (released) {
+    try {
+      await syncNotifier.refreshAfterProposalRelease(accountUuid);
+      return true;
+    } catch (e) {
+      log('$logContext: proposal released but balance refresh failed: $e');
+      return false;
     }
   }
   // Rust keeps the owner token when unlock fails, so another idempotent
@@ -635,6 +648,7 @@ Future<SendBroadcastOutcome> runSendBroadcast({
 }) async {
   var proposalConsumed = keystone != null;
   var proposalReleased = false;
+  final syncNotifier = ref.read(syncProvider.notifier);
 
   Future<bool> abortRequested() async {
     if (shouldAbort == null) return false;
@@ -646,6 +660,8 @@ Future<SendBroadcastOutcome> runSendBroadcast({
         proposalId: args.proposalId,
         sendFlowId: args.sendFlowId,
         logContext: 'SendBroadcast(abort)',
+        syncNotifier: syncNotifier,
+        accountUuid: args.proposalAccountUuid,
       );
       proposalReleased = true;
     }
@@ -673,6 +689,8 @@ Future<SendBroadcastOutcome> runSendBroadcast({
               proposalId: args.proposalId,
               sendFlowId: args.sendFlowId,
               logContext: 'SendBroadcast(params-declined)',
+              syncNotifier: syncNotifier,
+              accountUuid: args.proposalAccountUuid,
             );
             proposalReleased = true;
           }
@@ -884,6 +902,8 @@ Future<SendBroadcastOutcome> runSendBroadcast({
         proposalId: args.proposalId,
         sendFlowId: args.sendFlowId,
         logContext: 'SendBroadcast(pre-broadcast-failure)',
+        syncNotifier: syncNotifier,
+        accountUuid: args.proposalAccountUuid,
       );
       proposalReleased = true;
     }

--- a/lib/src/features/swap/providers/swap_hardware_signing_service.dart
+++ b/lib/src/features/swap/providers/swap_hardware_signing_service.dart
@@ -9,6 +9,7 @@ import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../keystone/services/keystone_batch_signing.dart';
+import '../../send/services/send_flow.dart';
 import '../models/swap_models.dart';
 
 final swapHardwareSigningServiceProvider = Provider<SwapHardwareSigningService>(
@@ -52,6 +53,7 @@ abstract interface class SwapHardwareSigningService {
 
 class SwapHardwarePcztDraft {
   const SwapHardwarePcztDraft({
+    required this.accountUuid,
     required this.pcztBytes,
     required this.needsSaplingParams,
     required this.feeZatoshi,
@@ -60,6 +62,7 @@ class SwapHardwarePcztDraft {
   });
 
   final List<int> pcztBytes;
+  final String accountUuid;
   final bool needsSaplingParams;
   final BigInt feeZatoshi;
   final BigInt proposalId;
@@ -129,6 +132,7 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
                 'needsSapling=${proposal.needsSaplingParams}',
               );
               return SwapHardwarePcztDraft(
+                accountUuid: accountUuid,
                 pcztBytes: pcztBytes,
                 needsSaplingParams: proposal.needsSaplingParams,
                 feeZatoshi: proposal.feeZatoshi,
@@ -212,34 +216,16 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
 
   @override
   Future<void> discardPcztDraft({required SwapHardwarePcztDraft draft}) async {
-    Object? lastError;
-    for (var attempt = 1; attempt <= 3; attempt++) {
-      try {
-        await rust_sync.discardProposal(
-          proposalId: draft.proposalId,
-          sendFlowId: draft.sendFlowId,
-        );
-        log(
-          'SwapHardwareSigning: released deposit proposal '
-          'flow=${draft.sendFlowId} proposal=${draft.proposalId}',
-        );
-        return;
-      } catch (e) {
-        lastError = e;
-        log(
-          'SwapHardwareSigning: discard deposit proposal attempt $attempt '
-          'failed flow=${draft.sendFlowId} proposal=${draft.proposalId} '
-          'error=$e',
-        );
-        if (attempt < 3) {
-          await Future<void>.delayed(Duration(milliseconds: attempt * 100));
-        }
-      }
-    }
-    log(
-      'SwapHardwareSigning: deposit proposal cleanup remains pending '
-      'flow=${draft.sendFlowId} proposal=${draft.proposalId} error=$lastError',
+    final released = await discardSendProposal(
+      proposalId: draft.proposalId,
+      sendFlowId: draft.sendFlowId,
+      accountUuid: draft.accountUuid,
+      syncNotifier: _ref.read(syncProvider.notifier),
+      logContext: 'SwapHardwareSigning',
     );
+    if (!released) {
+      throw StateError('Could not finish cancelling. Please try again.');
+    }
   }
 
   @override

--- a/lib/src/features/swap/screens/mobile/mobile_swap_keystone_sign_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_keystone_sign_screen.dart
@@ -8,6 +8,8 @@ import 'package:go_router/go_router.dart';
 import '../../../../../main.dart' show log;
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/navigation/payment_uri_busy_surface_hold.dart';
+import '../../../../core/widgets/app_toast.dart';
+import '../../../../core/widgets/app_icon.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../keystone/services/keystone_batch_signing.dart';
 import '../../../keystone/widgets/mobile_keystone_pczt_signing_flow.dart';
@@ -80,37 +82,49 @@ class _MobileSwapKeystoneSignScreenState
     with PaymentUriBusySurfaceHoldMixin {
   SwapHardwareSigningService? _signingService;
   SwapHardwarePcztDraft? _draft;
+  Future<SwapHardwarePcztDraft>? _draftCreation;
+  Future<void>? _discardFuture;
   SaplingParamsStatus? _saplingParams;
 
   @override
   void dispose() {
-    unawaited(_discardDraft());
+    unawaited(
+      _discardDraft().catchError((Object e) {
+        log('MobileSwapKeystoneSign: cleanup failed: $e');
+      }),
+    );
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return MobileKeystonePcztSigningFlow(
-      title: 'Sign ZEC deposit',
-      failedTitle: 'Keystone signing failed',
-      description:
-          'Use your Keystone wallet to scan this transaction QR code. '
-          'Follow the steps on your device.',
-      preparePczt: _preparePczt,
-      onSigned: _handleSignedPczt,
-      friendlyError: _friendlyError,
-      onCancel: _handleCancel,
-      signedPcztDecoder: widget.signedPcztDecoder ?? _decodeSigningResponse,
-      expectedSignedUrType: 'zcash-batch-sig-result',
-      unexpectedUrMessage:
-          'Open the signature result QR on Keystone, then scan again.',
-      scannerBuilder: widget.scannerBuilder,
-      forceScannerActiveForTesting: widget.forceScannerActiveForTesting,
-      keyPrefix: 'mobile_swap_keystone_sign',
-      scanCaption:
-          'Scan the QR code on your Keystone to finish the ZEC deposit',
-      finalizingSignatureLabel: 'Broadcasting ZEC deposit...',
-      logTag: 'MobileSwapKeystoneSign',
+    return PopScope<void>(
+      canPop: false,
+      child: AbsorbPointer(
+        absorbing: _cancelling,
+        child: MobileKeystonePcztSigningFlow(
+          title: _cancelling ? 'Cancelling…' : 'Sign ZEC deposit',
+          failedTitle: 'Keystone signing failed',
+          description:
+              'Use your Keystone wallet to scan this transaction QR code. '
+              'Follow the steps on your device.',
+          preparePczt: _preparePczt,
+          onSigned: _handleSignedPczt,
+          friendlyError: _friendlyError,
+          onCancel: _handleCancel,
+          signedPcztDecoder: widget.signedPcztDecoder ?? _decodeSigningResponse,
+          expectedSignedUrType: 'zcash-batch-sig-result',
+          unexpectedUrMessage:
+              'Open the signature result QR on Keystone, then scan again.',
+          scannerBuilder: widget.scannerBuilder,
+          forceScannerActiveForTesting: widget.forceScannerActiveForTesting,
+          keyPrefix: 'mobile_swap_keystone_sign',
+          scanCaption:
+              'Scan the QR code on your Keystone to finish the ZEC deposit',
+          finalizingSignatureLabel: 'Broadcasting ZEC deposit...',
+          logTag: 'MobileSwapKeystoneSign',
+        ),
+      ),
     );
   }
 
@@ -125,11 +139,17 @@ class _MobileSwapKeystoneSignScreenState
 
     final service = ref.read(swapHardwareSigningServiceProvider);
     _signingService = service;
-    final draft = await service.createZecDepositPczt(
+    final creation = service.createZecDepositPczt(
       accountUuid: accountUuid,
       intent: widget.args.intent,
     );
+    _draftCreation = creation;
+    final draft = await creation;
     _draft = draft;
+    if (!mounted || _cancelled) {
+      await _discardDraft();
+      throw const MobileKeystonePcztSigningAborted();
+    }
 
     try {
       SaplingParamsStatus? saplingParams;
@@ -152,6 +172,9 @@ class _MobileSwapKeystoneSignScreenState
       }
 
       final urParts = await service.encodeSigningUrParts(draft: draft);
+      if (!mounted || _cancelled) {
+        throw const MobileKeystonePcztSigningAborted();
+      }
       _saplingParams = saplingParams;
 
       return MobileKeystonePcztSigningPayload(
@@ -182,6 +205,11 @@ class _MobileSwapKeystoneSignScreenState
   }
 
   Future<Uint8List> _decodeSigningResponse(List<int> responseCbor) async {
+    if (_cancelled) {
+      throw StateError(
+        'Signing was cancelled. Return to the composer to try again.',
+      );
+    }
     final service = _signingService;
     final draft = _draft;
     if (service == null || draft == null) {
@@ -201,6 +229,11 @@ class _MobileSwapKeystoneSignScreenState
     List<int> pcztWithProofs,
     Uint8List signedPczt,
   ) async {
+    if (_cancelled) {
+      throw StateError(
+        'Signing was cancelled. Return to the composer to try again.',
+      );
+    }
     final draft = _draft;
     final saplingParams = _saplingParams;
     if (draft == null || (draft.needsSaplingParams && saplingParams == null)) {
@@ -309,13 +342,31 @@ class _MobileSwapKeystoneSignScreenState
   }
 
   var _cancelling = false;
+  var _cancelled = false;
 
   Future<void> _handleCancel() async {
     if (_cancelling) return;
-    _cancelling = true;
+    setState(() {
+      _cancelling = true;
+      _cancelled = true;
+    });
     // Awaited: the busy hold lifts on dispose, and a parked link must not be
     // pre-checked against inputs the draft's proposal still holds.
-    await _discardDraft();
+    try {
+      await _discardDraft();
+    } catch (e) {
+      if (mounted) setState(() => _cancelling = false);
+      log('MobileSwapKeystoneSign: cancellation failed: $e');
+      if (mounted) {
+        showAppToast(
+          context,
+          'Could not finish cancelling. Please try again.',
+          iconName: AppIcons.warningCircle,
+          tone: AppToastTone.destructive,
+        );
+      }
+      return;
+    }
     if (!mounted) return;
     if (widget.args.startedFromReview) {
       ref
@@ -331,11 +382,22 @@ class _MobileSwapKeystoneSignScreenState
     context.go(widget.args.returnTarget.path);
   }
 
-  Future<void> _discardDraft() async {
+  Future<void> _discardDraft() =>
+      _discardFuture ??= _releaseDraft().catchError((Object error) {
+        _discardFuture = null;
+        throw error;
+      });
+
+  Future<void> _releaseDraft() async {
+    try {
+      await _draftCreation;
+    } catch (_) {
+      // Failed creation owns cleanup of any partial proposal.
+    }
     final draft = _draft;
-    _draft = null;
     if (draft == null) return;
     await _signingService?.discardPcztDraft(draft: draft);
+    _draft = null;
   }
 
   bool _hasBroadcastTxid(rust_sync.ExtractAndBroadcastPcztResult result) {

--- a/lib/src/features/swap/widgets/swap_keystone_signing_overlay.dart
+++ b/lib/src/features/swap/widgets/swap_keystone_signing_overlay.dart
@@ -49,6 +49,10 @@ class _SwapKeystoneSigningOverlayState
   String? _error;
   SwapHardwareSigningService? _signingService;
   SwapHardwarePcztDraft? _draft;
+  Future<SwapHardwarePcztDraft>? _draftCreation;
+  Future<void>? _discardFuture;
+  bool _cancelling = false;
+  bool _cancelled = false;
   List<String> _urParts = const [];
   List<int>? _pcztWithProofs;
   SaplingParamsStatus? _saplingParams;
@@ -69,7 +73,11 @@ class _SwapKeystoneSigningOverlayState
     if (completer != null && !completer.isCompleted) {
       completer.complete(false);
     }
-    unawaited(_discardDraft());
+    unawaited(
+      _discardDraft().catchError((Object e) {
+        log('SwapKeystoneSigning: cleanup failed: $e');
+      }),
+    );
     super.dispose();
   }
 
@@ -82,11 +90,17 @@ class _SwapKeystoneSigningOverlayState
 
       final service = ref.read(swapHardwareSigningServiceProvider);
       _signingService = service;
-      final draft = await service.createZecDepositPczt(
+      final creation = service.createZecDepositPczt(
         accountUuid: accountUuid,
         intent: widget.intent,
       );
+      _draftCreation = creation;
+      final draft = await creation;
       _draft = draft;
+      if (!mounted || _cancelled) {
+        await _discardDraft();
+        return;
+      }
 
       SaplingParamsStatus? saplingParams;
       if (draft.needsSaplingParams) {
@@ -112,6 +126,7 @@ class _SwapKeystoneSigningOverlayState
       }
 
       final urParts = await service.encodeSigningUrParts(draft: draft);
+      if (!mounted || _cancelled) return;
       final pcztWithProofs = await service.addProofsForSigning(
         draft: draft,
         spendParamsPath: draft.needsSaplingParams
@@ -121,7 +136,7 @@ class _SwapKeystoneSigningOverlayState
             ? saplingParams!.outputPath
             : null,
       );
-      if (!mounted) return;
+      if (!mounted || _cancelled) return;
       setState(() {
         _phase = _SwapKeystonePhase.ready;
         _draft = draft;
@@ -131,8 +146,15 @@ class _SwapKeystoneSigningOverlayState
       });
     } catch (e, st) {
       log('SwapKeystoneSigning._preparePczt: ERROR: $e\n$st');
-      await _discardDraft();
-      if (!mounted) return;
+      if (_cancelling) return;
+      if (!mounted) {
+        unawaited(
+          _discardDraft().catchError((Object e) {
+            log('SwapKeystoneSigning: cleanup failed: $e');
+          }),
+        );
+        return;
+      }
       setState(() {
         _phase = _SwapKeystonePhase.failed;
         _error = _friendlyError(e);
@@ -164,13 +186,17 @@ class _SwapKeystoneSigningOverlayState
   }
 
   Future<void> _getSignature() async {
-    if (_phase != _SwapKeystonePhase.ready || _pcztWithProofs == null) return;
+    if (_cancelled ||
+        _phase != _SwapKeystonePhase.ready ||
+        _pcztWithProofs == null) {
+      return;
+    }
     setState(() => _error = null);
     final responseCbor = await context.push<List<int>>(
       '/send/keystone/scan',
       extra: const KeystoneSendScanArgs.batch(),
     );
-    if (responseCbor == null || !mounted) return;
+    if (responseCbor == null || !mounted || _cancelled) return;
     final service = _signingService;
     final draft = _draft;
     if (service == null || draft == null) return;
@@ -179,7 +205,7 @@ class _SwapKeystoneSigningOverlayState
         draft: draft,
         responseCbor: responseCbor,
       );
-      if (!mounted) return;
+      if (!mounted || _cancelled) return;
       await _broadcast(signatures);
     } catch (e, st) {
       log('SwapKeystoneSigning._getSignature: ERROR: $e\n$st');
@@ -271,17 +297,41 @@ class _SwapKeystoneSigningOverlayState
     };
   }
 
-  void _cancel() {
-    if (_phase == _SwapKeystonePhase.broadcasting) return;
-    unawaited(_discardDraft());
-    widget.onCancel();
+  Future<void> _cancel() async {
+    if (_cancelling || _phase == _SwapKeystonePhase.broadcasting) return;
+    setState(() {
+      _cancelling = true;
+      _cancelled = true;
+    });
+    try {
+      await _discardDraft();
+      if (mounted) widget.onCancel();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _cancelling = false;
+        _phase = _SwapKeystonePhase.failed;
+        _error = 'Could not finish cancelling. Please try again.';
+      });
+    }
   }
 
-  Future<void> _discardDraft() async {
+  Future<void> _discardDraft() =>
+      _discardFuture ??= _releaseDraft().catchError((Object error) {
+        _discardFuture = null;
+        throw error;
+      });
+
+  Future<void> _releaseDraft() async {
+    try {
+      await _draftCreation;
+    } catch (_) {
+      // Failed creation owns cleanup of any partial proposal.
+    }
     final draft = _draft;
-    _draft = null;
     if (draft == null) return;
     await _signingService?.discardPcztDraft(draft: draft);
+    _draft = null;
   }
 
   @override
@@ -320,13 +370,17 @@ class _SwapKeystoneSigningOverlayState
                 ? null
                 : 'Get signature',
             onPrimary:
-                _phase == _SwapKeystonePhase.ready && _pcztWithProofs != null
+                !_cancelling &&
+                    _phase == _SwapKeystonePhase.ready &&
+                    _pcztWithProofs != null
                 ? () => unawaited(_getSignature())
                 : null,
-            secondaryLabel: isBroadcasting
+            secondaryLabel: _cancelling
+                ? 'Cancelling…'
+                : isBroadcasting
                 ? null
                 : _phase == _SwapKeystonePhase.failed
-                ? 'Back to activity'
+                ? 'Cancel'
                 : 'Cancel',
             onSecondary: _cancel,
           ),

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -783,6 +783,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   bool _balanceRefreshQueued = false;
   bool _balanceRefreshQueuedReleaseSnapshot = false;
   bool _balanceRefreshQueuedClearRestoredSnapshotIfUnavailable = false;
+  bool _balanceRefreshQueuedRequireAuthoritativeBalance = false;
   Future<void>? _balanceRefreshChain;
 
   @override
@@ -1681,6 +1682,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _balanceRefreshQueued = false;
     _balanceRefreshQueuedReleaseSnapshot = false;
     _balanceRefreshQueuedClearRestoredSnapshotIfUnavailable = false;
+    _balanceRefreshQueuedRequireAuthoritativeBalance = false;
     _lastKnownByAccount.clear();
     state = AsyncData(SyncState());
 
@@ -2343,6 +2345,23 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   Future<void> refreshAfterSend() =>
       _requestBalanceRefresh(releaseSnapshotOnAuthoritativeBalance: true);
 
+  /// Reconcile released inputs before a cancelled send can be retried.
+  /// An outgoing account's locked snapshot must not be restored on switch-back.
+  /// Never publish that account's balance over a different active account.
+  Future<void> refreshAfterProposalRelease(String accountUuid) async {
+    _lastKnownByAccount.remove(accountUuid);
+    if (_requiresUnlock || _getActiveAccountUuid() != accountUuid) return;
+    try {
+      await _requestBalanceRefresh(
+        releaseSnapshotOnAuthoritativeBalance: true,
+        requireAuthoritativeBalance: true,
+      );
+    } finally {
+      // A switch during the read may have cached the outgoing locked state.
+      _lastKnownByAccount.remove(accountUuid);
+    }
+  }
+
   /// Reconciles the account selected by a switch or active-account removal.
   ///
   /// If its balance summary is temporarily unavailable, discard only the
@@ -2370,12 +2389,16 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   Future<void> _requestBalanceRefresh({
     bool releaseSnapshotOnAuthoritativeBalance = false,
     bool clearRestoredSnapshotIfUnavailable = false,
+    bool requireAuthoritativeBalance = false,
   }) {
     if (releaseSnapshotOnAuthoritativeBalance) {
       _balanceRefreshQueuedReleaseSnapshot = true;
     }
     if (clearRestoredSnapshotIfUnavailable) {
       _balanceRefreshQueuedClearRestoredSnapshotIfUnavailable = true;
+    }
+    if (requireAuthoritativeBalance) {
+      _balanceRefreshQueuedRequireAuthoritativeBalance = true;
     }
     if (_balanceRefreshInFlight) {
       _balanceRefreshQueued = true;
@@ -2393,6 +2416,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   Future<void> _runCoalescedBalanceRefresh() async {
     Object? terminalError;
     StackTrace? terminalStackTrace;
+    var requireAuthoritativeBalance = false;
     try {
       do {
         _balanceRefreshQueued = false;
@@ -2401,11 +2425,19 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         final clearRestoredSnapshotIfUnavailable =
             _balanceRefreshQueuedClearRestoredSnapshotIfUnavailable;
         _balanceRefreshQueuedClearRestoredSnapshotIfUnavailable = false;
+        // Keep this requirement for the whole chain: an ordinary trailing
+        // refresh must not turn an unavailable cancellation balance into success.
+        requireAuthoritativeBalance =
+            requireAuthoritativeBalance ||
+            _balanceRefreshQueuedRequireAuthoritativeBalance;
+        _balanceRefreshQueuedRequireAuthoritativeBalance = false;
         try {
           await _refreshBalance(
-            releaseSnapshotOnAuthoritativeBalance: releaseSnapshot,
+            releaseSnapshotOnAuthoritativeBalance:
+                releaseSnapshot || requireAuthoritativeBalance,
             clearRestoredSnapshotIfUnavailable:
                 clearRestoredSnapshotIfUnavailable,
+            requireAuthoritativeBalance: requireAuthoritativeBalance,
           );
           // A successful trailing pass satisfies every caller sharing this
           // chain, even if an earlier pass failed.
@@ -2428,6 +2460,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       _balanceRefreshQueued = false;
       _balanceRefreshQueuedReleaseSnapshot = false;
       _balanceRefreshQueuedClearRestoredSnapshotIfUnavailable = false;
+      _balanceRefreshQueuedRequireAuthoritativeBalance = false;
       _balanceRefreshChain = null;
     }
   }
@@ -2572,6 +2605,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   Future<void> _refreshBalance({
     bool releaseSnapshotOnAuthoritativeBalance = false,
     bool clearRestoredSnapshotIfUnavailable = false,
+    bool requireAuthoritativeBalance = false,
   }) async {
     if (_requiresUnlock) {
       state = AsyncData(SyncState());
@@ -2693,7 +2727,14 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     }
     if (balanceReadVersion != _balanceReadVersion) {
       log('SyncNotifier: discarding superseded balance refresh');
+      if (requireAuthoritativeBalance) {
+        _balanceRefreshQueued = true;
+        _balanceRefreshQueuedReleaseSnapshot = true;
+      }
       return;
+    }
+    if (requireAuthoritativeBalance && !hasAuthoritativeBalance) {
+      throw StateError('Balance unavailable after releasing send proposal');
     }
     // Commit against the latest state so a slow balance/history refresh
     // cannot roll sync progress or completion metadata back to the snapshot

--- a/test/app_incoming_link_host_test.dart
+++ b/test/app_incoming_link_host_test.dart
@@ -260,6 +260,7 @@ PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async => true,
 );
 

--- a/test/app_payment_request_mount_test.dart
+++ b/test/app_payment_request_mount_test.dart
@@ -168,6 +168,7 @@ PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async => true,
 );
 

--- a/test/app_payment_uri_busy_surface_first_frame_test.dart
+++ b/test/app_payment_uri_busy_surface_first_frame_test.dart
@@ -184,6 +184,7 @@ PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async => true,
 );
 

--- a/test/app_payment_uri_unlock_claim_test.dart
+++ b/test/app_payment_uri_unlock_claim_test.dart
@@ -194,6 +194,7 @@ PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async => true,
 );
 

--- a/test/app_payment_uri_wallet_reset_test.dart
+++ b/test/app_payment_uri_wallet_reset_test.dart
@@ -500,6 +500,7 @@ PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async => true,
 );
 

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -638,6 +638,7 @@ class _FakeSwapHardwareSigningService implements SwapHardwareSigningService {
     required SwapIntent intent,
   }) async {
     return SwapHardwarePcztDraft(
+      accountUuid: accountUuid,
       pcztBytes: const [1, 2, 3],
       needsSaplingParams: false,
       feeZatoshi: BigInt.zero,

--- a/test/fakes/fake_sync_notifier.dart
+++ b/test/fakes/fake_sync_notifier.dart
@@ -33,6 +33,10 @@ class FakeSyncNotifier extends SyncNotifier {
   }
 
   @override
+  Future<void> refreshAfterProposalRelease(String accountUuid) =>
+      refreshAfterSend();
+
+  @override
   Future<void> refreshAfterAccountSwitch() async {
     accountSwitchRefreshes++;
     await refreshAfterSend();

--- a/test/features/onboarding/mobile_unlock_screen_payment_uri_test.dart
+++ b/test/features/onboarding/mobile_unlock_screen_payment_uri_test.dart
@@ -108,6 +108,7 @@ PaymentRequestPrecheck _stubPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async => true,
 );
 

--- a/test/features/onboarding/unlock_screen_payment_uri_test.dart
+++ b/test/features/onboarding/unlock_screen_payment_uri_test.dart
@@ -106,6 +106,7 @@ PaymentRequestPrecheck _stubPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async => true,
 );
 

--- a/test/features/payment_links/payment_links_mobile_keystone_test.dart
+++ b/test/features/payment_links/payment_links_mobile_keystone_test.dart
@@ -1,6 +1,8 @@
 @Tags(['mobile'])
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -64,22 +66,72 @@ void main() {
     },
   );
 
+  testWidgets(
+    'cancelled gift card review remains inspectable when fee refresh fails',
+    (tester) async {
+      final signing = _FakePaymentLinkHardwareSigningService();
+      final operations = _FakePaymentLinkOperations();
+      await _pumpMobilePaymentLinks(
+        tester,
+        hardwareSigning: signing,
+        operations: operations,
+      );
+      await _walkToApproveAndCreate(tester);
+      operations.failQuote = true;
+      final semantics = tester.ensureSemantics();
+      await tester.tap(find.bySemanticsLabel('Back').last);
+      await tester.pumpAndSettle();
+      semantics.dispose();
+      expect(find.byType(MobileKeystonePcztSigningFlow), findsNothing);
+      expect(find.text('Approve & create'), findsOneWidget);
+      expect(
+        tester
+            .widget<AppButton>(
+              find.byKey(
+                const ValueKey('payment_link_mobile_review_continue_button'),
+              ),
+            )
+            .onPressed,
+        isNull,
+      );
+      expect(signing.discardedDrafts, [BigInt.one]);
+    },
+  );
+
   testWidgets('cancelling the mobile Keystone round returns a usable review', (
     tester,
   ) async {
     final hardwareSigning = _FakePaymentLinkHardwareSigningService();
-    await _pumpMobilePaymentLinks(tester, hardwareSigning: hardwareSigning);
+    final operations = _FakePaymentLinkOperations();
+    await _pumpMobilePaymentLinks(
+      tester,
+      hardwareSigning: hardwareSigning,
+      operations: operations,
+    );
 
     await _walkToApproveAndCreate(tester);
     expect(find.byType(MobileKeystonePcztSigningFlow), findsOneWidget);
+    final quotesBeforeCancel = operations.quoteCount;
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(MobileKeystonePcztSigningFlow)),
+    );
+    final sync = container.read(syncProvider.notifier) as FakeSyncNotifier;
+    final refreshesBeforeCancel = sync.balanceRefreshes;
 
     final semantics = tester.ensureSemantics();
+    final release = Completer<void>();
+    hardwareSigning.releaseCompleter = release;
     await tester.tap(find.bySemanticsLabel('Back').last);
+    await tester.pump();
+    expect(find.byType(MobileKeystonePcztSigningFlow), findsOneWidget);
+    release.complete();
     await tester.pumpAndSettle();
     semantics.dispose();
 
     expect(find.byType(MobileKeystonePcztSigningFlow), findsNothing);
     expect(hardwareSigning.discardedDrafts, [BigInt.one]);
+    expect(sync.balanceRefreshes, refreshesBeforeCancel + 1);
+    expect(operations.quoteCount, quotesBeforeCancel + 1);
     final cta = tester.widget<AppButton>(
       find.byKey(const ValueKey('payment_link_mobile_review_continue_button')),
     );
@@ -99,7 +151,19 @@ Future<void> _walkToApproveAndCreate(WidgetTester tester) async {
     '0.1',
   );
   await tester.pump(const Duration(milliseconds: 350));
-  await tester.pumpAndSettle();
+  // The gift card preview has a repeating caret animation. Wait for the
+  // debounce/quote, not for every animation on the amount page to settle.
+  await tester.pump(const Duration(milliseconds: 400));
+  expect(
+    tester
+        .widget<AppButton>(
+          find.byKey(
+            const ValueKey('payment_link_mobile_amount_continue_button'),
+          ),
+        )
+        .onPressed,
+    isNotNull,
+  );
 
   await tester.tap(
     find.byKey(const ValueKey('payment_link_mobile_amount_continue_button')),
@@ -220,6 +284,8 @@ final _hardwareLink = VizorPaymentLink(
 
 class _FakePaymentLinkOperations implements PaymentLinkOperations {
   final List<BigInt> createdAmounts = [];
+  int quoteCount = 0;
+  bool failQuote = false;
 
   @override
   Future<void> retainPendingClaim(PaymentLinkClaimSession session) async {}
@@ -247,6 +313,8 @@ class _FakePaymentLinkOperations implements PaymentLinkOperations {
     required BigInt amountZatoshi,
     required String sourceAccountUuid,
   }) async {
+    quoteCount++;
+    if (failQuote) throw StateError('fee unavailable');
     return PaymentLinkFundingQuote(
       sourceAccountUuid: sourceAccountUuid,
       recipientAmountZatoshi: amountZatoshi,
@@ -320,6 +388,7 @@ class _FakePaymentLinkHardwareSigningService
   final createdAmounts = <BigInt>[];
   final createdFromAccounts = <String>[];
   final discardedDrafts = <BigInt>[];
+  Completer<void>? releaseCompleter;
 
   PaymentLinkHardwarePcztDraft get draft => PaymentLinkHardwarePcztDraft(
     link: _hardwareLink,
@@ -364,6 +433,7 @@ class _FakePaymentLinkHardwareSigningService
     required PaymentLinkHardwarePcztDraft draft,
   }) async {
     discardedDrafts.add(draft.proposalId);
+    await releaseCompleter?.future;
   }
 
   @override

--- a/test/features/payment_links/payment_links_screen_test.dart
+++ b/test/features/payment_links/payment_links_screen_test.dart
@@ -1052,13 +1052,15 @@ void main() {
     expect(find.byType(KeystoneSigningModal), findsOneWidget);
     await tester.tap(find.text('Cancel'));
     await tester.pump();
-    expect(find.byType(KeystoneSigningModal), findsNothing);
+    expect(find.byType(KeystoneSigningModal), findsOneWidget);
+    expect(find.text('Cancelling…'), findsOneWidget);
 
     createCompleter.complete(hardwareSigning.draft);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
 
     expect(hardwareSigning.discardedDrafts, [BigInt.one]);
+    expect(find.byType(KeystoneSigningModal), findsNothing);
   });
 
   testWidgets('account switch cancels an open Keystone Gift Card request', (

--- a/test/features/send/mobile_keystone_sign_screen_busy_surface_test.dart
+++ b/test/features/send/mobile_keystone_sign_screen_busy_surface_test.dart
@@ -1,9 +1,12 @@
 @Tags(['mobile'])
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
@@ -11,6 +14,7 @@ import 'package:zcash_wallet/src/features/send/screens/mobile/mobile_keystone_si
 import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
 import '../../fakes/fake_sync_notifier.dart';
 import '../../support/payment_uri_busy_surface_expectations.dart';
@@ -19,6 +23,11 @@ import '../../support/payment_uri_busy_surface_expectations.dart';
 /// the flow is keyed per signing round, so a hold taken there would fall back
 /// to zero between rounds and let a parked link through in the gap.
 void main() {
+  final api = _ReleaseCountingApi();
+  setUpAll(() => RustLib.initMock(api: api));
+  tearDownAll(RustLib.dispose);
+  setUp(() => api.releaseCalls = 0);
+
   testWidgets('the mobile send signing screen holds the payment-URI busy '
       'latch', (tester) async {
     final container = _container();
@@ -30,7 +39,93 @@ void main() {
       drainExceptions: true,
       postUnmountSettle: const Duration(seconds: 2),
     );
+    expect(
+      api.releaseCalls,
+      1,
+      reason: 'abnormal unmount still releases inputs',
+    );
   });
+
+  for (final systemBack in [false, true]) {
+    testWidgets('signing cancellation returns cleanup ownership to review '
+        '(systemBack=$systemBack)', (tester) async {
+      final container = _container();
+      final dbPath = Completer<String>();
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, _) => Scaffold(
+              body: TextButton(
+                onPressed: () => context.push<void>('/review'),
+                child: const Text('Open review'),
+              ),
+            ),
+          ),
+          GoRoute(
+            path: '/review',
+            builder: (context, _) => Scaffold(
+              body: TextButton(
+                onPressed: () => context.push<void>('/sign'),
+                child: const Text('Open signing'),
+              ),
+            ),
+          ),
+          GoRoute(
+            path: '/sign',
+            builder: (_, _) => MobileKeystoneSignScreen(
+              args: _reviewArgs,
+              loadWalletDbPath: () => dbPath.future,
+            ),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: AppTheme(
+            data: AppThemeData.dark,
+            child: MaterialApp.router(routerConfig: router),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open review'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open signing'));
+      // The preparing screen deliberately animates until its platform-backed
+      // work completes. Cancellation must also work during that stage.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      if (systemBack) {
+        await tester.binding.handlePopRoute();
+      } else {
+        await tester.tap(find.text('Cancel'));
+      }
+      // Resolve preparation after pop while the outgoing screen is still
+      // mounted for its route animation. Its abort must not pop Review too.
+      dbPath.complete('/tmp/mobile-sign-cancel-test');
+      await tester.pumpAndSettle();
+      expect(find.text('Open signing'), findsOneWidget);
+      expect(api.releaseCalls, 0);
+    });
+  }
+}
+
+class _ReleaseCountingApi implements RustLibApi {
+  int releaseCalls = 0;
+
+  @override
+  Future<void> crateApiSyncDiscardProposal({
+    required BigInt proposalId,
+    required String sendFlowId,
+  }) async {
+    releaseCalls++;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 ProviderContainer _container() {

--- a/test/features/send/mobile_payment_request_host_test.dart
+++ b/test/features/send/mobile_payment_request_host_test.dart
@@ -120,6 +120,7 @@ PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async {
         final pending = _discardGate;
         if (pending != null) await pending.future;

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -2262,6 +2262,81 @@ void main() {
     expect(_proposeCalls, 1);
   });
 
+  for (final refreshFailure in [false, true]) {
+    for (final systemBack in [false, true]) {
+      testWidgets('pending cancellation blocks exit until cleanup succeeds '
+          '(refreshFailure=$refreshFailure, systemBack=$systemBack)', (
+        tester,
+      ) async {
+        _proposeSendSucceeds = true;
+        final sync = _CancelRecoverySyncNotifier();
+        await tester.pumpWidget(_cancelRecoveryApp(sync));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+        await tester.pumpAndSettle();
+        sync.publishLockedBalance();
+        _discardFails = !refreshFailure;
+        sync.refreshFails = refreshFailure;
+        await tester.tap(
+          find.byKey(const ValueKey('mobile_send_keystone_cancel')),
+        );
+        await tester.pumpAndSettle();
+        expect(
+          find.text('Could not finish cancellation. Try again.'),
+          findsOneWidget,
+        );
+        expect(find.bySemanticsLabel('Back'), findsNothing);
+        expect(
+          tester
+              .widget<AppButton>(
+                find.byKey(const ValueKey('mobile_send_cancel')),
+              )
+              .onPressed,
+          isNull,
+        );
+        final discardsBeforeRetry = _discardCalls;
+        final refreshesBeforeRetry = sync.refreshCalls;
+        if (systemBack) {
+          await tester.binding.handlePopRoute();
+        } else {
+          await tester.tap(find.byKey(const ValueKey('mobile_send_cancel')));
+        }
+        await tester.pumpAndSettle();
+        expect(find.text('Review Send'), findsOneWidget);
+        expect(find.text('home'), findsNothing);
+        expect(_discardCalls, discardsBeforeRetry);
+        expect(sync.refreshCalls, refreshesBeforeRetry);
+
+        _discardFails = false;
+        sync.refreshFails = false;
+        await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+        await tester.pumpAndSettle();
+        expect(_discardCalls, discardsBeforeRetry + 1);
+        expect(sync.refreshCalls, refreshesBeforeRetry + 1);
+        expect(_proposeCalls, 1);
+        expect(find.text('Confirm with Keystone'), findsOneWidget);
+        expect(find.bySemanticsLabel('Back'), findsOneWidget);
+        expect(
+          tester
+              .widget<AppButton>(
+                find.byKey(const ValueKey('mobile_send_cancel')),
+              )
+              .onPressed,
+          isNotNull,
+        );
+        if (systemBack) {
+          await tester.binding.handlePopRoute();
+          await tester.pumpAndSettle();
+          expect(find.text('Review Send'), findsNothing);
+        } else {
+          await tester.tap(find.byKey(const ValueKey('mobile_send_cancel')));
+          await tester.pumpAndSettle();
+          expect(find.text('home'), findsOneWidget);
+        }
+      });
+    }
+  }
+
   testWidgets('Keystone cancel requotes Max only after inputs are released', (
     tester,
   ) async {

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -1819,37 +1819,64 @@ void main() {
     );
   });
 
-  testWidgets('changed proposal fee requires a second confirmation', (
-    tester,
-  ) async {
-    _proposeSendSucceeds = true;
-    _proposalFeeZatoshi = BigInt.from(20000);
+  for (final recoveredFeeZatoshi in [20000, 30000]) {
+    testWidgets(
+      'changed proposal fee preserves recovery fee $recoveredFeeZatoshi',
+      (tester) async {
+        _proposeSendSucceeds = true;
+        _proposalFeeZatoshi = BigInt.from(20000);
 
-    await tester.pumpWidget(_sendFlowRouterApp());
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('mobile_send_open_from_home')));
-    await tester.pumpAndSettle();
-    await _toReviewStep(tester);
+        await tester.pumpWidget(
+          _sendFlowRouterApp(
+            estimateFee:
+                ({
+                  required dbPath,
+                  required network,
+                  required accountUuid,
+                  required toAddress,
+                  required amountZatoshi,
+                  memo,
+                }) async => BigInt.from(
+                  _proposeCalls == 0 ? 10000 : recoveredFeeZatoshi,
+                ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('mobile_send_open_from_home')),
+        );
+        await tester.pumpAndSettle();
+        await _toReviewStep(tester);
 
-    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
-    await tester.pumpAndSettle();
+        await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+        await tester.pumpAndSettle();
 
-    expect(find.text('Review Send'), findsOneWidget);
-    expect(
-      find.text('Fee updated after sync. Review and confirm again.'),
-      findsOneWidget,
+        expect(find.text('Review Send'), findsOneWidget);
+        expect(
+          find.text('Fee updated after sync. Review and confirm again.'),
+          findsOneWidget,
+        );
+        expect(
+          tester
+              .widget<Text>(find.byKey(const ValueKey('mobile_send_fee')))
+              .data,
+          ZecAmount.fromZatoshi(
+            BigInt.from(recoveredFeeZatoshi),
+          ).fee.toString(),
+        );
+        expect(find.text('status can pop'), findsNothing);
+        expect(_discardCalls, 1);
+        _proposalFeeZatoshi = BigInt.from(recoveredFeeZatoshi);
+
+        await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+        await tester.pumpAndSettle();
+
+        expect(find.text('status can pop'), findsOneWidget);
+        expect(_proposeCalls, 2);
+        expect(_discardCalls, 1);
+      },
     );
-    expect(
-      tester.widget<Text>(find.byKey(const ValueKey('mobile_send_fee'))).data,
-      ZecAmount.fromZatoshi(_proposalFeeZatoshi).fee.toString(),
-    );
-    expect(find.text('status can pop'), findsNothing);
-
-    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
-    await tester.pumpAndSettle();
-
-    expect(find.text('status can pop'), findsOneWidget);
-  });
+  }
 
   for (final insufficient in [false, true]) {
     testWidgets('changed proposal fee preserves recovery quote failure '

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -70,6 +70,9 @@ typedef _SendMaxEstimateBuilder =
 /// Holds `discardProposal` open so a test can look at the busy-surface hold
 /// while a cancelled send's proposal is still being released.
 Completer<void>? _discardGate;
+bool _discardFails = false;
+int _discardCalls = 0;
+int _proposeCalls = 0;
 
 class _RustApiFake implements RustLibApi {
   @override
@@ -77,8 +80,10 @@ class _RustApiFake implements RustLibApi {
     required BigInt proposalId,
     required String sendFlowId,
   }) async {
+    _discardCalls++;
     final gate = _discardGate;
     if (gate != null) await gate.future;
+    if (_discardFails) throw StateError('proposal release failed');
   }
 
   @override
@@ -170,6 +175,7 @@ class _RustApiFake implements RustLibApi {
     required BigInt amountZatoshi,
     String? memo,
   }) async {
+    _proposeCalls++;
     _lastProposeToAddress = toAddress;
     _lastProposeMemo = memo;
     final completer = _proposeSendCompleter;
@@ -233,6 +239,49 @@ class _FakeSyncNotifier extends SyncNotifier {
     spendableBalance: BigInt.from(500000000), // 5 ZEC
     totalBalance: BigInt.from(500000000),
   );
+
+  @override
+  Future<void> refreshAfterProposalRelease(String accountUuid) async {}
+}
+
+class _CancelRecoverySyncNotifier extends _FakeSyncNotifier {
+  Completer<void>? refreshGate;
+  int refreshCalls = 0;
+  bool refreshFails = false;
+
+  void publishAccount(String accountUuid) {
+    state = AsyncData(state.requireValue.copyWith(accountUuid: accountUuid));
+  }
+
+  void publishLockedBalance() {
+    state = AsyncData(
+      SyncState(
+        accountUuid: 'account-1',
+        hasAccountScopedData: true,
+        spendableBalance: BigInt.zero,
+        totalBalance: BigInt.from(500000000),
+      ),
+    );
+  }
+
+  @override
+  Future<void> refreshAfterProposalRelease(String accountUuid) async {
+    refreshCalls++;
+    await refreshGate?.future;
+    if (refreshFails) throw StateError('balance unavailable');
+    if (ref.read(accountProvider).value?.activeAccountUuid != accountUuid) {
+      return;
+    }
+    state = AsyncData(await build());
+  }
+}
+
+class _SwitchableAccountNotifier extends AccountNotifier {
+  void selectAccount(String accountUuid) {
+    state = AsyncData(
+      state.requireValue.copyWith(activeAccountUuid: accountUuid),
+    );
+  }
 }
 
 /// A sync notifier whose state can be pushed mid-test, so a test can force the
@@ -520,6 +569,8 @@ Widget _reviewApp({
 /// SendPrefillArgs)`, so `/send` becomes the entire stack and there is nothing
 /// under it to pop.
 Widget _sendFlowRouterApp({
+  AccountNotifier Function()? accountNotifier,
+  SyncNotifier Function()? syncNotifier,
   MobileSendFeeEstimator? estimateFee,
   String? initialMemo,
   bool preserveInitialMemoWhitespace = false,
@@ -652,11 +703,13 @@ Widget _sendFlowRouterApp({
   );
   return ProviderScope(
     overrides: [
+      if (accountNotifier != null)
+        accountProvider.overrideWith(accountNotifier),
       appBootstrapProvider.overrideWithValue(
         _bootstrap(accountState: accountState),
       ),
       sendProvingKeyWarmupProvider.overrideWithValue(() {}),
-      syncProvider.overrideWith(_FakeSyncNotifier.new),
+      syncProvider.overrideWith(syncNotifier ?? _FakeSyncNotifier.new),
       zecMarketDataSourceProvider.overrideWithValue(
         const _FakeMarketDataSource(),
       ),
@@ -756,6 +809,9 @@ void main() {
 
   setUp(() {
     _discardGate = null;
+    _discardFails = false;
+    _discardCalls = 0;
+    _proposeCalls = 0;
     _proposeSendSucceeds = false;
     _proposeSendCompleter = null;
     _proposalFeeZatoshi = BigInt.from(10000);
@@ -1795,6 +1851,132 @@ void main() {
     expect(find.text('status can pop'), findsOneWidget);
   });
 
+  for (final insufficient in [false, true]) {
+    testWidgets('changed proposal fee preserves recovery quote failure '
+        '(insufficient=$insufficient)', (tester) async {
+      _proposeSendSucceeds = true;
+      _proposalFeeZatoshi = BigInt.from(20000);
+      await tester.pumpWidget(
+        _sendFlowRouterApp(
+          estimateFee:
+              ({
+                required dbPath,
+                required network,
+                required accountUuid,
+                required toAddress,
+                required amountZatoshi,
+                memo,
+              }) async {
+                if (_proposeCalls > 0) {
+                  throw StateError(
+                    insufficient ? 'InsufficientFunds' : 'fee lookup failed',
+                  );
+                }
+                return BigInt.from(10000);
+              },
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('mobile_send_open_from_home')),
+      );
+      await tester.pumpAndSettle();
+      await _toReviewStep(tester);
+      await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+      await tester.pumpAndSettle();
+      expect(_proposeCalls, 1);
+      expect(find.text('status can pop'), findsNothing);
+      expect(find.text('Confirm & Send'), findsNothing);
+      if (insufficient) {
+        expect(find.text('Not enough ZEC'), findsOneWidget);
+        expect(_confirmButton(tester).onPressed, isNull);
+      } else {
+        expect(find.text('Fee unavailable. Try again.'), findsOneWidget);
+        expect(find.text('Try again'), findsOneWidget);
+        await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+        await tester.pumpAndSettle();
+        expect(_proposeCalls, 1);
+      }
+    });
+  }
+
+  testWidgets('changed proposal fee preserves the fresh Max amount and fee', (
+    tester,
+  ) async {
+    _proposeSendSucceeds = true;
+    _proposalFeeZatoshi = BigInt.from(20000);
+    _sendMaxEstimateBuilder = ({required toAddress, memo}) {
+      final fee = BigInt.from(_proposeCalls == 0 ? 10000 : 30000);
+      return SendMaxEstimateResult(
+        amountZatoshi: BigInt.from(500000000) - fee,
+        feeZatoshi: fee,
+        needsSaplingParams: false,
+      );
+    };
+    await tester.pumpWidget(
+      _cancelRecoveryApp(_CancelRecoverySyncNotifier(), isMaxMode: true),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+    await tester.pumpAndSettle();
+    expect(_proposeCalls, 1);
+    expect(
+      tester.widget<Text>(find.byKey(const ValueKey('mobile_send_fee'))).data,
+      ZecAmount.fromZatoshi(BigInt.from(30000)).fee.toString(),
+    );
+    expect(_confirmButton(tester).onPressed, isNotNull);
+  });
+
+  testWidgets('changed proposal fee preserves a new account recovery quote', (
+    tester,
+  ) async {
+    _proposeSendSucceeds = true;
+    _proposalFeeZatoshi = BigInt.from(20000);
+    final accounts = _SwitchableAccountNotifier();
+    final sync = _CancelRecoverySyncNotifier();
+    await tester.pumpWidget(
+      _sendFlowRouterApp(
+        accountNotifier: () => accounts,
+        syncNotifier: () => sync,
+        accountState: const AccountState(
+          accounts: [
+            AccountInfo(uuid: 'account-1', name: 'First', order: 0),
+            AccountInfo(uuid: 'account-2', name: 'Second', order: 1),
+          ],
+          activeAccountUuid: 'account-1',
+          activeAddress: 'u1activeaddress',
+        ),
+        estimateFee:
+            ({
+              required dbPath,
+              required network,
+              required accountUuid,
+              required toAddress,
+              required amountZatoshi,
+              memo,
+            }) async => BigInt.from(accountUuid == 'account-1' ? 10000 : 30000),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('mobile_send_open_from_home')));
+    await tester.pumpAndSettle();
+    await _toReviewStep(tester);
+    _discardGate = Completer<void>();
+    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+    await tester.pumpAndSettle();
+    accounts.selectAccount('account-2');
+    sync.publishAccount('account-2');
+    await tester.pumpAndSettle();
+    _discardGate!.complete();
+    await tester.pumpAndSettle();
+    expect(_proposeCalls, 1);
+    expect(
+      tester.widget<Text>(find.byKey(const ValueKey('mobile_send_fee'))).data,
+      ZecAmount.fromZatoshi(BigInt.from(30000)).fee.toString(),
+    );
+    expect(_confirmButton(tester).onPressed, isNotNull);
+  });
+
   testWidgets('route-step send status clears intermediate send pages', (
     tester,
   ) async {
@@ -1942,6 +2124,141 @@ void main() {
     discardGate.complete();
     await tester.pumpAndSettle();
     expect(container.read(paymentUriBusySurfaceProvider), 0);
+  });
+
+  testWidgets(
+    'Keystone cancel refreshes locked balance before enabling retry',
+    (tester) async {
+      _proposeSendSucceeds = true;
+      final sync = _CancelRecoverySyncNotifier();
+      await tester.pumpWidget(_cancelRecoveryApp(sync));
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(MobileSendScreen)),
+      );
+      await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+      await tester.pumpAndSettle();
+      expect(_proposeCalls, 1);
+
+      sync.publishLockedBalance();
+      await tester.pumpAndSettle();
+      _discardGate = Completer<void>();
+      sync.refreshGate = Completer<void>();
+      await tester.tap(
+        find.byKey(const ValueKey('mobile_send_keystone_cancel')),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Review Send'), findsOneWidget);
+      expect(_confirmButton(tester).onPressed, isNull);
+      expect(sync.refreshCalls, 0);
+      expect(container.read(paymentUriBusySurfaceProvider), 1);
+
+      _discardGate!.complete();
+      await tester.pumpAndSettle();
+      expect(sync.refreshCalls, 1);
+      expect(_confirmButton(tester).onPressed, isNull);
+      expect(container.read(paymentUriBusySurfaceProvider), 1);
+      expect(_proposeCalls, 1);
+
+      sync.refreshGate!.complete();
+      await tester.pumpAndSettle();
+      expect(find.text('Not enough ZEC'), findsNothing);
+      expect(find.text('Confirm with Keystone'), findsOneWidget);
+      expect(_confirmButton(tester).onPressed, isNotNull);
+      expect(container.read(paymentUriBusySurfaceProvider), 0);
+      await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+      await tester.pumpAndSettle();
+      expect(find.text('keystone sign'), findsOneWidget);
+      expect(_proposeCalls, 2);
+    },
+  );
+
+  testWidgets(
+    'Keystone release failure retries cleanup without a new proposal',
+    (tester) async {
+      _proposeSendSucceeds = true;
+      final sync = _CancelRecoverySyncNotifier();
+      await tester.pumpWidget(_cancelRecoveryApp(sync));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+      await tester.pumpAndSettle();
+      sync.publishLockedBalance();
+      _discardFails = true;
+      await tester.tap(
+        find.byKey(const ValueKey('mobile_send_keystone_cancel')),
+      );
+      await tester.pumpAndSettle();
+      expect(_discardCalls, 3);
+      expect(sync.refreshCalls, 0);
+      expect(_proposeCalls, 1);
+      expect(find.text('Confirm with Keystone'), findsNothing);
+      expect(find.text('Try again'), findsOneWidget);
+      expect(
+        find.text('Could not finish cancellation. Try again.'),
+        findsOneWidget,
+      );
+
+      _discardFails = false;
+      await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+      await tester.pumpAndSettle();
+      expect(_discardCalls, 4);
+      expect(sync.refreshCalls, 1);
+      expect(_proposeCalls, 1);
+      expect(find.text('Confirm with Keystone'), findsOneWidget);
+      expect(_confirmButton(tester).onPressed, isNotNull);
+    },
+  );
+
+  testWidgets('Keystone cancel keeps retry gated when balance refresh fails', (
+    tester,
+  ) async {
+    _proposeSendSucceeds = true;
+    final sync = _CancelRecoverySyncNotifier()..refreshFails = true;
+    await tester.pumpWidget(_cancelRecoveryApp(sync));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+    await tester.pumpAndSettle();
+    sync.publishLockedBalance();
+    await tester.tap(find.byKey(const ValueKey('mobile_send_keystone_cancel')));
+    await tester.pumpAndSettle();
+    expect(_discardCalls, 1);
+    expect(sync.refreshCalls, 1);
+    expect(find.text('Confirm with Keystone'), findsNothing);
+    expect(find.text('Try again'), findsOneWidget);
+    expect(_proposeCalls, 1);
+
+    sync.refreshFails = false;
+    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+    await tester.pumpAndSettle();
+    expect(sync.refreshCalls, 2);
+    expect(find.text('Confirm with Keystone'), findsOneWidget);
+    expect(_proposeCalls, 1);
+  });
+
+  testWidgets('Keystone cancel requotes Max only after inputs are released', (
+    tester,
+  ) async {
+    _proposeSendSucceeds = true;
+    final sync = _CancelRecoverySyncNotifier();
+    await tester.pumpWidget(_cancelRecoveryApp(sync, isMaxMode: true));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+    await tester.pumpAndSettle();
+    final initialMaxCalls = _estimateSendMaxCalls;
+    sync.publishLockedBalance();
+    await tester.pumpAndSettle();
+    expect(_estimateSendMaxCalls, initialMaxCalls);
+
+    _discardGate = Completer<void>();
+    await tester.tap(find.byKey(const ValueKey('mobile_send_keystone_cancel')));
+    await tester.pumpAndSettle();
+    expect(_estimateSendMaxCalls, initialMaxCalls);
+    expect(_confirmButton(tester).onPressed, isNull);
+    _discardGate!.complete();
+    await tester.pumpAndSettle();
+    expect(_estimateSendMaxCalls, greaterThan(initialMaxCalls));
+    expect(find.text('Confirm with Keystone'), findsOneWidget);
+    expect(_confirmButton(tester).onPressed, isNotNull);
   });
 
   testWidgets('a failed proposal gives the busy-surface hold back', (
@@ -3729,6 +4046,37 @@ void main() {
   });
 }
 
+AppButton _confirmButton(WidgetTester tester) =>
+    tester.widget<AppButton>(find.byKey(const ValueKey('mobile_send_confirm')));
+
+Widget _cancelRecoveryApp(
+  _CancelRecoverySyncNotifier sync, {
+  bool isMaxMode = false,
+}) => _sendFlowRouterApp(
+  syncNotifier: () => sync,
+  initialLocation: '/send/review',
+  initialReviewDraft: MobileSendReviewDraftArgs(
+    sendFlowId: 'cancel-recovery-flow',
+    recipient: _shieldedAddress,
+    addressType: 'unified',
+    amountText: '1.5',
+    isMaxMode: isMaxMode,
+    feeZatoshi: BigInt.from(10000),
+  ),
+  accountState: const AccountState(
+    accounts: [
+      AccountInfo(
+        uuid: 'account-1',
+        name: 'Keystone',
+        order: 0,
+        isHardware: true,
+      ),
+    ],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1activeaddress',
+  ),
+);
+
 Future<BigInt> _fixedFeeEstimator({
   required String dbPath,
   required String network,
@@ -3778,5 +4126,6 @@ PaymentRequestPrecheck _readyPaymentRequestPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async => true,
 );

--- a/test/features/send/mobile_send_status_screen_test.dart
+++ b/test/features/send/mobile_send_status_screen_test.dart
@@ -13,6 +13,9 @@ import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/send/screens/mobile/mobile_send_status_screen.dart';
 import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
 
 const _address =
     'u1l8xunezsvhq8fgzfl7404m450nwnd76zshe7f5dxv5z3w4gthawuwukdn5aalh6g'
@@ -42,6 +45,7 @@ MobileSendBroadcastRunner _runner(Future<SendBroadcastOutcome> outcome) {
 
 Widget _app({required MobileSendBroadcastRunner broadcastRunner}) {
   return ProviderScope(
+    overrides: [syncProvider.overrideWith(FakeSyncNotifier.new)],
     child: MaterialApp(
       home: AppTheme(
         data: AppThemeData.light,
@@ -395,7 +399,9 @@ void main() {
 
     // The test owns the container so the flag outlives the receipt; a
     // `ProviderScope` widget would dispose it together with the screen.
-    final container = ProviderContainer();
+    final container = ProviderContainer(
+      overrides: [syncProvider.overrideWith(FakeSyncNotifier.new)],
+    );
     addTearDown(container.dispose);
     final broadcast = Completer<SendBroadcastOutcome>();
     await tester.pumpWidget(
@@ -487,7 +493,9 @@ void main() {
 
   testWidgets('leaving mid-broadcast keeps terminal closed until the runner '
       'finishes', (tester) async {
-    final container = ProviderContainer();
+    final container = ProviderContainer(
+      overrides: [syncProvider.overrideWith(FakeSyncNotifier.new)],
+    );
     addTearDown(container.dispose);
     final broadcast = Completer<SendBroadcastOutcome>();
     await tester.pumpWidget(
@@ -660,6 +668,7 @@ void main() {
     );
     await tester.pumpWidget(
       ProviderScope(
+        overrides: [syncProvider.overrideWith(FakeSyncNotifier.new)],
         child: MaterialApp.router(
           routerConfig: router,
           builder: (context, child) =>

--- a/test/features/send/payment_request_host_test.dart
+++ b/test/features/send/payment_request_host_test.dart
@@ -123,6 +123,7 @@ PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async {
         _discarded.add(proposalId);
         final gate = _discardGate;
@@ -185,6 +186,7 @@ class _StallingSendApi {
           required BigInt proposalId,
           required String sendFlowId,
           required String logContext,
+          required String accountUuid,
         }) async {
           _discarded.add(proposalId);
           return true;

--- a/test/features/send/payment_request_pane_layout_test.dart
+++ b/test/features/send/payment_request_pane_layout_test.dart
@@ -209,6 +209,7 @@ PaymentRequestPrecheck _readyPrecheck() => PaymentRequestPrecheck(
         required BigInt proposalId,
         required String sendFlowId,
         required String logContext,
+        required String accountUuid,
       }) async => true,
 );
 

--- a/test/features/send/payment_request_precheck_test.dart
+++ b/test/features/send/payment_request_precheck_test.dart
@@ -53,6 +53,7 @@ class FakeSendApi {
   var proposeCalls = 0;
   String? lastValidatedNetwork;
   final discarded = <BigInt>[];
+  final discardedAccounts = <String>[];
   String? lastProposedMemo;
   String? lastRequestedBy;
 
@@ -108,8 +109,10 @@ class FakeSendApi {
     required BigInt proposalId,
     required String sendFlowId,
     required String logContext,
+    required String accountUuid,
   }) async {
     discarded.add(proposalId);
+    discardedAccounts.add(accountUuid);
     return true;
   }
 
@@ -558,6 +561,7 @@ void main() {
       await handle.discard();
 
       expect(api.discarded, [BigInt.from(7)]);
+      expect(api.discardedAccounts, ['account-1']);
     });
 
     test('release transfers ownership, so discard becomes a no-op', () async {

--- a/test/features/send/send_proposal_release_test.dart
+++ b/test/features/send/send_proposal_release_test.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
+
+void main() {
+  final api = _ReleaseApi();
+  late _ReleaseSyncNotifier sync;
+
+  setUpAll(() => RustLib.initMock(api: api));
+  tearDownAll(RustLib.dispose);
+  setUp(() {
+    api.gate = null;
+    api.failures = 0;
+    api.calls = 0;
+    sync = _ReleaseSyncNotifier();
+  });
+
+  Future<bool> release() => discardSendProposal(
+    proposalId: BigInt.one,
+    sendFlowId: 'send-1',
+    logContext: 'ReleaseTest',
+    syncNotifier: sync,
+    accountUuid: 'account-1',
+  );
+
+  test(
+    'release waits for unlock and then the owning account refresh',
+    () async {
+      api.gate = Completer<void>();
+      sync.gate = Completer<void>();
+      var completed = false;
+      final result = release().then((value) {
+        completed = true;
+        return value;
+      });
+      await Future<void>.delayed(Duration.zero);
+      expect(sync.accounts, isEmpty);
+      expect(completed, isFalse);
+
+      api.gate!.complete();
+      await Future<void>.delayed(Duration.zero);
+      expect(sync.accounts, ['account-1']);
+      expect(completed, isFalse);
+
+      sync.gate!.complete();
+      expect(await result, isTrue);
+    },
+  );
+
+  test('an unconfirmed unlock never refreshes or enables retry', () async {
+    api.failures = 3;
+    expect(await release(), isFalse);
+    expect(api.calls, 3);
+    expect(sync.accounts, isEmpty);
+  });
+
+  test('a transient unlock failure refreshes only after success', () async {
+    api.failures = 1;
+    expect(await release(), isTrue);
+    expect(api.calls, 2);
+    expect(sync.accounts, ['account-1']);
+  });
+
+  test(
+    'a refresh failure stays retryable after the proposal was released',
+    () async {
+      sync.fail = true;
+      expect(await release(), isFalse);
+      sync.fail = false;
+      expect(await release(), isTrue);
+      expect(api.calls, 2);
+      expect(sync.accounts, ['account-1', 'account-1']);
+    },
+  );
+}
+
+class _ReleaseSyncNotifier extends SyncNotifier {
+  final accounts = <String>[];
+  Completer<void>? gate;
+  bool fail = false;
+
+  @override
+  Future<void> refreshAfterProposalRelease(String accountUuid) async {
+    accounts.add(accountUuid);
+    if (gate != null) await gate!.future;
+    if (fail) throw StateError('balance unavailable');
+  }
+}
+
+class _ReleaseApi implements RustLibApi {
+  Completer<void>? gate;
+  int failures = 0;
+  int calls = 0;
+
+  @override
+  Future<void> crateApiSyncDiscardProposal({
+    required BigInt proposalId,
+    required String sendFlowId,
+  }) async {
+    calls++;
+    if (gate != null) await gate!.future;
+    if (failures > 0) {
+      failures--;
+      throw StateError('unlock unavailable');
+    }
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -37,6 +37,7 @@ import 'package:zcash_wallet/src/features/send/services/send_flow.dart'
         SendStatusRoutePayloadObserver,
         sendStatusRoutePayloadProvider;
 import 'package:zcash_wallet/src/features/send/widgets/send_review_content_view.dart';
+import 'package:zcash_wallet/src/features/send/widgets/sapling_params_prompt.dart';
 import 'package:zcash_wallet/src/features/send/widgets/verify_address_modal.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
@@ -430,6 +431,86 @@ void main() {
       expect(rustApi.proposedAccounts, isEmpty);
     });
   }
+
+  testWidgets('Keystone cancellation closes the stale Sapling params prompt', (
+    tester,
+  ) async {
+    final released = Completer<void>();
+    rustApi.discardCompleter = released;
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _harness(
+        _reviewArgs(addressType: 'unified', needsSaplingParams: true),
+        bootstrap: _bootstrap(isHardware: true),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Confirm with Keystone'));
+    await _flushRealAsync(tester);
+    final prompt = tester.widget<SaplingParamsPrompt>(
+      find.byType(SaplingParamsPrompt),
+    );
+
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+    expect(find.byType(SaplingParamsPrompt), findsNothing);
+    expect(rustApi.discardCalls, [(BigInt.one, 'test-send-flow')]);
+    expect(rustApi.proposedAccounts, isEmpty);
+    expect(find.text('Cancelling…'), findsWidgets);
+
+    released.complete();
+    await _flushRealAsync(tester);
+    await tester.pumpAndSettle();
+    expect(rustApi.proposedAccounts, ['test-account']);
+    expect(find.text('Review send'), findsOneWidget);
+    expect(find.text('0.0002 ZEC'), findsOneWidget);
+    expect(find.byType(KeystoneSigningModal), findsNothing);
+    // A delayed event from the removed prompt cannot start a download or
+    // release the refreshed proposal.
+    prompt.onCancel();
+    prompt.onDownload();
+    await tester.pumpAndSettle();
+    expect(rustApi.discardCalls, [(BigInt.one, 'test-send-flow')]);
+    expect(find.byType(KeystoneSigningModal), findsNothing);
+
+    await tester.tap(find.text('Confirm with Keystone'));
+    await _flushRealAsync(tester);
+    expect(rustApi.createdProposalIds, [BigInt.two]);
+    expect(find.text('Get signature'), findsOneWidget);
+  });
+
+  testWidgets('declining Sapling params still cancels the current proposal', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _harness(
+        _reviewArgs(addressType: 'unified', needsSaplingParams: true),
+        bootstrap: _bootstrap(isHardware: true),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Confirm with Keystone'));
+    await _flushRealAsync(tester);
+    await tester.tap(
+      find.descendant(
+        of: find.byType(SaplingParamsPrompt),
+        matching: find.text('Cancel'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(SaplingParamsPrompt), findsNothing);
+    expect(rustApi.discardCalls, [(BigInt.one, 'test-send-flow')]);
+    expect(rustApi.proposedAccounts, isEmpty);
+    expect(rustApi.createdProposalIds, isEmpty);
+    expect(
+      tester
+          .widget<KeystoneSigningModal>(find.byType(KeystoneSigningModal))
+          .phase,
+      KeystoneSigningModalPhase.failed,
+    );
+  });
 
   testWidgets('cancel discards the proposal and returns to send', (
     tester,
@@ -1524,6 +1605,7 @@ class _FakeAddressBookRepository implements AddressBookRepository {
 
 SendReviewArgs _reviewArgs({
   required String addressType,
+  bool needsSaplingParams = false,
   String? memo,
   String address = _longAddress,
   BigInt? amountZatoshi,
@@ -1540,7 +1622,7 @@ SendReviewArgs _reviewArgs({
     addressType: addressType,
     amountZatoshi: amountZatoshi ?? BigInt.from(1512000000),
     feeZatoshi: BigInt.from(12000),
-    needsSaplingParams: false,
+    needsSaplingParams: needsSaplingParams,
     memo: memo,
     isPaymentRequest: isPaymentRequest,
     requestedBy: requestedBy,

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -27,6 +27,7 @@ import 'package:zcash_wallet/src/core/widgets/review_info_row.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
 import 'package:zcash_wallet/src/features/keystone/widgets/keystone_signing_modal.dart';
+import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
 import 'package:zcash_wallet/src/features/send/screens/keystone_send_scan_screen.dart';
 import 'package:zcash_wallet/src/features/send/screens/send_review_screen.dart';
 import 'package:zcash_wallet/src/features/send/services/send_flow.dart'
@@ -37,7 +38,7 @@ import 'package:zcash_wallet/src/features/send/services/send_flow.dart'
         sendStatusRoutePayloadProvider;
 import 'package:zcash_wallet/src/features/send/widgets/send_review_content_view.dart';
 import 'package:zcash_wallet/src/features/send/widgets/verify_address_modal.dart';
-import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/api/keystone.dart'
@@ -315,6 +316,120 @@ void main() {
     expect(statusExtras.single, isA<SendReviewArgs>());
     expect(rustApi.discardCalls, isEmpty);
   });
+
+  testWidgets(
+    'sidebar account switch during Keystone cancellation leaves review',
+    (tester) async {
+      final released = Completer<void>();
+      rustApi.discardCompleter = released;
+      await _setDesktopViewport(tester);
+      await tester.pumpWidget(
+        _harness(
+          _reviewArgs(addressType: 'unified'),
+          bootstrap: _bootstrap(isHardware: true, secondAccount: true),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(SendReviewScreen)),
+      );
+      await tester.tap(find.text('Confirm with Keystone'));
+      await _flushRealAsync(tester);
+      await tester.tap(
+        find.descendant(
+          of: find.byType(KeystoneSigningModal),
+          matching: find.text('Cancel'),
+        ),
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('sidebar_accounts_button')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('sidebar_account_popover_row_account-b')),
+      );
+      await _flushRealAsync(tester);
+      await tester.pumpAndSettle();
+      expect(
+        container.read(accountProvider).value?.activeAccountUuid,
+        'account-b',
+      );
+      expect(find.text('home-route'), findsOneWidget);
+      expect(find.byType(SendReviewScreen), findsNothing);
+      released.complete();
+      await _flushRealAsync(tester);
+      await tester.pumpAndSettle();
+      expect(find.text('home-route'), findsOneWidget);
+      expect(find.byType(SendReviewScreen), findsNothing);
+      expect(rustApi.discardCalls, [(BigInt.one, 'test-send-flow')]);
+      expect(rustApi.proposedAccounts, isEmpty);
+    },
+  );
+
+  for (final refreshFailure in [false, true]) {
+    testWidgets('Back retries failed review cancellation and awaits cleanup '
+        '(refreshFailure=$refreshFailure)', (tester) async {
+      final syncNotifier = _FakeSyncNotifier();
+      await _setDesktopViewport(tester);
+      await tester.pumpWidget(
+        _harness(
+          _reviewArgs(addressType: 'unified'),
+          syncNotifier: syncNotifier,
+          initialLocation: '/send',
+        ),
+      );
+      await tester.pumpAndSettle();
+      GoRouter.of(tester.element(find.text('send-route'))).push('/send/review');
+      await tester.pumpAndSettle();
+      if (refreshFailure) {
+        syncNotifier.refreshError = StateError('balance unavailable');
+      } else {
+        rustApi.discardError = StateError('database busy');
+      }
+      await tester.tap(find.text('Cancel'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpAndSettle();
+      expect(find.text('Review send'), findsOneWidget);
+      expect(find.text('send-route'), findsNothing);
+      final discardsBeforeRetry = rustApi.discardCalls.length;
+      final refreshesBeforeRetry = syncNotifier.refreshedAccounts.length;
+      expect(discardsBeforeRetry, refreshFailure ? 1 : 3);
+
+      final released = Completer<void>();
+      final refreshed = Completer<void>();
+      rustApi.discardCompleter = released;
+      rustApi.discardError = null;
+      syncNotifier.refreshCompleter = refreshed;
+      syncNotifier.refreshError = null;
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+      expect(rustApi.discardCalls, hasLength(discardsBeforeRetry + 1));
+      expect(find.text('Review send'), findsOneWidget);
+      expect(find.text('send-route'), findsNothing);
+      expect(syncNotifier.refreshedAccounts, hasLength(refreshesBeforeRetry));
+
+      released.complete();
+      await tester.pumpAndSettle();
+      expect(
+        syncNotifier.refreshedAccounts,
+        hasLength(refreshesBeforeRetry + 1),
+      );
+      expect(find.text('send-route'), findsNothing);
+      expect(
+        tester
+            .widget<SendReviewContentView>(find.byType(SendReviewContentView))
+            .onConfirm,
+        isNull,
+      );
+
+      refreshed.complete();
+      await tester.pumpAndSettle();
+      expect(find.text('send-route'), findsOneWidget);
+      expect(rustApi.discardCalls, hasLength(discardsBeforeRetry + 1));
+      expect(rustApi.proposedAccounts, isEmpty);
+    });
+  }
 
   testWidgets('cancel discards the proposal and returns to send', (
     tester,
@@ -1256,6 +1371,9 @@ List<Override> _harnessOverrides({
     addressBookRepository ?? _FakeAddressBookRepository(),
   ),
   syncProvider.overrideWith(() => syncNotifier ?? _FakeSyncNotifier()),
+  ironwoodMigrationCoordinatorProvider.overrideWith(
+    _FakeMigrationCoordinator.new,
+  ),
 ];
 
 /// Drives [router] — built from the app's own `/send/review` page builder — so
@@ -1278,11 +1396,13 @@ Widget _harness(
   Listenable? routerRefresh,
   _FakeSyncNotifier? syncNotifier,
   bool cancelScan = false,
+  String initialLocation = '/send/review',
 }) {
   final router = GoRouter(
-    initialLocation: '/send/review',
+    initialLocation: initialLocation,
     refreshListenable: routerRefresh,
     routes: [
+      GoRoute(path: '/home', builder: (_, _) => const Text('home-route')),
       GoRoute(path: '/send', builder: (_, _) => const Text('send-route')),
       GoRoute(
         path: '/donation',
@@ -1338,7 +1458,10 @@ Widget _harness(
   );
 }
 
-AppBootstrapState _bootstrap({bool isHardware = false}) {
+AppBootstrapState _bootstrap({
+  bool isHardware = false,
+  bool secondAccount = false,
+}) {
   return AppBootstrapState(
     initialLocation: '/send/review',
     initialAccountState: AccountState(
@@ -1349,6 +1472,8 @@ AppBootstrapState _bootstrap({bool isHardware = false}) {
           order: 0,
           isHardware: isHardware,
         ),
+        if (secondAccount)
+          const AccountInfo(uuid: 'account-b', name: 'Account B', order: 1),
       ],
       activeAccountUuid: 'test-account',
       activeAddress: 'u1activeaddress',
@@ -1467,12 +1592,17 @@ class _FakePathProviderPlatform extends Fake
 
 class _FakeSyncNotifier extends SyncNotifier {
   Completer<void>? refreshCompleter;
+  Object? refreshError;
   final refreshedAccounts = <String>[];
+
+  @override
+  Future<void> refreshAfterAccountSwitch() async {}
 
   @override
   Future<void> refreshAfterProposalRelease(String accountUuid) async {
     refreshedAccounts.add(accountUuid);
     await refreshCompleter?.future;
+    if (refreshError != null) throw refreshError!;
   }
 
   @override
@@ -1490,8 +1620,15 @@ class _FakeSyncNotifier extends SyncNotifier {
   );
 }
 
+class _FakeMigrationCoordinator extends IronwoodMigrationCoordinator {
+  @override
+  IronwoodMigrationCoordinatorState build() =>
+      const IronwoodMigrationCoordinatorState();
+}
+
 class _RustApiFake implements RustLibApi {
   final discardCalls = <(BigInt, String)>[];
+  final proposedAccounts = <String>[];
   int createPcztCalls = 0;
   final createdProposalIds = <BigInt>[];
   int prepareBatchCalls = 0;
@@ -1507,6 +1644,7 @@ class _RustApiFake implements RustLibApi {
 
   void reset() {
     discardCalls.clear();
+    proposedAccounts.clear();
     createPcztCalls = 0;
     createdProposalIds.clear();
     prepareBatchCalls = 0;
@@ -1530,11 +1668,14 @@ class _RustApiFake implements RustLibApi {
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
-  }) async => ProposalResult(
-    proposalId: BigInt.two,
-    feeZatoshi: BigInt.from(20000),
-    needsSaplingParams: false,
-  );
+  }) async {
+    proposedAccounts.add(accountUuid);
+    return ProposalResult(
+      proposalId: BigInt.two,
+      feeZatoshi: BigInt.from(20000),
+      needsSaplingParams: false,
+    );
+  }
 
   @override
   Future<void> crateApiSyncDiscardProposal({

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -43,7 +43,7 @@ import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/api/keystone.dart'
     show KeystoneActionSig, KeystoneMsgSig, KeystoneSigResult;
 import 'package:zcash_wallet/src/rust/api/sync.dart'
-    show KeystoneBatchPczt, TexPcztPairResult;
+    show KeystoneBatchPczt, TexPcztPairResult, ProposalResult;
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 import 'package:zcash_wallet/src/rust/wallet/keystone.dart'
     show ZcashBatchMessageInput;
@@ -342,6 +342,67 @@ void main() {
     await tester.pump();
 
     expect(rustApi.discardCalls, hasLength(1));
+  });
+
+  testWidgets('cancel waits for refreshed balance before exposing Send', (
+    tester,
+  ) async {
+    final syncNotifier = _FakeSyncNotifier();
+    final refreshed = Completer<void>();
+    syncNotifier.refreshCompleter = refreshed;
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _harness(_reviewArgs(addressType: 'unified'), syncNotifier: syncNotifier),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(rustApi.discardCalls, hasLength(1));
+    expect(syncNotifier.refreshedAccounts, ['test-account']);
+    expect(find.text('send-route'), findsNothing);
+    expect(find.text('Cancelling…'), findsOneWidget);
+    expect(
+      tester
+          .widget<SendReviewContentView>(find.byType(SendReviewContentView))
+          .onConfirm,
+      isNull,
+    );
+
+    refreshed.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('send-route'), findsOneWidget);
+  });
+
+  testWidgets('failed cancellation stays on review and retries cleanup only', (
+    tester,
+  ) async {
+    rustApi.discardError = StateError('database busy');
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_harness(_reviewArgs(addressType: 'unified')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
+    expect(find.text('send-route'), findsNothing);
+    expect(find.text('Review send'), findsOneWidget);
+    expect(rustApi.discardCalls, hasLength(3));
+    expect(
+      tester
+          .widget<SendReviewContentView>(find.byType(SendReviewContentView))
+          .onConfirm,
+      isNull,
+    );
+
+    rustApi.discardError = null;
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(rustApi.discardCalls, hasLength(4));
+    expect(find.text('send-route'), findsOneWidget);
   });
 
   testWidgets(
@@ -672,6 +733,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(KeystoneSigningModal), findsNothing);
+    expect(find.text('Review send'), findsOneWidget);
+    expect(container.read(paymentUriBusySurfaceProvider), 1);
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
     expect(find.text('send-route'), findsOneWidget);
     expect(container.read(paymentUriBusySurfaceProvider), 0);
   });
@@ -692,11 +757,13 @@ void main() {
 
     await tester.tap(find.text('Cancel'));
     await tester.pumpAndSettle();
-    expect(find.text('send-route'), findsOneWidget);
+    expect(find.text('send-route'), findsNothing);
+    expect(find.text('Review send'), findsOneWidget);
     expect(container.read(paymentUriBusySurfaceProvider), 1);
 
     discardCompleter.complete();
-    await tester.pump();
+    await tester.pumpAndSettle();
+    expect(find.text('send-route'), findsOneWidget);
     expect(container.read(paymentUriBusySurfaceProvider), 0);
   });
 
@@ -1022,21 +1089,92 @@ void main() {
         matching: find.text('Cancel'),
       ),
     );
+    await _flushRealAsync(tester);
     await tester.pumpAndSettle();
 
-    expect(find.text('send-route'), findsOneWidget);
+    expect(find.text('send-route'), findsNothing);
+    expect(find.text('Review send'), findsOneWidget);
+    expect(find.byType(KeystoneSigningModal), findsNothing);
     expect(rustApi.discardCalls, hasLength(1));
     expect(rustApi.createPcztCalls, 0);
   });
 
   testWidgets(
-    'Keystone reject after PCZT creation releases the retained input lock',
+    'cancelling only signature scanning keeps the signing request live',
     (tester) async {
       await _setDesktopViewport(tester);
       await tester.pumpWidget(
         _harness(
           _reviewArgs(addressType: 'unified'),
           bootstrap: _bootstrap(isHardware: true),
+          cancelScan: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Confirm with Keystone'));
+      await _flushRealAsync(tester);
+      await tester.tap(find.text('Get signature'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('keystone-scan-route'));
+      await tester.pumpAndSettle();
+      expect(find.byType(KeystoneSigningModal), findsOneWidget);
+      expect(find.text('Get signature'), findsOneWidget);
+      expect(rustApi.discardCalls, isEmpty);
+      expect(rustApi.createPcztCalls, 1);
+    },
+  );
+
+  testWidgets(
+    'Keystone cancellation blocks late preparation until release finishes',
+    (tester) async {
+      final released = Completer<void>();
+      rustApi.discardCompleter = released;
+      await _setDesktopViewport(tester);
+      await tester.pumpWidget(
+        _harness(
+          _reviewArgs(addressType: 'unified'),
+          bootstrap: _bootstrap(isHardware: true),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Confirm with Keystone'));
+      await tester.pump();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(KeystoneSigningModal),
+          matching: find.text('Cancel'),
+        ),
+      );
+      await _flushRealAsync(tester);
+      expect(find.text('send-route'), findsNothing);
+      expect(find.text('Cancelling…'), findsWidgets);
+      expect(rustApi.createPcztCalls, 0);
+      expect(rustApi.discardCalls, hasLength(1));
+      expect(
+        tester
+            .widget<KeystoneSigningModal>(find.byType(KeystoneSigningModal))
+            .onPrimary,
+        isNull,
+      );
+      released.complete();
+      await _flushRealAsync(tester);
+      await tester.pumpAndSettle();
+      expect(find.text('send-route'), findsNothing);
+      expect(find.text('Review send'), findsOneWidget);
+      expect(find.byType(KeystoneSigningModal), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Keystone cancel then re-sign hands off the fresh proposal and fee',
+    (tester) async {
+      final statusExtras = <Object?>[];
+      await _setDesktopViewport(tester);
+      await tester.pumpWidget(
+        _harness(
+          _reviewArgs(addressType: 'unified'),
+          bootstrap: _bootstrap(isHardware: true),
+          statusExtras: statusExtras,
         ),
       );
       await tester.pumpAndSettle();
@@ -1051,12 +1189,27 @@ void main() {
           matching: find.text('Cancel'),
         ),
       );
+      await _flushRealAsync(tester);
       await tester.pumpAndSettle();
 
-      expect(find.text('send-route'), findsOneWidget);
+      expect(find.text('send-route'), findsNothing);
+      expect(find.text('Review send'), findsOneWidget);
+      expect(find.byType(KeystoneSigningModal), findsNothing);
       // createPcztFromProposal consumes the replayable proposal but retains
       // its owner-scoped DB input lock until the hardware flow finishes.
       expect(rustApi.discardCalls, [(BigInt.one, 'test-send-flow')]);
+      expect(find.text('0.0002 ZEC'), findsOneWidget);
+      await tester.tap(find.text('Confirm with Keystone'));
+      await _flushRealAsync(tester);
+      expect(rustApi.createdProposalIds, [BigInt.one, BigInt.two]);
+      expect(find.text('Get signature'), findsOneWidget);
+      await tester.tap(find.text('Get signature'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('keystone-scan-route'));
+      await tester.pumpAndSettle();
+      final handoff = statusExtras.last as KeystoneBroadcastArgs;
+      expect(handoff.reviewArgs.proposalId, BigInt.two);
+      expect(handoff.reviewArgs.feeZatoshi, BigInt.from(20000));
     },
   );
 }
@@ -1094,6 +1247,7 @@ Future<void> _flushRealAsync(WidgetTester tester) async {
 List<Override> _harnessOverrides({
   AppBootstrapState? bootstrap,
   AddressBookRepository? addressBookRepository,
+  _FakeSyncNotifier? syncNotifier,
 }) => [
   appBootstrapProvider.overrideWithValue(bootstrap ?? _bootstrap()),
   zecMarketDataSourceProvider.overrideWithValue(const _FakeMarketDataSource()),
@@ -1101,7 +1255,7 @@ List<Override> _harnessOverrides({
   addressBookRepositoryProvider.overrideWithValue(
     addressBookRepository ?? _FakeAddressBookRepository(),
   ),
-  syncProvider.overrideWith(_FakeSyncNotifier.new),
+  syncProvider.overrideWith(() => syncNotifier ?? _FakeSyncNotifier()),
 ];
 
 /// Drives [router] — built from the app's own `/send/review` page builder — so
@@ -1122,6 +1276,8 @@ Widget _harness(
   List<Object?>? statusExtras,
   List<Object?>? scanExtras,
   Listenable? routerRefresh,
+  _FakeSyncNotifier? syncNotifier,
+  bool cancelScan = false,
 }) {
   final router = GoRouter(
     initialLocation: '/send/review',
@@ -1141,7 +1297,9 @@ Widget _harness(
         builder: (context, state) {
           scanExtras?.add(state.extra);
           return GestureDetector(
-            onTap: () => context.pop(Uint8List.fromList(_fakeSignatureBytes)),
+            onTap: () => context.pop(
+              cancelScan ? null : Uint8List.fromList(_fakeSignatureBytes),
+            ),
             child: const Text('keystone-scan-route'),
           );
         },
@@ -1171,6 +1329,7 @@ Widget _harness(
     overrides: _harnessOverrides(
       bootstrap: bootstrap,
       addressBookRepository: addressBookRepository,
+      syncNotifier: syncNotifier,
     ),
     child: MaterialApp.router(
       routerConfig: router,
@@ -1307,6 +1466,21 @@ class _FakePathProviderPlatform extends Fake
 }
 
 class _FakeSyncNotifier extends SyncNotifier {
+  Completer<void>? refreshCompleter;
+  final refreshedAccounts = <String>[];
+
+  @override
+  Future<void> refreshAfterProposalRelease(String accountUuid) async {
+    refreshedAccounts.add(accountUuid);
+    await refreshCompleter?.future;
+  }
+
+  @override
+  Future<T> runWithAuthoritativeSpendable<T>({
+    required String accountUuid,
+    required Future<T> Function() operation,
+  }) => operation();
+
   @override
   Future<SyncState> build() async => SyncState(
     accountUuid: 'test-account',
@@ -1319,6 +1493,7 @@ class _FakeSyncNotifier extends SyncNotifier {
 class _RustApiFake implements RustLibApi {
   final discardCalls = <(BigInt, String)>[];
   int createPcztCalls = 0;
+  final createdProposalIds = <BigInt>[];
   int prepareBatchCalls = 0;
   int encodeBatchCalls = 0;
   int encodeFullPcztCalls = 0;
@@ -1326,12 +1501,14 @@ class _RustApiFake implements RustLibApi {
   int previousTransactionCount = 0;
   Object? prepareBatchError;
   Completer<void>? discardCompleter;
+  Object? discardError;
   String unifiedAddress = 'u1ownaccountaddressnotmatchingrecipient';
   String transparentAddress = 't1ownaccountaddressnotmatchingrecipient';
 
   void reset() {
     discardCalls.clear();
     createPcztCalls = 0;
+    createdProposalIds.clear();
     prepareBatchCalls = 0;
     encodeBatchCalls = 0;
     encodeFullPcztCalls = 0;
@@ -1339,9 +1516,25 @@ class _RustApiFake implements RustLibApi {
     previousTransactionCount = 0;
     prepareBatchError = null;
     discardCompleter = null;
+    discardError = null;
     unifiedAddress = 'u1ownaccountaddressnotmatchingrecipient';
     transparentAddress = 't1ownaccountaddressnotmatchingrecipient';
   }
+
+  @override
+  Future<ProposalResult> crateApiSyncProposeSend({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String sendFlowId,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+  }) async => ProposalResult(
+    proposalId: BigInt.two,
+    feeZatoshi: BigInt.from(20000),
+    needsSaplingParams: false,
+  );
 
   @override
   Future<void> crateApiSyncDiscardProposal({
@@ -1350,6 +1543,7 @@ class _RustApiFake implements RustLibApi {
   }) async {
     discardCalls.add((proposalId, sendFlowId));
     await discardCompleter?.future;
+    if (discardError != null) throw discardError!;
   }
 
   @override
@@ -1399,6 +1593,7 @@ class _RustApiFake implements RustLibApi {
     required String sendFlowId,
   }) async {
     createPcztCalls++;
+    createdProposalIds.add(proposalId);
     return Uint8List.fromList([1, 2, 3]);
   }
 

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/core/widgets/app_back_link.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/comma_to_dot_input_formatter.dart';
 import 'package:zcash_wallet/src/core/widgets/decimal_amount_input_formatter.dart';
@@ -19,6 +20,8 @@ import 'package:zcash_wallet/src/features/address_book/providers/address_book_pr
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
 import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
 import 'package:zcash_wallet/src/features/send/screens/send_screen.dart';
+import 'package:zcash_wallet/src/features/send/screens/send_review_screen.dart';
+import 'package:zcash_wallet/src/features/send/widgets/send_recipient_resolver.dart';
 import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
 import 'package:zcash_wallet/src/features/send/services/send_proving_key_warmup.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
@@ -55,6 +58,121 @@ void main() {
     expect(calls, 1);
     expect(find.byType(SendScreen), findsOneWidget);
   });
+
+  testWidgets(
+    'released spendable balance clears the visible amount error and permits retry',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final syncNotifier = _FakeSyncNotifier(
+        spendableBalance: BigInt.zero,
+        displaySpendableBalance: null,
+        ironwoodBalance: BigInt.zero,
+        displaySpendableFreshness: SpendableBalanceFreshness.authoritative,
+        transparentBalance: BigInt.zero,
+      );
+      await tester.pumpWidget(_sendHarness(syncNotifier: syncNotifier));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        _editableIn('send_address_field'),
+        _shieldedAddress,
+      );
+      await tester.enterText(_editableIn('send_amount_field'), '1');
+      await tester.pumpAndSettle();
+      expect(find.text('Insufficient shielded balance'), findsOneWidget);
+
+      syncNotifier.restoreSpendable(BigInt.from(500000000));
+      await tester.pumpAndSettle();
+      expect(find.text('Insufficient shielded balance'), findsNothing);
+      expect(_fieldText(tester, 'send_amount_field'), '1');
+      await tester.tap(find.byKey(const ValueKey('send_review_button')));
+      await tester.pumpAndSettle();
+      expect(rustApi.proposeSendCalls, 1);
+      expect(rustApi.lastProposeAmountZatoshi, BigInt.from(100000000));
+    },
+  );
+
+  testWidgets(
+    'Max is requoted when proposal release restores spendable balance',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final syncNotifier = _FakeSyncNotifier(
+        spendableBalance: BigInt.from(500000000),
+        displaySpendableBalance: null,
+        ironwoodBalance: BigInt.zero,
+        displaySpendableFreshness: SpendableBalanceFreshness.authoritative,
+        transparentBalance: BigInt.zero,
+      );
+      await tester.pumpWidget(_sendHarness(syncNotifier: syncNotifier));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        _editableIn('send_address_field'),
+        _shieldedAddress,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Use Max'));
+      await tester.pumpAndSettle();
+      final initialQuotes = rustApi.estimateSendMaxCalls;
+      expect(initialQuotes, greaterThan(0));
+
+      syncNotifier.restoreSpendable(BigInt.from(600000000));
+      await tester.pumpAndSettle();
+      expect(rustApi.estimateSendMaxCalls, greaterThan(initialQuotes));
+      expect(_fieldText(tester, 'send_amount_field'), isNotEmpty);
+      expect(find.text('Max amount unavailable'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'review Back releases its lock and restores the same amount for another review',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final syncNotifier = _FakeSyncNotifier(
+        spendableBalance: BigInt.from(500000000),
+        displaySpendableBalance: null,
+        ironwoodBalance: BigInt.zero,
+        displaySpendableFreshness: SpendableBalanceFreshness.authoritative,
+        transparentBalance: BigInt.zero,
+      );
+      syncNotifier.balanceAfterRelease = BigInt.from(500000000);
+      await tester.pumpWidget(
+        _sendHarness(
+          syncNotifier: syncNotifier,
+          realReview: true,
+          addressBookRepository: _FakeAddressBookRepository([]),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        _editableIn('send_address_field'),
+        _shieldedAddress,
+      );
+      await tester.enterText(_editableIn('send_amount_field'), '1');
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('send_review_button')));
+      await tester.pumpAndSettle();
+      expect(find.text('Review send'), findsOneWidget);
+
+      syncNotifier.restoreSpendable(BigInt.zero);
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AppBackLink),
+          matching: find.text('Send'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(SendScreen), findsOneWidget);
+      expect(_fieldText(tester, 'send_amount_field'), '1');
+      expect(find.text('Insufficient shielded balance'), findsNothing);
+      expect(rustApi.discardCalls, 1);
+
+      await tester.tap(find.byKey(const ValueKey('send_review_button')));
+      await tester.pumpAndSettle();
+      expect(find.text('Review send'), findsOneWidget);
+      expect(rustApi.proposeSendCalls, 2);
+      expect(rustApi.lastProposeAmountZatoshi, BigInt.from(100000000));
+    },
+  );
 
   testWidgets('keeps rendering if Orchard warmup cannot start', (tester) async {
     await _setDesktopViewport(tester);
@@ -1476,6 +1594,7 @@ Widget _sendHarness({
   _FakeSyncNotifier? syncNotifier,
   void Function()? warmProvingKey,
   void Function(SendReviewArgs?)? onReviewArgs,
+  bool realReview = false,
 }) {
   final router = GoRouter(
     initialLocation: '/send',
@@ -1488,6 +1607,9 @@ Widget _sendHarness({
         path: '/send/review',
         builder: (_, state) {
           onReviewArgs?.call(state.extra as SendReviewArgs?);
+          if (realReview) {
+            return SendReviewScreen(args: state.extra! as SendReviewArgs);
+          }
           return const SizedBox.shrink();
         },
       ),
@@ -1497,6 +1619,10 @@ Widget _sendHarness({
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(bootstrap ?? _bootstrap),
+      if (realReview)
+        ownAccountAddressesProvider.overrideWith((ref) async => {}),
+      if (realReview)
+        zecHomeUsdUnitPriceProvider.overrideWithValue(zecUsdPrice),
       sendWalletDbPathProvider.overrideWithValue(() async => '/tmp/test.db'),
       sendProvingKeyWarmupProvider.overrideWithValue(warmProvingKey ?? () {}),
       ironwoodHomeMigrationCtaProvider.overrideWithValue(
@@ -1659,6 +1785,22 @@ final _hardwareBootstrap = AppBootstrapState(
 );
 
 class _FakeSyncNotifier extends SyncNotifier {
+  BigInt? balanceAfterRelease;
+  void restoreSpendable(BigInt balance) {
+    state = AsyncData(
+      state.requireValue.copyWith(
+        spendableBalance: balance,
+        displaySpendableBalance: balance,
+      ),
+    );
+  }
+
+  @override
+  Future<void> refreshAfterProposalRelease(String accountUuid) async {
+    final balance = balanceAfterRelease;
+    if (balance != null && ref.mounted) restoreSpendable(balance);
+  }
+
   _FakeSyncNotifier({
     required this.spendableBalance,
     required this.displaySpendableBalance,
@@ -1711,6 +1853,16 @@ class _TestZecUsdPriceNotifier extends Notifier<double?> {
 }
 
 class _RustApiFake implements RustLibApi {
+  int discardCalls = 0;
+
+  @override
+  Future<void> crateApiSyncDiscardProposal({
+    required BigInt proposalId,
+    required String sendFlowId,
+  }) async {
+    discardCalls++;
+  }
+
   int proposeSendCalls = 0;
   String? lastValidateNetwork;
   int estimateSendMaxCalls = 0;
@@ -1721,6 +1873,7 @@ class _RustApiFake implements RustLibApi {
   String? lastEstimateSendMaxMemo;
 
   void reset() {
+    discardCalls = 0;
     lastValidateNetwork = null;
     proposeSendCalls = 0;
     estimateSendMaxCalls = 0;

--- a/test/features/send/send_status_screen_test.dart
+++ b/test/features/send/send_status_screen_test.dart
@@ -689,6 +689,8 @@ void main() {
         proposalId: BigInt.one,
         sendFlowId: 'test-send-flow',
         logContext: 'SendStatusTest',
+        syncNotifier: _FakeSyncNotifier(),
+        accountUuid: 'test-account',
       ),
     );
 
@@ -1071,6 +1073,9 @@ class _FakeSyncNotifier extends SyncNotifier {
 
   @override
   Future<void> refreshAfterSend() async {}
+
+  @override
+  Future<void> refreshAfterProposalRelease(String accountUuid) async {}
 
   @override
   Future<void> restartSync() async {}

--- a/test/features/swap/mobile_swap_keystone_signing_test.dart
+++ b/test/features/swap/mobile_swap_keystone_signing_test.dart
@@ -414,7 +414,12 @@ void main() {
 
     expect(find.text('Cancel'), findsOneWidget);
 
+    final release = Completer<void>();
+    hardwareSigningService.releaseCompleter = release;
     await tester.tap(find.text('Cancel'));
+    await tester.pump();
+    expect(find.byType(MobileSwapKeystoneSignScreen), findsOneWidget);
+    release.complete();
     await tester.pumpAndSettle();
 
     expect(swapNotifier.pendingCleared, isTrue);
@@ -472,17 +477,9 @@ void main() {
     expect(swapNotifier.pendingCleared, isTrue);
     expect(
       find.byKey(const ValueKey('mobile_swap_review_inactive_notice')),
-      findsOneWidget,
+      findsNothing,
     );
-    expect(
-      router.routerDelegate.currentConfiguration.uri.toString(),
-      '/swap/review',
-    );
-
-    await tester.tap(
-      find.byKey(const ValueKey('swap_review_return_to_swap_button')),
-    );
-    await tester.pumpAndSettle();
+    expect(router.routerDelegate.currentConfiguration.uri.toString(), '/swap');
 
     expect(find.byKey(const ValueKey('mobile_swap_route')), findsOneWidget);
     expect(router.routerDelegate.currentConfiguration.uri.toString(), '/swap');
@@ -646,50 +643,61 @@ void main() {
     );
   });
 
-  testWidgets('review-start pay signing cancel returns to the pay composer', (
-    tester,
-  ) async {
-    late _PendingSigningSwapNotifier swapNotifier;
-    final router = GoRouter(
-      initialLocation: '/swap/keystone-sign',
-      routes: [
-        GoRoute(
-          path: '/swap/keystone-sign',
-          builder: (_, _) => MobileSwapKeystoneSignScreen(
-            args: MobileSwapKeystoneSignArgs.fromReview(
-              intent: _hardwareIntent,
-              returnTarget: SwapActivityReturnTarget.pay,
+  for (final systemBack in [false, true]) {
+    testWidgets(
+      'review-start pay signing ${systemBack ? 'back' : 'cancel'} returns to the pay composer',
+      (tester) async {
+        late _PendingSigningSwapNotifier swapNotifier;
+        final router = GoRouter(
+          initialLocation: '/swap/keystone-sign',
+          routes: [
+            GoRoute(
+              path: '/swap/keystone-sign',
+              builder: (_, _) => MobileSwapKeystoneSignScreen(
+                args: MobileSwapKeystoneSignArgs.fromReview(
+                  intent: _hardwareIntent,
+                  returnTarget: SwapActivityReturnTarget.pay,
+                ),
+              ),
             ),
+            GoRoute(
+              path: '/pay',
+              builder: (_, _) =>
+                  const SizedBox(key: ValueKey('mobile_pay_route')),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          _app(
+            router,
+            swapNotifier: () {
+              swapNotifier = _PendingSigningSwapNotifier(_hardwareIntent);
+              return swapNotifier;
+            },
+            hardwareSigningService: _FakeSwapHardwareSigningService(),
           ),
-        ),
-        GoRoute(
-          path: '/pay',
-          builder: (_, _) => const SizedBox(key: ValueKey('mobile_pay_route')),
-        ),
-      ],
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Cancel'), findsOneWidget);
+
+        if (systemBack) {
+          await tester.binding.handlePopRoute();
+        } else {
+          await tester.tap(find.text('Cancel'));
+        }
+        await tester.pumpAndSettle();
+
+        expect(swapNotifier.pendingCleared, isTrue);
+        expect(find.byKey(const ValueKey('mobile_pay_route')), findsOneWidget);
+        expect(
+          router.routerDelegate.currentConfiguration.uri.toString(),
+          '/pay',
+        );
+      },
     );
-
-    await tester.pumpWidget(
-      _app(
-        router,
-        swapNotifier: () {
-          swapNotifier = _PendingSigningSwapNotifier(_hardwareIntent);
-          return swapNotifier;
-        },
-        hardwareSigningService: _FakeSwapHardwareSigningService(),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.text('Cancel'), findsOneWidget);
-
-    await tester.tap(find.text('Cancel'));
-    await tester.pumpAndSettle();
-
-    expect(swapNotifier.pendingCleared, isTrue);
-    expect(find.byKey(const ValueKey('mobile_pay_route')), findsOneWidget);
-    expect(router.routerDelegate.currentConfiguration.uri.toString(), '/pay');
-  });
+  }
 
   testWidgets(
     'review-start pay signing success opens the pay submitted screen',
@@ -1098,6 +1106,7 @@ class _FakeSwapDepositSender implements SwapDepositSender {
 
 class _FakeSwapHardwareSigningService implements SwapHardwareSigningService {
   final discardedDrafts = <BigInt>[];
+  Completer<void>? releaseCompleter;
 
   @override
   Future<SwapHardwarePcztDraft> createZecDepositPczt({
@@ -1105,6 +1114,7 @@ class _FakeSwapHardwareSigningService implements SwapHardwareSigningService {
     required SwapIntent intent,
   }) async {
     return SwapHardwarePcztDraft(
+      accountUuid: accountUuid,
       pcztBytes: const [1, 2, 3],
       needsSaplingParams: false,
       feeZatoshi: BigInt.from(10000),
@@ -1140,6 +1150,7 @@ class _FakeSwapHardwareSigningService implements SwapHardwareSigningService {
   @override
   Future<void> discardPcztDraft({required SwapHardwarePcztDraft draft}) async {
     discardedDrafts.add(draft.proposalId);
+    await releaseCompleter?.future;
   }
 
   @override

--- a/test/features/swap/support/swap_screen_test_fakes.dart
+++ b/test/features/swap/support/swap_screen_test_fakes.dart
@@ -905,6 +905,7 @@ class _FakeSwapHardwareSigningService implements SwapHardwareSigningService {
   }) async {
     depositDrafts.add(intent.id);
     return SwapHardwarePcztDraft(
+      accountUuid: accountUuid,
       pcztBytes: const [1, 2, 3],
       needsSaplingParams: false,
       feeZatoshi: BigInt.from(10000),

--- a/test/features/swap/swap_deposit_amount_test.dart
+++ b/test/features/swap/swap_deposit_amount_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_deposit_sender.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_hardware_signing_service.dart';
@@ -23,6 +24,48 @@ void main() {
   });
 
   tearDownAll(RustLib.dispose);
+
+  test(
+    'hardware draft release refreshes the owner balance after Rust unlock',
+    () async {
+      final events = <String>[];
+      rustApi.releaseEvents = events;
+      final sync = _ReleaseSyncNotifier(events);
+      final container = ProviderContainer(
+        overrides: [syncProvider.overrideWith(() => sync)],
+      );
+      addTearDown(container.dispose);
+      final service = container.read(swapHardwareSigningServiceProvider);
+      await service.discardPcztDraft(draft: _releaseDraft);
+      expect(events, ['release', 'refresh-account-1']);
+    },
+  );
+
+  test(
+    'hardware draft release does not hide balance refresh failure',
+    () async {
+      final events = <String>[];
+      rustApi.releaseEvents = events;
+      final sync = _ReleaseSyncNotifier(events)..failRefresh = true;
+      final container = ProviderContainer(
+        overrides: [syncProvider.overrideWith(() => sync)],
+      );
+      addTearDown(container.dispose);
+      final service = container.read(swapHardwareSigningServiceProvider);
+      await expectLater(
+        service.discardPcztDraft(draft: _releaseDraft),
+        throwsStateError,
+      );
+      sync.failRefresh = false;
+      await service.discardPcztDraft(draft: _releaseDraft);
+      expect(events, [
+        'release',
+        'refresh-account-1',
+        'release',
+        'refresh-account-1',
+      ]);
+    },
+  );
 
   test('software ZEC deposit uses quote base units, not display text', () {
     final quote = _quote(
@@ -161,12 +204,23 @@ SwapIntent _intent({
 }
 
 class _RustApiFake implements RustLibApi {
+  List<String>? releaseEvents;
+
+  @override
+  Future<void> crateApiSyncDiscardProposal({
+    required BigInt proposalId,
+    required String sendFlowId,
+  }) async {
+    releaseEvents?.add('release');
+  }
+
   int proposeSendCalls = 0;
 
   /// The network the last address validation was asked about.
   String? lastValidatedNetwork;
 
   void reset() {
+    releaseEvents = null;
     proposeSendCalls = 0;
     lastValidatedNetwork = null;
   }
@@ -214,3 +268,27 @@ class _RustApiFake implements RustLibApi {
 }
 
 const _texAddress = 'tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte';
+
+final _releaseDraft = SwapHardwarePcztDraft(
+  accountUuid: 'account-1',
+  pcztBytes: const [1],
+  needsSaplingParams: false,
+  feeZatoshi: BigInt.one,
+  proposalId: BigInt.one,
+  sendFlowId: 'release-test',
+);
+
+class _ReleaseSyncNotifier extends SyncNotifier {
+  _ReleaseSyncNotifier(this.events);
+  final List<String> events;
+  bool failRefresh = false;
+
+  @override
+  Future<SyncState> build() async => SyncState();
+
+  @override
+  Future<void> refreshAfterProposalRelease(String accountUuid) async {
+    events.add('refresh-$accountUuid');
+    if (failRefresh) throw StateError('balance unavailable');
+  }
+}

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -8840,6 +8840,96 @@ void main() {
     },
   );
 
+  testWidgets(
+    'hardware Pay cancel returns to an empty composer and requires a fresh quote',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final provider = _FakeSwapProvider();
+      final signing = _FakeSwapHardwareSigningService();
+      final router = GoRouter(
+        initialLocation: '/pay',
+        routes: [_payRoute(), _swapActivityRoute()],
+      );
+      await tester.pumpWidget(
+        _routerHarness(
+          router,
+          bootstrap: _hardwareBootstrap,
+          swapProvider: provider,
+          hardwareSigningService: signing,
+          seedSwapActivityFixtures: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('pay_amount_input')),
+        '25',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('pay_amount_continue_button')),
+      );
+      await tester.pumpAndSettle();
+      const recipient = '0x52908400098527886e0f7030069857d2e4169ee7';
+      await tester.enterText(
+        find.byKey(const ValueKey('pay_recipient_search_field')),
+        recipient,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('pay_select_recipient_button')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('pay_confirm_button')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byKey(
+            const ValueKey('swap_keystone_signing_overlay_surface'),
+          ),
+          matching: find.text('Cancel'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(router.routerDelegate.currentConfiguration.uri.path, '/pay');
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(PayScreen)),
+      );
+      final restored = container.read(swapStateProvider);
+      expect(restored.payMode, isTrue);
+      expect(restored.quoteMode, SwapQuoteMode.exactOutput);
+      expect(restored.receiveAmountText, isEmpty);
+      expect(restored.destinationText, isEmpty);
+      expect(restored.reviewQuote, isNull);
+      expect(restored.pendingKeystoneSigningIntent, isNull);
+      expect(
+        tester.widget<EditableText>(find.byType(EditableText)).controller.text,
+        isEmpty,
+      );
+      final requests = provider.requests.length;
+      await tester.enterText(
+        find.byKey(const ValueKey('pay_amount_input')),
+        '25',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('pay_amount_continue_button')),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('pay_recipient_search_field')),
+        recipient,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('pay_select_recipient_button')),
+      );
+      await tester.pumpAndSettle();
+      expect(provider.requests, hasLength(requests + 1));
+      expect(provider.requests.last.mode, SwapQuoteMode.exactOutput);
+      expect(provider.requests.last.amount, 25);
+    },
+  );
+
   testWidgets('hardware ZEC auto signing cancel drops the pending intent', (
     tester,
   ) async {
@@ -8905,6 +8995,39 @@ void main() {
     expect(hardwareSigningService.discardedDrafts, [BigInt.one]);
     expect(find.text('Sign ZEC deposit on Keystone'), findsNothing);
     expect(find.text('Deposit ZEC'), findsNothing);
+    expect(
+      tester
+          .widget<EditableText>(
+            find.descendant(
+              of: find.byKey(const ValueKey('swap_amount_field')),
+              matching: find.byType(EditableText),
+            ),
+          )
+          .controller
+          .text,
+      '',
+    );
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(SwapScreen)),
+    );
+    final restored = container.read(swapStateProvider);
+    expect(restored.destinationText, isEmpty);
+    expect(restored.reviewQuote, isNull);
+    expect(restored.pendingKeystoneSigningIntent, isNull);
+    final requestsBeforeRetry = swapProvider.requests.length;
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_amount_field')),
+      '0.003',
+    );
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+    await tester.pumpAndSettle();
+    expect(swapProvider.requests, hasLength(requestsBeforeRetry + 1));
+    expect(container.read(swapStateProvider).reviewQuote, isNotNull);
   });
 
   testWidgets(

--- a/test/providers/payment_request_flow_provider_test.dart
+++ b/test/providers/payment_request_flow_provider_test.dart
@@ -127,6 +127,7 @@ class _FakeSendApi {
           required BigInt proposalId,
           required String sendFlowId,
           required String logContext,
+          required String accountUuid,
         }) async {
           final pending = discardGate;
           if (pending != null) await pending.future;

--- a/test/providers/sync_provider_test.dart
+++ b/test/providers/sync_provider_test.dart
@@ -148,6 +148,206 @@ void main() {
     expect(notifier.balanceReadCount, 1);
   });
 
+  test('proposal release rejects an unavailable balance instead of accepting '
+      'the locked snapshot', () async {
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+        accountProvider.overrideWith(_ExistingAccountNotifier.new),
+        syncProvider.overrideWith(
+          () => _BalanceRefreshTestSyncNotifier(() async => 'wallet.db'),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.listen(syncProvider, (_, _) {});
+    await container.read(syncProvider.future);
+    await expectLater(
+      container
+          .read(syncProvider.notifier)
+          .refreshAfterProposalRelease(_accountUuid),
+      throwsStateError,
+    );
+  });
+
+  test(
+    'release for an inactive account never reads the active account balance',
+    () async {
+      late _BalanceRefreshTestSyncNotifier notifier;
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+          accountProvider.overrideWith(_ExistingAccountNotifier.new),
+          syncProvider.overrideWith(
+            () => notifier = _BalanceRefreshTestSyncNotifier(
+              () async => 'wallet.db',
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.listen(syncProvider, (_, _) {});
+      await container.read(syncProvider.future);
+      await notifier.refreshAfterProposalRelease(_otherAccountUuid);
+      expect(notifier.balanceReadCount, 0);
+    },
+  );
+
+  test(
+    'an ordinary queued refresh cannot hide an unavailable release balance',
+    () async {
+      late _BalanceRefreshTestSyncNotifier notifier;
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+          accountProvider.overrideWith(_ExistingAccountNotifier.new),
+          syncProvider.overrideWith(
+            () => notifier = _BalanceRefreshTestSyncNotifier(
+              () async => 'wallet.db',
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.listen(syncProvider, (_, _) {});
+      await container.read(syncProvider.future);
+      notifier.gateFirstBalanceRead();
+      final release = notifier.refreshAfterProposalRelease(_accountUuid);
+      final releaseExpectation = expectLater(release, throwsStateError);
+      await notifier.firstBalanceReadStarted;
+      final queued = notifier.refreshAfterUnlock();
+      final queuedExpectation = expectLater(queued, throwsStateError);
+      notifier.releaseFirstBalanceRead();
+      await Future.wait([releaseExpectation, queuedExpectation]);
+      expect(notifier.balanceReadCount, 2);
+    },
+  );
+
+  test(
+    'release queues a fresh balance read behind an older locked read',
+    () async {
+      late _BalanceRefreshTestSyncNotifier notifier;
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+          accountProvider.overrideWith(_ExistingAccountNotifier.new),
+          syncProvider.overrideWith(
+            () => notifier = _BalanceRefreshTestSyncNotifier(
+              () async => 'wallet.db',
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.listen(syncProvider, (_, _) {});
+      await container.read(syncProvider.future);
+      notifier.balance = _availableBalance(BigInt.zero);
+      notifier.gateFirstBalanceRead();
+      final stale = notifier.refreshAfterUnlock();
+      await notifier.firstBalanceReadStarted;
+      notifier.balance = _availableBalance(BigInt.from(160000));
+      final released = notifier.refreshAfterProposalRelease(_accountUuid);
+      notifier.releaseFirstBalanceRead();
+      await Future.wait([stale, released]);
+
+      expect(notifier.balanceReadCount, 2);
+      final state = container.read(syncProvider).requireValue;
+      expect(state.accountUuid, _accountUuid);
+      expect(state.spendableBalance, BigInt.from(160000));
+      expect(state.displaySpendableBalance, BigInt.from(160000));
+      expect(
+        state.displaySpendableFreshness,
+        SpendableBalanceFreshness.authoritative,
+      );
+    },
+  );
+
+  test(
+    'a successful ordinary trailing refresh releases the cancelled snapshot',
+    () async {
+      late _BalanceRefreshTestSyncNotifier notifier;
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+          accountProvider.overrideWith(_ExistingAccountNotifier.new),
+          syncProvider.overrideWith(
+            () => notifier = _BalanceRefreshTestSyncNotifier(
+              () async => 'wallet.db',
+              initialState: SyncState(
+                accountUuid: _accountUuid,
+                hasAccountScopedData: true,
+                isSyncing: true,
+                spendableBalance: BigInt.zero,
+                displaySpendableBalance: BigInt.from(40),
+                displaySpendableFreshness:
+                    SpendableBalanceFreshness.lastCompletedSync,
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.listen(syncProvider, (_, _) {});
+      await container.read(syncProvider.future);
+      notifier.gateFirstBalanceRead();
+      final release = notifier.refreshAfterProposalRelease(_accountUuid);
+      await notifier.firstBalanceReadStarted;
+      // The release's first read was unavailable. A normal resume refresh
+      // queues behind it and obtains the authoritative post-unlock balance.
+      notifier.balance = _availableBalance(BigInt.from(160000));
+      final queued = notifier.refreshAfterUnlock();
+      notifier.releaseFirstBalanceRead();
+      await Future.wait([release, queued]);
+      expect(notifier.balanceReadCount, 2);
+      final state = container.read(syncProvider).requireValue;
+      expect(state.spendableBalance, BigInt.from(160000));
+      expect(state.displaySpendableBalance, BigInt.from(160000));
+      expect(
+        state.displaySpendableFreshness,
+        SpendableBalanceFreshness.authoritative,
+      );
+    },
+  );
+
+  test(
+    'an account switch during release refresh cannot publish the old balance',
+    () async {
+      late _BalanceRefreshTestSyncNotifier notifier;
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+          accountProvider.overrideWith(_ExistingAccountNotifier.new),
+          syncProvider.overrideWith(
+            () => notifier = _BalanceRefreshTestSyncNotifier(
+              () async => 'wallet.db',
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.listen(syncProvider, (_, _) {});
+      await container.read(syncProvider.future);
+      notifier.balance = _availableBalance(BigInt.from(160000));
+      notifier.gateFirstBalanceRead();
+      final released = notifier.refreshAfterProposalRelease(_accountUuid);
+      await notifier.firstBalanceReadStarted;
+      (container.read(accountProvider.notifier) as _ExistingAccountNotifier)
+          .activateForTest(_otherAccountUuid);
+      notifier.replaceState(
+        SyncState(
+          accountUuid: _otherAccountUuid,
+          spendableBalance: BigInt.from(90),
+        ),
+      );
+      notifier.releaseFirstBalanceRead();
+      await released;
+
+      final state = container.read(syncProvider).requireValue;
+      expect(state.accountUuid, _otherAccountUuid);
+      expect(state.spendableBalance, BigInt.from(90));
+    },
+  );
+
   test('in-flight progress exits quietly after notifier disposal', () async {
     final resolverStarted = Completer<void>();
     final dbPath = Completer<String>();
@@ -543,6 +743,9 @@ class _BalanceRefreshTestSyncNotifier extends SyncNotifier {
   final List<rust_sync.TransactionInfo> history;
 
   var balanceReadCount = 0;
+  rust_sync.WalletBalance? balance;
+
+  void replaceState(SyncState next) => state = AsyncData(next);
 
   var _gateFirstBalanceRead = false;
   final _firstBalanceReadStarted = Completer<void>();
@@ -566,11 +769,12 @@ class _BalanceRefreshTestSyncNotifier extends SyncNotifier {
     required String accountUuid,
   }) async {
     balanceReadCount++;
+    final result = balance ?? _unavailableBalance;
     if (_gateFirstBalanceRead && !_firstBalanceReadStarted.isCompleted) {
       _firstBalanceReadStarted.complete();
       await _firstBalanceReadReleased.future;
     }
-    return _unavailableBalance;
+    return result;
   }
 
   @override
@@ -622,12 +826,41 @@ const _accountUuid = 'account-1';
 const _otherAccountUuid = 'account-2';
 
 class _ExistingAccountNotifier extends AccountNotifier {
+  void activateForTest(String accountUuid) {
+    state = AsyncData(
+      state.requireValue.copyWith(activeAccountUuid: accountUuid),
+    );
+  }
+
   @override
   AccountState build() => const AccountState(
     accounts: [AccountInfo(uuid: _accountUuid, name: 'Account 1', order: 0)],
     activeAccountUuid: _accountUuid,
   );
 }
+
+rust_sync.WalletBalance _availableBalance(BigInt amount) =>
+    rust_sync.WalletBalance(
+      availability: rust_sync.WalletBalanceAvailability.available,
+      transparent: BigInt.zero,
+      sapling: BigInt.zero,
+      orchard: amount,
+      ironwood: BigInt.zero,
+      transparentLocked: BigInt.zero,
+      saplingLocked: BigInt.zero,
+      orchardLocked: BigInt.zero,
+      ironwoodLocked: BigInt.zero,
+      transparentPending: BigInt.zero,
+      saplingPending: BigInt.zero,
+      orchardPending: BigInt.zero,
+      ironwoodPending: BigInt.zero,
+      changePendingConfirmation: BigInt.zero,
+      valuePendingSpendability: BigInt.zero,
+      uneconomicValue: BigInt.zero,
+      spendable: amount,
+      locked: BigInt.zero,
+      total: amount,
+    );
 
 final _unavailableBalance = rust_sync.WalletBalance(
   availability: rust_sync.WalletBalanceAvailability.summaryUnavailable,


### PR DESCRIPTION
## Problem

Cancelling signing could leave the spendable balance stale, making Home show a zero balance or Send report insufficient funds. While fixing that issue, this PR also aligns cancellation behavior between desktop and mobile.

## Behavior after cancellation

| Flow | Result |
| --- | --- |
| Send | Return to Review with the address, amount, and memo preserved. Refresh the balance and fees, then retry with a new proposal. |
| Swap / Pay | Both Cancel and Back return to the composer. Keep the existing input-reset behavior and request a fresh quote on the next Review. |
| Gift Card creation | Return to Review with the amount, message, and design preserved. Refresh the balance and fees before retrying. |
| Vote | Unchanged: preserve partial signatures and resume unsigned bundles. |

Closing only the QR scanner remains distinct from cancelling the entire signing step.

## Implementation

- Finish releasing reserved inputs and refreshing the balance before allowing a retry. Block duplicate actions during cleanup and prevent stale proposals from being reused if refresh fails.
- Prevent preparation or signature responses that complete after cancellation from reactivating the cancelled flow.
- Carry the refreshed Send proposal and fees through signing and submission.
- Add a short per-flow cancellation policy to `AGENTS.md`.

## Commit structure

1. Shared balance refresh and Send cancellation / Review recovery.
2. Swap / Pay cancellation cleanup and consistent return navigation.
3. Gift Card cancellation / Review refresh.
4. Cancellation policy documentation.

Commits are split by behavior. Swap / Pay input preservation is intentionally excluded.

## Verification

Focused tests cover balance-refresh failures and retries, account switching, late PCZT creation, Send re-signing after cancellation, Swap / Pay return navigation and fresh quotes, and Gift Card retry blocking when refresh fails.

| Scope | Desktop tests | Mobile tests |
| --- | ---: | ---: |
| Send | 223 passed | 107 passed |
| Swap / Pay | 170 passed | 41 passed |
| Gift Card | 66 passed | 38 passed |

- Validated each code slice incrementally in a separate worktree and reran the affected Swap / Pay checks after removing input preservation.
- `fvm flutter analyze --no-pub` and `git diff --check` passed.
- Confirmed the final source tree is unchanged after consolidating the commits.

Physical Keystone QR round-trips and regtest integration tests were not run in this verification pass.
