### PR TITLE
Fix gift card fiat display, review layout, and interaction feedback

### DIFF
--- a/lib/src/features/payment_links/providers/payment_link_cards_provider.dart
+++ b/lib/src/features/payment_links/providers/payment_link_cards_provider.dart
@@ -18,6 +18,17 @@ class PaymentLinkCardsSnapshot {
 
 typedef PaymentLinkCardsLoader = Future<PaymentLinkCardsSnapshot> Function();
 
+/// Sharing or refreshing a card must not move it in the created-card list.
+int compareCreatedPaymentLinks(
+  PaymentLinkRecoveryRecord a,
+  PaymentLinkRecoveryRecord b,
+) {
+  final byCreation = b.link.createdAt.compareTo(a.link.createdAt);
+  return byCreation != 0
+      ? byCreation
+      : a.link.address.compareTo(b.link.address);
+}
+
 final paymentLinkCardsLoaderProvider = Provider<PaymentLinkCardsLoader>((ref) {
   final operations = ref.watch(paymentLinkOperationsProvider);
   return () => loadPaymentLinkCardsSnapshot(operations);
@@ -36,7 +47,7 @@ Future<PaymentLinkCardsSnapshot> loadPaymentLinkCardsSnapshot(
   final received = List<PaymentLinkReceivedRecord>.of(
     results[1] as List<PaymentLinkReceivedRecord>,
   );
-  created.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+  created.sort(compareCreatedPaymentLinks);
   received.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
   return PaymentLinkCardsSnapshot(created: created, received: received);
 }

--- a/lib/src/features/payment_links/screens/payment_links_mobile_body.dart
+++ b/lib/src/features/payment_links/screens/payment_links_mobile_body.dart
@@ -57,6 +57,7 @@ class PaymentLinksMobileBody extends StatelessWidget {
     required this.reviewShowsBack,
     required this.hasPendingFundingMetadata,
     required this.readyLink,
+    required this.readyFiatText,
     required this.fundingProgressByAddress,
     required this.readyShowsBack,
     required this.receivedLink,
@@ -132,6 +133,7 @@ class PaymentLinksMobileBody extends StatelessWidget {
   final bool hasPendingFundingMetadata;
 
   final VizorPaymentLink? readyLink;
+  final String? readyFiatText;
   final Map<String, PaymentLinkFundingProgress> fundingProgressByAddress;
   final bool readyShowsBack;
 
@@ -362,6 +364,8 @@ class PaymentLinksMobileBody extends StatelessWidget {
       cardWidth: kPaymentLinkMobileCardWidth,
       cardHeight: kPaymentLinkMobileCardHeight,
       amountText: amountController.text,
+      supportingText: amountFiatText,
+      supportingLoading: amountFiatLoading,
       showCaret: false,
       onTap: message.isEmpty ? null : () => onReviewShowsBackChanged(true),
       semanticLabel: message.isEmpty ? null : 'Reveal gift card message',
@@ -423,6 +427,7 @@ class PaymentLinksMobileBody extends StatelessWidget {
       cardWidth: kPaymentLinkMobileCardWidth,
       cardHeight: kPaymentLinkMobileCardHeight,
       amountText: formatZecAmount(link.amountZatoshi),
+      supportingText: readyFiatText,
       showCaret: false,
     );
     final card = message.isEmpty

--- a/lib/src/features/payment_links/screens/payment_links_mobile_body.dart
+++ b/lib/src/features/payment_links/screens/payment_links_mobile_body.dart
@@ -58,6 +58,7 @@ class PaymentLinksMobileBody extends StatelessWidget {
     required this.hasPendingFundingMetadata,
     required this.readyLink,
     required this.readyFiatText,
+    required this.readyCopyInProgress,
     required this.fundingProgressByAddress,
     required this.readyShowsBack,
     required this.receivedLink,
@@ -134,6 +135,7 @@ class PaymentLinksMobileBody extends StatelessWidget {
 
   final VizorPaymentLink? readyLink;
   final String? readyFiatText;
+  final bool readyCopyInProgress;
   final Map<String, PaymentLinkFundingProgress> fundingProgressByAddress;
   final bool readyShowsBack;
 
@@ -454,10 +456,12 @@ class PaymentLinksMobileBody extends StatelessWidget {
           ? const PaymentLinkConfetti()
           : null,
       onHome: () => onShowPage(PaymentLinksLocalPage.home),
-      onCopy: ready && !operationInProgress ? () => onCopyLink(link) : null,
+      onCopy: ready && !operationInProgress && !readyCopyInProgress
+          ? () => onCopyLink(link)
+          : null,
       onCardTap: ready && message.isNotEmpty ? onToggleReadyBack : null,
       waitingStatusLabel: linkWaitLabel(progress),
-      copyLabel: operationInProgress ? 'Copying...' : 'Copy link',
+      copyLabel: readyCopyInProgress ? 'Copying...' : 'Copy link',
     );
   }
 

--- a/lib/src/features/payment_links/screens/payment_links_screen.dart
+++ b/lib/src/features/payment_links/screens/payment_links_screen.dart
@@ -1927,31 +1927,35 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
 
     final pricingEnabled = ref.watch(swapFeatureEnabledProvider);
     final amount = parseZecAmount(_amountController.text);
-    // Retain the quote through Review so submission can capture it once.
+    // Keep the price subscription through amount edits and Review so clearing
+    // the input does not restart the lookup or flash its loading state.
     final marketData =
         pricingEnabled &&
-            amount != null &&
-            amount > BigInt.zero &&
             (_page == PaymentLinksLocalPage.amount ||
                 _page == PaymentLinksLocalPage.message ||
                 _page == PaymentLinksLocalPage.review)
         ? ref.watch(zecHomeMarketDataStateProvider)
         : null;
 
+    final amountFiatText = !pricingEnabled || amount == null
+        ? null
+        : amount == BigInt.zero
+        ? r'$0.00'
+        : fiatTextForZatoshi(
+            amount,
+            zecUsdUnitPrice: marketData?.displayData?.usdPrice,
+          );
+    final amountFiatLoading =
+        amount != null &&
+        amount > BigInt.zero &&
+        (marketData?.isLoading ?? false);
+    final amountFiatSupportingText =
+        amountFiatText ??
+        (pricingEnabled && amount != null && !amountFiatLoading
+            ? 'Fiat unavailable'
+            : null);
+
     if (kAppFormFactor == AppFormFactor.mobile) {
-      final amountFiatText = !pricingEnabled || amount == null
-          ? null
-          : amount == BigInt.zero
-          ? r'$0.00'
-          : fiatTextForZatoshi(
-              amount,
-              zecUsdUnitPrice: marketData?.displayData?.usdPrice,
-            );
-      final amountFiatLoading =
-          amount != null &&
-          amount > BigInt.zero &&
-          amountFiatText == null &&
-          (marketData?.isLoading ?? false);
       final mobileKeystoneRequest = _keystoneFundingRequest;
       return PaymentLinksMobileBody(
         page: _page,
@@ -1980,11 +1984,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         amountController: _amountController,
         amountFocusNode: _amountFocusNode,
         amountInputFormatters: [_amountFormatter],
-        amountFiatText:
-            amountFiatText ??
-            (pricingEnabled && amount != null && !amountFiatLoading
-                ? 'Fiat unavailable'
-                : null),
+        amountFiatText: amountFiatSupportingText,
         amountFiatLoading: amountFiatLoading,
         maxAmountText: _maxAmountText,
         canContinueAmount: _canContinueAmount,
@@ -1998,10 +1998,11 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         reviewShowsBack: _reviewShowsBack,
         hasPendingFundingMetadata: _pendingFundingMetadata != null,
         readyLink: _readyLink,
+        readyFiatText: _savedCardFiatText(_readyLink),
         fundingProgressByAddress: _fundingProgressByAddress,
         readyShowsBack: _readyShowsBack,
         receivedLink: _receivedLink,
-        receivedFiatText: _receivedFiatText,
+        receivedFiatText: _savedCardFiatText(_receivedLink),
         receivedShowsBack: _receivedShowsBack,
         receivedClaimSession: _receivedClaimSession,
         linkWaitLabel: _estimatedLinkWaitLabel,
@@ -2035,7 +2036,10 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       );
     }
 
-    final currentPage = _buildCurrentPage();
+    final currentPage = _buildCurrentPage(
+      amountFiatText: amountFiatSupportingText,
+      amountFiatLoading: amountFiatLoading,
+    );
     final keystoneRequest = _keystoneFundingRequest;
     final longSyncLink = _longSyncLink;
     final pane = keystoneRequest != null
@@ -2079,12 +2083,21 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     );
   }
 
-  Widget _buildCurrentPage() {
+  Widget _buildCurrentPage({
+    required String? amountFiatText,
+    required bool amountFiatLoading,
+  }) {
     return switch (_page) {
       PaymentLinksLocalPage.home => _buildHome(),
-      PaymentLinksLocalPage.amount => _buildAmount(),
+      PaymentLinksLocalPage.amount => _buildAmount(
+        fiatText: amountFiatText,
+        fiatLoading: amountFiatLoading,
+      ),
       PaymentLinksLocalPage.message => _buildMessage(),
-      PaymentLinksLocalPage.review => _buildReview(),
+      PaymentLinksLocalPage.review => _buildReview(
+        fiatText: amountFiatText,
+        fiatLoading: amountFiatLoading,
+      ),
       PaymentLinksLocalPage.ready => _buildReady(),
       PaymentLinksLocalPage.shareQr => _buildShareQr(),
       PaymentLinksLocalPage.redeem =>
@@ -2479,7 +2492,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     );
   }
 
-  Widget _buildAmount() {
+  Widget _buildAmount({required String? fiatText, required bool fiatLoading}) {
     final maxAmountText = _maxAmountText;
     return PaymentLinkAmountDesktopView(
       state: _amountVisualState,
@@ -2490,6 +2503,8 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         amountEditorKey: const ValueKey('payment_link_amount_editor'),
         amountInputFormatters: [_amountFormatter],
         onAmountChanged: _handleAmountChanged,
+        supportingText: fiatText,
+        supportingLoading: fiatLoading,
         maxAmountText: maxAmountText,
         onUseMax: maxAmountText == null ? null : _useMaxAmount,
         showMaxButton: true,
@@ -2557,11 +2572,13 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     );
   }
 
-  Widget _buildReview() {
+  Widget _buildReview({required String? fiatText, required bool fiatLoading}) {
     final message = _messageController.text.trim();
     final front = PaymentLinkGiftCard(
       artwork: _selectedArtwork,
       amountText: _amountController.text,
+      supportingText: fiatText,
+      supportingLoading: fiatLoading,
       showCaret: false,
       onTap: message.isEmpty
           ? null
@@ -2618,25 +2635,23 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         _fundingProgressByAddress[link.address] ??
         const PaymentLinkFundingProgress(confirmationCount: 0);
     final readyToShare = fundingProgress.isReady;
+    final front = PaymentLinkGiftCard(
+      artwork: artwork,
+      amountText: amountText,
+      supportingText: _savedCardFiatText(link),
+      showCaret: false,
+    );
     final card = hasMessage
         ? PaymentLinkCardFlip(
             showBack: _readyShowsBack,
-            front: PaymentLinkGiftCard(
-              artwork: artwork,
-              amountText: amountText,
-              showCaret: false,
-            ),
+            front: front,
             back: PaymentLinkGiftCard(
               artwork: artwork,
               showBack: true,
               message: message,
             ),
           )
-        : PaymentLinkGiftCard(
-            artwork: artwork,
-            amountText: amountText,
-            showCaret: false,
-          );
+        : front;
     return PaymentLinkReadyDesktopView(
       state: !readyToShare
           ? PaymentLinkReadyVisualState.waiting
@@ -2656,8 +2671,8 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     );
   }
 
-  String? get _receivedFiatText {
-    final snapshot = _receivedLink?.presentation?.fiatSnapshot;
+  String? _savedCardFiatText(VizorPaymentLink? link) {
+    final snapshot = link?.presentation?.fiatSnapshot;
     if (snapshot == null ||
         !ref.watch(swapFeatureEnabledProvider) ||
         ref.watch(privacyModeProvider)) {
@@ -2677,7 +2692,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     final front = PaymentLinkGiftCard(
       artwork: artwork,
       amountText: formatZecAmount(link.amountZatoshi),
-      supportingText: _receivedFiatText,
+      supportingText: _savedCardFiatText(link),
       showCaret: false,
     );
     final card = hasMessage

--- a/lib/src/features/payment_links/screens/payment_links_screen.dart
+++ b/lib/src/features/payment_links/screens/payment_links_screen.dart
@@ -262,6 +262,14 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       _showHelp = false;
       _longSyncLink = null;
     });
+    if (page == PaymentLinksLocalPage.message &&
+        kAppFormFactor == AppFormFactor.mobile) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _page == PaymentLinksLocalPage.message) {
+          _messageFocusNode.requestFocus();
+        }
+      });
+    }
   }
 
   void _startCreate() {
@@ -1014,22 +1022,11 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       return;
     }
     setState(() => _messageEditorRevealed = true);
-    // Reduced-motion mode swaps the card face without running the flip, so
-    // focus the editor as soon as that face is mounted. In the animated path
-    // the editor is not mounted yet and onAnimationEnd handles the focus.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted ||
-          !_messageEditorRevealed ||
-          _page != PaymentLinksLocalPage.message ||
-          _messageFocusNode.context == null) {
-        return;
-      }
-      _messageFocusNode.requestFocus();
-    });
   }
 
-  void _focusMessageEditorAfterFlip() {
-    if (!mounted ||
+  void _focusVisibleMessageEditor(bool showingBack) {
+    if (!showingBack ||
+        !mounted ||
         !_messageEditorRevealed ||
         _page != PaymentLinksLocalPage.message) {
       return;
@@ -2582,7 +2579,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         showBack: _messageEditorRevealed,
         front: staticMessageCard,
         back: messageEditorCard,
-        onAnimationEnd: _focusMessageEditorAfterFlip,
+        onVisibleSideChanged: _focusVisibleMessageEditor,
       ),
       onBack: () => _showPage(PaymentLinksLocalPage.home),
       onSkip: _skipMessage,

--- a/lib/src/features/payment_links/screens/payment_links_screen.dart
+++ b/lib/src/features/payment_links/screens/payment_links_screen.dart
@@ -360,8 +360,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
           .read(paymentLinkOperationsProvider)
           .loadCreatedLinkRecoveries();
       if (!mounted) return;
-      final visible = records.toList()
-        ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+      final visible = records.toList()..sort(compareCreatedPaymentLinks);
       setState(() => _recoveries = visible);
       unawaited(_refreshFundingProgress(records: visible));
     } catch (_) {

--- a/lib/src/features/payment_links/screens/payment_links_screen.dart
+++ b/lib/src/features/payment_links/screens/payment_links_screen.dart
@@ -165,6 +165,9 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
   bool _receivedShowsBack = false;
   bool _messageEditorRevealed = false;
   bool _operationInProgress = false;
+  final Set<String> _copyingLinkAddresses = {};
+  final Set<String> _savingQrAddresses = {};
+  final Set<String> _sharingQrAddresses = {};
   bool _choosingClaimAccount = false;
   bool _redeemFromQrCode = false;
   bool _receivedRefreshInProgress = false;
@@ -1279,8 +1282,10 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
   }
 
   Future<void> _copyPaymentLink(VizorPaymentLink link) async {
-    if (_operationInProgress) return;
-    setState(() => _operationInProgress = true);
+    if (_operationInProgress || _copyingLinkAddresses.contains(link.address)) {
+      return;
+    }
+    setState(() => _copyingLinkAddresses.add(link.address));
     try {
       await ref
           .read(paymentLinkClipboardProvider)
@@ -1299,7 +1304,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     } catch (_) {
       if (mounted) _showError('Gift link could not be copied.');
     } finally {
-      if (mounted) setState(() => _operationInProgress = false);
+      if (mounted) setState(() => _copyingLinkAddresses.remove(link.address));
     }
   }
 
@@ -1999,6 +2004,9 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         hasPendingFundingMetadata: _pendingFundingMetadata != null,
         readyLink: _readyLink,
         readyFiatText: _savedCardFiatText(_readyLink),
+        readyCopyInProgress: _copyingLinkAddresses.contains(
+          _readyLink?.address,
+        ),
         fundingProgressByAddress: _fundingProgressByAddress,
         readyShowsBack: _readyShowsBack,
         receivedLink: _receivedLink,
@@ -2276,7 +2284,9 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
 
   Widget _buildRecoveryRow(PaymentLinkRecoveryRecord record) {
     final state = _recoveryRowState(record);
-    final copyEnabled = state.canUseLink && !_operationInProgress;
+    final actionsEnabled = state.canUseLink && !_operationInProgress;
+    final copyEnabled =
+        actionsEnabled && !_copyingLinkAddresses.contains(record.link.address);
     return PaymentLinkCardListRow(
       key: ValueKey('payment_link_recovery_${record.link.address}'),
       thumbnail: _cardThumbnail(record.link.presentation?.artworkId),
@@ -2286,14 +2296,16 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       onAction: null,
       showLinkActions: state.canUseLink,
       onCopyLink: copyEnabled ? () => _copyPaymentLink(record.link) : null,
-      onShowQr: copyEnabled ? () => _openShareQr(record) : null,
+      onShowQr: actionsEnabled ? () => _openShareQr(record) : null,
       showLoader: state.showLoader,
     );
   }
 
   Widget _buildMobileRecoveryRow(PaymentLinkRecoveryRecord record) {
     final state = _recoveryRowState(record);
-    final copyEnabled = state.canUseLink && !_operationInProgress;
+    final actionsEnabled = state.canUseLink && !_operationInProgress;
+    final copyEnabled =
+        actionsEnabled && !_copyingLinkAddresses.contains(record.link.address);
     return PaymentLinkCardListMobileRow(
       key: ValueKey('payment_link_mobile_recovery_${record.link.address}'),
       thumbnail: _cardThumbnail(record.link.presentation?.artworkId),
@@ -2302,7 +2314,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       statusText: state.canUseLink ? null : state.statusText,
       showLinkActions: state.canUseLink,
       onCopyLink: copyEnabled ? () => _copyPaymentLink(record.link) : null,
-      onShowQr: copyEnabled ? () => _openShareQr(record) : null,
+      onShowQr: actionsEnabled ? () => _openShareQr(record) : null,
       showLoader: state.showLoader,
     );
   }
@@ -2353,6 +2365,8 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
   Widget _buildShareQr() {
     final record = _shareQrRecord;
     if (record == null) return _buildHome();
+    final saving = _savingQrAddresses.contains(record.link.address);
+    final copying = _copyingLinkAddresses.contains(record.link.address);
     return PaymentLinkShareQrDesktopView(
       shareCardKey: _shareQrCardKey,
       artwork: PaymentLinkCardArtwork.fromProtocolId(
@@ -2360,19 +2374,24 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       ),
       qrData: record.link.toUri().toString(),
       onBack: () => _showPage(PaymentLinksLocalPage.home),
-      onSaveQr: _operationInProgress ? null : () => _savePaymentLinkQr(record),
-      onCopyLink: _operationInProgress
+      onSaveQr: _operationInProgress || saving
+          ? null
+          : () => _savePaymentLinkQr(record),
+      onCopyLink: _operationInProgress || copying
           ? null
           : () => _copyPaymentLink(record.link),
-      saveLabel: _operationInProgress ? 'Saving...' : 'Save QR code',
-      copyLabel: _operationInProgress ? 'Copying...' : 'Copy link',
+      saveLabel: saving ? 'Saving...' : 'Save QR code',
+      copyLabel: copying ? 'Copying...' : 'Copy link',
     );
   }
 
   Future<void> _savePaymentLinkQr(PaymentLinkRecoveryRecord record) async {
-    if (_operationInProgress) return;
+    if (_operationInProgress ||
+        _savingQrAddresses.contains(record.link.address)) {
+      return;
+    }
     final pixelRatio = max(3.0, View.of(context).devicePixelRatio);
-    setState(() => _operationInProgress = true);
+    setState(() => _savingQrAddresses.add(record.link.address));
     try {
       final png = await capturePaymentLinkQr(
         _shareQrCardKey,
@@ -2398,7 +2417,9 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     } catch (_) {
       if (mounted) _showError('Gift card QR could not be saved.');
     } finally {
-      if (mounted) setState(() => _operationInProgress = false);
+      if (mounted) {
+        setState(() => _savingQrAddresses.remove(record.link.address));
+      }
     }
   }
 
@@ -2407,9 +2428,12 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     Uint8List png,
     Rect origin,
   ) async {
-    if (!mounted || _operationInProgress) return;
+    if (!mounted ||
+        _operationInProgress ||
+        !_sharingQrAddresses.add(link.address)) {
+      return;
+    }
     final share = ref.read(paymentLinkQrShareHandlerProvider);
-    setState(() => _operationInProgress = true);
     try {
       final shared = await share(png: png, sharePositionOrigin: origin);
       if (!shared) return;
@@ -2422,7 +2446,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         }
       }
     } finally {
-      if (mounted) setState(() => _operationInProgress = false);
+      _sharingQrAddresses.remove(link.address);
     }
   }
 
@@ -2635,6 +2659,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         _fundingProgressByAddress[link.address] ??
         const PaymentLinkFundingProgress(confirmationCount: 0);
     final readyToShare = fundingProgress.isReady;
+    final copying = _copyingLinkAddresses.contains(link.address);
     final front = PaymentLinkGiftCard(
       artwork: artwork,
       amountText: amountText,
@@ -2659,7 +2684,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       card: card,
       decoration: const PaymentLinkConfetti(),
       onBack: () => _showPage(PaymentLinksLocalPage.home),
-      onCopy: !readyToShare || _operationInProgress
+      onCopy: !readyToShare || _operationInProgress || copying
           ? null
           : () => _copyPaymentLink(link),
       onCardTap: readyToShare && hasMessage
@@ -2667,7 +2692,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
           : null,
       onReturnHome: () => _showPage(PaymentLinksLocalPage.home),
       waitingStatusLabel: _estimatedLinkWaitLabel(fundingProgress),
-      copyLabel: _operationInProgress ? 'Copying...' : 'Copy link',
+      copyLabel: copying ? 'Copying...' : 'Copy link',
     );
   }
 

