### PR TITLE
Fix mobile Gift Cards back navigation while preserving existing UI

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../widgetbook/activity_use_cases.dart';
+import '../widgetbook/keystone_use_cases.dart';
 import '../widgetbook/payment_link_claim_outcome_use_cases.dart';
 import '../widgetbook/home_use_cases.dart';
 import '../widgetbook/donation_use_cases.dart';
@@ -51,6 +52,27 @@ class FigmaCompareScenario {
 /// storage, network, wallet, and Rust state. Widgetbook fixtures are preferred
 /// because they are already used to review the same UI states.
 const figmaCompareScenarios = <FigmaCompareScenario>[
+  FigmaCompareScenario(
+    id: 'mobile-gift-card-keystone-loading',
+    description: 'Shared Keystone signing loading',
+    builder: buildMobileKeystoneSigningLoadingUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-gift-card-keystone-ready',
+    description: 'Shared Keystone signing ready',
+    builder: buildMobileKeystoneSigningReadyUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-gift-card-keystone-scanner',
+    description: 'Shared Keystone signing scanner',
+    builder: buildMobileKeystoneSigningScannerUseCase,
+    desktop: false,
+    mobile: true,
+  ),
   FigmaCompareScenario(
     id: 'gift-card-claim-rejected',
     description: 'gift-card-claim-rejected',

--- a/lib/src/features/payment_links/screens/payment_links_mobile_body.dart
+++ b/lib/src/features/payment_links/screens/payment_links_mobile_body.dart
@@ -8,6 +8,7 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 
@@ -36,6 +37,8 @@ class PaymentLinksMobileBody extends StatelessWidget {
     required this.redeemActionLabel,
     required this.redeemFromQrCode,
     required this.keystoneOverlay,
+    required this.onCancelKeystone,
+    required this.navigationLocked,
     required this.hasCards,
     required this.cardsSections,
     required this.activeCardsTab,
@@ -85,6 +88,7 @@ class PaymentLinksMobileBody extends StatelessWidget {
     required this.onToggleReadyBack,
     required this.onToggleReceivedBack,
     required this.onAbandonReceivedPreview,
+    required this.onReceivedHome,
     required this.onClaimReceivedLink,
     super.key,
   });
@@ -101,6 +105,8 @@ class PaymentLinksMobileBody extends StatelessWidget {
   /// runs; without this overlay the mobile review CTA would sit on
   /// "Creating..." forever.
   final Widget? keystoneOverlay;
+  final VoidCallback onCancelKeystone;
+  final bool navigationLocked;
 
   /// Whether any created or received Card exists, which is what decides the
   /// home page between the empty landing surface and the cards list.
@@ -163,77 +169,36 @@ class PaymentLinksMobileBody extends StatelessWidget {
   final VoidCallback onToggleReadyBack;
   final VoidCallback onToggleReceivedBack;
   final VoidCallback onAbandonReceivedPreview;
+  final VoidCallback onReceivedHome;
   final VoidCallback onClaimReceivedLink;
 
   @override
-  Widget build(BuildContext context) {
-    final currentPage = switch (page) {
-      PaymentLinksLocalPage.home => _buildHome(context),
-      PaymentLinksLocalPage.amount => _buildAmount(),
-      PaymentLinksLocalPage.message => _buildMessage(),
-      PaymentLinksLocalPage.review => _buildReview(),
-      PaymentLinksLocalPage.ready => _buildReady(context),
-      PaymentLinksLocalPage.shareQr => _buildHome(context),
-      PaymentLinksLocalPage.redeem =>
-        claimOutcome ??
-            PaymentLinkRedeemMobileView(
-              state: PaymentLinkRedeemMobileState.values.byName(
-                redeemState.name,
+  Widget build(BuildContext context) =>
+      _PaymentLinksMobileNavigator(body: this);
+
+  Widget _buildPage(BuildContext context, PaymentLinksLocalPage page) =>
+      switch (page) {
+        PaymentLinksLocalPage.home => _buildHome(context),
+        PaymentLinksLocalPage.amount => _buildAmount(),
+        PaymentLinksLocalPage.message => _buildMessage(),
+        PaymentLinksLocalPage.review => _buildReview(),
+        PaymentLinksLocalPage.ready => _buildReady(context),
+        PaymentLinksLocalPage.shareQr => _buildHome(context),
+        PaymentLinksLocalPage.redeem =>
+          claimOutcome ??
+              PaymentLinkRedeemMobileView(
+                state: PaymentLinkRedeemMobileState.values.byName(
+                  redeemState.name,
+                ),
+                onBack: () => onShowPage(PaymentLinksLocalPage.home),
+                onPaste: operationInProgress ? null : onRunRedeemAction,
+                onScan: operationInProgress ? null : onScanCard,
+                fromQrCode: redeemFromQrCode,
+                onClearClipboard: operationInProgress ? null : onClearClipboard,
+                pasteLabel: redeemActionLabel,
               ),
-              onBack: () => onShowPage(PaymentLinksLocalPage.home),
-              onPaste: operationInProgress ? null : onRunRedeemAction,
-              onScan: operationInProgress ? null : onScanCard,
-              fromQrCode: redeemFromQrCode,
-              onClearClipboard: operationInProgress ? null : onClearClipboard,
-              pasteLabel: redeemActionLabel,
-            ),
-      PaymentLinksLocalPage.received => _buildReceived(context),
-    };
-
-    final overlay = keystoneOverlay;
-    final body = overlay == null
-        ? currentPage
-        : Stack(
-            fit: StackFit.expand,
-            children: [
-              currentPage,
-              Positioned.fill(child: overlay),
-            ],
-          );
-
-    // System Back does what the step's own back control does, so the draft
-    // survives; while the Keystone overlay is up, Back waits for it.
-    final stepBack = overlay == null ? _stepBack() : null;
-    return PopScope(
-      canPop: overlay == null && stepBack == null,
-      onPopInvokedWithResult: (didPop, _) {
-        if (!didPop) stepBack?.call();
-      },
-      child: Scaffold(
-        key: const ValueKey('payment_links_mobile_screen'),
-        backgroundColor: context.colors.background.window,
-        body: AppToastHost(child: SafeArea(child: body)),
-      ),
-    );
-  }
-
-  /// The pages whose visible back control steps within the screen. The rest
-  /// leave the route, so their Back keeps popping it.
-  VoidCallback? _stepBack() => switch (page) {
-    PaymentLinksLocalPage.amount => () => onShowPage(
-      PaymentLinksLocalPage.home,
-    ),
-    PaymentLinksLocalPage.message => () => onShowPage(
-      PaymentLinksLocalPage.amount,
-    ),
-    PaymentLinksLocalPage.review => () => onShowPage(
-      PaymentLinksLocalPage.message,
-    ),
-    PaymentLinksLocalPage.redeem => () => onShowPage(
-      PaymentLinksLocalPage.home,
-    ),
-    _ => null,
-  };
+        PaymentLinksLocalPage.received => _buildReceived(context),
+      };
 
   void _leavePaymentLinks(BuildContext context) {
     if (context.canPop()) {
@@ -508,7 +473,7 @@ class PaymentLinksMobileBody extends StatelessWidget {
             : PaymentLinkReadyMobileState.waiting,
         card: card,
         cardTop: kPaymentLinkMobileReceivedCardTop,
-        onHome: onAbandonReceivedPreview,
+        onHome: onReceivedHome,
         waitingHeading: 'Your Gift Card\nis almost ready!',
         waitingDescription:
             '$kPaymentLinkClaimWaitingDescription\n$kPaymentLinkWaitingDescription',
@@ -529,6 +494,136 @@ class PaymentLinksMobileBody extends StatelessWidget {
           : receivedClaimSession == null
           ? 'Try again'
           : 'Claim the gift',
+    );
+  }
+}
+
+/// Keep the wallet state above the navigator, but give each mobile step a real
+/// Cupertino route. The outer /payment-links route remains the intake owner.
+class _PaymentLinksMobileNavigator extends StatefulWidget {
+  const _PaymentLinksMobileNavigator({required this.body});
+  final PaymentLinksMobileBody body;
+
+  @override
+  State<_PaymentLinksMobileNavigator> createState() =>
+      _PaymentLinksMobileNavigatorState();
+}
+
+class _PaymentLinksMobileNavigatorState
+    extends State<_PaymentLinksMobileNavigator> {
+  final _navigatorKey = GlobalKey<NavigatorState>();
+  final _stepKeys = <PaymentLinksLocalPage, LocalKey>{};
+  ValueKey<Key?> get _signingKey => ValueKey(widget.body.keystoneOverlay?.key);
+
+  List<PaymentLinksLocalPage> get _steps => switch (widget.body.page) {
+    PaymentLinksLocalPage.home ||
+    PaymentLinksLocalPage.shareQr => [PaymentLinksLocalPage.home],
+    PaymentLinksLocalPage.amount => [
+      PaymentLinksLocalPage.home,
+      PaymentLinksLocalPage.amount,
+    ],
+    PaymentLinksLocalPage.message => [
+      PaymentLinksLocalPage.home,
+      PaymentLinksLocalPage.amount,
+      PaymentLinksLocalPage.message,
+    ],
+    PaymentLinksLocalPage.review => [
+      PaymentLinksLocalPage.home,
+      PaymentLinksLocalPage.amount,
+      PaymentLinksLocalPage.message,
+      PaymentLinksLocalPage.review,
+    ],
+    PaymentLinksLocalPage.ready => [
+      PaymentLinksLocalPage.home,
+      PaymentLinksLocalPage.ready,
+    ],
+    PaymentLinksLocalPage.redeem => [
+      PaymentLinksLocalPage.home,
+      PaymentLinksLocalPage.redeem,
+    ],
+    PaymentLinksLocalPage.received => [
+      PaymentLinksLocalPage.home,
+      PaymentLinksLocalPage.received,
+    ],
+  };
+
+  void _didRemovePage(Page<Object?> removed) {
+    final body = widget.body;
+    if (removed.key == _signingKey) {
+      if (body.keystoneOverlay != null) body.onCancelKeystone();
+      return;
+    }
+    // Declarative resets also remove routes. Only a user pop of the current
+    // step may update the owner; removed predecessors must not resurrect it.
+    if (body.keystoneOverlay != null || removed.key != _stepKeys[body.page]) {
+      return;
+    }
+    if (body.page == PaymentLinksLocalPage.received) {
+      body.onAbandonReceivedPreview();
+    } else {
+      final steps = _steps;
+      if (steps.length > 1) body.onShowPage(steps[steps.length - 2]);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final body = widget.body;
+    final signing = body.keystoneOverlay;
+    final steps = _steps;
+    // A newly entered step must not reuse the identity of its outgoing route.
+    // In particular, late removal callbacks must never dismiss a new draft.
+    _stepKeys.removeWhere((step, _) => !steps.contains(step));
+    for (final step in steps) {
+      _stepKeys.putIfAbsent(step, UniqueKey.new);
+    }
+    final hasInnerBack = steps.length > 1 || signing != null;
+    final outerRoute = ModalRoute.of(context);
+    return PopScope<Object?>(
+      canPop:
+          !hasInnerBack &&
+          !body.navigationLocked &&
+          outerRoute?.isFirst != true,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        if (hasInnerBack) {
+          _navigatorKey.currentState?.maybePop();
+        } else if (!body.navigationLocked) {
+          body._leavePaymentLinks(context);
+        }
+      },
+      child: Scaffold(
+        key: const ValueKey('payment_links_mobile_screen'),
+        backgroundColor: context.colors.background.window,
+        body: Navigator(
+          key: _navigatorKey,
+          onDidRemovePage: _didRemovePage,
+          pages: [
+            for (final step in steps)
+              CupertinoPage<Object?>(
+                key: _stepKeys[step],
+                child: PopScope<Object?>(
+                  canPop: !body.navigationLocked,
+                  child: Scaffold(
+                    backgroundColor: context.colors.background.window,
+                    body: AppToastHost(
+                      child: SafeArea(child: body._buildPage(context, step)),
+                    ),
+                  ),
+                ),
+              ),
+            if (signing != null)
+              CupertinoPage<Object?>(
+                key: _signingKey,
+                // The shared signing flow owns its decode/finalization guard.
+                child: Scaffold(
+                  backgroundColor: context.colors.background.window,
+                  body: AppToastHost(child: SafeArea(child: signing)),
+                ),
+              ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/src/features/payment_links/screens/payment_links_screen.dart
+++ b/lib/src/features/payment_links/screens/payment_links_screen.dart
@@ -132,6 +132,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
 
   int _mobileNavigationEpoch = 0;
   bool _softwareFundingInProgress = false;
+  bool _claimSubmissionInProgress = false;
 
   bool _isCurrentNavigation(int epoch) =>
       kAppFormFactor != AppFormFactor.mobile || epoch == _mobileNavigationEpoch;
@@ -241,6 +242,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
 
   bool get _mobileNavigationLocked =>
       _softwareFundingInProgress ||
+      _claimSubmissionInProgress ||
       _pendingFundingMetadata != null ||
       (_operationInProgress &&
           (_page == PaymentLinksLocalPage.review || _choosingClaimAccount));
@@ -616,6 +618,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       archived: record?.archived ?? false,
       onBack: () => _showPage(PaymentLinksLocalPage.home),
       onCheck: () async {
+        final epoch = _mobileNavigationEpoch;
         if (record?.isClaimInFlight ?? false) {
           setState(() => _operationInProgress = true);
           try {
@@ -629,7 +632,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
                     );
               },
             );
-            if (!mounted) return;
+            if (!mounted || !_isCurrentNavigation(epoch)) return;
             setState(() {
               _applyReceivedCards(records);
               final current = records
@@ -642,7 +645,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
               }
             });
           } catch (_) {
-            if (mounted) {
+            if (mounted && _isCurrentNavigation(epoch)) {
               _showError('Card status could not be checked. Try again.');
             }
           } finally {
@@ -663,6 +666,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     bool archived,
   ) async {
     if (_operationInProgress) return;
+    final epoch = _mobileNavigationEpoch;
     setState(() => _operationInProgress = true);
     try {
       await _paymentLinkOperations.setReceivedCardArchived(
@@ -670,14 +674,16 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         archived,
       );
       final records = await _paymentLinkOperations.loadReceivedLinkRecoveries();
-      if (!mounted) return;
+      if (!mounted || !_isCurrentNavigation(epoch)) return;
       setState(() {
         _receivedCards = records;
         _outcomeLink = null;
         _page = PaymentLinksLocalPage.home;
       });
     } catch (_) {
-      if (mounted) _showError('Card could not be updated. Try again.');
+      if (mounted && _isCurrentNavigation(epoch)) {
+        _showError('Card could not be updated. Try again.');
+      }
     } finally {
       if (mounted) setState(() => _operationInProgress = false);
     }
@@ -851,9 +857,13 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
 
   void _handleActiveAccountChanged(String? previous, String? current) {
     if (current != null) _handleClaimDestinationAccountChanged(current);
-    // The pending metadata save belongs to funding that already happened, so
-    // resetting the wizard here would strand its retry behind _showPage.
-    if (_pendingFundingMetadata != null) return;
+    // Keep the original review and loading label during mobile funding.
+    // An unsaved result must also retain its review so saving can be retried.
+    if (_pendingFundingMetadata != null ||
+        (kAppFormFactor == AppFormFactor.mobile &&
+            _softwareFundingInProgress)) {
+      return;
+    }
     final quotedAccount = _fundingQuote?.sourceAccountUuid;
     final priorAccount =
         previous ?? quotedAccount ?? _fundingQuoteRequestedAccountUuid;
@@ -1197,6 +1207,14 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
           _operationInProgress = false;
           _softwareFundingInProgress = false;
         });
+        // A switch during funding must keep the existing loading UI visible.
+        // Once it finishes, invalidate a failed draft for the new account.
+        if (kAppFormFactor == AppFormFactor.mobile) {
+          _handleActiveAccountChanged(
+            sourceAccountUuid,
+            ref.read(accountProvider).value?.activeAccountUuid,
+          );
+        }
         unawaited(_refreshFundingProgress());
       }
     }
@@ -1369,6 +1387,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
   Future<void> _scanPaymentLink() async {
     if (_operationInProgress) return;
     final page = _page;
+    final epoch = _mobileNavigationEpoch;
     setState(() => _operationInProgress = true);
     VizorPaymentLink? link;
     try {
@@ -1379,7 +1398,12 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     } finally {
       if (mounted) setState(() => _operationInProgress = false);
     }
-    if (!mounted || link == null || _page != page) return;
+    if (!mounted ||
+        !_isCurrentNavigation(epoch) ||
+        link == null ||
+        _page != page) {
+      return;
+    }
     setState(() {
       _redeemFromQrCode = true;
       _retryLink = null;
@@ -1684,10 +1708,20 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
   }
 
   Future<void> _clearClipboard() async {
-    await ref.read(paymentLinkClipboardProvider).clear();
+    final epoch = _mobileNavigationEpoch;
+    final page = _page;
     final claimSession = _receivedClaimSession;
+    await ref.read(paymentLinkClipboardProvider).clear();
+    if (!mounted ||
+        !_isCurrentNavigation(epoch) ||
+        _page != page ||
+        _operationInProgress ||
+        !identical(_receivedClaimSession, claimSession)) {
+      return;
+    }
     if (claimSession != null) {
       await _paymentLinkOperations.discardClaimSession(claimSession);
+      if (!mounted || !_isCurrentNavigation(epoch)) return;
     }
     _paymentLinkIntake.clearError();
     if (mounted) {
@@ -1860,6 +1894,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       // the card on mobile, so leaving the route cannot release its wallet.
       _receivedClaimSession = null;
       if (mobile) {
+        _claimSubmissionInProgress = true;
         _operationInProgress = true;
       } else {
         _receivedLink = null;
@@ -1955,6 +1990,10 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
               : 'Gift card claim failed. It may still be waiting for confirmation '
                     'or may already be spent.',
         );
+      }
+    } finally {
+      if (mounted && mobile) {
+        setState(() => _claimSubmissionInProgress = false);
       }
     }
   }

--- a/lib/src/features/payment_links/screens/payment_links_screen.dart
+++ b/lib/src/features/payment_links/screens/payment_links_screen.dart
@@ -130,6 +130,12 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       PaymentLinkAvailability.noBalance;
   bool _showArchivedCards = false;
 
+  int _mobileNavigationEpoch = 0;
+  bool _softwareFundingInProgress = false;
+
+  bool _isCurrentNavigation(int epoch) =>
+      kAppFormFactor != AppFormFactor.mobile || epoch == _mobileNavigationEpoch;
+
   PaymentLinksLocalPage _page = PaymentLinksLocalPage.home;
   PaymentLinkCardArtwork _selectedArtwork = PaymentLinkCardArtwork.gift;
   PaymentLinkRedeemVisualState _redeemState =
@@ -233,11 +239,28 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     setState(() => _amountFocused = _amountFocusNode.hasFocus);
   }
 
+  bool get _mobileNavigationLocked =>
+      _softwareFundingInProgress ||
+      _pendingFundingMetadata != null ||
+      (_operationInProgress &&
+          (_page == PaymentLinksLocalPage.review || _choosingClaimAccount));
+
   void _showPage(PaymentLinksLocalPage page) {
+    if (kAppFormFactor == AppFormFactor.mobile && _mobileNavigationLocked) {
+      return;
+    }
     if (_pendingFundingMetadata != null &&
         page != PaymentLinksLocalPage.review) {
       _showError('Save this gift card before leaving this screen.');
       return;
+    }
+    if (page != _page) {
+      _mobileNavigationEpoch++;
+      if (kAppFormFactor == AppFormFactor.mobile &&
+          _page == PaymentLinksLocalPage.redeem) {
+        _redeemState = PaymentLinkRedeemVisualState.paste;
+        _retryLink = null;
+      }
     }
     _amountFocusNode.unfocus();
     _messageFocusNode.unfocus();
@@ -262,6 +285,8 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
   }
 
   void _startCreate() {
+    if (_operationInProgress || _pendingFundingMetadata != null) return;
+    _mobileNavigationEpoch++;
     _fundingQuoteDebounce?.cancel();
     _fundingQuoteGeneration++;
     _maxFundingQuoteGeneration++;
@@ -507,6 +532,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
   /// An empty scan cannot prove that a Card will never receive funds. Keep
   /// listed Cards and their wallets for retry; new previews remain disposable.
   Future<void> _releaseUnavailableClaim(PaymentLinkClaimSession session) async {
+    final epoch = _mobileNavigationEpoch;
     final availability =
         session.availability == PaymentLinkAvailability.unchecked
         ? PaymentLinkAvailability.noBalance
@@ -523,6 +549,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     } else {
       await _paymentLinkOperations.discardClaimSession(session);
     }
+    if (!mounted || !_isCurrentNavigation(epoch)) return;
     _outcomeLink = session.link;
     _outcomeAvailability = availability;
   }
@@ -1113,7 +1140,10 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       return;
     }
 
-    setState(() => _operationInProgress = true);
+    setState(() {
+      _operationInProgress = true;
+      _softwareFundingInProgress = true;
+    });
     try {
       final funding = await ref
           .read(paymentLinkOperationsProvider)
@@ -1163,7 +1193,10 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       if (mounted) _showError('Gift card creation failed. Try again.');
     } finally {
       if (mounted) {
-        setState(() => _operationInProgress = false);
+        setState(() {
+          _operationInProgress = false;
+          _softwareFundingInProgress = false;
+        });
         unawaited(_refreshFundingProgress());
       }
     }
@@ -1305,6 +1338,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
 
   Future<void> _pastePaymentLink() async {
     if (_operationInProgress) return;
+    final epoch = _mobileNavigationEpoch;
     setState(() {
       _operationInProgress = true;
       _redeemState = PaymentLinkRedeemVisualState.loading;
@@ -1313,8 +1347,9 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     });
     try {
       final rawLink = await ref.read(paymentLinkClipboardProvider).readText();
+      if (!mounted || !_isCurrentNavigation(epoch)) return;
       if (rawLink == null || rawLink.trim().isEmpty) {
-        if (mounted) {
+        if (mounted && _isCurrentNavigation(epoch)) {
           setState(() => _redeemState = PaymentLinkRedeemVisualState.invalid);
         }
         return;
@@ -1323,7 +1358,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       if (!mounted) return;
       await _prepareDecodedPaymentLink(link);
     } catch (_) {
-      if (mounted) {
+      if (mounted && _isCurrentNavigation(epoch)) {
         setState(() => _redeemState = PaymentLinkRedeemVisualState.invalid);
       }
     } finally {
@@ -1388,6 +1423,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     VizorPaymentLink link, {
     bool allowLongSync = false,
   }) async {
+    final epoch = _mobileNavigationEpoch;
     final previousSession = _receivedClaimSession;
     if (previousSession != null &&
         paymentLinkClaimWalletDirectoryName(previousSession.link) !=
@@ -1395,16 +1431,21 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       await ref
           .read(paymentLinkOperationsProvider)
           .discardClaimSession(previousSession);
+      if (!mounted || !_isCurrentNavigation(epoch)) return;
       _receivedClaimSession = null;
     }
     try {
       final session = await ref
           .read(paymentLinkOperationsProvider)
           .prepareClaim(link, allowLongSync: allowLongSync);
-      if (!mounted) {
+      if (!mounted || !_isCurrentNavigation(epoch)) {
         // The element is defunct here, so its ref may already throw; the
         // captured operations still delete the temporary claim wallet.
-        await _paymentLinkOperations.discardClaimSession(session);
+        if (_shouldKeepCard(session)) {
+          await _paymentLinkOperations.retainPendingClaim(session);
+        } else {
+          await _paymentLinkOperations.discardClaimSession(session);
+        }
         return;
       }
       // Preparation can outlast an account switch; a session bound to the
@@ -1435,7 +1476,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       }
       if (!session.canClaim) {
         await _releaseUnavailableClaim(session);
-        if (!mounted) return;
+        if (!mounted || !_isCurrentNavigation(epoch)) return;
         setState(() {
           _receivedClaimSession = null;
           _longSyncLink = null;
@@ -1457,7 +1498,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       log('PaymentLinkClaim: preview ready');
     } on PaymentLinkLongSyncConfirmationRequired {
       log('PaymentLinkClaim: waiting for long sync confirmation');
-      if (!mounted) return;
+      if (!mounted || !_isCurrentNavigation(epoch)) return;
       setState(() {
         _redeemState = PaymentLinkRedeemVisualState.paste;
         if (kAppFormFactor == AppFormFactor.desktop) {
@@ -1467,13 +1508,13 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       if (kAppFormFactor == AppFormFactor.mobile) {
         final confirmed = await showPaymentLinkLongSyncWarningSheet(context);
         if (!confirmed) return;
-        if (!mounted) return;
+        if (!mounted || !_isCurrentNavigation(epoch)) return;
         setState(() => _redeemState = PaymentLinkRedeemVisualState.loading);
         await _prepareDecodedPaymentLink(link, allowLongSync: true);
       }
     } on PaymentLinkClaimInFlightException catch (error) {
       log('PaymentLinkClaim: ignored duplicate in-flight link');
-      if (!mounted) return;
+      if (!mounted || !_isCurrentNavigation(epoch)) return;
       setState(() {
         _activeCardsTab = PaymentLinkCardsTab.received;
         _longSyncLink = null;
@@ -1487,7 +1528,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         'PaymentLinkClaim: rejected link for another network '
         'link=${error.linkNetwork} wallet=${error.walletNetwork}',
       );
-      if (!mounted) return;
+      if (!mounted || !_isCurrentNavigation(epoch)) return;
       // A different network is a permanent property of the link, so there is
       // nothing to retry: clear the retry affordance and name the reason.
       setState(() {
@@ -1501,7 +1542,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         'PaymentLinkClaim: preparation rejected '
         'category=${_paymentLinkFormatFailureCategory(error)}',
       );
-      if (mounted) {
+      if (mounted && _isCurrentNavigation(epoch)) {
         setState(() {
           _longSyncLink = null;
           _retryLink = null;
@@ -1510,7 +1551,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       }
     } catch (error) {
       log('PaymentLinkClaim: preparation failed type=${error.runtimeType}');
-      if (mounted) {
+      if (mounted && _isCurrentNavigation(epoch)) {
         setState(() {
           _longSyncLink = null;
           _retryLink = link;
@@ -1589,7 +1630,9 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
   /// Backing out of a preview releases its prepared claim. A session
   /// left live would make a later account switch pull the user back into
   /// Redeem, and would hold the temporary claim wallet until route dispose.
-  void _abandonReceivedPreview() {
+  void _abandonReceivedPreview({bool goHome = false}) {
+    if (_mobileNavigationLocked) return;
+    _mobileNavigationEpoch++;
     final session = _receivedClaimSession;
     setState(() {
       _receivedClaimSession = null;
@@ -1599,7 +1642,8 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     if (session != null) {
       _releaseClaimSession(session, keepCard: _shouldKeepCard(session));
     }
-    if (kAppFormFactor == AppFormFactor.mobile) {
+    if (kAppFormFactor == AppFormFactor.mobile &&
+        (goHome || !context.canPop())) {
       context.go('/home');
     } else {
       _showPage(PaymentLinksLocalPage.home);
@@ -1830,10 +1874,17 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
     VizorPaymentLink link,
     Future<PaymentLinkClaimResult> submission,
   ) async {
+    final epoch = _mobileNavigationEpoch;
     final mobile = kAppFormFactor == AppFormFactor.mobile;
     try {
       final result = await submission;
-      if (!mounted) return;
+      if (!mounted || !_isCurrentNavigation(epoch)) {
+        if (mounted) {
+          setState(() => _operationInProgress = false);
+          unawaited(_refreshReceivedClaims());
+        }
+        return;
+      }
       if (mobile) {
         setState(() {
           _operationInProgress = false;
@@ -1861,7 +1912,14 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       );
       unawaited(_refreshReceivedClaims());
     } on PaymentLinkClaimDestinationChangedException {
-      if (mounted) {
+      if (!mounted || !_isCurrentNavigation(epoch)) {
+        if (mounted) {
+          setState(() => _operationInProgress = false);
+          unawaited(_refreshReceivedClaims());
+        }
+        return;
+      }
+      if (mounted && _isCurrentNavigation(epoch)) {
         setState(() {
           _setReceivedCardStatus(
             link.address,
@@ -1881,7 +1939,14 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         );
       }
     } catch (_) {
-      if (mounted) {
+      if (!mounted || !_isCurrentNavigation(epoch)) {
+        if (mounted) {
+          setState(() => _operationInProgress = false);
+          unawaited(_refreshReceivedClaims());
+        }
+        return;
+      }
+      if (mounted && _isCurrentNavigation(epoch)) {
         if (mobile) setState(() => _operationInProgress = false);
         unawaited(_refreshReceivedClaims());
         _showError(
@@ -1955,6 +2020,8 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
       final mobileKeystoneRequest = _keystoneFundingRequest;
       return PaymentLinksMobileBody(
         page: _page,
+        navigationLocked: _mobileNavigationLocked,
+        onCancelKeystone: _cancelKeystoneFunding,
         redeemState: _redeemState,
         claimOutcome: _buildClaimOutcome(),
         operationInProgress: _operationInProgress,
@@ -1963,6 +2030,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         keystoneOverlay: mobileKeystoneRequest == null
             ? null
             : PaymentLinkKeystoneSigningOverlay(
+                key: ObjectKey(mobileKeystoneRequest),
                 amountZatoshi: mobileKeystoneRequest.amountZatoshi,
                 sourceAccountUuid: mobileKeystoneRequest.sourceAccountUuid,
                 presentation: mobileKeystoneRequest.presentation,
@@ -2031,6 +2099,7 @@ class _PaymentLinksScreenState extends ConsumerState<PaymentLinksScreen> {
         onToggleReceivedBack: () =>
             setState(() => _receivedShowsBack = !_receivedShowsBack),
         onAbandonReceivedPreview: _abandonReceivedPreview,
+        onReceivedHome: () => _abandonReceivedPreview(goHome: true),
         onClaimReceivedLink: _confirmMobileClaim,
       );
     }

--- a/test/features/payment_links/payment_links_async_capture_mobile_test.dart
+++ b/test/features/payment_links/payment_links_async_capture_mobile_test.dart
@@ -14,119 +14,163 @@ void main() {
   const output = String.fromEnvironment('GIFT_CARD_CAPTURE_DIR');
   if (output.isEmpty) return;
   setUpAll(loadFigmaCompareFonts);
-  for (final state in [
-    'funding',
-    'funding-error',
-    'metadata',
-    'checking',
-    'claiming',
-    'claim-error',
-    'account-preparing',
-  ]) {
-    testWidgets(
-      'capture async gift card $state',
-      (tester) async {
-        final boundary = GlobalKey();
-        final gate = Completer<void>();
-        final claim = Completer<PaymentLinkClaimResult>();
-        final accounts = SwitchablePaymentLinkAccountNotifier();
-        final operations = state == 'claim-error'
-            ? _ClaimSaveFailure(gate)
-            : FakePaymentLinkOperations(
-                createFundedLinkGate: state.startsWith('funding') ? gate : null,
-                fundingMetadataSavedOnCreate: state != 'metadata',
-                prepareClaimGates: state == 'checking'
-                    ? {1: gate}
-                    : state == 'account-preparing'
-                    ? {2: gate}
-                    : {},
-                claimCompleter: state == 'claiming' ? claim : null,
-                readClaimDestination: state == 'account-preparing'
-                    ? () => accounts.current
-                    : null,
-              );
-        await pumpPaymentLinksScreen(
-          tester,
-          logicalSize: const Size(393, 852),
-          captureBoundaryKey: boundary,
-          operations: operations,
-          accountNotifier: state == 'account-preparing' ? accounts : null,
-          clipboard: FakePaymentLinkClipboard(
-            text: incomingLink.toUri().toString(),
-          ),
-        );
-        final router = GoRouter.of(
-          tester.element(
-            find.byKey(const ValueKey('payment_links_mobile_screen')),
-          ),
-        );
-        router.go('/settings');
-        await tester.pumpAndSettle();
-        unawaited(router.push('/payment-links'));
-        await tester.pumpAndSettle();
-        Future<void> frames() async {
-          for (var i = 0; i < 10; i++) {
-            await tester.pump(const Duration(milliseconds: 100));
-          }
-        }
-
-        Future<void> tap(String key) async {
-          await tester.tap(find.byKey(ValueKey(key)));
-          await frames();
-        }
-
-        Future<void> capture(String suffix) async {
-          await tester.runAsync(
-            () => Future<void>.delayed(const Duration(milliseconds: 150)),
+  // Visual parity uses an uninterrupted flow; back behavior is a separate run.
+  for (final exerciseBack in [false, true]) {
+    for (final state in [
+      'funding',
+      'funding-error',
+      'metadata',
+      'checking',
+      'claiming',
+      'claim-error',
+      'account-preparing',
+    ]) {
+      testWidgets(
+        'capture ${exerciseBack ? 'back behavior' : 'same state'} gift card $state',
+        (tester) async {
+          final boundary = GlobalKey();
+          final gate = Completer<void>();
+          final claim = Completer<PaymentLinkClaimResult>();
+          final accounts = SwitchablePaymentLinkAccountNotifier();
+          final operations = state == 'claim-error'
+              ? _ClaimSaveFailure(gate)
+              : FakePaymentLinkOperations(
+                  createFundedLinkGate: state.startsWith('funding')
+                      ? gate
+                      : null,
+                  fundingMetadataSavedOnCreate: state != 'metadata',
+                  prepareClaimGates: state == 'checking'
+                      ? {1: gate}
+                      : state == 'account-preparing'
+                      ? {2: gate}
+                      : {},
+                  claimCompleter: state == 'claiming' ? claim : null,
+                  readClaimDestination: state == 'account-preparing'
+                      ? () => accounts.current
+                      : null,
+                );
+          await pumpPaymentLinksScreen(
+            tester,
+            logicalSize: const Size(393, 852),
+            captureBoundaryKey: boundary,
+            operations: operations,
+            accountNotifier: state == 'account-preparing' ? accounts : null,
+            clipboard: FakePaymentLinkClipboard(
+              text: incomingLink.toUri().toString(),
+            ),
           );
-          await frames();
-          final file = File('$output/async/$state-$suffix.png');
-          file.parent.createSync(recursive: true);
-          await expectLater(find.byKey(boundary), matchesGoldenFile(file.uri));
-        }
-
-        if (state.startsWith('funding') || state == 'metadata') {
-          await tap('payment_links_mobile_create_button');
-          await tester.enterText(
-            find.byKey(const ValueKey('payment_link_amount_editor')),
-            '0.1',
+          final router = GoRouter.of(
+            tester.element(
+              find.byKey(const ValueKey('payment_links_mobile_screen')),
+            ),
           );
-          await frames();
-          await tap('payment_link_mobile_amount_continue_button');
-          await tap('payment_link_mobile_message_continue_button');
-          await tap('payment_link_mobile_review_continue_button');
-        } else {
-          await tap('payment_links_mobile_redeem_button');
-          await tester.tap(find.text('Paste card link'));
-          await frames();
-          if (state == 'claiming' ||
-              state == 'claim-error' ||
-              state == 'account-preparing') {
-            await tap('payment_link_mobile_claim_button');
-            if (state == 'account-preparing') {
-              await tap('payment_link_claim_account_account-2');
-              await tester.tap(find.text('Claim gift'));
-              await frames();
+          router.go('/settings');
+          await tester.pumpAndSettle();
+          unawaited(router.push('/payment-links'));
+          await tester.pumpAndSettle();
+          Future<void> frames() async {
+            for (var i = 0; i < 10; i++) {
+              await tester.pump(const Duration(milliseconds: 100));
             }
           }
-        }
-        await capture('pending');
-        await tester.binding.handlePopRoute();
-        await frames();
-        await capture('back');
-        if (!gate.isCompleted) {
-          if (state == 'funding-error' || state == 'claim-error') {
-            gate.completeError(StateError('connection lost'));
-          } else {
-            gate.complete();
+
+          Future<void> tap(String key) async {
+            await tester.tap(find.byKey(ValueKey(key)));
+            await frames();
           }
-        }
-        if (!claim.isCompleted) claim.complete(broadcastedClaimResult);
-        await frames();
-        await capture('settled');
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    );
+
+          Future<void> capture(String suffix) async {
+            await tester.runAsync(
+              () => Future<void>.delayed(const Duration(milliseconds: 150)),
+            );
+            await frames();
+            final lane = exerciseBack ? 'back-behavior' : 'same-state';
+            final file = File('$output/$lane/$state-$suffix.png');
+            file.parent.createSync(recursive: true);
+            await expectLater(
+              find.byKey(boundary),
+              matchesGoldenFile(file.uri),
+            );
+          }
+
+          if (state.startsWith('funding') || state == 'metadata') {
+            await tap('payment_links_mobile_create_button');
+            await tester.enterText(
+              find.byKey(const ValueKey('payment_link_amount_editor')),
+              '0.1',
+            );
+            await frames();
+            await tap('payment_link_mobile_amount_continue_button');
+            await tap('payment_link_mobile_message_continue_button');
+            await tap('payment_link_mobile_review_continue_button');
+          } else {
+            await tap('payment_links_mobile_redeem_button');
+            await tester.tap(find.text('Paste card link'));
+            await frames();
+            if (state == 'claiming' ||
+                state == 'claim-error' ||
+                state == 'account-preparing') {
+              await tap('payment_link_mobile_claim_button');
+              if (state == 'account-preparing') {
+                await tap('payment_link_claim_account_account-2');
+                await tester.tap(find.text('Claim gift'));
+                await frames();
+              }
+            }
+          }
+          if (state == 'checking') {
+            expect(
+              find.byKey(const ValueKey('payment_link_mobile_redeem_checking')),
+              findsOneWidget,
+            );
+          } else {
+            expect(
+              find.text(switch (state) {
+                'funding' || 'funding-error' => 'Creating...',
+                'metadata' => 'Try saving again',
+                'claiming' || 'claim-error' => 'Claiming...',
+                'account-preparing' => 'Preparing...',
+                _ => 'Checking card...',
+              }),
+              findsOneWidget,
+            );
+          }
+          await capture('pending');
+          if (exerciseBack) {
+            await tester.binding.handlePopRoute();
+            await frames();
+            await capture('back');
+          }
+          if (!gate.isCompleted) {
+            if (state == 'funding-error' || state == 'claim-error') {
+              gate.completeError(StateError('connection lost'));
+            } else {
+              gate.complete();
+            }
+          }
+          if (!claim.isCompleted) claim.complete(broadcastedClaimResult);
+          await frames();
+          if (!exerciseBack) {
+            if (state == 'claiming' || state == 'account-preparing') {
+              expect(router.state.uri.path, '/home');
+            } else {
+              expect(
+                find.text(switch (state) {
+                  'funding' => 'Go home',
+                  'funding-error' => 'Approve & create',
+                  'metadata' => 'Try saving again',
+                  'claim-error' => 'Try again',
+                  _ => 'Claim the gift',
+                }),
+                findsOneWidget,
+              );
+            }
+          }
+          await capture('settled');
+        },
+        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+      );
+    }
   }
 }
 

--- a/test/features/payment_links/payment_links_async_capture_mobile_test.dart
+++ b/test/features/payment_links/payment_links_async_capture_mobile_test.dart
@@ -1,0 +1,143 @@
+@Tags(['mobile', 'figma-capture'])
+library;
+
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import '../../support/payment_links_screen_support.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_service.dart';
+import '../../figma_compare/figma_compare_font_loader.dart';
+
+void main() {
+  const output = String.fromEnvironment('GIFT_CARD_CAPTURE_DIR');
+  if (output.isEmpty) return;
+  setUpAll(loadFigmaCompareFonts);
+  for (final state in [
+    'funding',
+    'funding-error',
+    'metadata',
+    'checking',
+    'claiming',
+    'claim-error',
+    'account-preparing',
+  ]) {
+    testWidgets(
+      'capture async gift card $state',
+      (tester) async {
+        final boundary = GlobalKey();
+        final gate = Completer<void>();
+        final claim = Completer<PaymentLinkClaimResult>();
+        final accounts = SwitchablePaymentLinkAccountNotifier();
+        final operations = state == 'claim-error'
+            ? _ClaimSaveFailure(gate)
+            : FakePaymentLinkOperations(
+                createFundedLinkGate: state.startsWith('funding') ? gate : null,
+                fundingMetadataSavedOnCreate: state != 'metadata',
+                prepareClaimGates: state == 'checking'
+                    ? {1: gate}
+                    : state == 'account-preparing'
+                    ? {2: gate}
+                    : {},
+                claimCompleter: state == 'claiming' ? claim : null,
+                readClaimDestination: state == 'account-preparing'
+                    ? () => accounts.current
+                    : null,
+              );
+        await pumpPaymentLinksScreen(
+          tester,
+          logicalSize: const Size(393, 852),
+          captureBoundaryKey: boundary,
+          operations: operations,
+          accountNotifier: state == 'account-preparing' ? accounts : null,
+          clipboard: FakePaymentLinkClipboard(
+            text: incomingLink.toUri().toString(),
+          ),
+        );
+        final router = GoRouter.of(
+          tester.element(
+            find.byKey(const ValueKey('payment_links_mobile_screen')),
+          ),
+        );
+        router.go('/settings');
+        await tester.pumpAndSettle();
+        unawaited(router.push('/payment-links'));
+        await tester.pumpAndSettle();
+        Future<void> frames() async {
+          for (var i = 0; i < 10; i++) {
+            await tester.pump(const Duration(milliseconds: 100));
+          }
+        }
+
+        Future<void> tap(String key) async {
+          await tester.tap(find.byKey(ValueKey(key)));
+          await frames();
+        }
+
+        Future<void> capture(String suffix) async {
+          await tester.runAsync(
+            () => Future<void>.delayed(const Duration(milliseconds: 150)),
+          );
+          await frames();
+          final file = File('$output/async/$state-$suffix.png');
+          file.parent.createSync(recursive: true);
+          await expectLater(find.byKey(boundary), matchesGoldenFile(file.uri));
+        }
+
+        if (state.startsWith('funding') || state == 'metadata') {
+          await tap('payment_links_mobile_create_button');
+          await tester.enterText(
+            find.byKey(const ValueKey('payment_link_amount_editor')),
+            '0.1',
+          );
+          await frames();
+          await tap('payment_link_mobile_amount_continue_button');
+          await tap('payment_link_mobile_message_continue_button');
+          await tap('payment_link_mobile_review_continue_button');
+        } else {
+          await tap('payment_links_mobile_redeem_button');
+          await tester.tap(find.text('Paste card link'));
+          await frames();
+          if (state == 'claiming' ||
+              state == 'claim-error' ||
+              state == 'account-preparing') {
+            await tap('payment_link_mobile_claim_button');
+            if (state == 'account-preparing') {
+              await tap('payment_link_claim_account_account-2');
+              await tester.tap(find.text('Claim gift'));
+              await frames();
+            }
+          }
+        }
+        await capture('pending');
+        await tester.binding.handlePopRoute();
+        await frames();
+        await capture('back');
+        if (!gate.isCompleted) {
+          if (state == 'funding-error' || state == 'claim-error') {
+            gate.completeError(StateError('connection lost'));
+          } else {
+            gate.complete();
+          }
+        }
+        if (!claim.isCompleted) claim.complete(broadcastedClaimResult);
+        await frames();
+        await capture('settled');
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+  }
+}
+
+class _ClaimSaveFailure extends FakePaymentLinkOperations {
+  _ClaimSaveFailure(this.gate);
+  final Completer<void> gate;
+  @override
+  Future<PaymentLinkClaimResult> claimPreparedLink(
+    PaymentLinkClaimSession session,
+  ) async {
+    await gate.future;
+    return super.claimPreparedLink(session);
+  }
+}

--- a/test/features/payment_links/payment_links_flow_capture_mobile_test.dart
+++ b/test/features/payment_links/payment_links_flow_capture_mobile_test.dart
@@ -1,0 +1,75 @@
+@Tags(['mobile', 'figma-capture'])
+library;
+
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../../support/payment_links_screen_support.dart';
+import '../../figma_compare/figma_compare_font_loader.dart';
+
+void main() {
+  const output = String.fromEnvironment('GIFT_CARD_CAPTURE_DIR');
+  if (output.isEmpty) return;
+  setUpAll(loadFigmaCompareFonts);
+  testWidgets(
+    'capture actual mobile gift card flow',
+    (tester) async {
+      final boundary = GlobalKey();
+      await pumpPaymentLinksScreen(
+        tester,
+        logicalSize: const Size(393, 852),
+        captureBoundaryKey: boundary,
+        clipboard: FakePaymentLinkClipboard(
+          text: incomingLink.toUri().toString(),
+        ),
+      );
+      Future<void> capture(String name) async {
+        await tester.pump(const Duration(milliseconds: 500));
+        final outputFile = File('$output/flow/$name.png');
+        outputFile.parent.createSync(recursive: true);
+        await expectLater(
+          find.byKey(boundary),
+          matchesGoldenFile(outputFile.uri),
+        );
+      }
+
+      Future<void> tapKey(String name) async {
+        await tester.tap(find.byKey(ValueKey(name)));
+        await tester.pumpAndSettle();
+      }
+
+      await capture('home');
+      await tapKey('payment_links_mobile_create_button');
+      await capture('amount-empty');
+      await tester.enterText(
+        find.byKey(const ValueKey('payment_link_amount_editor')),
+        '0.1',
+      );
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
+      FocusManager.instance.primaryFocus?.unfocus();
+      await capture('amount-filled');
+      await tapKey('payment_link_mobile_amount_continue_button');
+      await capture('message-empty');
+      await tester.enterText(
+        find.byKey(const ValueKey('payment_link_message_editor')),
+        'A gift for you',
+      );
+      FocusManager.instance.primaryFocus?.unfocus();
+      await capture('message-filled');
+      await tapKey('payment_link_mobile_message_continue_button');
+      await capture('review');
+      await tapKey('payment_link_mobile_review_continue_button');
+      await capture('ready');
+      await tester.tap(find.text('Go home'));
+      await tester.pumpAndSettle();
+      await capture('cards');
+      await tapKey('payment_links_mobile_redeem_button');
+      await capture('redeem');
+      await tester.tap(find.text('Paste card link'));
+      await tester.pumpAndSettle();
+      await capture('received');
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
+}

--- a/test/features/payment_links/payment_links_mobile_keystone_test.dart
+++ b/test/features/payment_links/payment_links_mobile_keystone_test.dart
@@ -88,6 +88,32 @@ void main() {
     expect(cta.onPressed, isNotNull);
     expect(find.text('Approve & create'), findsOneWidget);
   });
+  testWidgets(
+    'iOS swipe cancels only signing and releases its PCZT',
+    (tester) async {
+      final hardwareSigning = _FakePaymentLinkHardwareSigningService();
+      await _pumpMobilePaymentLinks(tester, hardwareSigning: hardwareSigning);
+      await _walkToApproveAndCreate(tester);
+      final route =
+          ModalRoute.of(
+                tester.element(find.byType(MobileKeystonePcztSigningFlow)),
+              )!
+              as PageRoute;
+      expect(route.popGestureEnabled, isTrue);
+      await tester.dragFrom(const Offset(1, 150), const Offset(1000, 0));
+      await tester.pumpAndSettle();
+      expect(find.byType(MobileKeystonePcztSigningFlow), findsNothing);
+      expect(hardwareSigning.discardedDrafts, [BigInt.one]);
+      expect(find.text('Approve & create'), findsOneWidget);
+      final cta = tester.widget<AppButton>(
+        find.byKey(
+          const ValueKey('payment_link_mobile_review_continue_button'),
+        ),
+      );
+      expect(cta.onPressed, isNotNull);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
 }
 
 Future<void> _walkToApproveAndCreate(WidgetTester tester) async {

--- a/test/features/payment_links/payment_links_navigation_mobile_test.dart
+++ b/test/features/payment_links/payment_links_navigation_mobile_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/features/payment_links/services/payment_link_service.dart';
 import '../../support/payment_links_screen_support.dart';
+import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
+import 'package:zcash_wallet/src/features/payment_links/widgets/mobile/payment_link_scan_sheet.dart';
 
 const _amount = 'payment_link_mobile_amount_continue_button';
 const _message = 'payment_link_mobile_message_continue_button';
@@ -18,13 +20,18 @@ Future<GoRouter> openFromSettings(
   WidgetTester tester, {
   FakePaymentLinkOperations? operations,
   SwitchablePaymentLinkAccountNotifier? accounts,
+  PaymentLinkScanner? scanner,
+  FakePaymentLinkClipboard? clipboard,
 }) async {
   await pumpPaymentLinksScreen(
     tester,
     operations: operations,
     accountNotifier: accounts,
+    scanner: scanner,
     logicalSize: const Size(393, 852),
-    clipboard: FakePaymentLinkClipboard(text: incomingLink.toUri().toString()),
+    clipboard:
+        clipboard ??
+        FakePaymentLinkClipboard(text: incomingLink.toUri().toString()),
   );
   final router = GoRouter.of(
     tester.element(keyed('payment_links_mobile_screen')),
@@ -152,7 +159,8 @@ void main() {
     await accounts.switchAccount('account-2');
     await tester.pump();
     await back(tester);
-    expect(keyed(_amount), findsOneWidget);
+    expect(keyed(_review), findsOneWidget);
+    expect(find.text('Creating...'), findsOneWidget);
     expect(keyed('payment_links_mobile_create_button'), findsNothing);
     gate.complete();
     await tester.pumpAndSettle();
@@ -254,26 +262,146 @@ void main() {
     variant: TargetPlatformVariant.only(TargetPlatform.iOS),
   );
 
+  testWidgets('claim execution blocks every back path until completion', (
+    tester,
+  ) async {
+    final gate = Completer<PaymentLinkClaimResult>();
+    final operations = FakePaymentLinkOperations(claimCompleter: gate);
+    final router = await openFromSettings(tester, operations: operations);
+    await tap(tester, 'payment_links_mobile_redeem_button');
+    await tester.tap(find.text('Paste card link'));
+    await tester.pumpAndSettle();
+    await tester.tap(keyed('payment_link_mobile_claim_button'));
+    await tester.pump();
+    await back(tester);
+    expect(find.text('Claiming...'), findsOneWidget);
+    await tester.tap(find.bySemanticsLabel('Close').last);
+    await tester.pump();
+    expect(find.text('Claiming...'), findsOneWidget);
+    expect(router.state.uri.path, '/payment-links');
+    gate.complete(broadcastedClaimResult);
+    for (var i = 0; i < 12; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    expect(router.state.uri.path, '/home');
+    expect(operations.discardedClaimAddresses, isEmpty);
+  }, variant: platforms);
+  testWidgets('claim failure unlocks the existing preview for checking', (
+    tester,
+  ) async {
+    final gate = Completer<PaymentLinkClaimResult>();
+    final operations = FakePaymentLinkOperations(claimCompleter: gate);
+    await openFromSettings(tester, operations: operations);
+    await tap(tester, 'payment_links_mobile_redeem_button');
+    await tester.tap(find.text('Paste card link'));
+    await tester.pumpAndSettle();
+    await tester.tap(keyed('payment_link_mobile_claim_button'));
+    await tester.pump();
+    await back(tester);
+    expect(find.text('Claiming...'), findsOneWidget);
+    gate.completeError(StateError('submission failed'));
+    await tester.pumpAndSettle();
+    expect(find.text('Try again'), findsOneWidget);
+    await back(tester);
+    expect(keyed('payment_links_mobile_create_button'), findsOneWidget);
+  }, variant: platforms);
+
+  testWidgets('failed funding after account change unlocks and requotes', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    final accounts = SwitchablePaymentLinkAccountNotifier();
+    await openFromSettings(
+      tester,
+      accounts: accounts,
+      operations: FakePaymentLinkOperations(createFundedLinkGate: gate),
+    );
+    await createToReview(tester);
+    await tester.tap(keyed(_review));
+    await tester.pump();
+    await accounts.switchAccount('account-2');
+    await tester.pump();
+    expect(find.text('Creating...'), findsOneWidget);
+    gate.completeError(StateError('funding failed'));
+    await tester.pumpAndSettle();
+    expect(keyed(_amount), findsOneWidget);
+    await back(tester);
+    expect(keyed('payment_links_mobile_create_button'), findsOneWidget);
+  }, variant: platforms);
+
+  testWidgets('scanner result from an earlier redeem visit is ignored', (
+    tester,
+  ) async {
+    final gate = Completer<VizorPaymentLink?>();
+    final operations = FakePaymentLinkOperations();
+    await openFromSettings(
+      tester,
+      operations: operations,
+      scanner: (context, {required networkName}) => gate.future,
+    );
+    await tap(tester, 'payment_links_mobile_redeem_button');
+    await tester.tap(find.text('Scan QR code'));
+    await tester.pump();
+    await back(tester);
+    await tap(tester, 'payment_links_mobile_redeem_button');
+    gate.complete(incomingLink);
+    await tester.pumpAndSettle();
+    expect(find.text('Paste card link'), findsOneWidget);
+    expect(operations.preparedLinks, isEmpty);
+  }, variant: platforms);
+
+  testWidgets('late clipboard clear cannot reset a new preview', (
+    tester,
+  ) async {
+    final clipboard = _DelayedClearClipboard();
+    await openFromSettings(tester, clipboard: clipboard);
+    await tap(tester, 'payment_links_mobile_redeem_button');
+    await tester.tap(find.text('Paste card link'));
+    await tester.pumpAndSettle();
+    await tester.tap(keyed('payment_link_mobile_clear_clipboard_button'));
+    await tester.pump();
+    await back(tester);
+    await tap(tester, 'payment_links_mobile_redeem_button');
+    clipboard.text = incomingLink.toUri().toString();
+    await tester.tap(find.text('Paste card link'));
+    await tester.pumpAndSettle();
+    expect(keyed('payment_link_mobile_claim_button'), findsOneWidget);
+    clipboard.gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('Claim the gift'), findsOneWidget);
+  }, variant: platforms);
   testWidgets(
-    'leaving submitted claim keeps ownership without late navigation',
+    'late clear preserves loading for a new check on the same visit',
     (tester) async {
-      final gate = Completer<PaymentLinkClaimResult>();
-      final operations = FakePaymentLinkOperations(claimCompleter: gate);
-      final router = await openFromSettings(tester, operations: operations);
+      final clipboard = _DelayedClearClipboard();
+      final gate = Completer<void>();
+      await openFromSettings(
+        tester,
+        clipboard: clipboard,
+        operations: FakePaymentLinkOperations(prepareClaimGates: {1: gate}),
+      );
       await tap(tester, 'payment_links_mobile_redeem_button');
       await tester.tap(find.text('Paste card link'));
       await tester.pumpAndSettle();
-      await tester.tap(keyed('payment_link_mobile_claim_button'));
+      await tester.tap(keyed('payment_link_mobile_clear_clipboard_button'));
       await tester.pump();
-      await back(tester);
-      expect(keyed('payment_links_mobile_create_button'), findsOneWidget);
-      gate.complete(broadcastedClaimResult);
-      for (var i = 0; i < 12; i++) {
-        await tester.pump(const Duration(milliseconds: 100));
-      }
-      expect(router.state.uri.path, '/payment-links');
-      expect(operations.discardedClaimAddresses, isEmpty);
+      clipboard.text = incomingLink.toUri().toString();
+      await tester.tap(find.text('Paste card link'));
+      await tester.pump();
+      clipboard.gate.complete();
+      await tester.pump();
+      expect(keyed('payment_link_mobile_redeem_checking'), findsOneWidget);
+      gate.complete();
+      await tester.pumpAndSettle();
+      expect(find.text('Claim the gift'), findsOneWidget);
     },
     variant: platforms,
   );
+}
+
+class _DelayedClearClipboard extends FakePaymentLinkClipboard {
+  _DelayedClearClipboard() : super(text: 'invalid');
+  final gate = Completer<void>();
+  @override
+  Future<void> clear() => gate.future;
 }

--- a/test/features/payment_links/payment_links_navigation_mobile_test.dart
+++ b/test/features/payment_links/payment_links_navigation_mobile_test.dart
@@ -1,0 +1,279 @@
+@Tags(['mobile'])
+library;
+
+import 'dart:async';
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/features/payment_links/services/payment_link_service.dart';
+import '../../support/payment_links_screen_support.dart';
+
+const _amount = 'payment_link_mobile_amount_continue_button';
+const _message = 'payment_link_mobile_message_continue_button';
+const _review = 'payment_link_mobile_review_continue_button';
+Finder keyed(String key) => find.byKey(ValueKey(key));
+
+Future<GoRouter> openFromSettings(
+  WidgetTester tester, {
+  FakePaymentLinkOperations? operations,
+  SwitchablePaymentLinkAccountNotifier? accounts,
+}) async {
+  await pumpPaymentLinksScreen(
+    tester,
+    operations: operations,
+    accountNotifier: accounts,
+    logicalSize: const Size(393, 852),
+    clipboard: FakePaymentLinkClipboard(text: incomingLink.toUri().toString()),
+  );
+  final router = GoRouter.of(
+    tester.element(keyed('payment_links_mobile_screen')),
+  );
+  router.go('/settings');
+  await tester.pumpAndSettle();
+  unawaited(router.push('/payment-links'));
+  await tester.pumpAndSettle();
+  return router;
+}
+
+Future<void> tap(WidgetTester tester, String key) async {
+  await tester.tap(keyed(key));
+  await tester.pumpAndSettle();
+}
+
+Future<void> createToReview(WidgetTester tester) async {
+  await tap(tester, 'payment_links_mobile_create_button');
+  await tester.enterText(keyed('payment_link_amount_editor'), '0.1');
+  await tester.pump(const Duration(milliseconds: 350));
+  await tester.pumpAndSettle();
+  await tap(tester, _amount);
+  await tester.enterText(
+    keyed('payment_link_message_editor'),
+    'Keep this message',
+  );
+  await tester.pump();
+  await tap(tester, _message);
+}
+
+Future<void> back(WidgetTester tester) async {
+  if (defaultTargetPlatform == TargetPlatform.iOS) {
+    await tester.dragFrom(const Offset(1, 150), const Offset(360, 0));
+  } else {
+    await tester.binding.handlePopRoute();
+  }
+  for (var i = 0; i < 12; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+}
+
+void main() {
+  setUpAll(loadPaymentLinksTestFonts);
+  final platforms = TargetPlatformVariant({
+    TargetPlatform.iOS,
+    TargetPlatform.android,
+  });
+  testWidgets('back traverses real gift card pages and preserves draft', (
+    tester,
+  ) async {
+    final router = await openFromSettings(tester);
+    await createToReview(tester);
+    await back(tester);
+    expect(keyed(_message), findsOneWidget);
+    expect(find.text('Keep this message'), findsOneWidget);
+    await back(tester);
+    expect(keyed(_amount), findsOneWidget);
+    expect(find.text('0.1'), findsOneWidget);
+    await tap(tester, _amount);
+    expect(find.text('Keep this message'), findsOneWidget);
+    await back(tester);
+    await back(tester);
+    expect(keyed('payment_links_mobile_create_button'), findsOneWidget);
+    expect(router.state.uri.path, '/payment-links');
+    await back(tester);
+    expect(router.state.uri.path, '/settings');
+  }, variant: platforms);
+
+  testWidgets(
+    'cancelled iOS swipe retains the page and message',
+    (tester) async {
+      await openFromSettings(tester);
+      await createToReview(tester);
+      final gesture = await tester.startGesture(const Offset(1, 150));
+      await gesture.moveBy(const Offset(30, 0));
+      await tester.pump();
+      await gesture.moveBy(const Offset(70, 0));
+      await tester.pump(const Duration(milliseconds: 500));
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(keyed(_review), findsOneWidget);
+      await back(tester);
+      expect(find.text('Keep this message'), findsOneWidget);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
+
+  testWidgets(
+    'funding blocks back until completion then discards draft routes',
+    (tester) async {
+      final gate = Completer<void>();
+      await openFromSettings(
+        tester,
+        operations: FakePaymentLinkOperations(createFundedLinkGate: gate),
+      );
+      await createToReview(tester);
+      await tester.tap(keyed(_review));
+      await tester.pump();
+      await back(tester);
+      expect(keyed(_review), findsOneWidget);
+      expect(find.text('Creating...'), findsOneWidget);
+      gate.complete();
+      await tester.pumpAndSettle();
+      expect(find.text('Go home'), findsOneWidget);
+      await back(tester);
+      expect(keyed('payment_links_mobile_create_button'), findsOneWidget);
+      expect(keyed(_review), findsNothing);
+    },
+    variant: platforms,
+  );
+
+  testWidgets('funding back guard survives an active account change', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    final accounts = SwitchablePaymentLinkAccountNotifier();
+    await openFromSettings(
+      tester,
+      accounts: accounts,
+      operations: FakePaymentLinkOperations(createFundedLinkGate: gate),
+    );
+    await createToReview(tester);
+    await tester.tap(keyed(_review));
+    await tester.pump();
+    await accounts.switchAccount('account-2');
+    await tester.pump();
+    await back(tester);
+    expect(keyed(_amount), findsOneWidget);
+    expect(keyed('payment_links_mobile_create_button'), findsNothing);
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('Go home'), findsOneWidget);
+  }, variant: platforms);
+
+  testWidgets('unsaved funding metadata blocks every back path', (
+    tester,
+  ) async {
+    final operations = FakePaymentLinkOperations(
+      fundingMetadataSavedOnCreate: false,
+    );
+    await openFromSettings(tester, operations: operations);
+    await createToReview(tester);
+    await tap(tester, _review);
+    await back(tester);
+    expect(find.text('Try saving again'), findsOneWidget);
+    await tester.tap(find.bySemanticsLabel('Back').last);
+    await tester.pumpAndSettle();
+    expect(find.text('Try saving again'), findsOneWidget);
+    expect(operations.createdAmounts, hasLength(1));
+  }, variant: platforms);
+
+  testWidgets('abandoned link check cannot reopen received preview', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    final operations = FakePaymentLinkOperations(prepareClaimGates: {1: gate});
+    await openFromSettings(tester, operations: operations);
+    await tap(tester, 'payment_links_mobile_redeem_button');
+    await tester.tap(find.text('Paste card link'));
+    await tester.pump();
+    await back(tester);
+    expect(keyed('payment_links_mobile_create_button'), findsOneWidget);
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(keyed('payment_links_mobile_create_button'), findsOneWidget);
+    expect(operations.discardedClaimAddresses, [incomingLink.address]);
+    await tester.tap(keyed('payment_links_mobile_redeem_button'));
+    for (var i = 0; i < 12; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    expect(find.text('Paste card link'), findsOneWidget);
+    expect(keyed('payment_link_mobile_redeem_checking'), findsNothing);
+  }, variant: platforms);
+
+  testWidgets(
+    'received preview back releases session and returns to cards',
+    (tester) async {
+      final operations = FakePaymentLinkOperations();
+      final router = await openFromSettings(tester, operations: operations);
+      await tap(tester, 'payment_links_mobile_redeem_button');
+      await tester.tap(find.text('Paste card link'));
+      await tester.pumpAndSettle();
+      await back(tester);
+      expect(keyed('payment_links_mobile_create_button'), findsOneWidget);
+      expect(router.state.uri.path, '/payment-links');
+      expect(operations.discardedClaimAddresses, [incomingLink.address]);
+    },
+    variant: platforms,
+  );
+
+  testWidgets(
+    'waiting received card Go home retains its explicit destination',
+    (tester) async {
+      final router = await openFromSettings(
+        tester,
+        operations: FakePaymentLinkOperations(
+          waitingForFundingConfirmations: true,
+        ),
+      );
+      await tap(tester, 'payment_links_mobile_redeem_button');
+      await tester.tap(find.text('Paste card link'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Go home'));
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, '/home');
+    },
+    variant: platforms,
+  );
+
+  testWidgets(
+    'received swipe reveals the cards destination',
+    (tester) async {
+      await openFromSettings(tester);
+      await tap(tester, 'payment_links_mobile_redeem_button');
+      await tester.tap(find.text('Paste card link'));
+      await tester.pumpAndSettle();
+      final gesture = await tester.startGesture(const Offset(1, 150));
+      await gesture.moveBy(const Offset(30, 0));
+      await tester.pump();
+      await gesture.moveBy(const Offset(200, 0));
+      await tester.pump();
+      expect(keyed('payment_links_mobile_create_button'), findsOneWidget);
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(keyed('payment_links_mobile_create_button'), findsOneWidget);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
+
+  testWidgets(
+    'leaving submitted claim keeps ownership without late navigation',
+    (tester) async {
+      final gate = Completer<PaymentLinkClaimResult>();
+      final operations = FakePaymentLinkOperations(claimCompleter: gate);
+      final router = await openFromSettings(tester, operations: operations);
+      await tap(tester, 'payment_links_mobile_redeem_button');
+      await tester.tap(find.text('Paste card link'));
+      await tester.pumpAndSettle();
+      await tester.tap(keyed('payment_link_mobile_claim_button'));
+      await tester.pump();
+      await back(tester);
+      expect(keyed('payment_links_mobile_create_button'), findsOneWidget);
+      gate.complete(broadcastedClaimResult);
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(router.state.uri.path, '/payment-links');
+      expect(operations.discardedClaimAddresses, isEmpty);
+    },
+    variant: platforms,
+  );
+}

--- a/test/figma_compare/figma_compare_capture_support.dart
+++ b/test/figma_compare/figma_compare_capture_support.dart
@@ -19,10 +19,11 @@ void runFigmaCompareCaptureTest({
   required AppFormFactor expectedFormFactor,
   required Size defaultLogicalSize,
   required double defaultPixelRatio,
+  FigmaCompareConfiguration? overrideConfiguration,
 }) {
-  testWidgets('captures the configured Figma comparison scenario', (
-    tester,
-  ) async {
+  final testName =
+      'captures ${overrideConfiguration?.scenarioId ?? 'configured scenario'} ${overrideConfiguration?.themeMode.name ?? ''}';
+  testWidgets(testName, (tester) async {
     expect(
       kAppFormFactor,
       expectedFormFactor,
@@ -35,13 +36,15 @@ void runFigmaCompareCaptureTest({
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     }
 
-    final configuration = FigmaCompareConfiguration.fromEnvironment(
-      defaultLogicalSize: defaultLogicalSize,
-      defaultPixelRatio: defaultPixelRatio,
-      defaultScenarioId: expectedFormFactor == AppFormFactor.mobile
-          ? 'mobile-home-default'
-          : 'pay-recipient',
-    );
+    final configuration =
+        overrideConfiguration ??
+        FigmaCompareConfiguration.fromEnvironment(
+          defaultLogicalSize: defaultLogicalSize,
+          defaultPixelRatio: defaultPixelRatio,
+          defaultScenarioId: expectedFormFactor == AppFormFactor.mobile
+              ? 'mobile-home-default'
+              : 'pay-recipient',
+        );
     final scenario = configuration.resolveScenario(expectedFormFactor);
     if (scenario.allowFocus) {
       EditableText.debugDeterministicCursor = true;

--- a/test/figma_compare/gift_cards_capture_mobile_test.dart
+++ b/test/figma_compare/gift_cards_capture_mobile_test.dart
@@ -1,0 +1,38 @@
+@Tags(['mobile', 'figma-capture'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/figma_compare/figma_compare_configuration.dart';
+import 'package:zcash_wallet/figma_compare/figma_compare_scenarios.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
+import 'figma_compare_capture_support.dart';
+
+/// Run with --update-goldens and GIFT_CARD_CAPTURE_DIR outside the repository.
+void main() {
+  const output = String.fromEnvironment('GIFT_CARD_CAPTURE_DIR');
+  if (output.isEmpty) return;
+  for (final scenario in figmaCompareScenarios.where(
+    (s) =>
+        s.mobile &&
+        (s.id.startsWith('mobile-payment-link') ||
+            s.id.startsWith('mobile-gift-card') ||
+            s.id.startsWith('gift-card-') ||
+            s.id.startsWith('activity-gift-card') && s.id.endsWith('-mobile')),
+  )) {
+    for (final theme in [ThemeMode.light, ThemeMode.dark]) {
+      runFigmaCompareCaptureTest(
+        expectedFormFactor: AppFormFactor.mobile,
+        defaultLogicalSize: const Size(393, 852),
+        defaultPixelRatio: 3,
+        overrideConfiguration: FigmaCompareConfiguration(
+          scenarioId: scenario.id,
+          themeMode: theme,
+          outputPath: '$output/${theme.name}/${scenario.id}.png',
+          logicalSize: const Size(393, 852),
+          pixelRatio: 3,
+        ),
+      );
+    }
+  }
+}

--- a/test/support/payment_links_screen_support.dart
+++ b/test/support/payment_links_screen_support.dart
@@ -53,8 +53,10 @@ Future<void> pumpPaymentLinksScreen(
   FakeSyncNotifier? syncNotifier,
   ZecMarketDataSource? marketDataSource,
   bool? pricingEnabled,
+  Size logicalSize = const Size(1080, 720),
+  GlobalKey? captureBoundaryKey,
 }) async {
-  await tester.binding.setSurfaceSize(const Size(1080, 720));
+  await tester.binding.setSurfaceSize(logicalSize);
   addTearDown(() => tester.binding.setSurfaceSize(null));
   final paymentLinkOperations = operations ?? FakePaymentLinkOperations();
   final paymentLinkClipboard = clipboard ?? FakePaymentLinkClipboard();
@@ -119,7 +121,12 @@ Future<void> pumpPaymentLinksScreen(
           FakeMigrationCoordinator.new,
         ),
       ],
-      child: const ZcashWalletApp(),
+      child: captureBoundaryKey == null
+          ? const ZcashWalletApp()
+          : RepaintBoundary(
+              key: captureBoundaryKey,
+              child: const ZcashWalletApp(),
+            ),
     ),
   );
   await tester.pump();


### PR DESCRIPTION
Mobile Gift Cards steps were rendered inside one route, so an edge swipe could not navigate from Create a card back to Gift Cards. Give the steps a nested Cupertino navigator, preserve amount/message drafts when moving back, and discard draft routes after completion.

Keep the existing screens, copy, and button loading states. Align the top back/close buttons, iOS back gesture, and Android system back during software funding and claim submission. Preserve the loading review if the active account changes during funding, and ignore stale scanner, clipboard, archive, and status callbacks after navigation. Keystone continues to use its existing shared signing flow and decode/finalization guards.

Validation:
- Mobile Gift Cards, shared Keystone signing, and mobile routes: 123 tests passed.
- Desktop/shared Gift Cards and related navigation/activity: 338 tests passed, 12 skipped.
- Flutter analyze: no issues; diff whitespace check passed.
- Independently captured the baseline and final implementation: 24 matching screen/state pairs are pixel-identical. A separate 21-pair back-behavior capture suite records navigation outcomes without treating different destinations as UI parity evidence.
- Four review passes completed; no unresolved findings.

Native device/regtest execution and physical Keystone QR scanning were not performed. Preparation checks may finish after the user leaves; stale results cannot reopen the abandoned screen. Existing metadata-save retry guards remain in place, and no UI timeout is treated as transaction cancellation.