--- a/lib/src/features/payment_links/widgets/mobile/payment_link_mobile_views.dart
+++ b/lib/src/features/payment_links/widgets/mobile/payment_link_mobile_views.dart
@@ -1073,6 +1073,8 @@ class PaymentLinkRedeemMobileView extends StatelessWidget {
     this.onScan,
     this.fromQrCode = false,
     this.onClearClipboard,
+    this.statusContent,
+    this.secondaryAction,
     this.title = kPaymentLinkRedeemTheCardTitle,
     this.subtitle = 'Paste a card link or scan its QR code.',
     this.pasteLabel = kPaymentLinkPasteLabel,
@@ -1088,6 +1090,8 @@ class PaymentLinkRedeemMobileView extends StatelessWidget {
   final VoidCallback? onScan;
   final bool fromQrCode;
   final VoidCallback? onClearClipboard;
+  final Widget? statusContent;
+  final Widget? secondaryAction;
   final String title;
   final String subtitle;
   final String pasteLabel;
@@ -1102,7 +1106,7 @@ class PaymentLinkRedeemMobileView extends StatelessWidget {
 
     final cardContent = switch (state) {
       PaymentLinkRedeemMobileState.paste => _MobileRedeemDropZone(
-        child: _actions(),
+        child: statusContent ?? _actions(),
       ),
       PaymentLinkRedeemMobileState.invalid => _MobileRedeemDropZone(
         child: Column(
@@ -1174,22 +1178,24 @@ class PaymentLinkRedeemMobileView extends StatelessWidget {
                 ),
               ),
             ),
-          if (invalid && !fromQrCode)
+          if (secondaryAction != null || (invalid && !fromQrCode))
             Positioned(
               top: _redeemSurfaceTop + _cardHeight + AppSpacing.md,
               left: 0,
               right: 0,
               child: Center(
-                child: AppButton(
-                  key: const ValueKey(
-                    'payment_link_mobile_clear_clipboard_button',
-                  ),
-                  onPressed: onClearClipboard,
-                  variant: AppButtonVariant.ghost,
-                  size: AppButtonSize.mediumLarge,
-                  leading: const AppIcon(AppIcons.trash, size: 20),
-                  child: Text(clearLabel),
-                ),
+                child:
+                    secondaryAction ??
+                    AppButton(
+                      key: const ValueKey(
+                        'payment_link_mobile_clear_clipboard_button',
+                      ),
+                      onPressed: onClearClipboard,
+                      variant: AppButtonVariant.ghost,
+                      size: AppButtonSize.mediumLarge,
+                      leading: const AppIcon(AppIcons.trash, size: 20),
+                      child: Text(clearLabel),
+                    ),
               ),
             ),
         ],

--- a/lib/src/features/payment_links/widgets/mobile/payment_link_share_sheet.dart
+++ b/lib/src/features/payment_links/widgets/mobile/payment_link_share_sheet.dart
@@ -33,37 +33,36 @@ class PaymentLinkShareSheet extends StatefulWidget {
   State<PaymentLinkShareSheet> createState() => _PaymentLinkShareSheetState();
 }
 
-enum _ShareAction { share, copy }
-
 class _PaymentLinkShareSheetState extends State<PaymentLinkShareSheet> {
   final _cardKey = GlobalKey();
   final _shareButtonKey = GlobalKey();
-  _ShareAction? _action;
+  bool _sharing = false;
+  bool _copying = false;
 
   Future<void> _share() async {
-    if (_action != null) return;
+    if (_sharing) return;
     final button =
         _shareButtonKey.currentContext!.findRenderObject()! as RenderBox;
     final origin = button.localToGlobal(Offset.zero) & button.size;
     final pixelRatio = max(3.0, View.of(context).devicePixelRatio);
-    setState(() => _action = _ShareAction.share);
+    setState(() => _sharing = true);
     try {
       final png = await capturePaymentLinkQr(_cardKey, pixelRatio: pixelRatio);
       if (mounted) await widget.onShare(png, origin);
     } catch (_) {
       if (mounted) widget.onShareError();
     } finally {
-      if (mounted) setState(() => _action = null);
+      if (mounted) setState(() => _sharing = false);
     }
   }
 
   Future<void> _copy() async {
-    if (_action != null) return;
-    setState(() => _action = _ShareAction.copy);
+    if (_copying) return;
+    setState(() => _copying = true);
     try {
       await widget.onCopyLink();
     } finally {
-      if (mounted) setState(() => _action = null);
+      if (mounted) setState(() => _copying = false);
     }
   }
 
@@ -97,11 +96,9 @@ class _PaymentLinkShareSheetState extends State<PaymentLinkShareSheet> {
               key: _shareButtonKey,
               expand: true,
               constrainContent: true,
-              onPressed: _action == null ? _share : null,
+              onPressed: _sharing ? null : _share,
               leading: const AppIcon(AppIcons.share),
-              child: Text(
-                _action == _ShareAction.share ? 'Sharing...' : 'Share card',
-              ),
+              child: Text(_sharing ? 'Sharing...' : 'Share card'),
             ),
             const SizedBox(height: AppSpacing.s),
             AppButton(
@@ -109,10 +106,8 @@ class _PaymentLinkShareSheetState extends State<PaymentLinkShareSheet> {
               variant: AppButtonVariant.secondary,
               expand: true,
               constrainContent: true,
-              onPressed: _action == null ? _copy : null,
-              child: Text(
-                _action == _ShareAction.copy ? 'Copying...' : 'Copy link',
-              ),
+              onPressed: _copying ? null : _copy,
+              child: Text(_copying ? 'Copying...' : 'Copy link'),
             ),
           ],
         ),

--- a/lib/src/features/payment_links/widgets/payment_link_card_flip.dart
+++ b/lib/src/features/payment_links/widgets/payment_link_card_flip.dart
@@ -16,7 +16,7 @@ class PaymentLinkCardFlip extends StatefulWidget {
     required this.showBack,
     required this.front,
     required this.back,
-    this.onAnimationEnd,
+    this.onVisibleSideChanged,
     super.key,
   });
 
@@ -28,7 +28,10 @@ class PaymentLinkCardFlip extends StatefulWidget {
   final bool showBack;
   final Widget front;
   final Widget back;
-  final VoidCallback? onAnimationEnd;
+
+  /// Called after the visible face is laid out, including the initial face.
+  /// This lets an editor take focus as soon as its face becomes interactive.
+  final ValueChanged<bool>? onVisibleSideChanged;
 
   @override
   State<PaymentLinkCardFlip> createState() => _PaymentLinkCardFlipState();
@@ -49,6 +52,7 @@ class _PaymentLinkCardFlipState extends State<PaymentLinkCardFlip>
     value: widget.showBack ? 1 : 0,
   );
   bool? _lastMotionDisabled;
+  bool? _lastVisibleSide;
 
   bool get _motionDisabled =>
       (MediaQuery.maybeOf(context)?.disableAnimations ?? false) ||
@@ -73,17 +77,10 @@ class _PaymentLinkCardFlipState extends State<PaymentLinkCardFlip>
     super.didUpdateWidget(oldWidget);
     if (oldWidget.showBack == widget.showBack) return;
     final target = widget.showBack ? 1.0 : 0.0;
-    if (_motionDisabled) {
-      widget.onAnimationEnd?.call();
-      return;
-    }
-    _controller
-        .animateWith(SpringSimulation(_spring, _controller.value, target, 0))
-        .then((_) {
-          if (mounted && widget.showBack == (target == 1)) {
-            widget.onAnimationEnd?.call();
-          }
-        });
+    if (_motionDisabled) return;
+    _controller.animateWith(
+      SpringSimulation(_spring, _controller.value, target, 0),
+    );
   }
 
   @override
@@ -113,16 +110,9 @@ class _PaymentLinkCardFlipState extends State<PaymentLinkCardFlip>
         final rawAngle = value * math.pi;
         // Keep a narrow projected width around the face swap instead of
         // rendering a fully edge-on (and therefore invisible) card frame.
-        final angle =
-            showingBack
-                ? math.max(
-                  rawAngle,
-                  (math.pi / 2) + PaymentLinkCardFlip.edgeBand,
-                )
-                : math.min(
-                  rawAngle,
-                  (math.pi / 2) - PaymentLinkCardFlip.edgeBand,
-                );
+        final angle = showingBack
+            ? math.max(rawAngle, (math.pi / 2) + PaymentLinkCardFlip.edgeBand)
+            : math.min(rawAngle, (math.pi / 2) - PaymentLinkCardFlip.edgeBand);
         final transform = Matrix4.identity();
         // PaymentLinkCardMotion owns the camera when present. Keeping the
         // local flip rotation but omitting a second perspective avoids the
@@ -145,13 +135,25 @@ class _PaymentLinkCardFlipState extends State<PaymentLinkCardFlip>
     );
   }
 
-  static Widget _faces({
+  Widget _faces({
     required bool showBack,
     required Widget front,
     required Widget back,
     required PaymentLinkCardMotionScope? motion,
     required double rotation,
   }) {
+    if (_lastVisibleSide != showBack) {
+      _lastVisibleSide = showBack;
+      if (widget.onVisibleSideChanged != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted &&
+              _lastVisibleSide == showBack &&
+              widget.showBack == showBack) {
+            widget.onVisibleSideChanged?.call(showBack);
+          }
+        });
+      }
+    }
     Widget faces = IndexedStack(
       index: showBack ? 1 : 0,
       children: [

--- a/lib/src/features/payment_links/widgets/payment_link_claim_outcome_view.dart
+++ b/lib/src/features/payment_links/widgets/payment_link_claim_outcome_view.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/widgets.dart';
 
+import '../../../core/layout/app_form_factor.dart';
 import '../../../core/theme/app_theme.dart';
-import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../services/payment_link_received_store.dart';
+import 'mobile/payment_link_mobile_views.dart';
+import 'payment_link_desktop_views.dart';
 
 extension PaymentLinkAvailabilityCopy on PaymentLinkAvailability {
   String get label => switch (this) {
@@ -31,7 +33,7 @@ extension PaymentLinkAvailabilityCopy on PaymentLinkAvailability {
   };
 }
 
-/// Shared outcome content uses form-factor tokens and scrolls on small screens.
+/// Claim outcomes stay inside the existing redeem surface in both form factors.
 class PaymentLinkClaimOutcomeView extends StatelessWidget {
   const PaymentLinkClaimOutcomeView({
     required this.availability,
@@ -50,54 +52,68 @@ class PaymentLinkClaimOutcomeView extends StatelessWidget {
   final bool busy;
 
   @override
-  Widget build(BuildContext context) => SafeArea(
-    child: SingleChildScrollView(
-      padding: const EdgeInsets.all(AppSpacing.md),
+  Widget build(BuildContext context) {
+    final isError = switch (availability) {
+      PaymentLinkAvailability.noBalance ||
+      PaymentLinkAvailability.claimedElsewhere ||
+      PaymentLinkAvailability.failed => true,
+      _ => false,
+    };
+    final content = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+        key: const ValueKey('payment_link_claim_outcome_content'),
+        mainAxisSize: MainAxisSize.min,
         children: [
-          AppBackLink(label: 'My Cards', onTap: onBack),
-          const SizedBox(height: AppSpacing.xl),
-          Center(
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 396),
-              child: Column(
-                children: [
-                  Text(
-                    availability.label,
-                    textAlign: TextAlign.center,
-                    style: AppTypography.headlineLarge.copyWith(
-                      color: context.colors.text.primary,
-                    ),
-                  ),
-                  const SizedBox(height: AppSpacing.s),
-                  Text(
-                    availability.description,
-                    textAlign: TextAlign.center,
-                    style: AppTypography.bodyMedium.copyWith(
-                      color: context.colors.text.secondary,
-                    ),
-                  ),
-                  const SizedBox(height: AppSpacing.lg),
-                  if (onCheck != null)
-                    AppButton(
-                      onPressed: busy ? null : onCheck,
-                      child: Text(busy ? 'Checking...' : 'Check status'),
-                    ),
-                  if (onArchive != null) ...[
-                    const SizedBox(height: AppSpacing.s),
-                    AppButton(
-                      onPressed: busy ? null : onArchive,
-                      variant: AppButtonVariant.secondary,
-                      child: Text(archived ? 'Restore card' : 'Hide card'),
-                    ),
-                  ],
-                ],
-              ),
+          Text(
+            availability.label,
+            textAlign: TextAlign.center,
+            style: AppTypography.bodyMediumStrong.copyWith(
+              color: isError
+                  ? context.colors.text.destructive
+                  : context.colors.text.primary,
             ),
           ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            availability.description,
+            textAlign: TextAlign.center,
+            style: AppTypography.bodyMedium.copyWith(
+              color: context.colors.text.secondary,
+            ),
+          ),
+          if (onCheck != null) ...[
+            const SizedBox(height: AppSpacing.sm),
+            AppButton(
+              onPressed: busy ? null : onCheck,
+              child: Text(busy ? 'Checking...' : 'Check status'),
+            ),
+          ],
         ],
       ),
-    ),
-  );
+    );
+    final archiveAction = onArchive == null
+        ? null
+        : AppButton(
+            onPressed: busy ? null : onArchive,
+            variant: AppButtonVariant.secondary,
+            child: Text(archived ? 'Restore card' : 'Hide card'),
+          );
+    if (kAppFormFactor == AppFormFactor.mobile) {
+      return PaymentLinkRedeemMobileView(
+        state: PaymentLinkRedeemMobileState.paste,
+        onBack: onBack,
+        subtitle: '',
+        statusContent: content,
+        secondaryAction: archiveAction,
+      );
+    }
+    return PaymentLinkRedeemDesktopView(
+      state: PaymentLinkRedeemVisualState.paste,
+      onBack: onBack,
+      subtitle: '',
+      statusContent: content,
+      secondaryAction: archiveAction,
+    );
+  }
 }

--- a/lib/src/features/payment_links/widgets/payment_link_claim_outcome_view.dart
+++ b/lib/src/features/payment_links/widgets/payment_link_claim_outcome_view.dart
@@ -59,37 +59,40 @@ class PaymentLinkClaimOutcomeView extends StatelessWidget {
       PaymentLinkAvailability.failed => true,
       _ => false,
     };
-    final content = Padding(
-      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
-      child: Column(
-        key: const ValueKey('payment_link_claim_outcome_content'),
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            availability.label,
-            textAlign: TextAlign.center,
-            style: AppTypography.bodyMediumStrong.copyWith(
-              color: isError
-                  ? context.colors.text.destructive
-                  : context.colors.text.primary,
+    final content = SingleChildScrollView(
+      key: const ValueKey('payment_link_claim_outcome_scroll'),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+        child: Column(
+          key: const ValueKey('payment_link_claim_outcome_content'),
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              availability.label,
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: isError
+                    ? context.colors.text.destructive
+                    : context.colors.text.primary,
+              ),
             ),
-          ),
-          const SizedBox(height: AppSpacing.xs),
-          Text(
-            availability.description,
-            textAlign: TextAlign.center,
-            style: AppTypography.bodyMedium.copyWith(
-              color: context.colors.text.secondary,
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              availability.description,
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMedium.copyWith(
+                color: context.colors.text.secondary,
+              ),
             ),
-          ),
-          if (onCheck != null) ...[
-            const SizedBox(height: AppSpacing.sm),
-            AppButton(
-              onPressed: busy ? null : onCheck,
-              child: Text(busy ? 'Checking...' : 'Check status'),
-            ),
+            if (onCheck != null) ...[
+              const SizedBox(height: AppSpacing.sm),
+              AppButton(
+                onPressed: busy ? null : onCheck,
+                child: Text(busy ? 'Checking...' : 'Check status'),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
     final archiveAction = onArchive == null

--- a/lib/src/features/payment_links/widgets/payment_link_desktop_views.dart
+++ b/lib/src/features/payment_links/widgets/payment_link_desktop_views.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -439,67 +441,128 @@ class PaymentLinkReviewDesktopView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PaymentLinkWizardPane(
-      title: title,
-      subtitle: subtitle,
-      currentStep: 2,
-      backLabel: backLabel,
-      onBack: onBack,
-      onStepSelected: onStepSelected,
-      childSpacing: _wizardCardTopSpacing,
-      action: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          SizedBox(
-            key: const ValueKey('payment_link_review_summary'),
-            width: 320,
-            height: 136,
+    // Keep the card, summary and CTA in one layout. A floating summary adds
+    // scroll reserve even though the Figma review fits the 720px window.
+    return LayoutBuilder(
+      builder: (context, constraints) => PaymentLinkPane(
+        backLabel: backLabel,
+        onBack: onBack,
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: SizedBox(
+            width: 420,
+            height: math.max(640, constraints.maxHeight - 64),
             child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: AppSpacing.s),
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.s,
+                0,
+                AppSpacing.s,
+                AppSpacing.sm,
+              ),
               child: Column(
                 children: [
-                  SizedBox(
-                    height: AppSpacing.base,
-                    child: _ReviewAmountRow(
-                      label: 'Card amount',
-                      value: cardAmountText,
+                  Text(
+                    title,
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodyLarge.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: context.colors.text.accent,
                     ),
                   ),
-                  SizedBox(
-                    height: AppSpacing.base,
-                    child: _ReviewAmountRow(
-                      label: kPaymentLinkCardFeeLabel,
-                      value: cardFeeText,
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    subtitle,
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: context.colors.text.secondary,
                     ),
                   ),
-                  const SizedBox(height: AppSpacing.sm),
-                  SizedBox(
-                    height: AppSpacing.base,
-                    child: _ReviewAmountRow(
-                      label: kPaymentLinkTotalDeductedLabel,
-                      value: totalAmountText,
-                      emphasized: true,
-                      showHelp: true,
+                  const SizedBox(height: AppSpacing.md),
+                  PaymentLinkWizardStepper(
+                    currentStep: 2,
+                    onStepSelected: onStepSelected,
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  Expanded(
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        Positioned(
+                          top: 53,
+                          left: 0,
+                          right: 0,
+                          child: Center(child: card),
+                        ),
+                        Positioned(
+                          bottom: 0,
+                          left: 0,
+                          right: 0,
+                          child: Center(
+                            child: SizedBox(
+                              key: const ValueKey(
+                                'payment_link_review_summary',
+                              ),
+                              width: 320,
+                              height: 136,
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: AppSpacing.s,
+                                ),
+                                child: Column(
+                                  children: [
+                                    SizedBox(
+                                      height: AppSpacing.base,
+                                      child: _ReviewAmountRow(
+                                        label: 'Card amount',
+                                        value: cardAmountText,
+                                      ),
+                                    ),
+                                    SizedBox(
+                                      height: AppSpacing.base,
+                                      child: _ReviewAmountRow(
+                                        label: kPaymentLinkCardFeeLabel,
+                                        value: cardFeeText,
+                                      ),
+                                    ),
+                                    const SizedBox(height: AppSpacing.sm),
+                                    SizedBox(
+                                      height: AppSpacing.base,
+                                      child: _ReviewAmountRow(
+                                        label: kPaymentLinkTotalDeductedLabel,
+                                        value: totalAmountText,
+                                        emphasized: true,
+                                        showHelp: true,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  AppButton(
+                    key: const ValueKey('payment_link_confirm_create_button'),
+                    onPressed: onConfirm,
+                    minWidth: 196,
+                    size: AppButtonSize.large,
+                    leading: const Center(
+                      child: AppIcon(
+                        AppIcons.giftCard,
+                        size: AppIconSize.medium,
+                      ),
+                    ),
+                    child: Text(confirmLabel),
                   ),
                 ],
               ),
             ),
           ),
-          const SizedBox(height: AppSpacing.md),
-          AppButton(
-            key: const ValueKey('payment_link_confirm_create_button'),
-            onPressed: onConfirm,
-            minWidth: 196,
-            size: AppButtonSize.large,
-            leading: const Center(
-              child: AppIcon(AppIcons.giftCard, size: AppIconSize.medium),
-            ),
-            child: Text(confirmLabel),
-          ),
-        ],
+        ),
       ),
-      child: card,
     );
   }
 }

--- a/lib/src/features/payment_links/widgets/payment_link_desktop_views.dart
+++ b/lib/src/features/payment_links/widgets/payment_link_desktop_views.dart
@@ -1378,104 +1378,115 @@ class PaymentLinkRedeemDesktopView extends StatelessWidget {
         alignment: Alignment.topCenter,
         child: SizedBox(
           width: 396,
-          height: 624,
-          child: Stack(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              Positioned(
-                top: 94,
-                left: 0,
-                right: 0,
-                child: Text(
-                  title ??
-                      (loading
-                          ? kPaymentLinkCheckingLabel
-                          : kPaymentLinkRedeemTheCardTitle),
-                  textAlign: TextAlign.center,
-                  style: AppTypography.headlineLarge.copyWith(
-                    color: context.colors.text.accent,
-                  ),
+              const SizedBox(height: 94),
+              Text(
+                title ??
+                    (loading
+                        ? kPaymentLinkCheckingLabel
+                        : kPaymentLinkRedeemTheCardTitle),
+                textAlign: TextAlign.center,
+                style: AppTypography.headlineLarge.copyWith(
+                  color: context.colors.text.accent,
                 ),
               ),
-              Positioned(
-                top: 179,
-                left: 18,
-                child: loading
-                    ? loadingPlaceholder ?? const PaymentLinkLoadingCard()
-                    : PaymentLinkDashedDropZone(
-                        child:
-                            statusContent ??
-                            (invalid
-                                ? Column(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      Text(
-                                        invalidTitle,
-                                        textAlign: TextAlign.center,
-                                        style: AppTypography.bodyMediumStrong
-                                            .copyWith(
-                                              color: context
-                                                  .colors
-                                                  .text
-                                                  .destructive,
+              const SizedBox(height: 52),
+              SizedBox(
+                height: 445,
+                child: Stack(
+                  children: [
+                    Positioned(
+                      top: 0,
+                      left: 18,
+                      child: loading
+                          ? loadingPlaceholder ?? const PaymentLinkLoadingCard()
+                          : PaymentLinkDashedDropZone(
+                              child:
+                                  statusContent ??
+                                  (invalid
+                                      ? Column(
+                                          mainAxisSize: MainAxisSize.min,
+                                          children: [
+                                            Text(
+                                              invalidTitle,
+                                              textAlign: TextAlign.center,
+                                              style: AppTypography
+                                                  .bodyMediumStrong
+                                                  .copyWith(
+                                                    color: context
+                                                        .colors
+                                                        .text
+                                                        .destructive,
+                                                  ),
                                             ),
-                                      ),
-                                      const SizedBox(height: AppSpacing.xs),
-                                      Text(
-                                        invalidSubtitle,
-                                        textAlign: TextAlign.center,
-                                        style: AppTypography.bodyMedium
-                                            .copyWith(
-                                              color:
-                                                  context.colors.text.secondary,
+                                            const SizedBox(
+                                              height: AppSpacing.xs,
                                             ),
-                                      ),
-                                      const SizedBox(height: AppSpacing.sm),
-                                      PaymentLinkPasteButton(
-                                        label: pasteLabel,
-                                        onPressed: onPaste,
-                                      ),
-                                    ],
-                                  )
-                                : PaymentLinkPasteButton(
-                                    label: pasteLabel,
-                                    onPressed: onPaste,
-                                  )),
-                      ),
-              ),
-              Positioned(
-                top: 462,
-                left: 0,
-                right: 0,
-                child: Center(
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 260),
-                    child: Text(
-                      subtitle,
-                      textAlign: TextAlign.center,
-                      style: AppTypography.bodyMedium.copyWith(
-                        color: context.colors.text.secondary,
+                                            Text(
+                                              invalidSubtitle,
+                                              textAlign: TextAlign.center,
+                                              style: AppTypography.bodyMedium
+                                                  .copyWith(
+                                                    color: context
+                                                        .colors
+                                                        .text
+                                                        .secondary,
+                                                  ),
+                                            ),
+                                            const SizedBox(
+                                              height: AppSpacing.sm,
+                                            ),
+                                            PaymentLinkPasteButton(
+                                              label: pasteLabel,
+                                              onPressed: onPaste,
+                                            ),
+                                          ],
+                                        )
+                                      : PaymentLinkPasteButton(
+                                          label: pasteLabel,
+                                          onPressed: onPaste,
+                                        )),
+                            ),
+                    ),
+                    Positioned(
+                      top: 283,
+                      left: 0,
+                      right: 0,
+                      child: Center(
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 260),
+                          child: Text(
+                            subtitle,
+                            textAlign: TextAlign.center,
+                            style: AppTypography.bodyMedium.copyWith(
+                              color: context.colors.text.secondary,
+                            ),
+                          ),
+                        ),
                       ),
                     ),
-                  ),
+                    if (secondaryAction != null || invalid)
+                      Positioned(
+                        top: secondaryAction != null
+                            ? PaymentLinkGiftCard.height + AppSpacing.md
+                            : 366,
+                        left: 0,
+                        right: 0,
+                        child: Center(
+                          child:
+                              secondaryAction ??
+                              PaymentLinkTextAction(
+                                label: clearLabel,
+                                onTap: onClearClipboard,
+                                leading: const AppIcon(AppIcons.trash),
+                              ),
+                        ),
+                      ),
+                  ],
                 ),
               ),
-              if (secondaryAction != null || invalid)
-                Positioned(
-                  top: secondaryAction != null
-                      ? 179 + PaymentLinkGiftCard.height + AppSpacing.md
-                      : 545,
-                  left: 0,
-                  right: 0,
-                  child: Center(
-                    child:
-                        secondaryAction ??
-                        PaymentLinkTextAction(
-                          label: clearLabel,
-                          onTap: onClearClipboard,
-                          leading: const AppIcon(AppIcons.trash),
-                        ),
-                  ),
-                ),
             ],
           ),
         ),

--- a/lib/src/features/payment_links/widgets/payment_link_desktop_views.dart
+++ b/lib/src/features/payment_links/widgets/payment_link_desktop_views.dart
@@ -1336,6 +1336,8 @@ class PaymentLinkRedeemDesktopView extends StatelessWidget {
     this.onPaste,
     this.onClearClipboard,
     this.loadingPlaceholder,
+    this.statusContent,
+    this.secondaryAction,
     this.backLabel = 'My Cards',
     this.title,
     this.subtitle = kPaymentLinkRedeemSubtitle,
@@ -1351,6 +1353,8 @@ class PaymentLinkRedeemDesktopView extends StatelessWidget {
   final VoidCallback? onPaste;
   final VoidCallback? onClearClipboard;
   final Widget? loadingPlaceholder;
+  final Widget? statusContent;
+  final Widget? secondaryAction;
   final String backLabel;
   final String? title;
   final String subtitle;
@@ -1394,38 +1398,44 @@ class PaymentLinkRedeemDesktopView extends StatelessWidget {
                 child: loading
                     ? loadingPlaceholder ?? const PaymentLinkLoadingCard()
                     : PaymentLinkDashedDropZone(
-                        child: invalid
-                            ? Column(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  Text(
-                                    invalidTitle,
-                                    textAlign: TextAlign.center,
-                                    style: AppTypography.bodyMediumStrong
-                                        .copyWith(
-                                          color:
-                                              context.colors.text.destructive,
-                                        ),
-                                  ),
-                                  const SizedBox(height: AppSpacing.xs),
-                                  Text(
-                                    invalidSubtitle,
-                                    textAlign: TextAlign.center,
-                                    style: AppTypography.bodyMedium.copyWith(
-                                      color: context.colors.text.secondary,
-                                    ),
-                                  ),
-                                  const SizedBox(height: AppSpacing.sm),
-                                  PaymentLinkPasteButton(
+                        child:
+                            statusContent ??
+                            (invalid
+                                ? Column(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Text(
+                                        invalidTitle,
+                                        textAlign: TextAlign.center,
+                                        style: AppTypography.bodyMediumStrong
+                                            .copyWith(
+                                              color: context
+                                                  .colors
+                                                  .text
+                                                  .destructive,
+                                            ),
+                                      ),
+                                      const SizedBox(height: AppSpacing.xs),
+                                      Text(
+                                        invalidSubtitle,
+                                        textAlign: TextAlign.center,
+                                        style: AppTypography.bodyMedium
+                                            .copyWith(
+                                              color:
+                                                  context.colors.text.secondary,
+                                            ),
+                                      ),
+                                      const SizedBox(height: AppSpacing.sm),
+                                      PaymentLinkPasteButton(
+                                        label: pasteLabel,
+                                        onPressed: onPaste,
+                                      ),
+                                    ],
+                                  )
+                                : PaymentLinkPasteButton(
                                     label: pasteLabel,
                                     onPressed: onPaste,
-                                  ),
-                                ],
-                              )
-                            : PaymentLinkPasteButton(
-                                label: pasteLabel,
-                                onPressed: onPaste,
-                              ),
+                                  )),
                       ),
               ),
               Positioned(
@@ -1445,17 +1455,21 @@ class PaymentLinkRedeemDesktopView extends StatelessWidget {
                   ),
                 ),
               ),
-              if (invalid)
+              if (secondaryAction != null || invalid)
                 Positioned(
-                  top: 545,
+                  top: secondaryAction != null
+                      ? 179 + PaymentLinkGiftCard.height + AppSpacing.md
+                      : 545,
                   left: 0,
                   right: 0,
                   child: Center(
-                    child: PaymentLinkTextAction(
-                      label: clearLabel,
-                      onTap: onClearClipboard,
-                      leading: const AppIcon(AppIcons.trash),
-                    ),
+                    child:
+                        secondaryAction ??
+                        PaymentLinkTextAction(
+                          label: clearLabel,
+                          onTap: onClearClipboard,
+                          leading: const AppIcon(AppIcons.trash),
+                        ),
                   ),
                 ),
             ],

--- a/lib/src/features/payment_links/widgets/payment_link_desktop_views.dart
+++ b/lib/src/features/payment_links/widgets/payment_link_desktop_views.dart
@@ -441,8 +441,8 @@ class PaymentLinkReviewDesktopView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Keep the card, summary and CTA in one layout. A floating summary adds
-    // scroll reserve even though the Figma review fits the 720px window.
+    // Preserve the standard window's geometry while letting scaled text grow
+    // the content. The card and summary must never compete for the same space.
     return LayoutBuilder(
       builder: (context, constraints) => PaymentLinkPane(
         backLabel: backLabel,
@@ -451,113 +451,117 @@ class PaymentLinkReviewDesktopView extends StatelessWidget {
           alignment: Alignment.topCenter,
           child: SizedBox(
             width: 420,
-            height: math.max(640, constraints.maxHeight - 64),
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(
-                AppSpacing.s,
-                0,
-                AppSpacing.s,
-                AppSpacing.sm,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                minHeight: math.max(640, constraints.maxHeight - 64),
               ),
-              child: Column(
-                children: [
-                  Text(
-                    title,
-                    textAlign: TextAlign.center,
-                    style: AppTypography.bodyLarge.copyWith(
-                      fontWeight: FontWeight.w600,
-                      color: context.colors.text.accent,
-                    ),
-                  ),
-                  const SizedBox(height: AppSpacing.xs),
-                  Text(
-                    subtitle,
-                    textAlign: TextAlign.center,
-                    style: AppTypography.bodyMedium.copyWith(
-                      color: context.colors.text.secondary,
-                    ),
-                  ),
-                  const SizedBox(height: AppSpacing.md),
-                  PaymentLinkWizardStepper(
-                    currentStep: 2,
-                    onStepSelected: onStepSelected,
-                  ),
-                  const SizedBox(height: AppSpacing.md),
-                  Expanded(
-                    child: Stack(
-                      fit: StackFit.expand,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.s,
+                  0,
+                  AppSpacing.s,
+                  AppSpacing.sm,
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
                       children: [
-                        Positioned(
-                          top: 53,
-                          left: 0,
-                          right: 0,
-                          child: Center(child: card),
+                        Text(
+                          title,
+                          textAlign: TextAlign.center,
+                          style: AppTypography.bodyLarge.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: context.colors.text.accent,
+                          ),
                         ),
-                        Positioned(
-                          bottom: 0,
-                          left: 0,
-                          right: 0,
-                          child: Center(
-                            child: SizedBox(
-                              key: const ValueKey(
-                                'payment_link_review_summary',
-                              ),
-                              width: 320,
-                              height: 136,
-                              child: Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  vertical: AppSpacing.s,
+                        const SizedBox(height: AppSpacing.xs),
+                        Text(
+                          subtitle,
+                          textAlign: TextAlign.center,
+                          style: AppTypography.bodyMedium.copyWith(
+                            color: context.colors.text.secondary,
+                          ),
+                        ),
+                        const SizedBox(height: AppSpacing.md),
+                        PaymentLinkWizardStepper(
+                          currentStep: 2,
+                          onStepSelected: onStepSelected,
+                        ),
+                        const SizedBox(height: AppSpacing.md + 53),
+                        card,
+                        const SizedBox(height: AppSpacing.sm),
+                      ],
+                    ),
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        SizedBox(
+                          key: const ValueKey('payment_link_review_summary'),
+                          width: 320,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              vertical: AppSpacing.s,
+                            ),
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                ConstrainedBox(
+                                  constraints: const BoxConstraints(
+                                    minHeight: AppSpacing.base,
+                                  ),
+                                  child: _ReviewAmountRow(
+                                    label: 'Card amount',
+                                    value: cardAmountText,
+                                  ),
                                 ),
-                                child: Column(
-                                  children: [
-                                    SizedBox(
-                                      height: AppSpacing.base,
-                                      child: _ReviewAmountRow(
-                                        label: 'Card amount',
-                                        value: cardAmountText,
-                                      ),
-                                    ),
-                                    SizedBox(
-                                      height: AppSpacing.base,
-                                      child: _ReviewAmountRow(
-                                        label: kPaymentLinkCardFeeLabel,
-                                        value: cardFeeText,
-                                      ),
-                                    ),
-                                    const SizedBox(height: AppSpacing.sm),
-                                    SizedBox(
-                                      height: AppSpacing.base,
-                                      child: _ReviewAmountRow(
-                                        label: kPaymentLinkTotalDeductedLabel,
-                                        value: totalAmountText,
-                                        emphasized: true,
-                                        showHelp: true,
-                                      ),
-                                    ),
-                                  ],
+                                ConstrainedBox(
+                                  constraints: const BoxConstraints(
+                                    minHeight: AppSpacing.base,
+                                  ),
+                                  child: _ReviewAmountRow(
+                                    label: kPaymentLinkCardFeeLabel,
+                                    value: cardFeeText,
+                                  ),
                                 ),
-                              ),
+                                const SizedBox(height: AppSpacing.sm),
+                                ConstrainedBox(
+                                  constraints: const BoxConstraints(
+                                    minHeight: AppSpacing.base,
+                                  ),
+                                  child: _ReviewAmountRow(
+                                    label: kPaymentLinkTotalDeductedLabel,
+                                    value: totalAmountText,
+                                    emphasized: true,
+                                    showHelp: true,
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
                         ),
+                        const SizedBox(height: AppSpacing.md),
+                        AppButton(
+                          key: const ValueKey(
+                            'payment_link_confirm_create_button',
+                          ),
+                          onPressed: onConfirm,
+                          minWidth: 196,
+                          size: AppButtonSize.large,
+                          leading: const Center(
+                            child: AppIcon(
+                              AppIcons.giftCard,
+                              size: AppIconSize.medium,
+                            ),
+                          ),
+                          child: Text(confirmLabel),
+                        ),
                       ],
                     ),
-                  ),
-                  const SizedBox(height: AppSpacing.md),
-                  AppButton(
-                    key: const ValueKey('payment_link_confirm_create_button'),
-                    onPressed: onConfirm,
-                    minWidth: 196,
-                    size: AppButtonSize.large,
-                    leading: const Center(
-                      child: AppIcon(
-                        AppIcons.giftCard,
-                        size: AppIconSize.medium,
-                      ),
-                    ),
-                    child: Text(confirmLabel),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/src/providers/zec_price_change_provider.dart
+++ b/lib/src/providers/zec_price_change_provider.dart
@@ -217,7 +217,7 @@ class ZecHomeMarketDataState {
   final ZecMarketData? liveData;
   final DateTime? fetchedAt;
 
-  /// The initial cache/network lookup has not completed yet.
+  /// The initial lookup or a network price refresh is in progress.
   final bool isLoading;
 
   bool isFreshAt(DateTime now) {
@@ -262,10 +262,10 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
       _expiryTimer?.cancel();
     });
 
-    void clearMarketData() {
+    void clearMarketData({bool isLoading = false}) {
       _expiryTimer?.cancel();
       _expiryTimer = null;
-      state = const ZecHomeMarketDataState();
+      state = ZecHomeMarketDataState(isLoading: isLoading);
     }
 
     void scheduleExpiry(DateTime fetchedAt) {
@@ -275,13 +275,12 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
           .add(zecMarketDataCacheTtl)
           .difference(now().toUtc());
       if (remaining <= Duration.zero) {
-        clearMarketData();
+        clearMarketData(isLoading: state.isLoading);
         return;
       }
       _expiryTimer = Timer(remaining, () {
         if (epoch != _epoch || state.fetchedAt != fetchedAt) return;
-        _expiryTimer = null;
-        state = const ZecHomeMarketDataState();
+        clearMarketData(isLoading: state.isLoading);
       });
     }
 
@@ -297,6 +296,12 @@ class ZecHomeMarketDataNotifier extends Notifier<ZecHomeMarketDataState> {
       if (state.displayData != null && !state.isFreshAt(now())) {
         clearMarketData();
       }
+      state = ZecHomeMarketDataState(
+        displayData: state.displayData,
+        liveData: state.liveData,
+        fetchedAt: state.fetchedAt,
+        isLoading: true,
+      );
       final data = await source.fetchMarketData();
       if (epoch != _epoch) return;
       if (data != null) {

--- a/lib/widgetbook/payment_link_mobile_use_cases.dart
+++ b/lib/widgetbook/payment_link_mobile_use_cases.dart
@@ -809,9 +809,8 @@ class _MobilePaymentLinkInteractivePreviewState
   final _amountFocusNode = FocusNode();
   final _messageController = TextEditingController();
   final _messageFocusNode = FocusNode();
-  Timer? _fiatTimer;
-  String? _fiatText;
-  var _fiatLoading = false;
+  Timer? _priceTimer;
+  var _priceLoading = true;
   var _step = _MobilePaymentLinkStep.amount;
   var _artwork = _fixtureArtwork;
 
@@ -827,8 +826,16 @@ class _MobilePaymentLinkInteractivePreviewState
       );
 
   @override
+  void initState() {
+    super.initState();
+    _priceTimer = Timer(kMobilePaymentLinkPreviewFiatDelay, () {
+      if (mounted) setState(() => _priceLoading = false);
+    });
+  }
+
+  @override
   void dispose() {
-    _fiatTimer?.cancel();
+    _priceTimer?.cancel();
     _amountController.dispose();
     _amountFocusNode.dispose();
     _messageController.dispose();
@@ -846,28 +853,16 @@ class _MobilePaymentLinkInteractivePreviewState
     setState(() {});
   }
 
-  void _handleAmountChanged(String value) {
-    _fiatTimer?.cancel();
+  String? get _fiatText {
+    final value = _amountController.text;
     final amount = double.tryParse(value.startsWith('.') ? '0$value' : value);
-    if (amount == null || amount <= 0) {
-      setState(() {
-        _fiatLoading = false;
-        _fiatText = null;
-      });
-      return;
-    }
+    if (amount == null || amount < 0) return null;
+    if (amount == 0) return r'$0.00';
+    return _priceLoading ? null : _formatUsd(amount * _usdPerZec);
+  }
 
-    setState(() {
-      _fiatLoading = true;
-      _fiatText = null;
-    });
-    _fiatTimer = Timer(kMobilePaymentLinkPreviewFiatDelay, () {
-      if (!mounted || _amountController.text != value) return;
-      setState(() {
-        _fiatLoading = false;
-        _fiatText = _formatUsd(amount * _usdPerZec);
-      });
-    });
+  void _handleAmountChanged(String _) {
+    setState(() {});
   }
 
   @override
@@ -886,7 +881,7 @@ class _MobilePaymentLinkInteractivePreviewState
           amountInputFormatters: [_amountFormatter],
           onAmountChanged: _handleAmountChanged,
           supportingText: _fiatText,
-          supportingLoading: _fiatLoading,
+          supportingLoading: _hasPositiveAmount && _priceLoading,
           maxAmountText: '142.23',
           onUseMax: () {
             _amountController.text = _fixtureAmount;
@@ -950,6 +945,8 @@ class _MobilePaymentLinkInteractivePreviewState
           cardWidth: _cardWidth,
           cardHeight: _cardHeight,
           amountText: _amountController.text,
+          supportingText: _fiatText,
+          supportingLoading: _hasPositiveAmount && _priceLoading,
           showCaret: false,
         ),
         onBack: () => _showStep(_MobilePaymentLinkStep.message),

--- a/lib/widgetbook/payment_link_mobile_use_cases.dart
+++ b/lib/widgetbook/payment_link_mobile_use_cases.dart
@@ -846,6 +846,13 @@ class _MobilePaymentLinkInteractivePreviewState
   void _showStep(_MobilePaymentLinkStep step) {
     FocusManager.instance.primaryFocus?.unfocus();
     setState(() => _step = step);
+    if (step == _MobilePaymentLinkStep.message) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _step == _MobilePaymentLinkStep.message) {
+          _messageFocusNode.requestFocus();
+        }
+      });
+    }
   }
 
   void _clearMessage() {

--- a/lib/widgetbook/payment_link_use_cases.dart
+++ b/lib/widgetbook/payment_link_use_cases.dart
@@ -1067,15 +1067,17 @@ class _PaymentLinkInteractiveDesktopPreviewState
   late final TextEditingController _amountController;
   final FocusNode _amountFocusNode = FocusNode();
   PaymentLinkCardArtwork _selectedArtwork = PaymentLinkCardArtwork.gift;
-  Timer? _fiatTimer;
-  String? _fiatText;
-  bool _fiatLoading = false;
+  Timer? _priceTimer;
+  bool _priceLoading = true;
   bool _amountFocused = false;
 
   @override
   void initState() {
     super.initState();
     _amountController = TextEditingController(text: widget.initialAmount);
+    _priceTimer = Timer(kPaymentLinkPreviewFiatDelay, () {
+      if (mounted) setState(() => _priceLoading = false);
+    });
     _amountFocused = widget.focusAmount;
     _amountFocusNode.addListener(_handleAmountFocus);
     if (widget.focusAmount) {
@@ -1087,7 +1089,7 @@ class _PaymentLinkInteractiveDesktopPreviewState
 
   @override
   void dispose() {
-    _fiatTimer?.cancel();
+    _priceTimer?.cancel();
     _amountFocusNode
       ..removeListener(_handleAmountFocus)
       ..dispose();
@@ -1100,28 +1102,16 @@ class _PaymentLinkInteractiveDesktopPreviewState
     setState(() => _amountFocused = _amountFocusNode.hasFocus);
   }
 
-  void _handleAmountChanged(String value) {
-    _fiatTimer?.cancel();
+  String? get _fiatText {
+    final value = _amountController.text;
     final amount = double.tryParse(value.startsWith('.') ? '0$value' : value);
-    if (amount == null || amount <= 0) {
-      setState(() {
-        _fiatLoading = false;
-        _fiatText = null;
-      });
-      return;
-    }
+    if (amount == null || amount < 0) return null;
+    if (amount == 0) return r'$0.00';
+    return _priceLoading ? null : _formatUsd(amount * _usdPerZec);
+  }
 
-    setState(() {
-      _fiatLoading = true;
-      _fiatText = null;
-    });
-    _fiatTimer = Timer(kPaymentLinkPreviewFiatDelay, () {
-      if (!mounted || _amountController.text != value) return;
-      setState(() {
-        _fiatLoading = false;
-        _fiatText = _formatUsd(amount * _usdPerZec);
-      });
-    });
+  void _handleAmountChanged(String _) {
+    setState(() {});
   }
 
   PaymentLinkAmountVisualState get _visualState {
@@ -1131,7 +1121,7 @@ class _PaymentLinkInteractiveDesktopPreviewState
           : PaymentLinkAmountVisualState.empty;
     }
     if (!_hasPositiveAmount) return PaymentLinkAmountVisualState.focused;
-    if (_fiatLoading) return PaymentLinkAmountVisualState.fiatLoading;
+    if (_priceLoading) return PaymentLinkAmountVisualState.fiatLoading;
     if (_fiatText != null) return PaymentLinkAmountVisualState.fiatLoaded;
     return PaymentLinkAmountVisualState.amount;
   }
@@ -1176,7 +1166,7 @@ class _PaymentLinkInteractiveDesktopPreviewState
                 onUseMax: _useMax,
                 showMaxButton: true,
                 supportingText: _fiatText,
-                supportingLoading: _fiatLoading,
+                supportingLoading: _hasPositiveAmount && _priceLoading,
                 emptyAmountLabel: 'Enter Amount',
                 semanticLabel: 'Gift card amount input',
               ),

--- a/lib/widgetbook/payment_link_use_cases.dart
+++ b/lib/widgetbook/payment_link_use_cases.dart
@@ -876,11 +876,6 @@ class _PaymentLinkInteractiveMessageDesktopPreviewState
     super.initState();
     _controller = TextEditingController(text: widget.initialMessage);
     _editorRevealed = widget.initialEditorRevealed;
-    if (_editorRevealed) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && _focusNode.context != null) _focusNode.requestFocus();
-      });
-    }
   }
 
   @override
@@ -902,14 +897,10 @@ class _PaymentLinkInteractiveMessageDesktopPreviewState
       return;
     }
     setState(() => _editorRevealed = true);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !_editorRevealed || _focusNode.context == null) return;
-      _focusNode.requestFocus();
-    });
   }
 
-  void _focusEditorAfterFlip() {
-    if (!mounted || !_editorRevealed) return;
+  void _focusVisibleEditor(bool showingBack) {
+    if (!showingBack || !mounted || !_editorRevealed) return;
     _focusNode.requestFocus();
   }
 
@@ -950,7 +941,7 @@ class _PaymentLinkInteractiveMessageDesktopPreviewState
                   onDeleteMessage: _hasMessage ? _clearMessage : null,
                   semanticLabel: 'Gift card message input',
                 ),
-                onAnimationEnd: _focusEditorAfterFlip,
+                onVisibleSideChanged: _focusVisibleEditor,
               ),
               onBack: _noop,
               onSkip: _clearMessage,

--- a/test/features/payment_links/payment_link_claim_outcome_view_test.dart
+++ b/test/features/payment_links/payment_link_claim_outcome_view_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
+import 'package:zcash_wallet/src/features/payment_links/widgets/payment_link_claim_outcome_view.dart';
+
+import '../../figma_compare/figma_compare_font_loader.dart';
+
+void main() {
+  setUpAll(loadFigmaCompareFonts);
+
+  for (final availability in [
+    PaymentLinkAvailability.claimedElsewhere,
+    PaymentLinkAvailability.failed,
+    PaymentLinkAvailability.noBalance,
+  ]) {
+    testWidgets(
+      '${availability.name} keeps its actions accessible with large text',
+      (tester) async {
+        const mobile = kAppFormFactor == AppFormFactor.mobile;
+        await tester.binding.setSurfaceSize(
+          mobile ? const Size(393, 852) : const Size(800, 704),
+        );
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+        var checks = 0;
+        var archives = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AppTheme(
+              data: AppThemeData.dark,
+              child: Scaffold(
+                body: PaymentLinkClaimOutcomeView(
+                  availability: availability,
+                  onBack: () {},
+                  onCheck: () => checks++,
+                  onArchive: () => archives++,
+                ),
+              ),
+            ),
+          ),
+        );
+        final scroll = find.byKey(
+          const ValueKey('payment_link_claim_outcome_scroll'),
+        );
+        final dropZone = find.byKey(
+          ValueKey(
+            mobile
+                ? 'payment_link_mobile_redeem_drop_zone'
+                : 'payment_link_redeem_drop_zone',
+          ),
+        );
+        final check = find.text('Check status');
+
+        for (final scale in [1.0, 2.0, 1.0]) {
+          tester.platformDispatcher.textScaleFactorTestValue = scale;
+          await tester.pumpAndSettle();
+          if (!mobile) {
+            expect(
+              tester.getBottomLeft(find.text('Redeem the Card')).dy,
+              lessThan(tester.getTopLeft(dropZone).dy),
+            );
+          }
+          final position = tester
+              .state<ScrollableState>(
+                find.descendant(of: scroll, matching: find.byType(Scrollable)),
+              )
+              .position;
+          expect(position.maxScrollExtent, scale == 1 ? 0 : greaterThan(0));
+          position.jumpTo(position.maxScrollExtent);
+          await tester.pumpAndSettle();
+          expect(check.hitTestable(), findsOneWidget);
+          expect(
+            tester.getBottomLeft(check).dy,
+            lessThanOrEqualTo(tester.getBottomLeft(dropZone).dy),
+          );
+          await tester.tap(check);
+          await tester.tap(find.text('Hide card'));
+          await tester.pumpAndSettle();
+          expect(tester.takeException(), isNull);
+        }
+        expect(checks, 3);
+        expect(archives, 3);
+      },
+    );
+  }
+}

--- a/test/features/payment_links/payment_link_desktop_views_test.dart
+++ b/test/features/payment_links/payment_link_desktop_views_test.dart
@@ -569,6 +569,18 @@ void main() {
       await tester.pump();
 
       expect(find.text(r'$680.00'), findsOneWidget);
+      for (final amount in ['3', '0', '2.5', '', '2.5']) {
+        await tester.enterText(
+          find.byKey(const ValueKey('payment_link_interactive_amount_editor')),
+          amount,
+        );
+        await tester.pump();
+        expect(
+          find.byKey(const ValueKey('payment_link_fiat_loading_placeholder')),
+          findsNothing,
+        );
+        if (amount == '2.5') expect(find.text(r'$680.00'), findsOneWidget);
+      }
       expect(
         find.byKey(const ValueKey('payment_link_fiat_loading_placeholder')),
         findsNothing,

--- a/test/features/payment_links/payment_link_desktop_views_test.dart
+++ b/test/features/payment_links/payment_link_desktop_views_test.dart
@@ -250,6 +250,94 @@ void main() {
     expect(gap, greaterThanOrEqualTo(30));
   });
 
+  for (final showMessage in [false, true]) {
+    testWidgets('review fits normally and scrolls with larger text '
+        '(message: $showMessage)', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1080, 720));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+      // Match the production pane without the unrelated sidebar fixtures.
+      await _pump(
+        tester,
+        SizedBox(
+          width: 800,
+          height: 704,
+          child: PaymentLinkReviewDesktopView(
+            card: PaymentLinkGiftCard(
+              artwork: PaymentLinkCardArtwork.ruby,
+              amountText: '4.45',
+              supportingText: r'$1,210.20',
+              showCaret: false,
+              showBack: showMessage,
+              message: showMessage ? 'Happy birthday!' : '',
+            ),
+            onBack: () {},
+            onConfirm: () {},
+            cardAmountText: '4.45 ZEC',
+            cardFeeText: '0.04 ZEC',
+            totalAmountText: '4.49 ZEC',
+          ),
+        ),
+      );
+      final summary = find.byKey(const ValueKey('payment_link_review_summary'));
+      final card = find.byType(PaymentLinkGiftCard);
+      final confirm = find.byKey(
+        const ValueKey('payment_link_confirm_create_button'),
+      );
+
+      for (final scale in [1.0, 1.3, 2.0, 1.0]) {
+        tester.platformDispatcher.textScaleFactorTestValue = scale;
+        await tester.pumpAndSettle();
+        final scroll = tester
+            .widget<SingleChildScrollView>(
+              find.byKey(const ValueKey('app_pane_scroll_view')),
+            )
+            .controller!;
+        scroll.jumpTo(0);
+        await tester.pumpAndSettle();
+        expect(
+          tester.getTopLeft(summary).dy - tester.getBottomLeft(card).dy,
+          greaterThanOrEqualTo(AppSpacing.sm),
+        );
+        expect(
+          scroll.position.maxScrollExtent,
+          scale == 1 ? 0 : greaterThan(0),
+        );
+
+        final rows = find.byWidgetPredicate(
+          (widget) =>
+              widget is Padding &&
+              widget.key is ValueKey<String> &&
+              (widget.key! as ValueKey<String>).value.startsWith(
+                'payment_link_review_row_',
+              ),
+        );
+        expect(rows, findsNWidgets(3));
+        for (var index = 0; index < 3; index++) {
+          final rowRect = tester.getRect(rows.at(index));
+          if (index > 0) {
+            expect(
+              rowRect.top,
+              greaterThanOrEqualTo(tester.getBottomLeft(rows.at(index - 1)).dy),
+            );
+          }
+          for (final text
+              in find
+                  .descendant(of: rows.at(index), matching: find.byType(Text))
+                  .evaluate()) {
+            final textRect = tester.getRect(find.byWidget(text.widget));
+            expect(textRect.top, greaterThanOrEqualTo(rowRect.top));
+            expect(textRect.bottom, lessThanOrEqualTo(rowRect.bottom));
+          }
+        }
+        scroll.jumpTo(scroll.position.maxScrollExtent);
+        await tester.pumpAndSettle();
+        expect(confirm.hitTestable(), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      }
+    });
+  }
+
   testWidgets('review exposes the total tooltip without a divider', (
     tester,
   ) async {

--- a/test/features/payment_links/payment_link_desktop_views_test.dart
+++ b/test/features/payment_links/payment_link_desktop_views_test.dart
@@ -628,6 +628,42 @@ void main() {
     expect(find.text('ZEC'), findsOneWidget);
   });
 
+  for (final reducedMotion in [false, true]) {
+    testWidgets(
+      'message focuses on reveal without a late focus reset ($reducedMotion)',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(1080, 720));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await _pump(
+          tester,
+          const PaymentLinkInteractiveMessageDesktopPreview(),
+          disableAnimations: reducedMotion,
+        );
+        await tester.tap(find.text('Start typing...'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 250));
+        await tester.pump();
+        final editor = find.byKey(
+          const ValueKey('payment_link_interactive_message_editor'),
+        );
+        expect(editor, findsOneWidget);
+        final focusNode = tester.widget<TextField>(editor).focusNode!;
+        expect(focusNode.hasFocus, isTrue);
+        // Type through the active input connection without tapping the editor.
+        tester.testTextInput.enterText('Ready to type');
+        await tester.pump();
+        expect(
+          tester.widget<TextField>(editor).controller!.text,
+          'Ready to type',
+        );
+        focusNode.unfocus();
+        await tester.pumpAndSettle();
+        expect(focusNode.hasFocus, isFalse);
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
   testWidgets(
     'interactive Widgetbook message preview accepts and clears text',
     (tester) async {

--- a/test/features/payment_links/payment_link_desktop_views_test.dart
+++ b/test/features/payment_links/payment_link_desktop_views_test.dart
@@ -1255,13 +1255,24 @@ void main() {
     );
     expect(
       tester.getTopLeft(find.byType(PaymentLinkGiftCard)),
-      const Offset(492, 251),
+      const Offset(492, 250),
     );
     final reviewSummary = find.byKey(
       const ValueKey('payment_link_review_summary'),
     );
     expect(tester.getTopLeft(reviewSummary), const Offset(512, 492));
     expect(tester.getSize(reviewSummary), const Size(320, 136));
+    expect(
+      tester.getTopLeft(
+        find.byKey(const ValueKey('payment_link_confirm_create_button')),
+      ),
+      const Offset(574, 652),
+    );
+    await tester.pumpAndSettle();
+    final reviewScroll = tester.widget<SingleChildScrollView>(
+      find.byKey(const ValueKey('app_pane_scroll_view')),
+    );
+    expect(reviewScroll.controller!.position.maxScrollExtent, 0);
 
     await _pump(
       tester,

--- a/test/features/payment_links/payment_links_screen_mobile_test.dart
+++ b/test/features/payment_links/payment_links_screen_mobile_test.dart
@@ -1038,9 +1038,16 @@ void main() {
       find.byKey(const ValueKey('payment_link_mobile_message_continue_button')),
       findsOneWidget,
     );
+    final messageFocus = tester
+        .widget<TextField>(
+          find.byKey(const ValueKey('payment_link_message_editor')),
+        )
+        .focusNode!;
+    expect(messageFocus.hasFocus, isTrue);
 
     await tester.binding.handlePopRoute();
     await tester.pumpAndSettle();
+    expect(messageFocus.hasFocus, isFalse);
 
     expect(
       find.byKey(const ValueKey('payment_links_mobile_screen')),

--- a/test/features/payment_links/payment_links_screen_mobile_test.dart
+++ b/test/features/payment_links/payment_links_screen_mobile_test.dart
@@ -7,6 +7,8 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/formatting/zec_amount.dart';
@@ -21,6 +23,122 @@ import 'package:zcash_wallet/src/features/payment_links/widgets/payment_link_qr_
 import '../../support/payment_links_screen_support.dart';
 
 void main() {
+  testWidgets('mobile share and copy keep independent pending feedback', (
+    tester,
+  ) async {
+    final copyGate = Completer<void>();
+    final shareGate = Completer<bool>();
+    final clipboard = FakePaymentLinkClipboard(copyCompleter: copyGate);
+    final operations = FakePaymentLinkOperations(records: [fundedRecovery]);
+    final images = <Uint8List>[];
+    await pumpPaymentLinksScreen(
+      tester,
+      operations: operations,
+      clipboard: clipboard,
+      qrShareHandler: ({required png, required sharePositionOrigin}) async {
+        images.add(png);
+        return shareGate.future;
+      },
+    );
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    await tester.pumpAndSettle();
+    await tester.tap(find.bySemanticsLabel('Show gift card QR code'));
+    await tester.pumpAndSettle();
+    final copy = find.byKey(const ValueKey('payment_link_share_copy_button'));
+    await tester.tap(copy);
+    await tester.pump();
+    expect(find.text('Copying...'), findsOneWidget);
+    expect(find.text('Sharing...'), findsNothing);
+    expect(
+      tester
+          .widget<AppButton>(find.widgetWithText(AppButton, 'Share card'))
+          .onPressed,
+      isNotNull,
+    );
+    await tester.tap(find.text('Share card'));
+    await tester.pump();
+    await tester.runAsync(() async {
+      for (var attempt = 0; attempt < 50 && images.isEmpty; attempt++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    });
+    await tester.pump();
+    expect(images, hasLength(1));
+    expect(find.text('Sharing...'), findsOneWidget);
+    copyGate.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('Copy link'), findsOneWidget);
+    expect(find.text('Sharing...'), findsOneWidget);
+    expect(tester.widget<AppButton>(copy).onPressed, isNotNull);
+    await tester.tap(find.text('Sharing...'), warnIfMissed: false);
+    await tester.pump();
+    expect(images, hasLength(1));
+    shareGate.complete(false);
+    await tester.pumpAndSettle();
+    expect(find.text('Share card'), findsOneWidget);
+    expect(find.text('Copy link'), findsOneWidget);
+    expect(operations.sharedLinks, hasLength(1));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('copying one card leaves other list icons unchanged', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    final clipboard = FakePaymentLinkClipboard(copyCompleter: gate);
+    final second = PaymentLinkRecoveryRecord(
+      link: otherAccountLink,
+      sourceAccountUuid: 'account-1',
+      claimFeeReserveZatoshi: BigInt.from(10000),
+      state: PaymentLinkRecoveryState.funded,
+      updatedAt: DateTime.utc(2026, 8, 5),
+      fundingTxids: 'funding-txid-2',
+    );
+    final operations = FakePaymentLinkOperations(
+      records: [fundedRecovery, second],
+    );
+    await pumpPaymentLinksScreen(
+      tester,
+      operations: operations,
+      clipboard: clipboard,
+    );
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    await tester.pumpAndSettle();
+    final copy = find.byKey(
+      const ValueKey('payment_link_mobile_card_copy_action'),
+    );
+    final qr = find.byKey(const ValueKey('payment_link_mobile_card_qr_action'));
+    Color? iconColor(Finder action) => tester
+        .widget<AppIcon>(
+          find.descendant(of: action, matching: find.byType(AppIcon)).first,
+        )
+        .color;
+    final qrColor = iconColor(qr.first);
+    final otherCopyColor = iconColor(copy.last);
+    await tester.tap(copy.first);
+    await tester.pump();
+    expect(clipboard.copiedSecrets, hasLength(1));
+    expect(iconColor(qr.first), qrColor);
+    expect(iconColor(qr.last), qrColor);
+    expect(iconColor(copy.last), otherCopyColor);
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(iconColor(qr.first), qrColor);
+    expect(iconColor(copy.last), otherCopyColor);
+    await tester.tap(copy.first, warnIfMissed: false);
+    await tester.pump();
+    expect(clipboard.copiedSecrets, hasLength(1));
+    await tester.tap(copy.last);
+    await tester.pump();
+    expect(clipboard.copiedSecrets, hasLength(2));
+    await tester.tap(qr.first);
+    await tester.pumpAndSettle();
+    expect(find.byType(PaymentLinkQrShareCard), findsOneWidget);
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(operations.sharedLinks, hasLength(2));
+    expect(tester.takeException(), isNull);
+  });
+
   for (final settings in [
     (true, true, 100.0),
     (true, false, 100.0),

--- a/test/features/payment_links/payment_links_screen_mobile_test.dart
+++ b/test/features/payment_links/payment_links_screen_mobile_test.dart
@@ -22,6 +22,126 @@ import '../../support/payment_links_screen_support.dart';
 
 void main() {
   for (final settings in [
+    (true, true, 100.0),
+    (true, false, 100.0),
+    (false, false, 100.0),
+    (true, false, null),
+  ]) {
+    testWidgets(
+      'completed card keeps saved fiat through waiting and sharing $settings',
+      (tester) async {
+        final source = _PendingCardPrice();
+        source.result.complete(
+          settings.$3 == null ? null : ZecMarketData(usdPrice: settings.$3!),
+        );
+        final operations = FakePaymentLinkOperations(
+          fundingBroadcastAcceptedOnCreate: false,
+          fundingConfirmationCount: 0,
+        );
+        final clipboard = FakePaymentLinkClipboard();
+        await pumpPaymentLinksScreen(
+          tester,
+          operations: operations,
+          clipboard: clipboard,
+          marketDataSource: source,
+          pricingEnabled: settings.$1,
+        );
+        await tester.binding.setSurfaceSize(const Size(390, 844));
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('payment_links_mobile_create_button')),
+        );
+        await tester.pumpAndSettle();
+        await tester.enterText(
+          find.byKey(const ValueKey('payment_link_amount_editor')),
+          '1.25',
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(
+            const ValueKey('payment_link_mobile_amount_continue_button'),
+          ),
+        );
+        await tester.pumpAndSettle();
+        if (settings.$2) {
+          await tester.enterText(
+            find.byKey(const ValueKey('payment_link_message_editor')),
+            'For you',
+          );
+          await tester.pumpAndSettle();
+        }
+        await tester.tap(
+          find.byKey(
+            const ValueKey('payment_link_mobile_message_continue_button'),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(
+            const ValueKey('payment_link_mobile_review_continue_button'),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final hasFiat = settings.$1 && settings.$3 != null;
+        void expectSavedFiat() {
+          expect(
+            find.text(r'$125.00'),
+            hasFiat ? findsOneWidget : findsNothing,
+          );
+          expect(find.text('Fiat unavailable'), findsNothing);
+          expect(
+            find.byKey(const ValueKey('payment_link_fiat_loading_placeholder')),
+            findsNothing,
+          );
+        }
+
+        expectSavedFiat();
+        expect(find.text('Copy link'), findsNothing);
+        operations.fundingConfirmationCount = 1;
+        await tester.pump(const Duration(seconds: 10));
+        await tester.pumpAndSettle();
+        expectSavedFiat();
+        expect(find.text('Copy link'), findsOneWidget);
+        if (settings.$2) {
+          await tester.tap(find.bySemanticsLabel('Flip gift card'));
+          await tester.pumpAndSettle();
+          expect(find.text('For you'), findsOneWidget);
+          await tester.tap(find.bySemanticsLabel('Flip gift card'));
+          await tester.pumpAndSettle();
+          expectSavedFiat();
+        }
+        await tester.pump(zecMarketDataRefreshInterval);
+        await tester.pumpAndSettle();
+        expectSavedFiat();
+        expect(source.fetchCount, settings.$1 ? 1 : 0);
+        await tester.tap(find.text('Copy link'));
+        await tester.pumpAndSettle();
+        expect(
+          VizorPaymentLink.parse(
+            clipboard.copiedSecrets.single,
+          ).presentation?.fiatSnapshot?.amount,
+          hasFiat ? 125 : null,
+        );
+        await tester.tap(
+          find.byKey(const ValueKey('payment_link_mobile_ready_home_button')),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.bySemanticsLabel('Show gift card QR code'));
+        await tester.pumpAndSettle();
+        final qr = tester.widget<PaymentLinkQrShareCard>(
+          find.byType(PaymentLinkQrShareCard),
+        );
+        expect(
+          VizorPaymentLink.parse(qr.qrData).presentation?.fiatSnapshot?.amount,
+          hasFiat ? 125 : null,
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
+  for (final settings in [
     (true, true, true),
     (true, true, false),
     (false, true, true),
@@ -127,6 +247,12 @@ void main() {
           'payment_link_mobile_message_continue_button',
           'payment_link_mobile_review_continue_button',
         ]) {
+          if (key == 'payment_link_mobile_review_continue_button') {
+            expect(
+              find.text(r'$125.00'),
+              pricingEnabled ? findsOneWidget : findsNothing,
+            );
+          }
           await tester.tap(find.byKey(ValueKey(key)));
           await tester.pumpAndSettle();
         }
@@ -225,6 +351,14 @@ void main() {
       expect(loading, findsNothing);
       expect(max, findsOneWidget);
 
+      for (final amount in ['0', '2', '', '2']) {
+        await tester.enterText(editor, amount);
+        await tester.pump();
+        expect(loading, findsNothing);
+        if (amount == '2') expect(find.text(r'$200.00'), findsOneWidget);
+        expect(source.fetchCount, 1);
+      }
+
       await tester.enterText(editor, '');
       await tester.pumpAndSettle();
       expect(find.textContaining('Use max:'), findsOneWidget);
@@ -239,8 +373,22 @@ void main() {
         zecUsdUnitPrice: 100,
       );
       expect(find.text(fiat!), findsOneWidget);
-      expect(find.textContaining('Use max:'), findsNothing);
-      expect(max, findsOneWidget);
+      await tester.tap(
+        find.byKey(
+          const ValueKey('payment_link_mobile_amount_continue_button'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(
+          const ValueKey('payment_link_mobile_message_continue_button'),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('Review a Card'), findsOneWidget);
+      expect(find.text(fiat), findsOneWidget);
+      expect(loading, findsNothing);
+      expect(source.fetchCount, 1);
     },
   );
 

--- a/test/features/payment_links/payment_links_screen_mobile_test.dart
+++ b/test/features/payment_links/payment_links_screen_mobile_test.dart
@@ -15,6 +15,7 @@ import 'package:zcash_wallet/src/core/formatting/zec_amount.dart';
 import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
 import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_intake_provider.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_cards_provider.dart';
 import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
 import 'package:zcash_wallet/src/features/payment_links/services/payment_link_service.dart';
 import 'package:zcash_wallet/src/features/payment_links/widgets/payment_link_gift_card.dart';
@@ -23,6 +24,66 @@ import 'package:zcash_wallet/src/features/payment_links/widgets/payment_link_qr_
 import '../../support/payment_links_screen_support.dart';
 
 void main() {
+  testWidgets('copying an older card preserves creation order after reload', (
+    tester,
+  ) async {
+    final older = PaymentLinkRecoveryRecord(
+      link: otherAccountLink,
+      sourceAccountUuid: 'account-1',
+      claimFeeReserveZatoshi: BigInt.from(10000),
+      state: PaymentLinkRecoveryState.funded,
+      updatedAt: DateTime.utc(2026, 8, 5),
+      fundingTxids: 'funding-txid-2',
+    );
+    final operations = FakePaymentLinkOperations(
+      records: [older, fundedRecovery],
+    );
+    final clipboard = FakePaymentLinkClipboard();
+    await pumpPaymentLinksScreen(
+      tester,
+      operations: operations,
+      clipboard: clipboard,
+    );
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    await tester.pumpAndSettle();
+    final newestRow = find.byKey(
+      ValueKey('payment_link_mobile_recovery_${incomingLink.address}'),
+    );
+    final olderRow = find.byKey(
+      ValueKey('payment_link_mobile_recovery_${otherAccountLink.address}'),
+    );
+    final originalPositions = [
+      tester.getTopLeft(newestRow),
+      tester.getTopLeft(olderRow),
+    ];
+    expect(originalPositions.first.dy, lessThan(originalPositions.last.dy));
+
+    await tester.tap(
+      find.descendant(
+        of: olderRow,
+        matching: find.byKey(
+          const ValueKey('payment_link_mobile_card_copy_action'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(clipboard.copiedSecrets, [otherAccountLink.toUri().toString()]);
+    expect(
+      operations.records.first.updatedAt.isAfter(fundedRecovery.updatedAt),
+      isTrue,
+    );
+    expect([
+      tester.getTopLeft(newestRow),
+      tester.getTopLeft(olderRow),
+    ], originalPositions);
+    final reloaded = await loadPaymentLinkCardsSnapshot(operations);
+    expect(reloaded.created.map((record) => record.link.address), [
+      incomingLink.address,
+      otherAccountLink.address,
+    ]);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('mobile share and copy keep independent pending feedback', (
     tester,
   ) async {

--- a/test/features/payment_links/payment_links_screen_mobile_test.dart
+++ b/test/features/payment_links/payment_links_screen_mobile_test.dart
@@ -141,6 +141,50 @@ void main() {
     );
   }
 
+  for (final outcome in [
+    (PaymentLinkAvailability.claimedElsewhere, 'Already claimed'),
+    (PaymentLinkAvailability.noBalance, 'No balance'),
+    (PaymentLinkAvailability.failed, 'Claim failed'),
+  ]) {
+    testWidgets('shows ${outcome.$2} inside the mobile redeem area', (
+      tester,
+    ) async {
+      final operations = FakePaymentLinkOperations(claimable: false)
+        ..claimAvailability = outcome.$1;
+      await pumpPaymentLinksScreen(
+        tester,
+        operations: operations,
+        clipboard: FakePaymentLinkClipboard(
+          text: incomingLink.toUri().toString(),
+        ),
+      );
+      await tester.binding.setSurfaceSize(const Size(390, 844));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('payment_links_mobile_redeem_button')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('payment_link_mobile_paste_button')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Redeem the Card'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byKey(
+            const ValueKey('payment_link_mobile_redeem_drop_zone'),
+          ),
+          matching: find.text(outcome.$2),
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Check status'), findsOneWidget);
+      expect(operations.claimedLinks, isEmpty);
+      expect(tester.takeException(), isNull);
+    });
+  }
+
   for (final settings in [
     (true, true, true),
     (true, true, false),

--- a/test/features/payment_links/payment_links_screen_test.dart
+++ b/test/features/payment_links/payment_links_screen_test.dart
@@ -26,11 +26,122 @@ import 'package:zcash_wallet/src/features/keystone/widgets/keystone_signing_moda
 import 'package:zcash_wallet/src/features/payment_links/widgets/payment_link_gift_card.dart';
 import 'package:zcash_wallet/src/features/payment_links/widgets/payment_link_confetti.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 
 import '../../fakes/fake_sync_notifier.dart';
 import '../../support/payment_links_screen_support.dart';
 
 void main() {
+  for (final settings in [
+    (true, true, 100.0),
+    (true, false, 100.0),
+    (false, false, 100.0),
+    (true, false, null),
+  ]) {
+    testWidgets(
+      'completed card keeps saved fiat through waiting and sharing $settings',
+      (tester) async {
+        final source = _PendingCardPrice();
+        source.result.complete(
+          settings.$3 == null ? null : ZecMarketData(usdPrice: settings.$3!),
+        );
+        final operations = FakePaymentLinkOperations(
+          fundingBroadcastAcceptedOnCreate: false,
+          fundingConfirmationCount: 0,
+        );
+        final clipboard = FakePaymentLinkClipboard();
+        await pumpPaymentLinksScreen(
+          tester,
+          operations: operations,
+          clipboard: clipboard,
+          marketDataSource: source,
+          pricingEnabled: settings.$1,
+        );
+        await tester.tap(find.text('Create new card'));
+        await tester.pumpAndSettle();
+        await tester.enterText(
+          find.byKey(const ValueKey('payment_link_amount_editor')),
+          '1.25',
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('payment_link_amount_continue_button')),
+        );
+        await tester.pumpAndSettle();
+        if (settings.$2) {
+          await tester.tap(
+            find.bySemanticsLabel('Start writing gift card message'),
+          );
+          await tester.pumpAndSettle();
+          await tester.enterText(
+            find.byKey(const ValueKey('payment_link_message_editor')),
+            'For you',
+          );
+          await tester.pumpAndSettle();
+        }
+        await tester.tap(
+          find.text(settings.$2 ? 'Confirm & review' : 'Skip message'),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Create card'));
+        await tester.pumpAndSettle();
+
+        final hasFiat = settings.$1 && settings.$3 != null;
+        void expectSavedFiat() {
+          expect(
+            find.text(r'$125.00'),
+            hasFiat ? findsOneWidget : findsNothing,
+          );
+          expect(find.text('Fiat unavailable'), findsNothing);
+          expect(
+            find.byKey(const ValueKey('payment_link_fiat_loading_placeholder')),
+            findsNothing,
+          );
+        }
+
+        expectSavedFiat();
+        expect(find.text('Copy link'), findsNothing);
+        operations.fundingConfirmationCount = 1;
+        await tester.pump(const Duration(seconds: 10));
+        await tester.pumpAndSettle();
+        expectSavedFiat();
+        expect(find.text('Copy link'), findsOneWidget);
+        if (settings.$2) {
+          await tester.tap(find.bySemanticsLabel('Flip gift card'));
+          await tester.pumpAndSettle();
+          expect(find.text('For you'), findsOneWidget);
+          await tester.tap(find.bySemanticsLabel('Flip gift card'));
+          await tester.pumpAndSettle();
+          expectSavedFiat();
+        }
+        await tester.pump(zecMarketDataRefreshInterval);
+        await tester.pumpAndSettle();
+        expectSavedFiat();
+        expect(source.fetchCount, settings.$1 ? 1 : 0);
+        await tester.tap(find.text('Copy link'));
+        await tester.pumpAndSettle();
+        expect(
+          VizorPaymentLink.parse(
+            clipboard.copiedSecrets.single,
+          ).presentation?.fiatSnapshot?.amount,
+          hasFiat ? 125 : null,
+        );
+        await tester.tap(find.text('Return home'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.bySemanticsLabel('Show gift card QR code'));
+        await tester.pumpAndSettle();
+        final qr = tester.widget<PaymentLinkQrShareCard>(
+          find.byType(PaymentLinkQrShareCard),
+        );
+        expect(
+          VizorPaymentLink.parse(qr.qrData).presentation?.fiatSnapshot?.amount,
+          hasFiat ? 125 : null,
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
   testWidgets(
     'claimed elsewhere can be hidden and restored without another submission',
     (tester) async {
@@ -225,6 +336,212 @@ void main() {
   }
 
   setUpAll(loadPaymentLinksTestFonts);
+
+  testWidgets(
+    'amount screen shows fiat loading and the latest converted value',
+    (tester) async {
+      final source = _PendingCardPrice();
+      await pumpPaymentLinksScreen(tester, marketDataSource: source);
+      await tester.tap(find.text('Create new card'));
+      await tester.pumpAndSettle();
+      final editor = find.byKey(const ValueKey('payment_link_amount_editor'));
+      final loading = find.byKey(
+        const ValueKey('payment_link_fiat_loading_placeholder'),
+      );
+      expect(loading, findsNothing);
+
+      await tester.enterText(editor, '4.45');
+      await tester.pump();
+      expect(loading, findsOneWidget);
+      await tester.enterText(editor, '2');
+      await tester.pump();
+      source.result.complete(const ZecMarketData(usdPrice: 100));
+      await tester.pumpAndSettle();
+      final fiat = find.text(r'$200.00');
+      expect(fiat, findsOneWidget);
+      expect(find.text(r'$445.00'), findsNothing);
+      expect(loading, findsNothing);
+      expect(
+        tester.getBottomLeft(fiat).dy,
+        lessThan(tester.getTopLeft(editor).dy),
+      );
+
+      await tester.enterText(editor, '3');
+      await tester.pumpAndSettle();
+      expect(find.text(r'$300.00'), findsOneWidget);
+      expect(fiat, findsNothing);
+
+      await tester.enterText(editor, '');
+      await tester.pumpAndSettle();
+      expect(find.text(r'$300.00'), findsNothing);
+      expect(find.text('Fiat unavailable'), findsNothing);
+      expect(loading, findsNothing);
+
+      await tester.enterText(editor, '0');
+      await tester.pumpAndSettle();
+      expect(find.text(r'$0.00'), findsOneWidget);
+      for (final amount in ['2', '', '2', '0', '2']) {
+        await tester.enterText(editor, amount);
+        await tester.pump();
+        expect(loading, findsNothing);
+        if (amount == '2') expect(find.text(r'$200.00'), findsOneWidget);
+        expect(source.fetchCount, 1);
+      }
+    },
+  );
+
+  testWidgets('review retains fiat and only shimmers on a price refresh', (
+    tester,
+  ) async {
+    final source = _RefreshingCardPrice();
+    await pumpPaymentLinksScreen(tester, marketDataSource: source);
+    await tester.tap(find.text('Create new card'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('payment_link_amount_editor')),
+      '2',
+    );
+    await tester.pump();
+    source.requests.single.complete(const ZecMarketData(usdPrice: 100));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('payment_link_amount_continue_button')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Skip message'));
+    await tester.pump();
+    final loading = find.byKey(
+      const ValueKey('payment_link_fiat_loading_placeholder'),
+    );
+    expect(find.text(r'$200.00'), findsOneWidget);
+    expect(loading, findsNothing);
+    expect(source.requests, hasLength(1));
+    await tester.pumpAndSettle();
+
+    await tester.pump(zecMarketDataRefreshInterval);
+    await tester.pump();
+    expect(source.requests, hasLength(2));
+    expect(loading, findsOneWidget);
+    source.requests.last.complete(const ZecMarketData(usdPrice: 120));
+    await tester.pumpAndSettle();
+    expect(find.text(r'$240.00'), findsOneWidget);
+    expect(loading, findsNothing);
+
+    await tester.tap(find.text('Create'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('payment_link_amount_editor')),
+      '3',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('payment_link_amount_continue_button')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Skip message'));
+    await tester.pump();
+    expect(find.text(r'$360.00'), findsOneWidget);
+    expect(loading, findsNothing);
+    expect(source.requests, hasLength(2));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('fiat fetch failure keeps the amount screen usable', (
+    tester,
+  ) async {
+    final source = _PendingCardPrice();
+    await pumpPaymentLinksScreen(tester, marketDataSource: source);
+    await tester.tap(find.text('Create new card'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('payment_link_amount_editor')),
+      '2',
+    );
+    await tester.pump();
+    source.result.complete(null);
+    await tester.pumpAndSettle();
+    expect(find.text('Fiat unavailable'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('payment_link_fiat_loading_placeholder')),
+      findsNothing,
+    );
+    expect(
+      tester
+          .widget<AppButton>(
+            find.byKey(const ValueKey('payment_link_amount_continue_button')),
+          )
+          .onPressed,
+      isNotNull,
+    );
+  });
+
+  testWidgets('only a price refresh restarts the amount skeleton', (
+    tester,
+  ) async {
+    final source = _RefreshingCardPrice();
+    await pumpPaymentLinksScreen(tester, marketDataSource: source);
+    await tester.tap(find.text('Create new card'));
+    await tester.pumpAndSettle();
+    final editor = find.byKey(const ValueKey('payment_link_amount_editor'));
+    final loading = find.byKey(
+      const ValueKey('payment_link_fiat_loading_placeholder'),
+    );
+    await tester.enterText(editor, '2');
+    await tester.pump();
+    source.requests.single.complete(const ZecMarketData(usdPrice: 100));
+    await tester.pumpAndSettle();
+    expect(find.text(r'$200.00'), findsOneWidget);
+    expect(loading, findsNothing);
+
+    await tester.pump(zecMarketDataRefreshInterval);
+    await tester.pump();
+    expect(source.requests, hasLength(2));
+    expect(loading, findsOneWidget);
+    expect(find.text(r'$200.00'), findsNothing);
+    await tester.enterText(editor, '3');
+    await tester.pump();
+    expect(source.requests, hasLength(2));
+    source.requests.last.complete(const ZecMarketData(usdPrice: 120));
+    await tester.pumpAndSettle();
+    expect(find.text(r'$360.00'), findsOneWidget);
+    expect(loading, findsNothing);
+
+    await tester.pump(zecMarketDataRefreshInterval);
+    await tester.pump();
+    expect(source.requests, hasLength(3));
+    expect(loading, findsOneWidget);
+    source.requests.last.complete(null);
+    await tester.pumpAndSettle();
+    expect(find.text(r'$360.00'), findsOneWidget);
+    expect(loading, findsNothing);
+  });
+
+  testWidgets('disabled pricing hides fiat and skips the price request', (
+    tester,
+  ) async {
+    final source = _PendingCardPrice();
+    await pumpPaymentLinksScreen(
+      tester,
+      marketDataSource: source,
+      pricingEnabled: false,
+    );
+    await tester.tap(find.text('Create new card'));
+    await tester.pumpAndSettle();
+    for (final amount in ['0', '2']) {
+      await tester.enterText(
+        find.byKey(const ValueKey('payment_link_amount_editor')),
+        amount,
+      );
+      await tester.pumpAndSettle();
+      expect(find.textContaining(r'$'), findsNothing);
+      expect(find.text('Fiat unavailable'), findsNothing);
+      expect(
+        find.byKey(const ValueKey('payment_link_fiat_loading_placeholder')),
+        findsNothing,
+      );
+    }
+    expect(source.fetchCount, 0);
+  });
 
   testWidgets('shows the truthful landing and help copy', (tester) async {
     await pumpPaymentLinksScreen(tester);
@@ -512,6 +829,7 @@ void main() {
     expect(find.text('Card amount'), findsOneWidget);
     expect(find.text('Card fee (deposit + redeem)'), findsOneWidget);
     expect(find.text('1.2502 ZEC'), findsOneWidget);
+    expect(find.text(r'$125.00'), findsOneWidget);
     expect(
       tester
           .widget<PaymentLinkCardFlip>(find.byType(PaymentLinkCardFlip))
@@ -538,6 +856,8 @@ void main() {
           .showBack,
       isFalse,
     );
+
+    expect(find.text(r'$125.00'), findsOneWidget);
 
     await tester.tap(find.text('Add Message'));
     await tester.pumpAndSettle();
@@ -2729,4 +3049,26 @@ void main() {
     expect(find.text('Copy link'), findsNothing);
     expect(find.text('Reclaim'), findsNothing);
   });
+}
+
+class _PendingCardPrice implements ZecMarketDataSource {
+  final result = Completer<ZecMarketData?>();
+  int fetchCount = 0;
+
+  @override
+  Future<ZecMarketData?> fetchMarketData() {
+    fetchCount++;
+    return result.future;
+  }
+}
+
+class _RefreshingCardPrice implements ZecMarketDataSource {
+  final requests = <Completer<ZecMarketData?>>[];
+
+  @override
+  Future<ZecMarketData?> fetchMarketData() {
+    final request = Completer<ZecMarketData?>();
+    requests.add(request);
+    return request.future;
+  }
 }

--- a/test/features/payment_links/payment_links_screen_test.dart
+++ b/test/features/payment_links/payment_links_screen_test.dart
@@ -906,7 +906,8 @@ void main() {
           .showBack,
       isTrue,
     );
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
     expect(messageEditor, findsOneWidget);
     expect(tester.widget<TextField>(messageEditor).focusNode?.hasFocus, isTrue);
     expect(

--- a/test/features/payment_links/payment_links_screen_test.dart
+++ b/test/features/payment_links/payment_links_screen_test.dart
@@ -417,6 +417,10 @@ void main() {
     expect(loading, findsNothing);
     expect(source.requests, hasLength(1));
     await tester.pumpAndSettle();
+    final scroll = tester.widget<SingleChildScrollView>(
+      find.byKey(const ValueKey('app_pane_scroll_view')),
+    );
+    expect(scroll.controller!.position.maxScrollExtent, 0);
 
     await tester.pump(zecMarketDataRefreshInterval);
     await tester.pump();

--- a/test/features/payment_links/payment_links_screen_test.dart
+++ b/test/features/payment_links/payment_links_screen_test.dart
@@ -142,6 +142,40 @@ void main() {
     );
   }
 
+  for (final outcome in [
+    (PaymentLinkAvailability.claimedElsewhere, 'Already claimed'),
+    (PaymentLinkAvailability.noBalance, 'No balance'),
+    (PaymentLinkAvailability.failed, 'Claim failed'),
+  ]) {
+    testWidgets('shows ${outcome.$2} inside the redeem area', (tester) async {
+      final operations = FakePaymentLinkOperations(claimable: false)
+        ..claimAvailability = outcome.$1;
+      await pumpPaymentLinksScreen(
+        tester,
+        operations: operations,
+        clipboard: FakePaymentLinkClipboard(
+          text: incomingLink.toUri().toString(),
+        ),
+      );
+      await tester.tap(find.text('Redeem a card'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Paste card link'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Redeem the Card'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byKey(const ValueKey('payment_link_redeem_drop_zone')),
+          matching: find.text(outcome.$2),
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Check status'), findsOneWidget);
+      expect(operations.claimedLinks, isEmpty);
+      expect(tester.takeException(), isNull);
+    });
+  }
+
   testWidgets(
     'claimed elsewhere can be hidden and restored without another submission',
     (tester) async {

--- a/test/features/payment_links/payment_links_screen_test.dart
+++ b/test/features/payment_links/payment_links_screen_test.dart
@@ -32,6 +32,121 @@ import '../../fakes/fake_sync_notifier.dart';
 import '../../support/payment_links_screen_support.dart';
 
 void main() {
+  for (final saveAccepted in [true, false]) {
+    testWidgets(
+      'share buttons track their own pending action (save: $saveAccepted)',
+      (tester) async {
+        final copyGate = Completer<void>();
+        final saveGate = Completer<bool>();
+        final clipboard = FakePaymentLinkClipboard(copyCompleter: copyGate);
+        final saver = FakePaymentLinkQrImageSaver(saveCompleter: saveGate);
+        final operations = FakePaymentLinkOperations(records: [fundedRecovery]);
+        await pumpPaymentLinksScreen(
+          tester,
+          operations: operations,
+          clipboard: clipboard,
+          qrImageSaver: saver,
+        );
+        await tester.tap(find.bySemanticsLabel('Show gift card QR code'));
+        await tester.pumpAndSettle();
+        final save = find.byKey(const ValueKey('payment_link_save_qr_button'));
+        final copy = find.byKey(
+          const ValueKey('payment_link_share_copy_button'),
+        );
+        await tester.tap(copy);
+        await tester.pump();
+        expect(find.text('Copying...'), findsOneWidget);
+        expect(find.text('Saving...'), findsNothing);
+        expect(tester.widget<AppButton>(save).onPressed, isNotNull);
+        await tester.tap(save);
+        await tester.pump();
+        await tester.runAsync(() async {
+          for (
+            var attempt = 0;
+            attempt < 50 && saver.savedImages.isEmpty;
+            attempt++
+          ) {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+          }
+        });
+        await tester.pump();
+        expect(saver.savedImages, hasLength(1));
+        expect(find.text('Saving...'), findsOneWidget);
+        copyGate.complete();
+        await tester.pumpAndSettle();
+        expect(find.text('Copy link'), findsOneWidget);
+        expect(find.text('Saving...'), findsOneWidget);
+        expect(tester.widget<AppButton>(copy).onPressed, isNotNull);
+        expect(tester.widget<AppButton>(save).onPressed, isNull);
+        await tester.tap(save, warnIfMissed: false);
+        await tester.pump();
+        expect(saver.savedImages, hasLength(1));
+        saveGate.complete(saveAccepted);
+        await tester.pumpAndSettle();
+        expect(find.text('Save QR code'), findsOneWidget);
+        expect(find.text('Copy link'), findsOneWidget);
+        expect(tester.widget<AppButton>(save).onPressed, isNotNull);
+        expect(operations.sharedLinks, hasLength(saveAccepted ? 2 : 1));
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
+  testWidgets('copying one card leaves other list icons unchanged', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    final clipboard = FakePaymentLinkClipboard(copyCompleter: gate);
+    final second = PaymentLinkRecoveryRecord(
+      link: otherAccountLink,
+      sourceAccountUuid: 'account-1',
+      claimFeeReserveZatoshi: BigInt.from(10000),
+      state: PaymentLinkRecoveryState.funded,
+      updatedAt: DateTime.utc(2026, 8, 5),
+      fundingTxids: 'funding-txid-2',
+    );
+    final operations = FakePaymentLinkOperations(
+      records: [fundedRecovery, second],
+    );
+    await pumpPaymentLinksScreen(
+      tester,
+      operations: operations,
+      clipboard: clipboard,
+    );
+
+    final copy = find.byKey(const ValueKey('payment_link_card_copy_action'));
+    final qr = find.byKey(const ValueKey('payment_link_card_qr_action'));
+    Color? iconColor(Finder action) => tester
+        .widget<AppIcon>(
+          find.descendant(of: action, matching: find.byType(AppIcon)).first,
+        )
+        .color;
+    final qrColor = iconColor(qr.first);
+    final otherCopyColor = iconColor(copy.last);
+    await tester.tap(copy.first);
+    await tester.pump();
+    expect(clipboard.copiedSecrets, hasLength(1));
+    expect(iconColor(qr.first), qrColor);
+    expect(iconColor(qr.last), qrColor);
+    expect(iconColor(copy.last), otherCopyColor);
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(iconColor(qr.first), qrColor);
+    expect(iconColor(copy.last), otherCopyColor);
+    await tester.tap(copy.first, warnIfMissed: false);
+    await tester.pump();
+    expect(clipboard.copiedSecrets, hasLength(1));
+    await tester.tap(copy.last);
+    await tester.pump();
+    expect(clipboard.copiedSecrets, hasLength(2));
+    await tester.tap(qr.first);
+    await tester.pumpAndSettle();
+    expect(find.byType(PaymentLinkQrShareCard), findsOneWidget);
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(operations.sharedLinks, hasLength(2));
+    expect(tester.takeException(), isNull);
+  });
+
   for (final settings in [
     (true, true, 100.0),
     (true, false, 100.0),

--- a/test/features/payment_links/payment_links_screen_test.dart
+++ b/test/features/payment_links/payment_links_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_modal_card.dart';
 import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
 import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_intake_provider.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_cards_provider.dart';
 import 'package:zcash_wallet/src/features/payment_links/services/payment_link_entry_policy.dart';
 import 'package:zcash_wallet/src/features/payment_links/services/payment_link_hardware_signing_service.dart';
 import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
@@ -32,6 +33,63 @@ import '../../fakes/fake_sync_notifier.dart';
 import '../../support/payment_links_screen_support.dart';
 
 void main() {
+  testWidgets('copying an older card preserves creation order after reload', (
+    tester,
+  ) async {
+    final older = PaymentLinkRecoveryRecord(
+      link: otherAccountLink,
+      sourceAccountUuid: 'account-1',
+      claimFeeReserveZatoshi: BigInt.from(10000),
+      state: PaymentLinkRecoveryState.funded,
+      updatedAt: DateTime.utc(2026, 8, 5),
+      fundingTxids: 'funding-txid-2',
+    );
+    final operations = FakePaymentLinkOperations(
+      records: [older, fundedRecovery],
+    );
+    final clipboard = FakePaymentLinkClipboard();
+    await pumpPaymentLinksScreen(
+      tester,
+      operations: operations,
+      clipboard: clipboard,
+    );
+    await tester.pumpAndSettle();
+    final newestRow = find.byKey(
+      ValueKey('payment_link_recovery_${incomingLink.address}'),
+    );
+    final olderRow = find.byKey(
+      ValueKey('payment_link_recovery_${otherAccountLink.address}'),
+    );
+    final originalPositions = [
+      tester.getTopLeft(newestRow),
+      tester.getTopLeft(olderRow),
+    ];
+    expect(originalPositions.first.dy, lessThan(originalPositions.last.dy));
+
+    await tester.tap(
+      find.descendant(
+        of: olderRow,
+        matching: find.byKey(const ValueKey('payment_link_card_copy_action')),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(clipboard.copiedSecrets, [otherAccountLink.toUri().toString()]);
+    expect(
+      operations.records.first.updatedAt.isAfter(fundedRecovery.updatedAt),
+      isTrue,
+    );
+    expect([
+      tester.getTopLeft(newestRow),
+      tester.getTopLeft(olderRow),
+    ], originalPositions);
+    final reloaded = await loadPaymentLinkCardsSnapshot(operations);
+    expect(reloaded.created.map((record) => record.link.address), [
+      incomingLink.address,
+      otherAccountLink.address,
+    ]);
+    expect(tester.takeException(), isNull);
+  });
+
   for (final saveAccepted in [true, false]) {
     testWidgets(
       'share buttons track their own pending action (save: $saveAccepted)',

--- a/test/providers/zec_price_change_provider_test.dart
+++ b/test/providers/zec_price_change_provider_test.dart
@@ -386,10 +386,12 @@ void main() {
 
       await Future<void>.delayed(const Duration(milliseconds: 30));
       expect(sub.read(), isNull);
+      expect(container.read(zecHomeMarketDataStateProvider).isLoading, isTrue);
 
       source.completer.complete(null);
       await Future<void>.delayed(Duration.zero);
       expect(sub.read(), isNull);
+      expect(container.read(zecHomeMarketDataStateProvider).isLoading, isFalse);
     });
 
     test('removes the last value after its one-hour TTL expires', () async {

--- a/test/support/payment_links_screen_support.dart
+++ b/test/support/payment_links_screen_support.dart
@@ -801,10 +801,11 @@ const broadcastedClaimResult = PaymentLinkClaimResult(
 );
 
 class FakePaymentLinkClipboard implements PaymentLinkClipboard {
-  FakePaymentLinkClipboard({this.text, this.readCompleter});
+  FakePaymentLinkClipboard({this.text, this.readCompleter, this.copyCompleter});
 
   String? text;
   final Completer<String?>? readCompleter;
+  final Completer<void>? copyCompleter;
   final List<String> copiedSecrets = [];
   int clearCalls = 0;
 
@@ -817,6 +818,7 @@ class FakePaymentLinkClipboard implements PaymentLinkClipboard {
   @override
   Future<void> copySecret(String text) async {
     copiedSecrets.add(text);
+    await copyCompleter?.future;
     this.text = text;
   }
 
@@ -825,12 +827,15 @@ class FakePaymentLinkClipboard implements PaymentLinkClipboard {
 }
 
 class FakePaymentLinkQrImageSaver implements PaymentLinkQrImageSaver {
+  FakePaymentLinkQrImageSaver({this.saveCompleter});
+
+  final Completer<bool>? saveCompleter;
   final List<Uint8List> savedImages = [];
 
   @override
   Future<bool> savePng(Uint8List pngBytes) async {
     savedImages.add(Uint8List.fromList(pngBytes));
-    return true;
+    return await saveCompleter?.future ?? true;
   }
 }
 

--- a/test/widgetbook/payment_link_mobile_use_cases_test.dart
+++ b/test/widgetbook/payment_link_mobile_use_cases_test.dart
@@ -231,6 +231,17 @@ void main() {
     await tester.pump(kMobilePaymentLinkPreviewFiatDelay);
     expect(find.text(r'$1,210.40'), findsOneWidget);
 
+    for (final amount in ['0', '2', '', '4.45']) {
+      await tester.enterText(amountEditor, amount);
+      await tester.pump();
+      expect(
+        find.byKey(const ValueKey('payment_link_fiat_loading_placeholder')),
+        findsNothing,
+      );
+      if (amount == '2') expect(find.text(r'$544.00'), findsOneWidget);
+    }
+    expect(find.text(r'$1,210.40'), findsOneWidget);
+
     final amountContinue = find.byKey(
       const ValueKey('payment_link_mobile_amount_continue_button'),
     );
@@ -262,6 +273,11 @@ void main() {
     await tester.pump();
 
     expect(find.text('Review a Card'), findsOneWidget);
+    expect(find.text(r'$1,210.40'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('payment_link_fiat_loading_placeholder')),
+      findsNothing,
+    );
     expect(find.text('Card amount'), findsOneWidget);
     expect(find.text('4.49 ZEC'), findsOneWidget);
     expect(tester.takeException(), isNull);

--- a/test/widgetbook/payment_link_mobile_use_cases_test.dart
+++ b/test/widgetbook/payment_link_mobile_use_cases_test.dart
@@ -253,9 +253,6 @@ void main() {
     final messageEditor = find.byKey(
       const ValueKey('mobile_payment_link_interactive_message_editor'),
     );
-    await tester.tap(
-      find.byKey(const ValueKey('payment_link_mobile_card_slot')),
-    );
     await tester.pump();
     expect(tester.widget<TextField>(messageEditor).focusNode?.hasFocus, isTrue);
     expect(


### PR DESCRIPTION
Gift cards now show fiat values throughout amount entry, review, funding, and sharing. Amount edits reuse the current price; loading placeholders appear only during the initial lookup or a price refresh. Funded cards display their saved fiat snapshot.

The changes are split into five separately verified commits:

- Restore fiat values and price-refresh behavior across desktop, mobile, and Widgetbook.
- Fit desktop Review into the standard 1080×720 window while preserving scrolling in smaller windows.
- Show already-claimed, empty, and failed card outcomes inside the existing redeem area, with status checks and hide/restore actions.
- Scope copy, QR save, and native-share feedback to the selected card and action, while preventing duplicate submissions of that action.
- Focus the message input when the editable face first appears, including reduced motion, without stealing focus when the animation finishes.

This is a draft because the repository-wide mobile lane has existing failures. The gift-card changes and every intermediate commit passed their focused checks.

Validation:

- Formatting check on all 16 changed Dart files; no changes required.
- `fvm flutter analyze --no-pub`: no issues.
- `fvm flutter test --no-pub --concurrency=4 --reporter expanded`: 3,587 passed and 111 skipped on the complete rerun (initial randomized-test failure described below).
- `fvm flutter test --no-pub --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile --concurrency=4 --reporter expanded`: 1,277 passed and 20 failed; unchanged `main` passed 1,268 with the exact same 20 failures (no new failing test names).
- Each intermediate commit passed its focused desktop/mobile tests before commit.
- Deterministic desktop/mobile captures checked fiat display, Review geometry, inline outcomes, and button/focus feedback. The Review geometry is covered by assertions against the [Figma reference](https://www.figma.com/design/jhozt3bbbVYms9MkpGJgoI/Vizor--Design-System?node-id=7766-61893&m=dev).
- `fvm flutter build macos --release --no-pub` with a local Apple Development signing override; strict codesign verification and app launch passed. The final committed files match that validated build byte for byte.

Rust, wallet transaction construction, storage formats, and link/QR payload formats are unchanged. No Windows/Linux builds or physical mobile/E2E runs were performed for these Dart UI and price-state changes.

Baseline failures confirmed on `main` (`f7f4078641`):

- Mobile: Keystone Widgetbook scanner copy (1), transparent receive-sheet geometry (1), Ironwood migration coordinator (15), onboarding progress (1), and birthday-date picker (2). The full mobile failure sets are identical on this branch and `main`.
- The first desktop run had one randomized profile-picture test failure: choosing the already-selected `pfp-02` leaves Update disabled. The same case was reproduced deterministically on unchanged `main`; the unmodified test passed when rerun in isolation on this branch.

These baseline failures are documented here for review and are outside this gift-card patch.
